### PR TITLE
go: pass -p option to `go tool asm` on Go v1.19+

### DIFF
--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -64,7 +64,7 @@ async def setup_assembly_pre_compilation(
 ) -> FallibleAssemblyPreCompilation:
     # On Go 1.19+, the import path must be supplied via the `-p` option to `go tool asm`.
     # See https://go.dev/doc/go1.19#assembler and
-    # https://github.com/bazelbuild/rules_go/commit/cde7d7bc27a34547c014369790ddaa95b932d08d (Bazel rule_go).
+    # https://github.com/bazelbuild/rules_go/commit/cde7d7bc27a34547c014369790ddaa95b932d08d (Bazel rules_go).
     maybe_package_path_args = (
         ["-p", request.import_path] if goroot.is_compatible_version("1.19") else []
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -246,7 +246,12 @@ async def build_go_package(
     if request.s_file_names:
         assembly_setup = await Get(
             FallibleAssemblyPreCompilation,
-            AssemblyPreCompilationRequest(input_digest, request.s_file_names, request.dir_path),
+            AssemblyPreCompilationRequest(
+                compilation_input=input_digest,
+                s_files=request.s_file_names,
+                dir_path=request.dir_path,
+                import_path=request.import_path,
+            ),
         )
         if assembly_setup.result is None:
             return FallibleBuiltGoPackage(


### PR DESCRIPTION
On Go v1.19+, the assembler (`go tool asm`) now requires the import path be specified via the `-p` option. 

Fixes https://github.com/pantsbuild/pants/issues/16380.

[ci skip-rust]

[ci skip-build-wheels]