### PR TITLE
Pants internally uses dedicated Sources and Dependencies fields

### DIFF
--- a/src/python/pants/backend/cc/target_types.py
+++ b/src/python/pants/backend/cc/target_types.py
@@ -20,6 +20,10 @@ from pants.engine.target import (
 CC_FILE_EXTENSIONS = (".c", ".h", ".cc", ".cpp", ".hpp")
 
 
+class CCDependenciesField(Dependencies):
+    pass
+
+
 class CCSourceField(SingleSourceField):
     expected_file_extensions = CC_FILE_EXTENSIONS
 
@@ -51,7 +55,7 @@ class CCSourceTarget(Target):
     alias = "cc_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        CCDependenciesField,
         CCSourceField,
     )
     help = "A single C/C++ source file or header file."

--- a/src/python/pants/backend/codegen/avro/target_types.py
+++ b/src/python/pants/backend/codegen/avro/target_types.py
@@ -20,8 +20,6 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
 
-# NB: We subclass Dependencies so that specific backends can add dependency injection rules to
-# `avro_source` targets.
 class AvroDependenciesField(Dependencies):
     pass
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -25,8 +25,6 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
 
-# NB: We subclass Dependencies so that specific backends can add dependency injection rules to
-# `protobuf_source` targets.
 class ProtobufDependenciesField(Dependencies):
     pass
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -24,8 +24,6 @@ from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
 
-# NB: We subclass Dependencies so that specific backends can add dependency injection rules to
-# `thrift_source` targets.
 class ThriftDependenciesField(Dependencies):
     pass
 

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
-    Dependencies,
     FieldSet,
     MultipleSourcesField,
     SingleSourceField,
@@ -18,6 +17,7 @@ from pants.engine.target import (
 )
 from pants.jvm.target_types import (
     JunitTestSourceField,
+    JvmDependenciesField,
     JvmJdkField,
     JvmProvidesTypesField,
     JvmResolveField,
@@ -60,7 +60,7 @@ class JunitTestTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         JavaJunitTestSourceField,
-        Dependencies,
+        JvmDependenciesField,
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
@@ -84,7 +84,7 @@ class JunitTestsGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = JunitTestTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
-        Dependencies,
+        JvmDependenciesField,
         JvmJdkField,
         JvmProvidesTypesField,
         JvmResolveField,
@@ -101,7 +101,7 @@ class JavaSourceTarget(Target):
     alias = "java_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        JvmDependenciesField,
         JavaSourceField,
         JvmResolveField,
         JvmProvidesTypesField,
@@ -126,7 +126,7 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
     generated_target_cls = JavaSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
-        Dependencies,
+        JvmDependenciesField,
         JvmResolveField,
         JvmJdkField,
         JvmProvidesTypesField,

--- a/src/python/pants/backend/javascript/target_types.py
+++ b/src/python/pants/backend/javascript/target_types.py
@@ -15,6 +15,10 @@ from pants.engine.target import (
 JS_FILE_EXTENSIONS = (".js",)
 
 
+class JSDependenciesField(Dependencies):
+    pass
+
+
 class JSSourceField(SingleSourceField):
     expected_file_extensions = JS_FILE_EXTENSIONS
 
@@ -32,7 +36,7 @@ class JSSourceTarget(Target):
     alias = "javascript_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        JSDependenciesField,
         JSSourceField,
     )
     help = "A single Javascript source file."
@@ -50,5 +54,5 @@ class JSSourcesGeneratorTarget(TargetFilesGenerator):
     )
     generated_target_cls = JSSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (JSDependenciesField,)
     help = "Generate a `javascript_source` target for each file in the `sources` field."

--- a/src/python/pants/backend/project_info/dependees_test.py
+++ b/src/python/pants/backend/project_info/dependees_test.py
@@ -15,9 +15,13 @@ class SpecialDeps(SpecialCasedDependencies):
     alias = "special_deps"
 
 
+class MockDepsField(Dependencies):
+    pass
+
+
 class MockTarget(Target):
     alias = "tgt"
-    core_fields = (Dependencies, SpecialDeps)
+    core_fields = (MockDepsField, SpecialDeps)
 
 
 @pytest.fixture

