### PR TITLE
Upgrade Toolchain Pants Plugin to 0.21.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -32,7 +32,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.20.0",
+  "toolchain.pants.plugin==0.21.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the
@@ -66,8 +66,6 @@ build_ignore.add = [
 unmatched_build_file_globs = "error"
 
 # NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
-remote_store_address = "grpcs://cache.toolchain.com:443"
-remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
 # TODO: May cause tests which experience missing digests to hang.
 # See https://github.com/pantsbuild/pants/issues/16096.
 remote_cache_eager_fetch = false


### PR DESCRIPTION
Changelog:
https://docs.toolchain.com/docs/toolchain-pants-plugin-changelog#0210----2022-07-27

This version remove the need to specify some configuration options that are now provided by the plugin.
namely, entry point and the address of the remote cache server.