### PR TITLE
Rename `__defaults__` to `set_defaults`

### DIFF
--- a/docs/markdown/Using Pants/concepts/targets.md
+++ b/docs/markdown/Using Pants/concepts/targets.md
@@ -160,9 +160,9 @@ Field default values
 As mentioned above in [BUILD files](doc:targets#build-files), most fields use sensible defaults. And
 for specific cases it is easy to provide some other value to a specific target. The issue is if you
 want to apply a specific non-default value for a field on many targets. This can get unwieldy, error
-prone and hard to maintain. Enter `__defaults__`.
+prone and hard to maintain. Enter `set_defaults`.
 
-Default field values per target are set using the `__defaults__` BUILD file symbol, and apply to the
+Default field values per target are set using the `set_defaults` BUILD file symbol, and apply to the
 current subtree.
 
 The defaults are provided as a dictionary mapping targets to the default field values. Multiple
@@ -172,7 +172,7 @@ Python tuple).
 Use the `all` keyword argument to provide default field values that should apply to all targets.
 
 The `extend=True` keyword argument allows to add to any existing default field values set by a
-previous `__defaults__` call rather than replacing them.
+previous `set_defaults` call rather than replacing them.
 
 Default fields and values are validated against their target types, except when provided using the
 `all` keyword, in which case only values for fields applicable to each target are validated.
@@ -184,14 +184,14 @@ Examples:
 
 ```python src/example/BUILD
     # Provide default `tags` to all targets in this subtree, and skip black, where applicable.
-    __defaults__(all=dict(tags=["example"], skip_black=True))
+    set_defaults(all=dict(tags=["example"], skip_black=True))
 ```
 
 Subdirectories may override defaults from a parent BUILD file:
 
 ```python src/example/override/BUILD
     # For `files` and `resources` targets, we want to use some other defaults.
-    __defaults__({
+    set_defaults({
       (files, resources): dict(tags=["example", "overridden"], description="Our assets")
     })
 ```
