### PR TITLE
Update docs for redesign of CLI arguments

### DIFF
--- a/docs/markdown/Docker/docker.md
+++ b/docs/markdown/Docker/docker.md
@@ -33,7 +33,7 @@ Pants uses [`docker_image`](doc:reference-docker_image) [targets](doc:targets) t
 You can generate initial BUILD files for your Docker images, using [tailor](doc:create-initial-build-files):
 
 ```
-❯ ./pants tailor
+❯ ./pants tailor ::
 Created src/docker/app1/BUILD:
   - Add docker_image target docker
 Created src/docker/app2/BUILD:

--- a/docs/markdown/Getting Started/getting-started/existing-repositories.md
+++ b/docs/markdown/Getting Started/getting-started/existing-repositories.md
@@ -23,7 +23,7 @@ Incremental adoption also allows you to immediately start benefitting from Pants
 [/block]
 ### 1. A basic `pants.toml`
 
-Follow the [Getting Started](doc:getting-started) guide to install Pants and [set up an initial `pants.toml`](doc:initial-configuration). Validate that running `./pants count-loc '**'` works properly. If you want to exclude a specific folder at first, you can use the [`pants_ignore`](https://www.pantsbuild.org/docs/reference-global#section-pants-ignore) option.
+Follow the [Getting Started](doc:getting-started) guide to install Pants and [set up an initial `pants.toml`](doc:initial-configuration). Validate that running `./pants count-loc ::` works properly. If you want to exclude a specific folder at first, you can use the [`pants_ignore`](https://www.pantsbuild.org/docs/reference-global#section-pants-ignore) option.
 
 Add the [relevant backends](doc:enabling-backends) to `[GLOBAL].backend_packages`.
 
@@ -31,7 +31,7 @@ Add the [relevant backends](doc:enabling-backends) to `[GLOBAL].backend_packages
 
 Formatters and linters are often the simplest to get working because—for all tools other than Pylint— you do not need to worry about things like dependencies and third-party requirements.
 
-First, run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This tells Pants which files to operate on, and will allow you to set additional metadata over time like test timeouts and dependencies on resources.
+First, run [`./pants tailor ::`](doc:create-initial-build-files) to generate BUILD files. This tells Pants which files to operate on, and will allow you to set additional metadata over time like test timeouts and dependencies on resources.
 
 Then, activate the [Linters and formatters](doc:python-linters-and-formatters) you'd like to use. Hook up the `fmt` and `lint` goals to your [CI](doc:using-pants-in-ci).
 

--- a/docs/markdown/Getting Started/getting-started/initial-configuration.md
+++ b/docs/markdown/Getting Started/getting-started/initial-configuration.md
@@ -84,14 +84,14 @@ If you use Git, we recommend adding these lines to your top-level `.gitignore` f
 [/block]
 # 5. Generate BUILD files
 
-Once you have enabled the backends for the language(s) you'd like to use, run [`./pants tailor`](doc:create-initial-build-files) to generate an initial set of [BUILD](doc:targets) files.
+Once you have enabled the backends for the language(s) you'd like to use, run [`./pants tailor ::`](doc:create-initial-build-files) to generate an initial set of [BUILD](doc:targets) files.
 
 [BUILD](doc:targets) files provide metadata about your code (the timeout of a test, any dependencies which cannot be inferred, etc). BUILD files are typically located in the same directory as the code they describe. Unlike many other systems, Pants BUILD files are usually very succinct, as most metadata is either inferred from static analysis, assumed from sensible defaults, or generated for you. 
 
-In general, you should create (and update) BUILD files by running `./pants tailor`:
+In general, you should create (and update) BUILD files by running `./pants tailor ::`:
 
 ```
-❯ ./pants tailor
+❯ ./pants tailor ::
 Created scripts/BUILD:
   - Add shell_sources target scripts
 Created src/py/project/BUILD:
@@ -109,8 +109,8 @@ To ignore false positives, set `[tailor].ignore_paths` and `[tailor].ignore_addi
 [block:callout]
 {
   "type": "info",
-  "body": "We recommend running `./pants tailor --check` in your [continuous integration](doc:doc:using-pants-in-ci) so that you don't forget to add any targets and BUILD files (which might mean that tests aren't run or code isn't validated).\n\n```\n❯ ./pants tailor --check\nWould create scripts/BUILD:\n  - Add shell_sources target scripts\n\nTo fix `tailor` failures, run `./pants tailor`.\n```",
-  "title": "Run `./pants tailor --check` in CI"
+  "body": "We recommend running `./pants tailor --check ::` in your [continuous integration](doc:doc:using-pants-in-ci) so that you don't forget to add any targets and BUILD files (which might mean that tests aren't run or code isn't validated).\n\n```\n❯ ./pants tailor --check ::\nWould create scripts/BUILD:\n  - Add shell_sources target scripts\n\nTo fix `tailor` failures, run `./pants tailor`.\n```",
+  "title": "Run `./pants tailor --check ::` in CI"
 }
 [/block]
 # 6. Visit a language specific overview

