### PR TITLE
add Go ASDF support

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -6,7 +6,6 @@ from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.goals import check, package_binary, run_binary, tailor, test
 from pants.backend.go.lint.gofmt import skip_field as gofmt_skip_field
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
-from pants.backend.go.subsystems import golang
 from pants.backend.go.target_types import (
     GoBinaryTarget,
     GoModTarget,
@@ -18,13 +17,15 @@ from pants.backend.go.util_rules import (
     build_pkg,
     build_pkg_target,
     first_party_pkg,
+    go_bootstrap,
     go_mod,
+    goroot,
     import_analysis,
     link,
     pkg_analyzer,
     sdk,
     tests_analysis,
-    third_party_pkg, go_bootstrap, goroot,
+    third_party_pkg,
 )
 
 

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -24,7 +24,7 @@ from pants.backend.go.util_rules import (
     pkg_analyzer,
     sdk,
     tests_analysis,
-    third_party_pkg,
+    third_party_pkg, go_bootstrap, goroot,
 )
 
 
@@ -39,7 +39,8 @@ def rules():
         *build_pkg_target.rules(),
         *check.rules(),
         *third_party_pkg.rules(),
-        *golang.rules(),
+        *go_bootstrap.rules(),
+        *goroot.rules(),
         *import_analysis.rules(),
         *go_mod.rules(),
         *first_party_pkg.rules(),

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass
 
 from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
 from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
-from pants.backend.go.subsystems import golang
-from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.target_types import GoPackageSourcesField
+from pants.backend.go.util_rules import goroot
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.goals.fmt import FmtRequest, FmtResult
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -65,6 +65,6 @@ async def gofmt_fmt(request: GofmtRequest, gofmt: GofmtSubsystem, goroot: GoRoot
 def rules():
     return [
         *collect_rules(),
-        *golang.rules(),
+        *goroot.rules(),
         UnionRule(FmtRequest, GofmtRequest),
     ]

--- a/src/python/pants/backend/go/subsystems/BUILD
+++ b/src/python/pants/backend/go/subsystems/BUILD
@@ -2,4 +2,3 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests")

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -112,7 +112,7 @@ class GolangSubsystem(Subsystem):
             """
             The path relative to an ASDF install directory to use to find the `bin` directory within an installed
             Go distribution. The default value for this option works for the `go-sdk` ASDF plugin. Other ASDF
-            plugins that install Go may have a different relative path to use. 
+            plugins that install Go may have a different relative path to use.
             """
         ),
         advanced=True,

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -7,7 +7,7 @@ import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.go.subsystems.golang import GoRoot
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -7,7 +7,6 @@ import hashlib
 import os.path
 from dataclasses import dataclass
 
-from pants.backend.go.subsystems.golang import GoRoot
 from pants.backend.go.util_rules.assembly import (
     AssemblyPostCompilation,
     AssemblyPostCompilationRequest,
@@ -15,6 +14,7 @@ from pants.backend.go.util_rules.assembly import (
     FallibleAssemblyPreCompilation,
 )
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -1,0 +1,99 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.core.util_rules import asdf
+from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
+from pants.engine.environment import Environment
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GoBootstrap:
+    EXTRA_ENV_VAR_NAMES = ("PATH",)
+
+    raw_go_search_paths: tuple[str, ...]
+    environment: Environment
+    asdf_standard_tool_paths: tuple[str, ...]
+    asdf_local_tool_paths: tuple[str, ...]
+
+    @property
+    def go_search_paths(self) -> tuple[str, ...]:
+        special_strings = {
+            "<PATH>": lambda: GoBootstrap.get_environment_paths(self.environment),
+            "<ASDF>": lambda: self.asdf_standard_tool_paths,
+            "<ASDF_LOCAL>": lambda: self.asdf_local_tool_paths,
+        }
+        expanded: list[str] = []
+        for s in self.raw_go_search_paths:
+            if s in special_strings:
+                special_paths = special_strings[s]()
+                expanded.extend(special_paths)
+            else:
+                expanded.append(s)
+        return tuple(expanded)
+
+    @staticmethod
+    def get_environment_paths(env: Environment) -> list[str]:
+        """Returns a list of paths specified by the PATH env var."""
+        pathstr = env.get("PATH")
+        if pathstr:
+            return pathstr.split(os.pathsep)
+        return []
+
+
+@rule
+async def resolve_go_bootstrap(golang_subsystem: GolangSubsystem) -> GoBootstrap:
+    raw_go_search_paths = golang_subsystem.raw_go_search_paths
+    result = await Get(
+        AsdfToolPathsResult,
+        AsdfToolPathsRequest(
+            tool_name=golang_subsystem.asdf_tool_name,
+            tool_description="Go distribution",
+            resolve_standard="<ASDF>" in raw_go_search_paths,
+            resolve_local="<ASDF_LOCAL>" in raw_go_search_paths,
+            extra_env_var_names=("PATH",),
+            paths_option_name="[golang].go_search_paths",
+            bin_relpath=golang_subsystem.asdf_bin_relpath,
+        ),
+    )
+
+    return GoBootstrap(
+        raw_go_search_paths=raw_go_search_paths,
+        environment=result.env,
+        asdf_standard_tool_paths=result.standard_tool_paths,
+        asdf_local_tool_paths=result.local_tool_paths,
+    )
+
+
+def compatible_go_version(*, compiler_version: str, target_version: str) -> bool:
+    """Can the Go compiler handle the target version?
+
+    Inspired by
+    https://github.com/golang/go/blob/30501bbef9fcfc9d53e611aaec4d20bb3cdb8ada/src/cmd/go/internal/work/exec.go#L429-L445.
+
+    Input expected in the form `1.17`.
+    """
+    if target_version == "1.0":
+        return True
+
+    def parse(v: str) -> tuple[int, int]:
+        major, minor = v.split(".", maxsplit=1)
+        return int(major), int(minor)
+
+    return parse(target_version) <= parse(compiler_version)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *asdf.rules(),
+    )

--- a/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
@@ -1,0 +1,131 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from pathlib import Path
+from textwrap import dedent
+from typing import Mapping
+
+from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
+from pants.backend.go.util_rules.go_bootstrap import rules as go_bootstrap_rules
+from pants.core.util_rules.asdf_test import fake_asdf_root, materialize_indices
+from pants.engine.environment import CompleteEnvironment
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+EXPECTED_VERSION = "1.17"
+EXPECTED_VERSION_NEXT_RELEASE = "1.18"
+
+
+def mock_go_binary(*, version_output: str, env_output: Mapping[str, str]) -> str:
+    """Return a bash script that emulates `go version` and `go env`."""
+    return dedent(
+        f"""\
+        #!/bin/bash
+
+        if [[ "$1" == version ]]; then
+            echo '{version_output}'
+        else
+            echo '{json.dumps(env_output)}'
+        fi
+        """
+    )
+
+
+def test_expand_search_paths() -> None:
+    all_go_versions = [
+        f"{EXPECTED_VERSION}.0",
+        f"{EXPECTED_VERSION}.1",
+        f"{EXPECTED_VERSION}.2",
+        f"{EXPECTED_VERSION}.3",
+    ]
+    asdf_home_versions = [0, 1, 2]
+    asdf_local_versions = [2, 1, 3]
+    asdf_local_versions_str = " ".join(materialize_indices(all_go_versions, asdf_local_versions))
+    rule_runner = RuleRunner(
+        rules=[
+            *go_bootstrap_rules(),
+            QueryRule(GoBootstrap, ()),
+        ]
+    )
+    rule_runner.write_files(
+        {
+            ".tool-versions": dedent(
+                f"""\
+                nodejs 16.0.1
+                java current
+                go-sdk {asdf_local_versions_str}
+                rust 1.52.0
+                """
+            ),
+        }
+    )
+    with fake_asdf_root(
+        all_go_versions, asdf_home_versions, asdf_local_versions, tool_name="go-sdk"
+    ) as (
+        home_dir,
+        asdf_dir,
+        expected_asdf_paths,
+        expected_asdf_home_paths,
+        expected_asdf_local_paths,
+    ):
+        for asdf_path in expected_asdf_paths:
+            script = mock_go_binary(
+                version_output=f"go version go{EXPECTED_VERSION} darwin/arm64",
+                env_output={"GOROOT": "/valid/binary"},
+            )
+            script_path = Path(asdf_path) / "go"
+            script_path.write_text(script)
+            script_path.chmod(0o755)
+
+        paths = [
+            "/foo",
+            "<PATH>",
+            "/bar",
+            "<ASDF>",
+            "<ASDF_LOCAL>",
+            "/qux",
+        ]
+        path_str = ", ".join(f'"{p}"' for p in paths)
+
+        rule_runner.set_options(
+            [
+                f"--golang-go-search-paths=[{path_str}]",
+                f"--golang-minimum-expected-version={EXPECTED_VERSION}",
+            ],
+            env_inherit={"PATH"},
+        )
+        rule_runner.set_session_values(
+            {
+                CompleteEnvironment: CompleteEnvironment(
+                    {
+                        "HOME": home_dir,
+                        "PATH": "/env/path1:/env/path2",
+                        "ASDF_DATA_DIR": asdf_dir,
+                    }
+                ),
+            }
+        )
+        go_bootstrap = rule_runner.request(GoBootstrap, ())
+
+    expected = (
+        "/foo",
+        "/env/path1",
+        "/env/path2",
+        "/bar",
+        *expected_asdf_home_paths,
+        *expected_asdf_local_paths,
+        "/qux",
+    )
+    assert expected == go_bootstrap.go_search_paths
+
+
+def test_compatible_go_version() -> None:
+    def check(version: str, expected: bool) -> None:
+        assert compatible_go_version(compiler_version="1.15", target_version=version) is expected
+
+    for v in range(16):
+        check(f"1.{v}", True)
+    for v in range(17, 40):
+        check(f"1.{v}", False)
+    for v in range(2, 4):
+        check(f"{v}.0", False)

--- a/src/python/pants/backend/go/util_rules/goroot.py
+++ b/src/python/pants/backend/go/util_rules/goroot.py
@@ -1,0 +1,162 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.util_rules import go_bootstrap
+from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
+from pants.core.util_rules.system_binaries import (
+    BinaryNotFoundError,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+)
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import Process, ProcessCacheScope, ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+from pants.util.strutil import bullet_list, softwrap
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GoRoot:
+    """Path to the Go installation (the `GOROOT`)."""
+
+    path: str
+    version: str
+
+    _raw_metadata: FrozenDict[str, str]
+
+    def is_compatible_version(self, version: str) -> bool:
+        """Can this Go compiler handle the target version?"""
+        return compatible_go_version(compiler_version=self.version, target_version=version)
+
+    @property
+    def full_version(self) -> str:
+        return self._raw_metadata["GOVERSION"]
+
+    @property
+    def goos(self) -> str:
+        return self._raw_metadata["GOOS"]
+
+    @property
+    def goarch(self) -> str:
+        return self._raw_metadata["GOARCH"]
+
+
+@rule(desc="Find Go binary", level=LogLevel.DEBUG)
+async def setup_goroot(golang_subsystem: GolangSubsystem, go_bootstrap: GoBootstrap) -> GoRoot:
+    search_paths = go_bootstrap.go_search_paths
+    all_go_binary_paths = await Get(
+        BinaryPaths,
+        BinaryPathRequest(
+            search_path=search_paths,
+            binary_name="go",
+            test=BinaryPathTest(["version"]),
+        ),
+    )
+    if not all_go_binary_paths.paths:
+        raise BinaryNotFoundError(
+            softwrap(
+                f"""
+                Cannot find any `go` binaries using the option `[golang].go_search_paths`:
+                {list(search_paths)}
+
+                To fix, please install Go (https://golang.org/doc/install) with the version
+                {golang_subsystem.minimum_expected_version} or newer (set by
+                `[golang].minimum_expected_version`). Then ensure that it is discoverable via
+                `[golang].go_search_paths`.
+                """
+            )
+        )
+
+    # `go env GOVERSION` does not work in earlier Go versions (like 1.15), so we must run
+    # `go version` and `go env GOROOT` to calculate both the version and GOROOT.
+    version_results = await MultiGet(
+        Get(
+            ProcessResult,
+            Process(
+                (binary_path.path, "version"),
+                description=f"Determine Go version for {binary_path.path}",
+                level=LogLevel.DEBUG,
+                cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
+            ),
+        )
+        for binary_path in all_go_binary_paths.paths
+    )
+
+    invalid_versions = []
+    for binary_path, version_result in zip(all_go_binary_paths.paths, version_results):
+        try:
+            _raw_version = version_result.stdout.decode("utf-8").split()[
+                2
+            ]  # e.g. go1.17 or go1.17.1
+            _version_components = _raw_version[2:].split(".")  # e.g. [1, 17] or [1, 17, 1]
+            version = f"{_version_components[0]}.{_version_components[1]}"
+        except IndexError:
+            raise AssertionError(
+                f"Failed to parse `go version` output for {binary_path}. Please open a bug at "
+                f"https://github.com/pantsbuild/pants/issues/new/choose with the below data."
+                f"\n\n"
+                f"{version_result}"
+            )
+
+        if compatible_go_version(
+            compiler_version=version, target_version=golang_subsystem.minimum_expected_version
+        ):
+            env_result = await Get(
+                ProcessResult,
+                Process(
+                    (binary_path.path, "env", "-json"),
+                    description=f"Determine Go SDK metadata for {binary_path.path}",
+                    level=LogLevel.DEBUG,
+                    cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
+                    env={"GOPATH": "/does/not/matter"},
+                ),
+            )
+            sdk_metadata = json.loads(env_result.stdout.decode())
+            return GoRoot(
+                path=sdk_metadata["GOROOT"], version=version, _raw_metadata=FrozenDict(sdk_metadata)
+            )
+
+        logger.debug(
+            f"Go binary at {binary_path.path} has version {version}, but this "
+            f"repository expects at least {golang_subsystem.minimum_expected_version} "
+            "(set by `[golang].expected_minimum_version`). Ignoring."
+        )
+
+        invalid_versions.append((binary_path.path, version))
+
+    invalid_versions_str = bullet_list(
+        f"{path}: {version}" for path, version in sorted(invalid_versions)
+    )
+    raise BinaryNotFoundError(
+        softwrap(
+            f"""
+            Cannot find a `go` binary compatible with the minimum version of
+            {golang_subsystem.minimum_expected_version} (set by `[golang].minimum_expected_version`).
+
+            Found these `go` binaries, but they had incompatible versions:
+
+            {invalid_versions_str}
+
+            To fix, please install the expected version or newer (https://golang.org/doc/install)
+            and ensure that it is discoverable via the option `[golang].go_search_paths`, or change
+            `[golang].expected_minimum_version`.
+            """
+        )
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *go_bootstrap.rules(),
+    )

--- a/src/python/pants/backend/go/util_rules/pkg_analyzer.py
+++ b/src/python/pants/backend/go/util_rules/pkg_analyzer.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
-from pants.backend.go.subsystems.golang import GoRoot
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.engine.fs import Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -7,8 +7,9 @@ import textwrap
 from dataclasses import dataclass
 from typing import Iterable, Mapping
 
-from pants.backend.go.subsystems import golang
-from pants.backend.go.subsystems.golang import GolangSubsystem, GoRoot
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.util_rules import goroot
+from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.environment import Environment, EnvironmentRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests
@@ -147,4 +148,4 @@ async def compute_go_tool_id(request: GoSdkToolIDRequest) -> GoSdkToolIDResult:
 
 
 def rules():
-    return (*collect_rules(), *golang.rules())
+    return (*collect_rules(), *goroot.rules())

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -122,13 +122,17 @@ def test_expand_interpreter_search_paths() -> None:
         }
     )
     with setup_pexrc_with_pex_python_path(["/pexrc/path1:/pexrc/path2"]):
