### PR TITLE
Enrich `MissingDigest` errors when we fail to recover from them

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 use crate::intrinsics::Intrinsics;
 use crate::nodes::{ExecuteProcess, NodeKey, NodeOutput, NodeResult, WrappedNode};
-use crate::python::Failure;
+use crate::python::{throw, Failure};
 use crate::session::{Session, Sessions};
 use crate::tasks::{Rule, Tasks};
 use crate::types::Types;
@@ -720,7 +720,11 @@ impl Context {
 
     if candidate_roots.is_empty() {
       // We did not identify any roots to invalidate: allow the Node to fail.
-      return result;
+      return result.map_err(|e| {
+        throw(format!(
+          "Could not identify a process to backtrack to for: {e}"
+        ))
+      });
     }
 
     // Attempt to trigger backtrack attempts for the matched Nodes. It's possible that we are not

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -479,7 +479,7 @@ impl fmt::Display for Failure {
     match self {
       Failure::Invalidated => write!(f, "Giving up on retrying due to changed files."),
       Failure::MissingDigest(s, d) => {
-        write!(f, "Could not recover from missing digest: {s}: {d:?}")
+        write!(f, "Missing digest: {s}: {d:?}")
       }
       Failure::Throw { val, .. } => {
         let repr = Python::with_gil(|py| {


### PR DESCRIPTION
In order to differentiate "uncaught" `MissingDigest` cases (where a `MissingDigest` error is converted into a string rather than being handled at the `Node` boundary) from those where we just cannot determine the source, enrich the latter case.

[ci skip-build-wheels]