### PR TITLE
Fill address parameters in all cases, rather than only when a consumer is `parametrize`d.

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1103,10 +1103,10 @@ async def resolve_dependencies(
         )
         generated_addresses = tuple(parametrizations.generated_for(tgt.address).keys())
 
-    # If the target is parametrized, see whether any explicitly provided dependencies are also
-    # parametrized, but with partial/no parameters. If so, fill them in.
+    # See whether any explicitly provided dependencies are parametrized, but with partial/no
+    # parameters. If so, fill them in.
     explicitly_provided_includes: Iterable[Address] = explicitly_provided.includes
-    if request.field.address.is_parametrized and explicitly_provided_includes:
+    if explicitly_provided_includes:
         explicit_dependency_parametrizations = await MultiGet(
             Get(
                 _TargetParametrizations,


### PR DESCRIPTION
Addresses the second half of #16175 by filling address parameters for all consuming targets, rather than only those which are `parametrize`d themselves.

[ci skip-rust]
[ci skip-build-wheels]