### PR TITLE
[internal] add compile test for Apache Thrift Java codegen

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
@@ -18,15 +18,26 @@ from pants.backend.codegen.thrift.target_types import (
     ThriftSourceField,
     ThriftSourcesGeneratorTarget,
 )
+from pants.backend.java.compile.javac import CompileJavaSourceRequest
+from pants.backend.java.compile.javac import rules as javac_rules
+from pants.backend.java.dependency_inference.rules import rules as java_dep_inf_rules
+from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JavaSourceTarget
+from pants.backend.scala.compile.scalac import rules as scalac_rules
 from pants.build_graph.address import Address
-from pants.core.util_rules import source_files, stripped_source_files
-from pants.engine.internals import graph
+from pants.core.util_rules import config_files, source_files, stripped_source_files
+from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.jvm import classpath, jdk_rules, testutil, util_rules
 from pants.jvm.dependency_inference import artifact_mapper
+from pants.jvm.resolve import coursier_fetch, coursier_setup
 from pants.jvm.target_types import JvmArtifactTarget
-from pants.source import source_root
-from pants.testutil.rule_runner import RuleRunner, logging
+from pants.jvm.testutil import (
+    RenderedClasspath,
+    expect_single_expanded_coarsened_target,
+    make_resolve,
+)
+from pants.testutil.rule_runner import RuleRunner
 from pants.testutil.skip_utils import requires_thrift
 
 
@@ -52,15 +63,30 @@ def rule_runner() -> RuleRunner:
             *thrift_rules(),
             *apache_thrift_rules(),
             *apache_thrift_java_rules(),
+            *config_files.rules(),
+            *classpath.rules(),
+            *coursier_fetch.rules(),
+            *coursier_setup.rules(),
+            *external_tool_rules(),
             *source_files.rules(),
-            *source_root.rules(),
-            *graph.rules(),
+            *util_rules.rules(),
+            *jdk_rules.rules(),
             *stripped_source_files.rules(),
             *artifact_mapper.rules(),
+            *javac_rules(),
+            *java_dep_inf_rules(),
+            *testutil.rules(),
+            *scalac_rules(),  # TODO: Figure out why this needed to avoid rule graph errors.
             QueryRule(HydratedSources, [HydrateSourcesRequest]),
             QueryRule(GeneratedSources, [GenerateJavaFromThriftRequest]),
+            QueryRule(RenderedClasspath, (CompileJavaSourceRequest,)),
         ],
-        target_types=[ThriftSourcesGeneratorTarget, JvmArtifactTarget],
+        target_types=[
+            ThriftSourcesGeneratorTarget,
+            JavaSourceTarget,
+            JavaSourcesGeneratorTarget,
+            JvmArtifactTarget,
+        ],
     )
 
 
@@ -85,9 +111,8 @@ def assert_files_generated(
     assert set(generated_sources.snapshot.files) == set(expected_files)
 
 
-@logging
 @requires_thrift
-def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfileFixture) -> None:
+def test_generates_java(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfileFixture) -> None:
     # This tests a few things:
     #  * We generate the correct file names.
     #  * Thrift files can import other thrift files, and those can import others
@@ -97,7 +122,7 @@ def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfi
         {
             "src/thrift/dir1/f.thrift": dedent(
                 """\
-                namespace py dir1
+                namespace java org.pantsbuild.example
                 struct Person {
                   1: string name
                   2: i32 id
@@ -107,7 +132,7 @@ def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfi
             ),
             "src/thrift/dir1/f2.thrift": dedent(
                 """\
-                namespace py dir1
+                namespace java org.pantsbuild.example
                 include "dir1/f.thrift"
                 struct ManagedPerson {
                   1: f.Person employee
@@ -137,6 +162,15 @@ def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfi
             "tests/thrift/test_thrifts/BUILD": "thrift_sources(dependencies=['src/thrift/dir2'])",
             "3rdparty/jvm/default.lock": libthrift_lockfile.serialized_lockfile,
             "3rdparty/jvm/BUILD": libthrift_lockfile.requirements_as_jvm_artifact_targets(),
+            "src/jvm/BUILD": "java_sources(dependencies=['src/thrift/dir1'])",
+            "src/jvm/TestScroogeThriftJava.java": dedent(
+                """\
+                package org.pantsbuild.example;
+                public class TestScroogeThriftJava {
+                    Person person;
+                }
+                """
+            ),
         }
     )
 
@@ -151,13 +185,13 @@ def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfi
     assert_gen(
         Address("src/thrift/dir1", relative_file_path="f.thrift"),
         [
-            "src/thrift/Person.java",
+            "src/thrift/org/pantsbuild/example/Person.java",
         ],
     )
     assert_gen(
         Address("src/thrift/dir1", relative_file_path="f2.thrift"),
         [
-            "src/thrift/ManagedPerson.java",
+            "src/thrift/org/pantsbuild/example/ManagedPerson.java",
         ],
     )
     # TODO: Fix package namespacing?
@@ -174,3 +208,11 @@ def test_generates_python(rule_runner: RuleRunner, libthrift_lockfile: JVMLockfi
             "tests/thrift/Executive.java",
         ],
     )
+
+    request = CompileJavaSourceRequest(
+        component=expect_single_expanded_coarsened_target(
+            rule_runner, Address(spec_path="src/jvm")
+        ),
+        resolve=make_resolve(rule_runner),
+    )
+    _ = rule_runner.request(RenderedClasspath, [request])


### PR DESCRIPTION
Add a compilation test for generated code from the Apache Thrift Java codegen backend.

[ci skip-rust]