### PR TITLE
Remove retired releaser(s) from release checks

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -70,7 +70,7 @@ _known_packages = [
 
 _expected_owners = {"benjyw", "John.Sirois", "stuhood"}
 
-_expected_maintainers = {"EricArellano", "gshuflin", "illicitonion", "wisechengyi"}
+_expected_maintainers = {"EricArellano", "illicitonion", "wisechengyi"}
 
 
 class PackageAccessValidator:


### PR DESCRIPTION
Remove `gshuflin` from release checks.

[ci skip-rust]