### PR TITLE
Dont use PEX as an API

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -244,7 +244,7 @@ async def setup_pytest_for_target(
             interpreter_constraints=interpreter_constraints,
             main=request.main or pytest.main,
             internal_only=True,
-            pex_path=[*request.additional_pexes, pytest_pex, requirements_pex, local_dists.pex],
+            pex_path=[pytest_pex, requirements_pex, local_dists.pex, *request.additional_pexes],
         ),
     )
     config_files_get = Get(

--- a/src/python/pants/backend/python/subsystems/debugpy.lock
+++ b/src/python/pants/backend/python/subsystems/debugpy.lock
@@ -9,7 +9,8 @@
 //     "CPython<3.11,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "debugpy==1.6.0"
+//     "debugpy==1.6.0",
+//     "importlib_metadata==1.4.0"
 //   ]
 // }
 // --- END PANTS LOCKFILE METADATA ---
@@ -80,16 +81,76 @@
           "requires_dists": [],
           "requires_python": ">=3.7",
           "version": "1.6"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
+              "url": "https://files.pythonhosted.org/packages/d7/31/74dcb59a601b95fce3b0334e8fc9db758f78e43075f22aeb3677dfb19f4c/importlib_metadata-1.4.0-py2.py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8",
+              "url": "https://files.pythonhosted.org/packages/8c/0e/10e247f40c89ba72b7f2a2104ccf1b65de18f79562ffe11bfb837b711acf/importlib_metadata-1.4.0.tar.gz"
+            }
+          ],
+          "project_name": "importlib-metadata",
+          "requires_dists": [
+            "configparser>=3.5; python_version < \"3\"",
+            "contextlib2; python_version < \"3\"",
+            "importlib-resources; python_version < \"3.7\" and extra == \"testing\"",
+            "packaging; extra == \"testing\"",
+            "pathlib2; python_version < \"3\"",
+            "rst.linker; extra == \"docs\"",
+            "sphinx; extra == \"docs\"",
+            "zipp>=0.5"
+          ],
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
+          "version": "1.4"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
+              "url": "https://files.pythonhosted.org/packages/f0/36/639d6742bcc3ffdce8b85c31d79fcfae7bb04b95f0e5c4c6f8b206a038cc/zipp-3.8.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
+              "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz"
+            }
+          ],
+          "project_name": "zipp",
+          "requires_dists": [
+            "func-timeout; extra == \"testing\"",
+            "jaraco.itertools; extra == \"testing\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx; extra == \"docs\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.8.1"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.99",
   "prefer_older_binary": false,
   "requirements": [
-    "debugpy==1.6.0"
+    "debugpy==1.6.0",
+    "importlib_metadata==1.4.0"
   ],
   "requires_python": [
     "<3.11,>=3.7"


### PR DESCRIPTION
At the very least this should fix the `No module named 'pex'` issue in #16099.

[ci skip-rust]
[ci skip-build-wheels]