### PR TITLE
Upgrade Pex to 2.1.98. (#16173)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.96
+pex==2.1.98
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -19,7 +19,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.96",
+//     "pex==2.1.98",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -783,13 +783,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86d916739c60a3dcbaa1cf294d75a7c2e4150a8e4e668cc29eed03195de7832e",
-              "url": "https://files.pythonhosted.org/packages/ec/c6/6c681c7ab22f09c52c8779b8ce4649b08f9cf9ae4ae810291124393a43d6/pex-2.1.96-py2.py3-none-any.whl"
+              "hash": "a4ae2cd7c19f21dbb91b350b58fd1dd474b2571639a9bb1902a805a38d1885a3",
+              "url": "https://files.pythonhosted.org/packages/35/e8/159621495705543286f7d1ad4e30f169271364590fb7629fed3252cd384c/pex-2.1.98-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b8ad4bc045e1beb7f202d2c367264787e0587c66c6af498b088df590a112da15",
-              "url": "https://files.pythonhosted.org/packages/48/1f/4170b055e2a30f5d1a3a34c45d92a43eb06f56b90566392d408c1bdf2d0f/pex-2.1.96.tar.gz"
+              "hash": "e6abdc6b16d147a32de25812c5095c7d211fc63cd6d77e212c9c71319c60e8b4",
+              "url": "https://files.pythonhosted.org/packages/bc/74/287adfa37d7be93d3183305f3f1e9685ecf1f6dae715b25bef0d69553bfc/pex-2.1.98.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -797,7 +797,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.96"
+          "version": "2.1.98"
         },
         {
           "artifacts": [
@@ -2186,7 +2186,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.98",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2199,7 +2199,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.96",
+    "pex==2.1.98",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86d916739c60a3dcbaa1cf294d75a7c2e4150a8e4e668cc29eed03195de7832e",
-              "url": "https://files.pythonhosted.org/packages/ec/c6/6c681c7ab22f09c52c8779b8ce4649b08f9cf9ae4ae810291124393a43d6/pex-2.1.96-py2.py3-none-any.whl"
+              "hash": "a4ae2cd7c19f21dbb91b350b58fd1dd474b2571639a9bb1902a805a38d1885a3",
+              "url": "https://files.pythonhosted.org/packages/35/e8/159621495705543286f7d1ad4e30f169271364590fb7629fed3252cd384c/pex-2.1.98-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b8ad4bc045e1beb7f202d2c367264787e0587c66c6af498b088df590a112da15",
-              "url": "https://files.pythonhosted.org/packages/48/1f/4170b055e2a30f5d1a3a34c45d92a43eb06f56b90566392d408c1bdf2d0f/pex-2.1.96.tar.gz"
+              "hash": "e6abdc6b16d147a32de25812c5095c7d211fc63cd6d77e212c9c71319c60e8b4",
+              "url": "https://files.pythonhosted.org/packages/bc/74/287adfa37d7be93d3183305f3f1e9685ecf1f6dae715b25bef0d69553bfc/pex-2.1.98.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,14 +63,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.96"
+          "version": "2.1.98"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.98",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.96"
+    default_version = "v2.1.98"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.96,<3.0"
+    version_constraints = ">=2.1.98,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "e3fbfb7cefb7e98f6900f86c406762bf3a6a3f7a93007b547f1b44877c4bfdc6",
-                    "3805966",
+                    "b3db597492c3d1250036749bec8330a0e8786ec7a4bd6f0c9f8ff1675c90c0b4",
+                    "3811372",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This pulls in a few fixes for artifact downloading. See the changes
here:
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.97
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.98

(cherry picked from commit e9f125c40a8d91bed1b1eedf613219d866e44899)

[ci skip-rust]
[ci skip-build-wheels]