### PR TITLE
Generically compute dynamic defaults for `Field`s (Cherry-pick of #16206)

### DIFF
--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -14,8 +14,6 @@ from pants.bsp.util_rules.targets import (
     BSPBuildTargetsMetadataResult,
     BSPCompileRequest,
     BSPCompileResult,
-    BSPResolveFieldFactoryRequest,
-    BSPResolveFieldFactoryResult,
     BSPResourcesRequest,
     BSPResourcesResult,
 )
@@ -28,7 +26,6 @@ from pants.jvm.bsp.compile import rules as jvm_compile_rules
 from pants.jvm.bsp.resources import _jvm_bsp_resources
 from pants.jvm.bsp.resources import rules as jvm_resources_rules
 from pants.jvm.compile import ClasspathEntryRequestFactory
-from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 
 LANGUAGE_ID = "java"
@@ -50,26 +47,13 @@ class JavaMetadataFieldSet(FieldSet):
     resolve: JvmResolveField
 
 
-class JavaBSPResolveFieldFactoryRequest(BSPResolveFieldFactoryRequest):
-    resolve_prefix = "jvm"
-
-
 class JavaBSPBuildTargetsMetadataRequest(BSPBuildTargetsMetadataRequest):
     language_id = LANGUAGE_ID
     can_merge_metadata_from = ()
     field_set_type = JavaMetadataFieldSet
+
     resolve_prefix = "jvm"
     resolve_field = JvmResolveField
-
-
-@rule
-def bsp_resolve_field_factory(
-    request: JavaBSPResolveFieldFactoryRequest,
-    jvm: JvmSubsystem,
-) -> BSPResolveFieldFactoryResult:
-    return BSPResolveFieldFactoryResult(
-        lambda target: target.get(JvmResolveField).normalized_value(jvm)
-    )
 
 
 @rule
@@ -169,7 +153,6 @@ def rules():
         *jvm_compile_rules(),
         *jvm_resources_rules(),
         UnionRule(BSPLanguageSupport, JavaBSPLanguageSupport),
-        UnionRule(BSPResolveFieldFactoryRequest, JavaBSPResolveFieldFactoryRequest),
         UnionRule(BSPBuildTargetsMetadataRequest, JavaBSPBuildTargetsMetadataRequest),
         UnionRule(BSPHandlerMapping, JavacOptionsHandlerMapping),
         UnionRule(BSPCompileRequest, JavaBSPCompileRequest),

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -16,6 +16,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     generate_multiple_sources_field_help_message,
 )
+from pants.jvm import target_types as jvm_target_types
 from pants.jvm.target_types import (
     JunitTestSourceField,
     JvmJdkField,
@@ -135,4 +136,7 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        *jvm_target_types.rules(),
+    ]

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -50,6 +50,8 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
+    FieldDefaultFactoryRequest,
+    FieldDefaultFactoryResult,
     FieldSet,
     GeneratedTargets,
     GenerateTargetsRequest,
