### PR TITLE
Deprecate implicit setting of `--remote-cache-{read,write,eager-fetch}` with `--remote-execution`

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -340,10 +340,10 @@ impl Core {
     )?;
 
     // TODO: Until we can deprecate letting the flag default, we implicitly disable
-    // eager_fetch when remote execution is in use.
+    // eager_fetch when remote execution is in use. See the TODO in `global_options.py`.
     let eager_fetch = remoting_opts.cache_eager_fetch && !remoting_opts.execution_enable;
     // TODO: Until we can deprecate letting remote-cache-{read,write} default, we implicitly
-    // enable them when remote execution is in use.
+    // enable them when remote execution is in use. See the TODO in `global_options.py`.
     let remote_cache_read = exec_strategy_opts.remote_cache_read || remoting_opts.execution_enable;
     let remote_cache_write =
       exec_strategy_opts.remote_cache_write || remoting_opts.execution_enable;


### PR DESCRIPTION
#15854 moved to using the `remote_cache` runner wrapped around the `remote` runner. That opened the door to using different values of various `--remote-cache` settings, but to preserve existing behavior, we implicitly enabled those settings with remote execution.

This change deprecates the implicit settings, asking that users set the previous defaults manually.

[ci skip-build-wheels]