### PR TITLE
Correct deprecation warning to 2.15

### DIFF
--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -468,7 +468,7 @@ def _handle_ambiguous_result(
     ):
         if field_set_to_default_to is PexBinaryFieldSet:
             warn_or_error(
-                "2.15.0dev0",
+                "2.15.0.dev0",
                 "referring to a `pex_binary` by using the filename specified in `entry_point`",
                 softwrap(
                     """


### PR DESCRIPTION
- In 2.13 we introduced the ambiguity, along with forcing our users to set the flag to choose behavior
- In 2.14, now the flag defaults to using the new behavior. But if the user still has it set to "use the old behavior" we should warn but honor that. There's still ambiguity.
- In 2.15 there's no choice, and therefore no ambiguity

[ci skip-build-wheels]