### PR TITLE
Upgrade Pex to 2.1.102. (Cherry-pick of #16313)

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -154,9 +154,9 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: github.repository_owner == 'pantsbuild'
-    name: Bootstrap Pants, test Rust (macOS10-x86_64)
+    name: Bootstrap Pants, test Rust (macOS11-x86_64)
     runs-on:
-    - macos-10.15
+    - macos-11
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -194,7 +194,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
         path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
@@ -205,7 +205,7 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
+        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
           }-v1
 
           '
@@ -214,7 +214,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
 
           '
     - id: get-engine-hash
@@ -226,7 +226,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS10-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
 
           '
         path: '.pants
@@ -259,12 +259,12 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-macOS10-x86_64
+        name: pants-log-bootstrap-macOS11-x86_64
         path: .pants.d/pants.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS10-x86_64
+        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -770,10 +770,10 @@ jobs:
     env:
       ARCHFLAGS: -arch x86_64
     if: github.repository_owner == 'pantsbuild'
-    name: Test Python (macOS10-x86_64)
+    name: Test Python (macOS11-x86_64)
     needs: bootstrap_pants_macos_x86_64
     runs-on:
-    - macos-10.15
+    - macos-11
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -818,7 +818,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS10-x86_64
+        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -830,7 +830,7 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-macOS10-x86_64
+        name: pants-log-python-test-macOS11-x86_64
         path: .pants.d/pants.log
     strategy:
       matrix:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -158,12 +158,12 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
       != 'DOCS_ONLY')
-    name: Bootstrap Pants, test Rust (macOS10-x86_64)
+    name: Bootstrap Pants, test Rust (macOS11-x86_64)
     needs:
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-11
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -201,7 +201,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
         path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
@@ -212,7 +212,7 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
+        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
           }-v1
 
           '
@@ -221,7 +221,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
 
           '
     - id: get-engine-hash
@@ -233,7 +233,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS10-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
 
           '
         path: '.pants
@@ -266,12 +266,12 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-macOS10-x86_64
+        name: pants-log-bootstrap-macOS11-x86_64
         path: .pants.d/pants.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS10-x86_64
+        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -521,12 +521,12 @@ jobs:
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
       != 'DOCS_ONLY')
-    name: Build wheels and fs_util (macOS10-x86_64)
+    name: Build wheels and fs_util (macOS11-x86_64)
     needs:
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-11
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -560,7 +560,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
         path: '~/.rustup/toolchains/1.61.0-*
 
           ~/.rustup/update-hashes
@@ -571,7 +571,7 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
+        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
           }-v1
 
           '
@@ -580,7 +580,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS10-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
 
           '
     - env:
@@ -609,7 +609,7 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-macOS10-x86_64
+        name: pants-log-wheels-macOS11-x86_64
         path: .pants.d/pants.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -1054,13 +1054,13 @@ jobs:
       ARCHFLAGS: -arch x86_64
     if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
       != 'DOCS_ONLY')
-    name: Test Python (macOS10-x86_64)
+    name: Test Python (macOS11-x86_64)
     needs:
     - bootstrap_pants_macos_x86_64
     - check_labels
     - docs_only_check
     runs-on:
-    - macos-10.15
+    - macos-11
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -1105,7 +1105,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS10-x86_64
+        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1117,7 +1117,7 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-macOS10-x86_64
+        name: pants-log-python-test-macOS11-x86_64
         path: .pants.d/pants.log
     strategy:
       matrix:

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.101
+pex==2.1.102
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -19,7 +19,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.101",
+//     "pex==2.1.102",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -783,13 +783,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fa501a025417bd35d07ece39482502501ba3bc2a94be476db33a5452be0da32f",
-              "url": "https://files.pythonhosted.org/packages/77/11/696975448606b1b29ebc877aae43035537cb1ddc2e6a8f85a2ee448ce2e2/pex-2.1.101-py2.py3-none-any.whl"
+              "hash": "3743864e09e1017224c5dc6476463ed24b6fea3ac62d379fedc2c6182b2f2159",
+              "url": "https://files.pythonhosted.org/packages/ef/41/a242ae32220cd2951faedddfed3db85393906497526060954b064f9022b7/pex-2.1.102-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d966f2ac9fbf32c6941a798fa8035f74546a056168ac3ef35fca72131e60e1a9",
-              "url": "https://files.pythonhosted.org/packages/70/ff/5eaeef82710ed8f43bede93e31f1801357e3f06407c99f9a24d72d35cd60/pex-2.1.101.tar.gz"
+              "hash": "fa34cef083bede3ea45413638c24e84698949904ef0559994e734b6d21de363c",
+              "url": "https://files.pythonhosted.org/packages/71/f1/125bbeb76821dfe20fc78eb6ebaf963c67ee3a32cc37c907ae54f743c69e/pex-2.1.102.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -797,7 +797,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.101"
+          "version": "2.1.102"
         },
         {
           "artifacts": [
@@ -1625,19 +1625,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "20588c285e5ca336d908d2705994830a83cfb6bda40fc356bbafaf430a262013",
-              "url": "https://files.pythonhosted.org/packages/04/9f/65ce26fb8b191c91ec7afe3804da305c02331111d8abec7bf706a35b68a5/types_urllib3-1.26.16-py3-none-any.whl"
+              "hash": "0d027fcd27dbb3cb532453b4d977e05bc1e13aefd70519866af211b3003d895d",
+              "url": "https://files.pythonhosted.org/packages/92/6f/37d8bc1572c4e6f1562ed7847f9ce3a48e23bd54ddbaf6786a6adee9f24d/types_urllib3-1.26.17-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8bb3832c684c30cbed40b96e28bc04703becb2b97d82ac65ba4b968783453b0e",
-              "url": "https://files.pythonhosted.org/packages/7f/71/f6078ac156b931e70ab206fc84938697ca1f3a08510a2e08a683ba1b0317/types-urllib3-1.26.16.tar.gz"
+              "hash": "73fd274524c3fc7cd8cd9ceb0cb67ed99b45f9cb2831013e46d50c1451044800",
+              "url": "https://files.pythonhosted.org/packages/ac/2f/79494805b4f9b55b9c09d78c4bef776e6bf59b49463a046cb3851d1dbd60/types-urllib3-1.26.17.tar.gz"
             }
           ],
           "project_name": "types-urllib3",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.26.16"
