### PR TITLE
[internal] Amend missing `timeout` field in target generators

### DIFF
--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -217,6 +217,16 @@ To add a timeout, set the `test_timeout` field to an integer value of seconds, l
 go_package(test_timeout=120)
 ```
 
+Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+
+```toml pants.toml
+[test]
+timeout_default = 60
+timeout_maximum = 600
+```
+
+If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
 Gofmt
 -----
 

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -217,7 +217,7 @@ To add a timeout, set the `test_timeout` field to an integer value of seconds, l
 go_package(test_timeout=120)
 ```
 
-Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+You can also set a default value and a maximum value in `pants.toml`:
 
 ```toml pants.toml
 [test]

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -227,6 +227,7 @@ timeout_maximum = 600
 
 If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
 
+Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 Gofmt
 -----
 

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -228,6 +228,7 @@ timeout_maximum = 600
 If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
 
 Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
+
 Gofmt
 -----
 

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -167,6 +167,38 @@ With the test files in places, you can now run `./pants test ::` and Pants will 
 ✓ testprojects/src/helm/example/tests/env-configmap_test.yaml succeeded in 0.75s.
 ```
 
+### Timeouts
+
+Pants can cancel tests that take too long, which is useful to prevent tests from hanging indefinitely.
+
+To add a timeout, set the `timeout` field to an integer value of seconds, like this:
+
+```python BUILD
+helm_unittest_test(name="tests", source="env-configmap_test.yaml", timeout=120)
+```
+
+When you set `timeout` on the `helm_unittest_tests` target generator, the same timeout will apply to every generated `helm_unittest_test` target. Instead, you can use the `overrides` field:
+
+```python BUILD
+helm_unittest_tests(
+    name="tests",
+    overrides={
+        "env-configmap_test.yaml": {"timeout": 20},
+        ("deployment_test.yaml", "pod_test.yaml"): {"timeout": 35},
+    },
+)
+```
+
+Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+
+```toml pants.toml
+[test]
+timeout_default = 60
+timeout_maximum = 600
+```
+
+If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
 Publishing Helm charts
 ======================
 

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -189,7 +189,7 @@ helm_unittest_tests(
 )
 ```
 
-Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+You can also set a default value and a maximum value in `pants.toml`:
 
 ```toml pants.toml
 [test]
@@ -198,6 +198,8 @@ timeout_maximum = 600
 ```
 
 If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
+Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
 Publishing Helm charts
 ======================

--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -179,6 +179,41 @@ You can also pass through arguments to the test runner with `--`, e.g.:
 ❯ ./pants test tests/jvm/org/pantsbuild/example/lib/ExampleLibSpec.scala -- -z hello
 ```
 
+Timeouts
+--------
+
+Pants can cancel tests which take too long. This is useful to prevent tests from hanging indefinitely.
+
+To add a timeout, set the `timeout` field to an integer value of seconds in any of the supported targets, like this:
+
+```python BUILD
+java_junit_test(name="java_test", source="Test.java", timeout=120)
+scala_junit_test(name="scala_junit_test", source="Test.scala", timeout=100)
+scalatest_test(name="scalatest_test", source="Spec.scala", timeout=80)
+```
+
+When you set timeout on any of the target generators (i.e. `java_junit_tests`, `scalatest_tests`, etc.), the same timeout will apply to every generated corresponding target.
+
+```python BUILD
+java_junit_tests(
+    name="tests",
+    overrides={
+        "MyClass1Test.java": {"timeout": 20},
+        ("MyClass2Test.java", "MyClass3Test.java"): {"timeout": 35},
+    },
+)
+```
+
+Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+
+```toml pants.toml
+[test]
+timeout_default = 60
+timeout_maximum = 600
+```
+
+If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
 Lint and Format
 ---------------
 

--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -179,8 +179,7 @@ You can also pass through arguments to the test runner with `--`, e.g.:
 ❯ ./pants test tests/jvm/org/pantsbuild/example/lib/ExampleLibSpec.scala -- -z hello
 ```
 
-Timeouts
---------
+### Timeouts
 
 Pants can cancel tests which take too long. This is useful to prevent tests from hanging indefinitely.
 

--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -203,7 +203,7 @@ java_junit_tests(
 )
 ```
 
-Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+You can also set a default value and a maximum value in `pants.toml`:
 
 ```toml pants.toml
 [test]
@@ -212,6 +212,8 @@ timeout_maximum = 600
 ```
 
 If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
+Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
 Lint and Format
 ---------------