--- a/docs/markdown/Getting Started/getting-started/installation.md
+++ b/docs/markdown/Getting Started/getting-started/installation.md
@@ -12,10 +12,10 @@ updatedAt: "2022-05-03T20:48:35.453Z"
 [/block]
 Pants is invoked via a launch script named `./pants` , saved at the root of the repository. This script will install Pants and handle upgrades.
 
-First, set up a minimal `pants.toml` config file to instruct the script to download the latest 2.11 release:
+First, set up a minimal `pants.toml` config file to instruct the script to download the latest 2.13 release:
 
 ```bash
-printf '[GLOBAL]\npants_version = "2.11.0"\n' > pants.toml
+printf '[GLOBAL]\npants_version = "2.13.0.dev5"\n' > pants.toml
 ```
 
 Then, download the script:

--- a/docs/markdown/Go/go-integrations/protobuf-go.md
+++ b/docs/markdown/Go/go-integrations/protobuf-go.md
@@ -104,10 +104,10 @@ Multiple Protobuf files can set the same `go_package` if their code should show 
   "title": "Step 4: Generate `protobuf_sources` targets"
 }
 [/block]
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
+Run [`./pants tailor ::`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
 
 ```
-$ ./pants tailor
+❯ ./pants tailor ::
 Created src/protos/BUILD:
   - Add protobuf_sources target protos
 ```

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -57,10 +57,10 @@ First, activate the Go backend and set the expected Go version in `pants.toml`:
 [/block]
 You can also set `[golang].go_search_paths` to influence where Pants looks for Go, e.g. `["/usr/bin"]`. It defaults to your `PATH`.
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This will add a `go_mod` target where you have your `go.mod` file, a `go_package` target for every directory with a `.go` file, and a `go_binary` target in every directory where you have `package main`.
+Then run [`./pants tailor ::`](doc:create-initial-build-files) to generate BUILD files. This will add a `go_mod` target where you have your `go.mod` file, a `go_package` target for every directory with a `.go` file, and a `go_binary` target in every directory where you have `package main`.
 
 ```
-❯ ./pants tailor
+❯ ./pants tailor ::
 Created BUILD:
   - Add go_mod target root
 Created cmd/deploy/BUILD:

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -64,10 +64,10 @@ version: 0.1.0
 > 
 > You can use the `helm create` command to create an initial skeleton for your chart but be sure you have properly configured your source root patterns (as shown in the previous section) since the `helm create` command will create a folder name with the name of your chart and place the sources inside.
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate `BUILD` files. This will scan your source repository in search of `Chart.yaml` or `Chart.yml` files and create a `helm_chart` target for each of them.
+Then run [`./pants tailor ::`](doc:create-initial-build-files) to generate `BUILD` files. This will scan your source repository in search of `Chart.yaml` or `Chart.yml` files and create a `helm_chart` target for each of them.
 
 ```
-❯ ./pants tailor
+❯ ./pants tailor ::
 Created src/helm/example/BUILD:
   - Add helm_chart target example
 ```

--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -31,10 +31,10 @@ backend_packages = [
 ]
 ```
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This will create `java_sources` and `scala_sources` targets in every directory containing library code, as well as test targets like `scalatest_tests` and `junit_tests` for filenames that look like tests.
+Then run [`./pants tailor ::`](doc:create-initial-build-files) to generate BUILD files. This will create `java_sources` and `scala_sources` targets in every directory containing library code, as well as test targets like `scalatest_tests` and `junit_tests` for filenames that look like tests.
 
 ```
-❯ ./pants tailor
+❯ ./pants tailor ::
 Created src/jvm/org/pantsbuild/example/app/BUILD:
   - Add scala_sources target app
 Created src/jvm/org/pantsbuild/example/lib/BUILD:

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -161,10 +161,10 @@ Pants will automatically include any relevant config files in the process's sand
 [/block]
 Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files. 
 
-The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor`](doc:create-initial-build-files) to automatically add this target:
+The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor ::`](doc:create-initial-build-files) to automatically add this target:
 
 ```
