### PR TITLE
consume inits part of package object within the inner scope

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -577,3 +577,19 @@ def test_object_extends_ctor(rule_runner: RuleRunner) -> None:
         "foo.Bar",
         "foo.hello",
     ]
+
+
+def test_package_object_extends_trait(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            package object bar extends Trait {
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == ["foo.Trait", "foo.bar.Trait"]


### PR DESCRIPTION
package objects `inits` (the constructor + any extends)` should be in the scope of the package object vs other scala templates (class, object) that are in the package scope.

This PR fixes that, by calling the apply on the inits within the package object scope.

fixes #16259