### PR TITLE
Handle anchors in doc_url() correctly. (#15812)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -41,7 +41,9 @@ from pants.version import MAJOR_MINOR
 
 logger = logging.getLogger(__name__)
 
-DOC_URL_RE = re.compile(r"https://www.pantsbuild.org/v(\d+\.[^/]+)/docs/(?P<slug>[a-zA-Z0-9_-]+)")
+DOC_URL_RE = re.compile(
+    r"https://www.pantsbuild.org/v(\d+\.[^/]+)/docs/(?P<slug>[a-zA-Z0-9_-]+)(?P<anchor>#[a-zA-Z0-9_-]+)?"
+)
 
 
 def main() -> None:
@@ -114,10 +116,11 @@ class DocUrlRewriter:
         # The docsite injects the version automatically at markdown rendering time, so we
         # must not also do so, or it will be doubled, and the resulting links will be broken.
         slug = mo.group("slug")
+        anchor = mo.group("anchor") or ""
         title = self._slug_to_title.get(slug)
         if not title:
             raise ValueError(f"Found empty or no title for {mo.group(0)}")
-        return f"[{title}](doc:{slug})"
+        return f"[{title}](doc:{slug}{anchor})"
 
     def rewrite(self, s: str) -> str:
         return DOC_URL_RE.sub(self._rewrite_url, s)

--- a/build-support/bin/generate_docs_test.py
+++ b/build-support/bin/generate_docs_test.py
@@ -20,9 +20,10 @@ def test_gather_value_strs():
     assert set(value_strs_iter(help_info)) == {"foo", "bar", "baz", "qux", "quux"}
 
 
-@pytest.mark.parametrize("slug", ["foo-bar", "baz3", "qux"])
-def test_slug_for_url(slug: str) -> None:
-    assert get_doc_slug(doc_url(slug)) == slug
+@pytest.mark.parametrize("arg", ["foo-bar", "baz3", "qux#anchor"])
+def test_slug_for_url(arg: str) -> None:
+    expected_slug = arg.split("#")[0]
+    assert get_doc_slug(doc_url(arg)) == expected_slug
 
 
 def test_slug_for_url_error() -> None:
@@ -66,4 +67,7 @@ def test_doc_url_rewriter():
         }
     )
     assert dur.rewrite(f"See {doc_url('foo')} for details.") == "See [Foo](doc:foo) for details."
-    assert dur.rewrite(f"Check out {doc_url('bar')}.") == "Check out [Welcome to Bar!](doc:bar)."
+    assert (
+        dur.rewrite(f"Check out {doc_url('bar#anchor')}.")
+        == "Check out [Welcome to Bar!](doc:bar#anchor)."
+    )


### PR DESCRIPTION
[ci skip-rust]

[ci skip-build-wheels]