--- a/src/python/pants/backend/project_info/filedeps_test.py
+++ b/src/python/pants/backend/project_info/filedeps_test.py
@@ -15,9 +15,13 @@ class MockSources(MultipleSourcesField):
     default = ("*.ext",)
 
 
+class MockDepsField(Dependencies):
+    pass
+
+
 class MockTarget(Target):
     alias = "tgt"
-    core_fields = (MockSources, Dependencies)
+    core_fields = (MockSources, MockDepsField)
 
 
 class MockSingleSourceField(SingleSourceField):
@@ -26,7 +30,7 @@ class MockSingleSourceField(SingleSourceField):
 
 class MockSingleSourceTarget(Target):
     alias = "single_source"
-    core_fields = (MockSingleSourceField, Dependencies)
+    core_fields = (MockSingleSourceField, MockDepsField)
 
 
 @pytest.fixture

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -43,14 +43,14 @@ class MockGeneratedFileTarget(Target):
     core_fields = (MockSingleSourceField, Tags)
 
 
-class MockmultipleSourcesField(MultipleSourcesField):
+class MockMultipleSourcesField(MultipleSourcesField):
     pass
 
 
-class MockFileTargetGenerator(MockmultipleSourcesField):
+class MockFileTargetGenerator(TargetFilesGenerator):
     alias = "file_generator"
     generated_target_cls = MockGeneratedFileTarget
-    core_fields = (MultipleSourcesField, Tags)
+    core_fields = (MockMultipleSourcesField, Tags)
     copied_fields = (Tags,)
     moved_fields = ()
 

--- a/src/python/pants/backend/project_info/filter_targets_test.py
+++ b/src/python/pants/backend/project_info/filter_targets_test.py
@@ -34,12 +34,20 @@ class MockTarget(Target):
     deprecated_alias_removal_version = "99.9.0.dev0"
 
 
+class MockSingleSourceField(SingleSourceField):
+    pass
+
+
 class MockGeneratedFileTarget(Target):
     alias = "file_generated"
-    core_fields = (SingleSourceField, Tags)
+    core_fields = (MockSingleSourceField, Tags)
 
 
-class MockFileTargetGenerator(TargetFilesGenerator):
+class MockmultipleSourcesField(MultipleSourcesField):
+    pass
+
+
+class MockFileTargetGenerator(MockmultipleSourcesField):
     alias = "file_generator"
     generated_target_cls = MockGeneratedFileTarget
     core_fields = (MultipleSourcesField, Tags)

--- a/src/python/pants/backend/project_info/paths_test.py
+++ b/src/python/pants/backend/project_info/paths_test.py
@@ -19,11 +19,15 @@ class MockSourceField(OptionalSingleSourceField):
     expected_file_extensions: ClassVar[tuple[str, ...]] = (".txt",)
 
 
+class MockDepsField(Dependencies):
+    pass
+
+
 class MockTarget(Target):
     alias = "tgt"
     core_fields = (
         MockSourceField,
-        Dependencies,
+        MockDepsField,
     )
 
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -85,6 +85,10 @@ class PythonSourceField(SingleSourceField):
     expected_file_extensions: ClassVar[tuple[str, ...]] = ("", ".py", ".pyi")
 
 
+class PythonDependenciesField(Dependencies):
+    pass
+
+
 class PythonGeneratingSourcesBase(MultipleSourcesField):
     expected_file_extensions: ClassVar[tuple[str, ...]] = ("", ".py", ".pyi")
 
@@ -930,7 +934,7 @@ class PythonSourceTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,
-        Dependencies,
+        PythonDependenciesField,
         PythonResolveField,
         PythonRunGoalUseSandboxField,
         PythonSourceField,
@@ -982,7 +986,7 @@ class PythonTestUtilsGeneratorTarget(TargetFilesGenerator):
     moved_fields = (
         PythonResolveField,
         PythonRunGoalUseSandboxField,
-        Dependencies,
+        PythonDependenciesField,
         InterpreterConstraintsField,
     )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
@@ -1013,7 +1017,7 @@ class PythonSourcesGeneratorTarget(TargetFilesGenerator):
     moved_fields = (
         PythonResolveField,
         PythonRunGoalUseSandboxField,
-        Dependencies,
+        PythonDependenciesField,
         InterpreterConstraintsField,
     )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