@@ -489,6 +491,23 @@ async def inject_python_distribution_dependencies(
 
 
 # -----------------------------------------------------------------------------------------------
+# Dynamic Field defaults
+# -----------------------------------------------------------------------------------------------
+
+
+class PythonResolveFieldDefaultFactoryRequest(FieldDefaultFactoryRequest):
+    field_type = PythonResolveField
+
+
+@rule
+def python_resolve_field_default_factory(
+    request: PythonResolveFieldDefaultFactoryRequest,
+    python_setup: PythonSetup,
+) -> FieldDefaultFactoryResult:
+    return FieldDefaultFactoryResult(lambda f: f.normalized_value(python_setup))
+
+
+# -----------------------------------------------------------------------------------------------
 # Dependency validation
 # -----------------------------------------------------------------------------------------------
 
@@ -553,6 +572,7 @@ def rules():
     return (
         *collect_rules(),
         *import_rules(),
+        UnionRule(FieldDefaultFactoryRequest, PythonResolveFieldDefaultFactoryRequest),
         UnionRule(TargetFilesGeneratorSettingsRequest, PythonFilesGeneratorSettingsRequest),
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromPexBinaries),
         UnionRule(InjectDependenciesRequest, InjectPexBinaryEntryPointDependency),

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -33,8 +33,6 @@ from pants.bsp.util_rules.targets import (
     BSPCompileResult,
     BSPDependencyModulesRequest,
     BSPDependencyModulesResult,
-    BSPResolveFieldFactoryRequest,
-    BSPResolveFieldFactoryResult,
     BSPResourcesRequest,
     BSPResourcesResult,
 )
@@ -86,14 +84,13 @@ class ScalaMetadataFieldSet(FieldSet):
     jdk: JvmJdkField
 
 
-class ScalaBSPResolveFieldFactoryRequest(BSPResolveFieldFactoryRequest):
-    resolve_prefix = "jvm"
-
-
 class ScalaBSPBuildTargetsMetadataRequest(BSPBuildTargetsMetadataRequest):
     language_id = LANGUAGE_ID
     can_merge_metadata_from = ("java",)
     field_set_type = ScalaMetadataFieldSet
+
+    resolve_prefix = "jvm"
+    resolve_field = JvmResolveField
 
 
 @dataclass(frozen=True)
@@ -175,16 +172,6 @@ async def _materialize_scala_runtime_jars(scala_version: str) -> Snapshot:
     return await Get(
         Snapshot,
         AddPrefix(tool_classpath.content.digest, f"jvm/scala-runtime/{scala_version}"),
-    )
-
-
-@rule
-def bsp_resolve_field_factory(
-    request: ScalaBSPResolveFieldFactoryRequest,
-    jvm: JvmSubsystem,
-) -> BSPResolveFieldFactoryResult:
-    return BSPResolveFieldFactoryResult(
-        lambda target: target.get(JvmResolveField).normalized_value(jvm)
     )
 
 
@@ -540,7 +527,6 @@ def rules():
         *jvm_resources_rules(),
         UnionRule(BSPLanguageSupport, ScalaBSPLanguageSupport),
         UnionRule(BSPBuildTargetsMetadataRequest, ScalaBSPBuildTargetsMetadataRequest),
-        UnionRule(BSPResolveFieldFactoryRequest, ScalaBSPResolveFieldFactoryRequest),
         UnionRule(BSPHandlerMapping, ScalacOptionsHandlerMapping),
         UnionRule(BSPHandlerMapping, ScalaMainClassesHandlerMapping),
         UnionRule(BSPHandlerMapping, ScalaTestClassesHandlerMapping),

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -24,6 +24,7 @@ from pants.engine.target import (
     generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
+from pants.jvm import target_types as jvm_target_types
 from pants.jvm.target_types import (
     JunitTestSourceField,
     JvmJdkField,
@@ -316,5 +317,6 @@ class ScalacPluginTarget(Target):
 def rules():
     return (
         *collect_rules(),
+        *jvm_target_types.rules(),
         UnionRule(TargetFilesGeneratorSettingsRequest, ScalaSettingsRequest),
     )

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import ClassVar, Generic, Sequence, Type, TypeVar
 
 import toml
-from typing_extensions import Protocol
 
 from pants.base.build_root import BuildRoot
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -48,11 +47,12 @@ from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDige
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import _uncacheable_rule, collect_rules, rule
 from pants.engine.target import (
+    Field,
+    FieldDefaults,
     FieldSet,
     SourcesField,
     SourcesPaths,
     SourcesPathsRequest,
-    Target,
     Targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
@@ -68,44 +68,15 @@ _FS = TypeVar("_FS", bound=FieldSet)
 
 @union
 @dataclass(frozen=True)
-class BSPResolveFieldFactoryRequest(Generic[_FS]):
-    """Requests an implementation of `BSPResolveFieldFactory` which can filter resolve fields.
-
-    TODO: This is to work around the fact that Field value defaulting cannot have arbitrary
-    subsystem requirements, and so `JvmResolveField` and `PythonResolveField` have methods
-    which compute the true value of the field given a subsytem argument. Consumers need to
-    be type aware, and `@rules` cannot have dynamic requirements.
-
-    See https://github.com/pantsbuild/pants/issues/12934 about potentially allowing unions
-    (including Field registrations) to have `@rule_helper` methods, which would allow the
-    computation of an AsyncFields to directly require a subsystem.
-    """
-
-    resolve_prefix: ClassVar[str]
-
-
-# TODO: Workaround for https://github.com/python/mypy/issues/5485, because we cannot directly use
-# a Callable.
-class _ResolveFieldFactory(Protocol):
-    def __call__(self, target: Target) -> str | None:
-        pass
-
-
-@dataclass(frozen=True)
-class BSPResolveFieldFactoryResult:
-    """Computes the resolve field value for a Target, if applicable."""
-
-    resolve_field_value: _ResolveFieldFactory
-
-
-@union
-@dataclass(frozen=True)
 class BSPBuildTargetsMetadataRequest(Generic[_FS]):
     """Hook to allow language backends to provide metadata for BSP build targets."""
 
     language_id: ClassVar[str]
     can_merge_metadata_from: ClassVar[tuple[str, ...]]
     field_set_type: ClassVar[Type[_FS]]  # type: ignore[misc]
+
+    resolve_prefix: ClassVar[str]
+    resolve_field: ClassVar[type[Field]]
 
     field_sets: tuple[_FS, ...]
 
@@ -261,6 +232,7 @@ async def resolve_bsp_build_target_identifier(
 async def resolve_bsp_build_target_addresses(
     bsp_target: BSPBuildTargetInternal,
     union_membership: UnionMembership,
+    field_defaults: FieldDefaults,
 ) -> Targets:
     # NB: Using `RawSpecs` directly rather than `RawSpecsWithoutFileOwners` results in a rule graph cycle.
     targets = await Get(
@@ -279,17 +251,19 @@ async def resolve_bsp_build_target_addresses(
             f"prefix like `$lang:$filter`, but the configured value: `{resolve_filter}` did not."
         )
 
-    # TODO: See `BSPResolveFieldFactoryRequest` re: this awkwardness.
-    factories = await MultiGet(
-        Get(BSPResolveFieldFactoryResult, BSPResolveFieldFactoryRequest, request())
-        for request in union_membership.get(BSPResolveFieldFactoryRequest)
-        if request.resolve_prefix == resolve_prefix
-    )
+    resolve_fields = {
+        impl.resolve_field
+        for impl in union_membership.get(BSPBuildTargetsMetadataRequest)
+        if impl.resolve_prefix == resolve_prefix
+    }
 
     return Targets(
         t
         for t in targets
-        if any((factory.resolve_field_value)(t) == resolve_value for factory in factories)
+        if any(
+            t.has_field(field) and field_defaults.value_or_default(t[field]) == resolve_value
+            for field in resolve_fields
+        )
     )
 
 

--- a/src/python/pants/bsp/util_rules/targets_test.py
+++ b/src/python/pants/bsp/util_rules/targets_test.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from pants.backend.java import target_types
 from pants.backend.java.bsp import rules as java_bsp_rules
 from pants.backend.java.compile import javac
 from pants.backend.java.target_types import JavaSourceTarget
@@ -29,6 +30,7 @@ def rule_runner() -> RuleRunner:
             *jvm_tool.rules(),
             *jvm_util_rules.rules(),
             *jdk_rules.rules(),
+            *target_types.rules(),
             QueryRule(BSPBuildTargets, ()),
             QueryRule(Targets, [BuildTargetIdentifier]),
         ],

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -45,6 +45,9 @@ from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
     Field,
+    FieldDefaultFactoryRequest,
+    FieldDefaultFactoryResult,
+    FieldDefaults,
     FieldSetsPerTarget,
     FieldSetsPerTargetRequest,
     FilteredTargets,
@@ -1070,6 +1073,7 @@ async def resolve_dependencies(
     target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
     union_membership: UnionMembership,
     subproject_roots: SubprojectRoots,
+    field_defaults: FieldDefaults,
 ) -> Addresses:
     wrapped_tgt, explicitly_provided = await MultiGet(
         Get(
@@ -1140,7 +1144,7 @@ async def resolve_dependencies(
         )
 
         explicitly_provided_includes = [
-            parametrizations.get_subset(address, tgt).address
+            parametrizations.get_subset(address, tgt, field_defaults).address
             for address, parametrizations in zip(
                 explicitly_provided_includes, explicit_dependency_parametrizations
             )
@@ -1262,6 +1266,25 @@ async def resolve_unparsed_address_inputs(
         for addr in addresses
     )
     return Addresses(addresses)
+
+
+# -----------------------------------------------------------------------------------------------
+# Dynamic Field defaults
+# -----------------------------------------------------------------------------------------------
+
+
+@rule
+async def field_defaults(union_membership: UnionMembership) -> FieldDefaults:
+    requests = list(union_membership.get(FieldDefaultFactoryRequest))
+    factories = await MultiGet(
+        Get(FieldDefaultFactoryResult, FieldDefaultFactoryRequest, impl()) for impl in requests
+    )
+    return FieldDefaults(
+        FrozenDict(
+            (request.field_type, factory.default_factory)
+            for request, factory in zip(requests, factories)
+        )
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -39,6 +39,8 @@ from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
     Field,
+    FieldDefaultFactoryRequest,
+    FieldDefaultFactoryResult,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
@@ -84,6 +86,21 @@ class SpecialCasedDeps2(SpecialCasedDependencies):
 
 class ResolveField(StringField, AsyncFieldMixin):
     alias = "resolve"
+    default = None
+
+
+_DEFAULT_RESOLVE = "default_test_resolve"
+
+
+class ResolveFieldDefaultFactoryRequest(FieldDefaultFactoryRequest):
+    field_type = ResolveField
+
+
+@rule
+def resolve_field_default_factory(
+    request: ResolveFieldDefaultFactoryRequest,
+) -> FieldDefaultFactoryResult:
+    return FieldDefaultFactoryResult(lambda f: f.value or _DEFAULT_RESOLVE)
 
 
 class MockTarget(Target):
@@ -821,6 +838,8 @@ def generated_targets_rule_runner() -> RuleRunner:
             QueryRule(Addresses, [Specs]),
             QueryRule(_DependencyMapping, [_DependencyMappingRequest]),
             QueryRule(_TargetParametrizations, [_TargetParametrizationsRequest]),
+            UnionRule(FieldDefaultFactoryRequest, ResolveFieldDefaultFactoryRequest),
+            resolve_field_default_factory,
         ],
         target_types=[MockTargetGenerator, MockGeneratedTarget],
         objects={"parametrize": Parametrize},
@@ -1103,12 +1122,11 @@ def test_parametrize_partial_atom_to_atom(generated_targets_rule_runner: RuleRun
             """\
             generated(
               name='t1',
-              resolve=parametrize('a', 'b'),
+              resolve=parametrize('default_test_resolve', 'b'),
               source='f1.ext',
             )
             generated(
               name='t2',
-              resolve='a',
               source='f2.ext',
               dependencies=[':t1'],
             )
@@ -1116,9 +1134,9 @@ def test_parametrize_partial_atom_to_atom(generated_targets_rule_runner: RuleRun
         ),
         ["f1.ext", "f2.ext"],
         expected_dependencies={
-            "demo:t1@resolve=a": set(),
+            "demo:t1@resolve=default_test_resolve": set(),
             "demo:t1@resolve=b": set(),
-            "demo:t2": {"demo:t1@resolve=a"},
+            "demo:t2": {"demo:t1@resolve=default_test_resolve"},
         },
     )
 

--- a/src/python/pants/engine/internals/parametrize_test.py
+++ b/src/python/pants/engine/internals/parametrize_test.py
@@ -15,7 +15,7 @@ from pants.engine.internals.parametrize import (
     _TargetParametrization,
     _TargetParametrizations,
 )
-from pants.engine.target import Field, Target
+from pants.engine.target import Field, FieldDefaults, Target
 from pants.util.frozendict import FrozenDict
 
 
@@ -144,10 +144,12 @@ def test_get_superset_targets() -> None:
 def test_concrete_fields_are_equivalent() -> None:
     class ParentField(Field):
         alias = "parent"
+        default = None
         help = "foo"
 
     class ChildField(ParentField):
         alias = "child"
+        default = None
         help = "foo"
 
     class UnrelatedField(Field):
@@ -164,66 +166,78 @@ def test_concrete_fields_are_equivalent() -> None:
         help = "foo"
         core_fields = (ChildField,)
 
+    # Validate literal value matches.
+    empty_defaults = FieldDefaults(FrozenDict())
+    unused_addr = Address("unused")
     parent_tgt = ParentTarget({"parent": "val"}, Address("parent"))
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=parent_tgt, candidate_field_type=ParentField, candidate_field_value="val"
-        )
-        is True
+    child_tgt = ChildTarget({"child": "val"}, Address("child"))
+
+    assert _concrete_fields_are_equivalent(
+        empty_defaults, consumer=parent_tgt, candidate_field=ParentField("val", unused_addr)
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=parent_tgt, candidate_field_type=ParentField, candidate_field_value="different"
-        )
-        is False
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults,
+        consumer=parent_tgt,
+        candidate_field=ParentField("different", unused_addr),
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=parent_tgt, candidate_field_type=ChildField, candidate_field_value="val"
-        )
-        is True
+    assert _concrete_fields_are_equivalent(
+        empty_defaults, consumer=parent_tgt, candidate_field=ChildField("val", unused_addr)
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=parent_tgt, candidate_field_type=ChildField, candidate_field_value="different"
-        )
-        is False
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults,
+        consumer=parent_tgt,
+        candidate_field=ChildField("different", unused_addr),
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=parent_tgt, candidate_field_type=UnrelatedField, candidate_field_value="val"
-        )
-        is False
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults, consumer=parent_tgt, candidate_field=UnrelatedField("val", unused_addr)
     )
 
-    child_tgt = ChildTarget({"child": "val"}, Address("child"))
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=child_tgt, candidate_field_type=ParentField, candidate_field_value="val"
-        )
-        is True
+    assert _concrete_fields_are_equivalent(
+        empty_defaults, consumer=child_tgt, candidate_field=ParentField("val", unused_addr)
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=child_tgt, candidate_field_type=ParentField, candidate_field_value="different"
-        )
-        is False
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults,
+        consumer=child_tgt,
+        candidate_field=ParentField("different", unused_addr),
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=child_tgt, candidate_field_type=ChildField, candidate_field_value="val"
-        )
-        is True
+    assert _concrete_fields_are_equivalent(
+        empty_defaults, consumer=child_tgt, candidate_field=ChildField("val", unused_addr)
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=child_tgt, candidate_field_type=ChildField, candidate_field_value="different"
-        )
-        is False
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults, consumer=child_tgt, candidate_field=ChildField("different", unused_addr)
     )
-    assert (
-        _concrete_fields_are_equivalent(
-            consumer=child_tgt, candidate_field_type=UnrelatedField, candidate_field_value="val"
+    assert not _concrete_fields_are_equivalent(
+        empty_defaults, consumer=child_tgt, candidate_field=UnrelatedField("val", unused_addr)
+    )
+
+    # Validate field defaulting.
+    parent_field_defaults = FieldDefaults(
+        FrozenDict(
+            {
+                ParentField: lambda f: f.value or "val",
+            }
         )
-        is False
+    )
+    child_field_defaults = FieldDefaults(
+        FrozenDict(
+            {
+                ChildField: lambda f: f.value or "val",
+            }
+        )
+    )
+    assert _concrete_fields_are_equivalent(
+        parent_field_defaults, consumer=child_tgt, candidate_field=ParentField(None, unused_addr)
+    )
+    assert _concrete_fields_are_equivalent(
+        parent_field_defaults,
+        consumer=ParentTarget({}, Address("parent")),
+        candidate_field=ChildField("val", unused_addr),
+    )
+    assert _concrete_fields_are_equivalent(
+        child_field_defaults, consumer=parent_tgt, candidate_field=ChildField(None, unused_addr)
+    )
+    assert _concrete_fields_are_equivalent(
+        child_field_defaults,
+        consumer=ChildTarget({}, Address("child")),
+        candidate_field=ParentField("val", unused_addr),
     )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -36,7 +36,7 @@ from typing import (
     get_type_hints,
 )
 
-from typing_extensions import final
+from typing_extensions import Protocol, final
 
 from pants.base.deprecated import warn_or_error
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
@@ -264,9 +264,73 @@ class AsyncFieldMixin(Field):
         )
 
 
+@union
+@dataclass(frozen=True)
+class FieldDefaultFactoryRequest:
+    """Registers a dynamic default for a Field.
+
+    See `FieldDefaults`.
+    """
+
+    field_type: ClassVar[type[Field]]
+
+
+# TODO: Workaround for https://github.com/python/mypy/issues/5485, because we cannot directly use
+# a Callable.
+class FieldDefaultFactory(Protocol):
+    def __call__(self, field: Field) -> Any:
+        pass
+
+
+@dataclass(frozen=True)
+class FieldDefaultFactoryResult:
+    """A wrapper for a function which computes the default value of a Field."""
+
+    default_factory: FieldDefaultFactory
+
+
+@dataclass(frozen=True)
+class FieldDefaults:
+    """Generic Field default values. To install a default, see `FieldDefaultFactoryRequest`.
+
+    TODO: This is to work around the fact that Field value defaulting cannot have arbitrary
+    subsystem requirements, and so e.g. `JvmResolveField` and `PythonResolveField` have methods
+    which compute the true value of the field given a subsytem argument. Consumers need to
+    be type aware, and `@rules` cannot have dynamic requirements.
+
+    Additionally, `__defaults__` should mean that computed default Field values should become
+    more rare: i.e. `JvmResolveField` and `PythonResolveField` could potentially move to
+    hardcoded default values which users override with `__defaults__` if they'd like to change
+    the default resolve names.
+
+    See https://github.com/pantsbuild/pants/issues/12934 about potentially allowing unions
+    (including Field registrations) to have `@rule_helper` methods, which would allow the
+    computation of an AsyncField to directly require a subsystem.
+    """
+
+    _factories: FrozenDict[type[Field], FieldDefaultFactory]
+
+    @memoized_method
+    def factory(self, field_type: type[Field]) -> FieldDefaultFactory:
+        """Looks up a Field default factory in a subclass-aware way."""
+        factory = self._factories.get(field_type, None)
+        if factory is not None:
+            return factory
+
+        for ft, factory in self._factories.items():
+            if issubclass(field_type, ft):
+                return factory
+
+        return lambda f: f.value
+
+    def value_or_default(self, field: Field) -> Any:
+        return (self.factory(type(field)))(field)
+
+
 # -----------------------------------------------------------------------------------------------
 # Core Target abstractions
 # -----------------------------------------------------------------------------------------------
+
 
 # NB: This TypeVar is what allows `Target.get()` to properly work with MyPy so that MyPy knows
 # the precise Field returned.

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -10,10 +10,13 @@ from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.engine.addresses import Address
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
     Dependencies,
+    FieldDefaultFactoryRequest,
+    FieldDefaultFactoryResult,
     FieldSet,
     InvalidFieldException,
     InvalidTargetException,
@@ -24,6 +27,7 @@ from pants.engine.target import (
     StringSequenceField,
     Target,
 )
+from pants.engine.unions import UnionRule
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
@@ -378,3 +382,27 @@ class JvmWarTarget(Target):
         deploys in Java Servlet containers.
         """
     )
+
+
+# -----------------------------------------------------------------------------------------------
+# Dynamic Field defaults
+# -----------------------------------------------------------------------------------------------#
+
+
+class JvmResolveFieldDefaultFactoryRequest(FieldDefaultFactoryRequest):
+    field_type = JvmResolveField
+
+
+@rule
+def jvm_resolve_field_default_factory(
+    request: JvmResolveFieldDefaultFactoryRequest,
+    jvm: JvmSubsystem,
+) -> FieldDefaultFactoryResult:
+    return FieldDefaultFactoryResult(lambda f: f.normalized_value(jvm))
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(FieldDefaultFactoryRequest, JvmResolveFieldDefaultFactoryRequest),
+    ]


### PR DESCRIPTION
As discussed on #16175, we don't currently consume the "dynamic" defaults of field values for the purposes of `parametrize`. That is at least partially because there is no generic way to do so: a `Field` has no way to declare a dynamic default currently, because `Field`s cannot declare a dependency `@rule_helper` to compute their value (...yet? see https://github.com/pantsbuild/pants/issues/12934#issuecomment-1111608974).

This change adds a mechanism for generically declaring the default value of a `Field`. This is definitely not the most ergonomic API: over the next few versions, many dynamic `Field` defaults will hopefully move to `__defaults__`. And https://github.com/pantsbuild/pants/issues/12934#issuecomment-1111608974 will hopefully allow for significantly cleaning up those that remain. 

Fixes #16175.