@@ -200,13 +200,13 @@ Use the `extend=True` keyword to update defaults rather than replace them, for a
 
 ```python src/example/extend/BUILD
     # Add a default description to all types, in addition to the inherited default tags.
-    __defaults__(extend=True, all=dict(description="Add default description to the defaults."))
+    set_defaults(extend=True, all=dict(description="Add default description to the defaults."))
 ```
 
 To reset any modified defaults, simply override with the empty dict:
 
 ```python src/example/nodefaults/BUILD
-    __defaults__(all={})
+    set_defaults(all={})
 ```
 
 Target generation

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -258,7 +258,7 @@ def test_target_adaptor_defaults_applied(target_adaptor_rule_runner: RuleRunner)
         {
             "helloworld/dir/BUILD": dedent(
                 """\
-                __defaults__({mock_tgt: dict(resolve="mock")}, all=dict(tags=["24"]))
+                set_defaults({mock_tgt: dict(resolve="mock")}, all=dict(tags=["24"]))
                 mock_tgt(tags=["42"])
                 mock_tgt(name='t2')
                 """
@@ -292,10 +292,10 @@ def test_target_adaptor_defaults_applied(target_adaptor_rule_runner: RuleRunner)
 def test_inherit_defaults(target_adaptor_rule_runner: RuleRunner) -> None:
     target_adaptor_rule_runner.write_files(
         {
-            "BUILD": """__defaults__(all=dict(tags=["root"]))""",
+            "BUILD": """set_defaults(all=dict(tags=["root"]))""",
             "helloworld/dir/BUILD": dedent(
                 """\
-                __defaults__({mock_tgt: dict(resolve="mock")}, extend=True)
+                set_defaults({mock_tgt: dict(resolve="mock")}, extend=True)
                 mock_tgt()
                 """
             ),

--- a/src/python/pants/engine/internals/defaults.py
+++ b/src/python/pants/engine/internals/defaults.py
@@ -1,7 +1,8 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 """The `BuildFileDefaultsParserState.set_defaults` is used by the pants.engine.internals.Parser,
-exposed as the `__defaults__` BUILD file symbol.
+exposed as the `set_defaults` BUILD file symbol.
 
 When parsing a BUILD (from the rule `pants.engine.internals.build_files.parse_address_family`) the
 defaults from the closest parent BUILD file is passed as input to the parser, and the new defaults
@@ -52,7 +53,7 @@ class BuildFileDefaultsParserState:
         union_membership: UnionMembership,
     ) -> BuildFileDefaultsParserState:
         return cls(
-            address=Address(path, generated_name="__defaults__"),
+            address=Address(path, generated_name="set_defaults"),
             defaults=dict(defaults),
             registered_target_types=registered_target_types,
             union_membership=union_membership,

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -145,7 +145,7 @@ Scenario = namedtuple(
                     ValueError,
                     match=(
                         r"Expected dictionary mapping targets to default field values for "
-                        r"//#__defaults__ but got: list\."
+                        r"//#set_defaults but got: list\."
                     ),
                 ),
             ),
@@ -157,7 +157,7 @@ Scenario = namedtuple(
                 expected_error=pytest.raises(
                     ValueError,
                     match=(
-                        r"Invalid default field values in //#__defaults__ for target type "
+                        r"Invalid default field values in //#set_defaults for target type "
                         r"test_type_1, must be an `dict` but was \(\) with type `tuple`\."
                     ),
                 ),
@@ -169,7 +169,7 @@ Scenario = namedtuple(
                 args=({"unknown_target": {}},),
                 expected_error=pytest.raises(
                     ValueError,
-                    match=r"Unrecognized target type unknown_target in //#__defaults__\.",
+                    match=r"Unrecognized target type unknown_target in //#set_defaults\.",
                 ),
             ),
             id="unknown target",
@@ -194,7 +194,7 @@ Scenario = namedtuple(
                 expected_error=pytest.raises(
                     InvalidFieldException,
                     match=(
-                        r"The 'tags' field in target src/proj/a#__defaults__ must be an "
+                        r"The 'tags' field in target src/proj/a#set_defaults must be an "
                         r"iterable of strings \(e\.g\. a list of strings\), but was "
                         r"`'foo-bar'` with type `str`\."
                     ),

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -64,7 +64,7 @@ class ParseState(threading.local):
     def defaults(self) -> BuildFileDefaultsParserState:
         if self._defaults is None:
             raise AssertionError(
-                "The BUILD file __defaults__ was accessed before being set. This indicates a "
+                "The BUILD file set_defaults was accessed before being set. This indicates a "
                 "programming error in Pants. Please file a bug report at "
                 "https://github.com/pantsbuild/pants/issues/new."
             )
@@ -128,7 +128,7 @@ class Parser:
         symbols: dict[str, Any] = {
             **object_aliases.objects,
             "build_file_dir": lambda: PurePath(parse_state.rel_path()),
-            "__defaults__": parse_state.set_defaults,
+            "set_defaults": parse_state.set_defaults,
         }
         symbols.update((alias, Registrar(alias)) for alias in target_type_aliases)
 

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -58,8 +58,8 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            f"All registered symbols: ['__defaults__', 'build_file_dir', 'caof', {fmt_extra_sym}"
-            "'obj', 'prelude', 'tgt']"
+            f"All registered symbols: ['build_file_dir', 'caof', {fmt_extra_sym}"
+            "'obj', 'prelude', 'set_defaults', 'tgt']"
         )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -298,9 +298,9 @@ class FieldDefaults:
     which compute the true value of the field given a subsytem argument. Consumers need to
     be type aware, and `@rules` cannot have dynamic requirements.
 
-    Additionally, `__defaults__` should mean that computed default Field values should become
+    Additionally, `set_defaults()` should mean that computed default Field values should become
     more rare: i.e. `JvmResolveField` and `PythonResolveField` could potentially move to
-    hardcoded default values which users override with `__defaults__` if they'd like to change
+    hardcoded default values which users override with `set_defaults()` if they'd like to change
     the default resolve names.
 
     See https://github.com/pantsbuild/pants/issues/12934 about potentially allowing unions


### PR DESCRIPTION
@asherf wisely pointed out in https://github.com/pantsbuild/pants/pull/16377#discussion_r936028718 that `__defaults__` is not an optimal name because it makes it sound like a private API, and also is Python-specific.

`set_defaults` is chosen because it is declarative. Unlike target types being a noun, it is intentionally a verb.

It is still safe to make this API change because 2.14 release candidates have not gone out yet.

[ci skip-rust]
[ci skip-build-wheels]