### PR TITLE
Enable `[python-infer].unowned_dependency_behavior="warning"` by default.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -180,7 +180,7 @@ class PythonInferSubsystem(Subsystem):
         ),
     )
     unowned_dependency_behavior = EnumOption(
-        default=UnownedDependencyUsage.DoNothing,
+        default=UnownedDependencyUsage.LogWarning,
         help=softwrap(
             """
             How to handle imports that don't have an inferrable owner.

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -95,7 +95,10 @@ def test_infer_python_imports(caplog) -> None:
     def run_dep_inference(
         address: Address, *, enable_string_imports: bool = False
     ) -> InferredDependencies:
-        args = ["--source-root-patterns=src/python"]
+        args = [
+            "--source-root-patterns=src/python",
+            "--python-infer-unowned-dependency-behavior=ignore",
+        ]
         if enable_string_imports:
             args.append("--python-infer-string-imports")
         rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})


### PR DESCRIPTION
Rough consensus was reached on #15326 and #14975 that enabling `unowned_dependency_behavior="warning"` by default would:
1. be helpful for new users, to guide them through fixing their missing dependencies
2. be useful in the case of adding additional resolves (due to the work done in #15326 to enrich the warning for that case)
3. reduce the chances of CI errors in #14975 (when users go a step further to make the warning an error)

`2.14.x` is a relatively quiet release so far, so it seems like there is room in the budget for a new warning like this.

The rendered message for this warning is very self-explanatory due to @thejcannon's original work, and @Eric-Arellano's followup work in #15326, so I don't see any obvious documentation changes that need to be made.

[ci skip-build-wheels]
[ci skip-rust]