### PR TITLE
[internal] refactor `find_jvm_artifacts_or_raise` to make its exceptions usable to show users

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -48,7 +48,6 @@ from pants.jvm import jdk_rules
 from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
-    MissingJvmArtifacts,
     UnversionedCoordinate,
     find_jvm_artifacts_or_raise,
 )
@@ -255,27 +254,24 @@ async def resolve_apache_avro_runtime_for_resolve(
     jvm_artifact_targets: AllJvmArtifactTargets,
     jvm: JvmSubsystem,
 ) -> ApacheAvroRuntimeForResolve:
-    try:
-        addresses = find_jvm_artifacts_or_raise(
-            required_coordinates=[
-                UnversionedCoordinate(
-                    group=_AVRO_GROUP,
-                    artifact="avro",
-                ),
-                UnversionedCoordinate(
-                    group=_AVRO_GROUP,
-                    artifact="avro-ipc",
-                ),
-            ],
-            resolve=request.resolve_name,
-            jvm_artifact_targets=jvm_artifact_targets,
-            jvm=jvm,
-        )
-        return ApacheAvroRuntimeForResolve(addresses)
-    except MissingJvmArtifacts:
-        raise MissingApacheAvroRuntimeInResolveError(
-            request.resolve_name,
-        )
+    addresses = find_jvm_artifacts_or_raise(
+        required_coordinates=[
+            UnversionedCoordinate(
+                group=_AVRO_GROUP,
+                artifact="avro",
+            ),
+            UnversionedCoordinate(
+                group=_AVRO_GROUP,
+                artifact="avro-ipc",
+            ),
+        ],
+        resolve=request.resolve_name,
+        jvm_artifact_targets=jvm_artifact_targets,
+        jvm=jvm,
+        subsystem="the Apache Avro runtime",
+        target_type="avro_sources",
+    )
+    return ApacheAvroRuntimeForResolve(addresses)
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/java/dependency_inference.py
@@ -16,15 +16,12 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
-    ConflictingJvmArtifactVersion,
-    MissingJvmArtifacts,
     UnversionedCoordinate,
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.dependency_inference.artifact_mapper import rules as artifact_mapper_rules
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
-from pants.util.docutil import bin_name
 
 _PROTOBUF_JAVA_RUNTIME_GROUP = "com.google.protobuf"
 _PROTOBUF_JAVA_RUNTIME_ARTIFACT = "protobuf-java"
@@ -50,22 +47,20 @@ async def resolve_protobuf_java_runtime_for_resolve(
     jvm: JvmSubsystem,
     request: ProtobufJavaRuntimeForResolveRequest,
 ) -> ProtobufJavaRuntimeForResolve:
-
-    try:
-        addresses = find_jvm_artifacts_or_raise(
-            required_coordinates=[
-                UnversionedCoordinate(
-                    group=_PROTOBUF_JAVA_RUNTIME_GROUP,
-                    artifact=_PROTOBUF_JAVA_RUNTIME_ARTIFACT,
-                )
-            ],
-            resolve=request.resolve_name,
-            jvm_artifact_targets=jvm_artifact_targets,
-            jvm=jvm,
-        )
-        return ProtobufJavaRuntimeForResolve(addresses)
-    except (MissingJvmArtifacts, ConflictingJvmArtifactVersion):
-        raise MissingProtobufJavaRuntimeInResolveError(request.resolve_name)
+    addresses = find_jvm_artifacts_or_raise(
+        required_coordinates=[
+            UnversionedCoordinate(
+                group=_PROTOBUF_JAVA_RUNTIME_GROUP,
+                artifact=_PROTOBUF_JAVA_RUNTIME_ARTIFACT,
+            )
+        ],
+        resolve=request.resolve_name,
+        jvm_artifact_targets=jvm_artifact_targets,
+        jvm=jvm,
+        subsystem="the Protobuf Java runtime",
+        target_type="protobuf_sources",
+    )
+    return ProtobufJavaRuntimeForResolve(addresses)
 
 
 @rule
@@ -90,25 +85,6 @@ async def inject_protobuf_java_runtime_dependency(
     )
 
     return InjectedDependencies(protobuf_java_runtime_target_info.addresses)
