### PR TITLE
Plugin fields should propagate to subclassed target types.

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -243,6 +243,10 @@ class BuildConfiguration:
                 )
             for target_type in target_types:
                 self._target_type_to_providers[target_type].append(plugin_or_backend)
+                # Access the Target._plugin_field_cls here to ensure the PluginField class is
+                # created before the UnionMembership is instantiated, as the class hierarchy is
+                # walked during union membership setup.
+                _ = target_type._plugin_field_cls
 
         def allow_unknown_options(self, allow: bool = True) -> None:
             """Allows overriding whether Options parsing will fail for unrecognized Options.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -406,8 +406,16 @@ class Target:
         # NB: We ensure that each Target subtype has its own `PluginField` class so that
         # registering a plugin field doesn't leak across target types.
 
+        baseclass = (
+            object
+            if cast("Type[Target]", cls) is Target
+            else next(
+                base for base in cast("Type[Target]", cls).__bases__ if issubclass(base, Target)
+            )._plugin_field_cls
+        )
+
         @union
-        class PluginField:
+        class PluginField(baseclass):  # type: ignore[misc, valid-type]
             pass
 
         return PluginField

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -296,6 +296,28 @@ def test_add_custom_fields() -> None:
     assert other_tgt.has_field(CustomField) is False
 
 
+def test_subclassed_target_inherits_plugin_fields() -> None:
+    class CustomFortranTarget(FortranTarget):
+        alias = "custom_fortran"
+
+    # Ensure that any `PluginField` is not lost on subclasses.
+    assert issubclass(CustomFortranTarget._plugin_field_cls, FortranTarget._plugin_field_cls)
+    assert issubclass(FortranTarget._plugin_field_cls, Target._plugin_field_cls)
+
+    class CustomField(BoolField):
+        alias = "custom_field"
+        default = False
+
+    union_membership = UnionMembership.from_rules(
+        [FortranTarget.register_plugin_field(CustomField)]
+    )
+
+    custom_tgt = CustomFortranTarget(
+        {}, Address("", target_name="custom"), union_membership=union_membership
+    )
+    assert custom_tgt.has_field(CustomField) is True
+
+
 def test_override_preexisting_field_via_new_target() -> None:
     # To change the behavior of a pre-existing field, you must create a new target as it would not
     # be safe to allow plugin authors to change the behavior of core target types.

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -72,6 +72,14 @@ class UnionMembership:
         mapping: DefaultDict[type, OrderedSet[type]] = defaultdict(OrderedSet)
         for rule in rules:
             mapping[rule.union_base].add(rule.union_member)
+        # Subclassed union bases should inherit the superclass's union members.
+        bases = list(mapping.keys())
+        while len(bases) > 0:
+            union_base = bases.pop()
+            for sub_union in union_base.__subclasses__():
+                if sub_union not in mapping:
+                    bases.append(sub_union)
+                mapping[sub_union].update(mapping[union_base])
         return cls(mapping)
 
     def __init__(self, union_rules: Mapping[type, Iterable[type]]) -> None:


### PR DESCRIPTION
Consider subclassed `PythonSourceTarget`. Now, all plugin fields that are registered on
`PythonSourceTarget` should also be registered on the custom subclassed target, otherwise
subclassing a target will lose any plugin fields in doing so, making it very difficult to customize
targets without inadvertently losing functionality added by plugin fields.

This is addressed by ensuring that the Target `PluginField` class mirrors the class hierarchy of the
owning Target class, and when registering unions all subclassed union bases are registered with the
same union members as the subclassed union base (in addition to any directly registered for the
subclassed union base type).

[ci skip-rust]