### PR TITLE
Optimize `get_expanded_specs` for `StreamingWorkunit` plugins

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
@@ -32,6 +32,7 @@ from pants.engine.target import (
     GeneratedSources,
     HydratedSources,
     HydrateSourcesRequest,
+    Targets,
 )
 from pants.jvm import classpath
 from pants.jvm.compile import rules as jvm_compile_rules
@@ -64,10 +65,12 @@ def rule_runner() -> RuleRunner:
             *javac_rules(),
             *javac_check_rules(),
             *java_dep_inf_rules(),
-            QueryRule(HydratedSources, [HydrateSourcesRequest]),
-            QueryRule(GeneratedSources, [GenerateJavaFromAvroRequest]),
             QueryRule(CheckResults, (JavacCheckRequest,)),
             QueryRule(CoarsenedTargets, (Addresses,)),
+            QueryRule(GeneratedSources, [GenerateJavaFromAvroRequest]),
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(Targets, (Addresses,)),
         ],
         target_types=[
             JavaSourceTarget,

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -155,8 +155,7 @@ class BSPConnection:
         workspace = Workspace(self._scheduler_session)
         params = Params(request, workspace)
         execution_request = self._scheduler_session.execution_request(
-            products=[method_mapping.response_type],
-            subjects=[params],
+            requests=[(method_mapping.response_type, params)],
         )
         returns, throws = self._scheduler_session.execute(execution_request)
         if len(returns) == 1 and len(throws) == 0:

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -157,19 +157,12 @@ class BSPConnection:
         execution_request = self._scheduler_session.execution_request(
             requests=[(method_mapping.response_type, params)],
         )
-        returns, throws = self._scheduler_session.execute(execution_request)
-        if len(returns) == 1 and len(throws) == 0:
-            # Initialize the BSPContext with the client-supplied init parameters. See earlier comment on why this
-            # call to `BSPContext.initialize_connection` is safe.
-            if method_name == self._INITIALIZE_METHOD_NAME:
-                self._context.initialize_connection(request, self.notify_client)
-            return returns[0][1].value.to_json_dict()
-        elif len(returns) == 0 and len(throws) == 1:
-            raise throws[0][1].exc
-        else:
-            raise AssertionError(
-                f"Received unexpected result from engine: returns={returns}; throws={throws}"
-            )
+        (result,) = self._scheduler_session.execute(execution_request)
+        # Initialize the BSPContext with the client-supplied init parameters. See earlier comment on why this
+        # call to `BSPContext.initialize_connection` is safe.
+        if method_name == self._INITIALIZE_METHOD_NAME:
+            self._context.initialize_connection(request, self.notify_client)
+        return result.to_json_dict()
 
     # Called by `Endpoint` to dispatch requests and notifications.
     # TODO: Should probably vendor `Endpoint` so we can detect notifications versus method calls, which

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -573,6 +573,8 @@ class Address(EngineAwareParameter):
         )
 
     def __eq__(self, other):
+        if self is other:
+            return True
         if not isinstance(other, Address):
             return False
         return self._equal_without_parameters(other) and self.parameters == other.parameters

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -40,6 +40,8 @@ class Collection(Tuple[T, ...]):
         return self.__class__(cast(Tuple[T, ...], result))
 
     def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
         return type(self) == type(other) and super().__eq__(other)
 
     def __ne__(self, other: Any) -> bool:

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, Sequence, Tuple
 
 from pants.base.specs import Specs
 from pants.engine.addresses import Addresses
@@ -102,23 +102,24 @@ class StreamingWorkunitContext:
         """Return a dict containing the canonicalized addresses of the specs for this run, and what
         files they expand to."""
 
-        (unexpanded_addresses,) = self._scheduler.product_request(
-            Addresses, [Params(self._specs, self._options_bootstrapper)]
-        )
+        params = Params(self._specs, self._options_bootstrapper)
+        request = self._scheduler.execution_request([(Addresses, params), (Targets, params)])
+        unexpanded_addresses, expanded_targets = self._scheduler.execute(request)
 
-        expanded_targets = self._scheduler.product_request(
-            Targets, [Params(Addresses([addr])) for addr in unexpanded_addresses]
-        )
-        targets_dict: dict[str, list[TargetInfo]] = {}
-        for addr, targets in zip(unexpanded_addresses, expanded_targets):
-            targets_dict[addr.spec] = [
+        targets_dict: Dict[str, list[TargetInfo]] = {str(addr): [] for addr in unexpanded_addresses}
+        for target in expanded_targets:
+            source = targets_dict.get(str(target.address.spec), None)
+            if source is None:
+                source = targets_dict[str(target.address.maybe_convert_to_target_generator())]
+            source.append(
                 TargetInfo(
                     filename=(
-                        tgt.address.filename if tgt.address.is_file_target else str(tgt.address)
+                        target.address.filename
+                        if target.address.is_file_target
+                        else str(target.address)
                     )
                 )
-                for tgt in targets
-            ]
+            )
         return ExpandedSpecs(targets=targets_dict)
 
 
@@ -306,7 +307,7 @@ class _InnerHandler(threading.Thread):
 def rules():
     return [
         QueryRule(WorkunitsCallbackFactories, (UnionMembership,)),
-        QueryRule(Targets, (Addresses,)),
+        QueryRule(Targets, (Specs, OptionsBootstrapper)),
         QueryRule(Addresses, (Specs, OptionsBootstrapper)),
         *collect_rules(),
     ]

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Iterable, Sequence, Tuple
+from typing import Any, Callable, Iterable, Sequence, Tuple
 
 from pants.base.specs import Specs
 from pants.engine.addresses import Addresses
@@ -106,7 +106,7 @@ class StreamingWorkunitContext:
         request = self._scheduler.execution_request([(Addresses, params), (Targets, params)])
         unexpanded_addresses, expanded_targets = self._scheduler.execute(request)
 
-        targets_dict: Dict[str, list[TargetInfo]] = {str(addr): [] for addr in unexpanded_addresses}
+        targets_dict: dict[str, list[TargetInfo]] = {str(addr): [] for addr in unexpanded_addresses}
         for target in expanded_targets:
             source = targets_dict.get(str(target.address.spec), None)
             if source is None:

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -103,7 +103,8 @@ def rules():
     return [
         *collect_rules(),
         *system_binaries.rules(),
+        QueryRule(CoarsenedTargets, (Addresses,)),
         QueryRule(RenderedClasspath, (Classpath,)),
         QueryRule(RenderedClasspath, (ClasspathEntry,)),
-        QueryRule(CoarsenedTargets, (Addresses,)),
+        QueryRule(Targets, (Addresses,)),
     ]


### PR DESCRIPTION
`StreamingWorkunit` plugins can use `get_expanded_specs` to capture the addresses associated with the input CLI specs for a run. But in cases with large numbers of input roots, this results in engine requests proportional to the number of targets in the repository.

This change adjusts the algorithm for building the mapping from unexpanded addresses to expanded targets, and cleans up the `Scheduler.execute` API to allow for making requests with different product types in parallel.

[ci skip-rust]
[ci skip-build-wheels]