### PR TITLE
Fill address parameters in all cases, rather than only when a consumer is `parametrize`d. (Cherry-pick of #16198)

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1109,10 +1109,10 @@ async def resolve_dependencies(
         )
         generated_addresses = tuple(parametrizations.generated_for(tgt.address).keys())
 
-    # If the target is parametrized, see whether any explicitly provided dependencies are also
-    # parametrized, but with partial/no parameters. If so, fill them in.
+    # See whether any explicitly provided dependencies are parametrized, but with partial/no
+    # parameters. If so, fill them in.
     explicitly_provided_includes: Iterable[Address] = explicitly_provided.includes
-    if request.field.address.is_parametrized and explicitly_provided_includes:
+    if explicitly_provided_includes:
         explicit_dependency_parametrizations = await MultiGet(
             Get(_TargetParametrizations, Address, address.maybe_convert_to_target_generator())
             for address in explicitly_provided_includes

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -2195,7 +2195,12 @@ def test_dependency_injection(dependencies_rule_runner: RuleRunner) -> None:
     dependencies_rule_runner.write_files(
         {
             "src/smalltalk/util/f1.st": "",
-            "BUILD": "smalltalk_libraries(name='target', sources=['*.st'])",
+            "BUILD": dedent(
+                """\
+                smalltalk_libraries(name='target', sources=['*.st'])
+                target(name='provided')
+                """
+            ),
         }
     )
 

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1268,6 +1268,31 @@ def test_parametrize_partial_atom_to_atom(generated_targets_rule_runner: RuleRun
             "demo:t2@resolve=b": {"demo:t1@resolve=b"},
         },
     )
+    assert_generated(
+        generated_targets_rule_runner,
+        Address("demo", target_name="t2"),
+        dedent(
+            """\
+            generated(
+              name='t1',
+              resolve=parametrize('a', 'b'),
+              source='f1.ext',
+            )
+            generated(
+              name='t2',
+              resolve='a',
+              source='f2.ext',
+              dependencies=[':t1'],
+            )
+            """
+        ),
+        ["f1.ext", "f2.ext"],
+        expected_dependencies={
+            "demo:t1@resolve=a": set(),
+            "demo:t1@resolve=b": set(),
+            "demo:t2": {"demo:t1@resolve=a"},
+        },
+    )
 
 
 def test_parametrize_partial_generator_to_generator(
@@ -2100,11 +2125,22 @@ def test_explicitly_provided_dependencies(dependencies_rule_runner: RuleRunner) 
 def test_normal_resolution(dependencies_rule_runner: RuleRunner) -> None:
     dependencies_rule_runner.write_files(
         {
-            "src/smalltalk/BUILD": "target(dependencies=['//:dep1', '//:dep2', ':sibling'])",
+            "src/smalltalk/BUILD": dedent(
+                """\
+                target(dependencies=['//:dep1', '//:dep2', ':sibling'])
+                target(name='sibling')
+                """
+            ),
             "no_deps/BUILD": "target()",
             # An ignore should override an include.
             "ignore/BUILD": (
                 "target(dependencies=['//:dep1', '!//:dep1', '//:dep2', '!!//:dep2'])"
+            ),
+            "BUILD": dedent(
+                """\
+                target(name='dep1')
+                target(name='dep2')
+                """
             ),
         }
     )
@@ -2203,8 +2239,8 @@ def test_dependency_inference(dependencies_rule_runner: RuleRunner) -> None:
                 smalltalk_libraries(name='inferred2')
                 smalltalk_libraries(name='inferred_but_ignored1', sources=['inferred_but_ignored1.st'])
                 smalltalk_libraries(name='inferred_but_ignored2', sources=['inferred_but_ignored2.st'])
-                smalltalk_libraries(name='inferred_and_provided1')
-                smalltalk_libraries(name='inferred_and_provided2')
+                target(name='inferred_and_provided1')
+                target(name='inferred_and_provided2')
                 """
             ),
             "demo/f1.st": dedent(


### PR DESCRIPTION
Addresses the second half of #16175 by filling address parameters for all consuming targets, rather than only those which are `parametrize`d themselves.

[ci skip-rust]
[ci skip-build-wheels]