### PR TITLE
Fix explicit dependencies of `parametrize`d targets not working for some target types (Cherry-pick of #16197)

### DIFF
--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 import itertools
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from pants.build_graph.address import BANNED_CHARS_IN_PARAMETERS
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
-from pants.engine.target import Target
+from pants.engine.target import Field, Target
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list
@@ -208,18 +208,16 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             return instance
 
         def remaining_fields_match(candidate: Target) -> bool:
-            """Returns true if all Fields absent from the candidate's Address match the consumer.
-
-            TODO: This does not account for the computed default values of Fields:
-              see https://github.com/pantsbuild/pants/issues/16175
-            """
-
+            """Returns true if all Fields absent from the candidate's Address match the consumer."""
             unspecified_param_field_names = {
                 key for key in candidate.address.parameters.keys() if key not in address.parameters
             }
-
             return all(
-                consumer.has_field(field_type) and consumer[field_type].value == field.value
+                _concrete_fields_are_equivalent(
+                    consumer=consumer,
+                    candidate_field_type=field_type,
+                    candidate_field_value=field.value,
+                )
                 for field_type, field in candidate.field_values.items()
                 if field_type.alias in unspecified_param_field_names
             )
@@ -276,3 +274,26 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             f"Target `{address}` can be addressed as:\n"
             f"{bullet_list(str(t.address) for t in self.all)}"
         )
+
+
+def _concrete_fields_are_equivalent(
+    *, consumer: Target, candidate_field_value: Any, candidate_field_type: type[Field]
+) -> bool:
+    # TODO(#16175): Does not account for the computed default values of Fields.
+    if consumer.has_field(candidate_field_type):
+        return cast(bool, consumer[candidate_field_type].value == candidate_field_value)
+    # Else, see if the consumer has a field that is a superclass of `candidate_field_value`, to
+    # handle https://github.com/pantsbuild/pants/issues/16190. This is only safe because we are
+    # confident that both `candidate_field_type` and the fields from `consumer` are _concrete_,
+    # meaning they are not abstract templates like `StringField`.
+    superclass = next(
+        (
+            consumer_field
+            for consumer_field in consumer.field_types
+            if issubclass(candidate_field_type, consumer_field)
+        ),
+        None,
+    )
+    if superclass is None:
+        return False
+    return cast(bool, consumer[superclass].value == candidate_field_value)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16190.

[ci skip-rust]
[ci skip-build-wheels]
