### PR TITLE
Add `--debug-adapter` flag to `run` (Cherry-pick of #15829)

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -70,7 +70,7 @@ _known_packages = [
 
 _expected_owners = {"benjyw", "John.Sirois", "stuhood"}
 
-_expected_maintainers = {"EricArellano", "gshuflin", "illicitonion", "wisechengyi"}
+_expected_maintainers = {"EricArellano", "illicitonion", "wisechengyi"}
 
 
 # Disable the Pants repository-internal internal_plugins.test_lockfile_fixtures plugin because
@@ -900,7 +900,6 @@ def publish() -> None:
     upload_wheels_via_twine()
     tag_release()
     banner("Successfully released to PyPI and GitHub")
-    prompt_apple_silicon()
     prompt_to_generate_docs()
 
 
@@ -1090,22 +1089,6 @@ def prompt_artifact_freshness() -> None:
         )
     else:
         print("No stale artifacts detected.")
-
-
-def prompt_apple_silicon() -> None:
-    input(
-        softwrap(
-            f"""
-            We need to release for Apple Silicon. Please message Eric on Slack asking to release
-            for {CONSTANTS.pants_stable_version}.
-
-            (You do not need to wait for Eric to finish their part. You can continue in the release
-            process once you've messaged them.)
-
-            Hit enter when you've messaged Eric:
-            """
-        )
-    )
 
 
 def prompt_to_generate_docs() -> None:

--- a/docs/markdown/Docker/tagging-docker-images.md
+++ b/docs/markdown/Docker/tagging-docker-images.md
@@ -54,6 +54,14 @@ docker_image(
 )
 ```
 
+You may also provide a registry specific value for the repository, see next section for more details.
+```toml pants.toml
+[docker.registries.company-registry3]
+address = "reg3.company.internal"
+repository = "{parent_directory}/{name}"
+```
+
+
 Setting a repository name
 -------------------------
 
@@ -67,10 +75,16 @@ docker_image(
     repository="example/demo",
 )
 ```
-
 ```shell
 $ ./pants package src/example:demo
 # Will build the image: example/demo:latest
+```
+
+To use a repository only for a specific registry, provide a `repository` value in the registry configuration, and this can contain placeholders in curly braces that will be interpolated for each image name.
+```toml pants.toml
+[docker.registries.demo]
+address = "reg.company.internal"
+repository = "example/{name}"
 ```
 
 You can also specify a default repository name in config, and this name can contain placeholders in curly braces that will be interpolated for each `docker_image`:
@@ -91,10 +105,16 @@ The default placeholders are:
 - `{parent_directory}`: The parent directory of `{directory}`.
 - `{name}`: The name of the docker_image target.
 - `{build_args.ARG_NAME}`: Each defined Docker build arg is available for interpolation under the `build_args.` prefix.
+- `{default_repository}`: The default repository from configuration.
+- `{target_repository}`: The repository on the `docker_image` if provided, otherwise the default repository.
 
-Since repository names often conform to patterns like these, this can save you on some boilerplate by allowing you to omit the `repository` field on each `docker_image`. But you can always override this field on specific `docker_image` targets, of course. In fact, you can use these placeholders in the `repository` field as well, if you find that helpful.
+Since repository names often conform to patterns like these, this can save you on some boilerplate
+by allowing you to omit the `repository` field on each `docker_image`. But you can always override
+this field on specific `docker_image` targets, of course. In fact, you can use these placeholders in
+the `repository` field as well, if you find that helpful.
 
 See [String interpolation using placeholder values](doc:tagging-docker-images#string-interpolation-using-placeholder-values) for more information.
+
 
 Tagging images
 --------------

--- a/docs/markdown/Python/python-goals/python-repl-goal.md
+++ b/docs/markdown/Python/python-goals/python-repl-goal.md
@@ -24,15 +24,11 @@ You can change IPython's version with `[ipython].version`. If you change it, Pan
 
 ```toml pants.toml
 [ipython]
-version = "ipython>=6.0.0"
+version = "ipython>=8.0.0"
 lockfile = "3rdparty/python/ipython_lock.txt"
 ```
 
 If you set the `version` lower than IPython 7, then you must set `[ipython].ignore_cwd = false` to avoid Pants setting an option that did not exist in earlier IPython releases.
-
-> ❗️ IPython does not yet work with Pantsd
-> 
-> When using IPython, use the option `--no-pantsd` to turn off the Pants daemon, e.g. `./pants --no-pantsd repl --shell=ipython`. We are working to [fix this](https://github.com/pantsbuild/pants/issues/9939).
 
 > 📘 Python 2 support
 > 
@@ -76,16 +72,10 @@ Type "help", "copyright", "credits" or "license" for more information.
 This will not load any of your code:
 
 ```text Shell
-$ ./pants --no-pantsd repl --shell=ipython
-
-Python 3.6.10 (default, Feb 26 2020, 08:26:13)
-Type "copyright", "credits" or "license" for more information.
-
-IPython 5.8.0 -- An enhanced Interactive Python.
-?         -> Introduction and overview of IPython's features.
-%quickref -> Quick reference.
-help      -> Python's own help system.
-object?   -> Details about 'object', use 'object??' for extra details.
+❯ ./pants repl --shell=ipython
+Python 3.9.12 (main, Mar 26 2022, 15:45:34)
+Type 'copyright', 'credits' or 'license' for more information
+IPython 7.34.0 -- An enhanced Interactive Python. Type '?' for help.
 
 In [1]: 21 * 4
 Out[1]: 84

--- a/docs/markdown/Python/python-goals/python-run-goal.md
+++ b/docs/markdown/Python/python-goals/python-run-goal.md
@@ -29,11 +29,11 @@ You may only run one target at a time.
 The program will have access to the same environment used by the parent `./pants` process, so you can set environment variables in the external environment, e.g. `FOO=bar ./pants run project/app.py`. (Pants will auto-set some values like `$PATH`).
 
 > 📘 Tip: check the return code
-> 
+>
 > Pants will propagate the return code from the underlying executable. Run `echo $?` after the Pants run to see the return code.
 
 > 🚧 Issues finding files?
-> 
+>
 > Run `./pants dependencies --transitive path/to/binary.py` to ensure that all the files you need are showing up, including for any [assets](doc:assets) you intend to use.
 
 Watching the filesystem
@@ -46,29 +46,36 @@ On the other hand, if your app is short lived (like a script) and you'd like to 
 Debugging
 ---------
 
+> 📘 Tip: using the VS Code (or any [DAP](https://microsoft.github.io/debug-adapter-protocol/)-compliant editor) remote debugger
+>
+>
+> 1. In your editor, set your breakpoints and any other debug settings (like break-on-exception).
+> 2. Run your code with `./pants run --debug-adapter`.
+> 3. Connect your editor to the server. The server host and port are logged by Pants when executing `run --debug-adaptor`. (They can also be configured using the `[debug-adapter]` subsystem).
+
 > 📘 Tip: Using the IntelliJ/PyCharm remote debugger
-> 
+>
 > First, add the following target in some BUILD file (e.g., the one containing your other 3rd-party dependencies):
-> 
+>
 > ```
 > python_requirement(
 >   name = "pydevd-pycharm",
 >   requirements=["pydevd-pycharm==203.5419.8"],  # Or whatever version you choose.
 > )
 > ```
-> 
+>
 > You can check this into your repo, for convenience.
-> 
+>
 > Now, use the remote debugger as usual:
-> 
+>
 > 1. Start a Python remote debugging session in PyCharm, say on port 5000.
 > 2. Add the following code at the point where you want execution to pause and connect to the debugger:
-> 
+>
 > ```
 > import pydevd_pycharm
 > pydevd_pycharm.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)
 > ```
-> 
-> Run your executable with `./pants run` as usual. 
-> 
+>
+> Run your executable with `./pants run` as usual.
+>
 > Note: The first time you do so you may see some extra dependency resolution work, as `pydevd-pycharm` has now been added to the binary's dependencies, via inference. If you have dependency inference turned off in your repo, you will have to manually add a temporary explicit dependency in your binary target on the `pydevd-pycharm` target.

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -6,12 +6,12 @@ hidden: false
 createdAt: "2020-03-16T16:19:56.071Z"
 updatedAt: "2022-05-12T05:33:10.060Z"
 ---
-Pants uses the popular [Pytest](https://docs.pytest.org/en/latest/) test runner to run Python tests. You may write your tests in Pytest-style, unittest-style, or mix and match both. 
+Pants uses the popular [Pytest](https://docs.pytest.org/en/latest/) test runner to run Python tests. You may write your tests in Pytest-style, unittest-style, or mix and match both.
 
 > 👍 Benefit of Pants: runs each file in parallel
-> 
+>
 > Each file gets run as a separate process, which gives you fine-grained caching and better parallelism. Given enough cores, Pants will be able to run all your tests at the same time.
-> 
+>
 > This also gives you fine-grained invalidation. If you run `./pants test ::`, and then you only change one file, then only tests that depended on that changed file will need to rerun.
 
 Examples
@@ -25,10 +25,10 @@ Examples
 ❯ ./pants test helloworld/util:
 
 # Run just the tests in this file.
-❯ ./pants test helloworld/util/lang_test.py  
+❯ ./pants test helloworld/util/lang_test.py
 
  # Run just one test.
-❯ ./pants test helloworld/util/lang_test.py -- -k test_language_translator 
+❯ ./pants test helloworld/util/lang_test.py -- -k test_language_translator
 ```
 
 Pytest version and plugins
@@ -57,15 +57,15 @@ pytest-django==3.10.0
 ```python helloworld/util/BUILD
 python_tests(
    name="tests",
-   # Normally, Pants infers dependencies based on imports. 
-   # Here, we don't actually import our plugin, though, so 
+   # Normally, Pants infers dependencies based on imports.
+   # Here, we don't actually import our plugin, though, so
    # we need to explicitly list it.
    dependencies=["//:pytest-django"],
 )
 ```
 
 > 🚧 Avoid the `pytest-xdist` plugin
-> 
+>
 > We do not recommend using this plugin because its concurrency conflicts with Pants' own parallelism. Using Pants will bring you similar benefits to `pytest-xdist` already: Pants will run each test target in parallel.
 
 Controlling output
@@ -81,17 +81,17 @@ output = "all"
 ```
 
 > 📘 Tip: Use Pytest options to make output more or less verbose
-> 
+>
 > See ["Passing arguments to Pytest"](doc:test#passing-arguments-to-pytest).
-> 
+>
 > For example:
-> 
+>
 > ```bash
 > ❯ ./pants test project/app_test.py -- -q
 > ```
-> 
+>
 > You may want to permanently set the Pytest option `--no-header` to avoid printing the Pytest version for each test run:
-> 
+>
 > ```toml
 > [pytest]
 > args = ["--no-header"]
@@ -114,15 +114,15 @@ args = ["-vv"]
 ```
 
 > 📘 Tip: some useful Pytest arguments
-> 
+>
 > See <https://docs.pytest.org/en/latest/usage.html> for more information.
-> 
+>
 > - `-k expression`: only run tests matching the expression.
 > - `-v`: verbose mode.
 > - `-s`: always print the stdout and stderr of your code, even if a test passes.
 
 > 🚧 How to use Pytest's `--pdb` option
-> 
+>
 > You must run `./pants test --debug` for this to work properly. See the section "Running tests interactively" for more information.
 
 Config files
@@ -133,7 +133,7 @@ Pants will automatically include any relevant config files in the process's sand
 `conftest.py`
 -------------
 
-Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files. 
+Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files.
 
 The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor ::`](doc:initial-configuration#5-generate-build-files) to automatically add this target:
 
@@ -152,7 +152,7 @@ Setting environment variables
 
 Test runs are _hermetic_, meaning that they are stripped of the parent `./pants` process's environment variables. This is important for reproducibility, and it also increases cache hits.
 
-To add any arbitrary environment variable back to the process, you can either add the environment variable to the specific tests with the `extra_env_vars` field on `python_test` / `python_tests` targets or to all your tests with the `[test].extra_env_vars` option. Generally, prefer the field `extra_env_vars` field so that more of your tests are hermetic. 
+To add any arbitrary environment variable back to the process, you can either add the environment variable to the specific tests with the `extra_env_vars` field on `python_test` / `python_tests` targets or to all your tests with the `[test].extra_env_vars` option. Generally, prefer the field `extra_env_vars` field so that more of your tests are hermetic.
 
 With both `[test].extra_env_vars` and the `extra_env_vars` field, you can either hardcode a value or leave off a value to "allowlist" it and read from the parent `./pants` process's environment.
 
@@ -163,7 +163,7 @@ extra_env_vars = ["VAR1", "VAR2=hardcoded_value"]
 ```python project/BUILD
 python_tests(
     name="tests",
-    # Adds to all generated `python_test` targets, 
+    # Adds to all generated `python_test` targets,
     # i.e. each file in the `sources` field.
     extra_env_vars=["VAR3", "VAR4=hardcoded"],
     # Even better, use `overrides` to be more granular.
@@ -182,7 +182,7 @@ To force your tests to run again, rather than reading from the cache, run `./pan
 Running tests interactively
 ---------------------------
 
-Because Pants runs multiple test targets in parallel, you will not see your test results appear on the screen until the test has completely finished. This means that you cannot use debuggers normally; the breakpoint will never show up on your screen and the test will hang indefinitely (or timeout, if timeouts are enabled). 
+Because Pants runs multiple test targets in parallel, you will not see your test results appear on the screen until the test has completely finished. This means that you cannot use debuggers normally; the breakpoint will never show up on your screen and the test will hang indefinitely (or timeout, if timeouts are enabled).
 
 Instead, if you want to run a test interactively—such as to use a debugger like `pdb`—run your tests with `./pants test --debug`. For example:
 
@@ -211,43 +211,52 @@ test_debug_example.py
 If you use multiple files with `test --debug`, they will run sequentially rather than in parallel.
 
 > 📘 Tip: using `ipdb` in tests
-> 
+>
 > [`ipdb`](https://github.com/gotcha/ipdb) integrates IPython with the normal `pdb` debugger for enhanced features like autocomplete and improved syntax highlighting. `ipdb` is very helpful when debugging tests.
-> 
+>
 > To be able to access `ipdb` when running tests, add this to your `pants.toml`:
-> 
+>
 > ```toml
 > [pytest]
 > extra_requirements.add = ["ipdb"]
 > ```
-> 
+>
 > Then, you can use `import ipdb; ipdb.set_trace()` in your tests.
-> 
-> To run the tests you will need to add `-- -s` to the test call since ipdb will need stdin and pytest will capture it. 
-> 
+>
+> To run the tests you will need to add `-- -s` to the test call since ipdb will need stdin and pytest will capture it.
+>
 > ```bash
 > ❯ ./pants test --debug  <target>   -- -s
 > ```
 
+> 📘 Tip: using the VS Code (or any [DAP](https://microsoft.github.io/debug-adapter-protocol/)-compliant editor) remote debugger in tests
+>
+>
+> 1. In your editor, set your breakpoints and any other debug settings (like break-on-exception).
+> 2. Run your test with `./pants test --debug-adapter`.
+> 3. Connect your editor to the server. The server host and port are logged by Pants when executing `test --debug-adaptor`. (They can also be configured using the `[debug-adapter]` subsystem).
+
+> Run your test with `./pants test --debug` as usual.
+
 > 📘 Tip: using the IntelliJ/PyCharm remote debugger in tests
-> 
+>
 > First, add this to your `pants.toml`:
-> 
+>
 > ```toml
 > [pytest]
 > extra_requirements.add = ["pydevd-pycharm==203.5419.8"]  # Or whatever version you choose.
 > ```
-> 
+>
 > Now, use the remote debugger as usual:
-> 
+>
 > 1. Start a Python remote debugging session in PyCharm, say on port 5000.
 > 2. Add the following code at the point where you want execution to pause and connect to the debugger:
-> 
+>
 > ```python
 > import pydevd_pycharm
 > pydevd_pycharm.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)
 > ```
-> 
+>
 > Run your test with `./pants test --debug` as usual.
 
 Timeouts
@@ -284,9 +293,9 @@ timeout_maximum = 600
 If a target sets its `timeout` higher than `[pytest].timeout_maximum`, Pants will use the value in `[pytest].timeout_maximum`.
 
 > 📘 Tip: temporarily ignoring timeouts
-> 
+>
 > When debugging locally, such as with `pdb`, you might want to temporarily disable timeouts. To do this, set `--no-pytest-timeouts`:
-> 
+>
 > ```bash
 > $ ./pants test project/app_test.py --no-pytest-timeouts
 > ```
@@ -296,18 +305,18 @@ Test utilities and resources
 
 ### Test utilities
 
-Use the target type `python_source` for test utilities, rather than `python_test`. 
+Use the target type `python_source` for test utilities, rather than `python_test`.
 
 To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor ::`](doc:initial-configuration#5-generate-build-files) to generate both these targets automatically.
 
 For example:
 
 ```python helloworld/BUILD
-# The default `sources` includes all files other than 
+# The default `sources` includes all files other than
 # `!*_test.py`, `!test_*.py`, and `tests.py`, and `conftest.py`.
 python_sources(name="lib")
 
-# We leave off the `dependencies` field because Pants will infer 
+# We leave off the `dependencies` field because Pants will infer
 # it based on import statements.
 python_tests(name="tests")
 ```
@@ -332,7 +341,7 @@ def test_app() -> None:
 
 Refer to [Assets](doc:assets) for how to include asset files in your tests by adding to the `dependencies` field.
 
-It's often most convenient to use  `file` / `files` and `relocated_files` targets in your test code, although you can also use `resource` / `resources` targets.  
+It's often most convenient to use  `file` / `files` and `relocated_files` targets in your test code, although you can also use `resource` / `resources` targets.
 
 Testing your packaging pipeline
 -------------------------------
@@ -386,27 +395,27 @@ use_coverage = true
 ```
 
 > 🚧 Failure to parse files?
-> 
+>
 > Coverage defaults to running with Python 3.6+ when generating a report, which means it may fail to parse Python 2 syntax and Python 3.8+ syntax. You can fix this by changing the interpreter constraints for running Coverage:
-> 
+>
 > ```toml
 > # pants.toml
 > [coverage-py]
 > interpreter_constraints = [">=3.8"]
 > ```
-> 
+>
 > However, if your repository has some Python 2-only code and some Python 3-only code, you will not be able to choose an interpreter that works with both versions. So, you will need to set up a `.coveragerc` config file and set `ignore_errors = True` under `[report]`, like this:
-> 
+>
 > ```
 > # .coveragerc
 > [report]
 > ignore_errors = True
 > ```
-> 
+>
 > `ignore_errors = True` means that those files will simply be left off of the final coverage report.
-> 
+>
 > (Pants should autodiscover the config file `.coveragerc`. See [coverage-py](https://www.pantsbuild.org/docs/reference-coverage-py#section-config-discovery).)
-> 
+>
 > There's a proposal for Pants to fix this by generating multiple reports when necessary: <https://github.com/pantsbuild/pants/issues/11137>. We'd appreciate your feedback.
 
 Coverage will report data on any files encountered during the tests. You can filter down the results by using the option `--coverage-py-filter` and passing the name(s) of modules you want coverage data for. Each module name is recursive, meaning submodules will be included. For example:
@@ -417,15 +426,15 @@ Coverage will report data on any files encountered during the tests. You can fil
 ```
 
 > 🚧 Coverage will not report on unencountered files
-> 
+>
 > Coverage will only report on files encountered during the tests' run. This means that your coverage score may be misleading; even with a score of 100%, you may have files without any tests. You can overcome this as follows:
-> 
+>
 > ```toml
 > # pants.toml
 > [coverage-py]
 > global_report = true
 > ```
-> 
+>
 > In this case, Coverage will report on [all files it considers importable](https://coverage.readthedocs.io/en/6.3.2/source.html), i.e. files at the root of the tree, or in directories with a `__init__.py` file, possibly omitting files in [implicit namespace packages](https://peps.python.org/pep-0420/) that lack `__init__.py` files. This is a shortcoming of Coverage itself.
 
 Pants will default to writing the results to the console, but you can also output in HTML, XML, JSON, or the raw SQLite file:

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -454,11 +454,11 @@ JUnit XML results
 
 Pytest can generate [JUnit XML result files](https://docs.pytest.org/en/6.2.x/usage.html#creating-junitxml-format-files). This allows you to hook up your results, for example, to dashboards.
 
-To save JUnit XML result files, set the option `[test].xml_dir`, like this:
+To save JUnit XML result files, set the option `[test].report`, like this:
 
 ```toml pants.toml
 [test]
-xml_dir = "dist/test_results"
+report = true
 ```
 
-You may also want to set the option `[pytest].junit_family` to change the format. Run `./pants help-advanced pytest` for more information.
+This will default to writing test reports to `dist/test/reports`. You may also want to set the option `[pytest].junit_family` to change the format. Run `./pants help-advanced pytest` for more information.

--- a/docs/markdown/Using Pants/restricted-internet-access.md
+++ b/docs/markdown/Using Pants/restricted-internet-access.md
@@ -24,7 +24,9 @@ You may want to check the binary into version control so that everyone in your o
 Setting up a Certificate Authority
 ----------------------------------
 
-You may need to configure Pants to use a custom Certificate Authority (CA) bundle: 
+By default, Pants will respect and pass through the `SSL_CERT_DIR` and `SSL_CERT_FILE` environment variables.
+
+If you need to override those values, you can configure Pants to use a custom Certificate Authority (CA) bundle:
 
 ```toml pants.toml
 [GLOBAL]

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -6,6 +6,17 @@ hidden: false
 createdAt: "2020-10-12T16:19:01.543Z"
 updatedAt: "2022-04-27T20:02:17.695Z"
 ---
+2.12
+----
+
+See <https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.12.x.md> for the changelog.
+
+### Unified formatters
+
+Formatters no longer need to be installed in both the `FmtRequest` and `LintTargetsRequest` `@unions`: instead, installing in the `FmtRequest` union is sufficient to act as both a linter and formatter.
+
+See [Add a formatter](doc:plugins-fmt-goal) for more information.
+
 2.11
 ----
 

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
@@ -61,8 +61,8 @@ class Shfmt(ExternalTool):
         return f"./shfmt_{self.version}_{plat_str}"
 ```
 
-2. Set up a `FieldSet` and `FmtRequest`/`LintTargetsRequest`
-------------------------------------------------------------
+2. Set up a `FieldSet` and `FmtRequest`
+---------------------------------------
 
 As described in [Rules and the Target API](doc:rules-api-and-target-api), a `FieldSet` is a way to tell Pants which `Field`s you care about targets having for your plugin to work.
 
@@ -84,18 +84,17 @@ class ShfmtFieldSet(FieldSet):
     sources: ShellSourceField
 ```
 
-Then, hook this up to a new subclass of both `LintTargetsRequest` and `FmtRequest`.
+Then, hook this up to a new subclass of `FmtRequest`.
 
 ```python
 from pants.core.goals.fmt import FmtRequest
-from pants.core.goals.lint import LintTargetsRequest
 
-class ShfmtRequest(FmtRequest, LintRequest):
+class ShfmtRequest(FmtRequest):
     field_set_type = ShfmtFieldSet
     name = "shfmt"
 ```
 
-Finally, register your new `LintTargetsRequest`/`FmtRequest` with two [`UnionRule`s](doc:rules-api-unions) so that Pants knows your formatter exists:
+Finally, register your new `FmtRequest` with a [`UnionRule`](doc:rules-api-unions) so that Pants knows your formatter exists:
 
 ```python
 from pants.engine.unions import UnionRule
@@ -106,45 +105,20 @@ def rules():
     return [
       	*collect_rules(),
         UnionRule(FmtRequest, ShfmtRequest),
-        UnionRule(LintTargetsRequest, ShfmtRequest),
     ]
 ```
 
-3. Create `fmt` and `lint` rules
---------------------------------
+3. Create `fmt` rules
+---------------------
 
-You will need rules for both `fmt` and `lint`. Both rules should take the `LintTargetsRequest`/`FmtRequest` from step 3  (e.g. `ShfmtRequest`) as a parameter. The `fmt` rule should return `FmtResult`, and the `lint` rule should return `LintResults`.
+You will need a rule for `fmt` which takes the `FmtRequest` from step 3  (e.g. `ShfmtRequest`) as a parameter and returns a `FmtResult`.
 
 ```python
-@rule(desc="Format with shfmt")
+@rule(desc="Format with shfmt", level=LogLevel.DEBUG)
 async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
-    ...
-    return FmtResult(..., formatter_name=request.name)
+    if shfmt.skip:
+        return FmtResult.skip(formatter_name=request.name)
 
-
-@rule(desc="Lint with shfmt")
-async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
-    ...
-    return LintResults([], linter_name=request.name)
-```
-
-The `fmt` and `lint` rules will be very similar, except that a) the `argv` to your `Process` will be different, b) for `lint`, you should use `await Get(FallibleProcessResult, Process)` so that you tolerate failures, whereas `fmt` should use `await Get(ProcessResult, Process)`. To avoid duplication between the `fmt` and `lint` rules, you should set up a helper `setup` rule, along with dataclasses for `SetupRequest` and `Setup`.
-
-```python
-@dataclass(frozen=True)
-class SetupRequest:
-    request: ShfmtRequest
-    check_only: bool
-
-
-@dataclass(frozen=True)
-class Setup:
-    process: Process
-    original_digest: Digest
-
-
-@rule(level=LogLevel.DEBUG)
-async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
     download_shfmt_get = Get(
         DownloadedExternalTool,
         ExternalToolRequest,
@@ -162,77 +136,41 @@ async def setup_shfmt(setup_request: SetupRequest, shfmt: Shfmt) -> Setup:
         ),
     )
 
-    source_files_get= Get(
-        SourceFiles,
-        SourceFilesRequest(
-            field_set.source for field_set in setup_request.request.field_sets
-        ),
-    )
-
-    downloaded_shfmt, source_files = await MultiGet(
-        download_shfmt_get, source_files_get
-    )
-
-    # If we were given an input digest from a previous formatter for the source files, then we
-    # should use that input digest instead of the one we read from the filesystem.
-    source_files_snapshot = (
-        source_files.snapshot
-        if setup_request.request.prior_formatter_result is None
-        else setup_request.request.prior_formatter_result
+    downloaded_shfmt, config_digest = await MultiGet(
+        download_shfmt_get, config_digest_get
     )
 
     input_digest = await Get(
         Digest,
         MergeDigests(
-            (source_files_snapshot.digest, downloaded_shfmt.digest)
+            (request.snapshot.digest, downloaded_shfmt.digest, config_digest)
         ),
     )
 
     argv = [
         downloaded_shfmt.exe,
-        "-d" if setup_request.check_only else "-w",
+        "-w",
         *shfmt.args,
-        *source_files_snapshot.files,
+        *request.snapshot.files,
     ]
     process = Process(
         argv=argv,
         input_digest=input_digest,
-        output_files=source_files_snapshot.files,
-        description=f"Run shfmt on {pluralize(len(setup_request.request.field_sets), 'file')}.",
+        output_files=request.snapshot.files,
+        description=f"Run shfmt on {pluralize(len(request.field_sets), 'file')}.",
         level=LogLevel.DEBUG,
     )
-    return Setup(process, original_digest=source_files_snapshot.digest)
 
-
-@rule(desc="Format with shfmt", level=LogLevel.DEBUG)
-async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
-    if shfm.skip:
-        return FmtResult.skip(formatter_name=request.name)
-    setup = await Get(Setup, SetupRequest(request, check_only=False))
-    result = await Get(ProcessResult, Process, setup.process)
-    return FmtResult.from_process_result(
-        result, original_digest=setup.original_digest, formatter_name=request.name
-    )
-
-
-@rule(desc="Lint with shfmt", level=LogLevel.DEBUG)
-async def shfmt_lint(request: ShfmtRequest, shfmt: Shfmt) -> LintResults:
-    if shfmt..skip:
-        return LintResults([], linter_name=request.name)
-    setup = await Get(Setup, SetupRequest(request, check_only=True))
-    result = await Get(FallibleProcessResult, Process, setup.process)
-    return LintResults(
-        [LintResult.from_fallible_process_result(result)], linter_name=request.name
-    )
+    result = await Get(ProcessResult, Process, process)
+    output_snapshot = await Get(Snapshot, result.output_digest)
+    return FmtResult.create(request, result, output_snapshot)
 ```
 
-The `FmtRequest`/`LintRequest` has a property called `.field_sets`, which stores a collection of the `FieldSet`s defined in step 2. Each `FieldSet` corresponds to a single target. Pants will have already validated that there is at least one valid `FieldSet`, so you can expect `ShfmtRequest.field_sets` to have 1-n `FieldSet` instances. 
+The `FmtRequest` has properties `.field_sets` and `.snapshot`, which store collections of the `FieldSet`s defined in step 2, and their sources. Each `FieldSet` corresponds to a single target. Pants will have already validated that there is at least one valid `FieldSet`, so you can expect `ShfmtRequest.field_sets` to have 1-n `FieldSet` instances.
 
 If you have a `--skip` option, you should check if it was used at the beginning of your `fmt` and `lint` rules and, if so, to early return an empty `LintResults()` and return `FmtResult.skip()`.
 
-Use `Get(SourceFiles, SourceFilesRequest)` to get all the sources you want to run your linter on. However, you should check if the `FmtRequest.prior_formatter_result` is set, and if so, use that value instead. This ensures that the result of any previous formatters is used, rather than the original source files. 
-
-If you used `ExternalTool` in step 1, you will use `Get(DownloadedExternalTool, ExternalToolRequest)` in the `setup` rule to install the tool.
+If you used `ExternalTool` in step 1, you will use `Get(DownloadedExternalTool, ExternalToolRequest)` to ensure that the tool is fetched.
 
 Use `Get(Digest, MergeDigests)` to combine the different inputs together, such as merging the source files and downloaded tool.
 

--- a/pants.toml
+++ b/pants.toml
@@ -211,6 +211,9 @@ scala_parser_dev = "src/python/pants/backend/scala/dependency_inference/scala_pa
 [scala]
 version_for_resolve = { "scala_parser_dev" = "2.13.8" }
 
+[scala-infer]
+force_add_siblings_as_dependencies = false
+
 [toolchain-setup]
 repo = "pants"
 org = "pantsbuild"

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import os.path
+from collections import namedtuple
 from textwrap import dedent
 from typing import Callable, ContextManager, cast
 
@@ -38,7 +39,10 @@ from pants.backend.docker.util_rules.docker_build_env import (
     DockerBuildEnvironmentRequest,
 )
 from pants.backend.docker.util_rules.docker_build_env import rules as build_env_rules
-from pants.backend.docker.value_interpolation import DockerInterpolationContext
+from pants.backend.docker.value_interpolation import (
+    DockerInterpolationContext,
+    DockerInterpolationError,
+)
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, EMPTY_FILE_DIGEST, EMPTY_SNAPSHOT, Snapshot
 from pants.engine.platform import Platform
@@ -245,7 +249,8 @@ def test_build_docker_image(rule_runner: RuleRunner) -> None:
     err1 = (
         r"Invalid value for the `repository` field of the `docker_image` target at "
         r"docker/test:err1: '{bad_template}'\.\n\nThe placeholder 'bad_template' is unknown\. "
-        r"Try with one of: build_args, directory, name, pants, parent_directory, tags\."
+        r"Try with one of: build_args, default_repository, directory, name, pants, "
+        r"parent_directory, tags, target_repository\."
     )
     with pytest.raises(DockerRepositoryNameError, match=err1):
         assert_build(
@@ -987,26 +992,62 @@ def test_parse_image_id_from_docker_build_output(expected: str, stdout: str, std
     assert expected == parse_image_id_from_docker_build_output(stdout.encode(), stderr.encode())
 
 
+ImageRefTest = namedtuple(
+    "ImageRefTest",
+    "docker_image, registries, default_repository, expect_refs, expect_error",
+    defaults=({}, {}, "{name}", (), None),
+)
+
+
 @pytest.mark.parametrize(
-    "raw_values, expect_raises, image_refs",
+    "test",
     [
-        (dict(name="lowercase"), no_exception(), ("lowercase:latest",)),
-        (dict(name="CamelCase"), no_exception(), ("camelcase:latest",)),
-        (dict(image_tags=["CamelCase"]), no_exception(), ("image:CamelCase",)),
-        (dict(registries=["REG1.example.net"]), no_exception(), ("REG1.example.net/image:latest",)),
+        ImageRefTest(docker_image=dict(name="lowercase"), expect_refs=("lowercase:latest",)),
+        ImageRefTest(docker_image=dict(name="CamelCase"), expect_refs=("camelcase:latest",)),
+        ImageRefTest(docker_image=dict(image_tags=["CamelCase"]), expect_refs=("image:CamelCase",)),
+        ImageRefTest(
+            docker_image=dict(registries=["REG1.example.net"]),
+            expect_refs=("REG1.example.net/image:latest",),
+        ),
+        ImageRefTest(
+            docker_image=dict(registries=["docker.io", "@private"], repository="our-the/pkg"),
+            registries=dict(private={"address": "our.registry", "repository": "the/pkg"}),
+            expect_refs=("docker.io/our-the/pkg:latest", "our.registry/the/pkg:latest"),
+        ),
+        ImageRefTest(
+            docker_image=dict(
+                registries=["docker.io", "@private"],
+                repository="{parent_directory}/{default_repository}",
+            ),
+            registries=dict(
+                private={"address": "our.registry", "repository": "{target_repository}/the/pkg"}
+            ),
+            expect_refs=("docker.io/test/image:latest", "our.registry/test/image/the/pkg:latest"),
+        ),
+        ImageRefTest(
+            docker_image=dict(repository="{default_repository}/a"),
+            default_repository="{target_repository}/b",
+            expect_error=pytest.raises(
+                DockerInterpolationError,
+                match=(
+                    r"Invalid value for the `repository` field of the `docker_image` target at "
+                    r"src/test/docker:image: '\{default_repository\}/a'\.\n\n"
+                    r"The formatted placeholders recurse too deep\.\n"
+                    r"'\{default_repository\}/a' => '\{target_repository\}/b/a' => "
+                    r"'\{default_repository\}/a/b/a'"
+                ),
+            ),
+        ),
     ],
 )
-def test_image_ref_formatting(
-    raw_values: dict, expect_raises: ContextManager, image_refs: tuple[str, ...]
-) -> None:
-    address = Address("test", target_name=raw_values.pop("name", "image"))
-    tgt = DockerImageTarget(raw_values, address)
+def test_image_ref_formatting(test: ImageRefTest) -> None:
+    address = Address("src/test/docker", target_name=test.docker_image.pop("name", "image"))
+    tgt = DockerImageTarget(test.docker_image, address)
     field_set = DockerFieldSet.create(tgt)
-    default_repository = "{name}"
-    registries = DockerRegistries.from_dict({})
+    registries = DockerRegistries.from_dict(test.registries)
     interpolation_context = DockerInterpolationContext.from_dict({})
-    with expect_raises:
+    with test.expect_error or no_exception():
         assert (
-            field_set.image_refs(default_repository, registries, interpolation_context)
-            == image_refs
+            field_set.image_refs(test.default_repository, registries, interpolation_context)
+            == test.expect_refs
         )

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -9,7 +9,7 @@ from pants.backend.docker.goals.package_image import BuiltDockerImage, DockerFie
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
@@ -26,6 +26,15 @@ async def docker_image_run_request(
     run = docker.run_image(tag, docker_run_args=options.run_args, env=env)
 
     return RunRequest(args=run.argv, digest=image.digest, extra_env=run.env)
+
+
+@rule
+async def docker_image_run_debug_adapter_request(
+    field_set: DockerFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a Docker image using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -31,6 +31,7 @@ class DockerRegistryOptions:
     default: bool = False
     skip_push: bool = False
     extra_image_tags: tuple[str, ...] = ()
+    repository: str | None = None
 
     @classmethod
     def from_dict(cls, alias: str, d: dict[str, Any]) -> DockerRegistryOptions:
@@ -42,6 +43,7 @@ class DockerRegistryOptions:
             extra_image_tags=tuple(
                 d.get("extra_image_tags", DockerRegistryOptions.extra_image_tags)
             ),
+            repository=Parser.to_value_type(d.get("repository"), str, None, None),
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -88,3 +88,11 @@ def test_extra_image_tags() -> None:
     reg1, reg2 = registries.get("@reg1", "@reg2")
     assert reg1.extra_image_tags == ()
     assert reg2.extra_image_tags == ("latest", "v{build_args.VERSION}")
+
+
+def test_repository() -> None:
+    registries = DockerRegistries.from_dict(
+        {"reg1": {"address": "registry1", "repository": "{name}/foo"}}
+    )
+    (reg1,) = registries.get("@reg1")
+    assert reg1.repository == "{name}/foo"

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -46,6 +46,7 @@ class DockerOptions(Subsystem):
                         "default": bool,
                         "extra_image_tags": [],
                         "skip_push": bool,
+                        "repository": str,
                     },
                     ...
                 }
@@ -67,6 +68,10 @@ class DockerOptions(Subsystem):
             `extra_image_tags` option. The tags may use value formatting the same as for the
             `image_tags` field of the `docker_image` target.
 
+            When a registry provides a `repository` value, it will be used instead of the
+            `docker_image.repository` or the default repository. Using the placeholders
+            `{target_repository}` or `{default_repository}` those overridden values may be
+            incorporated into the registry specific repository value.
             """
         ),
         fromfile=True,
@@ -80,7 +85,7 @@ class DockerOptions(Subsystem):
             The value is formatted and may reference these variables (in addition to the normal
             placeheolders derived from the Dockerfile and build args etc):
 
-            {bullet_list(["name", "directory", "parent_directory"])}
+            {bullet_list(["name", "directory", "parent_directory", "target_repository"])}
 
             Example: `--default-repository="{{directory}}/{{name}}"`.
 
@@ -89,6 +94,8 @@ class DockerOptions(Subsystem):
             target, and its parent directory respectively.
 
             Use the `repository` field to set this value directly on a `docker_image` target.
+
+            Registries may override the repository value for a specific registry.
 
             Any registries or tags are added to the image name as required, and should
             not be part of the repository name.

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -207,8 +207,10 @@ class DockerImageRepositoryField(StringField):
 
         {_interpolation_help.format(kind="repository")}
 
-        Additional placeholders for the repository field are: `name`, `directory` and
-        `parent_directory`.
+        Additional placeholders for the repository field are: `name`, `directory`,
+        `parent_directory`, and `default_repository`.
+
+        Registries may also configure the repository value for specific registries.
 
         See the documentation for `[docker].default_repository` for more information.
         """

--- a/src/python/pants/backend/go/goals/run_binary.py
+++ b/src/python/pants/backend/go/goals/run_binary.py
@@ -5,7 +5,7 @@ import os.path
 
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -17,6 +17,15 @@ async def create_go_binary_run_request(field_set: GoBinaryFieldSet) -> RunReques
     artifact_relpath = binary.artifacts[0].relpath
     assert artifact_relpath is not None
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact_relpath),))
+
+
+@rule
+async def go_binary_run_debug_adapter_request(
+    field_set: GoBinaryFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a Go binary using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -34,6 +34,7 @@ from pants.core.goals.test import (
     TestResult,
     TestSubsystem,
 )
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
@@ -405,6 +406,7 @@ async def debug_python_test(field_set: PythonTestFieldSet) -> TestDebugRequest:
 async def debugpy_python_test(
     field_set: PythonTestFieldSet,
     debugpy: DebugPy,
+    debug_adapter: DebugAdapterSubsystem,
     pytest: PyTest,
 ) -> TestDebugAdapterRequest:
     debugpy_pex = await Get(Pex, PexRequest, debugpy.to_pex_request())
@@ -426,7 +428,7 @@ async def debugpy_python_test(
             main=debugpy.main,
             prepend_argv=(
                 "--listen",
-                f"{debugpy.host}:{debugpy.port}",
+                f"{debug_adapter.host}:{debug_adapter.port}",
                 "--wait-for-client",
                 # @TODO: Techincally we should use `pytest.main`, however `debugpy` doesn't support
                 # launching an entry_point.

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+import unittest.mock
 from textwrap import dedent
 
 import pytest
@@ -610,7 +611,7 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
         "--listen",
         "127.0.0.1:5678",
         "--wait-for-client",
-        "-m",
-        "pytest",
+        "-c",
+        unittest.mock.ANY,
         "tests/python/pants_test/test_foo.py",
     )

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -1,9 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import os
 
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
+from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.target_types import (
     PexBinaryDefaults,
     ResolvedPexEntryPoint,
@@ -11,7 +13,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
-from pants.backend.python.util_rules.pex import Pex
+from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
@@ -21,12 +23,20 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+from pants.util.strutil import softwrap
+
+logger = logging.getLogger(__name__)
+
+
+def _in_chroot(relpath: str) -> str:
+    return os.path.join("{chroot}", relpath)
 
 
 @rule(level=LogLevel.DEBUG)
@@ -99,13 +109,12 @@ async def create_pex_binary_run_request(
     ]
     merged_digest = await Get(Digest, MergeDigests(input_digests))
 
-    def in_chroot(relpath: str) -> str:
-        return os.path.join("{chroot}", relpath)
-
     complete_pex_env = pex_env.in_workspace()
-    args = complete_pex_env.create_argv(in_chroot(pex.name), python=pex.python)
+    # NB. If this changes, please consider how it affects the `DebugRequest` below
+    # (which is not easy to write automated tests for)
+    args = complete_pex_env.create_argv(_in_chroot(pex.name), python=pex.python)
 
-    chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
+    chrooted_source_roots = [_in_chroot(sr) for sr in sources.source_roots]
     # The order here is important: we want the in-repo sources to take precedence over their
     # copies in the sandbox (see above for why those copies exist even in non-sandboxed mode).
     source_roots = [
@@ -114,11 +123,61 @@ async def create_pex_binary_run_request(
     ]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=pex.python is not None),
-        "PEX_PATH": in_chroot(local_dists.pex.name),
+        "PEX_PATH": _in_chroot(local_dists.pex.name),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(source_roots),
     }
 
     return RunRequest(digest=merged_digest, args=args, extra_env=extra_env)
+
+
+@rule
+async def run_pex_debug_adapter_binary(
+    field_set: PexBinaryFieldSet,
+    debugpy: DebugPy,
+    debug_adapter: DebugAdapterSubsystem,
+) -> RunDebugAdapterRequest:
+    if field_set.run_in_sandbox:
+        logger.warning(
+            softwrap(
+                f"""
+                Using `run --debug-adapter` on the target {field_set.address}, which sets the field
+                `run_in_sandbox` to `True`. This will likely cause your breakpoints to not be hit,
+                as your code will be run under the sandbox's path.
+                """
+            )
+        )
+
+    entry_point, regular_run_request, debugpy_pex = await MultiGet(
+        Get(
+            ResolvedPexEntryPoint,
+            ResolvePexEntryPointRequest(field_set.entry_point),
+        ),
+        Get(RunRequest, PexBinaryFieldSet, field_set),
+        Get(Pex, PexRequest, debugpy.to_pex_request()),
+    )
+
+    entry_point_or_script = entry_point.val or field_set.script.value
+    assert entry_point_or_script is not None
+    merged_digest = await Get(
+        Digest, MergeDigests([regular_run_request.digest, debugpy_pex.digest])
+    )
+    extra_env = dict(regular_run_request.extra_env)
+    extra_env["PEX_PATH"] = os.pathsep.join(
+        [
+            extra_env["PEX_PATH"],
+            # For debugpy to work properly, we need to have just one "environment" for our
+            # command to run in. Therefore, we cobble one together by exeucting debugpy's PEX, and
+            # shoehorning in the original PEX through PEX_PATH.
+            _in_chroot(os.path.basename(regular_run_request.args[1])),
+        ]
+    )
+    args = [
+        regular_run_request.args[0],  # python executable
+        _in_chroot(debugpy_pex.name),
+        *debugpy.get_args(debug_adapter, entry_point_or_script),
+    ]
+
+    return RunDebugAdapterRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 def rules():

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -23,7 +23,7 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -230,6 +230,15 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
     artifact = executable_binaries[0]
     assert artifact.relpath is not None
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact.relpath),))
+
+
+@rule
+async def run_pyoxidizer_debug_adapter_binary(
+    field_set: PyOxidizerFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a PyOxidizer binary using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -7,15 +7,18 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url
 
 
 class DebugPy(PythonToolBase):
     options_scope = "debugpy"
+    name = options_scope
     help = "An implementation of the Debug Adapter Protocol for Python (https://github.com/microsoft/debugpy)."
 
     default_version = "debugpy==1.6.0"
@@ -28,6 +31,37 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+
+    args = ArgsListOption(example="--log-to-stderr")
+
+    @staticmethod
+    def _get_main_spec_args(main: MainSpecification) -> tuple[str, ...]:
+        if isinstance(main, EntryPoint):
+            if main.function:
+                return ("-c", f"import {main.module};{main.module}.{main.function}();")
+            return ("-m", main.module)
+
+        assert isinstance(main, ConsoleScript)
+        # NB: This is only necessary while debugpy supports Py 3.7, as `importlib.metadata` was
+        # added in Py 3.8 and would allow us to resolve the console_script using just the stdlib.
+        return (
+            "-c",
+            (
+                "from pex.third_party.pkg_resources import working_set;"
+                + f"(next(working_set.iter_entry_points('console_scripts', '{main.name}')).resolve())()"
+            ),
+        )
+
+    def get_args(
+        self, debug_adapter: DebugAdapterSubsystem, main: MainSpecification
+    ) -> tuple[str, ...]:
+        return (
+            "--listen",
+            f"{debug_adapter.host}:{debug_adapter.port}",
+            "--wait-for-client",
+            *self.args,
+            *self._get_main_spec_args(main),
+        )
 
 
 class DebugPyLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -11,7 +11,6 @@ from pants.backend.python.target_types import EntryPoint
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import IntOption, StrOption
 from pants.util.docutil import git_url
 
 
@@ -29,15 +28,6 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-    host = StrOption(
-        "--host", default="127.0.0.1", help="The hostname to use when launching the debugpy server."
-    )
-    port = IntOption(
-        "--port",
-        default=5678,  # The canonical port
-        help="The port to use when launching the debugpy server.",
-    )
 
 
 class DebugPyLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/python/subsystems/ipython.lock
+++ b/src/python/pants/backend/python/subsystems/ipython.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "ipython==7.16.1"
+//     "ipython<8,>=7.34"
 //   ]
 // }
 // --- END PANTS LOCKFILE METADATA ---
@@ -27,19 +27,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442",
-              "url": "https://files.pythonhosted.org/packages/e4/fa/0c6c9786aa6927d12d100d322588e125e6ed466ab0a3d2d509ea18aeb56d/appnope-0.1.2-py2.py3-none-any.whl"
+              "hash": "265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e",
+              "url": "https://files.pythonhosted.org/packages/41/4a/381783f26df413dde4c70c734163d88ca0550a1361cb74a1c68f47550619/appnope-0.1.3-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a",
-              "url": "https://files.pythonhosted.org/packages/e9/bc/2d2c567fe5ac1924f35df879dbf529dd7e7cabd94745dc9d89024a934e76/appnope-0.1.2.tar.gz"
+              "hash": "02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
+              "url": "https://files.pythonhosted.org/packages/6a/cd/355842c0db33192ac0fc822e2dcae835669ef317fe56c795fb55fcddb26f/appnope-0.1.3.tar.gz"
             }
           ],
           "project_name": "appnope",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.1.2"
+          "version": "0.1.3"
         },
         {
           "artifacts": [
@@ -63,19 +63,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
-              "url": "https://files.pythonhosted.org/packages/44/98/5b86278fbbf250d239ae0ecb724f8572af1c91f4a11edf4d36a206189440/colorama-0.4.4-py2.py3-none-any.whl"
+              "hash": "854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+              "url": "https://files.pythonhosted.org/packages/77/8b/7550e87b2d308a1b711725dfaddc19c695f8c5fa413c640b2be01662f4e6/colorama-0.4.5-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-              "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz"
+              "hash": "e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4",
+              "url": "https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz"
             }
           ],
           "project_name": "colorama",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.4.4"
+          "version": "0.4.5"
         },
         {
           "artifacts": [
@@ -99,13 +99,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2dbcc8c27ca7d3cfe4fcdff7f45b27f9a8d3edfa70ff8024a71c7a8eb5f09d64",
-              "url": "https://files.pythonhosted.org/packages/23/6a/210816c943c9aeeb29e4e18a298f14bf0e118fe222a23e13bfcc2d41b0a4/ipython-7.16.1-py3-none-any.whl"
+              "hash": "c175d2440a1caff76116eb719d40538fbb316e214eda85c5515c303aacbfb23e",
+              "url": "https://files.pythonhosted.org/packages/7c/6a/1f1365f4bf9fcb349fcaa5b61edfcefa721aa13ff37c5631296b12fab8e5/ipython-7.34.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f4fcb31d3b2c533333893b9172264e4821c1ac91839500f31bd43f2c59b3ccf",
-              "url": "https://files.pythonhosted.org/packages/88/91/666a7fa24bab1396537fcd8e2b287a2d773605ad16020af81036c8c1438c/ipython-7.16.1.tar.gz"
+              "hash": "af3bdb46aa292bce5615b1b2ebc76c2080c5f77f54bda2ec72461317273e7cd6",
+              "url": "https://files.pythonhosted.org/packages/db/6c/3fcf0b8ee46656796099ac4b7b72497af5f090da3e43fd305f2a24c73915/ipython-7.34.0.tar.gz"
             }
           ],
           "project_name": "ipython",
