### PR TITLE
Default `--use-deprecated-pex-binary-run-semantics` to `False`.

### DIFF
--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -11,11 +11,11 @@ import pytest
 from pants.backend.python.target_types import PexExecutionMode
 from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
 
-use_new_semantics_args = pytest.mark.parametrize(
-    "use_new_semantics_args",
+use_deprecated_semantics_args = pytest.mark.parametrize(
+    "use_deprecated_semantics_args",
     [
         (),
-        ("--no-use-deprecated-pex-binary-run-semantics",),
+        ("--use-deprecated-pex-binary-run-semantics",),
     ],
 )
 
@@ -30,12 +30,12 @@ use_new_semantics_args = pytest.mark.parametrize(
         ("app.py:main", None, False),
     ],
 )
-@use_new_semantics_args
+@use_deprecated_semantics_args
 def test_run_sample_script(
     entry_point: str,
     execution_mode: Optional[PexExecutionMode],
     include_tools: bool,
-    use_new_semantics_args: tuple[str, ...],
+    use_deprecated_semantics_args: tuple[str, ...],
 ) -> None:
     """Test that we properly run a `pex_binary` target.
 
@@ -92,7 +92,7 @@ def test_run_sample_script(
             args = [
                 "--backend-packages=pants.backend.python",
                 "--backend-packages=pants.backend.codegen.protobuf.python",
-                *use_new_semantics_args,
+                *use_deprecated_semantics_args,
                 f"--source-root-patterns=['/{tmpdir}/src_root1', '/{tmpdir}/src_root2']",
                 "--pants-ignore=__pycache__",
                 "--pants-ignore=/src/python",
@@ -105,12 +105,12 @@ def test_run_sample_script(
     result = run()
     assert "Hola, mundo.\n" in result.stderr
     file = result.stdout.strip()
-    if use_new_semantics_args:
-        assert file.endswith("utils/strutil.py")
-        assert ".pants.d/tmp" not in file
-    else:
+    if use_deprecated_semantics_args:
         assert file.endswith("src_root2/utils/strutil.py")
         assert ".pants.d/tmp" in file
+    else:
+        assert file.endswith("utils/strutil.py")
+        assert ".pants.d/tmp" not in file
     assert result.exit_code == 23
 
     if include_tools:
@@ -121,14 +121,14 @@ def test_run_sample_script(
         assert ("prepend" if execution_mode is PexExecutionMode.VENV else "false") == pex_info[
             "venv_bin_path"
         ]
-        if use_new_semantics_args:
-            assert pex_info["strip_pex_env"]
-        else:
+        if use_deprecated_semantics_args:
             assert not pex_info["strip_pex_env"]
+        else:
+            assert pex_info["strip_pex_env"]
 
 
-@use_new_semantics_args
-def test_no_strip_pex_env_issues_12057(use_new_semantics_args: tuple[str, ...]) -> None:
+@use_deprecated_semantics_args
+def test_no_strip_pex_env_issues_12057(use_deprecated_semantics_args: tuple[str, ...]) -> None:
     sources = {
         "src/app.py": dedent(
             """\
