### PR TITLE
Remove advanced flags from python-repos subsystems

### DIFF
--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -29,7 +29,6 @@ class PythonRepos(Subsystem):
             corresponds to the `--find-links` option.
             """
         ),
-        advanced=True,
     )
     indexes = StrListOption(
         default=[pypi_index],
@@ -40,7 +39,6 @@ class PythonRepos(Subsystem):
             should be compliant with PEP 503.
             """
         ),
-        advanced=True,
     )
 
     @property


### PR DESCRIPTION
Currently, if you try to get help for this subsystem, `./pants help python-repos` you will get nothing useful and the user needs to repeat the command with the help-advanced directive (happened to me right now).
My thinking is: It is somewhat pointless to have a subsystem where all the options are advanced, it makes sense if there are multiple options and some are advanced and some or not.
But I don't think we should allow options scopes that only have advanced options since it a little confusing to users trying to get help about it.

This is just an opinion, feel free to close this PR.