-
-
-class MissingProtobufJavaRuntimeInResolveError(ValueError):
-    def __init__(self, resolve_name: str) -> None:
-        super().__init__(
-            f"The JVM resolve `{resolve_name}` does not contain a requirement for the protobuf-java "
-            "runtime. Since at least one JVM target type in this repository consumes a "
-            "`protobuf_sources` target in this resolve, the resolve must contain a `jvm_artifact` "
-            "target for the `protobuf-java` runtime.\n\n Please add the following `jvm_artifact` "
-            f"target somewhere in the repository and re-run `{bin_name()} generate-lockfiles "
-            f"--resolve={resolve_name}`:\n"
-            "jvm_artifact(\n"
-            f'  name="{_PROTOBUF_JAVA_RUNTIME_GROUP}_{_PROTOBUF_JAVA_RUNTIME_ARTIFACT}",\n'
-            f'  group="{_PROTOBUF_JAVA_RUNTIME_GROUP}",\n',
-            f'  artifact="{_PROTOBUF_JAVA_RUNTIME_ARTIFACT}",\n',
-            '  version="<your preferred runtime version>",\n',
-            f'  resolve="{resolve_name}",\n',
-            ")",
-        )
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -19,15 +19,11 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
-    ConflictingJvmArtifactVersion,
-    MissingJvmArtifacts,
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
-from pants.util.docutil import bin_name
-from pants.util.strutil import softwrap
 
 _SCALAPB_RUNTIME_GROUP = "com.thesamet.scalapb"
 _SCALAPB_RUNTIME_ARTIFACT = "scalapb-runtime"
