### PR TITLE
Add support for extra env variables in go tests

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -35,7 +35,7 @@ from pants.backend.go.util_rules import (
     third_party_pkg,
 )
 from pants.build_graph.address import Address
-from pants.core.goals.test import TestResult
+from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import Digest, DigestContents
@@ -70,6 +70,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             *tests_analysis.rules(),
             *third_party_pkg.rules(),
+            get_filtered_environment,
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GenerateGoFromProtobufRequest]),
             QueryRule(DigestContents, (Digest,)),

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -550,7 +550,13 @@ def test_extra_env_vars(rule_runner: RuleRunner) -> None:
             "foo/BUILD": textwrap.dedent(
                 """
                 go_mod(name='mod')
-                go_package()
+                go_package(
+                    test_extra_env_vars=(
+                        "GO_PACKAGE_VAR_WITHOUT_VALUE",
+                        "GO_PACKAGE_VAR_WITH_VALUE=go_package_var_with_value",
+                        "GO_PACKAGE_OVERRIDE_WITH_VALUE_VAR=go_package_override_with_value_var_override",
+                    )
+                )
                 """
             ),
             "foo/go.mod": "module foo",
@@ -574,6 +580,15 @@ def test_extra_env_vars(rule_runner: RuleRunner) -> None:
                   if !envIs("ARG_WITHOUT_VALUE_VAR", "arg_without_value_var") {
                       t.Fail()
                   }
+                  if !envIs("GO_PACKAGE_VAR_WITH_VALUE", "go_package_var_with_value") {
+                      t.Fail()
+                  }
+                  if !envIs("GO_PACKAGE_VAR_WITHOUT_VALUE", "go_package_var_without_value") {
+                      t.Fail()
+                  }
+                  if !envIs("GO_PACKAGE_OVERRIDE_WITH_VALUE_VAR", "go_package_override_with_value_var_override") {
+                      t.Fail()
+                  }
                 }
                 """
             ),
@@ -583,10 +598,12 @@ def test_extra_env_vars(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         args=[
             "--go-test-args=-v -bench=.",
-            '--test-extra-env-vars=["ARG_WITH_VALUE_VAR=arg_with_value_var", "ARG_WITHOUT_VALUE_VAR"]',
+            '--test-extra-env-vars=["ARG_WITH_VALUE_VAR=arg_with_value_var", "ARG_WITHOUT_VALUE_VAR", "GO_PACKAGE_OVERRIDE_ARG_WITH_VALUE_VAR"]',
         ],
         env={
             "ARG_WITHOUT_VALUE_VAR": "arg_without_value_var",
+            "GO_PACKAGE_VAR_WITHOUT_VALUE": "go_package_var_without_value",
+            "GO_PACKAGE_OVERRIDE_WITH_VALUE_VAR": "go_package_override_with_value_var",
         },
         env_inherit={"PATH"},
     )

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -24,7 +24,7 @@ from pants.backend.go.util_rules import (
     third_party_pkg,
 )
 from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.core.goals.test import TestResult
+from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.target_types import FileTarget
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
@@ -48,6 +48,7 @@ def rule_runner() -> RuleRunner:
             *tests_analysis.rules(),
             *third_party_pkg.rules(),
             *source_files.rules(),
+            get_filtered_environment,
             QueryRule(TestResult, [GoTestFieldSet]),
             QueryRule(ProcessResult, [GoSdkProcess]),
         ],
@@ -541,6 +542,57 @@ def test_fuzz_target_supported(rule_runner: RuleRunner) -> None:
     result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
     assert result.exit_code == 0
     assert "PASS: FuzzFoo" in result.stdout
+
+
+def test_extra_env_vars(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": textwrap.dedent(
+                """
+                go_mod(name='mod')
+                go_package()
+                """
+            ),
+            "foo/go.mod": "module foo",
+            "foo/add.go": textwrap.dedent(
+                """
+                package foo
+                import "os"
+                func envIs(e, v string) bool {
+                  return (os.Getenv(e) == v)
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """
+                package foo
+                import "testing"
+                func TestEnvs(t *testing.T) {
+                  if !envIs("ARG_WITH_VALUE_VAR", "arg_with_value_var") {
+                      t.Fail()
+                  }
+                  if !envIs("ARG_WITHOUT_VALUE_VAR", "arg_without_value_var") {
+                      t.Fail()
+                  }
+                }
+                """
+            ),
+        }
+    )
+    tgt = rule_runner.get_target(Address("foo"))
+    rule_runner.set_options(
+        args=[
+            "--go-test-args=-v -bench=.",
+            '--test-extra-env-vars=["ARG_WITH_VALUE_VAR=arg_with_value_var", "ARG_WITHOUT_VALUE_VAR"]',
+        ],
+        env={
+            "ARG_WITHOUT_VALUE_VAR": "arg_without_value_var",
+        },
+        env_inherit={"PATH"},
+    )
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    assert result.exit_code == 0
+    assert "PASS: TestEnvs" in result.stdout
 
 
 def test_skip_tests(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -21,6 +21,7 @@ from pants.engine.target import (
     InvalidTargetException,
     MultipleSourcesField,
     StringField,
+    StringSequenceField,
     Target,
     TargetGenerator,
     ValidNumbers,
@@ -179,6 +180,18 @@ class SkipGoTestsField(BoolField):
     help = "If true, don't run this package's tests."
 
 
+class GoTestExtraEnvVarsField(StringSequenceField):
+    alias = "test_extra_env_vars"
+    help = softwrap(
+        """
+         Additional environment variables to include in test processes.
+         Entries are strings in the form `ENV_VAR=value` to use explicitly; or just
+         `ENV_VAR` to copy the value of a variable in Pants's own environment.
+         This will be merged with and override values from [test].extra_env_vars.
+        """
+    )
+
+
 class GoTestTimeoutField(IntField):
     alias = "test_timeout"
     help = softwrap(
@@ -197,6 +210,7 @@ class GoPackageTarget(Target):
         *COMMON_TARGET_FIELDS,
         GoPackageDependenciesField,
         GoPackageSourcesField,
+        GoTestExtraEnvVarsField,
         GoTestTimeoutField,
         SkipGoTestsField,
     )

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -27,7 +27,7 @@ from pants.backend.go.util_rules import (
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.build_graph.address import Address
-from pants.core.goals.test import TestResult
+from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.target_types import ResourceTarget
 from pants.core.util_rules import source_files
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -49,6 +49,7 @@ def rule_runner() -> RuleRunner:
             *tests_analysis.rules(),
             *third_party_pkg.rules(),
             *source_files.rules(),
+            get_filtered_environment,
             QueryRule(TestResult, [GoTestFieldSet]),
         ],
         target_types=[GoModTarget, GoPackageTarget, ResourceTarget],


### PR DESCRIPTION
This addresses #15963 by plumbing through `[test].extra_env_vars` and adding the `test_extra_env_vars` field to `go_package`.

[ci skip-rust]

[ci skip-build-wheels]