### PR TITLE
Explicitly add directory entries to resources JARs  (Cherry-pick of #16264)

### DIFF
--- a/src/python/pants/jvm/resources_test.py
+++ b/src/python/pants/jvm/resources_test.py
@@ -65,6 +65,9 @@ def test_resources(rule_runner: RuleRunner) -> None:
             "BUILD": "resources(name='root', sources=['**/*.txt'])",
             "one.txt": "",
             "two.txt": "",
+            "three/four.txt": "",
+            "three/five.txt": "",
+            "three/six/seven/eight.txt": "",
             "3rdparty/jvm/default.lock": EMPTY_LOCKFILE,
         }
     )


### PR DESCRIPTION
Per @somdoron's discovery, resources JARs need directory entries in order to work correctly at runtime. This adds an entry for every directory that corresponds to a file in the set of resource files. Also includes a unit test that verifies that the directory entries are present.

Closes #16231.