@@ -123,7 +123,8 @@
             "ipyparallel; extra == \"parallel\"",
             "ipywidgets; extra == \"all\"",
             "ipywidgets; extra == \"notebook\"",
-            "jedi>=0.10",
+            "jedi>=0.16",
+            "matplotlib-inline",
             "nbconvert; extra == \"all\"",
             "nbconvert; extra == \"nbconvert\"",
             "nbformat; extra == \"all\"",
@@ -133,9 +134,9 @@
             "nose>=0.10.1; extra == \"test\"",
             "notebook; extra == \"all\"",
             "notebook; extra == \"notebook\"",
-            "numpy>=1.14; extra == \"all\"",
-            "numpy>=1.14; extra == \"test\"",
-            "pexpect; sys_platform != \"win32\"",
+            "numpy>=1.17; extra == \"all\"",
+            "numpy>=1.17; extra == \"test\"",
+            "pexpect>4.3; sys_platform != \"win32\"",
             "pickleshare",
             "prompt-toolkit!=3.0.0,!=3.0.1,<3.1.0,>=2.0.0",
             "pygments",
@@ -150,8 +151,8 @@
             "testpath; extra == \"test\"",
             "traitlets>=4.2"
           ],
-          "requires_python": ">=3.6",
-          "version": "7.16.1"
+          "requires_python": ">=3.7",
+          "version": "7.34"
         },
         {
           "artifacts": [
@@ -178,6 +179,26 @@
           ],
           "requires_python": ">=3.6",
           "version": "0.18.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c",
+              "url": "https://files.pythonhosted.org/packages/a6/2d/2230afd570c70074e80fd06857ba2bdc5f10c055bd9125665fe276fadb67/matplotlib_inline-0.1.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee",
+              "url": "https://files.pythonhosted.org/packages/0f/98/838f4c57f7b2679eec038ad0abefd1acaeec35e635d4d7af215acd7d1bd2/matplotlib-inline-0.1.3.tar.gz"
+            }
+          ],
+          "project_name": "matplotlib-inline",
+          "requires_dists": [
+            "traitlets"
+          ],
+          "requires_python": ">=3.5",
+          "version": "0.1.3"
         },
         {
           "artifacts": [
@@ -246,13 +267,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c",
-              "url": "https://files.pythonhosted.org/packages/00/e4/beb2fad0bec554a011b321d0f6b99981f9171c0b05d03a6948e45ac8a5be/prompt_toolkit-3.0.28-py3-none-any.whl"
+              "hash": "62291dad495e665fca0bda814e342c69952086afb0f4094d0893d357e5c78752",
+              "url": "https://files.pythonhosted.org/packages/3f/2d/dcb44d69f388ca2ee1a4a4d3c204ab66b36975c0d5166781eaeeff76b882/prompt_toolkit-3.0.29-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650",
-              "url": "https://files.pythonhosted.org/packages/37/34/c34c376882305c5051ed7f086daf07e68563d284015839bfb74d6e61d402/prompt_toolkit-3.0.28.tar.gz"
+              "hash": "bd640f60e8cecd74f0dc249713d433ace2ddc62b65ee07f96d358e0b152b6ea7",
+              "url": "https://files.pythonhosted.org/packages/59/68/4d80f22e889ea34f20483ae3d4ca3f8d15f15264bcfb75e52b90fb5aefa5/prompt_toolkit-3.0.29.tar.gz"
             }
           ],
           "project_name": "prompt-toolkit",
