### PR TITLE
Optimize `get_expanded_specs` for `StreamingWorkunit` plugins (Cherry-pick of #16106)

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
@@ -15,9 +15,10 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JavaSour
 from pants.build_graph.address import Address
 from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
+from pants.engine.addresses import Addresses
 from pants.engine.internals import graph
 from pants.engine.rules import QueryRule
-from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest, Targets
 from pants.jvm import classpath
 from pants.jvm.compile import rules as jvm_compile_rules
 from pants.jvm.jdk_rules import rules as jdk_rules
@@ -46,6 +47,7 @@ def rule_runner() -> RuleRunner:
             *stripped_source_files.rules(),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GenerateJavaFromAvroRequest]),
+            QueryRule(Targets, (Addresses,)),
         ],
         target_types=[
             JavaSourceTarget,

--- a/src/python/pants/bsp/protocol.py
+++ b/src/python/pants/bsp/protocol.py
@@ -155,22 +155,14 @@ class BSPConnection:
         workspace = Workspace(self._scheduler_session)
         params = Params(request, workspace)
         execution_request = self._scheduler_session.execution_request(
-            products=[method_mapping.response_type],
-            subjects=[params],
+            requests=[(method_mapping.response_type, params)],
         )
-        returns, throws = self._scheduler_session.execute(execution_request)
-        if len(returns) == 1 and len(throws) == 0:
-            # Initialize the BSPContext with the client-supplied init parameters. See earlier comment on why this
-            # call to `BSPContext.initialize_connection` is safe.
-            if method_name == self._INITIALIZE_METHOD_NAME:
-                self._context.initialize_connection(request, self.notify_client)
-            return returns[0][1].value.to_json_dict()
-        elif len(returns) == 0 and len(throws) == 1:
-            raise throws[0][1].exc
-        else:
-            raise AssertionError(
-                f"Received unexpected result from engine: returns={returns}; throws={throws}"
-            )
+        (result,) = self._scheduler_session.execute(execution_request)
+        # Initialize the BSPContext with the client-supplied init parameters. See earlier comment on why this
+        # call to `BSPContext.initialize_connection` is safe.
+        if method_name == self._INITIALIZE_METHOD_NAME:
+            self._context.initialize_connection(request, self.notify_client)
+        return result.to_json_dict()
 
     # Called by `Endpoint` to dispatch requests and notifications.
     # TODO: Should probably vendor `Endpoint` so we can detect notifications versus method calls, which

--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -573,6 +573,8 @@ class Address(EngineAwareParameter):
         )
 
     def __eq__(self, other):
+        if self is other:
+            return True
         if not isinstance(other, Address):
             return False
         return self._equal_without_parameters(other) and self.parameters == other.parameters

--- a/src/python/pants/engine/collection.py
+++ b/src/python/pants/engine/collection.py
@@ -40,6 +40,8 @@ class Collection(Tuple[T, ...]):
         return self.__class__(cast(Tuple[T, ...], result))
 
     def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
         return type(self) == type(other) and super().__eq__(other)
 
     def __ne__(self, other: Any) -> bool:

--- a/src/python/pants/jvm/testutil.py
+++ b/src/python/pants/jvm/testutil.py
@@ -103,7 +103,8 @@ def rules():
     return [
         *collect_rules(),
         *system_binaries.rules(),
+        QueryRule(CoarsenedTargets, (Addresses,)),
         QueryRule(RenderedClasspath, (Classpath,)),
         QueryRule(RenderedClasspath, (ClasspathEntry,)),
-        QueryRule(CoarsenedTargets, (Addresses,)),
+        QueryRule(Targets, (Addresses,)),
     ]


### PR DESCRIPTION
`StreamingWorkunit` plugins can use `get_expanded_specs` to capture the addresses associated with the input CLI specs for a run. But in cases with large numbers of input roots, this results in engine requests proportional to the number of targets in the repository.

This change adjusts the algorithm for building the mapping from unexpanded addresses to expanded targets, and cleans up the `Scheduler.execute` API to allow for making requests with different product types in parallel.

[ci skip-rust]
[ci skip-build-wheels]
