### PR TITLE
Scala: mark an object that extends another type as recursive (Cherry pick of #15865)

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -25,14 +25,17 @@ case class AnImport(
 )
 
 case class Analysis(
-    providedSymbols: Vector[String],
-    providedSymbolsEncoded: Vector[String],
+    providedSymbols: Vector[Analysis.ProvidedSymbol],
+    providedSymbolsEncoded: Vector[Analysis.ProvidedSymbol],
     importsByScope: HashMap[String, ArrayBuffer[AnImport]],
     consumedSymbolsByScope: HashMap[String, HashSet[String]],
     scopes: Vector[String]
 )
+object Analysis {
+  case class ProvidedSymbol(name: String, recursive: Boolean)
+}
 
-case class ProvidedSymbol(sawClass: Boolean, sawTrait: Boolean, sawObject: Boolean)
+case class ProvidedSymbol(sawClass: Boolean, sawTrait: Boolean, sawObject: Boolean, recursive: Boolean)
 
 class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
@@ -112,7 +115,8 @@ class SourceAnalysisTraverser extends Traverser {
       symbolName: String,
       sawClass: Boolean = false,
       sawTrait: Boolean = false,
-      sawObject: Boolean = false
+      sawObject: Boolean = false,
+      recursive: Boolean = false
   ): Unit = {
     if (!skipProvidedNames) {
       val fullPackageName = nameParts.mkString(".")
@@ -126,14 +130,16 @@ class SourceAnalysisTraverser extends Traverser {
         val newSymbol = ProvidedSymbol(
           sawClass = existingSymbol.sawClass || sawClass,
           sawTrait = existingSymbol.sawTrait || sawTrait,
-          sawObject = existingSymbol.sawObject || sawObject
+          sawObject = existingSymbol.sawObject || sawObject,
+          recursive = existingSymbol.recursive || recursive
         )
         providedSymbols(symbolName) = newSymbol
       } else {
         providedSymbols(symbolName) = ProvidedSymbol(
           sawClass = sawClass,
           sawTrait = sawTrait,
-          sawObject = sawObject
+          sawObject = sawObject,
+          recursive = recursive
         )
       }
     }
@@ -230,8 +236,18 @@ class SourceAnalysisTraverser extends Traverser {
     case Defn.Object(mods, nameNode, templ) => {
       visitMods(mods)
       val name = extractName(nameNode)
-      recordProvidedName(name, sawObject = true)
-      visitTemplate(templ, name)
+
+      // TODO: should object already be recursive?
+      // an object is recursive if extends another type because we cannot figure out the provided types
+      // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
+      val recursive = !templ.inits.isEmpty
+      recordProvidedName(name, sawObject = true, recursive = recursive)
+      
+      // If the object is recursive, no need to provide the symbols inside
+      if (recursive)
+        withSuppressProvidedNames(() => visitTemplate(templ, name))
+      else
+        visitTemplate(templ, name)
     }
 
     case Defn.Type(mods, nameNode, _tparams, body) => {
@@ -363,30 +379,30 @@ class SourceAnalysisTraverser extends Traverser {
     case node => super.apply(node)
   }
 
-  def gatherProvidedSymbols(): Vector[String] = {
+  def gatherProvidedSymbols(): Vector[Analysis.ProvidedSymbol] = {
     providedSymbolsByScope
       .flatMap({ case (scopeName, symbolsForScope) =>
-        symbolsForScope.keys.map(symbolName => s"${scopeName}.${symbolName}").toVector
+        symbolsForScope.map { case(symbolName, symbol) => Analysis.ProvidedSymbol(s"${scopeName}.${symbolName}", symbol.recursive)}.toVector
       })
       .toVector
   }
 
-  def gatherEncodedProvidedSymbols(): Vector[String] = {
+  def gatherEncodedProvidedSymbols(): Vector[Analysis.ProvidedSymbol] = {
     providedSymbolsByScope
       .flatMap({ case (scopeName, symbolsForScope) =>
         val encodedSymbolsForScope = symbolsForScope.flatMap({
           case (symbolName, symbol) => {
             val encodedSymbolName = NameTransformer.encode(symbolName)
-            val result = ArrayBuffer[String](encodedSymbolName)
+            val result = ArrayBuffer[Analysis.ProvidedSymbol](Analysis.ProvidedSymbol(encodedSymbolName, symbol.recursive))
             if (symbol.sawObject) {
-              result.append(encodedSymbolName + "$")
-              result.append(encodedSymbolName + "$.MODULE$")
+              result.append(Analysis.ProvidedSymbol(encodedSymbolName + "$", symbol.recursive))
+              result.append(Analysis.ProvidedSymbol(encodedSymbolName + "$.MODULE$", symbol.recursive))
             }
             result.toVector
           }
         })
 
-        encodedSymbolsForScope.map(symbolName => s"${scopeName}.${symbolName}")
+        encodedSymbolsForScope.map(symbol => symbol.copy(name = s"${scopeName}.${symbol.name}"))
       })
       .toVector
   }

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -9,6 +9,7 @@ from pants.backend.scala.dependency_inference import scala_parser
 from pants.backend.scala.dependency_inference.scala_parser import (
     AnalyzeScalaSourceRequest,
     ScalaImport,
+    ScalaProvidedSymbol,
     ScalaSourceDependencyAnalysis,
 )
 from pants.backend.scala.target_types import ScalaSourceField, ScalaSourceTarget
@@ -145,7 +146,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         ),
     )
 
-    assert sorted(analysis.provided_symbols) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -179,7 +180,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.OuterTrait.NestedVar",
     ]
 
-    assert sorted(analysis.provided_symbols_encoded) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols_encoded) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -441,7 +442,10 @@ def test_package_object(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    assert sorted(analysis.provided_symbols) == ["foo.bar", "foo.bar.Hello"]
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
+        "foo.bar",
+        "foo.bar.Hello",
+    ]
 
 
 def test_source3(rule_runner: RuleRunner) -> None:
@@ -523,4 +527,29 @@ def test_type_arguments(rule_runner: RuleRunner) -> None:
         "foo.AnotherType",
         "foo.B",
         "foo.SomeType",
+    ]
+
+
+def test_recursive_objects(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            object Bar {
+                def a = ???
+            }
+
+            object Foo extends Bar {
+                def b = ???
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.provided_symbols, key=lambda s: s.name) == [
+        ScalaProvidedSymbol("foo.Bar", False),
+        ScalaProvidedSymbol("foo.Bar.a", False),
+        ScalaProvidedSymbol("foo.Foo", True),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -73,9 +73,21 @@ async def map_first_party_scala_targets_to_symbols(
     for (address, resolve), analysis in address_and_analysis:
         namespace = _symbol_namespace(address)
         for symbol in analysis.provided_symbols:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
         for symbol in analysis.provided_symbols_encoded:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
 
     return SymbolMap((resolve, node.frozen()) for resolve, node in mapping.items())
 


### PR DESCRIPTION
Scala Parser cannot figure out the provided types of an object that extends another type. This PR solves this by marking the object as recursive.

The following example won't compile with Pants at the moment:

File A:
```
object A {
  def a(x: Int): Int = ???
}
```

File B:
```
import A

object B extends A {
  
}
```
File Main:
```
import B.a

def main() = println(a(5))
```
# Rust tests and lints will be skipped. Delete if not intended.
[ci skip-rust]