### PR TITLE
Clarify deprecation messages for `tailor` and `update-build-files` requiring CLI arguments

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -606,13 +606,13 @@ def specs_to_dirs(specs: RawSpecs) -> tuple[str, ...]:
                 recursively on. You specified {', '.join(str(spec) for spec in other_specs)}
 
                 To fix, either set `use_deprecated_cli_args_semantics` to false, or rerun with
-                specifying only literal directories, e.g. `tailor dir1 dir2`. If changing
-                `use_deprecated_cli_args_semantics` to false, you should specify which directories
-                to run on when using `tailor`:
+                specifying only literal directories, e.g. `{bin_name()} tailor dir1 dir2`. If
+                changing `use_deprecated_cli_args_semantics` to false, you should specify which
+                directories to run on when using `tailor`:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
+                  * `{bin_name()} tailor ::` to run on everything
+                  * `{bin_name()} tailor dir::` to run on `dir` and subdirs
+                  * `{bin_name()} tailor dir` to run on `dir`
                 """
             )
         )
@@ -651,9 +651,9 @@ async def tailor(
 
                 In Pants 2.14, you must use CLI arguments. Use:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
+                  * `{bin_name()} tailor ::` to run on everything
+                  * `{bin_name()} tailor dir::` to run on `dir` and subdirs
+                  * `{bin_name()} tailor dir` to run on `dir`
                 """
             ),
         )

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -613,6 +613,7 @@ def specs_to_dirs(specs: RawSpecs) -> tuple[str, ...]:
                   * `{bin_name()} tailor ::` to run on everything
                   * `{bin_name()} tailor dir::` to run on `dir` and subdirs
                   * `{bin_name()} tailor dir` to run on `dir`
+                  * `{bin_name()} --changed-since=HEAD tailor` to only run on changed and new files
                 """
             )
         )
@@ -654,6 +655,7 @@ async def tailor(
                   * `{bin_name()} tailor ::` to run on everything
                   * `{bin_name()} tailor dir::` to run on `dir` and subdirs
                   * `{bin_name()} tailor dir` to run on `dir`
+                  * `{bin_name()} --changed-since=HEAD tailor` to only run on changed and new files
                 """
             ),
         )

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -210,10 +210,11 @@ async def update_build_files(
 
                 In Pants 2.14, you must use CLI arguments. Use:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
-                  * `dir/BUILD` to run on that single BUILD file
+                  * `{bin_name()} update-build-files ::` to run on everything
+                  * `{bin_name()} update-build-files dir::` to run on `dir` and subdirs
+                  * `{bin_name()} update-build-files dir` to run on `dir`
+                  * `{bin_name()} update-build-files dir/BUILD` to run on that single BUILD file
+                  * `{bin_name()} --changed-since=HEAD update-build-files` to run only on changed BUILD files
                 """
             ),
         )


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15868.

[ci skip-rust]