### PR TITLE
Implement a `validate` mode to reduce network usage for remote caches (Cherry-pick of #16398)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -71,8 +71,10 @@ unmatched_build_file_globs = "error"
 remote_store_address = "grpcs://cache.toolchain.com:443"
 remote_instance_name = "main"
 remote_auth_plugin = "toolchain.pants.auth.plugin:toolchain_auth_plugin"
-# TODO: See https://github.com/pantsbuild/pants/issues/16096.
-remote_cache_eager_fetch = true
+# TODO: May cause tests which experience missing digests to hang. If you experience an
+# issue, please change this to `fetch` and then report an issue on:
+#   https://github.com/pantsbuild/pants/issues/16096.
+cache_content_behavior = "validate"
 
 [anonymous-telemetry]
 enabled = true

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -180,7 +180,7 @@ class Scheduler:
             store_rpc_concurrency=execution_options.remote_store_rpc_concurrency,
             store_batch_api_size_limit=execution_options.remote_store_batch_api_size_limit,
             cache_warnings_behavior=execution_options.remote_cache_warnings.value,
-            cache_eager_fetch=execution_options.remote_cache_eager_fetch,
+            cache_content_behavior=execution_options.cache_content_behavior.value,
             cache_rpc_concurrency=execution_options.remote_cache_rpc_concurrency,
             cache_read_timeout_millis=execution_options.remote_cache_read_timeout_millis,
             execution_extra_platform_properties=tuple(

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -480,13 +480,13 @@ impl ByteStore {
     }
   }
 
-  pub fn find_missing_blobs_request<'a, Digests: Iterator<Item = &'a Digest>>(
+  pub fn find_missing_blobs_request(
     &self,
-    digests: Digests,
+    digests: impl IntoIterator<Item = Digest>,
   ) -> remexec::FindMissingBlobsRequest {
     remexec::FindMissingBlobsRequest {
       instance_name: self.instance_name.as_ref().cloned().unwrap_or_default(),
-      blob_digests: digests.map(|d| d.into()).collect::<Vec<_>>(),
+      blob_digests: digests.into_iter().map(|d| d.into()).collect::<Vec<_>>(),
     }
   }
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -259,9 +259,7 @@ async fn list_missing_digests_none_missing() {
   let store = new_byte_store(&cas);
   assert_eq!(
     store
-      .list_missing_digests(
-        store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-      )
+      .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]),)
       .await,
     Ok(HashSet::new())
   );
@@ -281,7 +279,7 @@ async fn list_missing_digests_some_missing() {
 
   assert_eq!(
     store
-      .list_missing_digests(store.find_missing_blobs_request(vec![digest].iter()),)
+      .list_missing_digests(store.find_missing_blobs_request(vec![digest]))
       .await,
     Ok(digest_set)
   );
@@ -295,9 +293,7 @@ async fn list_missing_digests_error() {
   let store = new_byte_store(&cas);
 
   let error = store
-    .list_missing_digests(
-      store.find_missing_blobs_request(vec![TestData::roland().digest()].iter()),
-    )
+    .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]))
     .await
     .expect_err("Want error");
   assert!(

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -11,8 +11,9 @@ use testutil::relative_paths;
 use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, ImmutableInputs,
-  NamedCaches, Process, ProcessError, ProcessMetadata,
+  CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
+  FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Process, ProcessError,
+  ProcessMetadata,
 };
 
 struct RoundtripResults {
@@ -59,7 +60,7 @@ fn create_cached_runner(
     cache,
     store,
     true,
-    true,
+    CacheContentBehavior::Fetch,
     ProcessMetadata::default(),
   ));
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -44,7 +44,7 @@ use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use remexec::ExecutedActionMetadata;
 use serde::{Deserialize, Serialize};
 use store::{SnapshotOps, Store, StoreError};
-use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
+use workunit_store::{in_workunit, Level, RunId, RunningWorkunit, WorkunitStore};
 
 pub mod bounded;
 #[cfg(test)]
@@ -752,6 +752,67 @@ impl From<ProcessResultSource> for &'static str {
       ProcessResultSource::HitLocally => "hit_locally",
       ProcessResultSource::HitRemotely => "hit_remotely",
     }
