### PR TITLE
Allow for dependency inference plugins to provide excludes

### DIFF
--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -298,7 +298,7 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
                 )
             ],
         )
-        assert [main_addr] == list(inferred_addresses)
+        assert inferred_addresses == InferredDependencies([main_addr])
         return main_addr
 
     assert get_main(Address("explicit")) == Address("explicit", target_name="pkg")

--- a/src/python/pants/backend/helm/dependency_inference/chart_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart_test.py
@@ -147,10 +147,12 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
         InferredDependencies,
         [InferHelmChartDependenciesRequest(HelmChartDependenciesInferenceFieldSet.create(tgt))],
     )
-    assert set(inferred_deps.dependencies) == {
-        Address("3rdparty/helm/jetstack", target_name="cert-manager"),
-        Address("src/bar", target_name="bar"),
-    }
+    assert inferred_deps == InferredDependencies(
+        [
+            Address("3rdparty/helm/jetstack", target_name="cert-manager"),
+            Address("src/bar", target_name="bar"),
+        ]
+    )
 
 
 def test_disambiguate_chart_dependencies(rule_runner: RuleRunner) -> None:
@@ -190,9 +192,11 @@ def test_disambiguate_chart_dependencies(rule_runner: RuleRunner) -> None:
         InferredDependencies,
         [InferHelmChartDependenciesRequest(HelmChartDependenciesInferenceFieldSet.create(tgt))],
     )
-    assert set(inferred_deps.dependencies) == {
-        Address("src/bar", target_name="bar"),
-    }
+    assert inferred_deps == InferredDependencies(
+        [
+            Address("src/bar", target_name="bar"),
+        ]
+    )
 
 
 def test_raise_error_when_unknown_dependency_is_found(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/dependency_inference/unittest_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest_test.py
@@ -71,8 +71,7 @@ def test_infers_single_chart(rule_runner: RuleRunner) -> None:
         ],
     )
 
-    assert len(inferred_deps.dependencies) == 1
-    assert list(inferred_deps.dependencies)[0] == chart_tgt.address
+    assert inferred_deps == InferredDependencies([chart_tgt.address])
 
 
 def test_injects_parent_chart(rule_runner: RuleRunner) -> None:
@@ -119,8 +118,5 @@ def test_injects_parent_chart(rule_runner: RuleRunner) -> None:
         ],
     )
 
-    assert len(chart1_inferred_deps.dependencies) == 1
-    assert len(chart2_inferred_deps.dependencies) == 1
-
-    assert list(chart1_inferred_deps.dependencies)[0] == chart1_tgt.address
-    assert list(chart2_inferred_deps.dependencies)[0] == chart2_tgt.address
+    assert chart1_inferred_deps == InferredDependencies([chart1_tgt.address])
+    assert chart2_inferred_deps == InferredDependencies([chart2_tgt.address])

--- a/src/python/pants/backend/java/dependency_inference/rules.py
+++ b/src/python/pants/backend/java/dependency_inference/rules.py
@@ -64,7 +64,7 @@ async def infer_java_dependencies_via_source_analysis(
         JavaInferredDependencies,
         JavaInferredDependenciesAndExportsRequest(request.field_set.source),
     )
-    return InferredDependencies(dependencies=jids.dependencies)
+    return InferredDependencies(jids.dependencies)
 
 
 @rule(desc="Inferring Java dependencies and exports by source analysis")

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -98,12 +98,12 @@ def test_infer_java_imports_same_target(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
 
 @maybe_skip_jdk_test
@@ -150,12 +150,12 @@ def test_infer_java_imports(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
 
 @maybe_skip_jdk_test
@@ -205,12 +205,12 @@ def test_infer_java_imports_with_cycle(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[target_a.address])
+    ) == InferredDependencies([target_a.address])
 
 
 @maybe_skip_jdk_test
@@ -260,7 +260,7 @@ def test_infer_java_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
     assert len(caplog.records) == 1
     assert (
         "The target b/B.java imports `org.pantsbuild.a.A`, but Pants cannot safely" in caplog.text
@@ -269,7 +269,7 @@ def test_infer_java_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_c))],
-    ) == InferredDependencies(dependencies=[Address("a_one", relative_file_path="A.java")])
+    ) == InferredDependencies([Address("a_one", relative_file_path="A.java")])
 
 
 @maybe_skip_jdk_test
@@ -304,9 +304,7 @@ def test_infer_java_imports_unnamed_package(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(
-        dependencies=[Address("", target_name="a", relative_file_path="Lib.java")]
-    )
+    ) == InferredDependencies([Address("", target_name="a", relative_file_path="Lib.java")])
 
 
 @maybe_skip_jdk_test
@@ -348,12 +346,12 @@ def test_infer_java_imports_same_target_with_cycle(rule_runner: RuleRunner) -> N
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferJavaSourceDependencies(JavaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[target_a.address])
+    ) == InferredDependencies([target_a.address])
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
@@ -91,12 +91,12 @@ def test_infer_kotlin_imports_same_target(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
 
 @maybe_skip_jdk_test
@@ -140,12 +140,12 @@ def test_infer_kotlin_imports_with_cycle(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[target_a.address])
+    ) == InferredDependencies([target_a.address])
 
 
 @maybe_skip_jdk_test
