### PR TITLE
Fix poetry locks missing hashes. (Cherry-pick of #16112)

### DIFF
--- a/src/python/pants/backend/python/subsystems/poetry.py
+++ b/src/python/pants/backend/python/subsystems/poetry.py
@@ -24,7 +24,7 @@ class PoetrySubsystem(PythonToolRequirementsBase):
     options_scope = "poetry"
     help = "Used to generate lockfiles for third-party Python dependencies."
 
-    default_version = "poetry==1.1.8"
+    default_version = "poetry==1.1.14"
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]


### PR DESCRIPTION
This was due to this change on PyPI:
  https://discuss.python.org/t/backwards-incompatible-change-to-pypi-json-api/17154

Which was fixed in Poetry yesterday here:
  https://github.com/python-poetry/poetry/pull/5973

Unfortunately, the full fix requires blowing away the non-Pants
controlled Poetry cache at `~/.cache/pypoetry` on Linux and
`~/Library/Caches/pypoetry` on Mac.

Fixes #16111

(cherry picked from commit b97936e2e68edf5060163b66fa1bb21b2460d11b)

[ci skip-rust]
[ci skip-build-wheels]