### PR TITLE
Implement a `validate` mode to reduce network usage for remote caches

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -65,10 +65,10 @@ build_ignore.add = [
 
 unmatched_build_file_globs = "error"
 
-# NB: Users must still set `--remote-cache-{read,write}` to enable the remote cache.
-# TODO: May cause tests which experience missing digests to hang.
-# See https://github.com/pantsbuild/pants/issues/16096.
-remote_cache_eager_fetch = false
+# TODO: May cause tests which experience missing digests to hang. If you experience an
+# issue, please change this to `validate` and then report an issue on:
+#   https://github.com/pantsbuild/pants/issues/16096.
+cache_content_behavior = "defer"
 
 [anonymous-telemetry]
 enabled = true

--- a/pants.toml
+++ b/pants.toml
@@ -66,9 +66,9 @@ build_ignore.add = [
 unmatched_build_file_globs = "error"
 
 # TODO: May cause tests which experience missing digests to hang. If you experience an
-# issue, please change this to `validate` and then report an issue on:
+# issue, please change this to `fetch` and then report an issue on:
 #   https://github.com/pantsbuild/pants/issues/16096.
-cache_content_behavior = "defer"
+cache_content_behavior = "validate"
 
 [anonymous-telemetry]
 enabled = true

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -180,7 +180,7 @@ class Scheduler:
             store_rpc_concurrency=execution_options.remote_store_rpc_concurrency,
             store_batch_api_size_limit=execution_options.remote_store_batch_api_size_limit,
             cache_warnings_behavior=execution_options.remote_cache_warnings.value,
-            cache_eager_fetch=execution_options.remote_cache_eager_fetch,
+            cache_content_behavior=execution_options.cache_content_behavior.value,
             cache_rpc_concurrency=execution_options.remote_cache_rpc_concurrency,
             cache_read_timeout_millis=execution_options.remote_cache_read_timeout_millis,
             execution_extra_platform_properties=tuple(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -23,7 +23,7 @@ from pants.base.build_environment import (
     is_in_container,
     pants_version,
 )
-from pants.base.deprecated import deprecated_conditional
+from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
@@ -110,6 +110,13 @@ class RemoteCacheWarningsBehavior(Enum):
     ignore = "ignore"
     first_only = "first_only"
     backoff = "backoff"
+
+
+@enum.unique
+class CacheContentBehavior(Enum):
+    fetch = "fetch"
+    validate = "validate"
+    defer = "defer"
 
 
 @enum.unique
@@ -473,6 +480,7 @@ class ExecutionOptions:
     process_execution_remote_parallelism: int
     process_execution_cache_namespace: str | None
     process_execution_graceful_shutdown_timeout: int
+    cache_content_behavior: CacheContentBehavior
 
     process_total_child_memory_usage: int | None
     process_per_child_memory_usage: int
@@ -485,7 +493,6 @@ class ExecutionOptions:
     remote_store_rpc_concurrency: int
     remote_store_batch_api_size_limit: int
 
-    remote_cache_eager_fetch: bool
     remote_cache_warnings: RemoteCacheWarningsBehavior
     remote_cache_rpc_concurrency: int
     remote_cache_read_timeout_millis: int
@@ -518,6 +525,7 @@ class ExecutionOptions:
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             process_execution_graceful_shutdown_timeout=bootstrap_options.process_execution_graceful_shutdown_timeout,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
+            cache_content_behavior=GlobalOptions.resolve_cache_content_behavior(bootstrap_options),
             process_total_child_memory_usage=bootstrap_options.process_total_child_memory_usage,
             process_per_child_memory_usage=bootstrap_options.process_per_child_memory_usage,
             # Remote store setup.
@@ -529,7 +537,6 @@ class ExecutionOptions:
             remote_store_rpc_concurrency=dynamic_remote_options.store_rpc_concurrency,
             remote_store_batch_api_size_limit=bootstrap_options.remote_store_batch_api_size_limit,
             # Remote cache setup.
-            remote_cache_eager_fetch=bootstrap_options.remote_cache_eager_fetch,
             remote_cache_warnings=bootstrap_options.remote_cache_warnings,
             remote_cache_rpc_concurrency=dynamic_remote_options.cache_rpc_concurrency,
             remote_cache_read_timeout_millis=bootstrap_options.remote_cache_read_timeout_millis,
@@ -602,6 +609,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_cache_namespace=None,
     process_cleanup=True,
     local_cache=True,
+    cache_content_behavior=CacheContentBehavior.fetch,
     process_execution_local_enable_nailgun=True,
     process_execution_graceful_shutdown_timeout=3,
     # Remote store setup.
@@ -615,7 +623,6 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     remote_store_rpc_concurrency=128,
     remote_store_batch_api_size_limit=4194304,
     # Remote cache setup.
-    remote_cache_eager_fetch=True,
     remote_cache_warnings=RemoteCacheWarningsBehavior.backoff,
     remote_cache_rpc_concurrency=128,
     remote_cache_read_timeout_millis=1500,
@@ -1148,6 +1155,32 @@ class BootstrapOptions:
             """
         ),
     )
+    cache_content_behavior = EnumOption(
+        advanced=True,
+        default=DEFAULT_EXECUTION_OPTIONS.cache_content_behavior,
+        help=softwrap(
+            """
+            Controls how the content of cache entries is handled during process execution.
+
+            When using a remote cache, the `fetch` behavior will fetch remote cache content from the
+            remote store before considering the cache lookup a hit, while the `validate` behavior
+            will only validate (for either a local or remote cache) that the content exists, without
+            fetching it.
+
+            The `defer` behavior, on the other hand, will neither fetch nor validate the cache
+            content before calling a cache hit a hit. This "defers" actually consuming the cache
+            entry until a consumer consumes it.
+
+            The `defer` mode is the most network efficient (because it will completely skip network
+            requests in many cases), followed by the `validate` mode (since it can still skip
+            fetching the content if no consumer ends up needing it). But both the `validate` and
+            `defer` modes rely on an experimental feature called "backtracking" to attempt to
+            recover if content later turns out to be missing (`validate` has a much narrower window
+            for backtracking though, since content would need to disappear between validation and
+            consumption: generally, within one `pantsd` session).
+            """
+        ),
+    )
     ca_certs_path = StrOption(
         advanced=True,
         default=None,
@@ -1416,7 +1449,9 @@ class BootstrapOptions:
     )
     remote_cache_eager_fetch = BoolOption(
         advanced=True,
-        default=DEFAULT_EXECUTION_OPTIONS.remote_cache_eager_fetch,
+        default=(DEFAULT_EXECUTION_OPTIONS.cache_content_behavior != CacheContentBehavior.defer),
+        removal_version="2.15.0.dev1",
+        removal_hint="Use the `cache_content_behavior` option instead.",
         help=softwrap(
             """
             Eagerly fetch relevant content from the remote store instead of lazily fetching.
@@ -1834,6 +1869,29 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         return PyExecutor(
             core_threads=bootstrap_options.rule_threads_core, max_threads=rule_threads_max
         )
+
+    @staticmethod
+    def resolve_cache_content_behavior(
+        bootstrap_options: OptionValueContainer,
+    ) -> CacheContentBehavior:
+        resolved_value = resolve_conflicting_options(
+            old_option="remote_cache_eager_fetch",
+            new_option="cache_content_behavior",
+            old_scope="",
+            new_scope="",
+            old_container=bootstrap_options,
+            new_container=bootstrap_options,
+        )
+
+        if isinstance(resolved_value, bool):
+            # Is `remote_cache_eager_fetch`.
+            return CacheContentBehavior.fetch if resolved_value else CacheContentBehavior.defer
+        elif isinstance(resolved_value, CacheContentBehavior):
+            return resolved_value
+        else:
+            raise TypeError(
+                f"Unexpected option value for `cache_content_behavior`: {resolved_value}"
+            )
 
     @staticmethod
     def compute_pants_ignore(buildroot, global_options):

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -35,7 +35,7 @@ mod snapshot_ops_tests;
 mod snapshot_tests;
 pub use crate::snapshot_ops::{SnapshotOps, SubsetParams};
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{self, Debug, Display};
 use std::fs::OpenOptions;
 use std::future::Future;
@@ -749,8 +749,11 @@ impl Store {
         if Store::upload_is_faster_than_checking_whether_to_upload(&ingested_digests) {
           ingested_digests.keys().cloned().collect()
         } else {
-          let request = remote.find_missing_blobs_request(ingested_digests.keys());
-          remote.list_missing_digests(request).await?
+          remote
+            .list_missing_digests(
+              remote.find_missing_blobs_request(ingested_digests.keys().cloned()),
+            )
+            .await?
         };
 
       future::try_join_all(
@@ -851,6 +854,69 @@ impl Store {
         }
       })
       .await
+  }
+
+  ///
+  /// Return true if the given directory and file digests are loadable from either the local or remote
+  /// Store, without downloading any file content.
+  ///
+  /// The given directory digests will be recursively expanded, so it is not necessary to
+  /// explicitly list their file digests in the file digests list.
+  ///
+  pub async fn exists_recursive(
+    &self,
+    directory_digests: impl IntoIterator<Item = DirectoryDigest>,
+    file_digests: impl IntoIterator<Item = Digest>,
+  ) -> Result<bool, StoreError> {
+    // Load directories, which implicitly validates that they exist.
+    let digest_tries = future::try_join_all(
+      directory_digests
+        .into_iter()
+        .map(|dd| self.load_digest_trie(dd)),
+    )
+    .await?;
+
+    // Collect all file digests.
+    let mut file_digests = file_digests.into_iter().collect::<HashSet<_>>();
+    for digest_trie in digest_tries {
+      digest_trie.walk(&mut |_, entry| match entry {
+        directory::Entry::File(f) => {
+          file_digests.insert(f.digest());
+        }
+        directory::Entry::Directory(_) => (),
+      });
+    }
+
+    // Filter out file digests that exist locally.
+    // TODO: Implement a local batch API.
+    let local_file_exists = future::try_join_all(
+      file_digests
+        .iter()
+        .map(|file_digest| self.local.exists(EntryType::File, *file_digest))
+        .collect::<Vec<_>>(),
+    )
+    .await?;
+    let missing_locally = local_file_exists
+      .into_iter()
+      .zip(file_digests.into_iter())
+      .filter_map(|(exists, digest)| if exists { None } else { Some(digest) })
+      .collect::<Vec<_>>();
+
+    // If there are any digests which don't exist locally, check remotely.
+    if missing_locally.is_empty() {
+      return Ok(true);
+    }
+    let remote = if let Some(remote) = self.remote.clone() {
+      remote
+    } else {
+      return Ok(false);
+    };
+    let missing = remote
+      .store
+      .list_missing_digests(remote.store.find_missing_blobs_request(missing_locally))
+      .await?;
+
+    Ok(missing.is_empty())
   }
 
   ///

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -888,7 +888,7 @@ impl Store {
     }
 
     // Filter out file digests that exist locally.
-    // TODO: Implement a local batch API.
+    // TODO: Implement a local batch API: see https://github.com/pantsbuild/pants/issues/16400.
     let local_file_exists = future::try_join_all(
       file_digests
         .iter()

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -480,13 +480,13 @@ impl ByteStore {
     }
   }
 
-  pub fn find_missing_blobs_request<'a, Digests: Iterator<Item = &'a Digest>>(
+  pub fn find_missing_blobs_request(
     &self,
-    digests: Digests,
+    digests: impl IntoIterator<Item = Digest>,
   ) -> remexec::FindMissingBlobsRequest {
     remexec::FindMissingBlobsRequest {
       instance_name: self.instance_name.as_ref().cloned().unwrap_or_default(),
-      blob_digests: digests.map(|d| d.into()).collect::<Vec<_>>(),
+      blob_digests: digests.into_iter().map(|d| d.into()).collect::<Vec<_>>(),
     }
   }
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -259,9 +259,7 @@ async fn list_missing_digests_none_missing() {
   let store = new_byte_store(&cas);
   assert_eq!(
     store
-      .list_missing_digests(
-        store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-      )
+      .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]),)
       .await,
     Ok(HashSet::new())
   );
@@ -281,7 +279,7 @@ async fn list_missing_digests_some_missing() {
 
   assert_eq!(
     store
-      .list_missing_digests(store.find_missing_blobs_request(vec![digest].iter()),)
+      .list_missing_digests(store.find_missing_blobs_request(vec![digest]))
       .await,
     Ok(digest_set)
   );
@@ -295,9 +293,7 @@ async fn list_missing_digests_error() {
   let store = new_byte_store(&cas);
 
   let error = store
-    .list_missing_digests(
-      store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-    )
+    .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]))
     .await
     .expect_err("Want error");
   assert!(

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -5,7 +5,6 @@ use std::time::Instant;
 use async_trait::async_trait;
 use bytes::Bytes;
 use cache::PersistentCache;
-use futures::{future, FutureExt};
 use log::{debug, warn};
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
@@ -17,8 +16,8 @@ use workunit_store::{
 };
 
 use crate::{
-  CacheContentBehavior, Context, FallibleProcessResultWithPlatform, Platform, Process,
-  ProcessCacheScope, ProcessError, ProcessMetadata, ProcessResultSource,
+  check_cache_content, CacheContentBehavior, Context, FallibleProcessResultWithPlatform, Platform,
+  Process, ProcessCacheScope, ProcessError, ProcessMetadata, ProcessResultSource,
 };
 
 // TODO: Consider moving into protobuf as a CacheValue type.
@@ -205,28 +204,7 @@ impl CommandRunner {
       return Ok(None);
     };
 
-    // Optionally validate that all digests in the result are loadable, erroring if any are not.
-    // If content loading is deferred, a Digest which is discovered to be missing later on during
-    // execution will cause backtracking.
-    if self.cache_content_behavior != CacheContentBehavior::Defer {
-      // TODO: Should only validate that the Digest exists either locally or remotely: not
-      // fetch/`ensure_local_has` it.
-      let _ = future::try_join_all(vec![
-        self
-          .file_store
-          .ensure_local_has_file(result.stdout_digest)
-          .boxed(),
-        self
-          .file_store
-          .ensure_local_has_file(result.stderr_digest)
-          .boxed(),
-        self
-          .file_store
-          .ensure_local_has_recursive_directory(result.output_directory.clone())
-          .boxed(),
-      ])
-      .await?;
-    }
+    check_cache_content(&result, &self.file_store, self.cache_content_behavior).await?;
 
     Ok(Some(result))
   }

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -204,9 +204,11 @@ impl CommandRunner {
       return Ok(None);
     };
 
