### PR TITLE
Improve a docker backend warning.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -373,34 +373,36 @@ def format_docker_build_context_help_message(
         # No issues found.
         return None
 
-    msg = (
-        f"Docker build failed for `docker_image` {address}. The {context.dockerfile} have `COPY` "
-        "instructions where the source files may not have been found in the Docker build context."
-        "\n\n"
-    )
-
-    renames = sorted(
-        format_rename_suggestion(src, dst, colors=colors)
-        for src, dst in copy_source_vs_context_source
-        if src and dst
-    )
-    if renames:
+    msg = f"Docker build failed for `docker_image` {address}. "
+    has_unsourced_copy = any(src for src, _ in copy_source_vs_context_source)
+    if has_unsourced_copy:
         msg += (
-            f"However there are possible matches. Please review the following list of suggested "
-            f"renames:\n\n{bullet_list(renames)}\n\n"
+            f"The {context.dockerfile} has `COPY` instructions for source files that may not have "
+            f"been found in the Docker build context.\n\n"
         )
 
-    unknown = sorted(src for src, dst in copy_source_vs_context_source if src and not dst)
-    if unknown:
-        msg += (
-            f"The following files were not found in the Docker build context:\n\n"
-            f"{bullet_list(unknown)}\n\n"
+        renames = sorted(
+            format_rename_suggestion(src, dst, colors=colors)
+            for src, dst in copy_source_vs_context_source
+            if src and dst
         )
+        if renames:
+            msg += (
+                f"However there are possible matches. Please review the following list of "
+                f"suggested renames:\n\n{bullet_list(renames)}\n\n"
+            )
+
+        unknown = sorted(src for src, dst in copy_source_vs_context_source if src and not dst)
+        if unknown:
+            msg += (
+                f"The following files were not found in the Docker build context:\n\n"
+                f"{bullet_list(unknown)}\n\n"
+            )
 
     unreferenced = sorted(dst for src, dst in copy_source_vs_context_source if dst and not src)
     if unreferenced:
         msg += (
-            f"There are additional files in the Docker build context that were not referenced by "
+            f"There are files in the Docker build context that were not referenced by "
             f"any `COPY` instruction (this is not an error):\n\n{bullet_list(unreferenced, 10)}\n\n"
         )
 
@@ -411,8 +413,8 @@ def format_docker_build_context_help_message(
         msg += (
             "There are unreachable files in these directories, excluded from the build context "
             f"due to `context_root` being {context_root!r}:\n\n{bullet_list(unreachable, 10)}\n\n"
-            f"Suggested `context_root` setting is {new_context_root!r} in order to include all files "
-            "in the build context, otherwise relocate the files to be part of the current "
+            f"Suggested `context_root` setting is {new_context_root!r} in order to include all "
+            "files in the build context, otherwise relocate the files to be part of the current "
             f"`context_root` {context_root!r}."
         )
 

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -720,14 +720,11 @@ def test_docker_build_labels_option(rule_runner: RuleRunner) -> None:
         (
             None,
             ("src/project/bin.pex",),
-            (
-                "src.project/binary.pex",
-                "src/project/app.py",
-            ),
+            ("src.project/binary.pex", "src/project/app.py"),
             [(logging.WARNING, "Docker build failed for `docker_image` docker/test:test.")],
             [
                 "suggested renames:\n\n  * src/project/bin.pex => src.project/binary.pex\n\n",
-                "There are additional files",
+                "There are files in the Docker build context that were not referenced by ",
                 "  * src/project/app.py\n\n",
             ],
         ),
@@ -770,12 +767,9 @@ def test_docker_build_labels_option(rule_runner: RuleRunner) -> None:
                 (
                     logging.WARNING,
                     (
-                        "Docker build failed for `docker_image` docker/test:test. The "
-                        "docker/test/Dockerfile have `COPY` instructions where the source files "
-                        "may not have been found in the Docker build context.\n"
-                        "\n"
-                        "There are additional files in the Docker build context that were not "
-                        "referenced by any `COPY` instruction (this is not an error):\n"
+                        "Docker build failed for `docker_image` docker/test:test. "
+                        "There are files in the Docker build context that were not referenced by "
+                        "any `COPY` instruction (this is not an error):\n"
                         "\n"
                         "  * ..unusal-name\n"
                         "  * .a\n"


### PR DESCRIPTION
Previously, if a Dockerfile had no COPY instructions
at all we would still show the "The {context.dockerfile} has
`COPY` instructions for source files..." part of the warning,
which was confusing. Now we omit that in that case.

Also tweaks the message phrasing to be a bit clearer.

[ci skip-rust]

[ci skip-build-wheels]