### PR TITLE
Fix GCF Handler documentation.

### DIFF
--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -88,4 +88,4 @@ Step 4: Upload to Google Cloud
 
 You can use any of the various Google Cloud methods to upload your zip file, such as the Google Cloud console or the [Google Cloud CLI](https://cloud.google.com/functions/docs/deploying/filesystem#deploy_using_the_gcloud_tool).
 
-You must specify the handler as `main.handler`.
+You must specify the handler as `handler`.

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -74,7 +74,7 @@ For example:
 $ ./pants package project/google_cloud_function_example.py
 Wrote code bundle to dist/project.zip
   Runtime: python3.8
-  Handler: main.handler
+  Handler: handler
 ```
 
 > 🚧 Running from macOS and failing to build?

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -103,7 +103,7 @@ def complete_platform(rule_runner: RuleRunner) -> bytes:
         {
             "pex_exe/BUILD": dedent(
                 """\
-                python_requirement(name="req", requirements=["pex==2.1.66"])
+                python_requirement(name="req", requirements=["pex==2.1.99"])
                 pex_binary(dependencies=[":req"], script="pex")
                 """
             ),
@@ -162,7 +162,7 @@ def test_create_hello_world_lambda(
         expected_extra_log_lines=(
             "              Runtime: python37",
             "    Complete platform: src/python/foo/bar/platform.json",
-            "              Handler: main.handler",
+            "              Handler: handler",
         ),
         extra_args=[f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']"],
     )
@@ -225,7 +225,7 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
         Address("src/py/project", target_name="lambda"),
         expected_extra_log_lines=(
             "    Runtime: python37",
-            "    Handler: main.handler",
+            "    Handler: handler",
         ),
     )
     assert caplog.records


### PR DESCRIPTION
We were providing incorrect advice for setting the handler function name
when deploying a GCF Lambdex. Correct our incorrect documentation and
misleading logging and expand a code comment to cover what's going on
here.

Fixes #16242

[ci skip-rust]
[ci skip-build-wheels]