### PR TITLE
Upgrade to `nails` `0.13.0` to pick up support for `JDK >=13`.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1684,8 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.12.0"
-source = "git+https://github.com/stuhood/nails.git?rev=aee6120e2688488bc519dfedb77cc05f704cbc89#aee6120e2688488bc519dfedb77cc05f704cbc89"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5154dfd88b8bfac6aaee04a7063673c2e6da2a13ed18e8ce545ad7a847b82f"
 dependencies = [
  "byteorder",
  "bytes",

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -10,8 +10,7 @@ async_latch = { path = "../async_latch" }
 bytes = "1.0"
 futures = "0.3"
 log = "0.4"
-# TODO: Stabilize before landing.
-nails = { git = "https://github.com/stuhood/nails.git", rev = "aee6120e2688488bc519dfedb77cc05f704cbc89" }
+nails = "0.13"
 os_pipe = "1.0"
 task_executor = { path = "../task_executor" }
 tokio = { version = "1.16", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -22,8 +22,7 @@ futures = "0.3"
 hashing = { path = "../hashing" }
 libc = "0.2.126"
 log = "0.4"
-# TODO: Stabilize before landing.
-nails = { git = "https://github.com/stuhood/nails.git", rev = "aee6120e2688488bc519dfedb77cc05f704cbc89" }
+nails = "0.13"
 nix = "0.24"
 sha2 = "0.10"
 shell-quote = "0.3.0"


### PR DESCRIPTION
As described in #14445 and fixed in https://github.com/stuhood/nails/pull/11, JDKs >=13 have slightly different `nailgun` output. Upgrade to a new release of `nails` to add support for JDKs >=13.

With this change, JDKs up to `zulu-jre:17.0.3` appear to work.

Fixes #14445.

[ci skip-build-wheels]