### PR TITLE
Write to caches during backtracking

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -33,6 +33,7 @@ pub struct CommandRunner {
   inner: Arc<dyn crate::CommandRunner>,
   cache: PersistentCache,
   file_store: Store,
+  cache_read: bool,
   eager_fetch: bool,
   metadata: ProcessMetadata,
 }
@@ -42,6 +43,7 @@ impl CommandRunner {
     inner: Arc<dyn crate::CommandRunner>,
     cache: PersistentCache,
     file_store: Store,
+    cache_read: bool,
     eager_fetch: bool,
     metadata: ProcessMetadata,
   ) -> CommandRunner {
@@ -49,6 +51,7 @@ impl CommandRunner {
       inner,
       cache,
       file_store,
+      cache_read,
       eager_fetch,
       metadata,
     }
@@ -78,63 +81,66 @@ impl crate::CommandRunner for CommandRunner {
       key_type: CacheKeyType::Process.into(),
     };
 
-    let context2 = context.clone();
-    let key2 = key.clone();
-    let cache_read_result = in_workunit!(
-      "local_cache_read",
-      Level::Trace,
-      desc = Some(format!("Local cache lookup: {}", req.description)),
-      |workunit| async move {
-        workunit.increment_counter(Metric::LocalCacheRequests, 1);
+    if self.cache_read {
+      let context2 = context.clone();
+      let key2 = key.clone();
+      let cache_read_result = in_workunit!(
+        "local_cache_read",
+        Level::Trace,
+        desc = Some(format!("Local cache lookup: {}", req.description)),
+        |workunit| async move {
+          workunit.increment_counter(Metric::LocalCacheRequests, 1);
 
-        match self.lookup(&context2, &key2).await {
-          Ok(Some(result)) if result.exit_code == 0 || write_failures_to_cache => {
-            let lookup_elapsed = cache_lookup_start.elapsed();
-            workunit.increment_counter(Metric::LocalCacheRequestsCached, 1);
-            if let Some(time_saved) = result.metadata.time_saved_from_cache(lookup_elapsed) {
-              let time_saved = time_saved.as_millis() as u64;
-              workunit.increment_counter(Metric::LocalCacheTotalTimeSavedMs, time_saved);
-              context2
-                .workunit_store
-                .record_observation(ObservationMetric::LocalCacheTimeSavedMs, time_saved);
+          match self.lookup(&context2, &key2).await {
+            Ok(Some(result)) if result.exit_code == 0 || write_failures_to_cache => {
+              let lookup_elapsed = cache_lookup_start.elapsed();
+              workunit.increment_counter(Metric::LocalCacheRequestsCached, 1);
+              if let Some(time_saved) = result.metadata.time_saved_from_cache(lookup_elapsed) {
+                let time_saved = time_saved.as_millis() as u64;
+                workunit.increment_counter(Metric::LocalCacheTotalTimeSavedMs, time_saved);
+                context2
+                  .workunit_store
+                  .record_observation(ObservationMetric::LocalCacheTimeSavedMs, time_saved);
+              }
+              // When we successfully use the cache, we change the description and increase the
+              // level (but not so much that it will be logged by default).
+              workunit.update_metadata(|initial| {
+                initial.map(|(initial, _)| {
+                  (
+                    WorkunitMetadata {
+                      desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                      ..initial
+                    },
+                    Level::Debug,
+                  )
+                })
+              });
+              Ok(result)
             }
-            // When we successfully use the cache, we change the description and increase the level
-            // (but not so much that it will be logged by default).
-            workunit.update_metadata(|initial| {
-              initial.map(|(initial, _)| {
-                (
-                  WorkunitMetadata {
-                    desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-                    ..initial
-                  },
-                  Level::Debug,
-                )
-              })
-            });
-            Ok(result)
-          }
-          Err(err) => {
-            debug!(
-              "Error loading process execution result from local cache: {} - continuing to execute",
-              err
-            );
-            workunit.increment_counter(Metric::LocalCacheReadErrors, 1);
-            // Falling through to re-execute.
-            Err(())
-          }
-          Ok(_) => {
-            // Either we missed, or we hit for a failing result.
-            workunit.increment_counter(Metric::LocalCacheRequestsUncached, 1);
-            // Falling through to execute.
-            Err(())
+            Err(err) => {
+              debug!(
+                "Error loading process execution result from local cache: {} \
+                - continuing to execute",
+                err
+              );
+              workunit.increment_counter(Metric::LocalCacheReadErrors, 1);
+              // Falling through to re-execute.
+              Err(())
+            }
+            Ok(_) => {
+              // Either we missed, or we hit for a failing result.
+              workunit.increment_counter(Metric::LocalCacheRequestsUncached, 1);
+              // Falling through to execute.
+              Err(())
+            }
           }
         }
-      }
-    )
-    .await;
+      )
+      .await;
 
-    if let Ok(result) = cache_read_result {
-      return Ok(result);
+      if let Ok(result) = cache_read_result {
+        return Ok(result);
+      }
     }
 
     let result = self.inner.run(context.clone(), workunit, req).await?;

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -59,6 +59,7 @@ fn create_cached_runner(
     cache,
     store,
     true,
+    true,
     ProcessMetadata::default(),
   ));
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -301,11 +301,11 @@ impl Core {
     }
 
     if local_cache_read || local_cache_write {
-      // TODO: Conditionally read in the local cache.
       runner = Arc::new(process_execution::cache::CommandRunner::new(
         runner,
         local_cache.clone(),
         full_store.clone(),
+        local_cache_read,
         eager_fetch,
         process_execution_metadata.clone(),
       ));
@@ -346,7 +346,6 @@ impl Core {
     let remote_cache_read = exec_strategy_opts.remote_cache_read || remoting_opts.execution_enable;
     let remote_cache_write =
       exec_strategy_opts.remote_cache_write || remoting_opts.execution_enable;
-    // TODO: Conditionally read in the local cache.
     let local_cache_read_write = exec_strategy_opts.local_cache;
 
     let make_cached_runner = |should_cache_read: bool| -> Result<Arc<dyn CommandRunner>, String> {


### PR DESCRIPTION
As reported in #16009, processes were not being written to caches during backtrack attempts, which meant that future attempts to use the same partial/invalid cache entry would also need to backtrack.

To resolve this, we disable reading from all caches during backtrack attempts, but continue writing to them (if enabled) to allow partial/invalid entries to be repaired.

Fixes #16009.

[ci skip-build-wheels]