### PR TITLE
Fix reporting of time spent downloading files

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "graph",
  "grpc_util",
  "hashing",
+ "humansize",
  "indexmap",
  "internment",
  "itertools",
@@ -1234,6 +1235,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -124,6 +124,7 @@ futures-core = "^0.3.0"
 graph = { path = "graph" }
 grpc_util = { path = "grpc_util" }
 hashing = { path = "hashing" }
+humansize = "1.1"
 indexmap = "1.8"
 internment = "0.6"
 itertools = "0.10"

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1249,7 +1249,6 @@ impl NodeKey {
         // until we're certain that it has begun executing (if at all).
         Level::Debug
       }
-      NodeKey::DownloadedFile(..) => Level::Debug,
       _ => Level::Trace,
     }
   }
@@ -1293,14 +1292,14 @@ impl NodeKey {
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
-      NodeKey::DownloadedFile(ref d) => Some(format!("Downloading: {}", d.0)),
       NodeKey::ReadLink(ReadLink(Link(path))) => Some(format!("Reading link: {}", path.display())),
       NodeKey::Scandir(Scandir(Dir(path))) => {
         Some(format!("Reading directory: {}", path.display()))
       }
-      NodeKey::Select(..) => None,
-      NodeKey::SessionValues(..) => None,
-      NodeKey::RunId(..) => None,
+      NodeKey::DownloadedFile(..)
+      | NodeKey::Select(..)
+      | NodeKey::SessionValues(..)
+      | NodeKey::RunId(..) => None,
     }
   }
 


### PR DESCRIPTION
As described in #15800, currently the workunit for downloading a file is misleading: we begin reporting downloading before we have determined that we need to download anything.

Fixes #15800.

[ci skip-build-wheels]