### PR TITLE
Fix explicit dependencies of `parametrize`d targets not working for some target types (#16197)

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -38,6 +38,7 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
+    Field,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -1204,6 +1205,50 @@ def test_parametrize_partial_generator_to_generated(
             "demo:t2@resolve=b": {
                 "demo/f2.ext:t2@resolve=b",
             },
+        },
+    )
+
+
+def test_parametrize_16190(generated_targets_rule_runner: RuleRunner) -> None:
+    class ParentField(Field):
+        alias = "parent"
+        help = "foo"
+
+    class ChildField(ParentField):
+        alias = "child"
+        help = "foo"
+
+    class ParentTarget(Target):
+        alias = "parent_tgt"
+        help = "foo"
+        core_fields = (ParentField, Dependencies)
+
+    class ChildTarget(Target):
+        alias = "child_tgt"
+        help = "foo"
+        core_fields = (ChildField, Dependencies)
+
+    rule_runner = RuleRunner(
+        rules=generated_targets_rule_runner.rules,
+        target_types=[ParentTarget, ChildTarget],
+        objects={"parametrize": Parametrize},
+    )
+    build_content = dedent(
+        """\
+        child_tgt(name="child", child=parametrize("a", "b"))
+        parent_tgt(name="parent", parent=parametrize("a", "b"), dependencies=[":child"])
+        """
+    )
+    assert_generated(
+        rule_runner,
+        Address("demo", target_name="child"),
+        build_content,
+        [],
+        expected_dependencies={
+            "demo:child@child=a": set(),
+            "demo:child@child=b": set(),
+            "demo:parent@parent=a": {"demo:child@child=a"},
+            "demo:parent@parent=b": {"demo:child@child=b"},
         },
     )
 

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 import dataclasses
 import itertools
 from dataclasses import dataclass
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 from pants.build_graph.address import BANNED_CHARS_IN_PARAMETERS
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.target import Target
+from pants.engine.target import Field, Target
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list, softwrap
@@ -232,18 +232,16 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             return instance
 
         def remaining_fields_match(candidate: Target) -> bool:
-            """Returns true if all Fields absent from the candidate's Address match the consumer.
-
-            TODO: This does not account for the computed default values of Fields:
-              see https://github.com/pantsbuild/pants/issues/16175
-            """
-
+            """Returns true if all Fields absent from the candidate's Address match the consumer."""
             unspecified_param_field_names = {
                 key for key in candidate.address.parameters.keys() if key not in address.parameters
             }
-
             return all(
-                consumer.has_field(field_type) and consumer[field_type].value == field.value
+                _concrete_fields_are_equivalent(
+                    consumer=consumer,
+                    candidate_field_type=field_type,
+                    candidate_field_value=field.value,
+                )
                 for field_type, field in candidate.field_values.items()
                 if field_type.alias in unspecified_param_field_names
             )
@@ -300,3 +298,26 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             f"Target `{address}` can be addressed as:\n"
             f"{bullet_list(str(t.address) for t in self.all)}"
         )
+
+
+def _concrete_fields_are_equivalent(
+    *, consumer: Target, candidate_field_value: Any, candidate_field_type: type[Field]
+) -> bool:
+    # TODO(#16175): Does not account for the computed default values of Fields.
+    if consumer.has_field(candidate_field_type):
+        return cast(bool, consumer[candidate_field_type].value == candidate_field_value)
+    # Else, see if the consumer has a field that is a superclass of `candidate_field_value`, to
+    # handle https://github.com/pantsbuild/pants/issues/16190. This is only safe because we are
+    # confident that both `candidate_field_type` and the fields from `consumer` are _concrete_,
+    # meaning they are not abstract templates like `StringField`.
+    superclass = next(
+        (
+            consumer_field
+            for consumer_field in consumer.field_types
+            if issubclass(candidate_field_type, consumer_field)
+        ),
+        None,
+    )
+    if superclass is None:
+        return False
+    return cast(bool, consumer[superclass].value == candidate_field_value)


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16190.

[ci skip-rust]
[ci skip-build-wheels]