### PR TITLE
Fix defaulting of parameters in explicitly specified deps on `parametrize`d targets for AsyncFieldMixin

### DIFF
--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -232,14 +232,19 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             return instance
 
         def remaining_fields_match(candidate: Target) -> bool:
-            """Returns true if all Fields absent from the candidate's Address match the consumer."""
+            """Returns true if all Fields absent from the candidate's Address match the consumer.
+
+            TODO: This does not account for the computed default values of Fields:
+              see https://github.com/pantsbuild/pants/issues/16175
+            """
+
             unspecified_param_field_names = {
                 key for key in candidate.address.parameters.keys() if key not in address.parameters
             }
 
             return all(
-                consumer.has_field(field_type) and consumer[field_type] == field_value
-                for field_type, field_value in candidate.field_values.items()
+                consumer.has_field(field_type) and consumer[field_type].value == field.value
+                for field_type, field in candidate.field_values.items()
                 if field_type.alias in unspecified_param_field_names
             )
 


### PR DESCRIPTION
Although the tests for #14519 were reasonably good, they tested with `StringField`, rather than additionally with `AsyncFieldMixin`. The latter changes the definition of equality for the `Field` to include its address, meaning that comparing the `Field` instance itself will never match for `Field`s from different targets. That made #14519... not particularly useful in production.

This change fixes `Field` value comparisons to use `field.value`, references the newly opened #16175 (which is out of scope for now, given that it will likely be impacted by `__defaults__` and would be much harder to cherry-pick), and adds an additional test.

Fixes #14519.

[ci skip-rust]
[ci skip-build-wheels]