--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -288,19 +288,19 @@ python_tests(
 You can also set a default value and a maximum value in `pants.toml`:
 
 ```toml pants.toml
-[pytest]
+[test]
 timeout_default = 60
 timeout_maximum = 600
 ```
 
-If a target sets its `timeout` higher than `[pytest].timeout_maximum`, Pants will use the value in `[pytest].timeout_maximum`.
+If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
 
 > 📘 Tip: temporarily ignoring timeouts
 >
-> When debugging locally, such as with `pdb`, you might want to temporarily disable timeouts. To do this, set `--no-pytest-timeouts`:
+> When debugging locally, such as with `pdb`, you might want to temporarily disable timeouts. To do this, set `--no-test-timeouts`:
 >
 > ```bash
-> $ ./pants test project/app_test.py --no-pytest-timeouts
+> $ ./pants test project/app_test.py --no-test-timeouts
 > ```
 
 Test utilities and resources

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -336,7 +336,15 @@ shunit2_tests(
 )
 ```
 
-Unlike [with Python](doc:python-test-goal#timeouts), you cannot yet set a default or maximum timeout value, nor temporarily disable all timeouts. Please [let us know](doc:getting-help) if you would like this feature.
+Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+
+```toml pants.toml
+[test]
+timeout_default = 60
+timeout_maximum = 600
+```
+
+If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
 
 ### Testing your packaging pipeline
 

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -336,7 +336,7 @@ shunit2_tests(
 )
 ```
 
-Similar as [with Python](doc:python-test-goal#timeouts), you can also set a default value and a maximum value in `pants.toml`:
+You can also set a default value and a maximum value in `pants.toml`:
 
 ```toml pants.toml
 [test]
@@ -345,6 +345,8 @@ timeout_maximum = 600
 ```
 
 If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will use the value in `[test].timeout_maximum`.
+
+Use the option `./pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
 ### Testing your packaging pipeline
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -194,13 +194,6 @@ class GoTestExtraEnvVarsField(StringSequenceField):
 
 class GoTestTimeoutField(TestTimeoutField):
     alias = "test_timeout"
-    help = softwrap(
-        """
-        A timeout (in seconds) when running this package's tests.
-
-        If this field is not set, the test will never time out.
-        """
-    )
     valid_numbers = ValidNumbers.positive_and_zero
 
 

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -16,6 +16,7 @@ from pants.engine.target import (
     Dependencies,
     FieldSet,
     MultipleSourcesField,
+    OverridesField,
     SingleSourceField,
     StringField,
     StringSequenceField,
@@ -23,6 +24,7 @@ from pants.engine.target import (
     TargetFilesGenerator,
     Targets,
     TriBoolField,
+    generate_file_based_overrides_field_help_message,
     generate_multiple_sources_field_help_message,
 )
 from pants.util.docutil import bin_name
@@ -269,6 +271,18 @@ class HelmUnitTestGeneratingSourcesField(MultipleSourcesField):
     )
 
 
+class HelmUnitTestOverridesField(OverridesField):
+    help = generate_file_based_overrides_field_help_message(
+        HelmUnitTestTestTarget.alias,
+        """
+        overrides={
+            "configmap_test.yaml": {"timeout": 120},
+            ("deployment_test.yaml", "pod_test.yaml"): {"tags": ["slow_tests"]},
+        }
+        """,
+    )
+
+
 class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
     alias = "helm_unittest_tests"
     core_fields = (
@@ -277,10 +291,15 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
         HelmUnitTestDependenciesField,
         HelmUnitTestStrictField,
         HelmUnitTestTimeoutField,
+        HelmUnitTestOverridesField,
     )
     generated_target_cls = HelmUnitTestTestTarget
-    copied_fields = (*COMMON_TARGET_FIELDS, HelmUnitTestStrictField)
-    moved_fields = (HelmUnitTestDependenciesField, HelmUnitTestTimeoutField)
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = (
+        HelmUnitTestDependenciesField,
+        HelmUnitTestStrictField,
+        HelmUnitTestTimeoutField,
+    )
     help = f"Generates a `{HelmUnitTestTestTarget.alias}` target per each file in the `{HelmUnitTestGeneratingSourcesField.alias}` field."
 
 

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -217,7 +217,7 @@ class HelmUnitTestDependenciesField(Dependencies):
 
 
 class HelmUnitTestTimeoutField(TestTimeoutField):
-    help = "A timeout (in seconds) used by each Helm Unittest test file belonging to this target."
+    pass
 
 
 class HelmUnitTestSourceField(SingleSourceField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -808,29 +808,34 @@ class PythonTestsTimeoutField(IntField):
         """
         A timeout (in seconds) used by each test file belonging to this target.
 
-        If unset, will default to `[pytest].timeout_default`; if that option is also unset,
-        then the test will never time out. Will never exceed `[pytest].timeout_maximum`. Only
-        applies if the option `--pytest-timeouts` is set to true (the default).
+        If unset, will default to `[test].timeout_default`; if that option is also unset,
+        then the test will never time out. Will never exceed `[test].timeout_maximum`. Only
+        applies if the option `--test-timeouts` is set to true (the default).
         """
     )
     valid_numbers = ValidNumbers.positive_only
 
     def calculate_from_global_options(self, test: TestSubsystem, pytest: PyTest) -> Optional[int]:
-        """Determine the timeout (in seconds) after applying global `pytest` options."""
+        """Determine the timeout (in seconds) after resolving conflicting global options in the
+        `pytest` and `test` scopes.
 
-        def resolve_opt(*, old_option: str, new_option: str) -> Any:
+        This function is deprecated and should be replaced by the similarly named one in
+        `TestTimeoutField` once the deprecated options in the `pytest` scope are removed.
+        """
+
+        def resolve_opt(*, option: str) -> Any:
             return resolve_conflicting_options(
-                old_option=old_option,
-                new_option=new_option,
+                old_option=option,
+                new_option=option,
                 old_scope="pytest",
                 new_scope="test",
                 old_container=pytest.options,
                 new_container=test.options,
             )
 
-        enabled = resolve_opt(old_option="timeouts", new_option="timeouts")
-        timeout_default = resolve_opt(old_option="timeout_default", new_option="timeout_default")
-        timeout_maximum = resolve_opt(old_option="timeout_maximum", new_option="timeout_maximum")
+        enabled = resolve_opt(option="timeouts")
+        timeout_default = resolve_opt(option="timeout_default")
+        timeout_maximum = resolve_opt(option="timeout_maximum")
 
         if not enabled:
             return None

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -223,12 +223,14 @@ class ScalaJunitTestsGeneratorTarget(TargetFilesGenerator):
         *COMMON_TARGET_FIELDS,
         ScalaJunitTestsGeneratorSourcesField,
         ScalaJunitTestsSourcesOverridesField,
+        JunitTestTimeoutField,
     )
     generated_target_cls = ScalaJunitTestTarget
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (
         ScalaDependenciesField,
         ScalaConsumedPluginNamesField,
+        JunitTestTimeoutField,
         JvmJdkField,
         JvmProvidesTypesField,
         JvmResolveField,

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -104,11 +104,7 @@ class ScalatestTestSourceField(ScalaSourceField):
 
 
 class ScalatestTestTimeoutField(TestTimeoutField):
-    help = softwrap(
-        """
-        A timeout (in seconds) used by each ScalaTest test file belonging to this target.
-        """
-    )
+    pass
 
 
 class ScalatestTestTarget(Target):

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -237,7 +237,7 @@ async def setup_shunit2_for_target(
         description=f"Run shunit2 for {request.field_set.address}.",
         level=LogLevel.DEBUG,
         env=env_dict,
-        timeout_seconds=request.field_set.timeout.value,
+        timeout_seconds=request.field_set.timeout.calculate_from_global_options(test_subsystem),
         cache_scope=cache_scope,
     )
     return TestSetup(process)

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -7,7 +7,7 @@ import re
 from enum import Enum
 
 from pants.backend.shell.shell_setup import ShellSetup
-from pants.core.goals.test import RuntimePackageDependenciesField
+from pants.core.goals.test import RuntimePackageDependenciesField, TestTimeoutField
 from pants.core.util_rules.system_binaries import BinaryPathTest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
@@ -112,8 +112,7 @@ class Shunit2TestDependenciesField(Dependencies):
     supports_transitive_excludes = True
 
 
-class Shunit2TestTimeoutField(IntField):
-    alias = "timeout"
+class Shunit2TestTimeoutField(TestTimeoutField):
     help = softwrap(
         """
         A timeout (in seconds) used by each test file belonging to this target.
@@ -121,7 +120,6 @@ class Shunit2TestTimeoutField(IntField):
         If unset, the test will never time out.
         """
     )
-    valid_numbers = ValidNumbers.positive_only
 
 
 class SkipShunit2TestsField(BoolField):

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -113,13 +113,7 @@ class Shunit2TestDependenciesField(Dependencies):
 
 
 class Shunit2TestTimeoutField(TestTimeoutField):
-    help = softwrap(
-        """
-        A timeout (in seconds) used by each test file belonging to this target.
-
-        If unset, the test will never time out.
-        """
-    )
+    pass
 
 
 class SkipShunit2TestsField(BoolField):

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -439,6 +439,15 @@ class TestTimeoutField(IntField, metaclass=ABCMeta):
     alias = "timeout"
     required = False
     valid_numbers = ValidNumbers.positive_only
+    help = softwrap(
+        """
+        A timeout (in seconds) used by each test file belonging to this target.
+
+        If unset, will default to `[test].timeout_default`; if that option is also unset,
+        then the test will never time out. Will never exceed `[test].timeout_maximum`. Only
+        applies if the option `--test-timeouts` is set to true (the default).
+        """
+    )
 
     def calculate_from_global_options(self, test: TestSubsystem) -> Optional[int]:
         if not test.timeouts:

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -310,11 +310,7 @@ class JunitTestSourceField(SingleSourceField, metaclass=ABCMeta):
 
 
 class JunitTestTimeoutField(TestTimeoutField):
-    help = softwrap(
-        """
-        A timeout (in seconds) used by each JUnit test file belonging to this target.
-        """
-    )
+    pass
 
 
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
Adds missing `timeout` field to `scala_junit_tests` target and aligns the Shunit2 test timeout field with the same behaviour of the other backends that support test timeouts.

Documentation for each of the backends has also been updated to show the fact that now timeouts are supported for their respective target types and that they can also be applied globally.