### PR TITLE
Improve mypy runs by adding the "incremental" mypy cache

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -107,13 +107,11 @@ async def generate_python_from_protobuf(
         )
 
         if request.protocol_target.get(ProtobufGrpcToggleField).value:
-            mypy_info = await Get(PexResolveInfo, VenvPex, mypy_pex)
+            mypy_pex_info = await Get(PexResolveInfo, VenvPex, mypy_pex)
 
             # In order to generate stubs for gRPC code, we need mypy-protobuf 2.0 or above.
-            if any(
-                dist_info.project_name == "mypy-protobuf" and dist_info.version.major >= 2
-                for dist_info in mypy_info
-            ):
+            mypy_protobuf_info = mypy_pex_info.find("mypy-protobuf")
+            if mypy_protobuf_info and mypy_protobuf_info.version.major >= 2:
                 # TODO: Use `pex_path` once VenvPex stores a Pex field.
                 mypy_pex = await Get(
                     VenvPex,

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -74,11 +74,9 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
     # Isort 5+ changes how config files are handled. Determine which semantics we should use.
     is_isort5 = False
     if isort.config:
-        isort_info = await Get(PexResolveInfo, VenvPex, isort_pex)
-        is_isort5 = any(
-            dist_info.project_name == "isort" and dist_info.version.major >= 5
-            for dist_info in isort_info
-        )
+        isort_pex_info = await Get(PexResolveInfo, VenvPex, isort_pex)
+        isort_info = isort_pex_info.find("isort")
+        is_isort5 = isort_info is not None and isort_info.version.major >= 5
 
     input_digest = await Get(
         Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -11,7 +11,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Iterable, Iterator, Mapping
+from typing import Iterable, Iterator, Mapping, TypeVar
 
 import packaging.specifiers
 import packaging.version
@@ -1037,9 +1037,21 @@ class PexDistributionInfo:
     requires_dists: tuple[Requirement, ...]
 
 
+DefaultT = TypeVar("DefaultT")
+
+
 class PexResolveInfo(Collection[PexDistributionInfo]):
     """Information about all distributions resolved in a PEX file, as reported by `PEX_TOOLS=1
     repository info -v`."""
+
+    def find(
+        self, name: str, default: DefaultT | None = None
+    ) -> PexDistributionInfo | DefaultT | None:
+        """Returns the PexDistributionInfo with the given name, first one wins."""
+        try:
+            return next(info for info in self if info.project_name == name)
+        except StopIteration:
+            return default
 
 
 def parse_repository_info(repository_info: str) -> PexResolveInfo:


### PR DESCRIPTION
Leverages mypy's cache to allow for "incremental" runs. The cache is an `append_only_cache` which is a bit disingenuous here, but AFAICT mypy is process-safe w.r.t. the cache (I'll do more digging to be very sure).

Fixes #10864

[ci skip-rust]
[ci skip-build-wheels]