@@ -260,7 +281,7 @@
             "wcwidth"
           ],
           "requires_python": ">=3.6.2",
-          "version": "3.0.28"
+          "version": "3.0.29"
         },
         {
           "artifacts": [
@@ -284,31 +305,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65",
-              "url": "https://files.pythonhosted.org/packages/1d/17/ed4d2df187995561b28f1073df24137cb750e12f9879d291cc8ab67c65d2/Pygments-2.11.2-py3-none-any.whl"
+              "hash": "dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519",
+              "url": "https://files.pythonhosted.org/packages/5c/8e/1d9017950034297fffa336c72e693a5b51bbf85141b24a763882cf1977b5/Pygments-2.12.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a",
-              "url": "https://files.pythonhosted.org/packages/94/9c/cb656d06950268155f46d4f6ce25d7ffc51a0da47eadf1b164bbf23b718b/Pygments-2.11.2.tar.gz"
+              "hash": "5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+              "url": "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz"
             }
           ],
           "project_name": "pygments",
           "requires_dists": [],
-          "requires_python": ">=3.5",
-          "version": "2.11.2"
+          "requires_python": ">=3.6",
+          "version": "2.12"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "782ef48d58982ddb49920c11a0c5c9c0b02e7d7d1c2ad0aa44e1a1e133051c96",
-              "url": "https://files.pythonhosted.org/packages/7c/5b/3d92b9f0f7ca1645cba48c080b54fe7d8b1033a4e5720091d1631c4266db/setuptools-60.10.0-py3-none-any.whl"
+              "hash": "c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178",
+              "url": "https://files.pythonhosted.org/packages/e9/86/b2ede1d87122a6d4da86d84cc35d0e48b4aa2476e4281d06101c772c1961/setuptools-62.6.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6599055eeb23bfef457d5605d33a4d68804266e6cb430b0fb12417c5efeae36c",
-              "url": "https://files.pythonhosted.org/packages/af/e8/894c71e914dfbe01276a42dfad40025cd96119f2eefc39c554b6e8b9df86/setuptools-60.10.0.tar.gz"
+              "hash": "990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741",
+              "url": "https://files.pythonhosted.org/packages/dc/73/88920663229023b724a854d1ab7e3e50a1a28b63eeec399a604ba30f9242/setuptools-62.6.0.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -319,6 +340,7 @@
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
             "furo; extra == \"docs\"",
