### PR TITLE
Add `--debug-adapter` flag to `run` (Cherry-pick of #15829)

### DIFF
--- a/docs/markdown/Python/python-goals/python-run-goal.md
+++ b/docs/markdown/Python/python-goals/python-run-goal.md
@@ -29,11 +29,11 @@ You may only run one target at a time.
 The program will have access to the same environment used by the parent `./pants` process, so you can set environment variables in the external environment, e.g. `FOO=bar ./pants run project/app.py`. (Pants will auto-set some values like `$PATH`).
 
 > 📘 Tip: check the return code
-> 
+>
 > Pants will propagate the return code from the underlying executable. Run `echo $?` after the Pants run to see the return code.
 
 > 🚧 Issues finding files?
-> 
+>
 > Run `./pants dependencies --transitive path/to/binary.py` to ensure that all the files you need are showing up, including for any [assets](doc:assets) you intend to use.
 
 Watching the filesystem
@@ -46,29 +46,36 @@ On the other hand, if your app is short lived (like a script) and you'd like to 
 Debugging
 ---------
 
+> 📘 Tip: using the VS Code (or any [DAP](https://microsoft.github.io/debug-adapter-protocol/)-compliant editor) remote debugger
+>
+>
+> 1. In your editor, set your breakpoints and any other debug settings (like break-on-exception).
+> 2. Run your code with `./pants run --debug-adapter`.
+> 3. Connect your editor to the server. The server host and port are logged by Pants when executing `run --debug-adaptor`. (They can also be configured using the `[debug-adapter]` subsystem).
+
 > 📘 Tip: Using the IntelliJ/PyCharm remote debugger
-> 
+>
 > First, add the following target in some BUILD file (e.g., the one containing your other 3rd-party dependencies):
-> 
+>
 > ```
 > python_requirement(
 >   name = "pydevd-pycharm",
 >   requirements=["pydevd-pycharm==203.5419.8"],  # Or whatever version you choose.
 > )
 > ```
-> 
+>
 > You can check this into your repo, for convenience.
-> 
+>
 > Now, use the remote debugger as usual:
-> 
+>
 > 1. Start a Python remote debugging session in PyCharm, say on port 5000.
 > 2. Add the following code at the point where you want execution to pause and connect to the debugger:
-> 
+>
 > ```
 > import pydevd_pycharm
 > pydevd_pycharm.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)
 > ```
-> 
-> Run your executable with `./pants run` as usual. 
-> 
+>
+> Run your executable with `./pants run` as usual.
+>
 > Note: The first time you do so you may see some extra dependency resolution work, as `pydevd-pycharm` has now been added to the binary's dependencies, via inference. If you have dependency inference turned off in your repo, you will have to manually add a temporary explicit dependency in your binary target on the `pydevd-pycharm` target.

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -6,12 +6,12 @@ hidden: false
 createdAt: "2020-03-16T16:19:56.071Z"
 updatedAt: "2022-05-12T05:33:10.060Z"
 ---
-Pants uses the popular [Pytest](https://docs.pytest.org/en/latest/) test runner to run Python tests. You may write your tests in Pytest-style, unittest-style, or mix and match both. 
+Pants uses the popular [Pytest](https://docs.pytest.org/en/latest/) test runner to run Python tests. You may write your tests in Pytest-style, unittest-style, or mix and match both.
 
 > 👍 Benefit of Pants: runs each file in parallel
-> 
+>
 > Each file gets run as a separate process, which gives you fine-grained caching and better parallelism. Given enough cores, Pants will be able to run all your tests at the same time.
-> 
+>
 > This also gives you fine-grained invalidation. If you run `./pants test ::`, and then you only change one file, then only tests that depended on that changed file will need to rerun.
 
 Examples
@@ -25,10 +25,10 @@ Examples
 ❯ ./pants test helloworld/util:
 
 # Run just the tests in this file.
-❯ ./pants test helloworld/util/lang_test.py  
+❯ ./pants test helloworld/util/lang_test.py
 
  # Run just one test.
-❯ ./pants test helloworld/util/lang_test.py -- -k test_language_translator 
+❯ ./pants test helloworld/util/lang_test.py -- -k test_language_translator
 ```
 
 Pytest version and plugins
@@ -57,15 +57,15 @@ pytest-django==3.10.0
 ```python helloworld/util/BUILD
 python_tests(
    name="tests",
-   # Normally, Pants infers dependencies based on imports. 
-   # Here, we don't actually import our plugin, though, so 
+   # Normally, Pants infers dependencies based on imports.
+   # Here, we don't actually import our plugin, though, so
    # we need to explicitly list it.
    dependencies=["//:pytest-django"],
 )
 ```
 
 > 🚧 Avoid the `pytest-xdist` plugin
-> 
+>
 > We do not recommend using this plugin because its concurrency conflicts with Pants' own parallelism. Using Pants will bring you similar benefits to `pytest-xdist` already: Pants will run each test target in parallel.
 
 Controlling output
@@ -81,17 +81,17 @@ output = "all"
 ```
 
 > 📘 Tip: Use Pytest options to make output more or less verbose
-> 
+>
 > See ["Passing arguments to Pytest"](doc:test#passing-arguments-to-pytest).
-> 
+>
 > For example:
-> 
+>
 > ```bash
 > ❯ ./pants test project/app_test.py -- -q
 > ```
-> 
+>
 > You may want to permanently set the Pytest option `--no-header` to avoid printing the Pytest version for each test run:
-> 
+>
 > ```toml
 > [pytest]
 > args = ["--no-header"]
@@ -114,15 +114,15 @@ args = ["-vv"]
 ```
 
 > 📘 Tip: some useful Pytest arguments
-> 
+>
 > See <https://docs.pytest.org/en/latest/usage.html> for more information.
-> 
+>
 > - `-k expression`: only run tests matching the expression.
 > - `-v`: verbose mode.
 > - `-s`: always print the stdout and stderr of your code, even if a test passes.
 
 > 🚧 How to use Pytest's `--pdb` option
-> 
+>
 > You must run `./pants test --debug` for this to work properly. See the section "Running tests interactively" for more information.
 
 Config files
@@ -133,7 +133,7 @@ Pants will automatically include any relevant config files in the process's sand
 `conftest.py`
 -------------
 
-Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files. 
+Pytest uses [`conftest.py` files](https://docs.pytest.org/en/stable/fixture.html#conftest-py-sharing-fixture-functions) to share fixtures and config across multiple distinct test files.
 
 The default `sources` value for the `python_test_utils` target includes `conftest.py`. You can run [`./pants tailor ::`](doc:initial-configuration#5-generate-build-files) to automatically add this target:
 
@@ -152,7 +152,7 @@ Setting environment variables
 
 Test runs are _hermetic_, meaning that they are stripped of the parent `./pants` process's environment variables. This is important for reproducibility, and it also increases cache hits.
 
-To add any arbitrary environment variable back to the process, you can either add the environment variable to the specific tests with the `extra_env_vars` field on `python_test` / `python_tests` targets or to all your tests with the `[test].extra_env_vars` option. Generally, prefer the field `extra_env_vars` field so that more of your tests are hermetic. 
+To add any arbitrary environment variable back to the process, you can either add the environment variable to the specific tests with the `extra_env_vars` field on `python_test` / `python_tests` targets or to all your tests with the `[test].extra_env_vars` option. Generally, prefer the field `extra_env_vars` field so that more of your tests are hermetic.
 
 With both `[test].extra_env_vars` and the `extra_env_vars` field, you can either hardcode a value or leave off a value to "allowlist" it and read from the parent `./pants` process's environment.
 
@@ -163,7 +163,7 @@ extra_env_vars = ["VAR1", "VAR2=hardcoded_value"]
 ```python project/BUILD
 python_tests(
     name="tests",
-    # Adds to all generated `python_test` targets, 
+    # Adds to all generated `python_test` targets,
     # i.e. each file in the `sources` field.
     extra_env_vars=["VAR3", "VAR4=hardcoded"],
     # Even better, use `overrides` to be more granular.
@@ -182,7 +182,7 @@ To force your tests to run again, rather than reading from the cache, run `./pan
 Running tests interactively
 ---------------------------
 
-Because Pants runs multiple test targets in parallel, you will not see your test results appear on the screen until the test has completely finished. This means that you cannot use debuggers normally; the breakpoint will never show up on your screen and the test will hang indefinitely (or timeout, if timeouts are enabled). 
+Because Pants runs multiple test targets in parallel, you will not see your test results appear on the screen until the test has completely finished. This means that you cannot use debuggers normally; the breakpoint will never show up on your screen and the test will hang indefinitely (or timeout, if timeouts are enabled).
 
 Instead, if you want to run a test interactively—such as to use a debugger like `pdb`—run your tests with `./pants test --debug`. For example:
 
@@ -211,43 +211,52 @@ test_debug_example.py
 If you use multiple files with `test --debug`, they will run sequentially rather than in parallel.
 
 > 📘 Tip: using `ipdb` in tests
-> 
+>
 > [`ipdb`](https://github.com/gotcha/ipdb) integrates IPython with the normal `pdb` debugger for enhanced features like autocomplete and improved syntax highlighting. `ipdb` is very helpful when debugging tests.
-> 
+>
 > To be able to access `ipdb` when running tests, add this to your `pants.toml`:
-> 
+>
 > ```toml
 > [pytest]
 > extra_requirements.add = ["ipdb"]
 > ```
-> 
+>
 > Then, you can use `import ipdb; ipdb.set_trace()` in your tests.
-> 
-> To run the tests you will need to add `-- -s` to the test call since ipdb will need stdin and pytest will capture it. 
-> 
+>
+> To run the tests you will need to add `-- -s` to the test call since ipdb will need stdin and pytest will capture it.
+>
 > ```bash
 > ❯ ./pants test --debug  <target>   -- -s
 > ```
 
+> 📘 Tip: using the VS Code (or any [DAP](https://microsoft.github.io/debug-adapter-protocol/)-compliant editor) remote debugger in tests
+>
+>
+> 1. In your editor, set your breakpoints and any other debug settings (like break-on-exception).
+> 2. Run your test with `./pants test --debug-adapter`.
+> 3. Connect your editor to the server. The server host and port are logged by Pants when executing `test --debug-adaptor`. (They can also be configured using the `[debug-adapter]` subsystem).
+
+> Run your test with `./pants test --debug` as usual.
+
 > 📘 Tip: using the IntelliJ/PyCharm remote debugger in tests
-> 
+>
 > First, add this to your `pants.toml`:
-> 
+>
 > ```toml
 > [pytest]
 > extra_requirements.add = ["pydevd-pycharm==203.5419.8"]  # Or whatever version you choose.
 > ```
-> 
+>
 > Now, use the remote debugger as usual:
-> 
+>
 > 1. Start a Python remote debugging session in PyCharm, say on port 5000.
 > 2. Add the following code at the point where you want execution to pause and connect to the debugger:
-> 
+>
 > ```python
 > import pydevd_pycharm
 > pydevd_pycharm.settrace('localhost', port=5000, stdoutToServer=True, stderrToServer=True)
 > ```
-> 
+>
 > Run your test with `./pants test --debug` as usual.
 
 Timeouts
@@ -284,9 +293,9 @@ timeout_maximum = 600
 If a target sets its `timeout` higher than `[pytest].timeout_maximum`, Pants will use the value in `[pytest].timeout_maximum`.
 
 > 📘 Tip: temporarily ignoring timeouts
-> 
+>
 > When debugging locally, such as with `pdb`, you might want to temporarily disable timeouts. To do this, set `--no-pytest-timeouts`:
-> 
+>
 > ```bash
 > $ ./pants test project/app_test.py --no-pytest-timeouts
 > ```
@@ -296,18 +305,18 @@ Test utilities and resources
 
 ### Test utilities
 
-Use the target type `python_source` for test utilities, rather than `python_test`. 
+Use the target type `python_source` for test utilities, rather than `python_test`.
 
 To reduce boilerplate, you can use either the [`python_sources`](doc:reference-python_sources) or [`python_test_utils`](doc:reference-python_test_utils) targets to generate `python_source` targets. These behave the same, except that `python_test_utils` has a different default `sources` to include `conftest.py` and type stubs for tests (like `test_foo.pyi`). Use [`./pants tailor ::`](doc:initial-configuration#5-generate-build-files) to generate both these targets automatically.
 
 For example:
 
 ```python helloworld/BUILD
-# The default `sources` includes all files other than 
+# The default `sources` includes all files other than
 # `!*_test.py`, `!test_*.py`, and `tests.py`, and `conftest.py`.
 python_sources(name="lib")
 
-# We leave off the `dependencies` field because Pants will infer 
+# We leave off the `dependencies` field because Pants will infer
 # it based on import statements.
 python_tests(name="tests")
 ```
@@ -332,7 +341,7 @@ def test_app() -> None:
 
 Refer to [Assets](doc:assets) for how to include asset files in your tests by adding to the `dependencies` field.
 
-It's often most convenient to use  `file` / `files` and `relocated_files` targets in your test code, although you can also use `resource` / `resources` targets.  
+It's often most convenient to use  `file` / `files` and `relocated_files` targets in your test code, although you can also use `resource` / `resources` targets.
 
 Testing your packaging pipeline
 -------------------------------
@@ -386,27 +395,27 @@ use_coverage = true
 ```
 
 > 🚧 Failure to parse files?
-> 
+>
 > Coverage defaults to running with Python 3.6+ when generating a report, which means it may fail to parse Python 2 syntax and Python 3.8+ syntax. You can fix this by changing the interpreter constraints for running Coverage:
-> 
+>
 > ```toml
 > # pants.toml
 > [coverage-py]
 > interpreter_constraints = [">=3.8"]
 > ```
-> 
+>
 > However, if your repository has some Python 2-only code and some Python 3-only code, you will not be able to choose an interpreter that works with both versions. So, you will need to set up a `.coveragerc` config file and set `ignore_errors = True` under `[report]`, like this:
-> 
+>
 > ```
 > # .coveragerc
 > [report]
 > ignore_errors = True
 > ```
-> 
+>
 > `ignore_errors = True` means that those files will simply be left off of the final coverage report.
-> 
+>
 > (Pants should autodiscover the config file `.coveragerc`. See [coverage-py](https://www.pantsbuild.org/docs/reference-coverage-py#section-config-discovery).)
-> 
+>
 > There's a proposal for Pants to fix this by generating multiple reports when necessary: <https://github.com/pantsbuild/pants/issues/11137>. We'd appreciate your feedback.
 
 Coverage will report data on any files encountered during the tests. You can filter down the results by using the option `--coverage-py-filter` and passing the name(s) of modules you want coverage data for. Each module name is recursive, meaning submodules will be included. For example:
@@ -417,15 +426,15 @@ Coverage will report data on any files encountered during the tests. You can fil
 ```
 
 > 🚧 Coverage will not report on unencountered files
-> 
+>
 > Coverage will only report on files encountered during the tests' run. This means that your coverage score may be misleading; even with a score of 100%, you may have files without any tests. You can overcome this as follows:
-> 
+>
 > ```toml
 > # pants.toml
 > [coverage-py]
 > global_report = true
 > ```
-> 
+>
 > In this case, Coverage will report on [all files it considers importable](https://coverage.readthedocs.io/en/6.3.2/source.html), i.e. files at the root of the tree, or in directories with a `__init__.py` file, possibly omitting files in [implicit namespace packages](https://peps.python.org/pep-0420/) that lack `__init__.py` files. This is a shortcoming of Coverage itself.
 
 Pants will default to writing the results to the console, but you can also output in HTML, XML, JSON, or the raw SQLite file:

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -9,7 +9,7 @@ from pants.backend.docker.goals.package_image import BuiltDockerImage, DockerFie
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
@@ -26,6 +26,15 @@ async def docker_image_run_request(
     run = docker.run_image(tag, docker_run_args=options.run_args, env=env)
 
     return RunRequest(args=run.argv, digest=image.digest, extra_env=run.env)
+
+
+@rule
+async def docker_image_run_debug_adapter_request(
+    field_set: DockerFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a Docker image using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/go/goals/run_binary.py
+++ b/src/python/pants/backend/go/goals/run_binary.py
@@ -5,7 +5,7 @@ import os.path
 
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -17,6 +17,15 @@ async def create_go_binary_run_request(field_set: GoBinaryFieldSet) -> RunReques
     artifact_relpath = binary.artifacts[0].relpath
     assert artifact_relpath is not None
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact_relpath),))
+
+
+@rule
+async def go_binary_run_debug_adapter_request(
+    field_set: GoBinaryFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a Go binary using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -1,9 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import logging
 import os
 
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
+from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.target_types import (
     PexBinaryDefaults,
     ResolvedPexEntryPoint,
@@ -11,7 +13,7 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
-from pants.backend.python.util_rules.pex import Pex
+from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import (
     InterpreterConstraintsRequest,
@@ -21,12 +23,20 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+from pants.util.strutil import softwrap
+
+logger = logging.getLogger(__name__)
+
+
+def _in_chroot(relpath: str) -> str:
+    return os.path.join("{chroot}", relpath)
 
 
 @rule(level=LogLevel.DEBUG)
@@ -99,13 +109,12 @@ async def create_pex_binary_run_request(
     ]
     merged_digest = await Get(Digest, MergeDigests(input_digests))
 
-    def in_chroot(relpath: str) -> str:
-        return os.path.join("{chroot}", relpath)
-
     complete_pex_env = pex_env.in_workspace()
-    args = complete_pex_env.create_argv(in_chroot(pex.name), python=pex.python)
+    # NB. If this changes, please consider how it affects the `DebugRequest` below
+    # (which is not easy to write automated tests for)
+    args = complete_pex_env.create_argv(_in_chroot(pex.name), python=pex.python)
 
-    chrooted_source_roots = [in_chroot(sr) for sr in sources.source_roots]
+    chrooted_source_roots = [_in_chroot(sr) for sr in sources.source_roots]
     # The order here is important: we want the in-repo sources to take precedence over their
     # copies in the sandbox (see above for why those copies exist even in non-sandboxed mode).
     source_roots = [
@@ -114,11 +123,61 @@ async def create_pex_binary_run_request(
     ]
     extra_env = {
         **complete_pex_env.environment_dict(python_configured=pex.python is not None),
-        "PEX_PATH": in_chroot(local_dists.pex.name),
+        "PEX_PATH": _in_chroot(local_dists.pex.name),
         "PEX_EXTRA_SYS_PATH": os.pathsep.join(source_roots),
     }
 
     return RunRequest(digest=merged_digest, args=args, extra_env=extra_env)
+
+
+@rule
+async def run_pex_debug_adapter_binary(
+    field_set: PexBinaryFieldSet,
+    debugpy: DebugPy,
+    debug_adapter: DebugAdapterSubsystem,
+) -> RunDebugAdapterRequest:
+    if field_set.run_in_sandbox:
+        logger.warning(
+            softwrap(
+                f"""
+                Using `run --debug-adapter` on the target {field_set.address}, which sets the field
+                `run_in_sandbox` to `True`. This will likely cause your breakpoints to not be hit,
+                as your code will be run under the sandbox's path.
+                """
+            )
+        )
+
+    entry_point, regular_run_request, debugpy_pex = await MultiGet(
+        Get(
+            ResolvedPexEntryPoint,
+            ResolvePexEntryPointRequest(field_set.entry_point),
+        ),
+        Get(RunRequest, PexBinaryFieldSet, field_set),
+        Get(Pex, PexRequest, debugpy.to_pex_request()),
+    )
+
+    entry_point_or_script = entry_point.val or field_set.script.value
+    assert entry_point_or_script is not None
+    merged_digest = await Get(
+        Digest, MergeDigests([regular_run_request.digest, debugpy_pex.digest])
+    )
+    extra_env = dict(regular_run_request.extra_env)
+    extra_env["PEX_PATH"] = os.pathsep.join(
+        [
+            extra_env["PEX_PATH"],
+            # For debugpy to work properly, we need to have just one "environment" for our
+            # command to run in. Therefore, we cobble one together by exeucting debugpy's PEX, and
+            # shoehorning in the original PEX through PEX_PATH.
+            _in_chroot(os.path.basename(regular_run_request.args[1])),
+        ]
+    )
+    args = [
+        regular_run_request.args[0],  # python executable
+        _in_chroot(debugpy_pex.name),
+        *debugpy.get_args(debug_adapter, entry_point_or_script),
+    ]
+
+    return RunDebugAdapterRequest(digest=merged_digest, args=args, extra_env=extra_env)
 
 
 def rules():

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -23,7 +23,7 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -230,6 +230,15 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
     artifact = executable_binaries[0]
     assert artifact.relpath is not None
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact.relpath),))
+
+
+@rule
+async def run_pyoxidizer_debug_adapter_binary(
+    field_set: PyOxidizerFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a PyOxidizer binary using a debug adapter has not yet been implemented."
+    )
 
 
 def rules():

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -23,7 +23,7 @@ from pants.backend.shell.target_types import (
     ShellCommandToolsField,
 )
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import (
@@ -245,6 +245,15 @@ async def run_shell_command_request(shell_command: RunShellCommand) -> RunReques
         digest=process.input_digest,
         args=process.argv,
         extra_env=process.env,
+    )
+
+
+@rule
+async def run_shell_debug_adapter_binary(
+    field_set: RunShellCommand,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a shell command using a debug adapter has not yet been implemented."
     )
 
 

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -8,7 +8,15 @@ from typing import cast
 import pytest
 
 from pants.base.build_root import BuildRoot
-from pants.core.goals.run import Run, RunFieldSet, RunRequest, RunSubsystem, run
+from pants.core.goals.run import (
+    Run,
+    RunDebugAdapterRequest,
+    RunFieldSet,
+    RunRequest,
+    RunSubsystem,
+    run,
+)
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -43,6 +51,12 @@ def create_mock_run_request(rule_runner: RuleRunner, program_text: bytes) -> Run
     return RunRequest(digest=digest, args=(os.path.join("{chroot}", "program.py"),))
 
 
+def create_mock_run_debug_adapter_request(
+    rule_runner: RuleRunner, program_text: bytes
+) -> RunDebugAdapterRequest:
+    return cast(RunDebugAdapterRequest, create_mock_run_request(rule_runner, program_text))
+
+
 def single_target_run(
     rule_runner: RuleRunner,
     address: Address,
@@ -65,7 +79,12 @@ def single_target_run(
         res = run_rule_with_mocks(
             run,
             rule_args=[
-                create_goal_subsystem(RunSubsystem, args=[], cleanup=True),
+                create_goal_subsystem(RunSubsystem, args=[], cleanup=True, debug_adapter=False),
+                create_subsystem(
+                    DebugAdapterSubsystem,
+                    host="127.0.0.1",
+                    port="5678",
+                ),
                 create_subsystem(
                     GlobalOptions, pants_workdir=rule_runner.pants_workdir, process_cleanup=True
                 ),
@@ -88,6 +107,11 @@ def single_target_run(
                     output_type=RunRequest,
                     input_type=TestRunFieldSet,
                     mock=lambda _: create_mock_run_request(rule_runner, program_text),
+                ),
+                MockGet(
+                    output_type=RunDebugAdapterRequest,
+                    input_type=TestRunFieldSet,
+                    mock=lambda _: create_mock_run_debug_adapter_request(rule_runner, program_text),
                 ),
                 MockEffect(
                     output_type=InteractiveProcessResult,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -319,6 +319,7 @@ class TestSubsystem(GoalSubsystem):
             """
         ),
     )
+    # See also `run.py`'s same option
     debug_adapter = BoolOption(
         "--debug-adapter",
         default=False,

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.core.goals.package import BuiltPackage
-from pants.core.goals.run import RunFieldSet, RunRequest
+from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.native_engine import AddPrefix
 from pants.engine.process import Process, ProcessResult
@@ -103,6 +103,15 @@ async def create_deploy_jar_run_request(
         digest=request_digest,
         args=args,
         extra_env=env,
+    )
+
+
+@rule
+async def run_deploy_jar_debug_adapter_binary(
+    field_set: DeployJarFieldSet,
+) -> RunDebugAdapterRequest:
+    raise NotImplementedError(
+        "Debugging a deploy JAR using a debug adapter has not yet been implemented."
     )
 
 


### PR DESCRIPTION
`run`'s counterpart to https://github.com/pantsbuild/pants/pull/15799. Support is added for `pex_binary` (which will be spiritually lifted to the `python_source` with https://github.com/pantsbuild/pants/pull/15849)

[ci skip-rust]
[ci skip-build-wheels]
