### PR TITLE
Upgrade Rust to 1.62.0.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 
@@ -195,7 +195,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 
@@ -326,7 +326,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 
@@ -198,7 +198,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 
@@ -414,7 +414,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 
@@ -551,7 +551,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.61.0-*
+        path: '~/.rustup/toolchains/1.62.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.62.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
The announcement: https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html

[ci skip-build-wheels]