### PR TITLE
Refactor valid field aliases calculation for targets into a classmethod for easier re-use.

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -352,17 +352,11 @@ class Target:
         self, unhydrated_values: dict[str, Any], address: Address
     ) -> FrozenDict[type[Field], Field]:
         field_values = {}
-        valid_aliases = set()
-        aliases_to_field_types = {}
-        for field_type in self.field_types:
-            valid_aliases.add(field_type.alias)
-            aliases_to_field_types[field_type.alias] = field_type
-            if field_type.deprecated_alias is not None:
-                valid_aliases.add(field_type.deprecated_alias)
-                aliases_to_field_types[field_type.deprecated_alias] = field_type
+        aliases_to_field_types = self._get_field_aliases_to_field_types(self.field_types)
 
         for alias, value in unhydrated_values.items():
             if alias not in aliases_to_field_types:
+                valid_aliases = set(aliases_to_field_types.keys())
                 if isinstance(self, TargetGenerator):
                     # Even though moved_fields don't live on the target generator, they are valid
                     # for users to specify. It's intentional that these are only used for
@@ -388,6 +382,18 @@ class Target:
                 key=lambda field_type_to_val_pair: field_type_to_val_pair[0].alias,
             )
         )
+
+    @final
+    @classmethod
+    def _get_field_aliases_to_field_types(
+        cls, field_types: tuple[type[Field], ...]
+    ) -> dict[str, type[Field]]:
+        aliases_to_field_types = {}
+        for field_type in field_types:
+            aliases_to_field_types[field_type.alias] = field_type
+            if field_type.deprecated_alias is not None:
+                aliases_to_field_types[field_type.deprecated_alias] = field_type
+        return aliases_to_field_types
 
     @final
     @property


### PR DESCRIPTION
Marginal impact on performance, even if memoizing the results, which leaves this change as motivated with reduced complexity in terms of less code duplication. (To avoid implementing the same logic in the `__defaults__` PR)

[ci skip-rust]

[ci skip-build-wheels]