### PR TITLE
Improve debugpy's capabilities (Cherry-pick of #15946)

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+import unittest.mock
 from textwrap import dedent
 
 import pytest
@@ -610,7 +611,7 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
         "--listen",
         "127.0.0.1:5678",
         "--wait-for-client",
-        "-m",
-        "pytest",
+        "-c",
+        unittest.mock.ANY,
         "tests/python/pants_test/test_foo.py",
     )

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -7,15 +7,18 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url
 
 
 class DebugPy(PythonToolBase):
     options_scope = "debugpy"
+    name = options_scope
     help = "An implementation of the Debug Adapter Protocol for Python (https://github.com/microsoft/debugpy)."
 
     default_version = "debugpy==1.6.0"
@@ -28,6 +31,37 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+
+    args = ArgsListOption(example="--log-to-stderr")
+
+    @staticmethod
+    def _get_main_spec_args(main: MainSpecification) -> tuple[str, ...]:
+        if isinstance(main, EntryPoint):
+            if main.function:
+                return ("-c", f"import {main.module};{main.module}.{main.function}();")
+            return ("-m", main.module)
+
+        assert isinstance(main, ConsoleScript)
+        # NB: This is only necessary while debugpy supports Py 3.7, as `importlib.metadata` was
+        # added in Py 3.8 and would allow us to resolve the console_script using just the stdlib.
+        return (
+            "-c",
+            (
+                "from pex.third_party.pkg_resources import working_set;"
+                + f"(next(working_set.iter_entry_points('console_scripts', '{main.name}')).resolve())()"
+            ),
+        )
+
+    def get_args(
+        self, debug_adapter: DebugAdapterSubsystem, main: MainSpecification
+    ) -> tuple[str, ...]:
+        return (
+            "--listen",
+            f"{debug_adapter.host}:{debug_adapter.port}",
+            "--wait-for-client",
+            *self.args,
+            *self._get_main_spec_args(main),
+        )
 
 
 class DebugPyLockfileSentinel(GenerateToolLockfileSentinel):


### PR DESCRIPTION
- Adding an `args` flag for additional flags (especially useful for debug logs)
- Adds support for executing module/module+function/console_script

[ci skip-rust]
[ci skip-build-wheels]
