### PR TITLE
Update docs with 2.12 changes: default Pex lockfile generator, `pants.toml` env var interpolation, pip VCS requirements, and Python interpreter constraints (Cherry-pick of #16000)

### DIFF
--- a/docs/markdown/Python/python/python-third-party-dependencies.md
+++ b/docs/markdown/Python/python/python-third-party-dependencies.md
@@ -228,8 +228,11 @@ Then, use `./pants generate-lockfiles` to generate the lockfile.
 > 
 > As explained at the top of these docs, Pants only uses the subset of the "universe" of your dependencies that is actually needed for a build, such as running tests and packaging a wheel file. This gives fine-grained caching and has other benefits like built packages (e.g. PEX binaries) only including their true dependencies. However, naively, this would mean that you need to resolve dependencies multiple times, which can be slow.
 > 
-> If you use Pex-generated lockfiles (see below), Pants will only install the subset of the lockfile you need for a task. If you use Poetry-generated lockfiles, Pants will first install the entire lockfile and then it will [extract](https://blog.pantsbuild.org/introducing-pants-2-5/) the exact subset needed. 
-> 
+> If you use the default of Pex-generated lockfiles (see below), Pants will only install the
+> subset of the lockfile you need for a task. If you instead use Poetry-generated lockfiles,
+> Pants will first install the entire lockfile and then it
+> will [extract](https://blog.pantsbuild.org/introducing-pants-2-5/) the exact subset needed.
+>
 > This greatly speeds up performance and improves caching for goals like `test`, `run`, `package`, and `repl`.
 
 #### Multiple lockfiles
@@ -347,9 +350,11 @@ To disable lockfiles entirely for a tool, set `[tool].lockfile = "<none>"` for t
 
 ### Pex vs. Poetry for lockfile generation
 
-You should set `[python].lockfile_generator` to either `"pex"` or `"poetry"` in `pants.toml`. The default of `poetry` will change in Pants 2.12.
+Pants defaults to using [Pex](https://pex.readthedocs.io/) to generate lockfiles, but you can
+instead use [Poetry](https://python-poetry.org) by setting `[python].lockfile_generator = "poetry"`
+in `pants.toml`.
 
-We generally recommend using Pex, which has several benefits:
+We generally recommend using the default of Pex, which has several benefits:
 
 1. Supports `[python-repos]` if you have a custom index or repository other than PyPI.
 2. Supports `[GLOBAL].ca_certs_path`.
@@ -469,31 +474,22 @@ mongomock
 
 ### Version control and local requirements
 
-You might be used to using pip's proprietary VCS-style requirements for this, like `git+https://github.com/django/django.git#egg=django`. However, this proprietary format does not work with Pants.
+You can install requirements from version control using two styles:
 
-Instead of pip VCS-style requirements:
-
-```
-git+https://github.com/django/django.git#egg=Django
-git+https://github.com/django/django.git@stable/2.1.x#egg=Django
-git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8#egg=Django
-```
-
-Use direct references from [PEP 440](https://www.python.org/dev/peps/pep-0440/#direct-references):
-
-```
-Django@ git+https://github.com/django/django.git
-Django@ git+https://github.com/django/django.git@stable/2.1.x
-Django@ git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8
-```
+- pip's proprietary VCS-style requirements, e.g.
+  - `git+https://github.com/django/django.git#egg=Django`
+  - `git+https://github.com/django/django.git@stable/2.1.x#egg=Django`
+  - `git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8#egg=Django`
+- direct references from [PEP 440](https://www.python.org/dev/peps/pep-0440/#direct-references), e.g.
+  - `Django@ git+https://github.com/django/django.git`
+  - `Django@ git+https://github.com/django/django.git@stable/2.1.x`
+  - `Django@ git+https://github.com/django/django.git@fd209f62f1d83233cc634443cfac5ee4328d98b8`
 
 You can also install from local files using [PEP 440 direct references](https://www.python.org/dev/peps/pep-0440/#direct-references). You must use an absolute path to the file, and you should ensure that the file exists on your machine.
 
 ```
 Django @ file:///Users/pantsbuild/prebuilt_wheels/django-3.1.1-py3-none-any.whl
 ```
-
-Pip still works with these PEP 440-compliant formats, so you won't be losing any functionality by switching to using them.
 
 > 🚧 Local file requirements do not yet work with lockfiles
 > 
@@ -557,20 +553,25 @@ Indexes are assumed to have a nested structure (like <http://pypi.org/simple>), 
 
 #### Authenticating to custom repos
 
-To authenticate to these custom repos you may need to provide credentials (such as a username and password) in the URL, that you don't want to expose in your checked-in pants.toml file.  Instead you can do one of the following:
+To authenticate to custom repos, you may need to provide credentials 
+(such as a username and password) in the URL. 
 
-Create a private (not checked-in) [.pants.rc file](doc:options#pantsrc-file) in each user's Pants repo, that sets this config for the user:
+You can use [config file `%(env.ENV_VAR)s` interpolation](doc:options#config-file-interpolation)
+to load the values via environment variables. This avoids checking in sensitive information to
+version control.
+
+```toml pants.toml
+[python-repos]
+indexes.add = ["http://%(env.INDEX_USERNAME)s:%(INDEX_PASSWORD)s@my.custom.repo/index"]
+```
+
+Alternatively, you can hardcode the value in a private (not checked-in)
+[.pants.rc file](doc:options#pantsrc-file) in each user's Pants repo, that sets this config for
+the user:
 
 ```toml .pants.rc
 [python-repos]
 indexes.add = ["http://$USERNAME:$PASSWORD@my.custom.repo/index"]
-```
-
-Or, set the `indexes` or `repos` config in an environment variable:
-
-```shell
-$ export PANTS_PYTHON_REPOS_INDEXES='+["http://$USERNAME:$PASSWORD@my.custom.repo/index"]'
-$ ./pants package ::
 ```
 
 Tip: use `./pants export` to create a virtual environment for IDEs

--- a/docs/markdown/Using Pants/concepts/options.md
+++ b/docs/markdown/Using Pants/concepts/options.md
@@ -66,26 +66,38 @@ Config file entries
 
 Global options are set in the `GLOBAL` section of the config file:
 
-```toml
+```toml pants.toml
 [GLOBAL]
 level = "debug"
 ```
 
 Subsystem options are set in the section named for their scope:
 
-```toml
+```toml pants.toml
 [source]
 root_patterns = ["/src/python"]
 ```
 
 Note that any dashes in the option flag name are converted to underscores: `--multiword-name` becomes `multiword_name`.
 
-Additionally, a few different variables may be interpolated into strings in config files via a `%(var)s` syntax. For example, this expands to the absolute path of a file in the root of your repository:
+### Config file interpolation
 
-```toml
-[GLOBAL]
-pythonpath = ["%(buildroot)s/examples"]
+Environment variables can be interpolated by using the syntax `%(env.ENV_VAR)s`, e.g.:
+
+```toml pants.toml
+[python-repos]
+# This will substitute `%(env.PY_REPO)s` with the value of the environment
+# variable PY_REPO
+indexes.add = ["http://%(env.PY_REPO)s@my.custom.repo/index
 ```
+
+Additionally, a few special values are pre-populated with the `%(var)s` syntax:
+
+- `%(buildroot)s`: absolute path to the root of your repository
+- `%(homedir)s`: equivalent to `$HOME` or `~`
+- `%(user)s`: equivalent to `$USER`
+- `%(pants_distdir)s`: absolute path of the global option `--pants-distdir`, which defaults 
+   to `{buildroot}/dist/`
 
 Option types
 ============

--- a/docs/markdown/Using Pants/setting-up-an-ide.md
+++ b/docs/markdown/Using Pants/setting-up-an-ide.md
@@ -31,8 +31,8 @@ $ python3 -c "print('PYTHONPATH=\"./' + ':./'.join(\"${ROOTS}\".split()) + ':\$P
 
 See [Use of the PYTHONPATH variable](https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable) to learn more about using the `PYTHONPATH` variable in VSCode.
 
-Third-party dependencies (Python)
----------------------------------
+Python third-party dependencies and tools
+-----------------------------------------
 
 To get your editor to understand the repo's third-party dependencies, you will probably want to point it at a virtualenv containing those dependencies.
 
@@ -44,6 +44,19 @@ Wrote virtualenv for the resolve 'python-default' (using CPython==3.9.*) to dist
 ```
 
 If you are using the ["resolves" feature for Python lockfiles](doc:python-third-party-dependencies)—which we strongly recommend—Pants will write the virtualenv to `dist/export/python/virtualenvs/<resolve-name>`. If you have multiple resolves, this means that Pants will create one virtualenv per resolve. You can then point your IDE to whichever resolve you want to load at the time.
+
+### Tool virtualenvs
+
+`./pants export` will also create a virtualenv for certain Python tools you use via Pants, like
+formatters like Black and Isort. This allows you to configure your editor to use the same version
+of the tool that Pants uses for workflows like formatting on save.
+
+To disable a certain tool, set its `export` option to `false`, e.g.:
+
+```toml pants.toml
+[black]
+export = false
+```
 
 Generated code
 --------------

--- a/src/python/pants/notes/2.12.x.md
+++ b/src/python/pants/notes/2.12.x.md
@@ -118,6 +118,8 @@
 
 * Implement `tailor` goal for Helm charts ([#15192](https://github.com/pantsbuild/pants/pull/15192))
 
+* Write virtualenvs for Python tools as part of `export` ([#15098](https://github.com/pantsbuild/pants/pull/15098))
+
 ### User API Changes
 
 * Upgrade Pex to 2.1.84. ([#15288](https://github.com/pantsbuild/pants/pull/15288))
@@ -150,8 +152,6 @@
 
 * golang: add more cache keys based on tool IDs ([#15205](https://github.com/pantsbuild/pants/pull/15205))
 
-* Mention resolve when partitioning Mypy and Pylint ([#15172](https://github.com/pantsbuild/pants/pull/15172))
-
 ### Performance
 
 * `MyPy` and `Pylint` partition inputs via `CoarsenedTarget` ([#15141](https://github.com/pantsbuild/pants/pull/15141))
@@ -165,6 +165,10 @@
 * Improve cache-related error message to be less confusing ([#15202](https://github.com/pantsbuild/pants/pull/15202))
 
 * Show `experimental-bsp` goal in help ([#15208](https://github.com/pantsbuild/pants/pull/15208))
+
+* Mention resolve when partitioning Mypy and Pylint ([#15172](https://github.com/pantsbuild/pants/pull/15172))
+
+* Don't log set up of binary shims ([#15203](https://github.com/pantsbuild/pants/pull/15203))
 
 ## 2.12.0.dev3 (Apr 16, 2022)
 

--- a/src/python/pants/notes/2.13.x.md
+++ b/src/python/pants/notes/2.13.x.md
@@ -424,12 +424,6 @@
 
 * Add options to turn off `tailor` on a per-language basis ([#15335](https://github.com/pantsbuild/pants/pull/15335))
 
-* Add lz4 support to archive extraction ([#15245](https://github.com/pantsbuild/pants/pull/15245))
-
-* Implement `tailor` goal for Helm charts ([#15191](https://github.com/pantsbuild/pants/pull/15191))
-
-* Write virtualenvs for Python tools as part of `export` ([#15098](https://github.com/pantsbuild/pants/pull/15098))
-
 ### User API Changes
 
 * Upgrade hadolint to 2.10.0 and add linux arm64 support ([#15317](https://github.com/pantsbuild/pants/pull/15317))
@@ -438,14 +432,9 @@
 
 * Deprecate `[golang].expected_version` in favor of more flexible `[golang].minimum_expected_version` ([#15306](https://github.com/pantsbuild/pants/pull/15306))
 
-* Upgrade Pex to 2.1.84. ([#15288](https://github.com/pantsbuild/pants/pull/15288))
-
-
 ### Plugin API Changes
 
 * Add `update_env` to `process_execution::local`. ([#15340](https://github.com/pantsbuild/pants/pull/15340))
-
-* Allow for arbitrary suffixes when extracting ([#15257](https://github.com/pantsbuild/pants/pull/15257))
 
 ### Bug fixes
 
@@ -457,42 +446,10 @@
 
 * Fix non-determinism of `package_data` in generated `setup.py` files ([#15292](https://github.com/pantsbuild/pants/pull/15292))
 
-* Simplify BSP metadata merging, and handle the empty list. ([#15283](https://github.com/pantsbuild/pants/pull/15283))
-
-* BSP resolve filtering observes computed default values of resolve fields ([#15282](https://github.com/pantsbuild/pants/pull/15282))
-
-* Memoize equality for `CoarsenedTarget(s)` to avoid exponential runtime in `check`. ([#15277](https://github.com/pantsbuild/pants/pull/15277))
-
-* Fix ambiguity of Scala `package object`s with `class` or `object` definitions ([#15265](https://github.com/pantsbuild/pants/pull/15265))
-
-* Fix issue with Docker publish when using `[docker] tools`. ([#15255](https://github.com/pantsbuild/pants/pull/15255))
-
-* Do not lowercase Docker image tags. ([#15254](https://github.com/pantsbuild/pants/pull/15254))
-
-* Fix the placement of the pex verbosity args. ([#15243](https://github.com/pantsbuild/pants/pull/15243))
-
-* Fix use of `@` in path names. ([#15226](https://github.com/pantsbuild/pants/pull/15226))
-
-* Fix lockfile generation for duplicate `jvm_artifact` targets with `jar` fields. ([#15219](https://github.com/pantsbuild/pants/pull/15219))
-
-* Support poetry wildcard requirements. ([#15213](https://github.com/pantsbuild/pants/pull/15213))
-
-* golang: add more cache keys based on tool IDs ([#15205](https://github.com/pantsbuild/pants/pull/15205))
-
 ### Performance
 
 * Eagerly skip tools with default lockfiles in `export-lockfiles` goal ([#15304](https://github.com/pantsbuild/pants/pull/15304))
 
-* `MyPy` and `Pylint` partition inputs via `CoarsenedTarget` ([#15141](https://github.com/pantsbuild/pants/pull/15141))
-
 ### Documentation
 
 * Improve error message for resolves x interpreter constraints issues ([#15314](https://github.com/pantsbuild/pants/pull/15314))
-
-* Fix `ProtobufSourcesOverridesField` help message ([#15272](https://github.com/pantsbuild/pants/pull/15272))
-
-* Update `help` for python resolves with recent improvements ([#15228](https://github.com/pantsbuild/pants/pull/15228))
-
-* Don't log set up of binary shims ([#15203](https://github.com/pantsbuild/pants/pull/15203))
-
-* Mention resolve when partitioning Mypy and Pylint ([#15172](https://github.com/pantsbuild/pants/pull/15172))


### PR DESCRIPTION
[ci skip-rust]