@@ -1068,6 +1072,10 @@ class _PipRequirementSequenceField(Field):
             else:
                 raise invalid_type_error
         return tuple(result)
+
+
+class PythonRequirementDependenciesField(Dependencies):
+    pass
 
 
 class PythonRequirementsField(_PipRequirementSequenceField):
@@ -1161,8 +1169,8 @@ class PythonRequirementTarget(Target):
     alias = "python_requirement"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
         PythonRequirementsField,
+        PythonRequirementDependenciesField,
         PythonRequirementModulesField,
         PythonRequirementTypeStubModulesField,
         PythonRequirementResolveField,

--- a/src/python/pants/backend/python/util_rules/python_sources_test.py
+++ b/src/python/pants/backend/python/util_rules/python_sources_test.py
@@ -34,9 +34,13 @@ class PythonTarget(Target):
     core_fields = (PythonSourceField,)
 
 
+class NonPythonSourceField(SingleSourceField):
+    pass
+
+
 class NonPythonTarget(Target):
     alias = "non_python_target"
-    core_fields = (SingleSourceField,)
+    core_fields = (NonPythonSourceField,)
 
 
 @pytest.fixture

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -27,12 +27,7 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    Dependencies,
-    SourcesField,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
@@ -40,7 +35,7 @@ from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JvmJdkField
+from pants.jvm.target_types import JvmDependenciesField, JvmJdkField
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -55,7 +50,7 @@ class ScalatestTestFieldSet(TestFieldSet):
 
     sources: ScalatestTestSourceField
     jdk_version: JvmJdkField
-    dependencies: Dependencies
+    dependencies: JvmDependenciesField
 
 
 class ScalatestToolLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pants.backend.shell.lint.shellcheck.skip_field import SkipShellcheckField
 from pants.backend.shell.lint.shellcheck.subsystem import Shellcheck
-from pants.backend.shell.target_types import ShellSourceField
+from pants.backend.shell.target_types import ShellDependenciesField, ShellSourceField
 from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -14,14 +14,7 @@ from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    Dependencies,
-    DependenciesRequest,
-    FieldSet,
-    SourcesField,
-    Target,
-    Targets,
-)
+from pants.engine.target import DependenciesRequest, FieldSet, SourcesField, Target, Targets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -32,7 +25,7 @@ class ShellcheckFieldSet(FieldSet):
     required_fields = (ShellSourceField,)
 
     sources: ShellSourceField
-    dependencies: Dependencies
+    dependencies: ShellDependenciesField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -33,6 +33,10 @@ from pants.util.enums import match
 from pants.util.strutil import softwrap
 
 
+class ShellDependenciesField(Dependencies):
+    pass
+
+
 class ShellSourceField(SingleSourceField):
     # Normally, we would add `expected_file_extensions = ('.sh',)`, but Bash scripts don't need a
     # file extension, so we don't use this.
@@ -214,7 +218,7 @@ class Shunit2TestsGeneratorTarget(TargetFilesGenerator):
 
 class ShellSourceTarget(Target):
     alias = "shell_source"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ShellSourceField)
+    core_fields = (*COMMON_TARGET_FIELDS, ShellDependenciesField, ShellSourceField)
     help = "A single Bourne-based shell script, e.g. a Bash script."
 
 
@@ -247,7 +251,7 @@ class ShellSourcesGeneratorTarget(TargetFilesGenerator):
     )
     generated_target_cls = ShellSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (ShellDependenciesField,)
     help = "Generate a `shell_source` target for each file in the `sources` field."
 
 
