### PR TITLE
[internal] use CAS BatchReadBlobs API for small blob reads, take #2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -343,7 +343,9 @@ jobs:
     - env: {}
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
+      run: 'set -x
+
+        [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
         ./build-support/bin/release.sh build-local-pex
 
@@ -587,7 +589,9 @@ jobs:
         ARCHFLAGS: -arch x86_64
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
+      run: 'set -x
+
+        [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
         ./build-support/bin/release.sh build-local-pex
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -456,6 +456,7 @@ class Helper:
                     # it cleans out `dist/deploy`, which the build-wheels runs populate for
                     # later attention by deploy_to_s3.py.
                     """\
+                    set -x
                     [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
                     ./build-support/bin/release.sh build-local-pex
                     ./build-support/bin/release.sh build-wheels

--- a/src/rust/engine/protos/src/conversions.rs
+++ b/src/rust/engine/protos/src/conversions.rs
@@ -1,3 +1,5 @@
+use tonic::{Code, Status};
+
 impl<'a> From<&'a hashing::Digest> for crate::gen::build::bazel::remote::execution::v2::Digest {
   fn from(d: &'a hashing::Digest) -> Self {
     Self {
@@ -49,5 +51,11 @@ pub fn require_digest<
   match digest_opt.into() {
     Some(digest) => hashing::Digest::try_from(digest),
     None => Err("Protocol violation: Digest missing from a Remote Execution API protobuf.".into()),
+  }
+}
+
+impl From<crate::gen::google::rpc::Status> for Status {
+  fn from(rpc_status: crate::gen::google::rpc::Status) -> Self {
+    Status::new(Code::from_i32(rpc_status.code), rpc_status.message)
   }
 }

--- a/src/rust/engine/testutil/mock/src/cas_service.rs
+++ b/src/rust/engine/testutil/mock/src/cas_service.rs
@@ -446,6 +446,11 @@ impl ContentAddressableStorage for StubCASResponder {
     &self,
     request: Request<BatchReadBlobsRequest>,
   ) -> Result<Response<BatchReadBlobsResponse>, Status> {
+    {
+      let mut request_count = self.read_request_count.lock();
+      *request_count += 1;
+    }
+
     check_auth!(self, request);
 
     if self.always_errors {


### PR DESCRIPTION
In https://github.com/pantsbuild/pants/pull/12537, Pants learned how to send small blob writes to a remote store via the `BatchUpdateBlobs` API of the REAPI instead of the `ByteStream.Write` streaming API. This PR similarly teaches Pants how to use the `BatchReadBlobs` API for small blob reads instead of the `ByteStream.Read` API.

The goal is to reduce the overhead of small blob reads by avoiding the multiple message exchanges required by the streaming API.

Note: This PR does not batch multiple small blob reads together, which is an approach that could be worthwhile to evaluate in the future.

This is take #2 of this change and boxes the future used for storing blobs to avoid a stack overflow encountered with the prior PR.