### PR TITLE
[internal] test batch and stream API paths for load/store from remote store

### DIFF
--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -235,7 +235,7 @@ impl ByteStore {
     }
   }
 
-  async fn store_bytes_source_batch<ByteSource>(
+  pub(crate) async fn store_bytes_source_batch<ByteSource>(
     &self,
     digest: Digest,
     bytes: ByteSource,
@@ -259,7 +259,7 @@ impl ByteStore {
     Ok(())
   }
 
-  async fn store_bytes_source_stream<ByteSource>(
+  pub(crate) async fn store_bytes_source_stream<ByteSource>(
     &self,
     digest: Digest,
     bytes: ByteSource,
@@ -349,7 +349,7 @@ impl ByteStore {
     }
   }
 
-  async fn load_bytes_with_batch<
+  pub(crate) async fn load_bytes_with_batch<
     T: Send + 'static,
     F: Fn(Bytes) -> Result<T, String> + Send + Sync + Clone + 'static,
   >(
@@ -390,7 +390,7 @@ impl ByteStore {
     }
   }
 
-  async fn load_bytes_with_stream<
+  pub(crate) async fn load_bytes_with_stream<
     T: Send + 'static,
     F: Fn(Bytes) -> Result<T, String> + Send + Sync + Clone + 'static,
   >(


### PR DESCRIPTION
Add tests that guarantee to invoke both the batch and stream API variants for loads and stores from a remote CAS. The other tests rely on the wrapper methods for load and store which select the API to use based on blob size. For full test coverage, both paths need to be tested, so make them `pub(crate)` (since the tests are in a sibling module) and invoke directly.

[ci skip-build-wheels]