### PR TITLE
Remove deprecated `--excluded-target-regexp`, `--files-not-found-behavior`, and `--owners-not-found-behavior` global options

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -9,9 +9,9 @@ import logging
 import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, NamedTuple, Sequence, cast
+from typing import Iterable, NamedTuple, Sequence
 
-from pants.base.deprecated import resolve_conflicting_options, warn_or_error
+from pants.base.deprecated import warn_or_error
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
 from pants.build_graph.address import BuildFileAddressRequest, MaybeAddress, ResolveError
 from pants.engine.addresses import (

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -830,17 +830,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
 def extract_unmatched_build_file_globs(
     global_options: GlobalOptions,
 ) -> UnmatchedBuildFileGlobs:
-    return cast(
-        UnmatchedBuildFileGlobs,
-        resolve_conflicting_options(
-            old_option="files_not_found_behavior",
-            new_option="unmatched_build_file_globs",
-            old_scope=global_options.options_scope,
-            new_scope=global_options.options_scope,
-            old_container=global_options.options,
-            new_container=global_options.options,
-        ),
-    )
+    return global_options.unmatched_build_file_globs
 
 
 class AmbiguousCodegenImplementationsException(Exception):

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -161,7 +161,6 @@ def test_specs_filter() -> None:
         ),
         RegisteredTargetTypes({"tgt1": MockTgt1, "tgt2": MockTgt2}),
         tags=["-a", "+b"],
-        exclude_target_regexps=["skip-me"],
     )
 
     def make_tgt1(name: str, tags: list[str] | None = None) -> MockTgt1:
@@ -171,9 +170,7 @@ def test_specs_filter() -> None:
         return MockTgt2({Tags.alias: tags}, Address("", target_name=name))
 
     untagged_tgt = make_tgt1(name="untagged")
-    b_tagged_tgt = make_tgt1(name="b-tagged", tags=["b"])
-    b_tagged_exclude_regex_tgt = make_tgt1(name="skip-me", tags=["b"])
-    a_and_b_tagged_tgt = make_tgt1(name="a-and-b-tagged", tags=["a", "b"])
+    tagged_tgt = make_tgt1(name="tagged", tags=["b"])
 
     # Even though this has the tag `b`, it should be excluded because the target type.
     tgt2 = make_tgt2("tgt2", tags=["b"])
@@ -181,6 +178,6 @@ def test_specs_filter() -> None:
     def matches(tgt: Target) -> bool:
         return specs_filter.matches(tgt)
 
-    assert matches(b_tagged_tgt) is True
-    for t in (untagged_tgt, b_tagged_exclude_regex_tgt, a_and_b_tagged_tgt, tgt2):
-        assert matches(t) is False
+    assert matches(tagged_tgt) is True
+    assert matches(untagged_tgt) is False
+    assert matches(tgt2) is False

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -271,12 +271,7 @@ def setup_specs_filter(
     filter_subsystem: FilterSubsystem,
     registered_target_types: RegisteredTargetTypes,
 ) -> SpecsFilter:
-    return SpecsFilter.create(
-        filter_subsystem,
-        registered_target_types,
-        tags=global_options.tag,
-        exclude_target_regexps=global_options.exclude_target_regexp,
-    )
+    return SpecsFilter.create(filter_subsystem, registered_target_types, tags=global_options.tag)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1541,29 +1541,6 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         advanced=True,
     )
 
-    owners_not_found_behavior = EnumOption(
-        "--owners-not-found-behavior",
-        default=OwnersNotFoundBehavior.ignore,
-        help=softwrap(
-            """
-            What to do when file arguments do not have any owning target. This happens when
-            there are no targets whose `sources` fields include the file argument.
-            """
-        ),
-        advanced=True,
-        removal_version="2.14.0.dev0",
-        removal_hint=softwrap(
-            """
-            This option is no longer useful with Pants because we have goals that work without any
-            targets, e.g. the `count-loc` goal or the `regex-lint` linter from the `lint` goal. This
-            option caused us to error on valid use cases.
-
-            For goals that require targets, like `list`, the unowned file will simply be ignored. If
-            no owners are found at all, most goals will warn and some like `run` will error.
-            """
-        ),
-    )
-
     build_patterns = StrListOption(
         "--build-patterns",
         default=["BUILD", "BUILD.*"],

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1510,25 +1510,6 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         metavar="[+-]tag1,tag2,...",
     )
 
-    files_not_found_behavior = EnumOption(
-        "--files-not-found-behavior",
-        default=UnmatchedBuildFileGlobs.warn,
-        help=softwrap(
-            """
-            What to do when files and globs specified in BUILD files, such as in the
-            `sources` field, cannot be found. This happens when the files do not exist on
-            your machine or when they are ignored by the `--pants-ignore` option.
-            """
-        ),
-        advanced=True,
-        removal_version="2.14.0.dev0",
-        removal_hint=softwrap(
-            """
-            Use `[GLOBAL].unmatched_build_file_globs` instead, which behaves the same. This
-            option was renamed for clarity with the new `[GLOBAL].unmatched_cli_globs` option.
-            """
-        ),
-    )
     unmatched_build_file_globs = EnumOption(
         "--unmatched-build-file-globs",
         default=UnmatchedBuildFileGlobs.warn,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1509,21 +1509,6 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         ),
         metavar="[+-]tag1,tag2,...",
     )
-    exclude_target_regexp = StrListOption(
-        "--exclude-target-regexp",
-        help="Exclude targets that match these regexes. This does not impact file arguments.",
-        metavar="<regexp>",
-        removal_version="2.14.0.dev0",
-        removal_hint=softwrap(
-            """
-            Use the option `--filter-address-regex` instead, with `-` in front of the regex. For
-            example, `--exclude-target-regexp=dir/` should become `--filter-address-regex=-dir/`.
-
-            The `--filter` options can now be used with any goal, not only the `filter` goal,
-            so there is no need for this option anymore.
-            """
-        ),
-    )
 
     files_not_found_behavior = EnumOption(
         "--files-not-found-behavior",


### PR DESCRIPTION
In the process, this closes https://github.com/pantsbuild/pants/issues/15802. 

Before:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled --spec-files=tgts.txt list'
Benchmark 1: ./pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled --spec-files=tgts.txt list
  Time (mean ± σ):      4.255 s ±  0.034 s    [User: 3.906 s, System: 0.545 s]
  Range (min … max):    4.223 s …  4.314 s    5 runs
```

After:

```
❯ hyperfine -w 1 -r 5 './pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled --spec-files=tgts.txt list'
Benchmark 1: ./pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled --spec-files=tgts.txt list
  Time (mean ± σ):      3.837 s ±  0.271 s    [User: 3.315 s, System: 0.452 s]
  Range (min … max):    3.645 s …  4.302 s    5 runs
```
