### PR TITLE
Initial cleanup and simplification of DynamicRemoteOptions.from_options

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -178,7 +178,7 @@ class DynamicRemoteOptions:
 
     @classmethod
     def disabled(cls) -> DynamicRemoteOptions:
-        return DynamicRemoteOptions(
+        return cls(
             execution=False,
             cache_read=False,
             cache_write=False,
@@ -205,6 +205,10 @@ class DynamicRemoteOptions:
         execution = cast(bool, bootstrap_options.remote_execution)
         cache_read = cast(bool, bootstrap_options.remote_cache_read)
         cache_write = cast(bool, bootstrap_options.remote_cache_write)
+
+        if not (execution or cache_read or cache_write):
+            return cls.disabled(), None
+
         store_address = cast("str | None", bootstrap_options.remote_store_address)
         execution_address = cast("str | None", bootstrap_options.remote_execution_address)
         instance_name = cast("str | None", bootstrap_options.remote_instance_name)
@@ -229,11 +233,7 @@ class DynamicRemoteOptions:
             store_headers.update(token_header)
 
         auth_plugin_result: AuthPluginResult | None = None
-        if (
-            bootstrap_options.remote_auth_plugin
-            and bootstrap_options.remote_auth_plugin.strip()
-            and (execution or cache_read or cache_write)
-        ):
+        if bootstrap_options.remote_auth_plugin:
             if ":" not in bootstrap_options.remote_auth_plugin:
                 raise OptionsError(
                     "Invalid value for `--remote-auth-plugin`: "
@@ -305,22 +305,13 @@ class DynamicRemoteOptions:
                         )
                     )
                     execution_address = auth_plugin_result.execution_address
-
-        # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
-        # We validate that users set `grpc` and `grpcs` in the options system / plugin for clarity,
-        # but then normalize to `http`/`https`.
-        execution_address = (
-            re.sub(r"^grpc", "http", execution_address) if execution_address else None
-        )
-        store_address = re.sub(r"^grpc", "http", store_address) if store_address else None
-
-        opts = DynamicRemoteOptions(
+        opts = cls(
             execution=execution,
             cache_read=cache_read,
             cache_write=cache_write,
             instance_name=instance_name,
-            store_address=store_address,
-            execution_address=execution_address,
+            store_address=cls._normalize_address(store_address),
+            execution_address=cls._normalize_address(execution_address),
             store_headers=store_headers,
             execution_headers=execution_headers,
             parallelism=parallelism,
@@ -329,6 +320,13 @@ class DynamicRemoteOptions:
             execution_rpc_concurrency=execution_rpc_concurrency,
         )
         return opts, auth_plugin_result
+
+    @classmethod
+    def _normalize_address(cls, address: str | None) -> str | None:
+        # NB: Tonic expects the schemes `http` and `https`, even though they are gRPC requests.
+        # We validate that users set `grpc` and `grpcs` in the options system / plugin for clarity,
+        # but then normalize to `http`/`https`.
+        return re.sub(r"^grpc", "http", address) if address else None
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Note that this removes the call to `bootstrap_options.remote_auth_plugin.strip()` which means the config option needs to be clean w/o any spaces since we no will no longer clean it up.

Context for this change:
I am refactoring this logic in order to add support for specifying the remote_auth_plugin via a backend/plugin entrypoint instead of an option which will simplify the config.

Marking this as public api change due to the removal of the call to `strip()`