### PR TITLE
Only show the deprecated option section with `help` if there are deprecated options

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -51,7 +51,7 @@ class HelpFormatter(MaybeColor):
         add_option(oshi.basic)
         if self._show_advanced:
             add_option(oshi.advanced, category="advanced")
-        if self._show_deprecated:
+        if self._show_deprecated and oshi.deprecated:
             add_option(oshi.deprecated, category="deprecated")
         if oshi.advanced and not self._show_advanced:
             lines.append(


### PR DESCRIPTION
This is somewhat of an annoyance I had for a while, most subsystems don't have deprecated options, so seeing this section with nothing feels pointless and adds space/noise to the output.

Before:
![Screen Shot 2022-07-28 at 12 32 59 PM](https://user-images.githubusercontent.com/1268088/181590696-d7c4273f-c857-4ff5-baf5-b507b6eff856.png)


After:
 
![Screen Shot 2022-07-28 at 12 35 13 PM](https://user-images.githubusercontent.com/1268088/181591079-7154ede6-741e-44d3-bfa8-d5de4988d633.png)