+            "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing-integration\"",
             "jaraco.packaging>=9; extra == \"docs\"",
@@ -344,8 +366,10 @@
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-reredirects; extra == \"docs\"",
             "sphinx; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
+            "tomli-w>=1.0.0; extra == \"testing\"",
             "tomli; extra == \"testing-integration\"",
             "virtualenv>=13.0.0; extra == \"testing\"",
             "virtualenv>=13.0.0; extra == \"testing-integration\"",
@@ -353,27 +377,28 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "60.10"
+          "version": "62.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033",
-              "url": "https://files.pythonhosted.org/packages/37/46/be8a3c030bd3673f4800fa7f46eda972dfa2990089a51ec5dd0a26ed33e9/traitlets-5.1.1-py3-none-any.whl"
+              "hash": "65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a",
+              "url": "https://files.pythonhosted.org/packages/83/a9/1059771062cb80901c34a4dea020e76269412e69300b4ba12e3356865ad8/traitlets-5.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7",
-              "url": "https://files.pythonhosted.org/packages/db/cf/e6cbf07ce2d21a17c8379f3f2f12db413a38da5ee20809638226b1490e48/traitlets-5.1.1.tar.gz"
+              "hash": "0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2",
+              "url": "https://files.pythonhosted.org/packages/b2/ed/3c842dbe5a8f0f1ebf3f5b74fc1a46601ed2dfe0a2d256c8488d387b14dd/traitlets-5.3.0.tar.gz"
             }
           ],
           "project_name": "traitlets",
           "requires_dists": [
+            "pre-commit; extra == \"test\"",
             "pytest; extra == \"test\""
           ],
           "requires_python": ">=3.7",
