### PR TITLE
[internal] upgrade `async-trait` crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.42"
+version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -106,8 +106,7 @@ default = []
 [dependencies]
 address = { path = "address" }
 async_latch = { path = "async_latch" }
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 protos = { path = "protos" }
 bytes = "1.2"
 cache = { path = "cache" }

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 bytes = "1.2"
 # TODO: Waiting on https://github.com/Aeledfyr/deepsize/pull/{30,31,32}.
 deepsize = { git = "https://github.com/stuhood/deepsize.git", rev = "5c8bee5443fcafe4aaa9274490d354412d0955c1" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 
 [dependencies]
 async-stream = "0.3"
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 protos = { path = "../../protos" }
 bytes = "1.2"
 concrete_time = { path = "../../concrete_time" }

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 async_value = { path = "../async_value" }
 fnv = "1.0.5"
 futures = "0.3"

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -30,8 +30,7 @@ webpki = "0.21"
 workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 parking_lot = "0.11"
 prost-types = "0.9"
 

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -6,8 +6,7 @@ authors = [ "Pants Build <pantsbuild@gmail.com>" ]
 publish = false
 
 [dependencies]
-# Pin async-trait due to https://github.com/dtolnay/async-trait/issues/144.
-async-trait = "=0.1.42"
+async-trait = "0.1"
 async-lock = "2.5"
 walkdir = "2"
 protos = { path = "../protos" }


### PR DESCRIPTION
Upgrade the `async-trait` crate to latest version. Refactor `PathStatGetter` to use a boxed future to work around upstream bug in the `async-trait` crate: https://github.com/dtolnay/async-trait/issues/144