### PR TITLE
Re-enable `remote_cache_eager_fetch`.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -68,8 +68,8 @@ unmatched_build_file_globs = "error"
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
 remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
-# See https://github.com/pantsbuild/pants/issues/11331.
-remote_cache_eager_fetch = false
+# TODO: See https://github.com/pantsbuild/pants/issues/16096.
+remote_cache_eager_fetch = true
 
 [anonymous-telemetry]
 enabled = true


### PR DESCRIPTION
Re-enable `eager_fetch` due to #16096.

[ci skip-build-wheels]
[ci skip-rust]