-        with fake_asdf_root(all_python_versions, asdf_home_versions, asdf_local_versions, tool_name="python") as (
+        with fake_asdf_root(
+            all_python_versions, asdf_home_versions, asdf_local_versions, tool_name="python"
+        ) as (
             home_dir,
             asdf_dir,
             expected_asdf_paths,
             expected_asdf_home_paths,
             expected_asdf_local_paths,
-        ), fake_pyenv_root(all_python_versions, local_pyenv_version) as (
+        ), fake_pyenv_root(
+            all_python_versions, local_pyenv_version
+        ) as (
             pyenv_root,
             expected_pyenv_paths,
             expected_pyenv_local_paths,

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -122,7 +122,7 @@ def test_expand_interpreter_search_paths() -> None:
         }
     )
     with setup_pexrc_with_pex_python_path(["/pexrc/path1:/pexrc/path2"]):
-        with fake_asdf_root(all_python_versions, asdf_home_versions, asdf_local_versions) as (
+        with fake_asdf_root(all_python_versions, asdf_home_versions, asdf_local_versions, tool_name="python") as (
             home_dir,
             asdf_dir,
             expected_asdf_paths,

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -112,15 +112,14 @@ async def _resolve_asdf_tool_paths(
         # The definition of a tool-versions file can be found here:
         # https://asdf-vm.com/#/core-configuration?id=tool-versions
         tool_versions_lines = tool_versions_file.read_text().splitlines()
-        print(f"tool_versions_lines = {tool_versions_lines}")
-        last_line = None
+        last_line_fields = None
         for line in tool_versions_lines:
-            # Find the last line for this tool.
-            if line.lower().startswith(tool_name):
-                last_line = line
-        if last_line:
-            _, _, versions = last_line.partition(tool_name)
-            for v in re.split(r"\s+", versions.strip()):
+            fields = re.split(r"\s+", line.strip())
+            if not fields or fields[0] != tool_name:
+                continue
+            last_line_fields = fields
+        if last_line_fields:
+            for v in last_line_fields[1:]:
                 if ":" in v:
                     key, _, value = v.partition(":")
                     if key.lower() == "path":

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -112,6 +112,7 @@ async def _resolve_asdf_tool_paths(
         # The definition of a tool-versions file can be found here:
         # https://asdf-vm.com/#/core-configuration?id=tool-versions
         tool_versions_lines = tool_versions_file.read_text().splitlines()
+        print(f"tool_versions_lines = {tool_versions_lines}")
         last_line = None
         for line in tool_versions_lines:
             # Find the last line for this tool.
@@ -144,7 +145,7 @@ async def _resolve_asdf_tool_paths(
                     asdf_versions[v] = str(tool_versions_file)
 
     for version, source in asdf_versions.items():
-        install_dir = asdf_installs_dir / version / "bin"
+        install_dir = asdf_installs_dir / version / bin_relpath
         if install_dir.exists():
             asdf_paths.append(str(install_dir))
         else:

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -22,7 +22,11 @@ def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> tuple
 
 @contextmanager
 def fake_asdf_root(
-    fake_versions: list[str], fake_home_versions: list[int], fake_local_versions: list[int]
+    fake_versions: list[str],
+    fake_home_versions: list[int],
+    fake_local_versions: list[int],
+    *,
+    tool_name: str,
 ):
     with temporary_dir() as home_dir, temporary_dir() as asdf_dir:
 
@@ -32,11 +36,11 @@ def fake_asdf_root(
         fake_home_dir = Path(home_dir)
         fake_tool_versions = fake_home_dir / ".tool-versions"
         fake_home_versions_str = " ".join(materialize_indices(fake_versions, fake_home_versions))
-        fake_tool_versions.write_text(f"nodejs lts\njava 8\npython {fake_home_versions_str}\n")
+        fake_tool_versions.write_text(f"nodejs lts\njava 8\n{tool_name} {fake_home_versions_str}\n")
 
         fake_asdf_dir = Path(asdf_dir)
-        fake_asdf_plugin_dir = fake_asdf_dir / "plugins" / "python"
-        fake_asdf_installs_dir = fake_asdf_dir / "installs" / "python"
+        fake_asdf_plugin_dir = fake_asdf_dir / "plugins" / tool_name
+        fake_asdf_installs_dir = fake_asdf_dir / "installs" / tool_name
 
         fake_dirs.extend(
             [fake_home_dir, fake_asdf_dir, fake_asdf_plugin_dir, fake_asdf_installs_dir]
@@ -125,7 +129,9 @@ def test_get_asdf_paths() -> None:
         }
     )
 
-    with fake_asdf_root(all_python_versions, asdf_home_versions, asdf_local_versions) as (
+    with fake_asdf_root(
+        all_python_versions, asdf_home_versions, asdf_local_versions, tool_name="python"
+    ) as (
         home_dir,
         asdf_dir,
         expected_asdf_paths,


### PR DESCRIPTION
Add support using ASDF to locate installed Go distributions. `--golang-go-search-paths` supports `<ASDF>` and `<ASDF_LOCAL>` special strings to expand ASDF paths.

By default, Pants will support the `go-sdk` plugin to ASDF listed in the official ASDF plugin list, but can be configured for other Go plugins to ASDF via options.

Fixes https://github.com/pantsbuild/pants/issues/16187.

[ci skip-rust]

[ci skip-build-wheels]