### PR TITLE
Remove `python-infer` `inits` option.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -144,7 +144,6 @@ class PythonInferSubsystem(Subsystem):
             """
         ),
     )
-
     init_files = EnumOption(
         "--init-files",
         help=softwrap(
@@ -166,32 +165,6 @@ class PythonInferSubsystem(Subsystem):
         ),
         default=InitFilesInference.content_only,
     )
-    inits = BoolOption(
-        "--inits",
-        default=False,
-        help=softwrap(
-            f"""
-            Infer a target's dependencies on any `__init__.py` files in the packages
-            it is located in (recursively upward in the directory structure).
-
-            Even if this is disabled, Pants will still include any ancestor `__init__.py` files,
-            only they will not be 'proper' dependencies, e.g. they will not show up in
-            `{bin_name()} dependencies` and their own dependencies will not be used.
-
-            If you have empty `__init__.py` files, it's safe to leave this option off; otherwise,
-            you should enable this option.
-            """
-        ),
-        removal_version="2.14.0.dev1",
-        removal_hint=softwrap(
-            """
-            Use the more powerful option `[python-infer].init_files`. For identical
-            behavior, set to 'always'. Otherwise, we recommend the default of `content_only`
-            (simply delete the option `[python-infer].inits` to trigger the default).
-            """
-        ),
-    )
-
     conftests = BoolOption(
         "--conftests",
         default=True,
@@ -471,15 +444,10 @@ async def infer_python_init_dependencies(
     python_infer_subsystem: PythonInferSubsystem,
     python_setup: PythonSetup,
 ) -> InferredDependencies:
-    if (
-        not python_infer_subsystem.options.is_default("inits") and not python_infer_subsystem.inits
-    ) or python_infer_subsystem.init_files is InitFilesInference.never:
+    if python_infer_subsystem.init_files is InitFilesInference.never:
         return InferredDependencies([])
 
-    ignore_empty_files = (
-        python_infer_subsystem.options.is_default("inits")
-        and python_infer_subsystem.init_files is InitFilesInference.content_only
-    )
+    ignore_empty_files = python_infer_subsystem.init_files is InitFilesInference.content_only
     fp = request.sources_field.file_path
     assert fp is not None
     init_files = await Get(


### PR DESCRIPTION
This has been replaced by the more capable `init_files` option.

[ci skip-rust]
[ci skip-build-wheels]