+  }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, strum_macros::EnumString)]
+#[strum(serialize_all = "snake_case")]
+pub enum CacheContentBehavior {
+  Fetch,
+  Validate,
+  Defer,
+}
+
+///
+/// Optionally validate that all digests in the result are loadable, returning false if any are not.
+///
+/// If content loading is deferred, a Digest which is discovered to be missing later on during
+/// execution will cause backtracking.
+///
+pub(crate) async fn check_cache_content(
+  response: &FallibleProcessResultWithPlatform,
+  store: &Store,
+  cache_content_behavior: CacheContentBehavior,
+) -> Result<bool, StoreError> {
+  match cache_content_behavior {
+    CacheContentBehavior::Fetch => {
+      let response = response.clone();
+      let fetch_result = in_workunit!(
+        "eager_fetch_action_cache",
+        Level::Trace,
+        |_workunit| async move {
+          try_join_all(vec![
+            store.ensure_local_has_file(response.stdout_digest).boxed(),
+            store.ensure_local_has_file(response.stderr_digest).boxed(),
+            store
+              .ensure_local_has_recursive_directory(response.output_directory)
+              .boxed(),
+          ])
+          .await
+        }
+      )
+      .await;
+      match fetch_result {
+        Err(StoreError::MissingDigest { .. }) => Ok(false),
+        Ok(_) => Ok(true),
+        Err(e) => Err(e),
+      }
+    }
+    CacheContentBehavior::Validate => {
+      let directory_digests = vec![response.output_directory.clone()];
+      let file_digests = vec![response.stdout_digest, response.stderr_digest];
+      in_workunit!(
+        "eager_validate_action_cache",
+        Level::Trace,
+        |_workunit| async move {
+          store
+            .exists_recursive(directory_digests, file_digests)
+            .await
+        }
+      )
+      .await
+    }
+    CacheContentBehavior::Defer => Ok(true),
   }
 }
 

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use fs::{directory, DigestTrie, RelativePath};
-use futures::future::{self, BoxFuture, TryFutureExt};
+use futures::future::{BoxFuture, TryFutureExt};
 use futures::FutureExt;
 use grpc_util::retry::{retry_call, status_is_retryable};
 use grpc_util::{headers_to_http_header_map, layered_service, status_to_str, LayeredService};
