### PR TITLE
Don't break builds when pants.log upload fails

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -113,7 +113,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -255,7 +256,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -386,7 +388,8 @@ jobs:
         arch -arm64 ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -490,7 +493,8 @@ jobs:
         ./pants lint check ''**''
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -578,7 +582,8 @@ jobs:
       run: './pants test --shard=0/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -666,7 +671,8 @@ jobs:
       run: './pants test --shard=1/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -754,7 +760,8 @@ jobs:
       run: './pants test --shard=2/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -826,7 +833,8 @@ jobs:
         '
     - name: Run Python tests
       run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior'
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,7 +117,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -262,7 +263,8 @@ jobs:
         ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -360,7 +362,8 @@ jobs:
       if: github.event_name == 'push'
       name: Build fs_util
       run: ./build-support/bin/release.sh build-fs-util
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -482,7 +485,8 @@ jobs:
         arch -arm64 ./pants help subsystems
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -605,7 +609,8 @@ jobs:
       if: github.event_name == 'push'
       name: Build fs_util
       run: ./build-support/bin/release.sh build-fs-util
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -715,7 +720,8 @@ jobs:
         ./pants lint check ''**''
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -856,7 +862,8 @@ jobs:
       run: './pants test --shard=0/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -947,7 +954,8 @@ jobs:
       run: './pants test --shard=1/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -1038,7 +1046,8 @@ jobs:
       run: './pants test --shard=2/3 ::
 
         '
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
@@ -1113,7 +1122,8 @@ jobs:
         '
     - name: Run Python tests
       run: './pants --tag=+platform_specific_behavior test :: -- -m platform_specific_behavior'
-    - if: always()
+    - continue-on-error: true
+      if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -482,6 +482,7 @@ class Helper:
             "name": "Upload pants.log",
             "uses": "actions/upload-artifact@v3",
             "if": "always()",
+            "continue-on-error": True,
             "with": {
                 "name": f"pants-log-{name.replace('/', '_')}-{self.platform_name()}",
                 "path": ".pants.d/pants.log",


### PR DESCRIPTION
see: https://github.com/pantsbuild/pants/runs/7505701931?check_suite_focus=true#step:13:79
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error
![Screen Shot 2022-07-25 at 3 04 52 PM](https://user-images.githubusercontent.com/1268088/180854608-169dfccd-ad5d-4f22-a8b4-e0a11d874f33.png)



feel free to close if you think this is not a good idea.