### PR TITLE
allow JVM sources to have files dependencies (Cherry-pick of #16203)

### DIFF
--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import ClassVar, Iterable, Iterator, Sequence
 
+from pants.core.target_types import FilesGeneratingSourcesField, FileSourceField
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.fs import Digest
@@ -412,12 +413,19 @@ def classpath_dependency_requests(
         them = coarsened_dep.representative.address
         return us.spec_path == them.spec_path and us.target_name == them.target_name
 
+    def ignore_because_file(coarsened_dep: CoarsenedTarget) -> bool:
+        return sum(
+            1
+            for t in coarsened_dep.members
+            if t.has_field(FileSourceField) or t.has_field(FilesGeneratingSourcesField)
+        ) == len(coarsened_dep.members)
+
     return ClasspathEntryRequests(
         classpath_entry_request.for_targets(
             component=coarsened_dep, resolve=request.request.resolve
         )
         for coarsened_dep in request.request.component.dependencies
-        if not ignore_because_generated(coarsened_dep)
+        if not ignore_because_generated(coarsened_dep) and not ignore_because_file(coarsened_dep)
     )
 
 

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -362,9 +362,7 @@ def test_compile_mixed_cycle(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
-def test_allow_files_dependency(
-    rule_runner: RuleRunner, scala_stdlib_jvm_lockfile: JVMLockfileFixture
-) -> None:
+def test_allow_files_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -373,8 +371,8 @@ def test_allow_files_dependency(
                 files(name="files", sources=["File.txt"])
                 """
             ),
-            "3rdparty/jvm/BUILD": scala_stdlib_jvm_lockfile.requirements_as_jvm_artifact_targets(),
-            "3rdparty/jvm/default.lock": scala_stdlib_jvm_lockfile.serialized_lockfile,
+            "3rdparty/jvm/BUILD": DEFAULT_SCALA_LIBRARY_TARGET,
+            "3rdparty/jvm/default.lock": DEFAULT_LOCKFILE,
             "Example.scala": dedent(
                 """\
                 package org.pantsbuild.example

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -41,6 +41,7 @@ from pants.backend.scala.dependency_inference.rules import rules as scala_dep_in
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget
 from pants.backend.scala.target_types import rules as scala_target_types_rules
 from pants.build_graph.address import Address
+from pants.core.target_types import FilesGeneratorTarget
 from pants.core.util_rules import config_files, source_files, stripped_source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.addresses import Addresses
@@ -157,6 +158,7 @@ def rule_runner() -> RuleRunner:
             ProtobufSourceTarget,
             ProtobufSourcesGeneratorTarget,
             ScalaSourcesGeneratorTarget,
+            FilesGeneratorTarget,
         ],
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
@@ -357,3 +359,36 @@ def test_compile_mixed_cycle(rule_runner: RuleRunner) -> None:
     lib_address = Address(spec_path="lib")
     assert len(expect_single_expanded_coarsened_target(rule_runner, main_address).members) == 2
     rule_runner.request(Classpath, [Addresses([main_address, lib_address])])
+
+
+@maybe_skip_jdk_test
+def test_allow_files_dependency(
+    rule_runner: RuleRunner, scala_stdlib_jvm_lockfile: JVMLockfileFixture
+) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                scala_sources(name='main', dependencies=[":files"])
+                files(name="files", sources=["File.txt"])
+                """
+            ),
+            "3rdparty/jvm/BUILD": scala_stdlib_jvm_lockfile.requirements_as_jvm_artifact_targets(),
+            "3rdparty/jvm/default.lock": scala_stdlib_jvm_lockfile.serialized_lockfile,
+            "Example.scala": dedent(
+                """\
+                package org.pantsbuild.example
+
+                object Main {
+                    def main(args: Array[String]): Unit = {
+                        println("Hello World")
+                    }
+                }
+                """
+            ),
+            "File.txt": "HELLO WORLD",
+        }
+    )
+
+    main_address = Address(spec_path="", target_name="main")
+    rule_runner.request(Classpath, [Addresses([main_address])])


### PR DESCRIPTION
As with the test in the PR, we tried to add files dependency to `scala_sources` (actually to `scalatest_tests`) but if failed with:

```
Engine traceback:
  in select
  in pants.core.goals.test.run_tests
  in pants.backend.scala.test.scalatest.run_scalatest_test (modules/core/test/src/unit/core/integration/ReceivedPaymentIntegrationSpec.scala:tests)
  in pants.backend.scala.test.scalatest.setup_scalatest_for_target
  in pants.jvm.classpath.classpath
  in pants.jvm.compile.required_classfiles
  in pants.backend.scala.compile.scalac.compile_scala_source
  in pants.jvm.compile.compile_classpath_entries
  in pants.jvm.compile.classpath_dependency_requests
Traceback (most recent call last):
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 415, in classpath_dependency_requests
    return ClasspathEntryRequests(
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 416, in <genexpr>
    classpath_entry_request.for_targets(
  File "/Users/somdoron/.cache/pants/setup/bootstrap-Darwin-arm64/pants.sVxb8A/install/lib/python3.9/site-packages/pants/jvm/compile.py", line 146, in for_targets
    raise ClasspathSourceMissing(
pants.jvm.compile.ClasspathSourceMissing: No JVM classpath providers (from: CompileJavaSourceRequest, CompileScalaSourceRequest, CoursierFetchRequest, DeployJarClasspathEntryRequest, JvmResourcesRequest) were compatible with the combination of inputs:
  * modules/core/resources:migrations   (files)
```

This PR fixes it by not trying to resolve `FileTarget` as a classpath.
