### PR TITLE
Update Media page with Pycon

### DIFF
--- a/docs/markdown/Introduction/media.md
+++ b/docs/markdown/Introduction/media.md
@@ -9,6 +9,21 @@ updatedAt: "2022-04-05T22:02:38.457Z"
 Talks
 -----
 
+### Pycon 2022
+
+#### "Hermetic Environments in Pantsbuild" aka "Fast and Reproducible Tests, Packaging, and Deploys with Pantsbuild"
+
+April 24, 2022  
+<https://www.youtube.com/watch?v=0INmW9KaAp4>  
+<https://speakerdeck.com/chrisjrn/hermetic-environments-in-pantsbuild-31d03419-8a15-4cd3-9041-b817b8924b3c>  
+Pants maintainer Chris Neugebauer gives a deep dive into the sandboxing model used by Pants, the priorities driving its design, and the pros and cons.
+
+#### [LIGHTNING TALK] "Stop Running Your Tests"
+
+April 23, 2022  
+<https://youtu.be/r-rpo4Xm_lM?t=2799>  
+Chris Neugebauer gives a swift and cheeky introduction to Pants.
+
 ### EuroPython 2021
 
 #### "Python monorepos: what, why and how"
@@ -133,8 +148,6 @@ April 4, 2022
 [Tutorial] "It's Pants Plugins All the Way Down"  
 <https://sureshjoshi.com/development/pants-plugin-code-quality>  
 A follow-up to "Your first Pants plugin" detailing how to manage code quality via plugins, continuous integration checks, and pre-commit hooks.
-
-### Suresh Joshi
 
 January 25, 2022  
 [Tutorial] "Your first Pants plugin"  


### PR DESCRIPTION
These changes were applied to 2.11, but not yet 2.12 and `main`.

[ci skip-rust]
[ci skip-build-wheels]