### PR TITLE
[internal] terraform: use immutable input for Terraform tool (Cherry-pick of #15037)

### DIFF
--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -9,7 +9,7 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
-from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
+from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process
@@ -68,14 +68,12 @@ async def setup_terraform_process(request: TerraformProcess, terraform: Terrafor
         terraform.get_request(Platform.current),
     )
 
-    input_digest = await Get(
-        Digest,
-        MergeDigests((request.input_digest, downloaded_terraform.digest)),
-    )
+    immutable_input_digests = {"__terraform": downloaded_terraform.digest}
 
     return Process(
-        argv=("./terraform",) + request.args,
-        input_digest=input_digest,
+        argv=("__terraform/terraform",) + request.args,
+        input_digest=request.input_digest,
+        immutable_input_digests=immutable_input_digests,
         output_files=request.output_files,
         description=request.description,
         level=LogLevel.DEBUG,


### PR DESCRIPTION
Make the `terraform` binary be an immutable input in order to speed up invocations.

[ci skip-rust]

[ci skip-build-wheels]