### PR TITLE
allow specifying jvm_artifact packages in a different packages

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -21,7 +21,12 @@ from pants.jvm.goals import lockfile
 from pants.jvm.package import deploy_jar
 from pants.jvm.package.war import rules as war_rules
 from pants.jvm.resolve import coursier_fetch, jvm_tool
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
+from pants.jvm.target_types import (
+    DeployJarTarget,
+    JvmArtifactPackagesTarget,
+    JvmArtifactTarget,
+    JvmWarTarget,
+)
 from pants.jvm.test import junit
 
 
@@ -33,6 +38,7 @@ def target_types():
         JunitTestTarget,
         JunitTestsGeneratorTarget,
         JvmArtifactTarget,
+        JvmArtifactPackagesTarget,
         JvmWarTarget,
     ]
 

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -18,13 +18,19 @@ from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.goals import lockfile
 from pants.jvm.package import deploy_jar, war
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
+from pants.jvm.target_types import (
+    DeployJarTarget,
+    JvmArtifactPackagesTarget,
+    JvmArtifactTarget,
+    JvmWarTarget,
+)
 from pants.jvm.test.junit import rules as jvm_junit_rules
 
 
 def target_types():
     return [
         JvmArtifactTarget,
+        JvmArtifactPackagesTarget,
         KotlinSourceTarget,
         KotlinSourcesGeneratorTarget,
         KotlincPluginTarget,

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -22,7 +22,12 @@ from pants.jvm.goals import lockfile
 from pants.jvm.package import deploy_jar
 from pants.jvm.package.war import rules as war_rules
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
+from pants.jvm.target_types import (
+    DeployJarTarget,
+    JvmArtifactPackagesTarget,
+    JvmArtifactTarget,
+    JvmWarTarget,
+)
 from pants.jvm.test import junit
 
 
@@ -30,6 +35,7 @@ def target_types():
     return [
         DeployJarTarget,
         JvmArtifactTarget,
+        JvmArtifactPackagesTarget,
         JvmWarTarget,
         ScalaJunitTestTarget,
         ScalaJunitTestsGeneratorTarget,

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -295,6 +295,33 @@ class JvmArtifactTarget(Target):
             )
 
 
+class JvmArtifactPackagesFieldSet(FieldSet):
+    group: JvmArtifactGroupField
+    artifact: JvmArtifactArtifactField
+    packages: JvmArtifactPackagesField
+
+    required_fields = (
+        JvmArtifactGroupField,
+        JvmArtifactArtifactField,
+        JvmArtifactPackagesField,
+    )
+
+
+class JvmArtifactPackagesTarget(Target):
+    alias = "jvm_artifact_packages"
+    core_fields = (*COMMON_TARGET_FIELDS, *JvmArtifactPackagesFieldSet.required_fields)
+    help = softwrap(
+        """
+        Provide the packages for a JVM artifact for the purposes of dependency inference.
+
+        The artifact identified by its `group` and `artifact` components.
+
+        This is an alternative for providing the packages within the `jvm_artifact`,
+        allow breaking down the packages of an artifact outside of `jvm_artifact`.
+        """
+    )
+
+
 # -----------------------------------------------------------------------------------------------
 # JUnit test support field(s)
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
The advantage over providing with jvm_artifact is to provide it once per resolve or version.
The advantage over java-infer is that this is more modular.

Another advantage for us is that we currently maintain an sbt build and generate the pants `jvm_artifact`s from the sbt build file, with the new target we can maintain the mapping in a modular way and generate the dependencies from sbt.