### PR TITLE
Port `@rule` `Get`s to rust

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from io import RawIOBase
-from typing import Any, Iterable, Sequence, TextIO, Tuple
+from typing import Any, Generic, Iterable, Sequence, TextIO, Tuple, TypeVar, overload
 
 from typing_extensions import Protocol
 
@@ -334,6 +334,45 @@ def strongly_connected_components(
 ) -> Sequence[Sequence[Any]]: ...
 def hash_prefix_zero_bits(item: str) -> int: ...
 
+# ------------------------------------------------------------------------------
+# Selectors
+# ------------------------------------------------------------------------------
+
+class PyGeneratorResponseBreak:
+    def __init__(self, val: Any) -> None: ...
+
+_Output = TypeVar("_Output")
+_Input = TypeVar("_Input")
+
+class PyGeneratorResponseGet(Generic[_Output, _Input]):
+    output_type: type[_Output]
+    input_type: type[_Input]
+    input: _Input
+
+    @overload
+    def __init__(self, output_type: type[_Output], input_arg0: _Input) -> None: ...
+    @overload
+    def __init__(
+        self,
+        output_type: type[_Output],
+        input_arg0: type[_Input],
+        input_arg1: _Input,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        output_type: type[_Output],
+        input_arg0: type[_Input] | _Input,
+        input_arg1: _Input | None = None,
+    ) -> None: ...
+
+class PyGeneratorResponseGetMulti:
+    def __init__(self, gets: tuple[PyGeneratorResponseGet, ...]) -> None: ...
+
+# ------------------------------------------------------------------------------
+# (uncategorized)
+# ------------------------------------------------------------------------------
+
 class PyExecutionRequest:
     def __init__(
         self, *, poll: bool, poll_delay_in_ms: int | None, timeout_in_ms: int | None
@@ -341,15 +380,6 @@ class PyExecutionRequest:
 
 class PyExecutionStrategyOptions:
     def __init__(self, **kwargs: Any) -> None: ...
-
-class PyGeneratorResponseBreak:
-    def __init__(self, val: Any) -> None: ...
-
-class PyGeneratorResponseGet:
-    def __init__(self, product: type, declared_subject: type, subject: Any) -> None: ...
-
-class PyGeneratorResponseGetMulti:
-    def __init__(self, gets: tuple[PyGeneratorResponseGet, ...]) -> None: ...
 
 class PyNailgunServer:
     def port(self) -> int: ...

--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -94,7 +94,10 @@ def test_create_get() -> None:
     assert get.input == 42
 
     # Also test the equivalence of the 1-arg and 2-arg versions.
-    assert Get(AClass, BClass()) == Get(AClass, BClass, BClass())
+    get2 = Get(AClass, int(42))
+    assert get.output_type == get2.output_type
+    assert get.input_type == get2.input_type
+    assert get.input == get2.input
 
 
 def assert_invalid_get(create_get: Callable[[], Get], *, expected: str) -> None:
@@ -123,7 +126,7 @@ def test_invalid_get() -> None:
         ),
     )
     assert_invalid_get(
-        lambda: Get(AClass, 1, BClass),  # type: ignore[call-overload, no-any-return]
+        lambda: Get(AClass, 1, BClass),
         expected=(
             "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, "
             "input), the second argument must be a type, but given `1` of type "

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -351,6 +351,21 @@ impl PyGeneratorResponseGet {
       subject: subject.into_py(py),
     })
   }
+
+  #[getter]
+  fn output_type<'p>(&'p self, py: Python<'p>) -> &'p PyType {
+    self.product.as_ref(py)
+  }
+
+  #[getter]
+  fn input_type<'p>(&'p self, py: Python<'p>) -> &'p PyType {
+    self.declared_subject.as_ref(py)
+  }
+
+  #[getter]
+  fn input<'p>(&'p self, py: Python<'p>) -> &'p PyAny {
+    self.subject.as_ref(py)
+  }
 }
 
 #[pyclass]


### PR DESCRIPTION
The `Get` syntax for `@rule`s (particularly its validation and freezing via `@dataclass`) was expensive enough to show up in `py-spy` profiles.

This change ports `Get`/`Effect` to rust as subclasses of the existing `PyGeneratorResponseGet`, which improves the performance of `./pants --no-pantsd dependencies ::` by ~12%.

[ci skip-build-wheels]