### PR TITLE
Update 2.13.x changelog with recent cherry-picks for `2.13.0a1`

### DIFF
--- a/src/python/pants/notes/2.13.x.md
+++ b/src/python/pants/notes/2.13.x.md
@@ -4,11 +4,15 @@
 
 ### New Features
 
+* Add ability to `run` any `PythonSourceField` (Cherry-pick of #15849) ([#16022](https://github.com/pantsbuild/pants/pull/16022))
+
 * Add `--debug-adapter` flag to `run` (Cherry-pick of #15829) ([#15988](https://github.com/pantsbuild/pants/pull/15988))
 
 * Add repository config option to Docker registries. (Cherry pick of #15884) ([#15952](https://github.com/pantsbuild/pants/pull/15952))
 
 ### User API Changes
+
+* Deprecate not setting `tailor_pex_binary_targets` explictly (Cherry-pick of #15962) ([#16023](https://github.com/pantsbuild/pants/pull/16023))
 
 * Upgrade default iPython to 7.34, which drops Python 3.6 (Cherry-pick of #15934) ([#15938](https://github.com/pantsbuild/pants/pull/15938))
 


### PR DESCRIPTION
[ci skip-rust]