-./pants tailor
+./pants tailor ::
 Created project/BUILD:
   - Add python_sources target project
   - Add python_tests target tests
@@ -307,7 +307,7 @@ If a target sets its `timeout` higher than `[pytest].timeout_maximum`, Pants wil
 
 Use the target type `python_source` for test utilities, rather than `python_test`. 
 
-To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor`](doc:create-initial-build-files) to generate both these targets automatically.
+To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor ::`](doc:create-initial-build-files) to generate both these targets automatically.
 
 For example:
 [block:code]

--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -40,7 +40,7 @@ This adds the new `python_awslambda` target, which you can confirm by running `.
 [/block]
 First, add your lambda function in a Python file like you would [normally do with AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html). Specifically, create a function `def my_handler_name(event, context)` with the name you want.
 
-Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:create-initial-build-files) to automate this.
+Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor ::`](doc:create-initial-build-files) to automate this.
 
 Add a `python_awslambda` target and define the `runtime` and `handler` fields. The `runtime` should be one of the values from https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
 

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -40,7 +40,7 @@ This adds the new `python_google_cloud_function` target, which you can confirm b
 [/block]
 First, add your Cloud function in a Python file like you would [normally do with Google Cloud Functions](https://cloud.google.com/functions/docs/first-python), such as creating a function `def my_handler_name(event, context)` for event-based functions.
 
-Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:create-initial-build-files) to automate this.
+Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor ::`](doc:create-initial-build-files) to automate this.
 
 Add a `python_google_cloud_function` target and define the `runtime`, `handler`, and `type` fields. The `type` should be either `"event"` or `"http"`. The `runtime` should be one of the values from https://cloud.google.com/functions/docs/concepts/python-runtime. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
 

--- a/docs/markdown/Python/python-integrations/protobuf-python.md
+++ b/docs/markdown/Python/python-integrations/protobuf-python.md
@@ -88,10 +88,10 @@ Pants will then automatically add these dependencies to your `protobuf_source` t
   "title": "Step 3: Generate `protobuf_sources` target"
 }
 [/block]
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
+Run [`./pants tailor ::`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
 
 ```
-$ ./pants tailor
+$ ./pants tailor ::
 Created src/protos/BUILD:
   - Add protobuf_sources target protos
 ```

--- a/docs/markdown/Python/python-integrations/thrift-python.md
+++ b/docs/markdown/Python/python-integrations/thrift-python.md
@@ -92,10 +92,10 @@ Pants will then automatically add these dependencies to your `thrift_sources` ta
   "title": "Step 3: Generate `thrift_sources` target"
 }
 [/block]
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `thrift_sources` target wherever you have `.thrift` files:
+Run [`./pants tailor ::`](doc:create-initial-build-files) for Pants to create a `thrift_sources` target wherever you have `.thrift` files:
 
 ```
-$ ./pants tailor
+$ ./pants tailor ::
 Created src/thrift/BUILD:
   - Add thrift_sources target thrift
 ```

--- a/docs/markdown/Python/python/python-backend.md
+++ b/docs/markdown/Python/python/python-backend.md
@@ -40,9 +40,10 @@ python_sources(name="lib")
 python_tests(name="tests")
 ```
 
-You can generate these targets by running [`./pants tailor`](doc:create-initial-build-files).
+You can generate these targets by running [`./pants tailor ::`](doc:create-initial-build-files).
 
 ```
+❯ ./pants tailor ::
 Created project/BUILD:
   - Add python_sources target project
   - Add python_tests target tests

--- a/docs/markdown/Releases/upgrade-tips.md
+++ b/docs/markdown/Releases/upgrade-tips.md
@@ -30,13 +30,13 @@ First, see if Pants can automatically fix any safe deprecations for you:
 ```bash
 # You may want to use `--no-fmt` if your BUILD files are 
 # not already formatted by Black.
