### PR TITLE
Add a few popular python packages to default modules mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -55,6 +55,7 @@ DEFAULT_MODULE_MAPPING = {
     "django-safedelete": ("safedelete",),
     "django-simple-history": ("simple_history",),
     "djangorestframework": ("rest_framework",),
+    "django-csp": ["csp"],
     "enum34": ("enum",),
     "factory-boy": ("factory",),
     "fluent-logger": ("fluent",),
@@ -111,6 +112,7 @@ DEFAULT_MODULE_MAPPING = {
     "scikit-learn": ("sklearn",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
     "streamlit-aggrid": ("st_aggrid",),
+    "opensearch-py": ["opensearchpy"],
 }
 
 DEFAULT_TYPE_STUB_MODULE_MAPPING = {


### PR DESCRIPTION
OpenSearch-py is an OpenSearch client (OpenSearch is a fork of ElasticSearch that AWS started after Elastic changed their license) so as people who use AWS OpenSearch start migrating to this package it will become more and more popular. https://snyk.io/advisor/python/opensearch-py

The Django CSP although not super actively maintained (owned by Mozilla) use widely used to configure [CSP Headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) in Django web apps.