### PR TITLE
Port `@rule` `Get`s to rust (Cherry-pick of #16160)

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from io import RawIOBase
-from typing import Any, Iterable, Sequence, TextIO, Tuple
+from typing import Any, Generic, Iterable, Sequence, TextIO, Tuple, TypeVar, overload
 
 from typing_extensions import Protocol
 
@@ -334,6 +334,45 @@ def strongly_connected_components(
 ) -> Sequence[Sequence[Any]]: ...
 def hash_prefix_zero_bits(item: str) -> int: ...
 
+# ------------------------------------------------------------------------------
+# Selectors
+# ------------------------------------------------------------------------------
+
+class PyGeneratorResponseBreak:
+    def __init__(self, val: Any) -> None: ...
+
+_Output = TypeVar("_Output")
+_Input = TypeVar("_Input")
+
+class PyGeneratorResponseGet(Generic[_Output, _Input]):
+    output_type: type[_Output]
+    input_type: type[_Input]
+    input: _Input
+
+    @overload
+    def __init__(self, output_type: type[_Output], input_arg0: _Input) -> None: ...
+    @overload
+    def __init__(
+        self,
+        output_type: type[_Output],
+        input_arg0: type[_Input],
+        input_arg1: _Input,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        output_type: type[_Output],
+        input_arg0: type[_Input] | _Input,
+        input_arg1: _Input | None = None,
+    ) -> None: ...
+
+class PyGeneratorResponseGetMulti:
+    def __init__(self, gets: tuple[PyGeneratorResponseGet, ...]) -> None: ...
+
+# ------------------------------------------------------------------------------
+# (uncategorized)
+# ------------------------------------------------------------------------------
+
 class PyExecutionRequest:
     def __init__(
         self, *, poll: bool, poll_delay_in_ms: int | None, timeout_in_ms: int | None
@@ -341,15 +380,6 @@ class PyExecutionRequest:
 
 class PyExecutionStrategyOptions:
     def __init__(self, **kwargs: Any) -> None: ...
-
-class PyGeneratorResponseBreak:
-    def __init__(self, val: Any) -> None: ...
-
-class PyGeneratorResponseGet:
-    def __init__(self, product: type, declared_subject: type, subject: Any) -> None: ...
-
-class PyGeneratorResponseGetMulti:
-    def __init__(self, gets: tuple[PyGeneratorResponseGet, ...]) -> None: ...
 
 class PyNailgunServer:
     def port(self) -> int: ...

--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -94,7 +94,10 @@ def test_create_get() -> None:
     assert get.input == 42
 
     # Also test the equivalence of the 1-arg and 2-arg versions.
-    assert Get(AClass, BClass()) == Get(AClass, BClass, BClass())
+    get2 = Get(AClass, int(42))
+    assert get.output_type == get2.output_type
+    assert get.input_type == get2.input_type
+    assert get.input == get2.input
 
 
 def assert_invalid_get(create_get: Callable[[], Get], *, expected: str) -> None:
@@ -123,7 +126,7 @@ def test_invalid_get() -> None:
         ),
     )
     assert_invalid_get(
-        lambda: Get(AClass, 1, BClass),  # type: ignore[call-overload, no-any-return]
+        lambda: Get(AClass, 1, BClass),
         expected=(
             "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, "
             "input), the second argument must be a type, but given `1` of type "

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -9,10 +9,10 @@ use std::convert::TryInto;
 use std::fmt;
 
 use lazy_static::lazy_static;
-use pyo3::exceptions::PyException;
-use pyo3::import_exception;
+use pyo3::exceptions::{PyException, PyTypeError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyTuple, PyType};
+use pyo3::{import_exception, intern};
 use pyo3::{FromPyObject, ToPyObject};
 
 use logging::PythonLogLevel;
@@ -54,6 +54,16 @@ pub fn equals(h1: &PyAny, h2: &PyAny) -> bool {
     return false;
   }
   h1.eq(h2).unwrap()
+}
+
+pub fn is_union(py: Python, v: &PyType) -> PyResult<bool> {
+  let is_union_for_attr = intern!(py, "_is_union_for");
+  if !v.hasattr(is_union_for_attr)? {
+    return Ok(false);
+  }
+
+  let is_union_for = v.getattr(is_union_for_attr)?;
+  Ok(is_union_for.is(v))
 }
 
 pub fn store_tuple(py: Python, values: Vec<Value>) -> Value {
@@ -272,7 +282,7 @@ impl PyGeneratorResponseBreak {
   }
 }
 
-#[pyclass]
+#[pyclass(subclass)]
 pub struct PyGeneratorResponseGet {
   product: Py<PyType>,
   declared_subject: Py<PyType>,
@@ -282,12 +292,79 @@ pub struct PyGeneratorResponseGet {
 #[pymethods]
 impl PyGeneratorResponseGet {
   #[new]
-  fn __new__(product: Py<PyType>, declared_subject: Py<PyType>, subject: PyObject) -> Self {
-    Self {
-      product,
-      declared_subject,
-      subject,
-    }
+  fn __new__(
+    py: Python,
+    product: &PyAny,
+    input_arg0: &PyAny,
+    input_arg1: Option<&PyAny>,
+  ) -> PyResult<Self> {
+    let product = product.cast_as::<PyType>().map_err(|_| {
+      let actual_type = product.get_type();
+      PyTypeError::new_err(format!(
+        "Invalid Get. The first argument (the output type) must be a type, but given \
+        `{product}` with type {actual_type}."
+      ))
+    })?;
+
+    let (declared_subject, subject) = if let Some(input_arg1) = input_arg1 {
+      let declared_type = input_arg0.cast_as::<PyType>().map_err(|_| {
+        let input_arg0_type = input_arg0.get_type();
+        PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, \
+          input), the second argument must be a type, but given `{input_arg0}` of type \
+          {input_arg0_type}."
+        ))
+      })?;
+
+      if input_arg1.is_instance_of::<PyType>()? {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the longhand form \
+          Get(OutputType, InputType, input), the third argument should be \
+          an object, rather than a type, but given {input_arg1}."
+        )));
+      }
+
+      let actual_type = input_arg1.get_type();
+      if !declared_type.is(actual_type) && !is_union(py, declared_type)? {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. The third argument `{input_arg1}` must have the exact same type as the \
+          second argument, {declared_type}, but had the type {actual_type}."
+        )));
+      }
+
+      (declared_type, input_arg1)
+    } else {
+      if input_arg0.is_instance_of::<PyType>()? {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the shorthand form \
+          Get(OutputType, InputType(constructor args)), the second argument should be \
+          a constructor call, rather than a type, but given {input_arg0}."
+        )));
+      }
+
+      (input_arg0.get_type(), input_arg0)
+    };
+
+    Ok(Self {
+      product: product.into_py(py),
+      declared_subject: declared_subject.into_py(py),
+      subject: subject.into_py(py),
+    })
+  }
+
+  #[getter]
+  fn output_type<'p>(&'p self, py: Python<'p>) -> &'p PyType {
+    self.product.as_ref(py)
+  }
+
+  #[getter]
+  fn input_type<'p>(&'p self, py: Python<'p>) -> &'p PyType {
+    self.declared_subject.as_ref(py)
+  }
+
+  #[getter]
+  fn input<'p>(&'p self, py: Python<'p>) -> &'p PyAny {
+    self.subject.as_ref(py)
   }
 }
 


### PR DESCRIPTION
The `Get` syntax for `@rule`s (particularly its validation and freezing via `@dataclass`) was expensive enough to show up in `py-spy` profiles.

This change ports `Get`/`Effect` to rust as subclasses of the existing `PyGeneratorResponseGet`, which improves the performance of `./pants --no-pantsd dependencies ::` by ~12%.

[ci skip-build-wheels]
