### PR TITLE
[internal] CI: add :: to update-build-files invocation

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -485,7 +485,7 @@ jobs:
 
         '
     - name: Lint
-      run: './pants update-build-files --check
+      run: './pants update-build-files --check ::
 
         ./pants lint check ''**''
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -710,7 +710,7 @@ jobs:
 
         '
     - name: Lint
-      run: './pants update-build-files --check
+      run: './pants update-build-files --check ::
 
         ./pants lint check ''**''
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -737,7 +737,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     {
                         "name": "Lint",
                         "run": (
-                            "./pants update-build-files --check\n"
+                            "./pants update-build-files --check ::\n"
                             # Note: we use `**` rather than `::` because regex-lint.
                             "./pants lint check '**'\n"
                         ),


### PR DESCRIPTION
`./pants update-build-files` wants target specs currently. Provide `::` for the CI run to avoid the deprecation warning.