### PR TITLE
go: support third-party package embeds

### DIFF
--- a/src/python/pants/backend/go/go_sources/embedcfg/main.go
+++ b/src/python/pants/backend/go/go_sources/embedcfg/main.go
@@ -11,7 +11,7 @@
 package main
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -411,7 +411,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	result, err := computeEmbedConfigs("__resources__", &patterns)
+	rootDir := os.Args[2]
+	result, err := computeEmbedConfigs(rootDir, &patterns)
 	if err != nil {
 		fmt.Printf("{\"Error\": \"Failed to find embedded resources: %s\"}", err)
 		os.Exit(1)

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -189,6 +189,7 @@ async def setup_build_go_package_target_request(
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
         s_file_names = _third_party_pkg_info.s_files
+        embed_config = _third_party_pkg_info.embed_config
 
     else:
         raise AssertionError(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -342,7 +342,7 @@ async def setup_first_party_pkg_digest(
         embed_result = await Get(
             FallibleProcessResult,
             Process(
-                ("./embedder", "patterns.json"),
+                ("./embedder", "patterns.json", "__resources__"),
                 input_digest=input_digest,
                 description=f"Create embed mapping for {request.address}",
                 level=LogLevel.DEBUG,

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import json
 import logging
 import os
@@ -11,23 +12,27 @@ from typing import Any
 
 import ijson
 
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import pkg_analyzer
+from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.core.goals.tailor import group_by_dir
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
     EMPTY_DIGEST,
+    CreateDigest,
     Digest,
     DigestSubset,
+    FileContent,
     GlobExpansionConjunction,
     GlobMatchErrorBehavior,
     MergeDigests,
     PathGlobs,
     Snapshot,
 )
-from pants.engine.process import Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -59,6 +64,14 @@ class ThirdPartyPkgAnalysis:
     s_files: tuple[str, ...]
 
     minimum_go_version: str | None
+
+    embed_patterns: tuple[str, ...]
+    test_embed_patterns: tuple[str, ...]
+    xtest_embed_patterns: tuple[str, ...]
+
+    embed_config: EmbedConfig | None = None
+    test_embed_config: EmbedConfig | None = None
+    xtest_embed_config: EmbedConfig | None = None
 
     error: GoThirdPartyPkgError | None = None
 
@@ -430,8 +443,54 @@ async def analyze_go_third_party_package(
         go_files=tuple(request.pkg_json.get("GoFiles", ())),
         s_files=tuple(request.pkg_json.get("SFiles", ())),
         minimum_go_version=request.minimum_go_version,
+        embed_patterns=tuple(request.pkg_json.get("EmbedPatterns", [])),
+        test_embed_patterns=tuple(request.pkg_json.get("TestEmbedPatterns", [])),
+        xtest_embed_patterns=tuple(request.pkg_json.get("XTestEmbedPatterns", [])),
         error=maybe_error,
     )
+
+    if analysis.embed_patterns or analysis.test_embed_patterns or analysis.xtest_embed_patterns:
+        embedder = await Get(
+            LoadedGoBinary, LoadedGoBinaryRequest("embedcfg", ("main.go",), "./embedder")
+        )
+        patterns_json = {
+            "EmbedPatterns": analysis.embed_patterns,
+            "TestEmbedPatterns": analysis.test_embed_patterns,
+            "XTestEmbedPatterns": analysis.xtest_embed_patterns,
+        }
+        patterns_json_digest = await Get(
+            Digest,
+            CreateDigest([FileContent("patterns.json", json.dumps(patterns_json).encode("utf-8"))]),
+        )
+        input_digest = await Get(
+            Digest, MergeDigests((package_digest, patterns_json_digest, embedder.digest))
+        )
+        embed_result = await Get(
+            FallibleProcessResult,
+            Process(
+                ("./embedder", "patterns.json", request.package_path),
+                input_digest=input_digest,
+                description=f"Create embed mapping for {import_path}",
+                level=LogLevel.DEBUG,
+            ),
+        )
+        if embed_result.exit_code != 0:
+            return FallibleThirdPartyPkgAnalysis(
+                analysis=None,
+                import_path=import_path,
+                exit_code=1,
+                stderr=embed_result.stderr.decode(),
+            )
+        metadata = json.loads(embed_result.stdout)
+        embed_config = EmbedConfig.from_json_dict(metadata.get("EmbedConfig", {}))
+        test_embed_config = EmbedConfig.from_json_dict(metadata.get("TestEmbedConfig", {}))
+        xtest_embed_config = EmbedConfig.from_json_dict(metadata.get("XTestEmbedConfig", {}))
+        analysis = dataclasses.replace(
+            analysis,
+            embed_config=embed_config,
+            test_embed_config=test_embed_config,
+            xtest_embed_config=xtest_embed_config,
+        )
 
     return FallibleThirdPartyPkgAnalysis(
         analysis=analysis,
@@ -536,6 +595,9 @@ def maybe_raise_or_create_error_or_create_failed_pkg_info(
             go_files=(),
             s_files=(),
             minimum_go_version=None,
+            embed_patterns=(),
+            test_embed_patterns=(),
+            xtest_embed_patterns=(),
             error=error,
         )
 


### PR DESCRIPTION
The Go backend has all of the infrastructure in place to support third-party embedded files, but that infrastructure was only connected up for first-party packages and not third-party packages. This PR rectifies that omission and adds support for embeds in third-party packages.

[ci skip-rust]

[ci skip-build-wheels]