@@ -195,14 +195,14 @@ def test_infer_kotlin_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
     assert len(caplog.records) == 1
     assert "The target b/B.kt imports `org.pantsbuild.a.A`, but Pants cannot safely" in caplog.text
 
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_c))],
-    ) == InferredDependencies(dependencies=[Address("a_one", relative_file_path="A.kt")])
+    ) == InferredDependencies([Address("a_one", relative_file_path="A.kt")])
 
 
 @maybe_skip_jdk_test
@@ -242,7 +242,7 @@ def test_infer_same_package_via_consumed_symbol(rule_runner: RuleRunner) -> None
     assert rule_runner.request(
         InferredDependencies,
         [InferKotlinSourceDependencies(KotlinSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
     assert rule_runner.request(
         InferredDependencies,
@@ -251,4 +251,4 @@ def test_infer_same_package_via_consumed_symbol(rule_runner: RuleRunner) -> None
                 KotlinSourceDependenciesInferenceFieldSet.create(target_main)
             )
         ],
-    ) == InferredDependencies(dependencies=[target_a.address])
+    ) == InferredDependencies([target_a.address])

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -375,9 +375,9 @@ def test_infer_python_inits(behavior: InitFilesInference) -> None:
             [InferInitDependencies(InitDependenciesInferenceFieldSet.create(target))],
         )
         if behavior == InitFilesInference.never:
-            assert not result
-        else:
-            assert result == InferredDependencies(expected)
+            expected = []
+
+        assert result == InferredDependencies(expected)
 
     check(
         Address("src/python/root/mid/leaf", relative_file_path="f.py"),

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -90,12 +90,12 @@ def test_infer_scala_imports_same_target(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
 
 
 @maybe_skip_jdk_test
@@ -143,12 +143,12 @@ def test_infer_scala_imports_with_cycle(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_a))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[target_a.address])
+    ) == InferredDependencies([target_a.address])
 
 
 @maybe_skip_jdk_test
@@ -198,7 +198,7 @@ def test_infer_java_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_b))],
-    ) == InferredDependencies(dependencies=[])
+    ) == InferredDependencies([])
     assert len(caplog.records) == 1
     assert (
         "The target b/B.scala imports `org.pantsbuild.a.A`, but Pants cannot safely" in caplog.text
@@ -207,7 +207,7 @@ def test_infer_java_imports_ambiguous(rule_runner: RuleRunner, caplog) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_c))],
-    ) == InferredDependencies(dependencies=[Address("a_one", relative_file_path="A.scala")])
+    ) == InferredDependencies([Address("a_one", relative_file_path="A.scala")])
 
 
 def test_infer_unqualified_symbol_from_intermediate_scope(rule_runner: RuleRunner) -> None:
@@ -443,9 +443,9 @@ def test_recursive_objects(rule_runner: RuleRunner) -> None:
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_c))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])
 
     assert rule_runner.request(
         InferredDependencies,
         [InferScalaSourceDependencies(ScalaSourceDependenciesInferenceFieldSet.create(target_d))],
-    ) == InferredDependencies(dependencies=[target_b.address])
+    ) == InferredDependencies([target_b.address])

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1158,6 +1158,9 @@ async def resolve_dependencies(
             for addr in special_cased_field.to_unparsed_address_inputs().values
         )
 
+    excluded = explicitly_provided.ignores.union(
+        *itertools.chain(deps.exclude for deps in inferred)
+    )
     result = Addresses(
         sorted(
             {
@@ -1168,10 +1171,7 @@ async def resolve_dependencies(
                     *itertools.chain.from_iterable(deps.include for deps in inferred),
                     *special_cased,
                 )
-                if addr
-                not in explicitly_provided.ignores.union(
-                    *itertools.chain(deps.exclude for deps in inferred)
-                )
+                if addr not in excluded
             }
         )
     )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1165,10 +1165,13 @@ async def resolve_dependencies(
                 for addr in (
                     *generated_addresses,
                     *explicitly_provided_includes,
-                    *itertools.chain.from_iterable(inferred),
+                    *itertools.chain.from_iterable(deps.include for deps in inferred),
                     *special_cased,
                 )
-                if addr not in explicitly_provided.ignores
+                if addr
+                not in explicitly_provided.ignores.union(
+                    *itertools.chain(deps.exclude for deps in inferred)
+                )
             }
         )
     )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2553,17 +2553,18 @@ class InferDependenciesRequest(Generic[FS], EngineAwareParameter):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class InferredDependencies:
-    dependencies: FrozenOrderedSet[Address]
+    include: FrozenOrderedSet[Address]
+    exclude: FrozenOrderedSet[Address]
 
-    def __init__(self, dependencies: Iterable[Address]) -> None:
+    def __init__(
+        self,
+        include: Iterable[Address],
+        *,
+        exclude: Iterable[Address] = (),
+    ) -> None:
         """The result of inferring dependencies."""
-        self.dependencies = FrozenOrderedSet(sorted(dependencies))
-
-    def __bool__(self) -> bool:
-        return bool(self.dependencies)
-
-    def __iter__(self) -> Iterator[Address]:
-        return iter(self.dependencies)
+        self.include = FrozenOrderedSet(sorted(include))
+        self.exclude = FrozenOrderedSet(sorted(exclude))
 
 
 @union


### PR DESCRIPTION
Fixes #15726

[ci skip-rust]
[ci skip-build-wheels]