### PR TITLE
Fix bad "<infallible>" description in invalid addresses error messages (Cherry-pick of #15859)

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1251,6 +1251,16 @@ async def resolve_unparsed_address_inputs(
         return Addresses(valid_addresses)
 
     addresses = await MultiGet(Get(Address, AddressInput, ai) for ai in address_inputs)
+    # Validate that the addresses exist. We do this eagerly here because
+    # `Addresses -> UnexpandedTargets` does not preserve the `description_of_origin`, so it would
+    # be too late, per https://github.com/pantsbuild/pants/issues/15858.
+    await MultiGet(
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(addr, description_of_origin=request.description_of_origin),
+        )
+        for addr in addresses
+    )
     return Addresses(addresses)
 
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1936,7 +1936,7 @@ def test_resolve_unparsed_address_inputs() -> None:
                     UnparsedAddressInputs(
                         addresses,
                         owning_address=Address("project", target_name="t3"),
-                        description_of_origin="tests",
+                        description_of_origin="from my tests",
                         skip_invalid_addresses=skip_invalid_addresses,
                     )
                 ],
@@ -1948,5 +1948,5 @@ def test_resolve_unparsed_address_inputs() -> None:
 
     invalid_addresses = ["project:t1", "bad::", "project/fake.txt:tgt"]
     assert resolve(invalid_addresses, skip_invalid_addresses=True) == {t1}
-    with engine_error(AddressParseException):
+    with engine_error(AddressParseException, contains="from my tests"):
         resolve(invalid_addresses)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15858. See that ticket for the explanation of why we solve the issue this way.

[ci skip-rust]
[ci skip-build-wheels]