### PR TITLE
fix kotlin tailor for junit tests

### DIFF
--- a/src/python/pants/backend/kotlin/goals/tailor_test.py
+++ b/src/python/pants/backend/kotlin/goals/tailor_test.py
@@ -4,8 +4,11 @@
 import pytest
 
 from pants.backend.kotlin.goals import tailor
-from pants.backend.kotlin.goals.tailor import PutativeKotlinTargetsRequest
-from pants.backend.kotlin.target_types import KotlinSourcesGeneratorTarget
+from pants.backend.kotlin.goals.tailor import PutativeKotlinTargetsRequest, classify_source_files
+from pants.backend.kotlin.target_types import (
+    KotlinJunitTestsGeneratorTarget,
+    KotlinSourcesGeneratorTarget,
+)
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -28,13 +31,23 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
             "src/kotlin/owned/BUILD": "kotlin_sources()\n",
             "src/kotlin/owned/OwnedFile.kt": "package owned",
             "src/kotlin/unowned/UnownedFile.kt": "package unowned\n",
+            "tests/kotlin/owned/BUILD": "kotlin_junit_tests()\n",
+            "tests/kotlin/owned/OwnedTest.kt": "package owned",
+            "tests/kotlin/unowned/UnownedTest.kt": "package unowned\n",
         }
     )
     putative_targets = rule_runner.request(
         PutativeTargets,
         [
-            PutativeKotlinTargetsRequest(("src/kotlin/owned", "src/kotlin/unowned")),
-            AllOwnedSources(["src/kotlin/owned/OwnedFile.kt"]),
+            PutativeKotlinTargetsRequest(
+                (
+                    "src/kotlin/owned",
+                    "src/kotlin/unowned",
+                    "tests/kotlin/owned",
+                    "tests/kotlin/unowned",
+                )
+            ),
+            AllOwnedSources(["src/kotlin/owned/OwnedFile.kt", "tests/kotlin/owned/OwnedTest.kt"]),
         ],
     )
     assert (
@@ -46,7 +59,25 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     "unowned",
                     ["UnownedFile.kt"],
                 ),
+                PutativeTarget.for_target_type(
+                    KotlinJunitTestsGeneratorTarget,
+                    "tests/kotlin/unowned",
+                    "unowned",
+                    ["UnownedTest.kt"],
+                ),
             ]
         )
         == putative_targets
     )
+
+
+def test_classify_source_files() -> None:
+    junit_files = {
+        "foo/bar/BazTest.kt",
+    }
+    lib_files = {"foo/bar/Baz.scala"}
+
+    assert {
+        KotlinJunitTestsGeneratorTarget: junit_files,
+        KotlinSourcesGeneratorTarget: lib_files,
+    } == classify_source_files(junit_files | lib_files)


### PR DESCRIPTION
Fix `./pants tailor` for the Kotlin backend so that it properly detects Kotlin tests and generates `kotlin_junit_tests` targets for them.

[ci skip-build-wheels]