@@ -271,6 +275,10 @@ class ShellCommandOutputsField(StringSequenceField):
         Use a trailing slash on directory names, i.e. `my_dir/`.
         """
     )
+
+
+class ShellCommandDependenciesField(Dependencies):
+    pass
 
 
 class ShellCommandSourcesField(MultipleSourcesField):
@@ -328,7 +336,7 @@ class ShellCommandTarget(Target):
     alias = "experimental_shell_command"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        ShellCommandDependenciesField,
         ShellCommandCommandField,
         ShellCommandLogOutputField,
         ShellCommandOutputsField,
@@ -365,7 +373,7 @@ class ShellCommandRunTarget(Target):
     alias = "experimental_run_shell_command"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        ShellCommandDependenciesField,
         ShellCommandCommandField,
         ShellCommandRunWorkdirField,
     )

--- a/src/python/pants/backend/swift/target_types.py
+++ b/src/python/pants/backend/swift/target_types.py
@@ -15,6 +15,10 @@ from pants.engine.target import (
 SWIFT_FILE_EXTENSIONS = (".swift",)
 
 
+class SwiftDependenciesField(Dependencies):
+    pass
+
+
 class SwiftSourceField(SingleSourceField):
     expected_file_extensions = SWIFT_FILE_EXTENSIONS
 
@@ -32,7 +36,7 @@ class SwiftSourceTarget(Target):
     alias = "swift_source"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        SwiftDependenciesField,
         SwiftSourceField,
     )
     help = "A single Swift source file."
@@ -50,5 +54,5 @@ class SwiftSourcesGeneratorTarget(TargetFilesGenerator):
     )
     generated_target_cls = SwiftSourceTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (SwiftDependenciesField,)
     help = "Generate a `swift_source` target for each file in the `sources` field."

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -17,6 +17,10 @@ from pants.engine.target import (
 from pants.util.strutil import softwrap
 
 
+class TerraformDependenciesField(Dependencies):
+    pass
+
+
 class TerraformModuleSourcesField(MultipleSourcesField):
     default = ("*.tf",)
     expected_file_extensions = (".tf",)
@@ -35,7 +39,7 @@ class TerraformFieldSet(FieldSet):
 
 class TerraformModuleTarget(Target):
     alias = "terraform_module"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, TerraformModuleSourcesField)
+    core_fields = (*COMMON_TARGET_FIELDS, TerraformDependenciesField, TerraformModuleSourcesField)
     help = softwrap(
         """
         A single Terraform module corresponding to a directory.

--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -62,6 +62,8 @@ def dedicated_target_fields():
     for cls in Target.__subclasses__():
         if hasattr(cls, "core_fields"):
             for field_cls in cls.core_fields:
