### PR TITLE
Fix JVM symbol mapping debug output.

### DIFF
--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -195,7 +195,9 @@ class FrozenTrieNode:
     def to_json_dict(self) -> dict[str, Any]:
         return {
             "children": {name: child.to_json_dict() for name, child in self._children.items()},
-            **({"addresses": [str(a) for a in self._addresses]} if self._addresses else {}),
+            "addresses": {
+                ns: [str(a) for a in addresses] for ns, addresses in self._addresses.items()
+            },
             "recursive": self._recursive,
             "first_party": self._first_party,
         }


### PR DESCRIPTION
The rendered JSON stopped including the actual matched addresses in #15263, when the `_addresses` field switched from a `set` to a `dict`.

[ci skip-rust]
[ci skip-build-wheels]