### PR TITLE
use newer versions of macos and ubuntu in CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -156,7 +156,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Bootstrap Pants, test Rust (macOS10-x86_64)
     runs-on:
-    - macos-10.15
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -423,7 +423,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Ensure PR has a category label
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -440,7 +440,7 @@ jobs:
     name: Lint Python and Shell
     needs: bootstrap_pants_linux_x86_64
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -507,7 +507,7 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 0/3
     needs: bootstrap_pants_linux_x86_64
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -595,7 +595,7 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 1/3
     needs: bootstrap_pants_linux_x86_64
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -683,7 +683,7 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 2/3
     needs: bootstrap_pants_linux_x86_64
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -773,7 +773,7 @@ jobs:
     name: Test Python (macOS10-x86_64)
     needs: bootstrap_pants_macos_x86_64
     runs-on:
-    - macos-10.15
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -163,7 +163,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -299,7 +299,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -526,7 +526,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -622,7 +622,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Ensure PR has a category label
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -640,7 +640,7 @@ jobs:
     outputs:
       docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -665,7 +665,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -733,7 +733,7 @@ jobs:
     - set_merge_ok_docs_only
     - set_merge_ok_not_docs_only
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - run: "merge_ok_docs_only=\"${{ needs.set_merge_ok_docs_only.outputs.merge_ok\
         \ }}\"\nmerge_ok_not_docs_only=\"${{ needs.set_merge_ok_not_docs_only.outputs.merge_ok\
@@ -748,7 +748,7 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - id: set_merge_ok
       run: echo '::set-output name=merge_ok::true'
@@ -772,7 +772,7 @@ jobs:
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - id: set_merge_ok
       run: echo '::set-output name=merge_ok::true'
@@ -785,7 +785,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -876,7 +876,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -967,7 +967,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - ubuntu-20.04
+    - ubuntu-22.04
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -1060,7 +1060,7 @@ jobs:
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -334,11 +334,11 @@ class Helper:
 
     def runs_on(self) -> list[str]:
         if self.platform == Platform.MACOS10_X86_64:
-            return ["macos-10.15"]
+            return ["macos-12"]
         if self.platform == Platform.MACOS11_ARM64:
             return ["self-hosted", "macOS11", "ARM64"]
         if self.platform == Platform.LINUX_X86_64:
-            return ["ubuntu-20.04"]
+            return ["ubuntu-22.04"]
         raise ValueError(f"Unsupported platform: {self.platform_name()}")
 
     def platform_env(self):


### PR DESCRIPTION
saw this in GHA UI:
![Screen Shot 2022-07-19 at 4 31 19 PM](https://user-images.githubusercontent.com/1268088/179842834-fdff7f1d-aa57-4609-92ce-5ab6543e9005.png)
https://github.com/actions/virtual-environments/issues/5583


so I figured we might as well upgrade both.
