### PR TITLE
Move generic debug adapter settings to dedicated subsystem (Cherry-pick of #15928)

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -34,6 +34,7 @@ from pants.core.goals.test import (
     TestResult,
     TestSubsystem,
 )
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
@@ -405,6 +406,7 @@ async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
 async def debugpy_python_test(
     field_set: PythonTestFieldSet,
     debugpy: DebugPy,
+    debug_adapter: DebugAdapterSubsystem,
     pytest: PyTest,
 ) -> TestDebugAdapterRequest:
     debugpy_pex = await Get(Pex, PexRequest, debugpy.to_pex_request())
@@ -426,7 +428,7 @@ async def debugpy_python_test(
             main=debugpy.main,
             prepend_argv=(
                 "--listen",
-                f"{debugpy.host}:{debugpy.port}",
+                f"{debug_adapter.host}:{debug_adapter.port}",
                 "--wait-for-client",
                 # @TODO: Techincally we should use `pytest.main`, however `debugpy` doesn't support
                 # launching an entry_point.

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -11,7 +11,6 @@ from pants.backend.python.target_types import EntryPoint
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import IntOption, StrOption
 from pants.util.docutil import git_url
 
 
@@ -29,15 +28,6 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-    host = StrOption(
-        "--host", default="127.0.0.1", help="The hostname to use when launching the debugpy server."
-    )
-    port = IntOption(
-        "--port",
-        default=5678,  # The canonical port
-        help="The port to use when launching the debugpy server.",
-    )
 
 
 class DebugPyLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -34,6 +34,7 @@ from pants.core.goals.test import (
     build_runtime_package_dependencies,
     run_tests,
 )
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.addresses import Address
 from pants.engine.console import Console
@@ -55,7 +56,7 @@ from pants.engine.target import (
     TargetRootsToFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership
-from pants.testutil.option_util import create_goal_subsystem
+from pants.testutil.option_util import create_goal_subsystem, create_subsystem
 from pants.testutil.rule_runner import (
     MockEffect,
     MockGet,
@@ -167,6 +168,11 @@ def run_test_rule(
         extra_env_vars=[],
         shard="",
     )
+    debug_adapter_subsystem = create_subsystem(
+        DebugAdapterSubsystem,
+        host="127.0.0.1",
+        port="5678",
+    )
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
     union_membership = UnionMembership(
         {
@@ -207,6 +213,7 @@ def run_test_rule(
             rule_args=[
                 console,
                 test_subsystem,
+                debug_adapter_subsystem,
                 workspace,
                 union_membership,
                 DistDir(relpath=Path("dist")),

--- a/src/python/pants/core/subsystems/debug_adapter.py
+++ b/src/python/pants/core/subsystems/debug_adapter.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import IntOption, StrOption
+from pants.option.subsystem import Subsystem
+from pants.util.strutil import softwrap
+
+
+class DebugAdapterSubsystem(Subsystem):
+    options_scope = "debug-adapter"
+    help = softwrap(
+        """
+        Options used to configure and launch a Debug Adapter server.
+
+        See https://microsoft.github.io/debug-adapter-protocol/ for more information.
+        """
+    )
+
+    host = StrOption(
+        "--host", default="127.0.0.1", help="The hostname to use when launching the server."
+    )
+    port = IntOption(
+        "--port",
+        default=5678,
+        help="The port to use when launching the server.",
+    )


### PR DESCRIPTION
Users likely don't care about different settings per-language, and if they want to run multiple they can use the CLI.

Also, now we can log the server address.

[ci skip-rust]
[ci skip-build-wheels]
