### PR TITLE
Add support for strict and color flags in Helm unittest

### DIFF
--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -51,8 +51,6 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         help="Output type used for the test report.",
     )
 
-    strict = BoolOption("--strict", default=None, help="Strict parse the test suites.")
-
     def generate_exe(self, _: Platform) -> str:
         return "./untt"
 

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -43,7 +43,7 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
     }
 
     color = BoolOption(
-        "--color", default=False, help="Enforce printing colored output even stdout is not a tty."
+        "--color", default=False, help="Enforce printing colored output even if stdout is not a tty."
     )
 
     output_type = EnumOption(

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -43,7 +43,9 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
     }
 
     color = BoolOption(
-        "--color", default=False, help="Enforce printing colored output even if stdout is not a tty."
+        "--color",
+        default=False,
+        help="Enforce printing colored output even if stdout is not a tty.",
     )
 
     output_type = EnumOption(

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -11,7 +11,7 @@ from pants.backend.helm.util_rules.plugins import (
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import EnumOption
+from pants.option.option_types import BoolOption, EnumOption
 
 
 class HelmUnitTestReportFormat(Enum):
@@ -42,10 +42,16 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         "macos_x86_64": "macos-amd64",
     }
 
+    color = BoolOption(
+        "--color", default=False, help="Enforce printing colored output even stdout is not a tty."
+    )
+
     output_type = EnumOption(
         default=HelmUnitTestReportFormat.XUNIT,
-        help="Output type used for the test report",
+        help="Output type used for the test report.",
     )
+
+    strict = BoolOption("--strict", default=None, help="Strict parse the test suites.")
 
     def generate_exe(self, _: Platform) -> str:
         return "./untt"

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -220,12 +220,18 @@ class HelmUnitTestSourceField(SingleSourceField):
     )
 
 
+class HelmUnitTestStrictField(TriBoolField):
+    alias = "strict"
+    help = "If set to true, parses the UnitTest suite files strictly."
+
+
 class HelmUnitTestTestTarget(Target):
     alias = "helm_unittest_test"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         HelmUnitTestSourceField,
         HelmUnitTestDependenciesField,
+        HelmUnitTestStrictField,
     )
     help = "A single helm-unittest suite file."
 
@@ -263,6 +269,7 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         HelmUnitTestGeneratingSourcesField,
         HelmUnitTestDependenciesField,
+        HelmUnitTestStrictField,
     )
     generated_target_cls = HelmUnitTestTestTarget
     copied_fields = COMMON_TARGET_FIELDS

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -117,8 +117,7 @@ async def run_helm_unittest(
         ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
     )
 
-    strict = field_set.strict.value or unittest_subsystem.strict
-
+    strict = field_set.strict.value
     process_result = await Get(
         FallibleProcessResult,
         HelmProcess(

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -13,6 +13,7 @@ from pants.backend.helm.target_types import (
     HelmChartTarget,
     HelmUnitTestDependenciesField,
     HelmUnitTestSourceField,
+    HelmUnitTestStrictField,
     HelmUnitTestTestsGeneratorTarget,
     HelmUnitTestTestTarget,
 )
@@ -62,6 +63,7 @@ class HelmUnitTestFieldSet(TestFieldSet):
 
     source: HelmUnitTestSourceField
     dependencies: HelmUnitTestDependenciesField
+    strict: HelmUnitTestStrictField
 
 
 @rule(desc="Run Helm Unittest", level=LogLevel.DEBUG)
@@ -115,12 +117,16 @@ async def run_helm_unittest(
         ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
     )
 
+    strict = field_set.strict.value or unittest_subsystem.strict
+
     process_result = await Get(
         FallibleProcessResult,
         HelmProcess(
             argv=[
                 unittest_subsystem.plugin_name,
                 "--helm3",
+                *(("--color",) if unittest_subsystem.color else ()),
+                *(("--strict",) if strict else ()),
                 "--output-type",
                 unittest_subsystem.output_type.value,
                 "--output-file",

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -132,7 +132,7 @@ async def run_helm_unittest(
                 reports_file,
                 chart.path,
             ],
-            description=f"Running Helm unittest on: {field_set.address}",
+            description=f"Running Helm unittest suite {field_set.address}",
             input_digest=input_digest,
             cache_scope=cache_scope,
             output_directories=(reports_dir,),


### PR DESCRIPTION
Adds support for the `--strict` and `--color` flags in Helm unittest plugin via options in the subsystem. The former also with the addition of a field in `helm_unittest_test` and `helm_unittest_tests` to allow overriding the default value set in options.