### PR TITLE
[internal] Add missing timeout field to target generators

### DIFF
--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -279,8 +279,8 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
         HelmUnitTestTimeoutField,
     )
     generated_target_cls = HelmUnitTestTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, HelmUnitTestTimeoutField, HelmUnitTestStrictField)
-    moved_fields = (HelmUnitTestDependenciesField,)
+    copied_fields = (*COMMON_TARGET_FIELDS, HelmUnitTestStrictField)
+    moved_fields = (HelmUnitTestDependenciesField, HelmUnitTestTimeoutField)
     help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field."
 
 

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -80,10 +80,7 @@ class JavaTestsGeneratorSourcesField(JavaGeneratorSourcesField):
 
 class JunitTestsGeneratorTarget(TargetFilesGenerator):
     alias = "junit_tests"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        JavaTestsGeneratorSourcesField,
-    )
+    core_fields = (*COMMON_TARGET_FIELDS, JavaTestsGeneratorSourcesField, JunitTestTimeoutField)
     generated_target_cls = JunitTestTarget
     copied_fields = (*COMMON_TARGET_FIELDS, JunitTestTimeoutField)
     moved_fields = (

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -82,8 +82,9 @@ class JunitTestsGeneratorTarget(TargetFilesGenerator):
     alias = "junit_tests"
     core_fields = (*COMMON_TARGET_FIELDS, JavaTestsGeneratorSourcesField, JunitTestTimeoutField)
     generated_target_cls = JunitTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, JunitTestTimeoutField)
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
+        JunitTestTimeoutField,
         JvmDependenciesField,
         JvmJdkField,
         JvmProvidesTypesField,

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -156,6 +156,7 @@ class KotlinJunitTestsGeneratorTarget(TargetFilesGenerator):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         KotlinJunitTestsGeneratorSourcesField,
+        JunitTestTimeoutField,
     )
     generated_target_cls = KotlinJunitTestTarget
     copied_fields = (*COMMON_TARGET_FIELDS, JunitTestTimeoutField)

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -159,10 +159,11 @@ class KotlinJunitTestsGeneratorTarget(TargetFilesGenerator):
         JunitTestTimeoutField,
     )
     generated_target_cls = KotlinJunitTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, JunitTestTimeoutField)
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
         KotlinJunitTestDependenciesField,
         KotlincConsumedPluginIdsField,
+        JunitTestTimeoutField,
         JvmResolveField,
         JvmJdkField,
         JvmProvidesTypesField,

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -152,6 +152,7 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ScalatestTestsGeneratorSourcesField,
         ScalatestTestsSourcesOverridesField,
+        ScalatestTestTimeoutField,
     )
     generated_target_cls = ScalatestTestTarget
     copied_fields = (*COMMON_TARGET_FIELDS, ScalatestTestTimeoutField)

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -155,10 +155,11 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
         ScalatestTestTimeoutField,
     )
     generated_target_cls = ScalatestTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, ScalatestTestTimeoutField)
+    copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
         ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
+        ScalatestTestTimeoutField,
         JvmJdkField,
         JvmProvidesTypesField,
         JvmResolveField,


### PR DESCRIPTION
The PR #16126 was missing adding the test timeout fields to the `core_fields` class var in the target generators.