### PR TITLE
[internal] remove the instance name option from config

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -67,7 +67,6 @@ unmatched_build_file_globs = "error"
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
 remote_store_address = "grpcs://cache.toolchain.com:443"
-remote_instance_name = "main"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 # See https://github.com/pantsbuild/pants/issues/11331.
 remote_cache_eager_fetch = false


### PR DESCRIPTION
This is not the actual value that is being used.
the toolchain auth plugin provides that value to pants.