### PR TITLE
allow JVM sources to have files dependencies

### DIFF
--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import ClassVar, Iterable, Iterator, Sequence
 
+from pants.core.target_types import FilesGeneratingSourcesField, FileSourceField
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest
@@ -412,12 +413,19 @@ def classpath_dependency_requests(
         them = coarsened_dep.representative.address
         return us.spec_path == them.spec_path and us.target_name == them.target_name
 
+    def ignore_because_file(coarsened_dep: CoarsenedTarget) -> bool:
+        return sum(
+            1
+            for t in coarsened_dep.members
+            if t.has_field(FileSourceField) or t.has_field(FilesGeneratingSourcesField)
+        ) == len(coarsened_dep.members)
+
     return ClasspathEntryRequests(
         classpath_entry_request.for_targets(
             component=coarsened_dep, resolve=request.request.resolve
         )
         for coarsened_dep in request.request.component.dependencies
-        if not ignore_because_generated(coarsened_dep)
+        if not ignore_because_generated(coarsened_dep) and not ignore_because_file(coarsened_dep)
     )
 
 

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -348,7 +348,6 @@ def test_compile_mixed_cycle(
 def test_allow_files_dependency(
     rule_runner: RuleRunner, scala_stdlib_jvm_lockfile: JVMLockfileFixture
 ) -> None:
-    # Add an extra import to the Java file which will force a cycle between them.
     rule_runner.write_files(
         {
             "BUILD": dedent(

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -362,7 +362,7 @@ def test_allow_files_dependency(
             "Example.scala": dedent(
                 """\
                 package org.pantsbuild.example
-              
+
                 object Main {
                     def main(args: Array[String]): Unit = {
                         println("Hello World")


### PR DESCRIPTION
As with the test in the PR, we tried to add files dependency to `scala_sources` (actually to `scalatest_tests`) but if failed with:

```
Engine traceback:
  in select
  in pants.core.goals.test.run_tests
  in pants.backend.scala.test.scalatest.run_scalatest_test (modules/core/test/src/unit/core/integration/ReceivedPaymentIntegrationSpec.scala:tests)
  in pants.backend.scala.test.scalatest.setup_scalatest_for_target
  in pants.jvm.classpath.classpath
  in pants.jvm.compile.required_classfiles
  in pants.backend.scala.compile.scalac.compile_scala_source
  in pants.jvm.compile.compile_classpath_entries
  in pants.jvm.compile.classpath_dependency_requests
Traceback (most recent call last):
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 415, in classpath_dependency_requests
    return ClasspathEntryRequests(
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 416, in <genexpr>
    classpath_entry_request.for_targets(
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 146, in for_targets
    raise ClasspathSourceMissing(
pants.jvm.compile.ClasspathSourceMissing: No JVM classpath providers (from: CompileJavaSourceRequest, CompileScalaSourceRequest, CoursierFetchRequest, DeployJarClasspathEntryRequest, JvmResourcesRequest) were compatible with the combination of inputs:
  * modules/core/resources:migrations   (files)
```

This PR fixes it by not trying to resolve `FileTarget` as a classpath.