### PR TITLE
Explicitly add directory entries to resources JARs  (Cherry-pick of #16264)

### DIFF
--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -3,6 +3,7 @@
 import itertools
 import logging
 from itertools import chain
+from pathlib import Path
 
 from pants.core.target_types import ResourcesFieldSet, ResourcesGeneratorFieldSet
 from pants.core.util_rules import stripped_source_files
@@ -71,6 +72,13 @@ async def assemble_resources_jar(
     output_filename = f"{request.component.representative.address.path_safe_spec}.resources.jar"
     output_files = [output_filename]
 
+    # #16231: Valid JAR files need the directories of each resource file as well as the files
+    # themselves.
+
+    paths = {Path(filename) for filename in source_files.snapshot.files}
+    directories = {parent for path in paths for parent in path.parents}
+    input_files = {str(path) for path in chain(paths, directories)}
+
     resources_jar_input_digest = source_files.snapshot.digest
     resources_jar_result = await Get(
         ProcessResult,
@@ -78,7 +86,7 @@ async def assemble_resources_jar(
             argv=[
                 zip.path,
                 output_filename,
-                *source_files.snapshot.files,
+                *sorted(input_files),
             ],
             description="Build partial JAR containing resources files",
             input_digest=resources_jar_input_digest,

--- a/src/python/pants/jvm/resources_test.py
+++ b/src/python/pants/jvm/resources_test.py
@@ -3,13 +3,20 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+from zipfile import ZipFile
+
 import pytest
 
 from pants.build_graph.address import Address
 from pants.core.target_types import ResourcesGeneratorTarget, ResourceTarget
 from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.addresses import Addresses
-from pants.jvm import classpath, resources, testutil
+from pants.engine.fs import DigestContents, FileContent
+from pants.engine.internals.native_engine import Digest
+from pants.jvm import resources, testutil
+from pants.jvm.classpath import Classpath
+from pants.jvm.classpath import rules as classpath_rules
 from pants.jvm.goals import lockfile
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
@@ -29,10 +36,12 @@ def rule_runner() -> RuleRunner:
             *coursier_fetch_rules(),
             *lockfile.rules(),
             *resources.rules(),
-            *classpath.rules(),
+            *classpath_rules(),
             *util_rules(),
             *testutil.rules(),
+            QueryRule(Classpath, (Addresses,)),
             QueryRule(RenderedClasspath, (Addresses,)),
+            QueryRule(DigestContents, (Digest,)),
         ],
         target_types=[
             ResourcesGeneratorTarget,
@@ -43,36 +52,53 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
+def filenames_from_zip(file_content: FileContent) -> list[str]:
+    z = ZipFile(BytesIO(file_content.content))
+    files = z.filelist
+    return [file_.filename for file_ in files]
+
+
 @maybe_skip_jdk_test
 def test_resources(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "BUILD": "resources(name='root', sources=['*.txt'])",
+            "BUILD": "resources(name='root', sources=['**/*.txt'])",
             "one.txt": "",
             "two.txt": "",
+            "three/four.txt": "",
+            "three/five.txt": "",
+            "three/six/seven/eight.txt": "",
             "3rdparty/jvm/default.lock": EMPTY_LOCKFILE,
         }
     )
 
     # Building the generator target should exclude the individual files and result in a single jar
     # for the generator.
-    rendered_classpath = rule_runner.request(
-        RenderedClasspath, [Addresses([Address(spec_path="", target_name="root")])]
+    classpath = rule_runner.request(
+        Classpath, [Addresses([Address(spec_path="", target_name="root")])]
     )
-    assert rendered_classpath.content == {
-        ".root.resources.jar": {
-            "one.txt",
-            "two.txt",
-        }
+
+    contents = rule_runner.request(DigestContents, list(classpath.digests()))
+    assert contents[0].path == ".root.resources.jar"
+    resources_filenames = set(filenames_from_zip(contents[0]))
+    expected = {
+        "one.txt",
+        "two.txt",
+        "three/",
+        "three/four.txt",
+        "three/five.txt",
+        "three/six/",
+        "three/six/seven/",
+        "three/six/seven/eight.txt",
     }
 
+    assert resources_filenames == expected
+
     # But requesting a single file should individually package it.
-    rendered_classpath = rule_runner.request(
-        RenderedClasspath,
+    classpath = rule_runner.request(
+        Classpath,
         [Addresses([Address(spec_path="", target_name="root", relative_file_path="one.txt")])],
     )
-    assert rendered_classpath.content == {
-        ".one.txt.root.resources.jar": {
-            "one.txt",
-        }
-    }
+    contents = rule_runner.request(DigestContents, list(classpath.digests()))
+    assert contents[0].path == ".one.txt.root.resources.jar"
+    assert filenames_from_zip(contents[0]) == ["one.txt"]


### PR DESCRIPTION
Per @somdoron's discovery, resources JARs need directory entries in order to work correctly at runtime. This adds an entry for every directory that corresponds to a file in the set of resource files. Also includes a unit test that verifies that the directory entries are present.

Closes #16231.
