### PR TITLE
Improve memoization of interpreter constraints, Python parsing, and request classes (Cherry-pick of #16141)

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -107,6 +107,7 @@ class MaybeWarnPythonRepos:
     pass
 
 
+@dataclass(frozen=True)
 class MaybeWarnPythonReposRequest:
     pass
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -335,6 +335,7 @@ class GenericTarget(Target):
 # -----------------------------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
 class AllAssetTargetsRequest:
     pass
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -706,34 +706,42 @@ async def find_git() -> GitBinary:
 # -------------------------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
 class ZipBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class UnzipBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class GunzipBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class TarBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class MkdirBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class ChmodBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class DiffBinaryRequest:
     pass
 
 
+@dataclass(frozen=True)
 class GitBinaryRequest:
     pass
 

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 import uuid
+from dataclasses import dataclass
 from typing import cast
 
 from humbug.consent import HumbugConsent
@@ -153,6 +154,7 @@ class AnonymousTelemetryCallback(WorkunitsCallback):
         reporter.publish(report)
 
 
+@dataclass(frozen=True)
 class AnonymousTelemetryCallbackFactoryRequest:
     """A unique request type that is installed to trigger construction of the WorkunitsCallback."""
 

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import base64
 import logging
 from collections import Counter
+from dataclasses import dataclass
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
@@ -150,6 +151,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
             )
 
 
+@dataclass(frozen=True)
 class StatsAggregatorCallbackFactoryRequest:
     """A unique request type that is installed to trigger construction of the WorkunitsCallback."""
 


### PR DESCRIPTION
Profiling showed that:
1. `Requirement.parse` and `InterpreterConstraint.merge_*` were taking up a significant fraction of time even with singular requirements (~2%).
2. `AllAssetTargetsRequest` did not have stable equality due to not being marked as a `@dataclass`, and so `find_all_assets` was not being memoized (~11%).
3. Repeatedly loading and creating a `Digest` for the `dependency_parser.py` script took a noticeable amount of time (~6%).

Fixing these represents a ~19% performance improvement for `./pants --no-pantsd --changed-diffspec=fcaac98402..2a300002f0 --changed-dependees=transitive list`, which brings `2.12.x`/`2.13.x` roughly back in line with `2.11.x`.
