### PR TITLE
Allow using `--import` option with Autoflake (Cherry-pick of #16192)

### DIFF
--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -47,7 +47,6 @@ async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtR
             autoflake_pex,
             argv=(
                 "--in-place",
-                "--remove-all-unused-imports",
                 *autoflake.args,
                 *request.snapshot.files,
             ),

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -33,7 +33,13 @@ class Autoflake(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("fmt", "lint")
-    args = ArgsListOption(example="--target-version=py37 --quiet")
+    args = ArgsListOption(
+        example="--remove-all-unused-imports --target-version=py37 --quiet",
+        # This argument was previously hardcoded. Moved it a default argument
+        # to allow it to be overridden while maintaining the existing api.
+        # See: https://github.com/pantsbuild/pants/issues/16193
+        default=["--remove-all-unused-imports"],
+    )
     export = ExportToolOption()
 
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -209,7 +209,7 @@ class _ListOptionBase(
         cls,
         flag_name: str,
         *,
-        default: _MaybeDynamicT[list[_ListMemberT]] = [],
+        default: _MaybeDynamicT[list[_ListMemberT]] | None = [],
         help: _HelpT,
         # Additional bells/whistles
         register_if: _RegisterIfFuncT | None = None,
@@ -784,6 +784,7 @@ class ArgsListOption(ShellStrListOption):
         # instead of having to provide "--[scope]-args='--arg1 --arg2'".
         passthrough: bool | None = None,
         flag_name: str = "--args",
+        default: _MaybeDynamicT[list[_ListMemberT]] | None = None,
     ):
         if extra_help:
             extra_help = "\n\n" + extra_help
@@ -798,6 +799,7 @@ class ArgsListOption(ShellStrListOption):
                     """
                 )
             ),
+            default=default,  # type: ignore[arg-type]
         )
         if passthrough is not None:
             instance._extra_kwargs["passthrough"] = passthrough


### PR DESCRIPTION
The linter is currently hardcoded to do "--remove-all-unused-imports", which
unfortunately does not work for all repos since imports can have side effects.
With this removed a user can still provide the argument if they desire it, but
it is possible to run without it.

[ci skip-build-wheels]
[ci skip-rust]
