### PR TITLE
Add `include_sources` to `pex_binary` target (Cherry-pick of #16215)

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -14,6 +14,7 @@ from pants.backend.python.target_types import (
     PexExecutionModeField,
     PexIgnoreErrorsField,
     PexIncludeRequirementsField,
+    PexIncludeSourcesField,
     PexIncludeToolsField,
     PexInheritPathField,
     PexLayout,
@@ -69,6 +70,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     layout: PexLayoutField
     execution_mode: PexExecutionModeField
     include_requirements: PexIncludeRequirementsField
+    include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
 
     @property
@@ -148,6 +150,7 @@ async def package_pex_binary(
             layout=PexLayout(field_set.layout.value),
             additional_args=field_set.generate_additional_args(pex_binary_defaults),
             include_requirements=field_set.include_requirements.value,
+            include_source_files=field_set.include_sources.value,
             include_local_dists=True,
         ),
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -580,6 +580,16 @@ class PexIncludeRequirementsField(BoolField):
     )
 
 
+class PexIncludeSourcesField(BoolField):
+    alias = "include_sources"
+    default = True
+    help = softwrap(
+        """
+        Whether to include your first party sources the binary uses in the packaged PEX file.
+        """
+    )
+
+
 class PexIncludeToolsField(BoolField):
     alias = "include_tools"
     default = False
@@ -608,6 +618,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexLayoutField,
     PexExecutionModeField,
     PexIncludeRequirementsField,
+    PexIncludeSourcesField,
     PexIncludeToolsField,
     RestartableField,
 )


### PR DESCRIPTION
At first glance this might seem like a nonsensical yin to `include_requirements`'s yang. However... that's exactly what it is (minus the nonsensical part).

Consider the multi-stage build documented here: https://pex.readthedocs.io/en/latest/recipes.html#pex-app-in-a-container. 

Now consider if each stage consumed not a single all-in-one PEX, but the `deps` stage used a `PEX` build with `include_requirements=True` and `include_sources=False`. Likewise, but flipped, for the `srcs` stage. The `COPY` instruction in each stage wouldn't be invalidated unless truly something going into that stage changed.

For PEXs with large reqs, this cache re-use can save a lot of time, as the compilation of `deps` might take a long time.

[ci skip-rust]
[ci skip-build-wheels]
