### PR TITLE
Fix broken links to `tailor` documentation

### DIFF
--- a/docs/markdown/Docker/docker.md
+++ b/docs/markdown/Docker/docker.md
@@ -30,7 +30,7 @@ A Docker image is built from a recipe specified by a [Dockerfile](https://docs.d
 
 Pants uses [`docker_image`](doc:reference-docker_image) [targets](doc:targets) to indicate which Dockerfiles you want Pants to know about, and to add any necessary metadata. 
 
-You can generate initial BUILD files for your Docker images, using [tailor](doc:create-initial-build-files):
+You can generate initial BUILD files for your Docker images, using [tailor](doc:initial-configuration#5-generate-build-files):
 
 ```
 ❯ ./pants tailor

--- a/docs/markdown/Getting Started/getting-started/existing-repositories.md
+++ b/docs/markdown/Getting Started/getting-started/existing-repositories.md
@@ -27,7 +27,7 @@ Add the [relevant backends](doc:enabling-backends) to `[GLOBAL].backend_packages
 
 Formatters and linters are often the simplest to get working because—for all tools other than Pylint— you do not need to worry about things like dependencies and third-party requirements.
 
-First, run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This tells Pants which files to operate on, and will allow you to set additional metadata over time like test timeouts and dependencies on resources.
+First, run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate BUILD files. This tells Pants which files to operate on, and will allow you to set additional metadata over time like test timeouts and dependencies on resources.
 
 Then, activate the [Linters and formatters](doc:python-linters-and-formatters) you'd like to use. Hook up the `fmt` and `lint` goals to your [CI](doc:using-pants-in-ci).
 

--- a/docs/markdown/Getting Started/getting-started/initial-configuration.md
+++ b/docs/markdown/Getting Started/getting-started/initial-configuration.md
@@ -75,7 +75,7 @@ If you use Git, we recommend adding these lines to your top-level `.gitignore` f
 5. Generate BUILD files
 =======================
 
-Once you have enabled the backends for the language(s) you'd like to use, run [`./pants tailor`](doc:create-initial-build-files) to generate an initial set of [BUILD](doc:targets) files.
+Once you have enabled the backends for the language(s) you'd like to use, run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate an initial set of [BUILD](doc:targets) files.
 
 [BUILD](doc:targets) files provide metadata about your code (the timeout of a test, any dependencies which cannot be inferred, etc). BUILD files are typically located in the same directory as the code they describe. Unlike many other systems, Pants BUILD files are usually very succinct, as most metadata is either inferred from static analysis, assumed from sensible defaults, or generated for you. 
 

--- a/docs/markdown/Go/go-integrations/protobuf-go.md
+++ b/docs/markdown/Go/go-integrations/protobuf-go.md
@@ -79,7 +79,7 @@ Multiple Protobuf files can set the same `go_package` if their code should show 
 Step 4: Generate `protobuf_sources` targets
 -------------------------------------------
 
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
+Run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
 
 ```
 $ ./pants tailor

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -45,7 +45,7 @@ expected_version = "1.17"
 
 You can also set `[golang].go_search_paths` to influence where Pants looks for Go, e.g. `["/usr/bin"]`. It defaults to your `PATH`.
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This will add a `go_mod` target where you have your `go.mod` file, a `go_package` target for every directory with a `.go` file, and a `go_binary` target in every directory where you have `package main`.
+Then run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate BUILD files. This will add a `go_mod` target where you have your `go.mod` file, a `go_package` target for every directory with a `.go` file, and a `go_binary` target in every directory where you have `package main`.
 
 ```
 ❯ ./pants tailor

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -64,7 +64,7 @@ version: 0.1.0
 > 
 > You can use the `helm create` command to create an initial skeleton for your chart but be sure you have properly configured your source root patterns (as shown in the previous section) since the `helm create` command will create a folder name with the name of your chart and place the sources inside.
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate `BUILD` files. This will scan your source repository in search of `Chart.yaml` or `Chart.yml` files and create a `helm_chart` target for each of them.
+Then run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate `BUILD` files. This will scan your source repository in search of `Chart.yaml` or `Chart.yml` files and create a `helm_chart` target for each of them.
 
 ```
 ❯ ./pants tailor

--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -31,7 +31,7 @@ backend_packages = [
 ]
 ```
 
-Then run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files. This will create `java_sources` and `scala_sources` targets in every directory containing library code, as well as test targets like `scalatest_tests` and `junit_tests` for filenames that look like tests.
+Then run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate BUILD files. This will create `java_sources` and `scala_sources` targets in every directory containing library code, as well as test targets like `scalatest_tests` and `junit_tests` for filenames that look like tests.
 
 ```
 ❯ ./pants tailor

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -135,7 +135,7 @@ Pants will automatically include any relevant config files in the process's sand
 
 Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files. 
 
-The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor`](doc:create-initial-build-files) to automatically add this target:
+The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to automatically add this target:
 
 ```
 ./pants tailor
@@ -298,7 +298,7 @@ Test utilities and resources
 
 Use the target type `python_source` for test utilities, rather than `python_test`. 
 
-To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor`](doc:create-initial-build-files) to generate both these targets automatically.
+To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate both these targets automatically.
 
 For example:
 

--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -32,7 +32,7 @@ Step 2: Define a `python_awslambda` target
 
 First, add your lambda function in a Python file like you would [normally do with AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html). Specifically, create a function `def my_handler_name(event, context)` with the name you want.
 
-Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:create-initial-build-files) to automate this.
+Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to automate this.
 
 Add a `python_awslambda` target and define the `runtime` and `handler` fields. The `runtime` should be one of the values from <https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html>. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
 

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -32,7 +32,7 @@ Step 2: Define a `python_google_cloud_function ` target
 
 First, add your Cloud function in a Python file like you would [normally do with Google Cloud Functions](https://cloud.google.com/functions/docs/first-python), such as creating a function `def my_handler_name(event, context)` for event-based functions.
 
-Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:create-initial-build-files) to automate this.
+Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to automate this.
 
 Add a `python_google_cloud_function` target and define the `runtime`, `handler`, and `type` fields. The `type` should be either `"event"` or `"http"`. The `runtime` should be one of the values from <https://cloud.google.com/functions/docs/concepts/python-runtime>. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
 

--- a/docs/markdown/Python/python-integrations/protobuf-python.md
+++ b/docs/markdown/Python/python-integrations/protobuf-python.md
@@ -76,7 +76,7 @@ Pants will then automatically add these dependencies to your `protobuf_source` t
 Step 3: Generate `protobuf_sources` target
 ------------------------------------------
 
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
+Run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) for Pants to create a `protobuf_sources` target wherever you have `.proto` files:
 
 ```
 $ ./pants tailor

--- a/docs/markdown/Python/python-integrations/thrift-python.md
+++ b/docs/markdown/Python/python-integrations/thrift-python.md
@@ -70,7 +70,7 @@ Pants will then automatically add these dependencies to your `thrift_sources` ta
 Step 3: Generate `thrift_sources` target
 ----------------------------------------
 
-Run [`./pants tailor`](doc:create-initial-build-files) for Pants to create a `thrift_sources` target wherever you have `.thrift` files:
+Run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) for Pants to create a `thrift_sources` target wherever you have `.thrift` files:
 
 ```
 $ ./pants tailor

--- a/docs/markdown/Python/python/python-backend.md
+++ b/docs/markdown/Python/python/python-backend.md
@@ -40,7 +40,7 @@ python_sources(name="lib")
 python_tests(name="tests")
 ```
 
-You can generate these targets by running [`./pants tailor`](doc:create-initial-build-files).
+You can generate these targets by running [`./pants tailor`](doc:initial-configuration#5-generate-build-files).
 
 ```
 Created project/BUILD:

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -44,7 +44,7 @@ backend_packages = [
 ]
 ```
 
-Then, run [`./pants tailor`](doc:create-initial-build-files) to generate BUILD files:
+Then, run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to generate BUILD files:
 
 ```
 $ ./pants tailor
@@ -207,7 +207,7 @@ To use shunit2 with Pants:
 1. Create a test file like `tests.sh`, `test_foo.sh`, or `foo_test.sh`.
    - Refer to <https://github.com/kward/shunit2/> for how to write shUnit2 tests.
 2. Create a `shunit2_test` or `shunit2_tests` target in the directory's BUILD file.
-   - You can run [`./pants tailor`](doc:create-initial-build-files) to automate this step.
+   - You can run [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to automate this step.
 3. Specify which shell to run your tests with, either by setting a shebang directly in the test file or by setting the field `shell` on the `shunit2_test` / `shunit2_tests` target.
    - See [here](doc:reference-shunit2_tests#codeshellcode) for all supported shells.
 

--- a/docs/markdown/Using Pants/concepts/targets.md
+++ b/docs/markdown/Using Pants/concepts/targets.md
@@ -43,7 +43,7 @@ Each target type has different _fields_, or individual metadata values. Run `./p
 
 All target types have a `name` field, which is used to identify the target. Target names must be unique within a directory.
 
-Use [`./pants tailor`](doc:create-initial-build-files) to automate generating BUILD files, and [`./pants update-build-files`](doc:reference-update-build-files) to reformat them (using `black`, [by default](doc:reference-update-build-files#section-formatter)).
+Use [`./pants tailor`](doc:initial-configuration#5-generate-build-files) to automate generating BUILD files, and [`./pants update-build-files`](doc:reference-update-build-files) to reformat them (using `black`, [by default](doc:reference-update-build-files#section-formatter)).
 
 Target addresses
 ================
@@ -163,7 +163,7 @@ To reduce boilerplate, Pants provides target types that generate other targets. 
 - `python_tests` -> `python_test`
 - `go_mod` -> `go_third_party_package`
 
-Usually, prefer these target generators. [`./pants tailor`](doc:create-initial-build-files) will automatically add them for you.
+Usually, prefer these target generators. [`./pants tailor`](doc:initial-configuration#5-generate-build-files) will automatically add them for you.
 
 Run `./pants help targets` to see how the target determines what to generate. Targets for first-party code, like `resources` and `python_tests`, will generate one target for each file in their `sources` field.
 
@@ -225,7 +225,7 @@ You can use the address for the target generator as an alias for all of its gene
 > 
 > It's useful for metadata to be as fine-grained as feasible, such as by using the `overrides` field to only change the files you need to. Fine-grained metadata is key to having smaller cache keys (resulting in more cache hits), and allows you to more accurately reflect the status of your project. We have found that using one BUILD file per directory encourages fine-grained metadata by defining the metadata adjacent to where the code lives.
 > 
-> [`./pants tailor`](doc:create-initial-build-files) will automatically create targets that only apply metadata for the directory.
+> [`./pants tailor`](doc:initial-configuration#5-generate-build-files) will automatically create targets that only apply metadata for the directory.
 
 Parametrizing targets
 =====================


### PR DESCRIPTION
The page was inlined.

Fix was automated via `rg 'create-initial-build-files' -l | tr \\n \\0 | xargs -0 sd 'create-initial-build-files' 'initial-configuration#5-generate-build-files'`

[ci skip-rust]
[ci skip-build-wheels]