### PR TITLE
Upgrade to `nails` `0.13.0` to pick up support for `JDK >=13`. (Cherry-pick of #15899)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51ec690ac20be76e55d6939fa43309c3a6e3d5dd1eb2200c8fe27a087d5c92"
+checksum = "3e5154dfd88b8bfac6aaee04a7063673c2e6da2a13ed18e8ce545ad7a847b82f"
 dependencies = [
  "byteorder",
  "bytes",

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -10,7 +10,7 @@ async_latch = { path = "../async_latch" }
 bytes = "1.0"
 futures = "0.3"
 log = "0.4"
-nails = "0.12"
+nails = "0.13"
 os_pipe = "1.0"
 task_executor = { path = "../task_executor" }
 tokio = { version = "1.16", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 hashing = { path = "../hashing" }
 libc = "0.2.112"
 log = "0.4"
-nails = "0.12"
+nails = "0.13"
 nix = "0.23"
 sha2 = "0.10"
 shell-quote = "0.3.0"


### PR DESCRIPTION
As described in #14445 and fixed in https://github.com/stuhood/nails/pull/11, JDKs >=13 have slightly different `nailgun` output. Upgrade to a new release of `nails` to add support for JDKs >=13.

With this change, JDKs up to `zulu-jre:17.0.3` appear to work.

Fixes #14445.

[ci skip-build-wheels]
