### PR TITLE
Leverage a multiprocess-safe strategy for MyPy's cache

### DIFF
--- a/docs/markdown/Python/python-goals/python-check-goal.md
+++ b/docs/markdown/Python/python-goals/python-check-goal.md
@@ -253,8 +253,11 @@ Known limitations
 ### Performance is sometimes slower than normal
 
 Pants 2.14 added support for leveraging MyPy's cache, making subsequent runs of MyPy extremely performant.
-The support, however, requires features that were added to MyPy in version `0.700`. If you're using a version
-of MyPy older than `0.700`, consider upgrading to unlock super-speedy subsequent runs of MyPy.
+The support, however, requires features that were added to MyPy in version `0.700`, and requires that
+`python_version` isn't set in MyPy's config or in `[mypy].args`.
+
+If you're using a version of MyPy older than `0.700`, consider upgrading to unlock super-speedy subsequent runs of MyPy.
+Additionally consider not providing `python_version` in your config or args.
 
 
 Tip: only run over changed files and their dependees

--- a/docs/markdown/Python/python-goals/python-check-goal.md
+++ b/docs/markdown/Python/python-goals/python-check-goal.md
@@ -9,7 +9,7 @@ updatedAt: "2022-02-09T00:27:23.086Z"
 Activating MyPy
 ---------------
 
-To opt-in, add `pants.backend.python.typecheck.mypy` to `backend_packages` in your config file. 
+To opt-in, add `pants.backend.python.typecheck.mypy` to `backend_packages` in your config file.
 
 ```toml pants.toml
 [GLOBAL]
@@ -27,11 +27,11 @@ $ ./pants check ::
 ```
 
 > 👍 Benefit of Pants: typecheck Python 2-only and Python 3-only code at the same time
-> 
+>
 > MyPy determines which Python version to use based on its `python_version` option. If that's undefined, MyPy uses the interpreter the tool is run with. Because you can only use one config file at a time with MyPy, you cannot normally say to use `2.7` for part of your codebase but `3.6` for the rest; you must choose a single version.
-> 
+>
 > Instead, Pants will group your targets based on their [interpreter constraints](doc:python-interpreter-compatibility), and run all the Python 2 targets together and all the Python 3 targets together. It will automatically set `python_version` to the minimum compatible interpreter, such as a constraint like `["==2.7.*", ">3.6"]` using `2.7`.
-> 
+>
 > To turn this off, you can still set `python_version` in `mypy.ini` or `--python-version`/`--py2` in `--mypy-args`; Pants will respect the value you set.
 
 ### Hook up a MyPy config file