@@ -23,8 +23,8 @@ use workunit_store::{
 
 use crate::remote::{apply_headers, make_execute_request, populate_fallible_execution_result};
 use crate::{
-  Context, FallibleProcessResultWithPlatform, Platform, Process, ProcessCacheScope, ProcessError,
-  ProcessMetadata, ProcessResultSource,
+  check_cache_content, CacheContentBehavior, Context, FallibleProcessResultWithPlatform, Platform,
+  Process, ProcessCacheScope, ProcessError, ProcessMetadata, ProcessResultSource,
 };
 use tonic::{Code, Request, Status};
 
@@ -54,7 +54,7 @@ pub struct CommandRunner {
   platform: Platform,
   cache_read: bool,
   cache_write: bool,
-  eager_fetch: bool,
+  cache_content_behavior: CacheContentBehavior,
   warnings_behavior: RemoteCacheWarningsBehavior,
   read_errors_counter: Arc<Mutex<BTreeMap<String, usize>>>,
   write_errors_counter: Arc<Mutex<BTreeMap<String, usize>>>,
@@ -74,7 +74,7 @@ impl CommandRunner {
     cache_read: bool,
     cache_write: bool,
     warnings_behavior: RemoteCacheWarningsBehavior,
-    eager_fetch: bool,
+    cache_content_behavior: CacheContentBehavior,
     concurrency_limit: usize,
     read_timeout: Duration,
   ) -> Result<Self, String> {
@@ -106,7 +106,7 @@ impl CommandRunner {
       platform,
       cache_read,
       cache_write,
-      eager_fetch,
+      cache_content_behavior,
       warnings_behavior,
       read_errors_counter: Arc::new(Mutex::new(BTreeMap::new())),
       write_errors_counter: Arc::new(Mutex::new(BTreeMap::new())),
@@ -264,7 +264,7 @@ impl CommandRunner {
         &context,
         self.action_cache_client.clone(),
         self.store.clone(),
-        self.eager_fetch,
+        self.cache_content_behavior,
         self.read_timeout,
       )
       .await;
@@ -511,7 +511,7 @@ async fn check_action_cache(
   context: &Context,
   action_cache_client: Arc<ActionCacheClient<LayeredService>>,
   store: Store,
-  eager_fetch: bool,
+  cache_content_behavior: CacheContentBehavior,
   timeout_duration: Duration,
 ) -> Result<Option<FallibleProcessResultWithPlatform>, ProcessError> {
   in_workunit!(
@@ -555,29 +555,17 @@ async fn check_action_cache(
         .await
         .map_err(|e| Status::unavailable(format!("Output roots could not be loaded: {e}")))?;
 
-        if eager_fetch {
-          // NB: `ensure_local_has_file` and `ensure_local_has_recursive_directory` are internally
-          // retried.
-          let response = response.clone();
-          in_workunit!(
-            "eager_fetch_action_cache",
-            Level::Trace,
-            desc = Some("eagerly fetching after action cache hit".to_owned()),
-            |_workunit| async move {
-              future::try_join_all(vec![
-                store.ensure_local_has_file(response.stdout_digest).boxed(),
-                store.ensure_local_has_file(response.stderr_digest).boxed(),
-                store
-                  .ensure_local_has_recursive_directory(response.output_directory)
-                  .boxed(),
-              ])
-              .await
-            }
-          )
+        let cache_content_valid = check_cache_content(&response, &store, cache_content_behavior)
           .await
-          .map_err(|e| Status::unavailable(format!("Output content could not be loaded: {e}")))?;
+          .map_err(|e| {
+            Status::unavailable(format!("Output content could not be validated: {e}"))
+          })?;
+
+        if cache_content_valid {
+          Ok(response)
+        } else {
+          Err(Status::not_found(""))
         }
-        Ok(response)
       })
       .await;
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,7 +36,8 @@ use std::time::Duration;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  Context, ImmutableInputs, InputDigests, NamedCaches, Platform, ProcessCacheScope, ProcessMetadata,
+  CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches, Platform,
+  ProcessCacheScope, ProcessMetadata,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
@@ -318,7 +319,7 @@ async fn main() {
             true,
             true,
             process_execution::remote_cache::RemoteCacheWarningsBehavior::Backoff,
-            false,
+            CacheContentBehavior::Defer,
             args.cache_rpc_concurrency,
             Duration::from_secs(2),
           )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -26,8 +26,8 @@ use hashing::Digest;
 use log::info;
 use parking_lot::Mutex;
 use process_execution::{
-  self, bounded, local, nailgun, remote, remote_cache, CommandRunner, ImmutableInputs, NamedCaches,
-  Platform, ProcessMetadata, RemoteCacheWarningsBehavior,
+  self, bounded, local, nailgun, remote, remote_cache, CacheContentBehavior, CommandRunner,
+  ImmutableInputs, NamedCaches, Platform, ProcessMetadata, RemoteCacheWarningsBehavior,
 };
 use protos::gen::build::bazel::remote::execution::v2::ServerCapabilities;
 use regex::Regex;
@@ -93,7 +93,7 @@ pub struct RemotingOptions {
   pub store_rpc_concurrency: usize,
   pub store_batch_api_size_limit: usize,
   pub cache_warnings_behavior: RemoteCacheWarningsBehavior,
-  pub cache_eager_fetch: bool,
+  pub cache_content_behavior: CacheContentBehavior,
   pub cache_rpc_concurrency: usize,
   pub cache_read_timeout: Duration,
   pub execution_extra_platform_properties: Vec<(String, String)>,
@@ -273,9 +273,13 @@ impl Core {
     local_cache_read: bool,
     local_cache_write: bool,
   ) -> Result<Arc<dyn CommandRunner>, String> {
-    // TODO: Until we can deprecate letting the flag default, we implicitly disable
-    // eager_fetch when remote execution is in use.
-    let eager_fetch = remoting_opts.cache_eager_fetch && !remoting_opts.execution_enable;
+    // TODO: Until we can deprecate letting the flag default, we implicitly default
+    // cache_content_behavior when remote execution is in use.
+    let cache_content_behavior = if remoting_opts.execution_enable {
+      CacheContentBehavior::Defer
+    } else {
+      remoting_opts.cache_content_behavior
+    };
     if remote_cache_read || remote_cache_write {
       runner = Arc::new(remote_cache::CommandRunner::new(
         runner,
@@ -289,7 +293,7 @@ impl Core {
         remote_cache_read,
         remote_cache_write,
         remoting_opts.cache_warnings_behavior,
-        eager_fetch,
+        cache_content_behavior,
         remoting_opts.cache_rpc_concurrency,
         remoting_opts.cache_read_timeout,
       )?);
@@ -301,7 +305,7 @@ impl Core {
         local_cache.clone(),
         full_store.clone(),
         local_cache_read,
-        eager_fetch,
+        cache_content_behavior,
         process_execution_metadata.clone(),
       ));
     }
@@ -475,7 +479,7 @@ impl Core {
     )?;
 
     let store = if (exec_strategy_opts.remote_cache_read || exec_strategy_opts.remote_cache_write)
-      && remoting_opts.cache_eager_fetch
+      && remoting_opts.cache_content_behavior == CacheContentBehavior::Defer
     {
       // In remote cache mode with eager fetching, the only interaction with the remote CAS
       // should be through the remote cache code paths. Thus, the store seen by the rest of the

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -29,7 +29,7 @@ use log::{self, debug, error, warn, Log};
 use logging::logger::PANTS_LOGGER;
 use logging::{Logger, PythonLogLevel};
 use petgraph::graph::{DiGraph, Graph};
-use process_execution::RemoteCacheWarningsBehavior;
+use process_execution::{CacheContentBehavior, RemoteCacheWarningsBehavior};
 use pyo3::exceptions::{PyException, PyIOError, PyKeyboardInterrupt, PyValueError};
 use pyo3::prelude::{
   pyclass, pyfunction, pymethods, pymodule, wrap_pyfunction, PyModule, PyObject,
@@ -289,7 +289,7 @@ impl PyRemotingOptions {
     store_rpc_concurrency: usize,
     store_batch_api_size_limit: usize,
     cache_warnings_behavior: String,
-    cache_eager_fetch: bool,
+    cache_content_behavior: String,
     cache_rpc_concurrency: usize,
     cache_read_timeout_millis: u64,
     execution_extra_platform_properties: Vec<(String, String)>,
@@ -312,7 +312,7 @@ impl PyRemotingOptions {
       store_batch_api_size_limit,
       cache_warnings_behavior: RemoteCacheWarningsBehavior::from_str(&cache_warnings_behavior)
         .unwrap(),
-      cache_eager_fetch,
+      cache_content_behavior: CacheContentBehavior::from_str(&cache_content_behavior).unwrap(),
       cache_rpc_concurrency,
       cache_read_timeout: Duration::from_millis(cache_read_timeout_millis),
       execution_extra_platform_properties,


### PR DESCRIPTION
As reported in #16096, backtracking still has some kinks to work out, and is unlikely to be fully stable before `2.13.0` ships.

To gain "most" of the network-usage benefit of deferring fetching cache content while significantly narrowing the window in which backtracking is necessary, this change replaces the `remote_cache_eager_fetch` flag with a `cache_content_behavior` ternary option. As described in the `help` for the new option, the modes are:
* `fetch`: Eagerly fetches cache content: the default. Equivalent to `eager_fetch=True`, the previous default.
* `validate`: Validates that cache content exists either locally or remotely, without actually fetching files. This cannot be the default (without changing behavior), because it can still require backtracking if cache content expires during the lifetime of `pantsd` or a single run.
* `defer`: Does not validate or fetch content: equivalent to `eager_fetch=False`. Hopefully can eventually be made the default once all issues like #16096 are resolved.

Because `validate` narrows the window in which we backtrack to cases where content expires during a run, it should be relatively safe for use even within the `2.13.x` release.

[ci skip-build-wheels]