### PR TITLE
Fix typo in warning for `[python].resolve_all_constraints` (Cherry-pick of #16068)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -611,7 +611,7 @@ async def _setup_constraints_repository_pex(
                 The constraints file {constraints_path} does not contain
                 entries for the following requirements: {', '.join(unconstrained_projects)}.
 
-                Ignoring `[python_setup].resolve_all_constraints` option.
+                Ignoring `[python].resolve_all_constraints` option.
                 """
             )
         )


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]