### PR TITLE
Add new `visibility` field to targets to limit target dependencies.

### DIFF
--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -23,6 +23,7 @@ from pants.core.goals import (
 )
 from pants.core.target_types import (
     ArchiveTarget,
+    DefaultsTarget,
     FilesGeneratorTarget,
     FileTarget,
     GenericTarget,
@@ -84,12 +85,13 @@ def rules():
 def target_types():
     return [
         ArchiveTarget,
-        FileTarget,
+        DefaultsTarget,
         FilesGeneratorTarget,
+        FileTarget,
         GenericTarget,
-        ResourceTarget,
-        ResourcesGeneratorTarget,
         RelocatedFiles,
+        ResourcesGeneratorTarget,
+        ResourceTarget,
     ]
 
 

--- a/src/python/pants/engine/internals/visibility.py
+++ b/src/python/pants/engine/internals/visibility.py
@@ -1,0 +1,74 @@
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.core.target_types import DefaultsRequest
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    FieldSet,
+    Targets,
+    ValidatedDependencies,
+    ValidateDependenciesRequest,
+    VisibilityField,
+    VisibilityViolationError,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.util.strutil import softwrap
+
+
+class ValidateVisibilityRulesFieldSet(FieldSet):
+    required_fields = (VisibilityField,)
+
+
+class ValidateVisibilityRulesRequest(ValidateDependenciesRequest):
+    field_set_type = ValidateVisibilityRulesFieldSet
+
+
+@rule
+async def validate_visibility_rules(
+    request: ValidateVisibilityRulesRequest,
+) -> ValidatedDependencies:
+    wrapped_dependency_targets = await MultiGet(
+        Get(WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>"))
+        for address in request.dependencies
+    )
+    dependency_targets = [wrapped.target for wrapped in wrapped_dependency_targets]
+    targets_defaults = await MultiGet(
+        Get(Targets, DefaultsRequest, DefaultsRequest.for_target(tgt, "visibility"))
+        for tgt in dependency_targets
+    )
+    subject = request.field_set.address
+    for target, defaults in zip(dependency_targets, targets_defaults):
+        if defaults:
+            default_visibility = defaults[0].get(VisibilityField).value
+            default_origin = defaults[0]
+        else:
+            default_visibility = (VisibilityField.PUBLIC_VISIBILITY,)
+            default_origin = target
+        visibility_field = target.get(VisibilityField)
+        if visibility_field.value is not None:
+            origin = target
+        else:
+            origin = default_origin
+        if not visibility_field.visible(origin.address, subject, default=default_visibility):
+            raise VisibilityViolationError(
+                softwrap(
+                    f"""
+                    {target.address} is not visible to {subject}.
+
+                    Visibility from {origin.alias} {origin.address} : \
+                    {", ".join(visibility_field.get_visibility(default_visibility) or ("<none>",))}.
+                    """
+                )
+            )
+    return ValidatedDependencies()
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(ValidateDependenciesRequest, ValidateVisibilityRulesRequest),
+    )

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -19,7 +19,7 @@ from pants.engine import desktop, environment, fs, platform, process
 from pants.engine.console import Console
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
 from pants.engine.goal import Goal
-from pants.engine.internals import build_files, graph, options_parsing, specs_rules
+from pants.engine.internals import build_files, graph, options_parsing, specs_rules, visibility
 from pants.engine.internals.native_engine import PyExecutor, PySessionCancellationLatch
 from pants.engine.internals.parser import Parser
 from pants.engine.internals.scheduler import Scheduler, SchedulerSession
@@ -266,6 +266,7 @@ class EngineInitializer:
                 *changed_rules(),
                 *streaming_workunit_handler_rules(),
                 *specs_calculator.rules(),
+                *visibility.rules(),
                 *rules,
             )
         )


### PR DESCRIPTION
Also introduces a new `defaults` target which allows to dynamically provide "scoped" default field values.

Closes #13393.

TODO: add tests.

Example
```python

python_sources(
  ...,
  visibility=["private"]  # will only be importable from this subtree. Default is `["public"]`.
)

# or, this is equivalent as the above but for _ALL_ targets in this subtree, making them all private

defaults(name="visibility", visibility=["private"])
python_sources()

# 

.. visibility=["src/python/some/lib", "private"]  # will be private, except for `some/lib` which will be granted access.
```

The `defaults` target closest (at same level or above) will be used, if present unless the target has its own visibility field value.

Example error message:
```
pants.engine.target.VisibilityViolationError: src/python/pants/backend/docker/goals/tailor.py is not visible to src/python/pants/backend/docker/register.py.

Visibility from python_source src/python/pants/backend/docker/goals/tailor.py : private.
```

```
pants.engine.target.VisibilityViolationError: src/python/pants/backend/docker/goals/tailor.py is not visible to src/python/pants/backend/docker/register.py.

Visibility from defaults src/python/pants/backend/docker/goals:visibility : private.
```
