### PR TITLE
Upgrade Pex to 2.1.94. (Cherry-pick of #16029)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.90
+pex==2.1.94
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -19,7 +19,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.90",
+//     "pex==2.1.94",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -203,13 +203,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "687b5fe14be40aadcf547cae91337a1fdb84026046a39370274e54d3fe4fb4f9",
-              "url": "https://files.pythonhosted.org/packages/d8/32/77a2792d80c00083626e0d6ce41ba8254b632c960235d3a5a731c185d936/backports.cached_property-1.0.1-py3-none-any.whl"
+              "hash": "baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc",
+              "url": "https://files.pythonhosted.org/packages/eb/ae/69e52acdcf381b108b36d989ea58656de4a9ab8863aba6176d80d01041df/backports.cached_property-1.0.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1a5ef1e750f8bc7d0204c807aae8e0f450c655be0cf4b30407a35fd4bb27186c",
-              "url": "https://files.pythonhosted.org/packages/4f/d8/fd7b8e24a207023e39b9c0cd607a9b3ba757552ec0d81b4328183961af2e/backports.cached-property-1.0.1.tar.gz"
+              "hash": "9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd",
+              "url": "https://files.pythonhosted.org/packages/08/83/4cea5c665d2af765c02f7d8e8560b5918405c1d7d11ccfc60c4919c1cfd0/backports.cached-property-1.0.2.tar.gz"
             }
           ],
           "project_name": "backports-cached-property",
@@ -217,45 +217,45 @@
             "typing>=3.6; python_version < \"3.7\""
           ],
           "requires_python": ">=3.6.0",
-          "version": "1.0.1"
+          "version": "1.0.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f1d53542ee8cbedbe2118b5686372fb33c297fcd6379b050cca0ef13a597382a",
-              "url": "https://files.pythonhosted.org/packages/11/dd/e015f3780f42dd9af62cf0107b44ea1298926627ecd70c17b0e484e95bcd/certifi-2022.5.18.1-py3-none-any.whl"
+              "hash": "fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412",
+              "url": "https://files.pythonhosted.org/packages/e9/06/d3d367b7af6305b16f0d28ae2aaeb86154fa91f144f036c2d5002a5a202b/certifi-2022.6.15-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9c5705e395cd70084351dd8ad5c41e65655e08ce46f2ec9cf6c2c08390f71eb7",
-              "url": "https://files.pythonhosted.org/packages/07/10/75277f313d13a2b74fc56e29239d5c840c2bf09f17bf25c02b35558812c6/certifi-2022.5.18.1.tar.gz"
+              "hash": "84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+              "url": "https://files.pythonhosted.org/packages/cc/85/319a8a684e8ac6d87a1193090e06b6bbb302717496380e225ee10487c888/certifi-2022.6.15.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2022.5.18.1"
+          "version": "2022.6.15"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df",
-              "url": "https://files.pythonhosted.org/packages/06/b3/24afc8868eba069a7f03650ac750a778862dc34941a4bebeb58706715726/charset_normalizer-2.0.12-py3-none-any.whl"
+              "hash": "5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+              "url": "https://files.pythonhosted.org/packages/94/69/64b11e8c2fb21f08634468caef885112e682b0ebe2908e74d3616eb1c113/charset_normalizer-2.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
-              "url": "https://files.pythonhosted.org/packages/56/31/7bcaf657fafb3c6db8c787a865434290b726653c912085fbd371e9b92e1c/charset-normalizer-2.0.12.tar.gz"
+              "hash": "575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413",
+              "url": "https://files.pythonhosted.org/packages/93/1d/d9392056df6670ae2a29fcb04cfa5cee9f6fbde7311a1bb511d4115e9b7a/charset-normalizer-2.1.0.tar.gz"
             }
           ],
           "project_name": "charset-normalizer",
           "requires_dists": [
             "unicodedata2; extra == \"unicode_backport\""
           ],
-          "requires_python": ">=3.5.0",
-          "version": "2.0.12"
+          "requires_python": ">=3.6.0",
+          "version": "2.1"
         },
         {
           "artifacts": [
@@ -300,19 +300,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2",
-              "url": "https://files.pythonhosted.org/packages/44/98/5b86278fbbf250d239ae0ecb724f8572af1c91f4a11edf4d36a206189440/colorama-0.4.4-py2.py3-none-any.whl"
+              "hash": "854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
+              "url": "https://files.pythonhosted.org/packages/77/8b/7550e87b2d308a1b711725dfaddc19c695f8c5fa413c640b2be01662f4e6/colorama-0.4.5-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-              "url": "https://files.pythonhosted.org/packages/1f/bb/5d3246097ab77fa083a61bd8d3d527b7ae063c7d8e8671b1cf8c4ec10cbe/colorama-0.4.4.tar.gz"
+              "hash": "e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4",
+              "url": "https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz"
             }
           ],
           "project_name": "colorama",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.4.4"
