### PR TITLE
Deprecate not setting `tailor_pex_binary_targets` explictly (Cherry-pick of #15962)

### DIFF
--- a/docs/markdown/Python/python/python-backend.md
+++ b/docs/markdown/Python/python/python-backend.md
@@ -7,9 +7,9 @@ createdAt: "2020-03-02T22:39:55.355Z"
 updatedAt: "2022-05-16T05:07:38.169Z"
 ---
 > 📘 Example Python repository
-> 
+>
 > See [here](https://github.com/pantsbuild/example-python) for examples of Pants's Python functionality.
-> 
+>
 > See [here](https://github.com/pantsbuild/example-django) for Django-specific examples.
 
 Enable the Python [backend](doc:enabling-backends) like this:
@@ -20,6 +20,10 @@ Enable the Python [backend](doc:enabling-backends) like this:
 backend_packages = [
   "pants.backend.python"
 ]
+
+[python]
+# This will become the default in Pants 2.15.
+tailor_pex_binary_targets = false
 ```
 
 Pants use [`python_source`](doc:reference-python_source) and [`python_test`](doc:reference-python_test) targets to know which Python files to run on and to set any metadata.
@@ -50,37 +54,37 @@ Created project/BUILD:
 ```
 
 > 📘 Have content in your `__init__.py` files?
-> 
+>
 > Pants automatically uses all relevant `__init__.py` files, even if dependency inference does not include the files and you don't add it to the `dependencies` fields of your targets.
-> 
+>
 > This works if you have empty `__init__.py` files, like most Python projects do; but if you have actual code in your `__init__.py` files, you should turn on both of these options in your `pants.toml`:
-> 
+>
 > ```toml
 > [python]
 > tailor_ignore_solitary_init_files = false
-> 
+>
 > [python-infer]
 > inits = true
 > ```
-> 
+>
 > This option will cause Pants to infer "proper" dependencies on any ancestor `__init__.py` file. If you run `./pants dependencies project/util/foo.py`, you should see `project/__init__.py` and `project/util/__init__.py` show up. This will ensure that any of the `dependencies` of your `__init__.py` files are included.
 
 > 🚧 macOS users: you may need to change interpreter search paths
-> 
+>
 > By default, Pants will look at both your `$PATH` and—if you use Pyenv—your `$(pyenv root)/versions` folder when discovering Python interpreters. Your `$PATH` likely includes the system Pythons at `/usr/bin/python` and `/usr/bin/python3`, which are known to have many issues like failing to install some dependencies.
-> 
+>
 > Pants will prefer new Python versions, like 3.6.10 over 3.6.3. Because macOS system Pythons are usually very old, they will usually be ignored.
-> 
+>
 > However, if you run into issues, you can set the `search_paths` option in the `[python-bootstrap]` scope:
-> 
+>
 > ```toml
 > [python-bootstrap]
 > search_paths = [
 >     # This will use all interpreters in `$(pyenv root)/versions`.
 >     "<PYENV>",
->      # Brew usually installs Python here. 
+>      # Brew usually installs Python here.
 >     "/usr/local/bin",
 > ]
 > ```
-> 
+>
 > See [here](doc:python-interpreter-compatibility#changing-the-interpreter-search-path) for more information.

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -8,6 +8,7 @@ import logging
 import os
 from typing import Iterable, Iterator, Optional, cast
 
+from pants.base.deprecated import warn_or_error
 from pants.option.option_types import (
     BoolOption,
     DictOption,
@@ -445,7 +446,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    tailor_pex_binary_targets = BoolOption(
+    _tailor_pex_binary_targets = BoolOption(
         "--tailor-pex-binary-targets",
         default=True,
         help=softwrap(
@@ -456,6 +457,26 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
+
+    @property
+    def tailor_pex_binary_targets(self) -> bool:
+        if self.options.is_default("tailor_pex_binary_targets"):
+            warn_or_error(
+                "2.14.0.dev1",
+                "the [python] option `tailor_pex_binary_targets` defaulting to `true`",
+                softwrap(
+                    """
+                    In Pants 2.13, you can run a `python_source` target directly, without the need
+                    for a `pex_binary` target.
+
+                    We believe that most Python files which would've been flagged as `pex_binary`s
+                    (e.g. contain an `if __name__ == "__main__"` block) are likely user scripts and
+                    aren't meant to be packaged. Therefore in Pants 2.14 the default will be changed
+                    to `false`.
+                    """
+                ),
+            )
+        return self._tailor_pex_binary_targets
 
     macos_big_sur_compatibility = BoolOption(
         "--macos-big-sur-compatibility",


### PR DESCRIPTION
With https://github.com/pantsbuild/pants/pull/15849 the default for the `--tailor-pex-binary-targets` flag should naturally be `False`, so this begins the path to that.

[ci skip-rust]
[ci skip-build-wheels]
