### PR TITLE
Upgrade Pex to 2.1.100.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.99
+pex==2.1.100
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -20,7 +20,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.99",
+//     "pex==2.1.100",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -832,13 +832,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b9e7a1070c4f616b9114e10475e9c49f3ff9332789e581edf4b5646ae477d0b1",
-              "url": "https://files.pythonhosted.org/packages/cf/44/b4bddb5599370e86a8366e21fb6b2bb2a703e0d0d7a594e20d70f7082940/pex-2.1.99-py2.py3-none-any.whl"
+              "hash": "0b96e0d3071165b2170591726343d3af36254152f1cad86657c9af41ac1204b2",
+              "url": "https://files.pythonhosted.org/packages/3a/7a/3f00ca003568d4650005e3f074dd14fa75b65accbbfb55bebbe3dd3f095b/pex-2.1.100-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3feaf424e495c0855691044ebec6e9528730078c741eb572cbda18f4274d8fab",
-              "url": "https://files.pythonhosted.org/packages/f8/76/7e17f82344dd14a5a9cf76391cdf6edeede0e409432a319db98512d11375/pex-2.1.99.tar.gz"
+              "hash": "0846283f9e70fd9abb448d6ef2c6d8f6f8ea0e34fd8d22330eea1120c9b195f6",
+              "url": "https://files.pythonhosted.org/packages/75/40/aa3dc196b77f33a9954f1527334dd2dc928201898840d8089ec586bc0364/pex-2.1.100.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -846,7 +846,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.99"
+          "version": "2.1.100"
         },
         {
           "artifacts": [
@@ -2251,7 +2251,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.99",
+  "pex_version": "2.1.100",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2265,7 +2265,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.99",
+    "pex==2.1.100",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b9e7a1070c4f616b9114e10475e9c49f3ff9332789e581edf4b5646ae477d0b1",
-              "url": "https://files.pythonhosted.org/packages/cf/44/b4bddb5599370e86a8366e21fb6b2bb2a703e0d0d7a594e20d70f7082940/pex-2.1.99-py2.py3-none-any.whl"
+              "hash": "0b96e0d3071165b2170591726343d3af36254152f1cad86657c9af41ac1204b2",
+              "url": "https://files.pythonhosted.org/packages/3a/7a/3f00ca003568d4650005e3f074dd14fa75b65accbbfb55bebbe3dd3f095b/pex-2.1.100-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3feaf424e495c0855691044ebec6e9528730078c741eb572cbda18f4274d8fab",
-              "url": "https://files.pythonhosted.org/packages/f8/76/7e17f82344dd14a5a9cf76391cdf6edeede0e409432a319db98512d11375/pex-2.1.99.tar.gz"
+              "hash": "0846283f9e70fd9abb448d6ef2c6d8f6f8ea0e34fd8d22330eea1120c9b195f6",
+              "url": "https://files.pythonhosted.org/packages/75/40/aa3dc196b77f33a9954f1527334dd2dc928201898840d8089ec586bc0364/pex-2.1.100.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,14 +63,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.99"
+          "version": "2.1.100"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.99",
+  "pex_version": "2.1.100",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.99"
+    default_version = "v2.1.100"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.99,<3.0"
+    version_constraints = ">=2.1.100,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "7e00a1d81a43fb913085182b2eba2f3b61822dd99fe1ddd0931aa824959a759f",
-                    "3811337",
+                    "4f78d62c32f1e76e0e95375c3e39a6af8dc628bb8269eb79ab8b226d44209282",
+                    "3813144",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This pulls in a fix for creating locks with transitive dependencies
using the `os_name` environment marker to select for Windows (e.g.:
`; os_name == "nt"`).

See the changelog here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.100

[ci skip-rust]
[ci skip-build-wheels]