### PR TITLE
Dedupe `load_bytes_with` calls to a remote Store (Cherry-pick of #15901)

### DIFF
--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -165,7 +165,10 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
 pub trait SnapshotOps: Clone + Send + Sync + 'static {
   type Error: Debug + Display + From<String>;
 
-  async fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+  async fn load_file_bytes_with<
+    T: Send + 'static,
+    F: Fn(&[u8]) -> T + Clone + Send + Sync + 'static,
+  >(
     &self,
     digest: Digest,
     f: F,


### PR DESCRIPTION
As described in #15524: `remote::ByteStore::load_bytes_with` calls are not deduped currently, meaning that if multiple consumers identify a `Digest` which is missing from the local store, they might concurrently fetch it from the remote store.

This is primarily an issue with `--remote-cache-eager-fetch=false`, as the laziness means that all consumers of a process output might consider whether to download it simultaneously (rather than the output always being downloaded before the process is called complete).

Fixes #15524.

[ci skip-build-wheels]
