### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -3,6 +3,9 @@
 #   ./pants run build-support/bin/generate_github_workflows.py
 
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     if: ${{ github.repository_owner == 'pantsbuild' }}

--- a/.github/workflows/cancel.yaml
+++ b/.github/workflows/cancel.yaml
@@ -3,8 +3,13 @@
 #   ./pants run build-support/bin/generate_github_workflows.py
 
 
+permissions:
+  contents: read
+
 jobs:
   cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     if: ${{ github.repository_owner == 'pantsbuild' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
