### PR TITLE
Include Chris Livingston in Maintainers Emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -26,6 +26,7 @@ Emeritus
 
 * Andy Reitz
 * Chris Heisterkamp
+* Chris Livingston
 * David Taylor
 * David Turner
 * Dorothy Ordogh


### PR DESCRIPTION
Accidental omission detected and fixed. Our apologies to @CMLivingston for not already having you on this list. Thank you for your contributions to Pants!