### PR TITLE
Scala: mark an object that extends another type as recursive

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -9,6 +9,7 @@ from pants.backend.scala.dependency_inference import scala_parser
 from pants.backend.scala.dependency_inference.scala_parser import (
     AnalyzeScalaSourceRequest,
     ScalaImport,
+    ScalaProvidedSymbol,
     ScalaSourceDependencyAnalysis,
 )
 from pants.backend.scala.target_types import ScalaSourceField, ScalaSourceTarget
@@ -143,7 +144,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         ),
     )
 
-    assert sorted(analysis.provided_symbols) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -177,7 +178,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.OuterTrait.NestedVar",
     ]
 
-    assert sorted(analysis.provided_symbols_encoded) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols_encoded) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -409,7 +410,10 @@ def test_package_object(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    assert sorted(analysis.provided_symbols) == ["foo.bar", "foo.bar.Hello"]
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
+        "foo.bar",
+        "foo.bar.Hello",
+    ]
 
 
 def test_source3(rule_runner: RuleRunner) -> None:
@@ -467,4 +471,28 @@ def test_extract_annotations(rule_runner: RuleRunner) -> None:
         "foo.traitAnnotation",
         "foo.valAnnotation",
         "foo.varAnnotation",
+    ]
+
+
+def test_recursive_objects(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            object Bar {
+                def a = ???
+            }
+
+            object Foo extends Bar {
+                def b = ???
+            }
+            """
+        ),
+    )
+    assert sorted(analysis.provided_symbols, key=lambda s: s.name) == [
+        ScalaProvidedSymbol("foo.Bar", False),
+        ScalaProvidedSymbol("foo.Bar.a", False),
+        ScalaProvidedSymbol("foo.Foo", True),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -73,9 +73,21 @@ async def map_first_party_scala_targets_to_symbols(
     for (address, resolve), analysis in address_and_analysis:
         namespace = _symbol_namespace(address)
         for symbol in analysis.provided_symbols:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
         for symbol in analysis.provided_symbols_encoded:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
 
     return SymbolMap((resolve, node.frozen()) for resolve, node in mapping.items())
 


### PR DESCRIPTION
Scala Parser cannot figure out the provided types of an object that extends another type. This PR solves this by marking the object as recursive.

The following example won't compile with Pants at the moment:

File A:
```
object A {
  def a(x: Int): Int = ???
}
```

File B:
```
import A

object B extends A {
  
}
```
File Main:
```
import B.a

def main() = println(a(5))
```