### PR TITLE
go: pass -p option to `go tool asm` on Go v1.19+ (Cherry pick of #16381)

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -246,7 +246,12 @@ async def build_go_package(
     if request.s_file_names:
         assembly_setup = await Get(
             FallibleAssemblyPreCompilation,
-            AssemblyPreCompilationRequest(input_digest, request.s_file_names, request.dir_path),
+            AssemblyPreCompilationRequest(
+                compilation_input=input_digest,
+                s_files=request.s_file_names,
+                dir_path=request.dir_path,
+                import_path=request.import_path,
+            ),
         )
         if assembly_setup.result is None:
             return FallibleBuiltGoPackage(


### PR DESCRIPTION
On Go v1.19+, the assembler (`go tool asm`) now requires the import path be specified via the `-p` option. 

Fixes https://github.com/pantsbuild/pants/issues/16380.

[ci skip-rust]

[ci skip-build-wheels]