### PR TITLE
Ban `../` in `source` and `sources` fields (Cherry-pick of #16227)

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2105,6 +2105,17 @@ class MultipleSourcesField(SourcesField, StringSequenceField):
         cls, raw_value: Optional[Iterable[str]], address: Address
     ) -> Optional[Tuple[str, ...]]:
         value = super().compute_value(raw_value, address)
+        invalid_globs = [glob for glob in (value or ()) if glob.startswith("../") or "/../" in glob]
+        if invalid_globs:
+            raise InvalidFieldException(
+                softwrap(
+                    f"""
+                    The {repr(cls.alias)} field in target {address} must not have globs with the
+                    pattern `../` because targets can only have sources in the current directory
+                    or subdirectories. It was set to: {sorted(value or ())}
+                    """
+                )
+            )
         if cls.ban_subdirectories:
             invalid_globs = [glob for glob in (value or ()) if "**" in glob or os.path.sep in glob]
             if invalid_globs:
@@ -2149,17 +2160,36 @@ class OptionalSingleSourceField(SourcesField, StringField):
         value_or_default = super().compute_value(raw_value, address)
         if value_or_default is None:
             return None
+        if value_or_default.startswith("../") or "/../" in value_or_default:
+            raise InvalidFieldException(
+                softwrap(
+                    f"""\
+                    The {repr(cls.alias)} field in target {address} should not include `../`
+                    patterns because targets can only have sources in the current directory or
+                    subdirectories. It was set to {value_or_default}. Instead, use a normalized
+                    literal file path (relative to the BUILD file).
+                    """
+                )
+            )
         if "*" in value_or_default:
             raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} should not include `*` globs, "
-                f"but was set to {value_or_default}. Instead, use a literal file path (relative "
-                "to the BUILD file)."
+                softwrap(
+                    f"""\
+                    The {repr(cls.alias)} field in target {address} should not include `*` globs,
+                    but was set to {value_or_default}. Instead, use a literal file path (relative
+                    to the BUILD file).
+                    """
+                )
             )
         if value_or_default.startswith("!"):
             raise InvalidFieldException(
-                f"The {repr(cls.alias)} field in target {address} should not start with `!`, which "
-                f"is usually used in the `sources` field to exclude certain files. Instead, use a "
-                "literal file path (relative to the BUILD file)."
+                softwrap(
+                    f"""\
+                    The {repr(cls.alias)} field in target {address} should not start with `!`,
+                    which is usually used in the `sources` field to exclude certain files. Instead,
+                    use a literal file path (relative to the BUILD file).
+                    """
+                )
             )
         return value_or_default
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1077,14 +1077,22 @@ def test_single_source_file_path() -> None:
     assert TestSingleSourceField("f.ext", Address("project")).file_path == "project/f.ext"
 
 
-def test_single_source_field_bans_globs() -> None:
-    class TestSingleSourceField(SingleSourceField):
-        pass
+def test_sources_fields_ban_parent_dir_pattern() -> None:
+    with pytest.raises(InvalidFieldException):
+        SingleSourceField("../f.ext", Address("project"))
+    with pytest.raises(InvalidFieldException):
+        SingleSourceField("dir/../f.ext", Address("project"))
+    with pytest.raises(InvalidFieldException):
+        MultipleSourcesField(["../f.ext", "f.ext"], Address("project"))
+    with pytest.raises(InvalidFieldException):
+        MultipleSourcesField(["dir/../f.ext", "f.ext"], Address("project"))
 
+
+def test_single_source_field_bans_globs() -> None:
     with pytest.raises(InvalidFieldException):
-        TestSingleSourceField("*.ext", Address("project"))
+        SingleSourceField("*.ext", Address("project"))
     with pytest.raises(InvalidFieldException):
-        TestSingleSourceField("!f.ext", Address("project"))
+        SingleSourceField("!f.ext", Address("project"))
 
 
 def test_multiple_sources_field_ban_subdirs() -> None:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/4760.

This possibly will fix https://github.com/pantsbuild/pants/issues/15881? Unclear if it's the root cause of the issue, but at least it would fix one problematic part of the setup.

[ci skip-rust]
[ci skip-build-wheels]
