### PR TITLE
Re-enable `remote_cache_eager_fetch`. (Cherry-pick of #16097)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -71,8 +71,8 @@ unmatched_build_file_globs = "error"
 remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_instance_name = "main"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
-# See https://github.com/pantsbuild/pants/issues/11331.
-remote_cache_eager_fetch = false
+# TODO: See https://github.com/pantsbuild/pants/issues/16096.
+remote_cache_eager_fetch = true
 
 [anonymous-telemetry]
 enabled = true


### PR DESCRIPTION
Enable `remote_cache_eager_fetch`.

(cherry picked from commit ab13499e13ea91fa42b1b4cd6f3531eef1eaa985)

[ci skip-build-wheels]
[ci skip-rust]