### PR TITLE
Include Helm chart dependency inference rules

### DIFF
--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -11,6 +11,7 @@ from pants.backend.helm.goals.lint import HelmLintFieldSet, HelmLintRequest
 from pants.backend.helm.goals.lint import rules as helm_lint_rules
 from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.target_types import HelmChartTarget
+from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.testutil import (
     HELM_TEMPLATE_HELPERS_FILE,
     HELM_VALUES_FILE,
@@ -41,6 +42,7 @@ def rule_runner() -> RuleRunner:
             *stripped_source_files.rules(),
             *source_root_rules(),
             *sources.rules(),
+            *target_types_rules(),
             SubsystemRule(HelmSubsystem),
             QueryRule(LintResults, (HelmLintRequest,)),
         ],

--- a/src/python/pants/backend/helm/goals/package_test.py
+++ b/src/python/pants/backend/helm/goals/package_test.py
@@ -11,6 +11,7 @@ from pants.backend.helm.goals import package
 from pants.backend.helm.goals.package import BuiltHelmArtifact, HelmPackageFieldSet
 from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.target_types import HelmChartTarget
+from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.testutil import (
     HELM_TEMPLATE_HELPERS_FILE,
     HELM_VALUES_FILE,
@@ -39,6 +40,7 @@ def rule_runner() -> RuleRunner:
             *stripped_source_files.rules(),
             *source_root_rules(),
             *sources.rules(),
+            *target_types_rules(),
             SubsystemRule(HelmSubsystem),
             QueryRule(BuiltPackage, [HelmPackageFieldSet]),
         ],

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -7,6 +7,7 @@ import dataclasses
 import logging
 from dataclasses import dataclass
 
+from pants.backend.helm.dependency_inference import chart as chart_inference
 from pants.backend.helm.resolve import fetch
 from pants.backend.helm.resolve.artifacts import ResolvedHelmArtifact
 from pants.backend.helm.resolve.fetch import (
@@ -195,4 +196,10 @@ async def get_helm_chart(request: HelmChartRequest, subsystem: HelmSubsystem) ->
 
 
 def rules():
-    return [*collect_rules(), *sources.rules(), *chart_metadata.rules(), *fetch.rules()]
+    return [
+        *collect_rules(),
+        *sources.rules(),
+        *chart_metadata.rules(),
+        *chart_inference.rules(),
+        *fetch.rules(),
+    ]

--- a/src/python/pants/backend/helm/util_rules/chart_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_test.py
@@ -7,7 +7,6 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.helm.dependency_inference.chart import rules as chart_infer_rules
 from pants.backend.helm.target_types import HelmArtifactTarget, HelmChartTarget
 from pants.backend.helm.target_types import rules as target_types_rules
 from pants.backend.helm.testutil import (
@@ -39,7 +38,6 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *external_tool.rules(),
             *chart.rules(),
-            *chart_infer_rules(),
             *sources.rules(),
             *tool.rules(),
             *process.rules(),


### PR DESCRIPTION
Closes #16367

Since the `HelmChart` type is the central piece for all the operations done with charts, the inclusion of the rules is done in the `pants.backend.helm.util_rules.chart` module, hence any other module that depends on this will have them included.