### PR TITLE
Remove 2.13.0a0 entries from 2.14.0.dev0 release notes

### DIFF
--- a/src/python/pants/notes/2.14.x.md
+++ b/src/python/pants/notes/2.14.x.md
@@ -8,8 +8,6 @@
 
 * Add `__defaults__` BUILD file symbol ([#15836](https://github.com/pantsbuild/pants/pull/15836))
 
-* Add option for max wait before terminating interactive process ([#15767](https://github.com/pantsbuild/pants/pull/15767))
-
 ### User API Changes
 
 * Deprecate `--use-deprecated-directory-cli-args-semantics` and default to false ([#15939](https://github.com/pantsbuild/pants/pull/15939))
@@ -22,29 +20,11 @@
 
 * Deprecate implicit setting of `--remote-cache-{read,write,eager-fetch}` with `--remote-execution` ([#15900](https://github.com/pantsbuild/pants/pull/15900))
 
-* Add `[scala-infer].force_add_siblings_as_dependencies` and deprecate it defaulting to true ([#15841](https://github.com/pantsbuild/pants/pull/15841))
-
-* Add `--debug-adapter` flag to `test` goal ([#15799](https://github.com/pantsbuild/pants/pull/15799))
-
 ### Plugin API Changes
 
 * Plugin fields should propagate to subclassed target types. ([#15876](https://github.com/pantsbuild/pants/pull/15876))
 
 * Introduce a plugin API to provide all thread local state, and deprecate stdio-specific methods ([#15890](https://github.com/pantsbuild/pants/pull/15890))
-
-* Add `skip_invalid_addresses` field to `UnparsedAddressInputs` ([#15864](https://github.com/pantsbuild/pants/pull/15864))
-
-* Add `MaybeAddress` for infallible evaluation of `AddressInput` ([#15863](https://github.com/pantsbuild/pants/pull/15863))
-
-* Add optional `StringSequenceField.valid_choices` ([#15684](https://github.com/pantsbuild/pants/pull/15684))
-
-* `WrappedTarget` now requires `WrappedTargetRequest` ([#15789](https://github.com/pantsbuild/pants/pull/15789))
-
-* Move `ResolveError` from `pants.base.exceptions` to `pants.build_graph.address` ([#15790](https://github.com/pantsbuild/pants/pull/15790))
-
-* `_TargetParametrizations` now requires `_TargetParametrizationsRequest` ([#15759](https://github.com/pantsbuild/pants/pull/15759))
-
-* `BuildFileAddress` now requires `BuildFileAddressRequest` ([#15760](https://github.com/pantsbuild/pants/pull/15760))
 
 ### Bug fixes
 
@@ -64,19 +44,9 @@
 
 * Fix reporting of time spent downloading files ([#15873](https://github.com/pantsbuild/pants/pull/15873))
 
-* Support `--help` for builtin goals. ([#15798](https://github.com/pantsbuild/pants/pull/15798))
-
-* Handle venv path special chars in coursier fetch ([#15701](https://github.com/pantsbuild/pants/pull/15701))
-
-* Fix `[python-infer].inits` and `[python-infer].conftests` to consider `resolve` field ([#15787](https://github.com/pantsbuild/pants/pull/15787))
-
 ### Performance
 
 * Dedupe `load_bytes_with` calls to a remote Store ([#15901](https://github.com/pantsbuild/pants/pull/15901))
-
-* Backtrack execution for missing digests to make `eager_fetch=false` more resilient ([#15850](https://github.com/pantsbuild/pants/pull/15850))
-
-* Remove synchronous remote cache lookup from remote execution ([#15854](https://github.com/pantsbuild/pants/pull/15854))
 
 ### Documentation
 
@@ -85,9 +55,3 @@
 * Update certificate environment variable advice for #14808. ([#15943](https://github.com/pantsbuild/pants/pull/15943))
 
 * Clarify deprecation messages for `tailor` and `update-build-files` requiring CLI arguments ([#15932](https://github.com/pantsbuild/pants/pull/15932))
-
-* Fix broken links to `tailor` documentation ([#15842](https://github.com/pantsbuild/pants/pull/15842))
-
-* Update docs for redesign of CLI arguments ([#15816](https://github.com/pantsbuild/pants/pull/15816))
-
-* Better error message when an address does not exist ([#15788](https://github.com/pantsbuild/pants/pull/15788))


### PR DESCRIPTION
I suspect `changelog.py` was unintentionally run with `--old=2.13.0.dev5`, given that `a0` is a new thing.