@@ -60,28 +56,22 @@ async def resolve_scalapb_runtime_for_resolve(
     scala_binary_version, _, _ = scala_version.rpartition(".")
     version = scalapb.version
 
-    try:
-        addresses = find_jvm_artifacts_or_raise(
-            required_coordinates=[
-                Coordinate(
-                    group=_SCALAPB_RUNTIME_GROUP,
-                    artifact=f"{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",
-                    version=version,
-                )
-            ],
-            resolve=request.resolve_name,
-            jvm_artifact_targets=jvm_artifact_targets,
-            jvm=jvm,
-        )
-        return ScalaPBRuntimeForResolve(addresses)
-    except ConflictingJvmArtifactVersion as ex:
-        raise ConflictingScalaPBRuntimeVersionInResolveError(
-            request.resolve_name, ex.required_version, ex.found_coordinate
-        )
-    except MissingJvmArtifacts:
-        raise MissingScalaPBRuntimeInResolveError(
-            request.resolve_name, version, scala_binary_version
-        )
+    addresses = find_jvm_artifacts_or_raise(
+        required_coordinates=[
+            Coordinate(
+                group=_SCALAPB_RUNTIME_GROUP,
+                artifact=f"{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",
+                version=version,
+            )
+        ],
+        resolve=request.resolve_name,
+        jvm_artifact_targets=jvm_artifact_targets,
+        jvm=jvm,
+        subsystem="the ScalaPB runtime",
+        target_type="protobuf_sources",
+        requirement_source="the `[scalapb].version` option",
+    )
+    return ScalaPBRuntimeForResolve(addresses)
 
 
 @rule
@@ -105,44 +95,6 @@ async def inject_scalapb_runtime_dependency(
         ScalaPBRuntimeForResolve, ScalaPBRuntimeForResolveRequest(resolve)
     )
     return InjectedDependencies(scalapb_runtime_target_info.addresses)
-
-
-class ConflictingScalaPBRuntimeVersionInResolveError(ValueError):
-    """Exception for when there is a conflicting ScalaPB version in a resolve."""
-
-    def __init__(
-        self, resolve_name: str, required_version: str, conflicting_coordinate: Coordinate
-    ) -> None:
-        super().__init__(
-            softwrap(
-                f"""
-                The JVM resolve `{resolve_name}` contains a `jvm_artifact` for version
-                {conflicting_coordinate.version} of the ScalaPB runtime. This conflicts with version
-                {required_version} which is the configured version of ScalaPB for this resolve from
-                the `[scalapb].version` option. Please remove the `jvm_artifact` target with JVM
-                coordinate {conflicting_coordinate.to_coord_str()}, then re-run
-                `{bin_name()} generate-lockfiles --resolve={resolve_name}`
-                """
-            )
-        )
-
-
-class MissingScalaPBRuntimeInResolveError(ValueError):
-    def __init__(self, resolve_name: str, version: str, scala_binary_version: str) -> None:
-        super().__init__(
-            f"The JVM resolve `{resolve_name}` does not contain a requirement for the ScalaPB runtime. "
-            "Since at least one JVM target type in this repository consumes a `protobuf_sources` target "
-            "in this resolve, the resolve must contain a `jvm_artifact` target for the ScalaPB runtime.\n\n"
-            "Please add the following `jvm_artifact` target somewhere in the repository and re-run "
-            f"`{bin_name()} generate-lockfiles --resolve={resolve_name}`:\n"
-            "jvm_artifact(\n"
-            f'  name="{_SCALAPB_RUNTIME_GROUP}_{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",\n'
-            f'  group="{_SCALAPB_RUNTIME_GROUP}",\n',
-            f'  artifact="{_SCALAPB_RUNTIME_ARTIFACT}_{scala_binary_version}",\n',
-            f'  version="{version}",\n',
-            f'  resolve="{resolve_name}",\n',
-            ")",
-        )
 
 
 def rules():

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules.py
@@ -33,16 +33,13 @@ from pants.engine.unions import UnionRule
 from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
-    MissingJvmArtifacts,
     UnversionedCoordinate,
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField, PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
-from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
 
 
 class GenerateJavaFromThriftRequest(GenerateSourcesRequest):
@@ -101,23 +98,20 @@ async def resolve_apache_thrift_java_runtime_for_resolve(
     jvm_artifact_targets: AllJvmArtifactTargets,
     jvm: JvmSubsystem,
 ) -> ApacheThriftJavaRuntimeForResolve:
-    try:
-        addresses = find_jvm_artifacts_or_raise(
-            required_coordinates=[
-                UnversionedCoordinate(
-                    group=_LIBTHRIFT_GROUP,
-                    artifact=_LIBTHRIFT_ARTIFACT,
-                )
-            ],
-            resolve=request.resolve_name,
-            jvm_artifact_targets=jvm_artifact_targets,
-            jvm=jvm,
-        )
-        return ApacheThriftJavaRuntimeForResolve(addresses)
-    except MissingJvmArtifacts:
-        raise MissingApacheThriftJavaRuntimeInResolveError(
-            request.resolve_name,
-        )
+    addresses = find_jvm_artifacts_or_raise(
+        required_coordinates=[
+            UnversionedCoordinate(
+                group=_LIBTHRIFT_GROUP,
+                artifact=_LIBTHRIFT_ARTIFACT,
+            )
+        ],
+        resolve=request.resolve_name,
+        jvm_artifact_targets=jvm_artifact_targets,
+        jvm=jvm,
+        subsystem="the Apache Thrift runtime",
+        target_type="protobuf_sources",
+    )
+    return ApacheThriftJavaRuntimeForResolve(addresses)
 
 
 @rule
@@ -140,30 +134,6 @@ async def inject_apache_thrift_java_dependencies(
         ApacheThriftJavaRuntimeForResolve, ApacheThriftJavaRuntimeForResolveRequest(resolve)
     )
     return InjectedDependencies(dependencies_info.addresses)
-
-
-class MissingApacheThriftJavaRuntimeInResolveError(ValueError):
-    def __init__(self, resolve_name: str) -> None:
-        super().__init__(
-            softwrap(
-                f"""
-                The JVM resolve `{resolve_name}` does not contain a requirement for the Apache Thrift
-                runtime. Since at least one JVM target type in this repository consumes a
-                `protobuf_sources` target in this resolve, the resolve must contain a `jvm_artifact`
-                target for the Apache Thrift runtime.
-
-                Please add the following `jvm_artifact` target somewhere in the repository and re-run
-                `{bin_name()} generate-lockfiles --resolve={resolve_name}`:
-                    jvm_artifact(
-                        name="{_LIBTHRIFT_GROUP}_{_LIBTHRIFT_ARTIFACT}",
-                        group="{_LIBTHRIFT_GROUP}",
-                        artifact="{_LIBTHRIFT_ARTIFACT}",
-                        version="<your chosen version>",
-                        resolve="{resolve_name}",
-                    )
-                """
-            )
-        )
 
 
 def rules():

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -109,8 +109,6 @@ async def resolve_kotlin_runtime_for_resolve(
     kotlin_subsystem: KotlinSubsystem,
 ) -> KotlinRuntimeForResolve:
     kotlin_version = kotlin_subsystem.version_for_resolve(request.resolve_name)
-
-    # TODO: Nicer exception messages if this fails due to the resolve missing a jar.
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
             Coordinate(
@@ -132,6 +130,9 @@ async def resolve_kotlin_runtime_for_resolve(
         resolve=request.resolve_name,
         jvm_artifact_targets=jvm_artifact_targets,
         jvm=jvm,
+        subsystem="the Kotlin runtime",
+        target_type="kotlin_sources",
+        requirement_source="the relevant entry for this resolve in the `[kotlin].version_for_resolve` option",
     )
     return KotlinRuntimeForResolve(addresses)
 

--- a/src/python/pants/backend/kotlin/test/junit.py
+++ b/src/python/pants/backend/kotlin/test/junit.py
@@ -47,8 +47,6 @@ async def resolve_kotlin_junit_libraries_for_resolve(
     kotlin_subsystem: KotlinSubsystem,
 ) -> KotlinJunitLibrariesForResolve:
     kotlin_version = kotlin_subsystem.version_for_resolve(request.resolve_name)
-
-    # TODO: Nicer exception messages if this fails due to the resolve missing a jar.
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
             Coordinate(
@@ -60,6 +58,9 @@ async def resolve_kotlin_junit_libraries_for_resolve(
         resolve=request.resolve_name,
         jvm_artifact_targets=jvm_artifact_targets,
         jvm=jvm,
+        subsystem="the Kotlin test runtime for JUnit",
+        target_type="kotlin_junit_tests",
+        requirement_source="the relevant entry for this resolve in the `[kotlin].version_for_resolve` option",
     )
     return KotlinJunitLibrariesForResolve(addresses)
 

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -347,7 +347,13 @@ async def compute_java_third_party_symbol_mapping(
 
 class ConflictingJvmArtifactVersionInResolveError(ValueError):
     def __init__(
-        self, *, subsystem: str, requirement_source: str | None = None, resolve_name: str, required_version: str, conflicting_coordinate: Coordinate
+        self,
+        *,
+        subsystem: str,
+        requirement_source: str | None = None,
+        resolve_name: str,
+        required_version: str,
+        conflicting_coordinate: Coordinate,
     ) -> None:
         source = f" from {requirement_source}" if requirement_source else ""
         msg = (
@@ -362,7 +368,14 @@ class ConflictingJvmArtifactVersionInResolveError(ValueError):
 
 
 class MissingRequiredJvmArtifactsInResolve(ValueError):
-    def __init__(self, coordinates: Iterable[Coordinate | UnversionedCoordinate], *, subsystem: str, resolve_name: str, target_type: str) -> None:
+    def __init__(
+        self,
+        coordinates: Iterable[Coordinate | UnversionedCoordinate],
+        *,
+        subsystem: str,
+        resolve_name: str,
+        target_type: str,
+    ) -> None:
         msg = (
             f"The JVM resolve `{resolve_name}` is missing one or more requirements for {subsystem}. "
             f"Since at least one JVM target type in this repository consumes a `{target_type}` target "
@@ -443,7 +456,12 @@ def find_jvm_artifacts_or_raise(
             addresses.add(tgt.address)
 
     if remaining_coordinates:
-        raise MissingRequiredJvmArtifactsInResolve(remaining_coordinates, subsystem=subsystem, resolve_name=resolve, target_type=target_type)
+        raise MissingRequiredJvmArtifactsInResolve(
+            remaining_coordinates,
+            subsystem=subsystem,
+            resolve_name=resolve,
+            target_type=target_type,
+        )
 
     return frozenset(addresses)
 

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -20,6 +20,7 @@ from pants.jvm.target_types import (
     JvmProvidesTypesField,
     JvmResolveField,
 )
+from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
@@ -344,19 +345,54 @@ async def compute_java_third_party_symbol_mapping(
     )
 
 
-class ConflictingJvmArtifactVersion(ValueError):
+class ConflictingJvmArtifactVersionInResolveError(ValueError):
     def __init__(
-        self, group: str, artifact: str, required_version: str, found_coordinate: Coordinate
+        self, *, subsystem: str, requirement_source: str | None = None, resolve_name: str, required_version: str, conflicting_coordinate: Coordinate
     ) -> None:
-        self.group: str = group
-        self.artifact: str = artifact
-        self.required_version: str = required_version
-        self.found_coordinate: Coordinate = found_coordinate
+        source = f" from {requirement_source}" if requirement_source else ""
+        msg = (
+            f"The JVM resolve `{resolve_name}` contains a `jvm_artifact` for version {conflicting_coordinate.version} "
+            f"of {subsystem}. This conflicts with version {required_version} which is the configured version "
+            f"of {subsystem} for this resolve{source}. "
+            "Please remove the `jvm_artifact` target with JVM coordinate "
+            f"{conflicting_coordinate.to_coord_str()}, then re-run "
+            f"`{bin_name()} generate-lockfiles --resolve={resolve_name}`"
+        )
+        super().__init__(msg)
 
 
-class MissingJvmArtifacts(ValueError):
-    def __init__(self, coordinates: Iterable[Coordinate | UnversionedCoordinate]) -> None:
-        self.coordinates: tuple[Coordinate | UnversionedCoordinate, ...] = tuple(coordinates)
+class MissingRequiredJvmArtifactsInResolve(ValueError):
+    def __init__(self, coordinates: Iterable[Coordinate | UnversionedCoordinate], *, subsystem: str, resolve_name: str, target_type: str) -> None:
+        msg = (
+            f"The JVM resolve `{resolve_name}` is missing one or more requirements for {subsystem}. "
+            f"Since at least one JVM target type in this repository consumes a `{target_type}` target "
+            "in this resolve, this resolve must contain `jvm_artifact` targets for each requirement of "
+            f"{subsystem}.\n\n"
+            "Please add the following `jvm_artifact` target(s) somewhere in the repository and re-run "
+            f"`{bin_name()} generate-lockfiles --resolve={resolve_name}`:\n"
+        )
+        for coordinate in coordinates:
+            if isinstance(coordinate, Coordinate):
+                msg += (
+                    "\njvm_artifact(\n"
+                    f'  name="{coordinate.group}_{coordinate.artifact}",\n"'
+                    f'  group="{coordinate.group}",\n'
+                    f'  artifact="{coordinate.artifact}",\n'
+                    f'  version="{coordinate.version}",\n'
+                    f'  resolve="{resolve_name}",\n'
+                    ")\n"
+                )
+            elif isinstance(coordinate, UnversionedCoordinate):
+                msg += (
+                    "\njvm_artifact(\n"
+                    f'  name="{coordinate.group}_{coordinate.artifact}",\n'
+                    f'  group="{coordinate.group}",\n'
+                    f'  artifact="{coordinate.artifact}",\n'
+                    '  version="<your preferred runtime version>",\n'
+                    f'  resolve="{resolve_name}",\n'
+                    ")\n"
+                )
+        super().__init__(msg)
 
 
 def find_jvm_artifacts_or_raise(
@@ -364,6 +400,10 @@ def find_jvm_artifacts_or_raise(
     resolve: str,
     jvm_artifact_targets: AllJvmArtifactTargets,
     jvm: JvmSubsystem,
+    *,
+    subsystem: str,
+    target_type: str,
+    requirement_source: str | None = None,
 ) -> frozenset[Address]:
     remaining_coordinates: set[Coordinate | UnversionedCoordinate] = set(required_coordinates)
 
@@ -382,11 +422,12 @@ def find_jvm_artifacts_or_raise(
                 ):
                     continue
                 if artifact.coordinate.version != coordinate.version:
-                    raise ConflictingJvmArtifactVersion(
-                        group=coordinate.group,
-                        artifact=coordinate.artifact,
+                    raise ConflictingJvmArtifactVersionInResolveError(
+                        subsystem=subsystem,
+                        requirement_source=requirement_source,
+                        resolve_name=resolve,
                         required_version=coordinate.version,
-                        found_coordinate=artifact.coordinate,
+                        conflicting_coordinate=artifact.coordinate,
                     )
             elif isinstance(coordinate, UnversionedCoordinate):
                 if (
@@ -402,7 +443,7 @@ def find_jvm_artifacts_or_raise(
             addresses.add(tgt.address)
 
     if remaining_coordinates:
-        raise MissingJvmArtifacts(remaining_coordinates)
+        raise MissingRequiredJvmArtifactsInResolve(remaining_coordinates, subsystem=subsystem, resolve_name=resolve, target_type=target_type)
 
     return frozenset(addresses)
 


### PR DESCRIPTION
Modify `find_jvm_artifacts_or_raise` so that the exceptions it raises can be shown to users. This allows call sites to not have to have their own user-visible exceptions.