### PR TITLE
Write to caches during backtracking (Cherry-pick of #16078)

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -33,6 +33,7 @@ pub struct CommandRunner {
   inner: Arc<dyn crate::CommandRunner>,
   cache: PersistentCache,
   file_store: Store,
+  cache_read: bool,
   eager_fetch: bool,
   metadata: ProcessMetadata,
 }
@@ -42,6 +43,7 @@ impl CommandRunner {
     inner: Arc<dyn crate::CommandRunner>,
     cache: PersistentCache,
     file_store: Store,
+    cache_read: bool,
     eager_fetch: bool,
     metadata: ProcessMetadata,
   ) -> CommandRunner {
@@ -49,6 +51,7 @@ impl CommandRunner {
       inner,
       cache,
       file_store,
+      cache_read,
       eager_fetch,
       metadata,
     }
@@ -78,63 +81,66 @@ impl crate::CommandRunner for CommandRunner {
       key_type: CacheKeyType::Process.into(),
     };
 
-    let context2 = context.clone();
-    let key2 = key.clone();
-    let cache_read_result = in_workunit!(
-      "local_cache_read",
-      Level::Trace,
-      desc = Some(format!("Local cache lookup: {}", req.description)),
-      |workunit| async move {
-        workunit.increment_counter(Metric::LocalCacheRequests, 1);
+    if self.cache_read {
+      let context2 = context.clone();
+      let key2 = key.clone();
+      let cache_read_result = in_workunit!(
+        "local_cache_read",
+        Level::Trace,
+        desc = Some(format!("Local cache lookup: {}", req.description)),
+        |workunit| async move {
+          workunit.increment_counter(Metric::LocalCacheRequests, 1);
 
-        match self.lookup(&context2, &key2).await {
-          Ok(Some(result)) if result.exit_code == 0 || write_failures_to_cache => {
-            let lookup_elapsed = cache_lookup_start.elapsed();
-            workunit.increment_counter(Metric::LocalCacheRequestsCached, 1);
-            if let Some(time_saved) = result.metadata.time_saved_from_cache(lookup_elapsed) {
-              let time_saved = time_saved.as_millis() as u64;
-              workunit.increment_counter(Metric::LocalCacheTotalTimeSavedMs, time_saved);
-              context2
-                .workunit_store
-                .record_observation(ObservationMetric::LocalCacheTimeSavedMs, time_saved);
+          match self.lookup(&context2, &key2).await {
+            Ok(Some(result)) if result.exit_code == 0 || write_failures_to_cache => {
+              let lookup_elapsed = cache_lookup_start.elapsed();
+              workunit.increment_counter(Metric::LocalCacheRequestsCached, 1);
+              if let Some(time_saved) = result.metadata.time_saved_from_cache(lookup_elapsed) {
+                let time_saved = time_saved.as_millis() as u64;
+                workunit.increment_counter(Metric::LocalCacheTotalTimeSavedMs, time_saved);
+                context2
+                  .workunit_store
+                  .record_observation(ObservationMetric::LocalCacheTimeSavedMs, time_saved);
+              }
+              // When we successfully use the cache, we change the description and increase the
+              // level (but not so much that it will be logged by default).
+              workunit.update_metadata(|initial| {
+                initial.map(|(initial, _)| {
+                  (
+                    WorkunitMetadata {
+                      desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                      ..initial
+                    },
+                    Level::Debug,
+                  )
+                })
+              });
+              Ok(result)
             }
-            // When we successfully use the cache, we change the description and increase the level
-            // (but not so much that it will be logged by default).
-            workunit.update_metadata(|initial| {
-              initial.map(|(initial, _)| {
-                (
-                  WorkunitMetadata {
-                    desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
-                    ..initial
-                  },
-                  Level::Debug,
-                )
-              })
-            });
-            Ok(result)
-          }
-          Err(err) => {
-            debug!(
-              "Error loading process execution result from local cache: {} - continuing to execute",
-              err
-            );
-            workunit.increment_counter(Metric::LocalCacheReadErrors, 1);
-            // Falling through to re-execute.
-            Err(())
-          }
-          Ok(_) => {
-            // Either we missed, or we hit for a failing result.
-            workunit.increment_counter(Metric::LocalCacheRequestsUncached, 1);
-            // Falling through to execute.
-            Err(())
+            Err(err) => {
+              debug!(
+                "Error loading process execution result from local cache: {} \
+                - continuing to execute",
+                err
+              );
+              workunit.increment_counter(Metric::LocalCacheReadErrors, 1);
+              // Falling through to re-execute.
+              Err(())
+            }
+            Ok(_) => {
+              // Either we missed, or we hit for a failing result.
+              workunit.increment_counter(Metric::LocalCacheRequestsUncached, 1);
+              // Falling through to execute.
+              Err(())
+            }
           }
         }
-      }
-    )
-    .await;
+      )
+      .await;
 
-    if let Ok(result) = cache_read_result {
-      return Ok(result);
+      if let Ok(result) = cache_read_result {
+        return Ok(result);
+      }
     }
 
     let result = self.inner.run(context.clone(), workunit, req).await?;

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -59,6 +59,7 @@ fn create_cached_runner(
     cache,
     store,
     true,
+    true,
     ProcessMetadata::default(),
   ));
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -260,56 +260,58 @@ impl Core {
   }
 
   ///
-  /// Wraps the given runner in the local cache runner.
+  /// Creates a single stack of cached runners around the given "leaf" CommandRunner.
   ///
-  fn make_local_cached_runner(
-    inner_runner: Arc<dyn CommandRunner>,
+  /// The given cache read/write flags override the relevant cache flags to allow this method
+  /// to be called with all cache reads disabled, regardless of their configured values.
+  ///
+  fn make_cached_runner(
+    mut runner: Arc<dyn CommandRunner>,
     full_store: &Store,
-    local_cache: &PersistentCache,
-    eager_fetch: bool,
-    process_execution_metadata: &ProcessMetadata,
-  ) -> Arc<dyn CommandRunner> {
-    Arc::new(process_execution::cache::CommandRunner::new(
-      inner_runner,
-      local_cache.clone(),
-      full_store.clone(),
-      eager_fetch,
-      process_execution_metadata.clone(),
-    ))
-  }
-
-  ///
-  /// Wraps the given runner in any configured caches.
-  ///
-  fn make_remote_cached_runner(
-    inner_runner: Arc<dyn CommandRunner>,
-    full_store: &Store,
-    remote_store_address: &Option<String>,
     executor: &Executor,
+    local_cache: &PersistentCache,
     process_execution_metadata: &ProcessMetadata,
     root_ca_certs: &Option<Vec<u8>>,
-    _exec_strategy_opts: &ExecutionStrategyOptions,
     remoting_opts: &RemotingOptions,
     remote_cache_read: bool,
     remote_cache_write: bool,
-    eager_fetch: bool,
+    local_cache_read: bool,
+    local_cache_write: bool,
   ) -> Result<Arc<dyn CommandRunner>, String> {
-    Ok(Arc::new(remote_cache::CommandRunner::new(
-      inner_runner,
-      process_execution_metadata.clone(),
-      executor.clone(),
-      full_store.clone(),
-      remote_store_address.as_ref().unwrap(),
-      root_ca_certs.clone(),
-      remoting_opts.store_headers.clone(),
-      Platform::current()?,
-      remote_cache_read,
-      remote_cache_write,
-      remoting_opts.cache_warnings_behavior,
-      eager_fetch,
-      remoting_opts.cache_rpc_concurrency,
-      remoting_opts.cache_read_timeout,
-    )?))
+    // TODO: Until we can deprecate letting the flag default, we implicitly disable
+    // eager_fetch when remote execution is in use.
+    let eager_fetch = remoting_opts.cache_eager_fetch && !remoting_opts.execution_enable;
+    if remote_cache_read || remote_cache_write {
+      runner = Arc::new(remote_cache::CommandRunner::new(
+        runner,
+        process_execution_metadata.clone(),
+        executor.clone(),
+        full_store.clone(),
+        remoting_opts.store_address.as_ref().unwrap(),
+        root_ca_certs.clone(),
+        remoting_opts.store_headers.clone(),
+        Platform::current()?,
+        remote_cache_read,
+        remote_cache_write,
+        remoting_opts.cache_warnings_behavior,
+        eager_fetch,
+        remoting_opts.cache_rpc_concurrency,
+        remoting_opts.cache_read_timeout,
+      )?);
+    }
+
+    if local_cache_read || local_cache_write {
+      runner = Arc::new(process_execution::cache::CommandRunner::new(
+        runner,
+        local_cache.clone(),
+        full_store.clone(),
+        local_cache_read,
+        eager_fetch,
+        process_execution_metadata.clone(),
+      ));
+    }
+
+    Ok(runner)
   }
 
   ///
@@ -339,59 +341,38 @@ impl Core {
       capabilities_cell_opt,
     )?;
 
-    // TODO: Until we can deprecate letting the flag default, we implicitly disable
-    // eager_fetch when remote execution is in use.
-    let eager_fetch = remoting_opts.cache_eager_fetch && !remoting_opts.execution_enable;
     // TODO: Until we can deprecate letting remote-cache-{read,write} default, we implicitly
     // enable them when remote execution is in use.
     let remote_cache_read = exec_strategy_opts.remote_cache_read || remoting_opts.execution_enable;
     let remote_cache_write =
       exec_strategy_opts.remote_cache_write || remoting_opts.execution_enable;
-    let maybe_remote_cached_runner = if remote_cache_read || remote_cache_write {
-      Some(Self::make_remote_cached_runner(
+    let local_cache_read_write = exec_strategy_opts.local_cache;
+
+    let make_cached_runner = |should_cache_read: bool| -> Result<Arc<dyn CommandRunner>, String> {
+      Self::make_cached_runner(
         leaf_runner.clone(),
         full_store,
-        &remoting_opts.store_address,
         executor,
+        local_cache,
         process_execution_metadata,
         root_ca_certs,
-        exec_strategy_opts,
         remoting_opts,
-        remote_cache_read,
+        remote_cache_read && should_cache_read,
         remote_cache_write,
-        eager_fetch,
-      )?)
-    } else {
-      None
+        local_cache_read_write && should_cache_read,
+        local_cache_read_write,
+      )
     };
 
-    let maybe_local_cached_runner = if exec_strategy_opts.local_cache {
-      Some(Self::make_local_cached_runner(
-        maybe_remote_cached_runner
-          .clone()
-          .unwrap_or_else(|| leaf_runner.clone()),
-        full_store,
-        local_cache,
-        eager_fetch,
-        process_execution_metadata,
-      ))
-    } else {
-      None
-    };
+    // The first attempt is always with all caches.
+    let mut runners = vec![make_cached_runner(true)?];
+    // If any cache is both readable and writable, we additionally add a backtracking attempt which
+    // disables all cache reads.
+    if (remote_cache_read && remote_cache_write) || local_cache_read_write {
+      runners.push(make_cached_runner(false)?);
+    }
 
-    Ok(
-      vec![
-        // Use all enabled caches on the first attempt.
-        maybe_local_cached_runner,
-        // Remove local caching on the second attempt.
-        maybe_remote_cached_runner,
-        // Remove all caching on the third attempt.
-        Some(leaf_runner),
-      ]
-      .into_iter()
-      .flatten()
-      .collect(),
-    )
+    Ok(runners)
   }
 
   fn load_certificates(


### PR DESCRIPTION
As reported in #16009, processes were not being written to caches during backtrack attempts, which meant that future attempts to use the same partial/invalid cache entry would also need to backtrack.

To resolve this, we disable reading from all caches during backtrack attempts, but continue writing to them (if enabled) to allow partial/invalid entries to be repaired.

Fixes #16009.

[ci skip-build-wheels]