@@ -80,9 +80,9 @@ python_sources(
 When you run `./pants check ::`, Pants will skip any files belonging to skipped targets.
 
 > 🚧 MyPy may still try to check the skipped files!
-> 
-> The `skip_mypy` field only tells Pants not to provide the skipped files as direct input to MyPy. But MyPy, by default, will still try to check files that are [dependencies of the direct inputs](https://mypy.readthedocs.io/en/stable/running_mypy.html#following-imports).  So if your skipped files are dependencies of unskipped files, they may still be checked. 
-> 
+>
+> The `skip_mypy` field only tells Pants not to provide the skipped files as direct input to MyPy. But MyPy, by default, will still try to check files that are [dependencies of the direct inputs](https://mypy.readthedocs.io/en/stable/running_mypy.html#following-imports).  So if your skipped files are dependencies of unskipped files, they may still be checked.
+>
 > To change this behavior, use MyPy's [`--follow-imports` option](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-follow-imports), typically by setting it to `silent`. You can do so either by adding it to the [`args` option](https://www.pantsbuild.org/docs/reference-mypy#section-args) in the `[mypy]` section of your Pants config file, or by setting it in [`mypy.ini`](https://mypy.readthedocs.io/en/stable/config_file.html).
 
 ### First-party type stubs (`.pyi` files)
@@ -98,7 +98,7 @@ When writing stubs for third-party libraries, you may need the set up the `[sour
 root_patterns = ["mypy-stubs", "src/python"]
 ```
 ```python mypy-stubs/colors.pyi
-# Because we set `mypy-stubs` as a source root, this file will be 
+# Because we set `mypy-stubs` as a source root, this file will be
 # stripped to be simply `colors.pyi`. MyPy will look at this file for
 # imports of the `colors` module.
 
@@ -182,7 +182,7 @@ python_source(name="django_settings", source="django_settings.py")
 ```
 
 > 📘 MyPy Protobuf support
-> 
+>
 > Add `mypy_plugin = true` to the `[python-protobuf]` scope. See [Protobuf](doc:protobuf-python) for more information.
 
 ### Add a first-party plugin
@@ -207,7 +207,7 @@ plugins =
 python_source(name="plugin", source="change_return_type.py")
 ```
 ```python pants-plugins/mypy_plugins/change_return_type.py
-"""A contrived plugin that changes the return type of any 
+"""A contrived plugin that changes the return type of any
 function ending in `__overriden_by_plugin` to return None."""
 
 from typing import Callable, Optional, Type
@@ -236,7 +236,7 @@ Because this is a `python_source` or `python_sources` target, Pants will treat t
 
 ### Reports
 
-MyPy can generate [various report files](https://mypy.readthedocs.io/en/stable/command_line.html#report-generation). 
+MyPy can generate [various report files](https://mypy.readthedocs.io/en/stable/command_line.html#report-generation).
 
 For Pants to properly preserve the reports, instruct MyPy to write to the `reports/` folder by updating its config file or `--mypy-args`. For example, in your pants.toml:
 
@@ -250,11 +250,12 @@ Pants will copy all reports into the folder `dist/check/mypy`.
 Known limitations
 -----------------
 
-### Performance is often slower than normal
+### Performance is sometimes slower than normal
 
-Pants does not yet leverage MyPy's caching mechanism and daemon, so a typical run with Pants will likely be slower than using MyPy directly.
+Pants 2.14 added support for leveraging MyPy's cache, making subsequent runs of MyPy extremely performant.
+The support, however, requires features that were added to MyPy in version `0.700`. If you're using a version
+of MyPy older than `0.700`, consider upgrading to unlock super-speedy subsequent runs of MyPy.
 
-We are [working to figure out](https://github.com/pantsbuild/pants/issues/10864) how to leverage MyPy's cache in a way that is safe and allows for things like remote execution.
 
 Tip: only run over changed files and their dependees
 ----------------------------------------------------

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -263,7 +263,7 @@ async def mypy_typecheck_partition(
                             # Pants exposes "append_only_caches" we can leverage, but with the caveat
                             # that it requires either only appending files, or multiprocess-safe access.
                             #
-                            # MyPy guaruntees neither, but there's workarounds!
+                            # MyPy guarantees neither, but there's workarounds!
                             #
                             # By default, MyPy uses 2 cache files per source file, which introduces a
                             # whole slew of race conditions. We can mimize the race conditions by

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -272,6 +272,11 @@ async def mypy_typecheck_partition(
                             # as mv on the same filesystem is an atomic "rename", and any processes
                             # copying the "old" file will still have valid file descriptors for the
                             # "old" file.
+                            #
+                            # (MyPy uses the cache as a drop-in replacement for the dual-files solution,
+                            # and therefore uses two DB rows per source file and issues a different
+                            # query for each row. Therefore SQLite's own safety still doesn't protect
+                            # us from race-conditions between the two queries).
 
                             {mkdir.path} -p {run_cache_dir}/{py_version} 2>&1 > /dev/null
                             {cp.path} {named_cache_dir}/{py_version}/cache.db {run_cache_dir}/{py_version}/cache.db 2>&1 > /dev/null || true

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -266,7 +266,7 @@ async def mypy_typecheck_partition(
                             # MyPy guarantees neither, but there's workarounds!
                             #
                             # By default, MyPy uses 2 cache files per source file, which introduces a
-                            # whole slew of race conditions. We can mimize the race conditions by
+                            # whole slew of race conditions. We can minimize the race conditions by
                             # using MyPy's SQLite cache. MyPy still has race conditions when using the
                             # db, as it issues at least 2 single-row queries per source file at different
                             # points in time (therefore SQLite's own safety guarantees don't apply).

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -47,7 +47,7 @@ from pants.engine.target import CoarsenedTargets, FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
-from pants.util.strutil import pluralize
+from pants.util.strutil import pluralize, shell_quote
 
 
 @dataclass(frozen=True)
@@ -293,7 +293,7 @@ async def mypy_typecheck_partition(
 
                             {mkdir.path} -p {run_cache_dir}/{py_version} 2>&1 > /dev/null
                             {cp.path} {named_cache_dir}/{py_version}/cache.db {run_cache_dir}/{py_version}/cache.db 2>&1 > /dev/null || true
-                            {' '.join(argv)}
+                            {' '.join((shell_quote(arg) for arg in argv))}
                             EXIT_CODE=$?
                             {mv.path} {run_cache_dir}/{py_version}/cache.db {named_cache_dir}/{py_version}/cache.db 2>&1 > /dev/null || true
                             exit $EXIT_CODE

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -200,9 +200,11 @@ class MyPy(PythonToolBase):
                     ({doc_url('python-interpreter-compatibility')}). Instead, it will
                     use what you set.
 
-                    (Automatically setting the option allows Pants to partition your targets by their
-                    constraints, so that, for example, you can run MyPy on Python 2-only code and
-                    Python 3-only code at the same time. This feature may no longer work.)
+                    (Allowing Pants to automatically set the option allows Pants to partition your
+                    targets by their constraints, so that, for example, you can run MyPy on
+                    Python 2-only code and Python 3-only code at the same time. It also allows Pants
+                    to leverage MyPy's cache, making subsequent runs of MyPy very fast.
+                    In the future, this feature may no longer work.)
                     """
                 )
             )

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -326,6 +326,14 @@ class MkdirBinary(BinaryPath):
     pass
 
 
+class CpBinary(BinaryPath):
+    pass
+
+
+class MvBinary(BinaryPath):
+    pass
+
+
 class ChmodBinary(BinaryPath):
     pass
 
@@ -685,6 +693,22 @@ async def find_mkdir() -> MkdirBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path_or_raise(request, rationale="create directories")
     return MkdirBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `cp` binary", level=LogLevel.DEBUG)
+async def find_cp() -> CpBinary:
+    request = BinaryPathRequest(binary_name="cp", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="copy files")
+    return CpBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `mv` binary", level=LogLevel.DEBUG)
+async def find_mv() -> MvBinary:
+    request = BinaryPathRequest(binary_name="mv", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="move files")
+    return MvBinary(first_path.path, first_path.fingerprint)
 
 
 @rule(desc="Finding the `chmod` binary", level=LogLevel.DEBUG)


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/16276 added support for using MyPy's cache combined with `append_only_caches`. After investigation, however, it was found to be grossly unsafe for multiple processes.

This PR fixes that by shifting the multiprocess safety into Pants' support. To do that we:
- Leverage MyPy's SQLite file cache. This means we only need to make a single file "safe".
- To make the file access "safe", we `cp` it to a temporary location and use that for the run. Then we `mv` the updated file back. This is "safe" because `mv` is an atomic `rename` (on the same filesystem) which doesn't invalidate existing file descriptors (to the old file). Each concurrent `cp` command should continue to operate on the "old" file, while and future ones will be given the new file. 

I also updated docs.

[ci skip-rust]
[ci skip-build-wheels]