-    check_cache_content(&result, &self.file_store, self.cache_content_behavior).await?;
-
-    Ok(Some(result))
+    if check_cache_content(&result, &self.file_store, self.cache_content_behavior).await? {
+      Ok(Some(result))
+    } else {
+      Ok(None)
+    }
   }
 
   async fn store(

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -11,8 +11,9 @@ use testutil::relative_paths;
 use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, ImmutableInputs,
-  NamedCaches, Process, ProcessError, ProcessMetadata,
+  CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
+  FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Process, ProcessError,
+  ProcessMetadata,
 };
 
 struct RoundtripResults {
@@ -59,7 +60,7 @@ fn create_cached_runner(
     cache,
     store,
     true,
-    true,
+    CacheContentBehavior::Fetch,
     ProcessMetadata::default(),
   ));
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -755,6 +755,14 @@ impl From<ProcessResultSource> for &'static str {
   }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, strum_macros::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum CacheContentBehavior {
+  Fetch,
+  Validate,
+  Defer,
+}
+
 #[derive(Clone)]
 pub struct Context {
   workunit_store: WorkunitStore,

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -20,9 +20,9 @@ use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
 use crate::remote::{ensure_action_stored_locally, make_execute_request};
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, Platform,
-  Process, ProcessError, ProcessMetadata, ProcessResultMetadata, ProcessResultSource,
-  RemoteCacheWarningsBehavior,
+  CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
+  FallibleProcessResultWithPlatform, Platform, Process, ProcessError, ProcessMetadata,
+  ProcessResultMetadata, ProcessResultSource, RemoteCacheWarningsBehavior,
 };
 
 const CACHE_READ_TIMEOUT: Duration = Duration::from_secs(5);
