### PR TITLE
Show advanced options with `help` if there are no basic options

### DIFF
--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -50,13 +50,12 @@ class HelpFormatter(MaybeColor):
                 lines.extend([*self.format_option(ohi), ""])
 
         add_option(oshi.basic)
-        if self._show_advanced or (
-            not oshi.basic and oshi.advanced
-        ):  # show advanced options if there are no basic ones.
+        show_advanced = self._show_advanced or (not oshi.basic and oshi.advanced)
+        if show_advanced:  # show advanced options if there are no basic ones.
             add_option(oshi.advanced, category="advanced")
         if self._show_deprecated and oshi.deprecated:
             add_option(oshi.deprecated, category="deprecated")
-        if oshi.advanced and not self._show_advanced:
+        if not show_advanced and oshi.advanced:
             lines.append(
                 self.maybe_green(
                     f"Advanced options available. You can list them by running "

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -1,10 +1,11 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import json
 import textwrap
 from enum import Enum
-from typing import List, Optional
 
 from pants.help.help_info_extracter import OptionHelpInfo, OptionScopeHelpInfo, to_help_str
 from pants.help.maybe_color import MaybeColor
@@ -20,11 +21,11 @@ class HelpFormatter(MaybeColor):
         self._show_deprecated = show_deprecated
         self._width = terminal_width()
 
-    def format_options(self, oshi: OptionScopeHelpInfo):
+    def format_options(self, oshi: OptionScopeHelpInfo) -> list[str]:
         """Return a help message for the specified options."""
         lines = []
 
-        def add_option(ohis, *, category=None):
+        def add_option(ohis, *, category=None) -> None:
             lines.append("")
             goal_or_subsystem = "goal" if oshi.is_goal else "subsystem"
             display_scope = f"`{oshi.scope}` {goal_or_subsystem}" if oshi.scope else "Global"
@@ -49,7 +50,9 @@ class HelpFormatter(MaybeColor):
                 lines.extend([*self.format_option(ohi), ""])
 
         add_option(oshi.basic)
-        if self._show_advanced:
+        if self._show_advanced or (
+            not oshi.basic and oshi.advanced
+        ):  # show advanced options if there are no basic ones.
             add_option(oshi.advanced, category="advanced")
         if self._show_deprecated and oshi.deprecated:
             add_option(oshi.deprecated, category="deprecated")
@@ -62,17 +65,17 @@ class HelpFormatter(MaybeColor):
             )
         return [*lines, ""]
 
-    def format_option(self, ohi: OptionHelpInfo) -> List[str]:
+    def format_option(self, ohi: OptionHelpInfo) -> list[str]:
         """Format the help output for a single option.
 
         :param ohi: Extracted information for option to print
         :return: Formatted help text for this option
         """
 
-        def maybe_parens(s: Optional[str]) -> str:
+        def maybe_parens(s: str | None) -> str:
             return f" ({s})" if s else ""
 
-        def format_value(ranked_val: RankedValue, prefix: str, left_padding: str) -> List[str]:
+        def format_value(ranked_val: RankedValue, prefix: str, left_padding: str) -> list[str]:
             if isinstance(ranked_val.value, (list, dict)):
                 is_enum_list = (
                     isinstance(ranked_val.value, list)
@@ -92,7 +95,7 @@ class HelpFormatter(MaybeColor):
             val_lines = [self.maybe_cyan(f"{left_padding}{line}") for line in val_lines]
             return val_lines
 
-        def wrap(s: str) -> List[str]:
+        def wrap(s: str) -> list[str]:
             return hard_wrap(s, indent=len(indent), width=self._width)
 
         indent = "      "

--- a/src/python/pants/help/help_formatter_test.py
+++ b/src/python/pants/help/help_formatter_test.py
@@ -1,7 +1,7 @@
 # Copyright 2015 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
-import unittest
 from dataclasses import replace
 
 from pants.help.help_formatter import HelpFormatter
@@ -13,7 +13,7 @@ from pants.option.parser import OptionValueHistory, Parser
 from pants.option.ranked_value import Rank, RankedValue
 
 
-class OptionHelpFormatterTest(unittest.TestCase):
+class OptionHelpFormatterTest:
     @staticmethod
     def _format_for_single_option(**kwargs):
         ohi = OptionHelpInfo(
@@ -45,18 +45,20 @@ class OptionHelpFormatterTest(unittest.TestCase):
         assert "help for foo" in lines[6 if choices else 5]
         return lines[4] if choices else lines[3]
 
-    def test_format_help(self):
+    def test_format_help(self) -> None:
         default_line = self._format_for_single_option(default="MYDEFAULT")
         assert default_line.lstrip() == "default: MYDEFAULT"
 
-    def test_format_help_choices(self):
+    def test_format_help_choices(self) -> None:
         default_line = self._format_for_single_option(
             typ=str, default="kiwi", choices=["apple", "banana", "kiwi"]
         )
         assert default_line.lstrip() == "default: kiwi"
 
     @staticmethod
-    def _format_for_global_scope(show_advanced, show_deprecated, args, kwargs):
+    def _format_for_global_scope(
+        show_advanced: bool, show_deprecated: bool, args: list[str], kwargs
+    ) -> list[str]:
         parser = Parser(
             env={},
             config=Config.load([]),
@@ -70,16 +72,16 @@ class OptionHelpFormatterTest(unittest.TestCase):
             show_advanced=show_advanced, show_deprecated=show_deprecated, color=False
         ).format_options(oshi)
 
-    def test_suppress_advanced(self):
+    def test_suppress_advanced(self) -> None:
         args = ["--foo"]
         kwargs = {"advanced": True}
         lines = self._format_for_global_scope(False, False, args, kwargs)
-        assert len(lines) == 9
+        assert len(lines) == 18
         assert not any("--foo" in line for line in lines)
         lines = self._format_for_global_scope(True, False, args, kwargs)
         assert len(lines) == 18
 
-    def test_suppress_deprecated(self):
+    def test_suppress_deprecated(self) -> None:
         args = ["--foo"]
         kwargs = {"removal_version": "33.44.55.dev0"}
         lines = self._format_for_global_scope(False, False, args, kwargs)
@@ -88,7 +90,7 @@ class OptionHelpFormatterTest(unittest.TestCase):
         lines = self._format_for_global_scope(True, True, args, kwargs)
         assert len(lines) == 23
 
-    def test_provider_info(self):
+    def test_provider_info(self) -> None:
         lines = self._format_for_global_scope(False, False, ["--foo"], {})
         assert len(lines) == 14
         assert "Activated by help.test" in lines


### PR DESCRIPTION
also added some missing type annotations because why not.

see further discussions: https://github.com/pantsbuild/pants/pull/16318#pullrequestreview-1053315941
![Screen Shot 2022-07-29 at 9 53 44 AM](https://user-images.githubusercontent.com/1268088/181775284-7ceba133-0e9c-4171-aef6-02852ce12a9d.png)

 