### PR TITLE
Move `ResolveError` from `pants.base.exceptions` to `pants.build_graph.address`

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -34,8 +34,8 @@ from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
 )
-from pants.base.exceptions import ResolveError
 from pants.base.specs import DirGlobSpec, RawSpecs
+from pants.build_graph.address import ResolveError
 from pants.core.target_types import (
     TargetGeneratorSourcesHelperSourcesField,
     TargetGeneratorSourcesHelperTarget,

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -29,8 +29,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
-from pants.base.exceptions import ResolveError
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, ResolveError
 from pants.core.target_types import (
     GenericTarget,
     TargetGeneratorSourcesHelperSourcesField,

--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Iterable
-
 
 class TargetDefinitionException(Exception):
     """Indicates an invalid target definition.
@@ -30,17 +28,3 @@ class BackendConfigurationError(BuildConfigurationError):
 
 class MappingError(Exception):
     """Indicates an error mapping addressable objects."""
-
-
-class ResolveError(MappingError):
-    """Indicates an error resolving targets."""
-
-    @classmethod
-    def did_you_mean(
-        cls, *, bad_name: str, known_names: Iterable[str], namespace: str
-    ) -> ResolveError:
-        possibilities = "\n  ".join(f":{target_name}" for target_name in sorted(known_names))
-        return cls(
-            f"'{bad_name}' was not found in namespace '{namespace}'. Did you mean one "
-            f"of:\n  {possibilities}"
-        )

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -7,8 +7,9 @@ import dataclasses
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
+from pants.base.exceptions import MappingError
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import (  # noqa: F401
@@ -623,3 +624,17 @@ class BuildFileAddress:
 
     address: Address
     rel_path: str
+
+
+class ResolveError(MappingError):
+    """Indicates an error resolving target addresses."""
+
+    @classmethod
+    def did_you_mean(
+        cls, *, bad_name: str, known_names: Iterable[str], namespace: str
+    ) -> ResolveError:
+        possibilities = "\n  ".join(f":{target_name}" for target_name in sorted(known_names))
+        return cls(
+            f"'{bad_name}' was not found in namespace '{namespace}'. Did you mean one "
+            f"of:\n  {possibilities}"
+        )

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, Sequence
 
-from pants.base.exceptions import ResolveError
 from pants.build_graph.address import Address as Address
 from pants.build_graph.address import AddressInput as AddressInput  # noqa: F401: rexport.
 from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # noqa: F401: rexport.
 from pants.build_graph.address import (  # noqa: F401: rexport.
     BuildFileAddressRequest as BuildFileAddressRequest,
 )
+from pants.build_graph.address import ResolveError
 from pants.engine.collection import Collection
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -7,8 +7,7 @@ import os.path
 from dataclasses import dataclass
 from typing import Any
 
-from pants.base.exceptions import ResolveError
-from pants.build_graph.address import BuildFileAddressRequest
+from pants.build_graph.address import BuildFileAddressRequest, ResolveError
 from pants.engine.addresses import Address, AddressInput, BuildFileAddress
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -12,9 +12,8 @@ from pathlib import PurePath
 from typing import Iterable, NamedTuple, Sequence, cast
 
 from pants.base.deprecated import resolve_conflicting_options, warn_or_error
-from pants.base.exceptions import ResolveError
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
-from pants.build_graph.address import BuildFileAddressRequest
+from pants.build_graph.address import BuildFileAddressRequest, ResolveError
 from pants.engine.addresses import (
     Address,
     Addresses,

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -9,7 +9,6 @@ from typing import Iterable, Type
 
 import pytest
 
-from pants.base.exceptions import ResolveError
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import (
     AddressLiteralSpec,
@@ -26,7 +25,7 @@ from pants.base.specs import (
     Specs,
 )
 from pants.base.specs_parser import SpecsParser
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, ResolveError
 from pants.engine.addresses import Addresses
 from pants.engine.fs import SpecsPaths
 from pants.engine.internals.parametrize import Parametrize


### PR DESCRIPTION
This avoids a cyclical import with https://github.com/pantsbuild/pants/pull/15788.

[ci skip-rust]
[ci skip-build-wheels]