### PR TITLE
upgrade to Rust v1.62.1

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 
@@ -195,7 +195,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 
@@ -326,7 +326,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 
@@ -202,7 +202,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 
@@ -422,7 +422,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 
@@ -561,7 +561,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.62.0-*
+        path: '~/.rustup/toolchains/1.62.1-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.62.0"
+channel = "1.62.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.62.1 which fixes several regressions in v1.62.0: https://blog.rust-lang.org/2022/07/19/Rust-1.62.1.html