-❯ ./pants update-build-files --no-fmt
+❯ ./pants update-build-files --no-fmt ::
 ```
 
 You can add `update-build-files` to your [continuous integration](doc:using-pants-in-ci) so that developers don't accidentally use removed features:
 
 ```bash
-❯ ./pants update-build-files --check
+❯ ./pants update-build-files --check ::
 ```
 
 Then, see if there are any remaining deprecation warnings:

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -44,10 +44,10 @@ First, activate the Shell backend in your `pants.toml`:
   ]
 }
 [/block]
-Then, run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files:
+Then, run [`./pants tailor ::`](doc:create-initial-build-files) to generate BUILD files:
 
 ```
-$ ./pants tailor
+$ ./pants tailor ::
 Created scripts/BUILD:
   - Add shell_sources target scripts
 Created scripts/subdir/BUILD:

--- a/docs/markdown/Using Pants/advanced-target-selection.md
+++ b/docs/markdown/Using Pants/advanced-target-selection.md
@@ -6,7 +6,7 @@ hidden: false
 createdAt: "2020-05-11T20:10:29.560Z"
 updatedAt: "2022-02-08T23:44:44.463Z"
 ---
-See [File arguments vs. target arguments](doc:goals#file-arguments-vs-target-arguments) for the normal techniques for telling Pants what to run on. 
+See [File arguments vs. target arguments](doc:goals#goal-arguments) for the normal techniques for telling Pants what to run on. 
 
 See [Project introspection](doc:project-introspection) for queries that you can run and then pipe into another Pants run, such as running over certain target types.
 [block:api-header]
@@ -31,18 +31,11 @@ To run against another branch, run:
 By default, `--changed-since` will only run over files directly changed. Often, though, you will want to run over any [dependees](doc:project-introspection) of those changed files, meaning any targets that depend on the changed files. Use ` --changed-dependees=direct` or ` --changed-dependees=transitive` for this:
 
 ```bash
-$ ./pants \
+❯ ./pants \
   --changed-since=origin/main \
   --changed-dependees=transitive \
   test
 ```
-[block:callout]
-{
-  "type": "warning",
-  "title": "Using a version control system other than Git?",
-  "body": "Please message us on Slack or open a GitHub issue (see [Community](doc:getting-help)). We would be happy to look into adding support for your VCS, such as helping you with a PR to add support."
-}
-[/block]
 
 [block:api-header]
 {

--- a/docs/markdown/Using Pants/concepts/goals.md
+++ b/docs/markdown/Using Pants/concepts/goals.md
@@ -20,71 +20,58 @@ You'll see more goals activated as you activate more [backends](doc:enabling-bac
 
 For example:
 
-```bash
-❯ ./pants test project/app_test.py
-15:40:37.89 [INFO] Completed: test - project/app_test.py:tests succeeded.
-
-✓ project/app_test.py:tests succeeded.
+```
+❯ ./pants count-loc project/app_test.py
+───────────────────────────────────────────────────────────────────────────────
+Language                 Files     Lines   Blanks  Comments     Code Complexity
+───────────────────────────────────────────────────────────────────────────────
+Python                       1       374       16        19      339          6
+───────────────────────────────────────────────────────────────────────────────
+Total                        1       374       16        19      339          6
+───────────────────────────────────────────────────────────────────────────────
 ```
 
 You can also run multiple goals in a single run of Pants, in which case they will run sequentially:
 
 ```bash
-# Format all code, and then lint it:
-❯ ./pants fmt lint ::
+# Format all code, and then test it:
+❯ ./pants fmt test ::
 ```
 
-Finally, Pants supports running goals in a `--loop`: in this mode, all goals specified will run sequentially, and then Pants will wait until a relevant file has changed to try running them again.
+Finally, Pants supports running goals in a `--loop`. In this mode, all goals specified will run
+sequentially, and then Pants will wait until a relevant file has changed to try running them again.
 
 ```bash
-# Re-run typechecking and testing continuously as files or their dependencies change:
-❯ ./pants --loop check test project/app_test.py
+# Re-run linters and testing continuously as files or their dependencies change:
+❯ ./pants --loop lint test project/app_test.py
 ```
 
 Use `Ctrl+C` to exit the `--loop`.
 
 # Goal arguments
 
-Some simple goals—such as the `roots` goal—do not require arguments. But most goals require some arguments to work on. 
+Most goals require arguments to know what to work on. 
 
-For example, to run the `count-loc` goal, which counts lines of code in your repository, you need to provide a set of files and/or targets to run on:
-[block:code]
-{
-  "codes": [
-    {
-      "code": "$ ./pants count-loc '**'\n───────────────────────────────────────────────────────────────────────────────\nLanguage                 Files     Lines   Blanks  Comments     Code Complexity\n───────────────────────────────────────────────────────────────────────────────\nPython                      13       155       50        22       83          5\nBASH                         2       261       29        22      210         10\nJSON                         2        25        0         0       25          0\nPlain Text                   2        43        1         0       42          0\nTOML                         2        65       14        18       33          0\n...",
-      "language": "text",
-      "name": "Shell"
-    }
-  ]
-}
-[/block]
+You can use several argument types:
+
+| Argument type                   | Semantics                                   | Example                         |
+|---------------------------------|---------------------------------------------|---------------------------------|
+| File path                       | Match the file                              | `./pants test project/tests.py` |
+| Directory path                  | Match everything in the directory           | `./pants test project/utils`    |
+| `::` globs                      | Match everything in the directory and below | `./pants test project::`        |
+| [Target addresses](doc:targets) | Match the target                            | `./pants package project:tests` |
+
+You can combine argument types, e.g. `./pants fmt src/go:: src/py/app.py`.
+
+To ignore something, prefix the argument with `-`. For example, 
+`./pants test :: -project/integration_tests` will run all your tests except for those in the 
+directory `project/integration_tests`.
 
 [block:callout]
 {
-  "type": "info",
-  "title": "Quoting file patterns",
-  "body": "Note the single-quotes around the file pattern `'**'`. This is so that your shell doesn't attempt to expand the pattern, but instead passes it unaltered to Pants."
-}
-[/block]
-## File arguments vs. target arguments
-
-Goal arguments can be of one of two types:
-
-- *File arguments*: file paths and/or globs.
-- *Target arguments*: addresses and/or address globs of [targets](doc:targets).
-
-Typically you can just use file arguments, and not worry about targets.
-
-Any goal can take either type of argument: 
-
-- If a target argument is given, the goal acts on all the files in the matching targets.
-- If a file argument is given, Pants will map the file back to its containing target to read any necessary metadata. 
-[block:callout]
-{
-  "type": "info",
-  "title": "File/target globs",
-  "body": "For file arguments, use `'*'` and `'**'`, with the same semantics as the shell. Reminder: quote the argument if you want Pants to evaluate the glob, rather than your shell.\n\nFor target arguments, you can use:\n\n- `dir::`, where `::` means every target in the current directory and recursively in subdirectories.\n- `dir:`, where `:` means every target in that directory, but not subdirectories.\n\nFor example, `./pants list ::` will find every target in your project."
+  "type": "warning",
+  "title": "Set `[GLOBAL].use_deprecated_directory_cli_args_semantics = false` in `pants.toml`",
+  "body": "This will become the default in Pants 2.14."
 }
 [/block]
 

--- a/docs/markdown/Using Pants/concepts/targets.md
+++ b/docs/markdown/Using Pants/concepts/targets.md
@@ -40,7 +40,7 @@ Each target type has different _fields_, or individual metadata values. Run `./p
 
 All target types have a `name` field, which is used to identify the target. Target names must be unique within a directory.
 
-Use [`./pants tailor`](doc:create-initial-build-files) to automate generating BUILD files, and [`./pants update-build-files`](doc:reference-update-build-files) to reformat them (using `black`, [by default](doc:reference-update-build-files#section-formatter)).
+Use [`./pants tailor ::`](doc:create-initial-build-files) to automate generating BUILD files, and [`./pants update-build-files ::`](doc:reference-update-build-files) to reformat them (using `black`, [by default](doc:reference-update-build-files#section-formatter)).
 
 # Target addresses
 
@@ -134,7 +134,7 @@ To reduce boilerplate, Pants provides target types that generate other targets. 
 * `python_tests` -> `python_test`
 * `go_mod` -> `go_third_party_package`
 
-Usually, prefer these target generators. [`./pants tailor`](doc:create-initial-build-files) will automatically add them for you.
+Usually, prefer these target generators. [`./pants tailor ::`](doc:create-initial-build-files) will automatically add them for you.
 
 Run `./pants help targets` to see how the target determines what to generate. Targets for first-party code, like `resources` and `python_tests`, will generate one target for each file in their `sources` field.
 
@@ -185,7 +185,7 @@ You can use the address for the target generator as an alias for all of its gene
 {
   "type": "info",
   "title": "Tip: one BUILD file per directory",
-  "body": "Target generation means that it is technically possible to put everything in a single BUILD file.\n\nHowever, we've found that it usually scales much better to use a single BUILD file per directory. Even if you start with using the defaults for everything, projects usually need to change some metadata over time, like adding a `timeout` to a test file or adding `dependencies` on resources. \n\nIt's useful for metadata to be as fine-grained as feasible, such as by using the `overrides` field to only change the files you need to. Fine-grained metadata is key to having smaller cache keys (resulting in more cache hits), and allows you to more accurately reflect the status of your project. We have found that using one BUILD file per directory encourages fine-grained metadata by defining the metadata adjacent to where the code lives.\n\n[`./pants tailor`](doc:create-initial-build-files) will automatically create targets that only apply metadata for the directory."
+  "body": "Target generation means that it is technically possible to put everything in a single BUILD file.\n\nHowever, we've found that it usually scales much better to use a single BUILD file per directory. Even if you start with using the defaults for everything, projects usually need to change some metadata over time, like adding a `timeout` to a test file or adding `dependencies` on resources. \n\nIt's useful for metadata to be as fine-grained as feasible, such as by using the `overrides` field to only change the files you need to. Fine-grained metadata is key to having smaller cache keys (resulting in more cache hits), and allows you to more accurately reflect the status of your project. We have found that using one BUILD file per directory encourages fine-grained metadata by defining the metadata adjacent to where the code lives.\n\n[`./pants tailor ::`](doc:create-initial-build-files) will automatically create targets that only apply metadata for the directory."
 }
 [/block]
 # Parametrizing targets

--- a/docs/markdown/Using Pants/project-introspection.md
+++ b/docs/markdown/Using Pants/project-introspection.md
@@ -283,28 +283,17 @@ $ ./pants paths --from=helloworld/main.py --to=helloworld/translator/translator.
 {
   "codes": [
     {
-      "code": "$ ./pants count-loc ::\n───────────────────────────────────────────────────────────────────────────────\nLanguage                 Files     Lines   Blanks  Comments     Code Complexity\n───────────────────────────────────────────────────────────────────────────────\nPython                    1690    618679    23906      7270   587503      18700\nHTML                        61      6522      694        67     5761          0\nJSON                        36     18755        6         0    18749          0\nYAML                        30      2451        4        19     2428          0\nJavaScript                   6       671       89         8      574         32\nCSV                          1         2        0         0        2          0\nJSONL                        1         4        0         0        4          0\nJinja                        1        11        0         0       11          2\nShell                        1        13        2         2        9          4\nTOML                         1       146        5         0      141          0\n───────────────────────────────────────────────────────────────────────────────\nTotal                     1828    647254    24706      7366   615182      18738\n───────────────────────────────────────────────────────────────────────────────\nEstimated Cost to Develop $22,911,268\nEstimated Schedule Effort 50.432378 months\nEstimated People Required 53.813884\n───────────────────────────────────────────────────────────────────────────────",
+      "code": "❯ ./pants count-loc ::\n───────────────────────────────────────────────────────────────────────────────\nLanguage                 Files     Lines   Blanks  Comments     Code Complexity\n───────────────────────────────────────────────────────────────────────────────\nPython                    1690    618679    23906      7270   587503      18700\nHTML                        61      6522      694        67     5761          0\nJSON                        36     18755        6         0    18749          0\nYAML                        30      2451        4        19     2428          0\nJavaScript                   6       671       89         8      574         32\nCSV                          1         2        0         0        2          0\nJSONL                        1         4        0         0        4          0\nJinja                        1        11        0         0       11          2\nShell                        1        13        2         2        9          4\nTOML                         1       146        5         0      141          0\n───────────────────────────────────────────────────────────────────────────────\nTotal                     1828    647254    24706      7366   615182      18738\n───────────────────────────────────────────────────────────────────────────────\nEstimated Cost to Develop $22,911,268\nEstimated Schedule Effort 50.432378 months\nEstimated People Required 53.813884\n───────────────────────────────────────────────────────────────────────────────",
       "language": "shell"
     }
   ]
 }
 [/block]
 
-[block:code]
-{
-  "codes": [
-    {
-      "code": "$ ./pants count-loc '**/*.py' '**/*.proto'\n───────────────────────────────────────────────────────────────────────────────\nLanguage                 Files     Lines   Blanks  Comments     Code Complexity\n───────────────────────────────────────────────────────────────────────────────\nPython                      13       155       50        22       83          5\nProtocol Buffers             1        11        3         2        6          0\n───────────────────────────────────────────────────────────────────────────────\nTotal                       14       166       53        24       89          5\n───────────────────────────────────────────────────────────────────────────────",
-      "language": "text",
-      "name": "Shell"
-    }
-  ]
-}
-[/block]
 SCC has [dozens of options](https://github.com/boyter/scc#usage). You can pass through options by either setting `--scc-args` or using `--` at the end of your command, like this:
 
 ```bash
-./pants count-loc '**' -- --no-cocomo
+./pants count-loc :: -- --no-cocomo
 ```
 [block:callout]
 {

--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -88,7 +88,7 @@ Is the missing import from a third-party dependency? Common issues:
 
 - Pants does know about your third-party requirements, e.g. missing `python_requirements` and `go_mod` target generators.
   - To see all third-party requirement targets Pants knows, run `./pants filter --target-type=$tgt ::`, where Python: `python_requirement`, Go: `go_third_party_package`, and JVM: `jvm_artifact`.
-  - Run `./pants tailor`, or manually add the relevant targets.
+  - Run `./pants tailor ::`, or manually add the relevant targets.
 - The dependency is missing from your third-party requirements list, e.g. `go.mod` or `requirements.txt`.
 - The dependency exposes a module different than the default Pants uses, e.g. Python's `ansicolors` exposing `colors`.
   - [Python](doc:python-third-party-dependencies): set the `modules` field and `module_mapping` fields.
@@ -101,7 +101,7 @@ Is the missing import from first-party code? Common issues:
   - Or, it's ignored by Pants. See the above guide "Pants cannot find a file in your project".
 - The file is missing an owning target like `python_sources`, `go_package`, or `resources`.
   - Run `./pants list path/to/file.ext` to see all owning targets.
-  - Try running `./pants tailor`. Warning: some target types like [`resources` and `files`](doc:assets) must be manually added.
+  - Try running `./pants tailor ::`. Warning: some target types like [`resources` and `files`](doc:assets) must be manually added.
 - [Source roots](doc:source-roots) are not set up properly (Python and JVM only).
   - This allows converting file paths like `src/py/project/app.py` to the Python module `project.app`.
 

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -63,17 +63,18 @@ We recommend running these commands in CI:
 
 ```shell
 ❯ ./pants --version  # Bootstrap Pants.
-❯ ./pants \  # Check for updates to BUILD files.
-   tailor --check \
-   update-build-files --check
-❯ ./pants --changed-since=origin/main lint
+❯ ./pants \
+  --changed-since=origin/main \
+  tailor --check \
+  update-build-files --check \
+  lint
 ❯ ./pants \
   --changed-since=origin/main \
   --changed-dependees=transitive \
   check test
 ```
 
-Because most linters do not care about a target's dependencies, we lint all changed targets, but not any dependees of those changed targets.
+Because most linters do not care about a target's dependencies, we lint all changed files and targets, but not any dependees of those changes.
 
 Meanwhile, tests should be rerun when any changes are made to the tests _or_ to dependencies of those tests, so we use the option `--changed-dependees=transitive`. `check` should also run on any transitive changes.
 
@@ -107,10 +108,10 @@ Alternatively, you can simply run over all your code. Pants's caching means that
 
 ```bash
 ❯ ./pants --version  # Bootstrap Pants.
-❯ ./pants \  # Check for updates to BUILD files.
+❯ ./pants \
    tailor --check \
-   update-build-files --check
-❯ ./pants lint check test ::
+   update-build-files --check \
+   lint check test ::
 ```
 
 However, when the cache gets too big, it should be nuked (see "Directories to cache"), so your CI may end up doing more work than Approach #1.


### PR DESCRIPTION
Rewrites `goals.md`. Also updates all references to the `count-loc`, `update-build-files`, and `tailor` goals to use consistent CLI args.

[ci skip-rust]
[ci skip-build-wheels]