### PR TITLE
Work around a Rust build breakage.

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -2,7 +2,7 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-"${REPO_ROOT}/cargo" install cargo-ensure-prefix "=0.1.7"
+"${REPO_ROOT}/cargo" install cargo-ensure-prefix --locked "=0.1.7"
 
 if ! out="$("${REPO_ROOT}/cargo" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \


### PR DESCRIPTION
Apparently the issue is due to the release of
https://crates.io/crates/cargo-util/0.1.3.

[ci skip-build-wheels]