### PR TITLE
`WrappedTarget` now requires `WrappedTargetRequest`

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -32,6 +32,7 @@ from pants.engine.target import (
     StringField,
     Target,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
@@ -156,7 +157,12 @@ async def inject_lambda_handler_dependency(
 ) -> InjectedDependencies:
     if not python_infer_subsystem.entry_points:
         return InjectedDependencies()
-    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    original_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     explicitly_provided_deps, handler = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(original_tgt.target[Dependencies])),
         Get(

--- a/src/python/pants/backend/cc/dependency_inference/rules.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules.py
@@ -28,6 +28,7 @@ from pants.engine.target import (
     InferredDependencies,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -120,7 +121,9 @@ async def infer_cc_source_dependencies(
         return InferredDependencies([])
 
     address = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     explicitly_provided_deps, hydrated_sources = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
         Get(HydratedSources, HydrateSourcesRequest(request.sources_field)),

--- a/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
@@ -7,7 +7,12 @@ from pants.backend.codegen.protobuf.target_types import ProtobufDependenciesFiel
 from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, WrappedTarget
+from pants.engine.target import (
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
@@ -68,7 +73,12 @@ async def inject_protobuf_java_runtime_dependency(
     request: InjectProtobufJavaRuntimeDependencyRequest,
     jvm: JvmSubsystem,
 ) -> InjectedDependencies:
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):

--- a/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/protobuf_dependency_inference.py
@@ -23,6 +23,7 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -93,7 +94,9 @@ async def infer_protobuf_dependencies(
         return InferredDependencies([])
 
     address = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     explicitly_provided_deps, hydrated_sources = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
         Get(HydratedSources, HydrateSourcesRequest(request.sources_field)),

--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -10,7 +10,12 @@ from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, WrappedTarget
+from pants.engine.target import (
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
@@ -84,7 +89,12 @@ async def inject_scalapb_runtime_dependency(
     request: InjectScalaPBRuntimeDependencyRequest,
     jvm: JvmSubsystem,
 ) -> InjectedDependencies:
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules.py
@@ -27,6 +27,7 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
@@ -123,7 +124,12 @@ async def resolve_apache_thrift_java_runtime_for_resolve(
 async def inject_apache_thrift_java_dependencies(
     request: InjectApacheThriftJavaDependencies, jvm: JvmSubsystem
 ) -> InjectedDependencies:
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):

--- a/src/python/pants/backend/codegen/thrift/apache/python/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/rules.py
@@ -14,7 +14,6 @@ from pants.backend.codegen.utils import find_python_runtime_library_or_raise_err
 from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField, PythonSourceField
-from pants.engine.addresses import Address
 from pants.engine.fs import AddPrefix, Digest, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
@@ -23,6 +22,7 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -78,7 +78,12 @@ async def find_apache_thrift_python_requirement(
     if not thrift_python.infer_runtime_dependency:
         return InjectedDependencies()
 
-    wrapped_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     resolve = wrapped_tgt.target.get(PythonResolveField).normalized_value(python_setup)
 
     addr = find_python_runtime_library_or_raise_error(

--- a/src/python/pants/backend/codegen/thrift/dependency_inference.py
+++ b/src/python/pants/backend/codegen/thrift/dependency_inference.py
@@ -21,6 +21,7 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -78,7 +79,9 @@ async def infer_thrift_dependencies(
         return InferredDependencies([])
 
     address = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     explicitly_provided_deps, parsed_thrift = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
         Get(ParsedThrift, ParsedThriftRequest(request.sources_field)),

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -10,14 +10,18 @@ from pants.backend.codegen.thrift.target_types import (
     ThriftSourcesGeneratorTarget,
     ThriftSourceTarget,
 )
-from pants.build_graph.address import Address
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest, WrappedTarget
+from pants.engine.target import (
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
@@ -58,7 +62,12 @@ async def generate_scrooge_thrift_sources(
         Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.thrift_source_field.address])),
         Get(Digest, CreateDigest([Directory(output_dir)])),
-        Get(WrappedTarget, Address, request.thrift_source_field.address),
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(
+                request.thrift_source_field.address, description_of_origin="<infallible>"
+            ),
+        ),
     )
 
     transitive_sources, target_sources = await MultiGet(

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -39,7 +39,7 @@ from pants.core.goals.run import RunFieldSet
 from pants.engine.addresses import Address
 from pants.engine.process import FallibleProcessResult, Process, ProcessExecutionFailure
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Target, WrappedTarget
+from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions, ProcessCleanupOption
 from pants.util.strutil import bullet_list
@@ -234,7 +234,10 @@ async def build_docker_image(
                 build_upstream_images=True,
             ),
         ),
-        Get(WrappedTarget, Address, field_set.address),
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(field_set.address, description_of_origin="<infallible>"),
+        ),
     )
 
     tags = field_set.image_refs(

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -48,7 +48,7 @@ from pants.engine.process import (
     ProcessExecutionFailure,
     ProcessResultMetadata,
 )
-from pants.engine.target import InvalidFieldException, WrappedTarget
+from pants.engine.target import InvalidFieldException, WrappedTarget, WrappedTargetRequest
 from pants.option.global_options import GlobalOptions, ProcessCleanupOption
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.pytest_util import assert_logged, no_exception
@@ -158,7 +158,7 @@ def assert_build(
             ),
             MockGet(
                 output_type=WrappedTarget,
-                input_type=Address,
+                input_type=WrappedTargetRequest,
                 mock=lambda _: WrappedTarget(tgt),
             ),
             MockGet(

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -22,7 +22,13 @@ from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest, SourcesField, WrappedTarget
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    SourcesField,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
@@ -139,7 +145,9 @@ class DockerfileInfoRequest:
 
 @rule
 async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
-    wrapped_target = await Get(WrappedTarget, Address, request.address)
+    wrapped_target = await Get(
+        WrappedTarget, WrappedTargetRequest(request.address, description_of_origin="<infallible>")
+    )
     target = wrapped_target.target
     sources = await Get(
         HydratedSources,

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -55,6 +55,7 @@ from pants.engine.target import (
     InvalidFieldException,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.frozendict import FrozenDict
@@ -165,7 +166,7 @@ async def inject_go_third_party_package_dependencies(
     addr = request.dependencies_field.address
     go_mod_address = addr.maybe_convert_to_target_generator()
     wrapped_target, go_mod_info = await MultiGet(
-        Get(WrappedTarget, Address, addr),
+        Get(WrappedTarget, WrappedTargetRequest(addr, description_of_origin="<infallible>")),
         Get(GoModInfo, GoModInfoRequest(go_mod_address)),
     )
     tgt = wrapped_target.target
@@ -262,16 +263,21 @@ async def determine_main_pkg_for_go_binary(
 ) -> GoBinaryMainPackage:
     addr = request.field.address
     if request.field.value:
-        wrapped_specified_tgt = await Get(
-            WrappedTarget,
+        description_of_origin = (
+            f"the `{request.field.alias}` field from the target {request.field.address}"
+        )
+        specified_address = await Get(
+            Address,
             AddressInput,
             AddressInput.parse(
                 request.field.value,
                 relative_to=addr.spec_path,
-                description_of_origin=(
-                    f"the `{request.field.alias}` field from the target {request.field.address}"
-                ),
+                description_of_origin=description_of_origin,
             ),
+        )
+        wrapped_specified_tgt = await Get(
+            WrappedTarget,
+            WrappedTargetRequest(specified_address, description_of_origin=description_of_origin),
         )
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
             raise InvalidFieldException(
@@ -298,18 +304,16 @@ async def determine_main_pkg_for_go_binary(
     if len(relevant_pkg_targets) == 1:
         return GoBinaryMainPackage(relevant_pkg_targets[0].address)
 
-    wrapped_tgt = await Get(WrappedTarget, Address, addr)
-    alias = wrapped_tgt.target.alias
     if not relevant_pkg_targets:
         raise ResolveError(
-            f"The `{alias}` target {addr} requires that there is a `go_package` "
+            f"The target {addr} requires that there is a `go_package` "
             f"target defined in its directory {addr.spec_path}, but none were found.\n\n"
             "To fix, add a target like `go_package()` or `go_package(name='pkg')` to the BUILD "
             f"file in {addr.spec_path}."
         )
     raise ResolveError(
         f"There are multiple `go_package` targets for the same directory of the "
-        f"`{alias}` target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
+        f"target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
         "package.\n\n"
         f"To fix, please either set the `main` field for `{addr} or remove these "
         "`go_package` targets so that only one remains: "
@@ -325,7 +329,12 @@ class InjectGoBinaryMainDependencyRequest(InjectDependenciesRequest):
 async def inject_go_binary_main_dependency(
     request: InjectGoBinaryMainDependencyRequest,
 ) -> InjectedDependencies:
-    wrapped_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     main_pkg = await Get(
         GoBinaryMainPackage,
         GoBinaryMainPackageRequest(wrapped_tgt.target[GoBinaryMainPackageField]),

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -40,6 +40,7 @@ from pants.engine.target import (
     Target,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
@@ -112,7 +113,10 @@ def maybe_get_codegen_request_type(
 async def setup_build_go_package_target_request(
     request: BuildGoPackageTargetRequest, union_membership: UnionMembership
 ) -> FallibleBuildGoPackageRequest:
-    wrapped_target = await Get(WrappedTarget, Address, request.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(request.address, description_of_origin="<build_pkg_target.py>"),
+    )
     target = wrapped_target.target
 
     codegen_request = maybe_get_codegen_request_type(target, union_membership)

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -21,6 +21,7 @@ from pants.engine.target import (
     InvalidTargetException,
     UnexpandedTargets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.util.docutil import bin_name
 
@@ -92,7 +93,10 @@ async def determine_go_mod_info(
     request: GoModInfoRequest,
 ) -> GoModInfo:
     if isinstance(request.source, Address):
-        wrapped_target = await Get(WrappedTarget, Address, request.source)
+        wrapped_target = await Get(
+            WrappedTarget,
+            WrappedTargetRequest(request.source, description_of_origin="<go mod info rule>"),
+        )
         sources_field = wrapped_target.target[GoModSourcesField]
     else:
         sources_field = request.source

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -32,6 +32,7 @@ from pants.engine.target import (
     StringField,
     Target,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
@@ -146,7 +147,12 @@ async def inject_cloud_function_handler_dependency(
 ) -> InjectedDependencies:
     if not python_infer_subsystem.entry_points:
         return InjectedDependencies()
-    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    original_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     explicitly_provided_deps, handler = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(original_tgt.target[Dependencies])),
         Get(

--- a/src/python/pants/backend/helm/dependency_inference/chart.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart.py
@@ -25,6 +25,7 @@ from pants.engine.target import (
     InferDependenciesRequest,
     InferredDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -93,7 +94,9 @@ async def infer_chart_dependencies_via_metadata(
     subsystem: HelmSubsystem,
 ) -> InferredDependencies:
     original_addr = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, original_addr)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(original_addr, description_of_origin="<infallible>")
+    )
     tgt = wrapped_tgt.target
 
     # Parse Chart.yaml for explicitly set dependencies.

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -23,6 +23,7 @@ from pants.engine.target import (
     InferredDependencies,
     SourcesField,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
@@ -71,7 +72,9 @@ async def infer_java_dependencies_and_exports_via_source_analysis(
 
     address = request.source.address
 
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     tgt = wrapped_tgt.target
     source_files = await Get(SourceFiles, SourceFilesRequest([tgt[JavaSourceField]]))
 

--- a/src/python/pants/backend/kotlin/test/junit.py
+++ b/src/python/pants/backend/kotlin/test/junit.py
@@ -9,7 +9,12 @@ from pants.backend.kotlin.target_types import KotlinJunitTestDependenciesField
 from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import InjectDependenciesRequest, InjectedDependencies, WrappedTarget
+from pants.engine.target import (
+    InjectDependenciesRequest,
+    InjectedDependencies,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
@@ -64,7 +69,12 @@ async def inject_kotlin_junit_dependency(
     request: InjectKotlinJunitTestDependencyRequest,
     jvm: JvmSubsystem,
 ) -> InjectedDependencies:
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -48,6 +48,7 @@ from pants.engine.target import (
     InferredDependencies,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.option.global_options import OwnersNotFoundBehavior
@@ -387,7 +388,10 @@ async def infer_python_dependencies_via_source(
     if not python_infer_subsystem.imports and not python_infer_subsystem.assets:
         return InferredDependencies([])
 
-    _wrapped_tgt = await Get(WrappedTarget, Address, request.sources_field.address)
+    _wrapped_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(request.sources_field.address, description_of_origin="<infallible>"),
+    )
     tgt = _wrapped_tgt.target
     interpreter_constraints = InterpreterConstraints.create_from_targets([tgt], python_setup)
     if interpreter_constraints is None:
@@ -489,7 +493,12 @@ async def infer_python_init_dependencies(
     owners = await MultiGet(Get(Owners, OwnersRequest((f,))) for f in init_files.snapshot.files)
 
     original_tgt, owner_tgts = await MultiGet(
-        Get(WrappedTarget, Address, request.sources_field.address),
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(
+                request.sources_field.address, description_of_origin="<infallible>"
+            ),
+        ),
         Get(Targets, Addresses(itertools.chain.from_iterable(owners))),
     )
     resolve = original_tgt.target[PythonResolveField].normalized_value(python_setup)
@@ -531,7 +540,12 @@ async def infer_python_conftest_dependencies(
     )
 
     original_tgt, owner_tgts = await MultiGet(
-        Get(WrappedTarget, Address, request.sources_field.address),
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(
+                request.sources_field.address, description_of_origin="<infallible>"
+            ),
+        ),
         Get(Targets, Addresses(itertools.chain.from_iterable(owners))),
     )
     resolve = original_tgt.target[PythonResolveField].normalized_value(python_setup)

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -54,7 +54,13 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import Target, TransitiveTargets, TransitiveTargetsRequest, WrappedTarget
+from pants.engine.target import (
+    Target,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
@@ -110,7 +116,9 @@ class AllPytestPluginSetupsRequest:
 async def run_all_setup_plugins(
     request: AllPytestPluginSetupsRequest, union_membership: UnionMembership
 ) -> AllPytestPluginSetups:
-    wrapped_tgt = await Get(WrappedTarget, Address, request.address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(request.address, description_of_origin="<infallible>")
+    )
     applicable_setup_request_types = tuple(
         request
         for request in union_membership.get(PytestPluginSetupRequest)

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -503,7 +503,9 @@ async def validate_python_dependencies(
     dependencies = await MultiGet(
         Get(
             WrappedTarget,
-            WrappedTargetRequest(d, description_of_origin=f"the dependencies of {request.address}"),
+            WrappedTargetRequest(
+                d, description_of_origin=f"the dependencies of {request.field_set.address}"
+            ),
         )
         for d in request.dependencies
     )

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -62,6 +62,7 @@ from pants.engine.target import (
     ValidatedDependencies,
     ValidateDependenciesRequest,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -209,7 +210,12 @@ async def inject_pex_binary_entry_point_dependency(
 ) -> InjectedDependencies:
     if not python_infer_subsystem.entry_points:
         return InjectedDependencies()
-    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    original_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     entry_point_field = original_tgt.target.get(PexEntryPointField)
     if entry_point_field.value is None:
         return InjectedDependencies()
@@ -408,7 +414,12 @@ async def inject_python_distribution_dependencies(
     if not python_infer_subsystem.entry_points:
         return InjectedDependencies()
 
-    original_tgt = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    original_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     explicitly_provided_deps, distribution_entry_points, provides_entry_points = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(original_tgt.target[Dependencies])),
         Get(
@@ -489,7 +500,13 @@ async def validate_python_dependencies(
     request: PythonValidateDependenciesRequest,
     python_setup: PythonSetup,
 ) -> ValidatedDependencies:
-    dependencies = await MultiGet(Get(WrappedTarget, Address, d) for d in request.dependencies)
+    dependencies = await MultiGet(
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(d, description_of_origin=f"the dependencies of {request.address}"),
+        )
+        for d in request.dependencies
+    )
 
     # Validate that the ICs for dependencies are all compatible with our own.
     target_ics = request.field_set.interpreter_constraints.value_or_global_default(python_setup)

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -23,7 +23,12 @@ from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest, WrappedTarget
+from pants.engine.target import (
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import doc_url
 from pants.util.meta import frozen_after_init
@@ -57,7 +62,10 @@ async def isolate_local_dist_wheels(
     wheels = [wheel for wheel in wheels_snapshot.files if wheel in artifacts]
 
     if not wheels:
-        tgt = await Get(WrappedTarget, Address, dist_field_set.address)
+        tgt = await Get(
+            WrappedTarget,
+            WrappedTargetRequest(dist_field_set.address, description_of_origin="<infallible>"),
+        )
         logger.warning(
             softwrap(
                 f"""

--- a/src/python/pants/backend/scala/dependency_inference/rules.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules.py
@@ -32,6 +32,7 @@ from pants.engine.target import (
     InjectDependenciesRequest,
     InjectedDependencies,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
@@ -63,7 +64,9 @@ async def infer_scala_dependencies_via_source_analysis(
         return InferredDependencies([])
 
     address = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     tgt = wrapped_tgt.target
     explicitly_provided_deps, analysis = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(tgt[Dependencies])),
@@ -149,7 +152,12 @@ async def inject_scala_library_dependency(
     request: InjectScalaLibraryDependencyRequest,
     jvm: JvmSubsystem,
 ) -> InjectedDependencies:
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):
@@ -169,7 +177,12 @@ async def inject_scala_plugin_dependencies(
     """Adds dependencies on plugins for scala source files, so that they get included in the
     target's resolve."""
 
-    wrapped_target = await Get(WrappedTarget, Address, request.dependencies_field.address)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.dependencies_field.address, description_of_origin="<infallible>"
+        ),
+    )
     target = wrapped_target.target
 
     if not target.has_field(JvmResolveField):

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -11,7 +11,6 @@ from typing import Any, Iterator, Mapping
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
-from pants.build_graph.address import Address
 from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
@@ -27,7 +26,7 @@ from pants.engine.fs import (
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import WrappedTarget
+from pants.engine.target import WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
@@ -183,8 +182,13 @@ async def create_analyze_scala_source_request(
 ) -> AnalyzeScalaSourceRequest:
     address = request.sources_fields[0].address
 
-    (wrapped_tgt, source_files) = await MultiGet(
-        Get(WrappedTarget, Address, address),
+    wrapped_tgt, source_files = await MultiGet(
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(
+                address, description_of_origin="<the Scala analyze request setup rule>"
+            ),
+        ),
         Get(SourceFiles, SourceFilesRequest, request),
     )
 

--- a/src/python/pants/backend/shell/dependency_inference.py
+++ b/src/python/pants/backend/shell/dependency_inference.py
@@ -31,6 +31,7 @@ from pants.engine.target import (
     InferredDependencies,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
@@ -162,7 +163,9 @@ async def infer_shell_dependencies(
         return InferredDependencies([])
 
     address = request.sources_field.address
-    wrapped_tgt = await Get(WrappedTarget, Address, address)
+    wrapped_tgt = await Get(
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
+    )
     explicitly_provided_deps, hydrated_sources = await MultiGet(
         Get(ExplicitlyProvidedDependencies, DependenciesRequest(wrapped_tgt.target[Dependencies])),
         Get(HydratedSources, HydrateSourcesRequest(request.sources_field)),

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -32,7 +32,6 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
 )
-from pants.engine.addresses import Address
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
@@ -55,6 +54,7 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
@@ -236,7 +236,10 @@ async def prepare_shell_command_process(
 
 @rule
 async def run_shell_command_request(shell_command: RunShellCommand) -> RunRequest:
-    wrapped_tgt = await Get(WrappedTarget, Address, shell_command.address)
+    wrapped_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(shell_command.address, description_of_origin="<infallible>"),
+    )
     process = await Get(Process, ShellCommandProcessRequest(wrapped_tgt.target))
     return RunRequest(
         digest=process.input_digest,

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -7,7 +7,6 @@ from pathlib import PurePath
 from typing import Iterable, Mapping, Optional, Tuple
 
 from pants.base.build_root import BuildRoot
-from pants.build_graph.address import Address
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
@@ -20,6 +19,7 @@ from pants.engine.target import (
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
@@ -132,7 +132,9 @@ async def run(
     )
     field_set = targets_to_valid_field_sets.field_sets[0]
     request = await Get(RunRequest, RunFieldSet, field_set)
-    wrapped_target = await Get(WrappedTarget, Address, field_set.address)
+    wrapped_target = await Get(
+        WrappedTarget, WrappedTargetRequest(field_set.address, description_of_origin="<infallible>")
+    )
     restartable = wrapped_target.target.get(RestartableField).value
     # Cleanup is the default, so we want to preserve the chroot if either option is off.
     cleanup = run_subsystem.cleanup and global_options.process_cleanup

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.option.global_options import GlobalOptions
 from pants.testutil.option_util import create_goal_subsystem, create_subsystem
@@ -80,7 +81,7 @@ def single_target_run(
                 ),
                 MockGet(
                     output_type=WrappedTarget,
-                    input_type=Address,
+                    input_type=WrappedTargetRequest,
                     mock=lambda _: WrappedTarget(target),
                 ),
                 MockGet(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -80,6 +80,7 @@ from pants.engine.target import (
     ValidatedDependencies,
     ValidateDependenciesRequest,
     WrappedTarget,
+    WrappedTargetRequest,
     _generate_file_level_targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule
@@ -105,7 +106,10 @@ logger = logging.getLogger(__name__)
 
 @rule
 async def resolve_unexpanded_targets(addresses: Addresses) -> UnexpandedTargets:
-    wrapped_targets = await MultiGet(Get(WrappedTarget, Address, a) for a in addresses)
+    wrapped_targets = await MultiGet(
+        Get(WrappedTarget, WrappedTargetRequest(a, description_of_origin="TODO(#14468)"))
+        for a in addresses
+    )
     return UnexpandedTargets(wrapped_target.target for wrapped_target in wrapped_targets)
 
 
@@ -301,13 +305,16 @@ async def resolve_target_parametrizations(
 
 @rule
 async def resolve_target(
-    address: Address,
+    request: WrappedTargetRequest,
     target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
 ) -> WrappedTarget:
+    address = request.address
     base_address = address.maybe_convert_to_target_generator()
     parametrizations = await Get(
         _TargetParametrizations,
-        _TargetParametrizationsRequest(base_address, description_of_origin="TODO(#14468)"),
+        _TargetParametrizationsRequest(
+            base_address, description_of_origin=request.description_of_origin
+        ),
     )
     if address.is_generated_target:
         # TODO: This is an accommodation to allow using file/generator Addresses for
@@ -906,7 +913,10 @@ async def hydrate_sources(
     # Finally, return if codegen is not in use; otherwise, run the relevant code generator.
     if not request.enable_codegen or generate_request_type is None:
         return HydratedSources(snapshot, sources_field.filespec, sources_type=sources_type)
-    wrapped_protocol_target = await Get(WrappedTarget, Address, sources_field.address)
+    wrapped_protocol_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(sources_field.address, description_of_origin="<infallible>"),
+    )
     generated_sources = await Get(
         GeneratedSources,
         GenerateSourcesRequest,
@@ -1030,7 +1040,10 @@ async def resolve_dependencies(
     subproject_roots: SubprojectRoots,
 ) -> Addresses:
     wrapped_tgt, explicitly_provided = await MultiGet(
-        Get(WrappedTarget, Address, request.field.address),
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(request.field.address, description_of_origin="<infallible>"),
+        ),
         Get(ExplicitlyProvidedDependencies, DependenciesRequest, request),
     )
     tgt = wrapped_tgt.target

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -51,6 +51,7 @@ from pants.engine.target import (
     TargetRootsToFieldSetsRequest,
     Targets,
     WrappedTarget,
+    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions, OwnersNotFoundBehavior
@@ -111,7 +112,10 @@ async def _determine_literal_addresses_from_raw_specs(
 
     # We eagerly call the `WrappedTarget` rule because it will validate that every final address
     # actually exists, such as with generated target addresses.
-    return await MultiGet(Get(WrappedTarget, Address, addr) for addr in all_candidate_addresses)
+    return await MultiGet(
+        Get(WrappedTarget, WrappedTargetRequest(addr, description_of_origin=description_of_origin))
+        for addr in all_candidate_addresses
+    )
 
 
 @rule

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -626,6 +626,18 @@ class Target:
 
 
 @dataclass(frozen=True)
+class WrappedTargetRequest:
+    """Used with `WrappedTarget` to get the Target corresponding to an address.
+
+    `description_of_origin` is used for error messages when the address does not actually exist. If
+    you are confident this cannot happen, set the string to something like `<infallible>`.
+    """
+
+    address: Address
+    description_of_origin: str = dataclasses.field(hash=False, compare=False)
+
+
+@dataclass(frozen=True)
 class WrappedTarget:
     """A light wrapper to encapsulate all the distinct `Target` subclasses into a single type.
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -33,7 +33,7 @@ from pants.engine.internals.session import SessionValues
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule as QueryRule
 from pants.engine.rules import Rule
-from pants.engine.target import AllTargets, Target, WrappedTarget
+from pants.engine.target import AllTargets, Target, WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import initialize_stdio, initialize_stdio_raw, stdio_destination
@@ -217,7 +217,7 @@ class RuleRunner:
         all_rules = (
             *(rules or ()),
             *source_root.rules(),
-            QueryRule(WrappedTarget, [Address]),
+            QueryRule(WrappedTarget, [WrappedTargetRequest]),
             QueryRule(AllTargets, []),
             QueryRule(UnionMembership, []),
         )
@@ -476,7 +476,10 @@ class RuleRunner:
 
         :API: public
         """
-        return self.request(WrappedTarget, [address]).target
+        return self.request(
+            WrappedTarget,
+            [WrappedTargetRequest(address, description_of_origin="RuleRunner.get_target()")],
+        ).target
 
     def write_digest(self, digest: Digest, *, path_prefix: str | None = None) -> None:
         """Write a digest to disk, relative to the test's build root.


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/15759 for the motivation as prework for https://github.com/pantsbuild/pants/issues/14468.

The majority of call-sites here are infallible: we are going from something like `Target -> DependenciesRequest -> WrappedTarget`. That is, we know the target already exists and it's infallible. This suggests that our APIs may need to be redesigned so we don't have to re-request the target, e.g. fix our dependency inference API with https://github.com/pantsbuild/pants/issues/15400.

[ci skip-rust]
[ci skip-build-wheels]