### PR TITLE
Clarify limited logo usage rights granted by orgs

### DIFF
--- a/.github/ISSUE_TEMPLATE/user_registration.yml
+++ b/.github/ISSUE_TEMPLATE/user_registration.yml
@@ -33,8 +33,10 @@ body:
       description: |
         We'd love to use your company's logo on the Users Page!
 
-        Please ensure that you have the right to grant us permission to use the logo in
-        this manner before adding it.
+        By attaching it here, permission is granted to display this logo on pantsbuild.org 
+        in affirmation that the organization uses Pants. No other usage rights are granted to 
+        the organization's intellectual property. Please ensure that you have the right to 
+        grant us permission to use the logo in this manner before adding it. 
 
         If you're unsure, please submit this page without the logo, and we can revisit it later,
         if/when permission has been established. The other information is still very helpful!


### PR DESCRIPTION
Several users have reported that securing internal permission to put their company logo on Who Uses Pants is easiest when legal/PR/etc have clarity that the usage rights granted are limited. This is an attempt to communicate more clearly with people interacting with this form and those whose authorization they seek.