### PR TITLE
[internal] remove TestCoursierWrapper

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -28,7 +28,7 @@ from pants.jvm import jdk_rules, testutil
 from pants.jvm.compile import ClasspathEntry, CompileResult, FallibleClasspathEntry
 from pants.jvm.goals import lockfile
 from pants.jvm.resolve import jvm_tool
-from pants.jvm.resolve.coursier_test_util import TestCoursierWrapper
+from pants.jvm.resolve.coursier_test_util import EMPTY_JVM_LOCKFILE
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.testutil import (
     RenderedClasspath,
@@ -115,7 +115,7 @@ def test_compile_no_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "java_sources(name='lib')",
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "ExampleLib.java": JAVA_LIB_SOURCE,
         }
     )
@@ -155,7 +155,7 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "ExampleLib.java": JAVA_LIB_SOURCE,
         }
     )
@@ -190,7 +190,7 @@ def test_compile_jdk_specified_in_build_file(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "ExampleLib.java": JAVA_LIB_JDK12_SOURCE,
         }
     )
@@ -219,7 +219,7 @@ def test_compile_jdk_12_file_fails_with_jdk_11(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "ExampleLib.java": JAVA_LIB_JDK12_SOURCE,
         }
     )
@@ -246,7 +246,7 @@ def test_compile_multiple_source_files(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "ExampleLib.java": JAVA_LIB_SOURCE,
             "OtherLib.java": dedent(
                 """\
@@ -324,7 +324,7 @@ def test_compile_with_cycle(rule_runner: RuleRunner) -> None:
                 """\
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "a/BUILD": dedent(
                 """\
                 java_sources(
@@ -410,7 +410,7 @@ def test_compile_with_transitive_cycle(rule_runner: RuleRunner) -> None:
                 public class Main implements A {}
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "a/BUILD": dedent(
                 """\
                 java_sources(
@@ -494,7 +494,7 @@ def test_compile_with_transitive_multiple_sources(rule_runner: RuleRunner) -> No
                 class Other implements B {}
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "lib/BUILD": dedent(
                 """\
                 java_sources(
@@ -553,7 +553,7 @@ def test_compile_with_deps(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "Example.java": JAVA_LIB_MAIN_SOURCE,
             "lib/BUILD": dedent(
                 """\
@@ -594,7 +594,7 @@ def test_compile_of_package_info(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "package-info.java": dedent(
                 """
                 package org.pantsbuild.example;
@@ -633,7 +633,7 @@ def test_compile_with_missing_dep_fails(rule_runner: RuleRunner) -> None:
                 """
             ),
             "Example.java": JAVA_LIB_MAIN_SOURCE,
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
         }
     )
     request = CompileJavaSourceRequest(
@@ -718,7 +718,7 @@ def test_compile_with_missing_maven_dep_fails(rule_runner: RuleRunner) -> None:
                 )
                 """
             ),
-            "3rdparty/jvm/default.lock": TestCoursierWrapper.new(entries=()).serialize(),
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
             "Example.java": dedent(
                 """
                 package org.pantsbuild.example;

--- a/src/python/pants/jvm/resolve/coursier_test_util.py
+++ b/src/python/pants/jvm/resolve/coursier_test_util.py
@@ -1,33 +1,23 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from dataclasses import dataclass
-from typing import Iterable
 
-from pants.jvm.resolve.common import ArtifactRequirement
-from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
+from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
-from pants.util.docutil import bin_name
 
 
-@dataclass
+def _make_empty_lockfile() -> bytes:
+    lockfile = CoursierResolvedLockfile(entries=())
+    metadata = JVMLockfileMetadata.new([])
+    return metadata.add_header_to_lockfile(
+        lockfile.to_serialized(),
+        regenerate_command="N/A - empty lockfile for test",
+        delimeter="#",
+    )
+
+
+EMPTY_JVM_LOCKFILE = _make_empty_lockfile()
+
+
 class TestCoursierWrapper:
-    """Utility class to make it easier to create a serialized Coursier lockfile with a correct
-    metadata header in tests."""
-
-    lockfile: CoursierResolvedLockfile
-
-    @classmethod
-    def new(cls, entries: Iterable[CoursierLockfileEntry]):
-        return cls(CoursierResolvedLockfile(entries=tuple(entries)))
-
-    def serialize(self, requirements: Iterable[ArtifactRequirement] = ()) -> str:
-        return (
-            JVMLockfileMetadata.new(requirements)
-            .add_header_to_lockfile(
-                self.lockfile.to_serialized(),
-                regenerate_command=f"{bin_name()} generate-lockfiles",
-                delimeter="#",
-            )
-            .decode()
-        )
+    pass

--- a/src/python/pants/jvm/resources_test.py
+++ b/src/python/pants/jvm/resources_test.py
@@ -11,14 +11,11 @@ from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.addresses import Addresses
 from pants.jvm import classpath, resources, testutil
 from pants.jvm.goals import lockfile
-from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
-from pants.jvm.resolve.coursier_test_util import TestCoursierWrapper
+from pants.jvm.resolve.coursier_test_util import EMPTY_JVM_LOCKFILE
 from pants.jvm.testutil import RenderedClasspath, maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
-
-EMPTY_LOCKFILE = TestCoursierWrapper(CoursierResolvedLockfile(())).serialize([])
 
 
 @pytest.fixture
@@ -50,7 +47,7 @@ def test_resources(rule_runner: RuleRunner) -> None:
             "BUILD": "resources(name='root', sources=['*.txt'])",
             "one.txt": "",
             "two.txt": "",
-            "3rdparty/jvm/default.lock": EMPTY_LOCKFILE,
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
         }
     )
 


### PR DESCRIPTION
Remove `TestCoursierWrapper` since it is no longer used to generate lockfiles. Add a `EMPTY_JVM_LOCKFILE` constant for the remaining call sites that just needed an empty JVM lockfile.

[ci skip-build-wheels]

[ci skip-rust]