### PR TITLE
jvm: fix fetching artifacts with non-jar packaging

### DIFF
--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -232,7 +232,7 @@ class ClasspathEntry:
 
     Note: Non-jar artifacts (e.g., executables with "exe" packaging) may end up on the classpath if
     they are dependencies.
-    TODO: Does there need to be a filtering mechanism to exclude non-jar artifacgs in the default case?
+    TODO: Does there need to be a filtering mechanism to exclude non-jar artifacts in the default case?
     """
 
     digest: Digest

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -229,6 +229,10 @@ class ClasspathEntry:
 
     TODO: Move to `classpath.py`.
     TODO: Generalize via https://github.com/pantsbuild/pants/issues/13112.
+
+    Note: Non-jar artifacts (e.g., executables with "exe" packaging) may end up on the classpath if
+    they are dependencies.
+    TODO: Does there need to be a filtering mechanism to exclude non-jar artifacgs in the default case?
     """
 
     digest: Digest

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -353,6 +353,16 @@ async def prepare_coursier_resolve_info(
         for (req, _), path in zip(jars, jar_file_paths)
     ]
 
+    # Coursier only fetches non-jar artifact types ("packaging" in Pants parlance) if passed an `-A` option
+    # explicitly requesting that the non-jar artifact(s) be fetched. This is an addition to passing the coordinate
+    # with the desired type (packaging) value.
+    extra_types: set[str] = set()
+    for no_jar in no_jars:
+        if no_jar.coordinate.packaging != "jar":
+            extra_types.add(no_jar.coordinate.packaging)
+    if extra_types:
+        extra_args.extend(["-A", ",".join(sorted(["jar", "bundle", *extra_types]))])
+
     to_resolve = chain(no_jars, resolvable_jar_requirements)
 
     digest = await Get(

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -361,6 +361,8 @@ async def prepare_coursier_resolve_info(
         if no_jar.coordinate.packaging != "jar":
             extra_types.add(no_jar.coordinate.packaging)
     if extra_types:
+        # Note: `-A` defaults to `jar,bundle` and any value set replaces (and does not supplement) those defaults,
+        # so the defaults must be included here for them to remain usable.
         extra_args.extend(["-A", ",".join(sorted(["jar", "bundle", *extra_types]))])
 
     to_resolve = chain(no_jars, resolvable_jar_requirements)

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -579,7 +579,7 @@ def test_fetch_one_coord_with_mismatched_coord(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_fetch_one_coord_with_non_jar_packaging(rule_runner: RuleRunner) -> None:
     """This test demonstrates that fetch_one_coord is able to download non-jar artifacts such as
-    protoc plugin binaries that are distribured via Maven Central."""
+    protoc plugin binaries that are distributed via Maven Central."""
     coordinate = Coordinate(
         group="io.grpc",
         artifact="protoc-gen-grpc-java",

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -109,13 +109,12 @@ async def gather_coordinates_for_jvm_lockfile(
     for artifact_input in request.artifact_inputs:
         # Try parsing as a `Coordinate` first since otherwise `AddressInput.parse` will try to see if the
         # group name is a file on disk.
-        if 2 <= artifact_input.count(":") <= 3:
-            try:
-                maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
-                requirements.add(maybe_coord)
-                continue
-            except Exception:
-                pass
+        try:
+            maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
+            requirements.add(maybe_coord)
+            continue
+        except Exception:
+            pass
 
         try:
             address_input = AddressInput.parse(

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -109,12 +109,13 @@ async def gather_coordinates_for_jvm_lockfile(
     for artifact_input in request.artifact_inputs:
         # Try parsing as a `Coordinate` first since otherwise `AddressInput.parse` will try to see if the
         # group name is a file on disk.
-        try:
-            maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
-            requirements.add(maybe_coord)
-            continue
-        except Exception:
-            pass
+        if 2 <= artifact_input.count(":"):
+            try:
+                maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
+                requirements.add(maybe_coord)
+                continue
+            except Exception:
+                pass
 
         try:
             address_input = AddressInput.parse(


### PR DESCRIPTION
Fix fetching artifacts that have non-jar packaging, e.g. protoc plugin binaries distributed via Maven Central:
1. Allow coordinate strings used in `JvmToolBase` to provide packaging and classifier items by not limiting the number of `:`-separated fields.
2. Pass `-A` option to Coursier with an explicit list of artifact types ("packaging" in Pants parlance) to retain because Courser only fetches non-jar artifact types if passed this option. This is necessary in addition to also passing the coordinate with the desired artifact type.

[ci skip-rust]

[ci skip-build-wheels]