### PR TITLE
fix scala plugins args order causing cache issues (Cherry-pick of #16228)

### DIFF
--- a/src/python/pants/backend/scala/compile/scalac_plugins.py
+++ b/src/python/pants/backend/scala/compile/scalac_plugins.py
@@ -24,6 +24,7 @@ from pants.jvm.resolve.jvm_tool import rules as jvm_tool_rules
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
+from pants.util.ordered_set import OrderedSet
 
 
 @dataclass(frozen=True)
@@ -55,8 +56,8 @@ class ScalaPluginsRequest:
         seq: Iterable[ScalaPluginTargetsForTarget],
         resolve: CoursierResolveKey,
     ) -> ScalaPluginsRequest:
-        plugins: set[Target] = set()
-        artifacts: set[Target] = set()
+        plugins: OrderedSet[Target] = OrderedSet()
+        artifacts: OrderedSet[Target] = OrderedSet()
 
         for spft in seq:
             plugins.update(spft.plugins)


### PR DESCRIPTION
Use `OrderedSet` instead of `set` to solve non-determinstic order of targets. See https://github.com/pantsbuild/pants/issues/14195#issuecomment-1114087237 for followup.

[ci skip-rust]
[ci skip-build-wheels]