@@ -127,7 +127,7 @@ fn create_local_runner(
 fn create_cached_runner(
   local: Box<dyn CommandRunnerTrait>,
   store_setup: &StoreSetup,
-  eager_fetch: bool,
+  cache_content_behavior: CacheContentBehavior,
 ) -> Box<dyn CommandRunnerTrait> {
   Box::new(
     crate::remote_cache::CommandRunner::new(
@@ -142,7 +142,7 @@ fn create_cached_runner(
       true,
       true,
       RemoteCacheWarningsBehavior::FirstOnly,
-      eager_fetch,
+      cache_content_behavior,
       256,
       CACHE_READ_TIMEOUT,
     )
@@ -170,7 +170,7 @@ async fn cache_read_success() {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let store_setup = StoreSetup::new();
   let (local_runner, local_runner_call_counter) = create_local_runner(1, 1000);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
 
   let (process, action_digest) = create_process(&store_setup).await;
   store_setup
@@ -194,7 +194,7 @@ async fn cache_read_skipped_on_action_cache_errors() {
   let (workunit_store, mut workunit) = WorkunitStore::setup_for_tests();
   let store_setup = StoreSetup::new();
   let (local_runner, local_runner_call_counter) = create_local_runner(1, 500);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
 
   let (process, action_digest) = create_process(&store_setup).await;
   store_setup
@@ -231,7 +231,7 @@ async fn cache_read_skipped_on_store_errors() {
   let (workunit_store, mut workunit) = WorkunitStore::setup_for_tests();
   let store_setup = StoreSetup::new();
   let (local_runner, local_runner_call_counter) = create_local_runner(1, 500);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, true);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Fetch);
 
   // Claim that the process has a non-empty and not-persisted stdout digest.
   let (process, action_digest) = create_process(&store_setup).await;
@@ -266,10 +266,13 @@ async fn cache_read_skipped_on_store_errors() {
 async fn cache_read_eager_fetch() {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
 
-  async fn run_process(eager_fetch: bool, workunit: &mut RunningWorkunit) -> (i32, usize) {
+  async fn run_process(
+    cache_content_behavior: CacheContentBehavior,
+    workunit: &mut RunningWorkunit,
+  ) -> (i32, usize) {
     let store_setup = StoreSetup::new();
     let (local_runner, local_runner_call_counter) = create_local_runner(1, 1000);
-    let cache_runner = create_cached_runner(local_runner, &store_setup, eager_fetch);
+    let cache_runner = create_cached_runner(local_runner, &store_setup, cache_content_behavior);
 
     let (process, action_digest) = create_process(&store_setup).await;
     store_setup.cas.action_cache.insert(
@@ -289,11 +292,13 @@ async fn cache_read_eager_fetch() {
     (remote_result.exit_code, final_local_count)
   }
 
-  let (lazy_exit_code, lazy_local_call_count) = run_process(false, &mut workunit).await;
+  let (lazy_exit_code, lazy_local_call_count) =
+    run_process(CacheContentBehavior::Defer, &mut workunit).await;
   assert_eq!(lazy_exit_code, 0);
   assert_eq!(lazy_local_call_count, 0);
 
-  let (eager_exit_code, eager_local_call_count) = run_process(true, &mut workunit).await;
+  let (eager_exit_code, eager_local_call_count) =
+    run_process(CacheContentBehavior::Fetch, &mut workunit).await;
   assert_eq!(eager_exit_code, 1);
   assert_eq!(eager_local_call_count, 1);
 }
@@ -314,7 +319,8 @@ async fn cache_read_speculation() {
         .build(),
     );
     let (local_runner, local_runner_call_counter) = create_local_runner(1, local_delay_ms);
-    let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+    let cache_runner =
+      create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
 
     let (process, action_digest) = create_process(&store_setup).await;
     if cache_hit {
@@ -355,7 +361,7 @@ async fn cache_write_success() {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let store_setup = StoreSetup::new();
   let (local_runner, local_runner_call_counter) = create_local_runner(0, 100);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
   let (process, action_digest) = create_process(&store_setup).await;
 
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
@@ -387,7 +393,7 @@ async fn cache_write_not_for_failures() {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let store_setup = StoreSetup::new();
   let (local_runner, local_runner_call_counter) = create_local_runner(1, 100);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
   let (process, _action_digest) = create_process(&store_setup).await;
 
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
@@ -415,7 +421,7 @@ async fn cache_write_does_not_block() {
       .build(),
   );
   let (local_runner, local_runner_call_counter) = create_local_runner(0, 100);
-  let cache_runner = create_cached_runner(local_runner, &store_setup, false);
+  let cache_runner = create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
   let (process, action_digest) = create_process(&store_setup).await;
 
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
@@ -608,7 +614,7 @@ async fn make_action_result_basic() {
     true,
     true,
     RemoteCacheWarningsBehavior::FirstOnly,
-    false,
+    CacheContentBehavior::Defer,
     256,
     CACHE_READ_TIMEOUT,
   )

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,7 +36,8 @@ use std::time::Duration;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  Context, ImmutableInputs, InputDigests, NamedCaches, Platform, ProcessCacheScope, ProcessMetadata,
+  CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches, Platform,
+  ProcessCacheScope, ProcessMetadata,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
@@ -318,7 +319,7 @@ async fn main() {
             true,
             true,
             process_execution::remote_cache::RemoteCacheWarningsBehavior::Backoff,
-            false,
+            CacheContentBehavior::Defer,
             args.cache_rpc_concurrency,
             Duration::from_secs(2),
           )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -26,8 +26,8 @@ use hashing::Digest;
 use log::info;
 use parking_lot::Mutex;
 use process_execution::{
-  self, bounded, local, nailgun, remote, remote_cache, CommandRunner, ImmutableInputs, NamedCaches,
-  Platform, ProcessMetadata, RemoteCacheWarningsBehavior,
+  self, bounded, local, nailgun, remote, remote_cache, CacheContentBehavior, CommandRunner,
+  ImmutableInputs, NamedCaches, Platform, ProcessMetadata, RemoteCacheWarningsBehavior,
 };
 use protos::gen::build::bazel::remote::execution::v2::ServerCapabilities;
 use regex::Regex;
@@ -93,7 +93,7 @@ pub struct RemotingOptions {
   pub store_rpc_concurrency: usize,
   pub store_batch_api_size_limit: usize,
   pub cache_warnings_behavior: RemoteCacheWarningsBehavior,
-  pub cache_eager_fetch: bool,
+  pub cache_content_behavior: CacheContentBehavior,
   pub cache_rpc_concurrency: usize,
   pub cache_read_timeout: Duration,
   pub execution_extra_platform_properties: Vec<(String, String)>,
@@ -273,9 +273,13 @@ impl Core {
     local_cache_read: bool,
     local_cache_write: bool,
   ) -> Result<Arc<dyn CommandRunner>, String> {
-    // TODO: Until we can deprecate letting the flag default, we implicitly disable
-    // eager_fetch when remote execution is in use. See the TODO in `global_options.py`.
-    let eager_fetch = remoting_opts.cache_eager_fetch && !remoting_opts.execution_enable;
+    // TODO: Until we can deprecate letting the flag default, we implicitly default
+    // cache_content_behavior when remote execution is in use. See the TODO in `global_options.py`.
+    let cache_content_behavior = if remoting_opts.execution_enable {
+      CacheContentBehavior::Defer
+    } else {
+      remoting_opts.cache_content_behavior
+    };
     if remote_cache_read || remote_cache_write {
       runner = Arc::new(remote_cache::CommandRunner::new(
         runner,
@@ -289,7 +293,7 @@ impl Core {
         remote_cache_read,
         remote_cache_write,
         remoting_opts.cache_warnings_behavior,
-        eager_fetch,
+        cache_content_behavior,
         remoting_opts.cache_rpc_concurrency,
         remoting_opts.cache_read_timeout,
       )?);
@@ -301,7 +305,7 @@ impl Core {
         local_cache.clone(),
         full_store.clone(),
         local_cache_read,
-        eager_fetch,
+        cache_content_behavior,
         process_execution_metadata.clone(),
       ));
     }
@@ -475,7 +479,7 @@ impl Core {
     )?;
 
     let store = if (exec_strategy_opts.remote_cache_read || exec_strategy_opts.remote_cache_write)
-      && remoting_opts.cache_eager_fetch
+      && remoting_opts.cache_content_behavior == CacheContentBehavior::Defer
     {
       // In remote cache mode with eager fetching, the only interaction with the remote CAS
       // should be through the remote cache code paths. Thus, the store seen by the rest of the

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -29,7 +29,7 @@ use log::{self, debug, error, warn, Log};
 use logging::logger::PANTS_LOGGER;
 use logging::{Logger, PythonLogLevel};
 use petgraph::graph::{DiGraph, Graph};
-use process_execution::RemoteCacheWarningsBehavior;
+use process_execution::{CacheContentBehavior, RemoteCacheWarningsBehavior};
 use pyo3::exceptions::{PyException, PyIOError, PyKeyboardInterrupt, PyValueError};
 use pyo3::prelude::{
   pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, PyModule, PyObject,
@@ -289,7 +289,7 @@ impl PyRemotingOptions {
     store_rpc_concurrency: usize,
     store_batch_api_size_limit: usize,
     cache_warnings_behavior: String,
-    cache_eager_fetch: bool,
+    cache_content_behavior: String,
     cache_rpc_concurrency: usize,
     cache_read_timeout_millis: u64,
     execution_extra_platform_properties: Vec<(String, String)>,
@@ -312,7 +312,7 @@ impl PyRemotingOptions {
       store_batch_api_size_limit,
       cache_warnings_behavior: RemoteCacheWarningsBehavior::from_str(&cache_warnings_behavior)
         .unwrap(),
-      cache_eager_fetch,
+      cache_content_behavior: CacheContentBehavior::from_str(&cache_content_behavior).unwrap(),
       cache_rpc_concurrency,
       cache_read_timeout: Duration::from_millis(cache_read_timeout_millis),
       execution_extra_platform_properties,


### PR DESCRIPTION
As reported in #16096, backtracking still has some kinks to work out, and is unlikely to be fully stable before `2.13.0` ships.

To gain "most" of the network-usage benefit of deferring fetching cache content while significantly narrowing the window in which backtracking is necessary, this change replaces the `remote_cache_eager_fetch` flag with a `cache_content_behavior` ternary option. As described in the `help` for the new option, the modes are:
* `fetch`: Eagerly fetches cache content: the default. Equivalent to `eager_fetch=True`, the previous default.
* `validate`: Validates that cache content exists either locally or remotely, without actually fetching files. This cannot be the default (without changing behavior), because it can still require backtracking if cache content expires during the lifetime of `pantsd` or a single run.
* `defer`: Does not validate or fetch content: equivalent to `eager_fetch=False`. Hopefully can eventually be made the default once all issues like #16096 are resolved.

Because `validate` narrows the window in which we backtrack to cases where content expires during a run, it should be relatively safe for use even within the `2.13.x` release.