### PR TITLE
Use filelists to make archive creation tasks more reliable (Cherry-pick of #16183)

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+import logging
 import os
+import textwrap
 from dataclasses import dataclass
 from pathlib import PurePath
 
@@ -11,6 +13,8 @@ from pants.core.util_rules import system_binaries
 from pants.core.util_rules.system_binaries import SEARCH_PATHS
 from pants.core.util_rules.system_binaries import ArchiveFormat as ArchiveFormat
 from pants.core.util_rules.system_binaries import (
+    BashBinary,
+    BashBinaryRequest,
     GunzipBinary,
     GunzipBinaryRequest,
     TarBinary,
@@ -20,10 +24,20 @@ from pants.core.util_rules.system_binaries import (
     ZipBinary,
     ZipBinaryRequest,
 )
-from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    Directory,
+    FileContent,
+    MergeDigests,
+    RemovePrefix,
+    Snapshot,
+)
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -40,15 +54,43 @@ class CreateArchive:
 
 @rule(desc="Creating an archive file", level=LogLevel.DEBUG)
 async def create_archive(request: CreateArchive) -> Digest:
+
+    # #16091 -- if an arg list is really long, archive utilities tend to get upset.
+    # passing a list of filenames into the utilities fixes this.
+    FILE_LIST_FILENAME = "__pants_archive_filelist__"
+    file_list_file = FileContent(
+        FILE_LIST_FILENAME, "\n".join(request.snapshot.files).encode("utf-8")
+    )
+    file_list_file_digest = await Get(Digest, CreateDigest([file_list_file]))
+    files_digests = [file_list_file_digest, request.snapshot.digest]
+
     if request.format == ArchiveFormat.ZIP:
-        zip_binary = await Get(ZipBinary, ZipBinaryRequest())
-        argv = zip_binary.create_archive_argv(request.output_filename, request.snapshot.files)
+        zip_binary, bash_binary = await MultiGet(
+            Get(ZipBinary, ZipBinaryRequest()),
+            Get(BashBinary, BashBinaryRequest()),
+        )
+        ZIP_SCRIPT_FILENAME = "__pants_zip_wrapper_script__.sh"
+        zip_script = FileContent(
+            ZIP_SCRIPT_FILENAME,
+            # Using POSIX location/arg format for `cat`. If this gets more complicated, refactor.
+            textwrap.dedent(
+                f"""\
+                set -e
+                /bin/cat {FILE_LIST_FILENAME} | {zip_binary.path} --names-stdin {request.output_filename}
+                """
+            ).encode("utf-8"),
+        )
+        zip_script_digest = await Get(Digest, CreateDigest([zip_script]))
+
         env = {}
-        input_digest = request.snapshot.digest
+        input_digests = [zip_script_digest]
+        argv: tuple[str, ...] = (bash_binary.path, ZIP_SCRIPT_FILENAME)
     else:
         tar_binary = await Get(TarBinary, TarBinaryRequest())
         argv = tar_binary.create_archive_argv(
-            request.output_filename, request.snapshot.files, request.format
+            request.output_filename,
+            request.format,
+            input_file_list_filename=FILE_LIST_FILENAME,
         )
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
@@ -56,7 +98,9 @@ async def create_archive(request: CreateArchive) -> Digest:
         output_dir_digest = await Get(
             Digest, CreateDigest([Directory(os.path.dirname(request.output_filename))])
         )
-        input_digest = await Get(Digest, MergeDigests([output_dir_digest, request.snapshot.digest]))
+        input_digests = [output_dir_digest]
+
+    input_digest = await Get(Digest, MergeDigests([*files_digests, *input_digests]))
 
     result = await Get(
         ProcessResult,

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -294,7 +294,12 @@ class GunzipBinary:
 
 class TarBinary(BinaryPath):
     def create_archive_argv(
-        self, output_filename: str, input_files: Sequence[str], tar_format: ArchiveFormat
+        self,
+        output_filename: str,
+        tar_format: ArchiveFormat,
+        *,
+        input_files: Sequence[str] = (),
+        input_file_list_filename: str | None = None,
     ) -> tuple[str, ...]:
         # Note that the parent directory for the output_filename must already exist.
         #
@@ -304,7 +309,9 @@ class TarBinary(BinaryPath):
         compression = {ArchiveFormat.TGZ: "z", ArchiveFormat.TBZ2: "j", ArchiveFormat.TXZ: "J"}.get(
             tar_format, ""
         )
-        return (self.path, f"c{compression}f", output_filename, *input_files)
+
+        files_from = ("--files-from", input_file_list_filename) if input_file_list_filename else ()
+        return (self.path, f"c{compression}f", output_filename, *input_files) + files_from
 
     def extract_archive_argv(
         self, archive_path: str, extract_path: str, *, archive_suffix: str


### PR DESCRIPTION
Previously, creating an archive with a large number of input files would cause the binary to fail due to having a too-long command line.

This makes use of `tar`'s `--files-from` option to consume the input filenames from a file, and replaces our direct `zip` invocation with a bash script that provides the input filenames by stdin.

There is no practical limit to the length of the file list that can be provided in this way.

Closes #16091
