### PR TITLE
Apply parameter filling for `parametrize`d dependencies to excludes, and fix accommodation for file-addressed atom targets

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -338,13 +338,7 @@ async def resolve_target(
             base_address, description_of_origin=request.description_of_origin
         ),
     )
-    if address.is_generated_target:
-        # TODO: This is an accommodation to allow using file/generator Addresses for
-        # non-generator atom targets. See https://github.com/pantsbuild/pants/issues/14419.
-        original_target = parametrizations.get(base_address)
-        if original_target and not target_types_to_generate_requests.is_generator(original_target):
-            return WrappedTarget(original_target)
-    target = parametrizations.get(address)
+    target = parametrizations.get(address, target_types_to_generate_requests)
     if target is None:
         raise ResolveError(
             softwrap(
@@ -1125,7 +1119,9 @@ async def resolve_dependencies(
         )
 
         explicitly_provided_includes = [
-            parametrizations.get_subset(address, tgt, field_defaults).address
+            parametrizations.get_subset(
+                address, tgt, field_defaults, target_types_to_generate_requests
+            ).address
             for address, parametrizations in zip(
                 explicitly_provided_includes, explicit_dependency_parametrizations
             )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -9,7 +9,7 @@ import logging
 import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Iterable, NamedTuple, Sequence, Type, cast
+from typing import Iterable, Iterator, NamedTuple, Sequence, Type, cast
 
 from pants.base.deprecated import warn_or_error
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
@@ -33,7 +33,7 @@ from pants.engine.internals.parametrize import (  # noqa: F401
     _TargetParametrizationsRequest as _TargetParametrizationsRequest,
 )
 from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRequest
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import (
     AllTargets,
     AllTargetsRequest,
@@ -1049,6 +1049,35 @@ async def determine_explicitly_provided_dependencies(
     )
 
 
+@rule_helper
+async def _fill_parameters(
+    field_alias: str,
+    consumer_tgt: Target,
+    addresses: Iterable[Address],
+    target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
+    field_defaults: FieldDefaults,
+) -> tuple[Address, ...]:
+    assert not isinstance(addresses, Iterator)
+
+    parametrizations = await MultiGet(
+        Get(
+            _TargetParametrizations,
+            _TargetParametrizationsRequest(
+                address.maybe_convert_to_target_generator(),
+                description_of_origin=f"the `{field_alias}` field of the target {consumer_tgt.address}",
+            ),
+        )
+        for address in addresses
+    )
+
+    return tuple(
+        parametrizations.get_subset(
+            address, consumer_tgt, field_defaults, target_types_to_generate_requests
+        ).address
+        for address, parametrizations in zip(addresses, parametrizations)
+    )
+
+
 @rule(desc="Resolve direct dependencies")
 async def resolve_dependencies(
     request: DependenciesRequest,
@@ -1105,27 +1134,24 @@ async def resolve_dependencies(
     # parameters. If so, fill them in.
     explicitly_provided_includes: Iterable[Address] = explicitly_provided.includes
     if explicitly_provided_includes:
-        explicit_dependency_parametrizations = await MultiGet(
-            Get(
-                _TargetParametrizations,
-                _TargetParametrizationsRequest(
-                    address.maybe_convert_to_target_generator(),
-                    description_of_origin=(
-                        f"the `{request.field.alias}` field of the target {tgt.address}"
-                    ),
-                ),
-            )
-            for address in explicitly_provided_includes
+        explicitly_provided_includes = await _fill_parameters(
+            request.field.alias,
+            tgt,
+            explicitly_provided_includes,
+            target_types_to_generate_requests,
+            field_defaults,
         )
-
-        explicitly_provided_includes = [
-            parametrizations.get_subset(
-                address, tgt, field_defaults, target_types_to_generate_requests
-            ).address
-            for address, parametrizations in zip(
-                explicitly_provided_includes, explicit_dependency_parametrizations
+    explicitly_provided_ignores: FrozenOrderedSet[Address] = explicitly_provided.ignores
+    if explicitly_provided_ignores:
+        explicitly_provided_ignores = FrozenOrderedSet(
+            await _fill_parameters(
+                request.field.alias,
+                tgt,
+                tuple(explicitly_provided_ignores),
+                target_types_to_generate_requests,
+                field_defaults,
             )
-        ]
+        )
 
     # If the target has `SpecialCasedDependencies`, such as the `archive` target having
     # `files` and `packages` fields, then we possibly include those too. We don't want to always
@@ -1158,7 +1184,7 @@ async def resolve_dependencies(
             for addr in special_cased_field.to_unparsed_address_inputs().values
         )
 
-    excluded = explicitly_provided.ignores.union(
+    excluded = explicitly_provided_ignores.union(
         *itertools.chain(deps.exclude for deps in inferred)
     )
     result = Addresses(

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -12,7 +12,7 @@ from pants.build_graph.address import BANNED_CHARS_IN_PARAMETERS
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.target import Field, FieldDefaults, Target
+from pants.engine.target import Field, FieldDefaults, Target, TargetTypesToGenerateTargetsRequests
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list, softwrap
@@ -193,12 +193,27 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
 
         raise self._bare_address_error(address)
 
-    def get(self, address: Address) -> Target | None:
+    def get(
+        self,
+        address: Address,
+        target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests | None = None,
+    ) -> Target | None:
         """Find the Target with an exact Address match, if any."""
         for parametrization in self:
             instance = parametrization.get(address)
             if instance is not None:
                 return instance
+
+        # TODO: This is an accommodation to allow using file/generator Addresses for
+        # non-generator atom targets. See https://github.com/pantsbuild/pants/issues/14419.
+        if target_types_to_generate_requests and address.is_generated_target:
+            base_address = address.maybe_convert_to_target_generator()
+            original_target = self.get(base_address, target_types_to_generate_requests)
+            if original_target and not target_types_to_generate_requests.is_generator(
+                original_target
+            ):
+                return original_target
+
         return None
 
     def get_all_superset_targets(self, address: Address) -> Iterator[Address]:
@@ -225,11 +240,15 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
                     yield parametrized_tgt.address
 
     def get_subset(
-        self, address: Address, consumer: Target, field_defaults: FieldDefaults
+        self,
+        address: Address,
+        consumer: Target,
+        field_defaults: FieldDefaults,
+        target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
     ) -> Target:
         """Find the Target with the given Address, or with fields matching the given consumer."""
         # Check for exact matches.
-        instance = self.get(address)
+        instance = self.get(address, target_types_to_generate_requests)
         if instance is not None:
             return instance
 


### PR DESCRIPTION
As described in #16241, parameter filling for `parametrize`d dependencies is currently not applied to excludes, which makes it impossible to use excludes with a `parametrize`d dependee.

Additionally, the accommodation from #14419 that allows an atom target to be addressed by a file address was not being applied to parametrization, which caused the failure described in #16230.

Fixes #16241 and fixes #16230.

[ci skip-rust]
[ci skip-build-wheels]