+                # NB: We want to check for all kinds of SourcesFields, like SingleSourceField and
+                # MultipleSourcesField.
                 if (
                     issubclass(field_cls, SourcesField)
                     and field_cls.__module__ is SourcesField.__module__

--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 # The top-level `pants` module must be a namespace package, because we build two dists from it
 # (pantsbuild.pants, and pantsbuild.pants.testutil) and consumers of these dists need to be
 # able to import from both.
@@ -42,3 +44,35 @@ def pytest_sessionfinish(session) -> None:
     # Technically unecessary, but nice if people are running tests directly from repo
     # (not using pants).
     namespace_init_path.unlink()
+
+
+@pytest.fixture(autouse=True, scope="session")
+def dedicated_target_fields():
+    """Ensures we follow our convention of dedicated source and dependencies field per-target.
+
+    This help ensure that plugin authors can do dependency inference on _specific_ field types, and
+    not have to filter targets using generic field types.
+
+    Note that this can't help us if a target type should use an _even more specialized_ dependencies
+    field type (E.g. 100 different target subclasses could use 1 custom dependencies field type,
+    when in reality there should be many more). However, this is a good sanity check.
+    """
+    from pants.engine.target import Dependencies, SourcesField, Target
+
+    for cls in Target.__subclasses__():
+        if hasattr(cls, "core_fields"):
+            for field_cls in cls.core_fields:
+                if (
+                    issubclass(field_cls, SourcesField)
+                    and field_cls.__module__ is SourcesField.__module__
+                ):
+                    raise ValueError(
+                        f"{cls.__name__} should have a dedicated field type for the source(s) field."
+                    )
+                if (
+                    issubclass(field_cls, Dependencies)
+                    and field_cls.__module__ is Dependencies.__module__
+                ):
+                    raise ValueError(
+                        f"{cls.__name__} should have a dedicated field type for the dependencies field."
+                    )

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -26,13 +26,17 @@ from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_ru
 from pants.util.logging import LogLevel
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTarget(Target):
     alias = "mock_target"
-    core_fields = (MultipleSourcesField,)
+    core_fields = (MockMultipleSourcesField,)
 
 
 class MockCheckFieldSet(FieldSet):
-    required_fields = (MultipleSourcesField,)
+    required_fields = (MockMultipleSourcesField,)
 
 
 class MockCheckRequest(CheckRequest, metaclass=ABCMeta):

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -36,7 +36,7 @@ class MockTarget(Target):
 
 
 class MockCheckFieldSet(FieldSet):
-    required_fields = (MockMultipleSourcesField,)
+    required_fields = (MultipleSourcesField,)
 
 
 class MockCheckRequest(CheckRequest, metaclass=ABCMeta):

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -35,15 +35,19 @@ from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_ru
 from pants.util.logging import LogLevel
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTarget(Target):
     alias = "mock_target"
-    core_fields = (MultipleSourcesField,)
+    core_fields = (MockMultipleSourcesField,)
 
 
 @dataclass(frozen=True)
 class MockLinterFieldSet(FieldSet):
-    required_fields = (MultipleSourcesField,)
-    sources: MultipleSourcesField
+    required_fields = (MockMultipleSourcesField,)
+    sources: MockMultipleSourcesField
 
 
 class MockLintRequest(LintTargetsRequest, metaclass=ABCMeta):

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -46,8 +46,8 @@ class MockTarget(Target):
 
 @dataclass(frozen=True)
 class MockLinterFieldSet(FieldSet):
-    required_fields = (MockMultipleSourcesField,)
-    sources: MockMultipleSourcesField
+    required_fields = (MultipleSourcesField,)
+    sources: MultipleSourcesField
 
 
 class MockLintRequest(LintTargetsRequest, metaclass=ABCMeta):

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -68,9 +68,13 @@ from pants.testutil.rule_runner import (
 from pants.util.logging import LogLevel
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTarget(Target):
     alias = "mock_target"
-    core_fields = (MultipleSourcesField,)
+    core_fields = (MockMultipleSourcesField,)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -193,9 +193,13 @@ class FileSourceField(AssetSourceField):
     uses_source_roots = False
 
 
+class FileDependenciesField(Dependencies):
+    pass
+
+
 class FileTarget(Target):
     alias = "file"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, FileSourceField)
+    core_fields = (*COMMON_TARGET_FIELDS, FileDependenciesField, FileSourceField)
     help = softwrap(
         """
         A single loose file that lives outside of code packages.
@@ -248,7 +252,7 @@ class FilesGeneratorTarget(TargetFilesGenerator):
     )
     generated_target_cls = FileTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (FileDependenciesField,)
     help = "Generate a `file` target for each file in the `sources` field."
 
 
@@ -403,13 +407,17 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
 # -----------------------------------------------------------------------------------------------
 
 
+class ResourceDependenciesField(Dependencies):
+    pass
+
+
 class ResourceSourceField(AssetSourceField):
     uses_source_roots = True
 
 
 class ResourceTarget(Target):
     alias = "resource"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies, ResourceSourceField)
+    core_fields = (*COMMON_TARGET_FIELDS, ResourceDependenciesField, ResourceSourceField)
     help = softwrap(
         """
         A single resource file embedded in a code package and accessed in a
@@ -462,7 +470,7 @@ class ResourcesGeneratorTarget(TargetFilesGenerator):
     )
     generated_target_cls = ResourceTarget
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (ResourceDependenciesField,)
     help = "Generate a `resource` target for each file in the `sources` field."
 
 
@@ -485,9 +493,13 @@ class ResourcesGeneratorFieldSet(FieldSet):
 # -----------------------------------------------------------------------------------------------
 
 
+class GenericTargetDependenciesField(Dependencies):
+    pass
+
+
 class GenericTarget(Target):
     alias = "target"
-    core_fields = (*COMMON_TARGET_FIELDS, Dependencies)
+    core_fields = (*COMMON_TARGET_FIELDS, GenericTargetDependenciesField)
     help = softwrap(
         """
         A generic target with no specific type.

--- a/src/python/pants/core/util_rules/stripped_source_files_test.py
+++ b/src/python/pants/core/util_rules/stripped_source_files_test.py
@@ -22,9 +22,13 @@ from pants.engine.target import MultipleSourcesField, SourcesPathsRequest, Targe
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
+class MyMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class TargetWithSources(Target):
     alias = "target"
-    core_fields = (MultipleSourcesField,)
+    core_fields = (MyMultipleSourcesField,)
 
 
 @pytest.fixture

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -122,9 +122,13 @@ class ResolveField(StringField):
     alias = "resolve"
 
 
+class MockDepsField(Dependencies):
+    pass
+
+
 class MockTgt(Target):
     alias = "mock_tgt"
-    core_fields = (Dependencies, MultipleSourcesField, Tags, ResolveField)
+    core_fields = (MockDepsField, MultipleSourcesField, Tags, ResolveField)
 
 
 def test_resolve_address() -> None:

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -126,9 +126,13 @@ class MockDepsField(Dependencies):
     pass
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTgt(Target):
     alias = "mock_tgt"
-    core_fields = (MockDepsField, MultipleSourcesField, Tags, ResolveField)
+    core_fields = (MockDepsField, MockMultipleSourcesField, Tags, ResolveField)
 
 
 def test_resolve_address() -> None:

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 
 import pytest
 
-from pants.core.target_types import GenericTarget
+from pants.core.target_types import GenericTarget, GenericTargetDependenciesField
 from pants.engine.internals.defaults import BuildFileDefaults, BuildFileDefaultsParserState
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -38,7 +38,7 @@ class TestGenTargetGenerator(TargetGenerator):
     generated_target_cls = TestGenTarget
     core_fields = COMMON_TARGET_FIELDS
     copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = (Dependencies,)
+    moved_fields = (GenericTargetDependenciesField,)
 
 
 @pytest.fixture

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -85,11 +85,15 @@ class ResolveField(StringField):
     alias = "resolve"
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTarget(Target):
     alias = "target"
     core_fields = (
         MockDependencies,
-        MultipleSourcesField,
+        MockMultipleSourcesField,
         SpecialCasedDeps1,
         SpecialCasedDeps2,
         ResolveField,

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1569,9 +1569,12 @@ def test_transitive_excludes_error() -> None:
         alias = "valid2"
         core_fields = (MockDependencies,)
 
+    class InvalidDepsField(Dependencies):
+        pass
+
     class Invalid(Target):
         alias = "invalid"
-        core_fields = (Dependencies,)
+        core_fields = (InvalidDepsField,)
 
     exc = TransitiveExcludesNotSupportedError(
         bad_value="!!//:bad",

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -67,6 +67,10 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 from pants.util.ordered_set import FrozenOrderedSet
 
 
+class MockSingleSourceField(SingleSourceField):
+    pass
+
+
 class MockDependencies(Dependencies):
     supports_transitive_excludes = True
     deprecated_alias = "deprecated_field"
@@ -105,12 +109,12 @@ class MockTarget(Target):
 
 class MockGeneratedTarget(Target):
     alias = "generated"
-    core_fields = (MockDependencies, Tags, SingleSourceField, ResolveField)
+    core_fields = (MockDependencies, Tags, MockSingleSourceField, ResolveField)
 
 
 class MockTargetGenerator(TargetFilesGenerator):
     alias = "generator"
-    core_fields = (MultipleSourcesField, OverridesField)
+    core_fields = (MockMultipleSourcesField, OverridesField)
     generated_target_cls = MockGeneratedTarget
     copied_fields = ()
     moved_fields = (Dependencies, Tags, ResolveField)

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -68,6 +68,10 @@ class MockDepsField(Dependencies):
     pass
 
 
+class MockSingleSourcesField(SingleSourceField):
+    pass
+
+
 class MockMultipleSourcesField(MultipleSourcesField):
     pass
 
@@ -79,7 +83,7 @@ class MockTarget(Target):
 
 class MockGeneratedFileTarget(Target):
     alias = "file_generated"
-    core_fields = (MockDepsField, SingleSourceField, Tags, ResolveField)
+    core_fields = (MockDepsField, MockSingleSourcesField, Tags, ResolveField)
 
 
 class MockFileTargetGenerator(TargetFilesGenerator):

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -64,14 +64,18 @@ class ResolveField(StringField):
     alias = "resolve"
 
 
+class MockDepsField(Dependencies):
+    pass
+
+
 class MockTarget(Target):
     alias = "target"
-    core_fields = (Dependencies, MultipleSourcesField, Tags, ResolveField)
+    core_fields = (MockDepsField, MultipleSourcesField, Tags, ResolveField)
 
 
 class MockGeneratedFileTarget(Target):
     alias = "file_generated"
-    core_fields = (Dependencies, SingleSourceField, Tags, ResolveField)
+    core_fields = (MockDepsField, SingleSourceField, Tags, ResolveField)
 
 
 class MockFileTargetGenerator(TargetFilesGenerator):
@@ -79,19 +83,19 @@ class MockFileTargetGenerator(TargetFilesGenerator):
     generated_target_cls = MockGeneratedFileTarget
     core_fields = (MultipleSourcesField, Tags, OverridesField)
     copied_fields = (Tags,)
-    moved_fields = (Dependencies, ResolveField)
+    moved_fields = (MockDepsField, ResolveField)
 
 
 class MockGeneratedNonfileTarget(Target):
     alias = "nonfile_generated"
-    core_fields = (Dependencies, Tags, ResolveField)
+    core_fields = (MockDepsField, Tags, ResolveField)
 
 
 class MockNonfileTargetGenerator(TargetGenerator):
     alias = "nonfile_generator"
     core_fields = (Tags,)
     copied_fields = (Tags,)
-    moved_fields = (Dependencies, ResolveField)
+    moved_fields = (MockDepsField, ResolveField)
 
 
 class MockGenerateTargetsRequest(GenerateTargetsRequest):

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -68,9 +68,13 @@ class MockDepsField(Dependencies):
     pass
 
 
+class MockMultipleSourcesField(MultipleSourcesField):
+    pass
+
+
 class MockTarget(Target):
     alias = "target"
-    core_fields = (MockDepsField, MultipleSourcesField, Tags, ResolveField)
+    core_fields = (MockDepsField, MockMultipleSourcesField, Tags, ResolveField)
 
 
 class MockGeneratedFileTarget(Target):
@@ -81,7 +85,7 @@ class MockGeneratedFileTarget(Target):
 class MockFileTargetGenerator(TargetFilesGenerator):
     alias = "file_generator"
     generated_target_cls = MockGeneratedFileTarget
-    core_fields = (MultipleSourcesField, Tags, OverridesField)
+    core_fields = (MockMultipleSourcesField, Tags, OverridesField)
     copied_fields = (Tags,)
     moved_fields = (MockDepsField, ResolveField)
 

--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -31,7 +31,7 @@ from pants.jvm.compile import (
     FallibleClasspathEntries,
     FallibleClasspathEntry,
 )
-from pants.jvm.target_types import JvmJdkField, JvmMainClassNameField
+from pants.jvm.target_types import JvmDependenciesField, JvmJdkField, JvmMainClassNameField
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ class DeployJarFieldSet(PackageFieldSet, RunFieldSet):
 
     main_class: JvmMainClassNameField
     output_path: OutputPathField
-    dependencies: Dependencies
+    dependencies: JvmDependenciesField
     jdk_version: JvmJdkField
 
 

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -33,6 +33,10 @@ from pants.util.strutil import softwrap
 # -----------------------------------------------------------------------------------------------
 
 
+class JvmDependenciesField(Dependencies):
+    pass
+
+
 class JvmResolveField(StringField, AsyncFieldMixin):
     alias = "resolve"
     required = False
@@ -320,7 +324,7 @@ class DeployJarTarget(Target):
     alias = "deploy_jar"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        Dependencies,
+        JvmDependenciesField,
         OutputPathField,
         JvmMainClassNameField,
         JvmJdkField,

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -27,12 +27,7 @@ from pants.engine.process import (
     ProcessCacheScope,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    Dependencies,
-    SourcesField,
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-)
+from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
@@ -40,7 +35,7 @@ from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
-from pants.jvm.target_types import JunitTestSourceField, JvmJdkField
+from pants.jvm.target_types import JunitTestSourceField, JvmDependenciesField, JvmJdkField
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -55,7 +50,7 @@ class JunitTestFieldSet(TestFieldSet):
 
     sources: JunitTestSourceField
     jdk_version: JvmJdkField
-    dependencies: Dependencies
+    dependencies: JvmDependenciesField
 
 
 class JunitToolLockfileSentinel(GenerateToolLockfileSentinel):


### PR DESCRIPTION
Fixes #15727. Note there's an auto-use fixture now which validates the convention. This is easier than a flake8 plugin.

[ci skip-rust]