### PR TITLE
Backtrack through calls from `@rules` to synchronous engine methods (Cherry-pick of #15979)

### DIFF
--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pants.engine.internals.native_engine import PyFailure
+
 
 class TargetDefinitionException(Exception):
     """Indicates an invalid target definition.
@@ -28,3 +33,15 @@ class BackendConfigurationError(BuildConfigurationError):
 
 class MappingError(Exception):
     """Indicates an error mapping addressable objects."""
+
+
+class NativeEngineFailure(Exception):
+    """A wrapper around a `Failure` instance.
+
+    TODO: This type is defined in Python because pyo3 doesn't support declaring Exceptions with
+    additional fields. See https://github.com/PyO3/pyo3/issues/295
+    """
+
+    def __init__(self, msg: str, failure: PyFailure) -> None:
+        super().__init__(msg)
+        self.failure = failure

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -18,6 +18,12 @@ from pants.engine.process import InteractiveProcessResult
 # flake8: noqa: E302
 
 # ------------------------------------------------------------------------------
+# (core)
+# ------------------------------------------------------------------------------
+
+class PyFailure: ...
+
+# ------------------------------------------------------------------------------
 # Address (parsing)
 # ------------------------------------------------------------------------------
 
@@ -187,7 +193,7 @@ class PyStubCAS:
     def builder(cls) -> PyStubCASBuilder: ...
     @property
     def address(self) -> str: ...
-    def remove(self, digest: FileDigest) -> bool: ...
+    def remove(self, digest: FileDigest | Digest) -> bool: ...
     def action_cache_len(self) -> int: ...
 
 # ------------------------------------------------------------------------------

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -19,6 +19,8 @@ use fs::{
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
 use store::Snapshot;
 
+use crate::Failure;
+
 pub(crate) fn register(m: &PyModule) -> PyResult<()> {
   m.add_class::<PyDigest>()?;
   m.add_class::<PyFileDigest>()?;
@@ -36,11 +38,16 @@ pub(crate) fn register(m: &PyModule) -> PyResult<()> {
   Ok(())
 }
 
-// TODO: This method is a marker, but in a followup PR we will need to propagate a particular
-// Exception type out of `@rule` bodies and back into `Failure::MissingDigest`, to allow for retry
-// via #11331.
-pub fn todo_possible_store_missing_digest(e: store::StoreError) -> PyErr {
-  PyException::new_err(e.to_string())
+///
+/// A marker indicating that a `StoreError` is being converted into a python exception, since retry
+/// via #11331 needs to preserve `Failure` information across Python boundaries.
+///
+/// TODO: Any use of `PyErr::from(Failure::from(StoreError))` would trigger this same conversion,
+/// so this method can eventually be replaced with direct conversion via `?`.
+///
+pub fn possible_store_missing_digest(e: store::StoreError) -> PyErr {
+  let failure: Failure = e.into();
+  failure.into()
 }
 
 #[pyclass(name = "Digest")]

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -45,7 +45,7 @@ use workunit_store::{
   WorkunitStoreHandle,
 };
 
-use crate::externs::fs::{todo_possible_store_missing_digest, PyFileDigest};
+use crate::externs::fs::{possible_store_missing_digest, PyFileDigest};
 use crate::{
   externs, nodes, Context, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination,
   Failure, Function, Intrinsic, Intrinsics, Key, LocalStoreOptions, Params, RemotingOptions, Rule,
@@ -54,6 +54,7 @@ use crate::{
 
 #[pymodule]
 fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
+  externs::register(py, m)?;
   externs::address::register(py, m)?;
   externs::fs::register(m)?;
   externs::nailgun::register(py, m)?;
@@ -65,9 +66,9 @@ fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
 
   m.add_class::<PyExecutionRequest>()?;
   m.add_class::<PyExecutionStrategyOptions>()?;
+  m.add_class::<PyLocalStoreOptions>()?;
   m.add_class::<PyNailgunServer>()?;
   m.add_class::<PyRemotingOptions>()?;
-  m.add_class::<PyLocalStoreOptions>()?;
   m.add_class::<PyResult>()?;
   m.add_class::<PyScheduler>()?;
   m.add_class::<PySession>()?;
@@ -810,7 +811,7 @@ async fn workunit_to_py_value(
           })?;
         let snapshot = store::Snapshot::from_digest(store, digest.clone())
           .await
-          .map_err(todo_possible_store_missing_digest)?;
+          .map_err(possible_store_missing_digest)?;
         let gil = Python::acquire_gil();
         let py = gil.python();
         crate::nodes::Snapshot::store_snapshot(py, snapshot).map_err(PyException::new_err)?
@@ -1428,7 +1429,7 @@ fn lease_files_in_graph(
         .executor
         .block_on(core.store().lease_all_recursively(digests.iter()))
     })
-    .map_err(todo_possible_store_missing_digest)
+    .map_err(possible_store_missing_digest)
   })
 }
 
@@ -1515,7 +1516,7 @@ fn ensure_remote_has_recursive(
         .executor
         .block_on(core.store().ensure_remote_has_recursive(digests))
     })
-    .map_err(todo_possible_store_missing_digest)?;
+    .map_err(possible_store_missing_digest)?;
     Ok(())
   })
 }
@@ -1535,7 +1536,7 @@ fn ensure_directory_digest_persisted(
         .executor
         .block_on(core.store().ensure_directory_digest_persisted(digest))
     })
-    .map_err(todo_possible_store_missing_digest)?;
+    .map_err(possible_store_missing_digest)?;
     Ok(())
   })
 }
@@ -1564,7 +1565,7 @@ fn single_file_digests_to_bytes<'py>(
     let bytes_values: Vec<PyObject> = py
       .allow_threads(|| core.executor.block_on(future::try_join_all(digest_futures)))
       .map(|values| values.into_iter().map(|val| val.into()).collect())
-      .map_err(todo_possible_store_missing_digest)?;
+      .map_err(possible_store_missing_digest)?;
 
     let output_list = PyList::new(py, &bytes_values);
     Ok(output_list)
@@ -1601,7 +1602,7 @@ fn write_digest(
         )
         .await
     })
-    .map_err(todo_possible_store_missing_digest)
+    .map_err(possible_store_missing_digest)
   })
 }
 

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -10,6 +10,7 @@ use std::fmt;
 
 use lazy_static::lazy_static;
 use pyo3::exceptions::PyException;
+use pyo3::import_exception;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
 use pyo3::{FromPyObject, ToPyObject};
@@ -30,6 +31,19 @@ pub mod scheduler;
 mod stdio;
 pub mod testutil;
 pub mod workunits;
+
+pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
+  m.add_class::<PyFailure>()?;
+  Ok(())
+}
+
+#[derive(Clone)]
+#[pyclass]
+pub struct PyFailure(pub Failure);
+
+// TODO: We import this exception type because `pyo3` doesn't support declaring exceptions with
+// additional fields. See https://github.com/PyO3/pyo3/issues/295
+import_exception!(pants.base.exceptions, NativeEngineFailure);
 
 pub fn equals(h1: &PyAny, h2: &PyAny) -> bool {
   // NB: Although it does not precisely align with Python's definition of equality, we ban matches

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -544,10 +544,6 @@ fn interactive_process(
 
     let session = context.session;
 
-    if !restartable {
-        task_side_effected()?;
-    }
-
     let maybe_tempdir = if run_in_workspace {
       None
     } else {
@@ -646,6 +642,10 @@ fn interactive_process(
 
     command.env_clear();
     command.envs(env);
+
+    if !restartable {
+        task_side_effected()?;
+    }
 
     let exit_status = session.clone()
       .with_console_ui_disabled(async move {

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -427,6 +427,16 @@ impl Failure {
   }
 
   pub fn from_py_err_with_gil(py: Python, py_err: PyErr) -> Failure {
+    // If this is a wrapped Failure, return it immediately.
+    if let Ok(n_e_failure) = py_err.value(py).downcast::<externs::NativeEngineFailure>() {
+      let failure = n_e_failure
+        .getattr("failure")
+        .unwrap()
+        .extract::<externs::PyFailure>()
+        .unwrap();
+      return failure.0;
+    }
+
     let maybe_ptraceback = py_err
       .traceback(py)
       .map(|traceback| traceback.to_object(py));
@@ -497,6 +507,12 @@ impl From<StoreError> for Failure {
       StoreError::MissingDigest(s, d) => Self::MissingDigest(s, d),
       StoreError::Unclassified(s) => throw(s),
     }
+  }
+}
+
+impl From<Failure> for PyErr {
+  fn from(err: Failure) -> Self {
+    externs::NativeEngineFailure::new_err((err.to_string(), externs::PyFailure(err)))
   }
 }
 


### PR DESCRIPTION
As reported in #15954, backtracking doesn't currently work when a synchronous method like `Workspace.write_digests` is the source of a `MissingDigest` error. This was due to a TODO left behind in #15761, where we did not propagate the `Failure` type "through" `@rule` bodies.

To fix this, we add a conversion from `Failure` to `PrErr` which wraps in a well known exception type, and then look for that type when converting back from `PyErr` to `Failure`.

Fixes #15954.