+          "version": "1.26.17"
         },
         {
           "artifacts": [
@@ -2187,7 +2187,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.101",
+  "pex_version": "2.1.102",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2200,7 +2200,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.101",
+    "pex==2.1.102",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -33,7 +33,7 @@ Env = Dict[str, str]
 
 class Platform(Enum):
     LINUX_X86_64 = "Linux-x86_64"
-    MACOS10_X86_64 = "macOS10-x86_64"
+    MACOS11_X86_64 = "macOS11-x86_64"
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
@@ -333,8 +333,8 @@ class Helper:
         return str(self.platform.value)
 
     def runs_on(self) -> list[str]:
-        if self.platform == Platform.MACOS10_X86_64:
-            return ["macos-10.15"]
+        if self.platform == Platform.MACOS11_X86_64:
+            return ["macos-11"]
         if self.platform == Platform.MACOS11_ARM64:
             return ["self-hosted", "macOS11", "ARM64"]
         if self.platform == Platform.LINUX_X86_64:
@@ -343,7 +343,7 @@ class Helper:
 
     def platform_env(self):
         ret = {}
-        if self.platform == Platform.MACOS10_X86_64:
+        if self.platform == Platform.MACOS11_X86_64:
             # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
             # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
             ret["ARCHFLAGS"] = "-arch x86_64"
@@ -593,7 +593,7 @@ def linux_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
 
 
 def macos_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
-    helper = Helper(Platform.MACOS10_X86_64)
+    helper = Helper(Platform.MACOS11_X86_64)
     jobs = {
         "bootstrap_pants_macos_x86_64": {
             "name": f"Bootstrap Pants, test Rust ({helper.platform_name()})",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fa501a025417bd35d07ece39482502501ba3bc2a94be476db33a5452be0da32f",
-              "url": "https://files.pythonhosted.org/packages/77/11/696975448606b1b29ebc877aae43035537cb1ddc2e6a8f85a2ee448ce2e2/pex-2.1.101-py2.py3-none-any.whl"
+              "hash": "3743864e09e1017224c5dc6476463ed24b6fea3ac62d379fedc2c6182b2f2159",
+              "url": "https://files.pythonhosted.org/packages/ef/41/a242ae32220cd2951faedddfed3db85393906497526060954b064f9022b7/pex-2.1.102-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d966f2ac9fbf32c6941a798fa8035f74546a056168ac3ef35fca72131e60e1a9",
-              "url": "https://files.pythonhosted.org/packages/70/ff/5eaeef82710ed8f43bede93e31f1801357e3f06407c99f9a24d72d35cd60/pex-2.1.101.tar.gz"
+              "hash": "fa34cef083bede3ea45413638c24e84698949904ef0559994e734b6d21de363c",
+              "url": "https://files.pythonhosted.org/packages/71/f1/125bbeb76821dfe20fc78eb6ebaf963c67ee3a32cc37c907ae54f743c69e/pex-2.1.102.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,14 +63,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.101"
+          "version": "2.1.102"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.101",
+  "pex_version": "2.1.102",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.6"

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,7 +39,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.101"
+    default_version = "v2.1.102"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.101,<3.0"
 
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "d1e29e060b79307719be2a40d16234d1cadd5fc1abab039e091ce3cba8a47cd9",
-                    "3813284",
+                    "e088ac4608095f49fa232be142e9845fe27d84b86797e52e0d03e1b62488ea5c",
+                    "3814219",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This pulls in a hotfix for the `python-certifi-win32 1.6.1` handling
introduced in Pex 2.1.101 that broke PEX creation for Red Hat system
Pythons.

See the change log here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.102

(cherry picked from commit aaaedbb01c3f8b4c5a26bc6fee601418e4cd551c)

[ci skip-rust]
[ci skip-build-wheels]