### PR TITLE
Skip CI checks on docs-only PRs.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,12 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     needs:
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -154,10 +156,12 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Bootstrap Pants, test Rust (macOS10-x86_64)
     needs:
     - check_labels
+    - docs_only_check
     runs-on:
     - macos-10.15
     steps:
@@ -288,10 +292,12 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Build wheels and fs_util (Linux-x86_64)
     needs:
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -372,10 +378,12 @@ jobs:
       ARCHFLAGS: -arch arm64
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Bootstrap Pants, build wheels and fs_util (macOS11-ARM64)
     needs:
     - check_labels
+    - docs_only_check
     runs-on:
     - self-hosted
     - macOS11
@@ -511,10 +519,12 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Build wheels and fs_util (macOS10-x86_64)
     needs:
     - check_labels
+    - docs_only_check
     runs-on:
     - macos-10.15
     steps:
@@ -624,12 +634,35 @@ jobs:
         labels: category:new feature, category:user api change, category:plugin api
           change, category:performance, category:bugfix, category:documentation, category:internal
         mode: exactly
-  lint_python:
+  docs_only_check:
     if: ${{ github.repository_owner == 'pantsbuild' }}
+    name: Check for docs-only change
+    outputs:
+      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+    runs-on:
+    - ubuntu-20.04
+    steps:
+    - continue-on-error: true
+      id: files
+      name: Get changed files
+      uses: jitterbit/get-changed-files@v1
+      with:
+        format: json
+    - id: docs_only_check
+      name: Check for docs-only changes
+      run: "readarray -t all_files <<<\"$(jq -r '.[]' <<<'${{ steps.files.outputs.all\
+        \ }}')\"\nDOCS_ONLY=1\nfor file in ${all_files[@]}; do\n    if [[ ${file}\
+        \ != docs/* ]]; then\n      DOCS_ONLY=0\n    fi\ndone\nif [[ ${DOCS_ONLY}\
+        \ == 1 ]]; then\n    echo \"::set-output name=docs_only::1\"\nelse\n    echo\
+        \ \"::set-output name=docs_only::0\"\nfi\n"
+  lint_python:
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Lint Python and Shell
     needs:
     - bootstrap_pants_linux_x86_64
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -692,30 +725,44 @@ jobs:
         python-version:
         - '3.7'
     timeout-minutes: 30
-  merge_ok:
+  merge_ok_docs_only:
+    if: needs.docs_only_check.outputs.docs_only == 1
     name: Merge OK
     needs:
-    - check_labels
+    - docs_only_check
+    runs-on:
+    - ubuntu-20.04
+    steps:
+    - run: echo 'Merge OK'
+  merge_ok_not_docs_only:
+    if: needs.docs_only_check.outputs.docs_only == 0
+    name: Merge OK
+    needs:
+    - docs_only_check
     - bootstrap_pants_linux_x86_64
+    - bootstrap_pants_macos_x86_64
+    - build_wheels_linux_x86_64
+    - build_wheels_macos_arm64
+    - build_wheels_macos_x86_64
+    - check_labels
+    - docs_only_check
+    - lint_python
     - test_python_linux_x86_64_0
     - test_python_linux_x86_64_1
     - test_python_linux_x86_64_2
-    - build_wheels_linux_x86_64
-    - bootstrap_pants_macos_x86_64
     - test_python_macos_x86_64
-    - build_wheels_macos_x86_64
-    - build_wheels_macos_arm64
-    - lint_python
     runs-on:
     - ubuntu-20.04
     steps:
     - run: echo 'Merge OK'
   test_python_linux_x86_64_0:
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Test Python (Linux-x86_64) Shard 0/3
     needs:
     - bootstrap_pants_linux_x86_64
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -800,11 +847,13 @@ jobs:
         - '3.7'
     timeout-minutes: 90
   test_python_linux_x86_64_1:
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Test Python (Linux-x86_64) Shard 1/3
     needs:
     - bootstrap_pants_linux_x86_64
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -889,11 +938,13 @@ jobs:
         - '3.7'
     timeout-minutes: 90
   test_python_linux_x86_64_2:
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Test Python (Linux-x86_64) Shard 2/3
     needs:
     - bootstrap_pants_linux_x86_64
     - check_labels
+    - docs_only_check
     runs-on:
     - ubuntu-20.04
     steps:
@@ -980,11 +1031,13 @@ jobs:
   test_python_macos_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
-    if: ${{ github.repository_owner == 'pantsbuild' }}
+    if: (${{ github.repository_owner == 'pantsbuild' }}) && needs.docs_only_check.outputs.docs_only
+      == 0
     name: Test Python (macOS10-x86_64)
     needs:
     - bootstrap_pants_macos_x86_64
     - check_labels
+    - docs_only_check
     runs-on:
     - macos-10.15
     steps:


### PR DESCRIPTION
A new job detects whether the change is "docs only", and all the other jobs
run only if "docs only" is false.

The complication is that we have a branch protection rule on main that prevents 
merges unless a CI job named "Merge OK" passes. Today that job depends on all 
the other jobs (running tests etc.) and if we skip those jobs, the "Merge OK" job 
will not run and so we won't be able to merge.

Therefore we generate *two* "Merge OK" jobs: one that depends on all the checks but
runs only if "docs only" is false, and another that runs with no other dependencies, but
only if "docs only" is true.

Note that we cannot implement this using GitHub Action's path filtering, because that
provides only "run a workflow if any path is under a dir" or "skip a workflow if all paths
are under a dir". It does not provide "run a workflow if all paths are under a dir", 
which is what we'd need for the "Merge OK" logic above.