### PR TITLE
Add MacStadium logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,6 @@ Some noteworthy features include:
 
 Documentation: [www.pantsbuild.org](https://www.pantsbuild.org/).
 
-We release to [PyPI](https://pypi.org/pypi)
-[![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
-[![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
-
 # Requirements
 
 To run Pants, you need:
@@ -28,3 +24,12 @@ To run Pants, you need:
 * Python 3.7+ discoverable on your `PATH`.
 * A C compiler, system headers and Python headers (to compile native Python modules).
 * Internet access (so that Pants can fully bootstrap itself).
+
+# Credits
+
+We release to [PyPI](https://pypi.org/pypi)
+
+[![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
+[![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
+
+<img width="150" height="61" src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png">


### PR DESCRIPTION
They've generously provided us with free credits as an OSS project, and have asked that we place their logo on our github landing page.

To avoid clutter, this change creates a "Credits" section at the bottom of the readme, and moves the PyPI links there too.

[ci skip-rust]
[ci skip-build-wheels]