### PR TITLE
Correct deprecation warning to 2.15 (Cherry-pick of #16056)

### DIFF
--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -487,6 +487,7 @@ class AmbiguousImplementationsException(Exception):
         )
 
 
+# NOTE: When this is removed in 2.15, also remove the `SecondaryOwnerMixin` of `PexBinaryEntryPoint`
 def _handle_ambiguous_result(
     request: TargetRootsToFieldSetsRequest,
     result: TargetRootsToFieldSets,
@@ -505,11 +506,11 @@ def _handle_ambiguous_result(
     ):
         if field_set_to_default_to is PexBinaryFieldSet:
             warn_or_error(
-                "2.14.0dev1",
+                "2.15.0.dev0",
                 "referring to a `pex_binary` by using the filename specified in `entry_point`",
                 softwrap(
                     """
-                        In Pants 2.14, a `pex_binary` can no longer be referred to by the filename that
+                        In Pants 2.15, a `pex_binary` can no longer be referred to by the filename that
                         the `entry_point` field uses.
 
                         This is due to a change in Pants 2.13, which allows you to use the `run` goal
@@ -529,6 +530,7 @@ def _handle_ambiguous_result(
                         """
                 ),
             )
+        # Otherwise, the appropriate flag was set to select the new behavior, so roll with that.
         return TargetRootsToFieldSets(
             {
                 target: field_sets


### PR DESCRIPTION
- In 2.13 we introduced the ambiguity, along with forcing our users to set the flag to choose behavior
- In 2.14, now the flag defaults to using the new behavior. But if the user still has it set to "use the old behavior" we should warn but honor that. There's still ambiguity.
- In 2.15 there's no choice, and therefore no ambiguity

[ci skip-build-wheels]