@@ -157,7 +157,7 @@ def test_no_strip_pex_env_issues_12057(use_new_semantics_args: tuple[str, ...]) 
     with setup_tmpdir(sources) as tmpdir:
         args = [
             "--backend-packages=pants.backend.python",
-            *use_new_semantics_args,
+            *use_deprecated_semantics_args,
             f"--source-root-patterns=['/{tmpdir}/src']",
             "run",
             f"{tmpdir}/src:binary",
@@ -166,8 +166,8 @@ def test_no_strip_pex_env_issues_12057(use_new_semantics_args: tuple[str, ...]) 
         assert result.exit_code == 42, result.stderr
 
 
-@use_new_semantics_args
-def test_local_dist(use_new_semantics_args: tuple[str, ...]) -> None:
+@use_deprecated_semantics_args
+def test_local_dist(use_deprecated_semantics_args: tuple[str, ...]) -> None:
     sources = {
         "foo/bar.py": "BAR = 'LOCAL DIST'",
         "foo/setup.py": dedent(
@@ -204,7 +204,7 @@ def test_local_dist(use_new_semantics_args: tuple[str, ...]) -> None:
     with setup_tmpdir(sources) as tmpdir:
         args = [
             "--backend-packages=pants.backend.python",
-            *use_new_semantics_args,
+            *use_deprecated_semantics_args,
             f"--source-root-patterns=['/{tmpdir}']",
             "run",
             f"{tmpdir}/foo:bin",
@@ -213,8 +213,8 @@ def test_local_dist(use_new_semantics_args: tuple[str, ...]) -> None:
         assert result.stdout == "LOCAL DIST\n"
 
 
-@use_new_semantics_args
-def test_run_script_from_3rdparty_dist_issue_13747(use_new_semantics_args) -> None:
+@use_deprecated_semantics_args
+def test_run_script_from_3rdparty_dist_issue_13747(use_deprecated_semantics_args) -> None:
     sources = {
         "src/BUILD": dedent(
             """\
@@ -227,7 +227,7 @@ def test_run_script_from_3rdparty_dist_issue_13747(use_new_semantics_args) -> No
         SAY = "moooo"
         args = [
             "--backend-packages=pants.backend.python",
-            *use_new_semantics_args,
+            *use_deprecated_semantics_args,
             f"--source-root-patterns=['/{tmpdir}/src']",
             "run",
             f"{tmpdir}/src:test",
@@ -240,8 +240,8 @@ def test_run_script_from_3rdparty_dist_issue_13747(use_new_semantics_args) -> No
 
 
 # NB: Can be removed in 2.15
-@use_new_semantics_args
-def test_filename_spec_ambiutity(use_new_semantics_args) -> None:
+@use_deprecated_semantics_args
+def test_filename_spec_ambiutity(use_deprecated_semantics_args) -> None:
     sources = {
         "src/app.py": dedent(
             """\
@@ -262,7 +262,7 @@ def test_filename_spec_ambiutity(use_new_semantics_args) -> None:
     with setup_tmpdir(sources) as tmpdir:
         args = [
             "--backend-packages=pants.backend.python",
-            *use_new_semantics_args,
+            *use_deprecated_semantics_args,
             f"--source-root-patterns=['/{tmpdir}/src']",
             "run",
             f"{tmpdir}/src/app.py",

--- a/src/python/pants/core/goals/run_integration_test.py
+++ b/src/python/pants/core/goals/run_integration_test.py
@@ -41,6 +41,7 @@ def test_run_then_edit(use_pantsd: bool) -> None:
         client_handle = run_pants_with_workdir_without_waiting(
             [
                 "--backend-packages=['pants.backend.python']",
+                "--use-deprecated-pex-binary-run-semantics",
                 "run",
                 f"{dirname}/slow.py",
             ],

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -371,7 +371,10 @@ def test_url_assets(asset_type) -> None:
     with mock_console(rule_runner.options_bootstrapper) as (console, stdout_reader):
         rule_runner.run_goal_rule(
             run.Run,
-            args=["app/app.py"],
+            args=[
+                "app/app.py",
+                f"--use-deprecated-pex-binary-run-semantics={asset_type == 'file'}",
+            ],
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
         stdout = stdout_reader.get_stdout()

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -23,7 +23,7 @@ from pants.base.build_environment import (
     is_in_container,
     pants_version,
 )
-from pants.base.deprecated import deprecated_conditional, warn_or_error
+from pants.base.deprecated import deprecated_conditional
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
@@ -1662,9 +1662,9 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         ),
     )
 
-    _use_deprecated_pex_binary_run_semantics = BoolOption(
+    use_deprecated_pex_binary_run_semantics = BoolOption(
         "--use-deprecated-pex-binary-run-semantics",
-        default=True,
+        default=False,
         help=softwrap(
             """
             If `true`, `run`ning a `pex_binary` will run your firstparty code by copying sources to
@@ -1694,35 +1694,6 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             """
         ),
     )
-
-    @property
-    def use_deprecated_pex_binary_run_semantics(self) -> bool:
-        if self.options.is_default("use_deprecated_pex_binary_run_semantics"):
-            warn_or_error(
-                "2.14.0.dev1",
-                "the option --use-deprecated-pex-binary-run-semantics defaulting to true",
-                softwrap(
-                    f"""
-                    Currently, running a `pex_binary` by default will not include the source files
-                    in the PEX, and will instead put them in a temporary sandbox.
-
-                    In Pants 2.14, the default will change to instead build the PEX like you had run
-                    the `package` goal, and then execute that PEX. This is more consistent and
-                    intuitive behavior.
-
-                    To fix this deprecation, explictly set `use_deprecated_pex_binary_run_semantics`
-                    in the `[GLOBAL]` section of `pants.toml`.
-                    Set it to `true` to use the "old" behavior.
-                    Set it to `false` to use the "new" behavior.
-
-                    When set to `false`, you can still run the binary as before because you can now
-                    run on a `python_source` target. The simplest way to do this is to use
-                    `{bin_name()} run path/to/file.py`, which will find the owning `python_source`.
-                    Pants will run the file the same way it used to with `pex_binary` targets.
-                    """
-                ),
-            )
-        return self._use_deprecated_pex_binary_run_semantics
 
     @classmethod
     def validate_instance(cls, opts):


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]