### PR TITLE
Move some remote cache & remote execution validation to post init

### DIFF
--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -26,9 +26,14 @@ class OptionsInitializerTest(unittest.TestCase):
     def test_global_options_validation(self) -> None:
         # Specify an invalid combination of options.
         ob = OptionsBootstrapper.create(
-            env={}, args=["--backend-packages=[]", "--remote-execution"], allow_pantsrc=False
+            env={},
+            args=["--backend-packages=[]", "--no-watch-filesystem", "--loop"],
+            allow_pantsrc=False,
         )
         env = CompleteEnvironment({})
         with self.assertRaises(ExecutionError) as exc:
             OptionsInitializer(ob).build_config_and_options(ob, env, raise_=True)
-        self.assertIn("The `--remote-execution` option requires", str(exc.exception))
+        self.assertIn(
+            "The `--no-watch-filesystem` option may not be set if `--pantsd` or `--loop` is set.",
+            str(exc.exception),
+        )


### PR DESCRIPTION
This will allow to auth plugin to specify those addresses (via AuthPluginResult) and will prevent pants from requiring those addresses to be set in config even if the plugin provides them.

The next version of the TC pants plugin will add support for specifying the remote cache address, so this change is required so users can remove that setting from the pants.toml file.