+          "version": "0.4.5"
         },
         {
           "artifacts": [
@@ -776,13 +776,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec",
-              "url": "https://files.pythonhosted.org/packages/ab/b5/1bd220dd470b0b912fc31499e0d9c652007a60caf137995867ccc4b98cb6/importlib_metadata-4.11.4-py3-none-any.whl"
+              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
+              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700",
-              "url": "https://files.pythonhosted.org/packages/35/a8/f2bd0d488c2bf932b4dda0fb91cbb687c0b1132b33130d1cfad4e2b4b963/importlib_metadata-4.11.4.tar.gz"
+              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
+              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -796,7 +796,7 @@
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
             "pytest-flake8; extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
@@ -807,7 +807,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.11.4"
+          "version": "4.12"
         },
         {
           "artifacts": [
@@ -869,13 +869,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1c00bb8ca43a44a76ed2b3c6b9acfd2804630d704c788e41474843d6250fb83",
-              "url": "https://files.pythonhosted.org/packages/b6/3b/95bfd873b10b15fb5ea5bcdad444803d4af4d2e3c967ab47d8adbd5c7730/pex-2.1.90-py2.py3-none-any.whl"
+              "hash": "92ee1a63ef89de279818ae9e1e67ab2b02553a701485e42422f2461f12445c00",
+              "url": "https://files.pythonhosted.org/packages/ca/6a/1c5ca509304e56b7316922db212964383286b4ff425195a22fa79e83aa43/pex-2.1.94-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "17d929929d59ef44d666383ded7d191cca269acc23d3bb09c505e22953cc9d15",
-              "url": "https://files.pythonhosted.org/packages/2b/8e/da8f418efa126a862c3165458777dec24995615f0a1b65c3f7caec1123d8/pex-2.1.90.tar.gz"
+              "hash": "4c6ef7f9601c463634342fa7d90dc04827d31b4ddd2f9cb3f903a663ddd698c1",
+              "url": "https://files.pythonhosted.org/packages/f1/d3/5c2f03ea70c263bf33a354b58631edb3cf45587c4bacd83cd4337356e167/pex-2.1.94.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -883,7 +883,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.90"
+          "version": "2.1.94"
         },
         {
           "artifacts": [
@@ -1425,29 +1425,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d",
-              "url": "https://files.pythonhosted.org/packages/2d/61/08076519c80041bc0ffa1a8af0cbd3bf3e2b62af10435d269a9d0f40564d/requests-2.27.1-py2.py3-none-any.whl"
+              "hash": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
+              "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61",
-              "url": "https://files.pythonhosted.org/packages/60/f3/26ff3767f099b73e0efa138a9998da67890793bfa475d8278f84a30fec77/requests-2.27.1.tar.gz"
+              "hash": "7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+              "url": "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz"
             }
           ],
           "project_name": "requests",
           "requires_dists": [
             "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
             "certifi>=2017.4.17",
-            "chardet<5,>=3.0.2; extra == \"use_chardet_on_py3\"",
-            "chardet<5,>=3.0.2; python_version < \"3\"",
-            "charset-normalizer~=2.0.0; python_version >= \"3\"",
-            "idna<3,>=2.5; python_version < \"3\"",
-            "idna<4,>=2.5; python_version >= \"3\"",
-            "urllib3<1.27,>=1.21.1",
-            "win-inet-pton; (sys_platform == \"win32\" and python_version == \"2.7\") and extra == \"socks\""
+            "chardet<6,>=3.0.2; extra == \"use_chardet_on_py3\"",
+            "charset-normalizer<3,>=2",
+            "idna<4,>=2.5",
+            "urllib3<1.27,>=1.21.1"
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "2.27.1"
+          "requires_python": "<4,>=3.7",
+          "version": "2.28.1"
         },
         {
           "artifacts": [
@@ -2451,15 +2448,11 @@
           "version": "3.8"
         }
       ],
-      "platform_tag": [
-        "cp38",
-        "cp38",
-        "macosx_12_0_x86_64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.94",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2472,7 +2465,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.90",
+    "pex==2.1.94",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -14,7 +14,10 @@ python_sources(
     },
 )
 
-python_tests(name="py_tests", overrides={"reversion_test.py": {"timeout": 90}})
+python_tests(
+    name="py_tests",
+    overrides={"reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]}}
+)
 
 pex_binaries(
     entry_points=[

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -16,7 +16,7 @@ python_sources(
 
 python_tests(
     name="py_tests",
-    overrides={"reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]}}
+    overrides={"reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]}},
 )
 
 pex_binaries(

--- a/build-support/bin/reversion_test.py
+++ b/build-support/bin/reversion_test.py
@@ -1,22 +1,24 @@
 # Copyright 2017 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
-
+import json
+import os
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 
 import requests
-from pex.bin import pex as pex_main
 from reversion import reversion
 
 
 def test_reversion(tmp_path: Path) -> None:
     # Download an input whl.
-    name_template = "virtualenv-{}-py2.py3-none-any.whl"
-    input_name = name_template.format("15.1.0")
+    name_template = "ansicolors-{}-py2.py3-none-any.whl"
+    input_version = "1.1.8"
+    input_name = name_template.format(input_version)
     url = (
-        "https://files.pythonhosted.org/packages/6f/86/"
-        "3dc328ee7b1a6419ebfac7896d882fba83c48e3561d22ddddf38294d3e83/{}".format(input_name)
+        "https://files.pythonhosted.org/packages/53/18/"
+        "a56e2fe47b259bb52201093a3a9d4a32014f9d85071ad07e9d60600890ca/{}".format(input_name)
     )
     input_whl_file = tmp_path / input_name
     with input_whl_file.open(mode="wb") as f:
@@ -37,5 +39,45 @@ def test_reversion(tmp_path: Path) -> None:
 
     # Confirm that it can be consumed.
     output_pex_file = tmp_path / "out.pex"
-    pex_main.main(["--disable-cache", "-o", output_pex_file.as_posix(), output_whl_file.as_posix()])
-    assert output_pex_file.is_file() is True
+    subprocess.run(
+        args=[
+            sys.executable,
+            "-mpex",
+            "--include-tools",
+            "--disable-cache",
+            "-o",
+            str(output_pex_file),
+            str(output_whl_file),
+        ],
+        check=True,
+    )
+    assert output_pex_file.is_file()
+
+    assert (
+        input_version
+        == subprocess.run(
+            args=[
+                sys.executable,
+                str(output_pex_file),
+                "-c",
+                "import colors; print(colors.__version__)",
+            ],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode()
+        .strip()
+    ), "Did not expect re-versioning to change the version stored in code."
+
+    info = json.loads(
+        subprocess.run(
+            args=[sys.executable, str(output_pex_file), "repository", "info", "-v"],
+            check=True,
+            stdout=subprocess.PIPE,
+            env={"PEX_TOOLS": "1", **os.environ},
+        ).stdout
+    )
+    assert "ansicolors" == info["project_name"]
+    assert (
+        output_version == info["version"]
+    ), "Expected re-versioning to change the version stored in wheel metadata."

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,8 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a1c00bb8ca43a44a76ed2b3c6b9acfd2804630d704c788e41474843d6250fb83",
-              "url": "https://files.pythonhosted.org/packages/b6/3b/95bfd873b10b15fb5ea5bcdad444803d4af4d2e3c967ab47d8adbd5c7730/pex-2.1.90-py2.py3-none-any.whl"
+              "hash": "92ee1a63ef89de279818ae9e1e67ab2b02553a701485e42422f2461f12445c00",
+              "url": "https://files.pythonhosted.org/packages/ca/6a/1c5ca509304e56b7316922db212964383286b4ff425195a22fa79e83aa43/pex-2.1.94-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4c6ef7f9601c463634342fa7d90dc04827d31b4ddd2f9cb3f903a663ddd698c1",
+              "url": "https://files.pythonhosted.org/packages/f1/d3/5c2f03ea70c263bf33a354b58631edb3cf45587c4bacd83cd4337356e167/pex-2.1.94.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -58,18 +63,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.90"
+          "version": "2.1.94"
         }
       ],
-      "platform_tag": [
-        "cp37",
-        "cp37m",
-        "manylinux_2_35_x86_64"
-      ]
+      "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.90",
+  "pex_version": "2.1.94",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.90"
+    default_version = "v2.1.94"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.90,<3.0"
+    version_constraints = ">=2.1.94,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "2781255baf77c2a8fdc85c5e830f7191a6048fd91d2e20b5c7a20e5a0b7beb66",
-                    "3755345",
+                    "775c22b97e057d595a8b334fab89f5a07ac9c552a36912504f62577f53a2d2d2",
+                    "3802178",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
There are numerous changes, most in 2.1.93, but the two changes of
most interest to Pants immediately are support for local projects in
locks and a fix for custom index authentication when fetching artifacts
recorded in a lock.

The Pex changelogs are here:
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.91
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.92
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.93
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.94

Supplants #15911

(cherry picked from commit b2f131f167e92c30a1007a09cc7bc6737cdab701)

[ci skip-rust]
[ci skip-build-wheels]