-          "version": "5.1.1"
+          "version": "5.3"
         },
         {
           "artifacts": [
@@ -397,16 +422,17 @@
         }
       ],
       "platform_tag": [
-        "cp39",
-        "cp39",
+        "cp310",
+        "cp310",
         "macosx_11_0_arm64"
       ]
     }
   ],
-  "pex_version": "2.1.72",
+  "path_mappings": {},
+  "pex_version": "2.1.90",
   "prefer_older_binary": false,
   "requirements": [
-    "ipython==7.16.1"
+    "ipython<8,>=7.34"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -25,7 +25,7 @@ class IPython(PythonToolBase):
     options_scope = "ipython"
     help = "The IPython enhanced REPL (https://ipython.org/)."
 
-    default_version = "ipython==7.16.1"  # The last version to support Python 3.6.
+    default_version = "ipython>=7.34,<8"  # ipython 8 does not support Python 3.7.
     default_main = ConsoleScript("ipython")
 
     register_lockfile = True

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -39,8 +39,7 @@ case class ProvidedSymbol(sawClass: Boolean, sawTrait: Boolean, sawObject: Boole
 
 class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
-  var skipProvidedNames = false
-  var visitInitArgs = false
+  var skipProvidedNames = false  
 
   val providedSymbolsByScope = HashMap[String, HashMap[String, ProvidedSymbol]]()
   val importsByScope = HashMap[String, ArrayBuffer[AnImport]]()
@@ -193,11 +192,8 @@ class SourceAnalysisTraverser extends Traverser {
 
   def visitMods(mods: List[Mod]): Unit = {
     mods.foreach({
-      case Mod.Annot(init) =>
-        val currentVisitInitArgs = visitInitArgs
-        visitInitArgs = true
-        apply(init) // rely on `Init` extraction in main parsing match code
-        visitInitArgs = currentVisitInitArgs
+      case Mod.Annot(init) =>        
+        apply(init) // rely on `Init` extraction in main parsing match code        
       case _               => ()
     })
   }
@@ -337,10 +333,8 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Init(tpe, _name, argss) => {
-      extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
-
-      if (visitInitArgs)
-        argss.foreach(_.foreach(apply))
+      extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))      
+      argss.foreach(_.foreach(apply))
     }
 
     case Term.Param(mods, _name, decltpe, _default) => {

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -25,14 +25,17 @@ case class AnImport(
 )
 
 case class Analysis(
-    providedSymbols: Vector[String],
-    providedSymbolsEncoded: Vector[String],
+    providedSymbols: Vector[Analysis.ProvidedSymbol],
+    providedSymbolsEncoded: Vector[Analysis.ProvidedSymbol],
     importsByScope: HashMap[String, ArrayBuffer[AnImport]],
     consumedSymbolsByScope: HashMap[String, HashSet[String]],
     scopes: Vector[String]
 )
+object Analysis {
+  case class ProvidedSymbol(name: String, recursive: Boolean)
+}
 
-case class ProvidedSymbol(sawClass: Boolean, sawTrait: Boolean, sawObject: Boolean)
+case class ProvidedSymbol(sawClass: Boolean, sawTrait: Boolean, sawObject: Boolean, recursive: Boolean)
 
 class SourceAnalysisTraverser extends Traverser {
   val nameParts = ArrayBuffer[String]()
@@ -112,7 +115,8 @@ class SourceAnalysisTraverser extends Traverser {
       symbolName: String,
       sawClass: Boolean = false,
       sawTrait: Boolean = false,
-      sawObject: Boolean = false
+      sawObject: Boolean = false,
+      recursive: Boolean = false
   ): Unit = {
     if (!skipProvidedNames) {
       val fullPackageName = nameParts.mkString(".")
@@ -126,14 +130,16 @@ class SourceAnalysisTraverser extends Traverser {
         val newSymbol = ProvidedSymbol(
           sawClass = existingSymbol.sawClass || sawClass,
           sawTrait = existingSymbol.sawTrait || sawTrait,
-          sawObject = existingSymbol.sawObject || sawObject
+          sawObject = existingSymbol.sawObject || sawObject,
+          recursive = existingSymbol.recursive || recursive
         )
         providedSymbols(symbolName) = newSymbol
       } else {
         providedSymbols(symbolName) = ProvidedSymbol(
           sawClass = sawClass,
           sawTrait = sawTrait,
-          sawObject = sawObject
+          sawObject = sawObject,
+          recursive = recursive
         )
       }
     }
@@ -230,8 +236,18 @@ class SourceAnalysisTraverser extends Traverser {
     case Defn.Object(mods, nameNode, templ) => {
       visitMods(mods)
       val name = extractName(nameNode)
-      recordProvidedName(name, sawObject = true)
-      visitTemplate(templ, name)
+
+      // TODO: should object already be recursive?
+      // an object is recursive if extends another type because we cannot figure out the provided types
+      // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
+      val recursive = !templ.inits.isEmpty
+      recordProvidedName(name, sawObject = true, recursive = recursive)
+      
+      // If the object is recursive, no need to provide the symbols inside
+      if (recursive)
+        withSuppressProvidedNames(() => visitTemplate(templ, name))
+      else
+        visitTemplate(templ, name)
     }
 
     case Defn.Type(mods, nameNode, _tparams, body) => {
@@ -363,30 +379,30 @@ class SourceAnalysisTraverser extends Traverser {
     case node => super.apply(node)
   }
 
-  def gatherProvidedSymbols(): Vector[String] = {
+  def gatherProvidedSymbols(): Vector[Analysis.ProvidedSymbol] = {
     providedSymbolsByScope
       .flatMap({ case (scopeName, symbolsForScope) =>
-        symbolsForScope.keys.map(symbolName => s"${scopeName}.${symbolName}").toVector
+        symbolsForScope.map { case(symbolName, symbol) => Analysis.ProvidedSymbol(s"${scopeName}.${symbolName}", symbol.recursive)}.toVector
       })
       .toVector
   }
 
-  def gatherEncodedProvidedSymbols(): Vector[String] = {
+  def gatherEncodedProvidedSymbols(): Vector[Analysis.ProvidedSymbol] = {
     providedSymbolsByScope
       .flatMap({ case (scopeName, symbolsForScope) =>
         val encodedSymbolsForScope = symbolsForScope.flatMap({
           case (symbolName, symbol) => {
             val encodedSymbolName = NameTransformer.encode(symbolName)
-            val result = ArrayBuffer[String](encodedSymbolName)
+            val result = ArrayBuffer[Analysis.ProvidedSymbol](Analysis.ProvidedSymbol(encodedSymbolName, symbol.recursive))
             if (symbol.sawObject) {
-              result.append(encodedSymbolName + "$")
-              result.append(encodedSymbolName + "$.MODULE$")
+              result.append(Analysis.ProvidedSymbol(encodedSymbolName + "$", symbol.recursive))
+              result.append(Analysis.ProvidedSymbol(encodedSymbolName + "$.MODULE$", symbol.recursive))
             }
             result.toVector
           }
         })
 
-        encodedSymbolsForScope.map(symbolName => s"${scopeName}.${symbolName}")
+        encodedSymbolsForScope.map(symbol => symbol.copy(name = s"${scopeName}.${symbol.name}"))
       })
       .toVector
   }

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -282,6 +282,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
                     "ABaseClass",
                     "ATrait1",
                     "SomeTypeInPrimaryConstructor",
+                    "foo",
                     "ATrait2.Nested",
                     "BaseWithConstructor",
                 ]
@@ -552,4 +553,27 @@ def test_recursive_objects(rule_runner: RuleRunner) -> None:
         ScalaProvidedSymbol("foo.Bar", False),
         ScalaProvidedSymbol("foo.Bar.a", False),
         ScalaProvidedSymbol("foo.Foo", True),
+    ]
+
+
+def test_object_extends_ctor(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            import example._
+
+            object Foo extends Bar(hello) {
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == [
+        "example.Bar",
+        "example.hello",
+        "foo.Bar",
+        "foo.hello",
     ]

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -9,6 +9,7 @@ from pants.backend.scala.dependency_inference import scala_parser
 from pants.backend.scala.dependency_inference.scala_parser import (
     AnalyzeScalaSourceRequest,
     ScalaImport,
+    ScalaProvidedSymbol,
     ScalaSourceDependencyAnalysis,
 )
 from pants.backend.scala.target_types import ScalaSourceField, ScalaSourceTarget
@@ -145,7 +146,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         ),
     )
 
-    assert sorted(analysis.provided_symbols) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -179,7 +180,7 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
         "org.pantsbuild.example.OuterTrait.NestedVar",
     ]
 
-    assert sorted(analysis.provided_symbols_encoded) == [
+    assert sorted(symbol.name for symbol in analysis.provided_symbols_encoded) == [
         "org.pantsbuild.example.ASubClass",
         "org.pantsbuild.example.ASubTrait",
         "org.pantsbuild.example.ApplyQualifier",
@@ -441,7 +442,10 @@ def test_package_object(rule_runner: RuleRunner) -> None:
             """
         ),
     )
-    assert sorted(analysis.provided_symbols) == ["foo.bar", "foo.bar.Hello"]
+    assert sorted(symbol.name for symbol in analysis.provided_symbols) == [
+        "foo.bar",
+        "foo.bar.Hello",
+    ]
 
 
 def test_source3(rule_runner: RuleRunner) -> None:
@@ -523,4 +527,29 @@ def test_type_arguments(rule_runner: RuleRunner) -> None:
         "foo.AnotherType",
         "foo.B",
         "foo.SomeType",
+    ]
+
+
+def test_recursive_objects(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            object Bar {
+                def a = ???
+            }
+
+            object Foo extends Bar {
+                def b = ???
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.provided_symbols, key=lambda s: s.name) == [
+        ScalaProvidedSymbol("foo.Bar", False),
+        ScalaProvidedSymbol("foo.Bar.a", False),
+        ScalaProvidedSymbol("foo.Foo", True),
     ]

--- a/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
+++ b/src/python/pants/backend/scala/dependency_inference/symbol_mapper.py
@@ -73,9 +73,21 @@ async def map_first_party_scala_targets_to_symbols(
     for (address, resolve), analysis in address_and_analysis:
         namespace = _symbol_namespace(address)
         for symbol in analysis.provided_symbols:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
         for symbol in analysis.provided_symbols_encoded:
-            mapping[resolve].insert(symbol, [address], first_party=True, namespace=namespace)
+            mapping[resolve].insert(
+                symbol.name,
+                [address],
+                first_party=True,
+                namespace=namespace,
+                recursive=symbol.recursive,
+            )
 
     return SymbolMap((resolve, node.frozen()) for resolve, node in mapping.items())
 

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -23,7 +23,7 @@ from pants.backend.shell.target_types import (
     ShellCommandToolsField,
 )
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import (
@@ -245,6 +245,15 @@ async def run_shell_command_request(shell_command: RunShellCommand) -> RunReques
         digest=process.input_digest,
         args=process.argv,
         extra_env=process.env,
+    )
+
+
+@rule
+async def run_shell_debug_adapter_binary(
+    field_set: RunShellCommand,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a shell command using a debug adapter has not yet been implemented."
     )
 
 

--- a/src/python/pants/bsp/testutil.py
+++ b/src/python/pants/bsp/testutil.py
@@ -16,7 +16,7 @@ from pylsp_jsonrpc.streams import JsonRpcStreamReader, JsonRpcStreamWriter  # ty
 from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPConnection
 from pants.bsp.rules import rules as bsp_rules
-from pants.engine.internals import native_engine
+from pants.engine.internals.native_engine import PyThreadLocals
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -93,7 +93,7 @@ def setup_bsp_server(
 ):
     rule_runner = rule_runner or RuleRunner(rules=bsp_rules())
     notification_names = notification_names or set()
-    stdio_destination = native_engine.stdio_thread_get_destination()
+    thread_locals = PyThreadLocals.get_for_current_thread()
 
     with setup_pipes() as pipes:
         context = BSPContext()
@@ -107,7 +107,7 @@ def setup_bsp_server(
         )
 
         def run_bsp_server():
-            native_engine.stdio_thread_set_destination(stdio_destination)
+            thread_locals.set_for_current_thread()
             conn.run()
 
         bsp_thread = Thread(target=run_bsp_server)

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -8,7 +8,15 @@ from typing import cast
 import pytest
 
 from pants.base.build_root import BuildRoot
-from pants.core.goals.run import Run, RunFieldSet, RunRequest, RunSubsystem, run
+from pants.core.goals.run import (
+    Run,
+    RunDebugAdapterRequest,
+    RunFieldSet,
+    RunRequest,
+    RunSubsystem,
+    run,
+)
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -43,6 +51,12 @@ def create_mock_run_request(rule_runner: RuleRunner, program_text: bytes) -> Run
     return RunRequest(digest=digest, args=(os.path.join("{chroot}", "program.py"),))
 
 
+def create_mock_run_debug_adapter_request(
+    rule_runner: RuleRunner, program_text: bytes
+) -> RunDebugAdapterRequest:
+    return cast(RunDebugAdapterRequest, create_mock_run_request(rule_runner, program_text))
+
+
 def single_target_run(
     rule_runner: RuleRunner,
     address: Address,
@@ -65,7 +79,12 @@ def single_target_run(
         res = run_rule_with_mocks(
             run,
             rule_args=[
-                create_goal_subsystem(RunSubsystem, args=[], cleanup=True),
+                create_goal_subsystem(RunSubsystem, args=[], cleanup=True, debug_adapter=False),
+                create_subsystem(
+                    DebugAdapterSubsystem,
+                    host="127.0.0.1",
+                    port="5678",
+                ),
                 create_subsystem(
                     GlobalOptions, pants_workdir=rule_runner.pants_workdir, process_cleanup=True
                 ),
@@ -88,6 +107,11 @@ def single_target_run(
                     output_type=RunRequest,
                     input_type=TestRunFieldSet,
                     mock=lambda _: create_mock_run_request(rule_runner, program_text),
+                ),
+                MockGet(
+                    output_type=RunDebugAdapterRequest,
+                    input_type=TestRunFieldSet,
+                    mock=lambda _: create_mock_run_debug_adapter_request(rule_runner, program_text),
                 ),
                 MockEffect(
                     output_type=InteractiveProcessResult,

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -606,13 +606,14 @@ def specs_to_dirs(specs: RawSpecs) -> tuple[str, ...]:
                 recursively on. You specified {', '.join(str(spec) for spec in other_specs)}
 
                 To fix, either set `use_deprecated_cli_args_semantics` to false, or rerun with
-                specifying only literal directories, e.g. `tailor dir1 dir2`. If changing
-                `use_deprecated_cli_args_semantics` to false, you should specify which directories
-                to run on when using `tailor`:
+                specifying only literal directories, e.g. `{bin_name()} tailor dir1 dir2`. If
+                changing `use_deprecated_cli_args_semantics` to false, you should specify which
+                directories to run on when using `tailor`:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
+                  * `{bin_name()} tailor ::` to run on everything
+                  * `{bin_name()} tailor dir::` to run on `dir` and subdirs
+                  * `{bin_name()} tailor dir` to run on `dir`
+                  * `{bin_name()} --changed-since=HEAD tailor` to only run on changed and new files
                 """
             )
         )
@@ -651,9 +652,10 @@ async def tailor(
 
                 In Pants 2.14, you must use CLI arguments. Use:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
+                  * `{bin_name()} tailor ::` to run on everything
+                  * `{bin_name()} tailor dir::` to run on `dir` and subdirs
+                  * `{bin_name()} tailor dir` to run on `dir`
+                  * `{bin_name()} --changed-since=HEAD tailor` to only run on changed and new files
                 """
             ),
         )

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -319,6 +319,7 @@ class TestSubsystem(GoalSubsystem):
             """
         ),
     )
+    # See also `run.py`'s same option
     debug_adapter = BoolOption(
         "--debug-adapter",
         default=False,

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -34,6 +34,7 @@ from pants.core.goals.test import (
     build_runtime_package_dependencies,
     run_tests,
 )
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.addresses import Address
 from pants.engine.console import Console
@@ -55,7 +56,7 @@ from pants.engine.target import (
     TargetRootsToFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership
-from pants.testutil.option_util import create_goal_subsystem
+from pants.testutil.option_util import create_goal_subsystem, create_subsystem
 from pants.testutil.rule_runner import (
     MockEffect,
     MockGet,
@@ -167,6 +168,11 @@ def run_test_rule(
         extra_env_vars=[],
         shard="",
     )
+    debug_adapter_subsystem = create_subsystem(
+        DebugAdapterSubsystem,
+        host="127.0.0.1",
+        port="5678",
+    )
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
     union_membership = UnionMembership(
         {
@@ -207,6 +213,7 @@ def run_test_rule(
             rule_args=[
                 console,
                 test_subsystem,
+                debug_adapter_subsystem,
                 workspace,
                 union_membership,
                 DistDir(relpath=Path("dist")),

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -210,10 +210,11 @@ async def update_build_files(
 
                 In Pants 2.14, you must use CLI arguments. Use:
 
-                  * `::` to run on everything
-                  * `dir::` to run on `dir` and subdirs
-                  * `dir` to run on `dir`
-                  * `dir/BUILD` to run on that single BUILD file
+                  * `{bin_name()} update-build-files ::` to run on everything
+                  * `{bin_name()} update-build-files dir::` to run on `dir` and subdirs
+                  * `{bin_name()} update-build-files dir` to run on `dir`
+                  * `{bin_name()} update-build-files dir/BUILD` to run on that single BUILD file
+                  * `{bin_name()} --changed-since=HEAD update-build-files` to run only on changed BUILD files
                 """
             ),
         )

--- a/src/python/pants/core/subsystems/debug_adapter.py
+++ b/src/python/pants/core/subsystems/debug_adapter.py
@@ -1,0 +1,28 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import IntOption, StrOption
+from pants.option.subsystem import Subsystem
+from pants.util.strutil import softwrap
+
+
+class DebugAdapterSubsystem(Subsystem):
+    options_scope = "debug-adapter"
+    help = softwrap(
+        """
+        Options used to configure and launch a Debug Adapter server.
+
+        See https://microsoft.github.io/debug-adapter-protocol/ for more information.
+        """
+    )
+
+    host = StrOption(
+        "--host", default="127.0.0.1", help="The hostname to use when launching the server."
+    )
+    port = IntOption(
+        "--port",
+        default=5678,
+        help="The port to use when launching the server.",
+    )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1251,6 +1251,16 @@ async def resolve_unparsed_address_inputs(
         return Addresses(valid_addresses)
 
     addresses = await MultiGet(Get(Address, AddressInput, ai) for ai in address_inputs)
+    # Validate that the addresses exist. We do this eagerly here because
+    # `Addresses -> UnexpandedTargets` does not preserve the `description_of_origin`, so it would
+    # be too late, per https://github.com/pantsbuild/pants/issues/15858.
+    await MultiGet(
+        Get(
+            WrappedTarget,
+            WrappedTargetRequest(addr, description_of_origin=request.description_of_origin),
+        )
+        for addr in addresses
+    )
     return Addresses(addresses)
 
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1936,7 +1936,7 @@ def test_resolve_unparsed_address_inputs() -> None:
                     UnparsedAddressInputs(
                         addresses,
                         owning_address=Address("project", target_name="t3"),
-                        description_of_origin="tests",
+                        description_of_origin="from my tests",
                         skip_invalid_addresses=skip_invalid_addresses,
                     )
                 ],
@@ -1948,5 +1948,5 @@ def test_resolve_unparsed_address_inputs() -> None:
 
     invalid_addresses = ["project:t1", "bad::", "project/fake.txt:tgt"]
     assert resolve(invalid_addresses, skip_invalid_addresses=True) == {t1}
-    with engine_error(AddressParseException):
+    with engine_error(AddressParseException, contains="from my tests"):
         resolve(invalid_addresses)

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -386,5 +386,10 @@ class PyTypes:
 class PyStdioDestination:
     pass
 
+class PyThreadLocals:
+    @classmethod
+    def get_for_current_thread(cls) -> PyThreadLocals: ...
+    def set_for_current_thread(self) -> None: ...
+
 class PollTimeout(Exception):
     pass

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Iterable, Sequence, Tuple
 from pants.base.specs import Specs
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Digest, DigestContents, FileDigest, Snapshot
-from pants.engine.internals import native_engine
+from pants.engine.internals.native_engine import PyThreadLocals
 from pants.engine.internals.scheduler import SchedulerSession, Workunit
 from pants.engine.internals.selectors import Params
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, rule
@@ -28,6 +28,24 @@ logger = logging.getLogger(__name__)
 # -----------------------------------------------------------------------------------------------
 # Streaming workunits plugin API
 # -----------------------------------------------------------------------------------------------
+
+
+def thread_locals_get_for_current_thread() -> PyThreadLocals:
+    """Gets the engine's thread local state for the current thread.
+
+    In order to safely use StreamingWorkunitContext methods from additional threads,
+    StreamingWorkunit plugins should propagate thread local state from the threads that they are
+    initialized on to any additional threads that they spawn.
+    """
+    return PyThreadLocals.get_for_current_thread()
+
+
+def thread_locals_set_for_current_thread(thread_locals: PyThreadLocals) -> None:
+    """Sets the engine's thread local state for the current thread.
+
+    See `thread_locals_get`.
+    """
+    thread_locals.set_for_current_thread()
 
 
 @dataclass(frozen=True)
@@ -246,9 +264,9 @@ class _InnerHandler(threading.Thread):
         self.block_until_complete = not allow_async_completion or any(
             callback.can_finish_async is False for callback in self.callbacks
         )
-        # Get the parent thread's logging destination. Note that this thread has not yet started
+        # Get the parent thread's thread locals. Note that this thread has not yet started
         # as we are only in the constructor.
-        self.logging_destination = native_engine.stdio_thread_get_destination()
+        self.thread_locals = PyThreadLocals.get_for_current_thread()
 
     def poll_workunits(self, *, finished: bool) -> None:
         workunits = self.scheduler.poll_workunits(self.max_workunit_verbosity)
@@ -261,8 +279,9 @@ class _InnerHandler(threading.Thread):
             )
 
     def run(self) -> None:
-        # First, set the thread's logging destination to the parent thread's, meaning the console.
-        native_engine.stdio_thread_set_destination(self.logging_destination)
+        # First, set the thread's thread locals to the parent thread's in order to propagate the
+        # console, workunit stores, etc.
+        self.thread_locals.set_for_current_thread()
         while not self.stop_request.isSet():
             self.poll_workunits(finished=False)
             self.stop_request.wait(timeout=self.report_interval)

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -146,6 +146,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
                 f"  mean: {histogram.get_mean_value():.3f}\n"
                 f"  std dev: {histogram.get_stddev():.3f}\n"
                 f"  total observations: {histogram.total_count}\n"
+                f"  sum: {int(histogram.get_mean_value() * histogram.total_count)}\n"
                 f"{percentile_to_vals}"
             )
 

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.core.goals.package import BuiltPackage
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.native_engine import AddPrefix
 from pants.engine.process import Process, ProcessResult
@@ -103,6 +103,15 @@ async def create_deploy_jar_run_request(
         digest=request_digest,
         args=args,
         extra_env=env,
+    )
+
+
+@rule
+async def run_deploy_jar_debug_adapter_binary(
+    field_set: DeployJarFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a deploy JAR using a debug adapter has not yet been implemented."
     )
 
 

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -501,12 +501,13 @@ class Parser:
         except ValueError as error:
             raise ParseError(str(error))
 
-    def to_value_type(self, val_str, type_arg, member_type, dest):
+    @classmethod
+    def to_value_type(cls, val_str, type_arg, member_type, dest):
         """Convert a string to a value of the option's type."""
         if val_str is None:
             return None
         if type_arg == bool:
-            return self.ensure_bool(val_str)
+            return cls.ensure_bool(val_str)
         try:
             if type_arg == list:
                 return ListValueComponent.create(val_str, member_type=member_type)

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "nails"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51ec690ac20be76e55d6939fa43309c3a6e3d5dd1eb2200c8fe27a087d5c92"
+checksum = "3e5154dfd88b8bfac6aaee04a7063673c2e6da2a13ed18e8ce545ad7a847b82f"
 dependencies = [
  "byteorder",
  "bytes",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -694,6 +694,7 @@ dependencies = [
  "graph",
  "grpc_util",
  "hashing",
+ "humansize",
  "indexmap",
  "internment",
  "itertools",
@@ -1234,6 +1235,12 @@ name = "httpdate"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
+
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -124,6 +124,7 @@ futures-core = "^0.3.0"
 graph = { path = "graph" }
 grpc_util = { path = "grpc_util" }
 hashing = { path = "hashing" }
+humansize = "1.1"
 indexmap = "1.8"
 internment = "0.6"
 itertools = "0.10"

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -165,7 +165,10 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
 pub trait SnapshotOps: Clone + Send + Sync + 'static {
   type Error: Debug + Display + From<String>;
 
-  async fn load_file_bytes_with<T: Send + 'static, F: Fn(&[u8]) -> T + Send + Sync + 'static>(
+  async fn load_file_bytes_with<
+    T: Send + 'static,
+    F: Fn(&[u8]) -> T + Clone + Send + Sync + 'static,
+  >(
     &self,
     digest: Digest,
     f: F,

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -10,7 +10,7 @@ async_latch = { path = "../async_latch" }
 bytes = "1.0"
 futures = "0.3"
 log = "0.4"
-nails = "0.12"
+nails = "0.13"
 os_pipe = "1.0"
 task_executor = { path = "../task_executor" }
 tokio = { version = "1.16", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 hashing = { path = "../hashing" }
 libc = "0.2.126"
 log = "0.4"
-nails = "0.12"
+nails = "0.13"
 nix = "0.24"
 sha2 = "0.10"
 shell-quote = "0.3.0"

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -13,13 +13,16 @@ use std::time::{Duration, Instant};
 
 use async_lock::{Mutex, MutexGuardArc};
 use futures::future;
-use hashing::Fingerprint;
 use lazy_static::lazy_static;
 use log::{debug, info};
 use regex::Regex;
+use tempfile::TempDir;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+use hashing::Fingerprint;
 use store::Store;
 use task_executor::Executor;
-use tempfile::TempDir;
+use workunit_store::{in_workunit, Level};
 
 use crate::local::prepare_workdir;
 use crate::{ImmutableInputs, NamedCaches, Process, ProcessError, ProcessMetadata};
@@ -52,14 +55,11 @@ pub type Port = u16;
 /// Mutations of the Vec are protected by a Mutex, but each NailgunProcess is also protected by its
 /// own Mutex, which is used to track when the process is in use.
 ///
-/// NB: This pool expects to be used under a semaphore with size equal to the pool size. Because of
-/// this, it never actually waits for a pool entry to complete, and can instead assume that at
-/// least one pool slot is always idle when `acquire` is entered.
-///
 #[derive(Clone)]
 pub struct NailgunPool {
   workdir_base: PathBuf,
   size: usize,
+  sema: Arc<Semaphore>,
   store: Store,
   executor: Executor,
   processes: Arc<Mutex<Vec<PoolEntry>>>,
@@ -70,6 +70,7 @@ impl NailgunPool {
     NailgunPool {
       workdir_base,
       size,
+      sema: Arc::new(Semaphore::new(size)),
       store,
       executor,
       processes: Arc::default(),
@@ -91,20 +92,34 @@ impl NailgunPool {
   ) -> Result<BorrowedNailgunProcess, ProcessError> {
     let name = server_process.description.clone();
     let requested_fingerprint = NailgunProcessFingerprint::new(name.clone(), &server_process)?;
+    let semaphore_acquisition = self.sema.clone().acquire_owned();
+    let permit = in_workunit!(
+      "acquire_nailgun_process",
+      // TODO: See also `acquire_command_runner_slot` in `bounded::CommandRunner`.
+      // https://github.com/pantsbuild/pants/issues/14680
+      Level::Debug,
+      |workunit| async move {
+        let _blocking_token = workunit.blocking();
+        semaphore_acquisition
+          .await
+          .expect("Semaphore should not have been closed.")
+      }
+    )
+    .await;
+
     let mut process_ref = {
       let mut processes = self.processes.lock().await;
 
       // Start by seeing whether there are any idle processes with a matching fingerprint.
       if let Some((_idx, process)) = Self::find_usable(&mut *processes, &requested_fingerprint)? {
-        return Ok(BorrowedNailgunProcess::new(process));
+        return Ok(BorrowedNailgunProcess::new(process, permit));
       }
 
       // There wasn't a matching, valid, available process. We need to start one.
       if processes.len() >= self.size {
         // Find the oldest idle non-matching process and remove it.
         let idx = Self::find_lru_idle(&mut *processes)?.ok_or_else(|| {
-          // NB: See the method docs: the pool assumes that it is running under a semaphore, so this
-          // should be impossible.
+          // NB: We've acquired a semaphore permit, so this should be impossible.
           "No idle slots in nailgun pool.".to_owned()
         })?;
 
@@ -137,7 +152,7 @@ impl NailgunPool {
       .await?,
     );
 
-    Ok(BorrowedNailgunProcess::new(process_ref))
+    Ok(BorrowedNailgunProcess::new(process_ref, permit))
   }
 
   ///
@@ -422,12 +437,12 @@ impl NailgunProcessFingerprint {
 /// A wrapper around a NailgunProcess checked out from the pool. If `release` is not called, the
 /// guard assumes cancellation, and kills the underlying process.
 ///
-pub struct BorrowedNailgunProcess(Option<NailgunProcessRef>);
+pub struct BorrowedNailgunProcess(Option<NailgunProcessRef>, OwnedSemaphorePermit);
 
 impl BorrowedNailgunProcess {
-  fn new(process: NailgunProcessRef) -> Self {
+  fn new(process: NailgunProcessRef, permit: OwnedSemaphorePermit) -> Self {
     assert!(process.is_some());
-    Self(Some(process))
+    Self(Some(process), permit)
   }
 
   pub fn name(&self) -> &str {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -216,9 +216,10 @@ impl CommandRunner {
           .as_micros()
           .try_into();
         if let Ok(obs) = timing {
-          context
-            .workunit_store
-            .record_observation(ObservationMetric::RemoteExecutionRPCFirstResponseTime, obs);
+          context.workunit_store.record_observation(
+            ObservationMetric::RemoteExecutionRPCFirstResponseTimeMicros,
+            obs,
+          );
         }
       }
 

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -521,6 +521,7 @@ async fn check_action_cache(
     |workunit| async move {
       workunit.increment_counter(Metric::RemoteCacheRequests, 1);
 
+      let start = Instant::now();
       let client = action_cache_client.as_ref().clone();
       let response = retry_call(
         client,
@@ -579,6 +580,11 @@ async fn check_action_cache(
         Ok(response)
       })
       .await;
+
+      workunit.record_observation(
+        ObservationMetric::RemoteCacheGetActionResultTimeMicros,
+        start.elapsed().as_micros() as u64,
+      );
 
       match response {
         Ok(response) => {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -372,7 +372,7 @@ impl Core {
           .unwrap_or_else(|| leaf_runner.clone()),
         full_store,
         local_cache,
-        remoting_opts.cache_eager_fetch,
+        eager_fetch,
         process_execution_metadata,
       ))
     } else {
@@ -653,7 +653,7 @@ pub struct Context {
   /// Presence in this map at process runtime indicates that the pricess is being retried, and that
   /// there was something invalid or unusable about previous attempts. Successive attempts should
   /// run in a different mode (skipping caches, etc) to attempt to produce a valid result.
-  backtrack_attempts: Arc<Mutex<HashMap<ExecuteProcess, usize>>>,
+  backtrack_levels: Arc<Mutex<HashMap<ExecuteProcess, usize>>>,
   stats: Arc<Mutex<graph::Stats>>,
 }
 
@@ -665,7 +665,7 @@ impl Context {
       core,
       session,
       run_id,
-      backtrack_attempts: Arc::default(),
+      backtrack_levels: Arc::default(),
       stats: Arc::default(),
     }
   }
@@ -704,37 +704,59 @@ impl Context {
       return result;
     };
 
-    // Locate the source(s) of this Digest.
+    // Locate the source(s) of this Digest and their backtracking levels.
     // TODO: Currently needs a combination of `visit_live` and `invalidate_from_roots` because
-    // `invalidate_from_roots` cannot view `Node` results. This could lead to a race condition
-    // where a `Node` is invalidated multiple times, which might cause it to increment its attempt
-    // count multiple times. See https://github.com/pantsbuild/pants/issues/15867
-    let mut roots = HashSet::new();
+    // `invalidate_from_roots` cannot view `Node` results. Would be more efficient as a merged
+    // method.
+    let mut candidate_roots = Vec::new();
     self.core.graph.visit_live(self, |k, v| match k {
       NodeKey::ExecuteProcess(p) if v.digests().contains(&digest) => {
-        roots.insert(p.clone());
+        if let NodeOutput::ProcessResult(pr) = v {
+          candidate_roots.push((p.clone(), pr.backtrack_level));
+        }
       }
       _ => (),
     });
 
-    if roots.is_empty() {
+    if candidate_roots.is_empty() {
       // We did not identify any roots to invalidate: allow the Node to fail.
       return result;
     }
 
-    // Trigger backtrack attempts for the matched Nodes.
-    {
-      let mut backtrack_attempts = self.backtrack_attempts.lock();
-      for root in &roots {
-        let attempt = backtrack_attempts.entry((**root).clone()).or_insert(1);
-        let description = &root.process.description;
-        workunit.increment_counter(Metric::BacktrackAttempts, 1);
-        log::warn!(
-          "Making attempt {attempt} to backtrack and retry `{description}`, due to \
-            missing digest {digest:?}."
-        );
-      }
-    }
+    // Attempt to trigger backtrack attempts for the matched Nodes. It's possible that we are not
+    // the first consumer to notice that this Node needs to backtrack, so we only actually report
+    // that we're backtracking if the new level is an increase from the old level.
+    let roots = candidate_roots
+      .into_iter()
+      .filter_map(|(root, invalid_level)| {
+        let next_level = invalid_level + 1;
+        let maybe_new_level = {
+          let mut backtrack_levels = self.backtrack_levels.lock();
+          if let Some(old_backtrack_level) = backtrack_levels.get_mut(&root) {
+            if next_level > *old_backtrack_level {
+              *old_backtrack_level = next_level;
+              Some(next_level)
+            } else {
+              None
+            }
+          } else {
+            backtrack_levels.insert((*root).clone(), next_level);
+            Some(next_level)
+          }
+        };
+        if let Some(new_level) = maybe_new_level {
+          workunit.increment_counter(Metric::BacktrackAttempts, 1);
+          let description = &root.process.description;
+          log::warn!(
+            "Making attempt {new_level} to backtrack and retry `{description}`, due to \
+              missing digest {digest:?}."
+          );
+          Some(root)
+        } else {
+          None
+        }
+      })
+      .collect::<HashSet<_>>();
 
     // Invalidate the matched roots.
     self
@@ -753,22 +775,12 @@ impl Context {
   }
 
   ///
-  /// Called before executing a process to determine whether it is backtracking, and if so, to
-  /// increment the attempt count.
+  /// Called before executing a process to determine whether it is backtracking.
   ///
-  /// A process which has not been marked backtracking will always return 0, regardless of the
-  /// number of calls to this method.
+  /// A process which has not been marked backtracking will always return 0.
   ///
   pub fn maybe_start_backtracking(&self, node: &ExecuteProcess) -> usize {
-    let mut backtrack_attempts = self.backtrack_attempts.lock();
-    let entry: Option<&mut usize> = backtrack_attempts.get_mut(node);
-    if let Some(entry) = entry {
-      let attempt = *entry;
-      *entry += 1;
-      attempt
-    } else {
-      0
-    }
+    self.backtrack_levels.lock().get(node).cloned().unwrap_or(0)
   }
 }
 
@@ -790,7 +802,7 @@ impl NodeContext for Context {
       core: self.core.clone(),
       session: self.session.clone(),
       run_id: self.run_id,
-      backtrack_attempts: self.backtrack_attempts.clone(),
+      backtrack_levels: self.backtrack_levels.clone(),
       stats: self.stats.clone(),
     }
   }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -42,6 +42,7 @@ use rule_graph::{self, RuleGraph};
 use task_executor::Executor;
 use workunit_store::{
   ArtifactOutput, ObservationMetric, UserMetadataItem, Workunit, WorkunitState, WorkunitStore,
+  WorkunitStoreHandle,
 };
 
 use crate::externs::fs::{todo_possible_store_missing_digest, PyFileDigest};
@@ -73,6 +74,7 @@ fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
   m.add_class::<PySessionCancellationLatch>()?;
   m.add_class::<PyStdioDestination>()?;
   m.add_class::<PyTasks>()?;
+  m.add_class::<PyThreadLocals>()?;
   m.add_class::<PyTypes>()?;
 
   m.add_class::<externs::PyGeneratorResponseBreak>()?;
@@ -225,7 +227,7 @@ impl PyTypes {
 struct PyScheduler(Scheduler);
 
 #[pyclass]
-struct PyStdioDestination(Arc<stdio::Destination>);
+struct PyStdioDestination(PyThreadLocals);
 
 /// Represents configuration related to process execution strategies.
 ///
@@ -497,6 +499,30 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> PyResult {
         engine_traceback,
       }
     }
+  }
+}
+
+#[pyclass]
+struct PyThreadLocals(Arc<stdio::Destination>, Option<WorkunitStoreHandle>);
+
+impl PyThreadLocals {
+  fn get() -> Self {
+    let stdio_dest = stdio::get_destination();
+    let workunit_store_handle = workunit_store::get_workunit_store_handle();
+    Self(stdio_dest, workunit_store_handle)
+  }
+}
+
+#[pymethods]
+impl PyThreadLocals {
+  #[classmethod]
+  fn get_for_current_thread(_cls: &PyType) -> Self {
+    Self::get()
+  }
+
+  fn set_for_current_thread(&self) {
+    stdio::set_thread_destination(self.0.clone());
+    workunit_store::set_thread_workunit_store_handle(self.1.clone());
   }
 }
 
@@ -1641,15 +1667,18 @@ fn stdio_thread_console_clear() {
   stdio::get_destination().console_clear();
 }
 
+// TODO: Deprecated, but without easy access to the decorator. Use
+// `PyThreadLocals::get_for_current_thread` instead. Remove in Pants 2.17.0.dev0.
 #[pyfunction]
 fn stdio_thread_get_destination() -> PyStdioDestination {
-  let dest = stdio::get_destination();
-  PyStdioDestination(dest)
+  PyStdioDestination(PyThreadLocals::get())
 }
 
+// TODO: Deprecated, but without easy access to the decorator. Use
+// `PyThreadLocals::set_for_current_thread` instead. Remove in Pants 2.17.0.dev0.
 #[pyfunction]
 fn stdio_thread_set_destination(stdio_destination: &PyStdioDestination) {
-  stdio::set_thread_destination(stdio_destination.0.clone());
+  stdio_destination.0.set_for_current_thread();
 }
 
 // TODO: Needs to be thread-local / associated with the Console.

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -179,7 +179,7 @@ fn process_request_to_process_result(
       .map_err(|e| e.enrich("Error lifting Process"))
       .await?;
 
-    let result = context.get(process_request).await?.0;
+    let result = context.get(process_request).await?.result;
 
     let store = context.core.store();
     let (stdout_bytes, stderr_bytes) = try_join!(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -384,18 +384,22 @@ impl ExecuteProcess {
     self,
     context: Context,
     workunit: &mut RunningWorkunit,
-    attempt: usize,
+    backtrack_level: usize,
   ) -> NodeResult<ProcessResult> {
     let request = self.process;
 
-    let command_runner = context.core.command_runners.get(attempt).ok_or_else(|| {
-      // NB: We only backtrack for a Process if it produces a Digest which cannot be consumed
-      // from disk: if we've fallen all the way back to local execution, and even that
-      // produces an unreadable Digest, then there is a fundamental implementation issue.
-      throw(format!(
-        "Process {request:?} produced an invalid result on all configured command runners."
-      ))
-    })?;
+    let command_runner = context
+      .core
+      .command_runners
+      .get(backtrack_level)
+      .ok_or_else(|| {
+        // NB: We only backtrack for a Process if it produces a Digest which cannot be consumed
+        // from disk: if we've fallen all the way back to local execution, and even that
+        // produces an unreadable Digest, then there is a fundamental implementation issue.
+        throw(format!(
+          "Process {request:?} produced an invalid result on all configured command runners."
+        ))
+      })?;
 
     let execution_context = process_execution::Context::new(
       context.session.workunit_store(),
@@ -456,7 +460,10 @@ impl ExecuteProcess {
       }
     }
 
-    Ok(ProcessResult(res))
+    Ok(ProcessResult {
+      result: res,
+      backtrack_level,
+    })
   }
 }
 
@@ -471,7 +478,13 @@ impl WrappedNode for ExecuteProcess {
 }
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, PartialEq)]
-pub struct ProcessResult(pub process_execution::FallibleProcessResultWithPlatform);
+pub struct ProcessResult {
+  pub result: process_execution::FallibleProcessResultWithPlatform,
+  /// The backtrack_level which produced this result. If a Digest from a particular result is
+  /// missing, the next attempt needs to use a higher level of backtracking (i.e.: remove more
+  /// caches).
+  pub backtrack_level: usize,
+}
 
 ///
 /// A Node that represents reading the destination of a symlink (non-recursively).
@@ -1375,8 +1388,8 @@ impl Node for NodeKey {
           NodeKey::DigestFile(n) => n.run_node(context).await.map(NodeOutput::FileDigest),
           NodeKey::DownloadedFile(n) => n.run_node(context).await.map(NodeOutput::Snapshot),
           NodeKey::ExecuteProcess(n) => {
-            let attempt = context.maybe_start_backtracking(&n);
-            n.run_node(context, workunit, attempt)
+            let backtrack_level = context.maybe_start_backtracking(&n);
+            n.run_node(context, workunit, backtrack_level)
               .await
               .map(|r| NodeOutput::ProcessResult(Box::new(r)))
           }
@@ -1461,7 +1474,7 @@ impl Node for NodeKey {
         match ep.process.cache_scope {
           ProcessCacheScope::Always | ProcessCacheScope::PerRestartAlways => true,
           ProcessCacheScope::Successful | ProcessCacheScope::PerRestartSuccessful => {
-            process_result.0.exit_code == 0
+            process_result.result.exit_code == 0
           }
           ProcessCacheScope::PerSession => false,
         }
@@ -1572,9 +1585,9 @@ impl NodeOutput {
         dd.digests()
       }
       NodeOutput::ProcessResult(p) => {
-        let mut digests = p.0.output_directory.digests();
-        digests.push(p.0.stdout_digest);
-        digests.push(p.0.stderr_digest);
+        let mut digests = p.result.output_directory.digests();
+        digests.push(p.result.stdout_digest);
+        digests.push(p.result.stderr_digest);
         digests
       }
       NodeOutput::DirectoryListing(_)

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1262,7 +1262,6 @@ impl NodeKey {
         // until we're certain that it has begun executing (if at all).
         Level::Debug
       }
-      NodeKey::DownloadedFile(..) => Level::Debug,
       _ => Level::Trace,
     }
   }
@@ -1306,14 +1305,14 @@ impl NodeKey {
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
-      NodeKey::DownloadedFile(ref d) => Some(format!("Downloading: {}", d.0)),
       NodeKey::ReadLink(ReadLink(Link(path))) => Some(format!("Reading link: {}", path.display())),
       NodeKey::Scandir(Scandir(Dir(path))) => {
         Some(format!("Reading directory: {}", path.display()))
       }
-      NodeKey::Select(..) => None,
-      NodeKey::SessionValues(..) => None,
-      NodeKey::RunId(..) => None,
+      NodeKey::DownloadedFile(..)
+      | NodeKey::Select(..)
+      | NodeKey::SessionValues(..)
+      | NodeKey::RunId(..) => None,
     }
   }
 

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -49,10 +49,6 @@ pub enum Metric {
   RemoteExecutionSuccess,
   RemoteExecutionTimeouts,
   RemoteStoreMissingDigest,
-  /// Total number of bytes of blobs downloaded from a remote CAS.
-  RemoteStoreBlobBytesDownloaded,
-  /// Total number of bytes of blobs uploaded to a remote CAS.
-  RemoteStoreBlobBytesUploaded,
   /// Number of times that we backtracked due to missing digests.
   BacktrackAttempts,
 }
@@ -71,9 +67,13 @@ pub enum ObservationMetric {
   LocalStoreReadBlobSize,
   LocalStoreReadBlobTimeMicros,
   RemoteProcessTimeRunMs,
-  RemoteExecutionRPCFirstResponseTime,
-  RemoteStoreTimeToFirstByte,
+  RemoteExecutionRPCFirstResponseTimeMicros,
+  RemoteStoreTimeToFirstByteMicros,
   RemoteStoreReadBlobTimeMicros,
+  /// Total number of bytes of blobs downloaded from a remote CAS.
+  RemoteStoreBlobBytesDownloaded,
+  /// Total number of bytes of blobs uploaded to a remote CAS.
+  RemoteStoreBlobBytesUploaded,
   /// The time saved (in milliseconds) thanks to a local cache hit instead of running the process
   /// directly.
   LocalCacheTimeSavedMs,

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -80,4 +80,6 @@ pub enum ObservationMetric {
   /// The time saved (in milliseconds) thanks to a remote cache hit instead of running the process
   /// directly.
   RemoteCacheTimeSavedMs,
+  /// Remote cache timing (in microseconds) for GetActionResult calls.
+  RemoteCacheGetActionResultTimeMicros,
 }


### PR DESCRIPTION
- Scala: mark an object that extends another type as recursive (Cherry pick of #15865) (#15891)
- Scala: should visit ctor args of base type (Cherry pick of #15880) (#15892)
- Increment the missing-digest backtracking level once per attempt (Cherry pick of #15889) (#15897)
- Release script fixups (Cherry-pick of #15875) (#15920)
- Dedupe `load_bytes_with` calls to a remote Store (Cherry-pick of #15901) (#15915)
- Introduce a plugin API to provide all thread local state, and deprecate stdio-specific methods (Cherry-pick of #15890) (#15916)
- Allow JVM memory controls to bound the process pool size to less than the process parallelism (Cherry-pick of #15903) (#15917)
- Upgrade to `nails` `0.13.0` to pick up support for `JDK >=13`. (Cherry-pick of #15899) (#15918)
- Silence `[scala-infer].force_add_siblings_as_dependencies` deprecation. (Cherry-pick of #15898) (#15919)
- Fix reporting of time spent downloading files (Cherry-pick of #15873) (#15921)
- Improve performance of file arguments when `--owners-not-found-behavior` not used (#15931)
- Upgrade default iPython to 7.34, which drops Python 3.6 (Cherry-pick of #15934) (#15938)
- Fix bad "<infallible>" description in invalid addresses error messages (Cherry-pick of #15859) (#15936)
- Clarify deprecation messages for `tailor` and `update-build-files` requiring CLI arguments (Cherry-pick of #15932) (#15937)
- Add repository config option to Docker registries. (Cherry pick of #15884) (#15952)
- [internal] add observation metric for REAPI GetActionResult calls (Cherry pick of #15967) (#15975)
- Update the docs for `fmt` and test report changes (Cherry-pick of #15968) (#15971)
- Update certificate environment variable advice for #14808. (Cherry-pick of #15943) (#15974)
- Assorted remote metrics fixes. (Cherry-pick of #15914) (#15976)
- Move generic debug adapter settings to dedicated subsystem (Cherry-pick of #15928) (#15977)
- Improve debugpy's capabilities (Cherry-pick of #15946) (#15980)
- Add `--debug-adapter` flag to `run` (#15829)
