### PR TITLE
Use filelists to make archive creation tasks more reliable

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -84,7 +84,9 @@ async def create_archive(request: CreateArchive) -> Digest:
     else:
         tar_binary = await Get(TarBinary, TarBinaryRequest())
         argv = tar_binary.create_archive_argv(
-            request.output_filename, ["--files-from", FILE_LIST_FILENAME], request.format
+            request.output_filename,
+            request.format,
+            input_file_list_filename=FILE_LIST_FILENAME,
         )
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -63,8 +63,10 @@ async def create_archive(request: CreateArchive) -> Digest:
     )
 
     if request.format == ArchiveFormat.ZIP:
-        zip_binary = await Get(ZipBinary, ZipBinaryRequest())
-        bash_binary = await Get(BashBinary, BashBinaryRequest())
+        zip_binary, bash_binary = await MultiGet(
+            Get(ZipBinary, ZipBinaryRequest()),
+            Get(BashBinary, BashBinaryRequest()),
+        )
         ZIP_SCRIPT_FILENAME = "__pants_zip_wrapper_script__.sh"
         zip_script = FileContent(
             ZIP_SCRIPT_FILENAME,

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -294,7 +294,12 @@ class GunzipBinary:
 
 class TarBinary(BinaryPath):
     def create_archive_argv(
-        self, output_filename: str, input_files: Sequence[str], tar_format: ArchiveFormat
+        self,
+        output_filename: str,
+        tar_format: ArchiveFormat,
+        *,
+        input_files: Sequence[str] = (),
+        input_file_list_filename: str | None = None,
     ) -> tuple[str, ...]:
         # Note that the parent directory for the output_filename must already exist.
         #
@@ -304,7 +309,9 @@ class TarBinary(BinaryPath):
         compression = {ArchiveFormat.TGZ: "z", ArchiveFormat.TBZ2: "j", ArchiveFormat.TXZ: "J"}.get(
             tar_format, ""
         )
-        return (self.path, f"c{compression}f", output_filename, *input_files)
+
+        files_from = ("--files-from", input_file_list_filename) if input_file_list_filename else ()
+        return (self.path, f"c{compression}f", output_filename, *input_files) + files_from
 
     def extract_archive_argv(
         self, archive_path: str, extract_path: str, *, archive_suffix: str


### PR DESCRIPTION
Previously, creating an archive with a large number of input files would cause the binary to fail due to having a too-long command line. 

This makes use of `tar`'s `--files-from` option to consume the input filenames from a file, and replaces our direct `zip` invocation with a bash script that provides the input filenames by stdin. 

There is no practical limit to the length of the file list that can be provided in this way.

Closes #16091