### PR TITLE
Assorted remote metrics fixes.

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -216,9 +216,10 @@ impl CommandRunner {
           .as_micros()
           .try_into();
         if let Ok(obs) = timing {
-          context
-            .workunit_store
-            .record_observation(ObservationMetric::RemoteExecutionRPCFirstResponseTime, obs);
+          context.workunit_store.record_observation(
+            ObservationMetric::RemoteExecutionRPCFirstResponseTimeMicros,
+            obs,
+          );
         }
       }
 

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -49,10 +49,6 @@ pub enum Metric {
   RemoteExecutionSuccess,
   RemoteExecutionTimeouts,
   RemoteStoreMissingDigest,
-  /// Total number of bytes of blobs downloaded from a remote CAS.
-  RemoteStoreBlobBytesDownloaded,
-  /// Total number of bytes of blobs uploaded to a remote CAS.
-  RemoteStoreBlobBytesUploaded,
   /// Number of times that we backtracked due to missing digests.
   BacktrackAttempts,
 }
@@ -71,9 +67,13 @@ pub enum ObservationMetric {
   LocalStoreReadBlobSize,
   LocalStoreReadBlobTimeMicros,
   RemoteProcessTimeRunMs,
-  RemoteExecutionRPCFirstResponseTime,
-  RemoteStoreTimeToFirstByte,
+  RemoteExecutionRPCFirstResponseTimeMicros,
+  RemoteStoreTimeToFirstByteMicros,
   RemoteStoreReadBlobTimeMicros,
+  /// Total number of bytes of blobs downloaded from a remote CAS.
+  RemoteStoreBlobBytesDownloaded,
+  /// Total number of bytes of blobs uploaded to a remote CAS.
+  RemoteStoreBlobBytesUploaded,
   /// The time saved (in milliseconds) thanks to a local cache hit instead of running the process
   /// directly.
   LocalCacheTimeSavedMs,


### PR DESCRIPTION
* Fix the `RemoteStoreReadBlobTimeMicros` metric, which was not including the actual fetch time.
* Add the relevant unit suffix to time-based metrics which don't have one.
* Move `RemoteStoreBlobBytes{Up,Down}loaded` to observation metrics, in order to record histograms.
* Simplify the "time to first byte" calculation by using an `Option<Instant>` for the start time.

[ci skip-build-wheels]