### PR TITLE
[internal] add observation metric for REAPI GetActionResult calls

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -521,6 +521,7 @@ async fn check_action_cache(
     |workunit| async move {
       workunit.increment_counter(Metric::RemoteCacheRequests, 1);
 
+      let start = Instant::now();
       let client = action_cache_client.as_ref().clone();
       let response = retry_call(
         client,
@@ -579,6 +580,11 @@ async fn check_action_cache(
         Ok(response)
       })
       .await;
+
+      workunit.record_observation(
+        ObservationMetric::RemoteCacheGetActionResultTimeMicros,
+        start.elapsed().as_micros() as u64,
+      );
 
       match response {
         Ok(response) => {

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -80,4 +80,6 @@ pub enum ObservationMetric {
   /// The time saved (in milliseconds) thanks to a remote cache hit instead of running the process
   /// directly.
   RemoteCacheTimeSavedMs,
+  /// Remote cache timing (in microseconds) for GetActionResult calls.
+  RemoteCacheGetActionResultTimeMicros,
 }


### PR DESCRIPTION
Add an observation metric (histogram) for calls to Action Cache `GetActionResult` RPC. This will help with monitoring reads from remote cache.