### PR TITLE
Fix the experimental_run_shell_command example.

### DIFF
--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -21,6 +21,6 @@ files(name="sources_directory", sources=["sources/**/*"])
 
 experimental_run_shell_command(
     name="cmd",
-    command='{{ tree {chroot}; echo "in: $CHROOT"; }} | tee output.log',
+    command='{ find {chroot} -type f; echo "in: $CHROOT"; } | tee output.log',
     dependencies=[":hello_directory"],
 )


### PR DESCRIPTION
1) The double-braces are incorrect, should be single braces
   (perhaps this used to be used as input for interplation?)
2) Use `find` instead of `tree` as many systems do not have the
   latter by default.

Note that`testprojects/` is intended to be a home for inputs to
integration tests.  So possibly we should either write a test that
uses this example, or remove it.

[ci skip-rust]

[ci skip-build-wheels]