### PR TITLE
Add `MaybeAddress` for infallible evaluation of `AddressInput`

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -652,3 +652,20 @@ class ResolveError(MappingError):
                 + bullet_list(f":{name}" for name in known_names)
             )
         )
+
+
+@dataclass(frozen=True)
+class MaybeAddress:
+    """A target address, or an error if it could not be created.
+
+    Use `Get(MaybeAddress, AddressInput)`, rather than the fallible variant
+    `Get(Address, AddressInput)`.
+
+    Note that this does not validate the address's target actually exists. It only validates that
+    the address is well-formed and that its spec_path exists.
+
+    Reminder: you may need to catch errors when creating the input `AddressInput` if the address is
+    not well-formed.
+    """
+
+    val: Address | ResolveError

--- a/src/python/pants/engine/addresses.py
+++ b/src/python/pants/engine/addresses.py
@@ -12,6 +12,7 @@ from pants.build_graph.address import BuildFileAddress as BuildFileAddress  # no
 from pants.build_graph.address import (  # noqa: F401: rexport.
     BuildFileAddressRequest as BuildFileAddressRequest,
 )
+from pants.build_graph.address import MaybeAddress as MaybeAddress  # noqa: F401: rexport.
 from pants.build_graph.address import ResolveError
 from pants.engine.collection import Collection
 from pants.util.meta import frozen_after_init

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -7,8 +7,14 @@ import os.path
 from dataclasses import dataclass
 from typing import Any
 
-from pants.build_graph.address import BuildFileAddressRequest, ResolveError
-from pants.engine.addresses import Address, AddressInput, BuildFileAddress
+from pants.build_graph.address import (
+    Address,
+    AddressInput,
+    BuildFileAddress,
+    BuildFileAddressRequest,
+    MaybeAddress,
+    ResolveError,
+)
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import DigestContents, GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.internals.mapper import AddressFamily, AddressMap
@@ -62,7 +68,7 @@ async def evaluate_preludes(build_file_options: BuildFileOptions) -> BuildFilePr
 
 
 @rule
-async def resolve_address(address_input: AddressInput) -> Address:
+async def maybe_resolve_address(address_input: AddressInput) -> MaybeAddress:
     # Determine the type of the path_component of the input.
     if address_input.path_component:
         paths = await Get(Paths, PathGlobs(globs=(address_input.path_component,)))
@@ -72,14 +78,14 @@ async def resolve_address(address_input: AddressInput) -> Address:
         is_file, is_dir = False, True
 
     if is_file:
-        return address_input.file_to_address()
-    elif is_dir:
-        return address_input.dir_to_address()
-    else:
-        spec = address_input.path_component
-        if address_input.target_component:
-            spec += f":{address_input.target_component}"
-        raise ResolveError(
+        return MaybeAddress(address_input.file_to_address())
+    if is_dir:
+        return MaybeAddress(address_input.dir_to_address())
+    spec = address_input.path_component
+    if address_input.target_component:
+        spec += f":{address_input.target_component}"
+    return MaybeAddress(
+        ResolveError(
             softwrap(
                 f"""
                 The file or directory '{address_input.path_component}' does not exist on disk in
@@ -88,6 +94,14 @@ async def resolve_address(address_input: AddressInput) -> Address:
                 """
             )
         )
+    )
+
+
+@rule
+async def resolve_address(maybe_address: MaybeAddress) -> Address:
+    if isinstance(maybe_address.val, ResolveError):
+        raise maybe_address.val
+    return maybe_address.val
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/issues/15585.

I at first tried to make the rule `AddressInput -> Address` infallible by no longer eagerly validating that the `spec_path` exists. But this didn't work well because it would require assuming that a non-existent address like `path/to/f.ext:tgt` should use one of `address_input.dir_to_address()` or `address_input.file_to_address()`, which we cannot deduce.

[ci skip-rust]
[ci skip-build-wheels]