### PR TITLE
Helper to make linters

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -7,17 +7,11 @@ import os
 from typing import Iterable
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
+from pants.backend.python.helpers import metalint
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
-from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.rules import Rule, collect_rules
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.docutil import git_url
@@ -65,36 +59,10 @@ class ClangFormat(PythonToolBase):
         )
 
 
-class ClangFormatLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = ClangFormat.options_scope
-
-
-@rule
-def setup_clangformat_lockfile(
-    _: ClangFormatLockfileSentinel, clangformat: ClangFormat, python_setup: PythonSetup
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        clangformat, use_pex=python_setup.generate_lockfiles_with_pex
-    )
-
-
-class ClangFormatExportSentinel(ExportPythonToolSentinel):
-    pass
-
-
-@rule
-def clangformat_export(_: ClangFormatExportSentinel, clangformat: ClangFormat) -> ExportPythonTool:
-    if not clangformat.export:
-        return ExportPythonTool(resolve_name=clangformat.options_scope, pex_request=None)
-    return ExportPythonTool(
-        resolve_name=clangformat.options_scope, pex_request=clangformat.to_pex_request()
-    )
-
-
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, ClangFormatLockfileSentinel),
-        UnionRule(ExportPythonToolSentinel, ClangFormatExportSentinel),
+        *metalint.make_export_rules(ClangFormat),
+        *metalint.make_lockfile_rules(ClangFormat),
     )

--- a/src/python/pants/backend/python/helpers/BUILD
+++ b/src/python/pants/backend/python/helpers/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/src/python/pants/backend/python/helpers/BUILD
+++ b/src/python/pants/backend/python/helpers/BUILD
@@ -1,1 +1,3 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 python_sources()

--- a/src/python/pants/backend/python/helpers/README.md
+++ b/src/python/pants/backend/python/helpers/README.md
@@ -1,3 +1,0 @@
-# Metalint
-
-A helper generate all the ceremony for linters

--- a/src/python/pants/backend/python/helpers/README.md
+++ b/src/python/pants/backend/python/helpers/README.md
@@ -1,0 +1,3 @@
+# Metalint
+
+A helper generate all the ceremony for linters

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -32,14 +32,14 @@ class Metalint:
         ]
 
 
-def mk(metalint_argv):
+def mk(linter_name, metalint_argv):
     class MetalintTool(PythonToolBase):
-        options_scope = "metalint"
-        name = "Metalint"
+        options_scope = linter_name
+        name = linter_name
         help = """ """
 
         default_version = "radon==5.1.0"
-        default_main = ConsoleScript("radon")
+        default_main = ConsoleScript(linter_name)
 
         register_interpreter_constraints = True
         default_interpreter_constraints = ["CPython>=3.7"]
@@ -55,7 +55,7 @@ def mk(metalint_argv):
 
     class MetalintRequest(LintTargetsRequest):
         field_set_type = MetalintFieldSet
-        name = "radon"
+        name = linter_name
 
     @rule(level=LogLevel.DEBUG)
     async def run_metalint(
@@ -64,7 +64,7 @@ def mk(metalint_argv):
         metalint_pex = Get(
             Pex,
             PexRequest(
-                output_filename="radon.pex",
+                output_filename=f"{linter_name}.pex",
                 internal_only=True,
                 requirements=metalint.pex_requirements(),
                 interpreter_constraints=metalint.interpreter_constraints,
@@ -96,7 +96,7 @@ def mk(metalint_argv):
                 downloaded_metalint,
                 argv=argv,
                 input_digest=input_digest,
-                description=f"Run Radon on {pluralize(len(request.field_sets), 'file')}.",
+                description=f"Run {linter_name} on {pluralize(len(request.field_sets), 'file')}.",
                 level=LogLevel.DEBUG,
             ),
         )
@@ -107,13 +107,13 @@ def mk(metalint_argv):
 
 
 def rules():
-    radon_argv = [
+    radon_cc = [
         "cc",
         "-s",
         "--total-average",
         "--no-assert",
         "-n",
     ]
-    radon = mk(radon_argv)
+    radon = mk("radoncc", radon_cc)
 
     return radon.rules()

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -32,7 +32,7 @@ class Metalint:
         ]
 
 
-def mk(linter_name, binary_name, version_spec, metalint_argv):
+def make_linter(linter_name, binary_name, version_spec, metalint_argv):
     class MetalintTool(PythonToolBase):
         options_scope = linter_name
         name = linter_name
@@ -59,7 +59,7 @@ def mk(linter_name, binary_name, version_spec, metalint_argv):
 
     @rule(level=LogLevel.DEBUG)
     async def run_metalint(
-            request: MetalintRequest, metalint: MetalintTool
+        request: MetalintRequest, metalint: MetalintTool
     ) -> LintResults:
         metalint_pex = Get(
             Pex,
@@ -107,18 +107,13 @@ def mk(linter_name, binary_name, version_spec, metalint_argv):
 
 
 def rules():
-    radon_cc = [
-        "cc",
-        "-s",
-        "--total-average",
-        "--no-assert",
-        "-n",
-    ]
-    radoncc = mk("radoncc", "radon", "radon==5.1.0", radon_cc)
-    radon_mi = [
-        "mi", "-m", "-s",
-    ]
-    radonmi = mk("radonmi", "radon", "radon==5.1.0", radon_mi)
-    vulture = mk("vulture", "vulture", "vulture==2.5", [])
+    radoncc = make_linter(
+        "radoncc",
+        "radon",
+        "radon==5.1.0",
+        ["cc", "-s", "--total-average", "--no-assert", "-n"],
+    )
+    radonmi = make_linter("radonmi", "radon", "radon==5.1.0", ["mi", "-m", "-s"])
+    vulture = make_linter("vulture", "vulture", "vulture==2.5", [])
 
     return [*radoncc.rules(), *radonmi.rules(), *vulture.rules()]

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -60,9 +60,10 @@ class MetalintTool(PythonToolBase):
         default=True,
         advanced=True,
         help=lambda cls: softwrap(
-            f"""
+            """
             If true, Pants will include any relevant config files during
-            runs (`.pylintrc`, `pylintrc`, `pyproject.toml`, and `setup.cfg`).
+            runs, as defined by the `config_request` function. By default
+            pulls in `pyproject.toml`.
 
             Use `[{cls.options_scope}].config` instead if your config is in a
             non-standard location.
@@ -82,7 +83,7 @@ class MetalintTool(PythonToolBase):
             specified=self.config,
             specified_option_name=f"[{self.options_scope}].config",
             discovery=self.config_discovery,
-            check_content={"pyproject.toml": b"[tool.vulture"},
+            check_existence="pyproject.toml",  # default to pull in pyproject.toml, since that's probably expected
         )
 
 

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -1,3 +1,14 @@
+"""
+Helper to rapidly incorporate Linters into pants.
+TODO:
+- does help work
+- lockfiles
+- export
+- config files
+- ? mutliple uses of the same tool (eg `radon cc`, `radon mi`)
+-
+"""
+
 from dataclasses import dataclass
 from typing import Callable, Iterable, Optional, Tuple, Type
 
@@ -19,6 +30,9 @@ from pants.util.strutil import pluralize
 
 class MetalintTool(PythonToolBase):
     args: ArgsListOption
+
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython>=3.7"]
 
 
 @dataclass(frozen=True)
@@ -130,9 +144,6 @@ def rules():
         default_version = "radon==5.1.0"
         default_main = ConsoleScript("radon")
 
-        register_interpreter_constraints = True
-        default_interpreter_constraints = ["CPython>=3.7"]
-
         args = ArgsListOption(example="--no-assert")
 
     def radon_cc_args(tool: MetalintTool, files: Tuple[str, ...]):
@@ -152,9 +163,6 @@ def rules():
 
         default_version = "vulture==2.5"
         default_main = ConsoleScript("vulture")
-
-        register_interpreter_constraints = True
-        default_interpreter_constraints = ["CPython>=3.7"]
 
         args = ArgsListOption(example="--min-confidence 95")
 

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -35,6 +35,16 @@ class Metalint:
 ArgvMaker = Callable[[PythonToolBase, Tuple[str, ...]], Iterable[str]]
 
 
+def no_argv(tool: PythonToolBase, files: Tuple[str, ...]):
+    """Helper for tools that just run without any args"""
+    return []
+
+
+def files_argv(tool: PythonToolBase, files: Tuple[str, ...]):
+    """Helper for tools that just take a list of files to run against"""
+    return files
+
+
 def make_linter(python_tool: Type[PythonToolBase], linter_name, argv_maker: ArgvMaker):
     @dataclass(frozen=True)
     class MetalintFieldSet(FieldSet):
@@ -133,9 +143,6 @@ def rules():
 
         args = ArgsListOption(example="")
 
-    def vulture_args(tool: PythonToolBase, files: Tuple[str, ...]):
-        return files
-
-    vulture = make_linter(VultureTool, "vulture", vulture_args)
+    vulture = make_linter(VultureTool, "vulture", files_argv)
 
     return [*radoncc.rules(), *radonmi.rules(), *vulture.rules()]

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -32,7 +32,7 @@ class Metalint:
         ]
 
 
-def mk():
+def mk(metalint_argv):
     class MetalintTool(PythonToolBase):
         options_scope = "metalint"
         name = "Metalint"
@@ -89,19 +89,12 @@ def mk():
             ),
         )
 
-        radon_argv = [
-            "cc",
-            "-s",
-            "--total-average",
-            "--no-assert",
-            "-n",
-            *sources.snapshot.files,
-        ]
+        argv = [*metalint_argv, *sources.snapshot.files]
         process_result = await Get(
             FallibleProcessResult,
             PexProcess(
                 downloaded_metalint,
-                argv=radon_argv,
+                argv=argv,
                 input_digest=input_digest,
                 description=f"Run Radon on {pluralize(len(request.field_sets), 'file')}.",
                 level=LogLevel.DEBUG,
@@ -114,6 +107,13 @@ def mk():
 
 
 def rules():
-    radon = mk()
+    radon_argv = [
+        "cc",
+        "-s",
+        "--total-average",
+        "--no-assert",
+        "-n",
+    ]
+    radon = mk(radon_argv)
 
     return radon.rules()

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -2,8 +2,6 @@
 Helper to rapidly incorporate Linters into pants.
 TODO:
 - config files
-- ? mutliple uses of the same tool (eg `radon cc`, `radon mi`)
--
 """
 import functools
 from dataclasses import dataclass
@@ -30,7 +28,7 @@ from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.target import Dependencies, FieldSet
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption
+from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -46,6 +44,8 @@ class MetalintTool(PythonToolBase):
     register_lockfile = True
     default_lockfile_resource = ("", "")
     default_lockfile_url = "hihello"
+
+    skip = SkipOption("lint")
 
     @property
     def lockfile(self) -> str:
@@ -158,6 +158,9 @@ def make_linter(
     async def run_metalint(
         request: MetalintRequest, metalint: python_tool
     ) -> LintResults:
+        if metalint.skip:
+            return LintResults([], linter_name=request.name)
+
         metalint_pex = Get(
             Pex,
             PexRequest(

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, Iterable, Tuple, Type
+from typing import Callable, Iterable, Optional, Tuple, Type
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript, PythonSourceField
@@ -49,17 +49,28 @@ def files_argv(tool: MetalintTool, files: Tuple[str, ...]):
     return files
 
 
-def make_linter(python_tool: Type[MetalintTool], linter_name, argv_maker: ArgvMaker):
-    @dataclass(frozen=True)
-    class MetalintFieldSet(FieldSet):
-        required_fields = (PythonSourceField,)
+def make_linter(
+    python_tool: Type[MetalintTool],
+    linter_name,
+    argv_maker: ArgvMaker,
+    MetalintFieldSet: Optional[Type[FieldSet]] = None,
+    MetalintRequest: Optional[Type[LintTargetsRequest]] = None,
+):
 
-        sources: PythonSourceField
-        dependencies: Dependencies
+    if not MetalintFieldSet:
 
-    class MetalintRequest(LintTargetsRequest):
-        field_set_type = MetalintFieldSet
-        name = linter_name
+        @dataclass(frozen=True)
+        class MetalintFieldSet(FieldSet):
+            required_fields = (PythonSourceField,)
+
+            sources: PythonSourceField
+            dependencies: Dependencies
+
+    if not MetalintRequest:
+
+        class MetalintRequest(LintTargetsRequest):
+            field_set_type = MetalintFieldSet
+            name = linter_name
 
     @rule(level=LogLevel.DEBUG)
     async def run_metalint(

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -32,13 +32,13 @@ class Metalint:
         ]
 
 
-def mk(linter_name, binary_name, metalint_argv):
+def mk(linter_name, binary_name, version_spec, metalint_argv):
     class MetalintTool(PythonToolBase):
         options_scope = linter_name
         name = linter_name
         help = """ """
 
-        default_version = "radon==5.1.0"
+        default_version = version_spec
         default_main = ConsoleScript(binary_name)
 
         register_interpreter_constraints = True
@@ -114,10 +114,10 @@ def rules():
         "--no-assert",
         "-n",
     ]
-    radoncc = mk("radoncc", "radon", radon_cc)
+    radoncc = mk("radoncc", "radon", "radon==5.1.0", radon_cc)
     radon_mi = [
         "mi", "-m", "-s",
     ]
-    radonmi = mk("radonmi", "radon", radon_mi)
+    radonmi = mk("radonmi", "radon", "radon==5.1.0", radon_mi)
 
     return [*radoncc.rules(), *radonmi.rules()]

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -1,0 +1,116 @@
+from dataclasses import dataclass
+from typing import Callable, Type
+
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript, PythonSourceField
+from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
+from pants.core.goals.lint import LintResult, LintResults, LintTargetsRequest
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import FallibleProcessResult, Process
+from pants.engine.rules import SubsystemRule, collect_rules, rule
+from pants.engine.target import Dependencies, FieldSet
+from pants.engine.unions import UnionRule
+from pants.option.option_types import ArgsListOption
+from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
+
+
+@dataclass(frozen=True)
+class Metalint:
+    tool: Type[PythonToolBase]
+    fs: Type[FieldSet]
+    lint_req: Type[LintTargetsRequest]
+    run_rule: Callable
+
+
+def mk():
+    class MetalintTool(PythonToolBase):
+        options_scope = "metalint"
+        name = "Metalint"
+        help = """ """
+
+        default_version = "radon==5.1.0"
+        default_main = ConsoleScript("radon")
+
+        register_interpreter_constraints = True
+        default_interpreter_constraints = ["CPython>=3.7"]
+
+        args = ArgsListOption(example="")
+
+    @dataclass(frozen=True)
+    class MetalintFieldSet(FieldSet):
+        required_fields = (PythonSourceField,)
+
+        sources: PythonSourceField
+        dependencies: Dependencies
+
+    class MetalintRequest(LintTargetsRequest):
+        field_set_type = MetalintFieldSet
+        name = "radon"
+
+    @rule(level=LogLevel.DEBUG)
+    async def run_metalint(
+        request: MetalintRequest, metalint: MetalintTool
+    ) -> LintResults:
+        metalint_pex = Get(
+            Pex,
+            PexRequest(
+                output_filename="radon.pex",
+                internal_only=True,
+                requirements=metalint.pex_requirements(),
+                interpreter_constraints=metalint.interpreter_constraints,
+                main=metalint.main,
+            ),
+        )
+
+        sources_request = Get(
+            SourceFiles,
+            SourceFilesRequest(field_set.sources for field_set in request.field_sets),
+        )
+
+        downloaded_metalint, sources = await MultiGet(metalint_pex, sources_request)
+
+        input_digest = await Get(
+            Digest,
+            MergeDigests(
+                (
+                    downloaded_metalint.digest,
+                    sources.snapshot.digest,
+                )
+            ),
+        )
+
+        radon_argv = [
+            "cc",
+            "-s",
+            "--total-average",
+            "--no-assert",
+            "-n",
+            *sources.snapshot.files,
+        ]
+        process_result = await Get(
+            FallibleProcessResult,
+            PexProcess(
+                downloaded_metalint,
+                argv=radon_argv,
+                input_digest=input_digest,
+                description=f"Run Radon on {pluralize(len(request.field_sets), 'file')}.",
+                level=LogLevel.DEBUG,
+            ),
+        )
+        result = LintResult.from_fallible_process_result(process_result)
+        return LintResults([result], linter_name=request.name)
+
+    return Metalint(MetalintTool, MetalintFieldSet, MetalintRequest, run_metalint)
+
+
+def rules():
+    radon = mk()
+
+    return [
+        SubsystemRule(radon.tool),
+        UnionRule(LintTargetsRequest, radon.lint_req),
+        radon.run_rule,
+    ]

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -24,6 +24,13 @@ class Metalint:
     lint_req: Type[LintTargetsRequest]
     run_rule: Callable
 
+    def rules(self):
+        return [
+            SubsystemRule(self.tool),
+            UnionRule(LintTargetsRequest, self.lint_req),
+            self.run_rule,
+        ]
+
 
 def mk():
     class MetalintTool(PythonToolBase):
@@ -52,7 +59,7 @@ def mk():
 
     @rule(level=LogLevel.DEBUG)
     async def run_metalint(
-        request: MetalintRequest, metalint: MetalintTool
+            request: MetalintRequest, metalint: MetalintTool
     ) -> LintResults:
         metalint_pex = Get(
             Pex,
@@ -109,8 +116,4 @@ def mk():
 def rules():
     radon = mk()
 
-    return [
-        SubsystemRule(radon.tool),
-        UnionRule(LintTargetsRequest, radon.lint_req),
-        radon.run_rule,
-    ]
+    return radon.rules()

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -32,14 +32,14 @@ class Metalint:
         ]
 
 
-def mk(linter_name, metalint_argv):
+def mk(linter_name, binary_name, metalint_argv):
     class MetalintTool(PythonToolBase):
         options_scope = linter_name
         name = linter_name
         help = """ """
 
         default_version = "radon==5.1.0"
-        default_main = ConsoleScript(linter_name)
+        default_main = ConsoleScript(binary_name)
 
         register_interpreter_constraints = True
         default_interpreter_constraints = ["CPython>=3.7"]
@@ -114,6 +114,10 @@ def rules():
         "--no-assert",
         "-n",
     ]
-    radon = mk("radoncc", radon_cc)
+    radoncc = mk("radoncc", "radon", radon_cc)
+    radon_mi = [
+        "mi", "-m", "-s",
+    ]
+    radonmi = mk("radonmi", "radon", radon_mi)
 
-    return radon.rules()
+    return [*radoncc.rules(), *radonmi.rules()]

--- a/src/python/pants/backend/python/helpers/metalint.py
+++ b/src/python/pants/backend/python/helpers/metalint.py
@@ -119,5 +119,6 @@ def rules():
         "mi", "-m", "-s",
     ]
     radonmi = mk("radonmi", "radon", "radon==5.1.0", radon_mi)
+    vulture = mk("vulture", "vulture", "vulture==2.5", [])
 
-    return [*radoncc.rules(), *radonmi.rules()]
+    return [*radoncc.rules(), *radonmi.rules(), *vulture.rules()]

--- a/src/python/pants/backend/python/helpers/register.py
+++ b/src/python/pants/backend/python/helpers/register.py
@@ -1,11 +1,61 @@
-from __future__ import annotations
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Tuple
 
-from typing import Iterable
+from pants.backend.python.helpers.metalint import MetalintTool, make_linter
+from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import ConfigFilesRequest
+from pants.option.option_types import ArgsListOption
 
-from experimental.metalint import metalint
-from pants.engine.rules import Rule
-from pants.engine.unions import UnionRule
 
+def rules():
+    class RadonTool(MetalintTool):
+        options_scope = "radon"
+        name = "radon"
+        help = """Radon is a Python tool which computes various code metrics."""
 
-def rules() -> Iterable[Rule | UnionRule]:
-    return (*metalint.rules(),)
+        default_version = "radon==5.1.0"
+        default_main = ConsoleScript("radon")
+
+        args = ArgsListOption(example="--no-assert")
+
+        def config_request(self) -> ConfigFilesRequest:
+            """https://radon.readthedocs.io/en/latest/commandline.html#radon-configuration-files."""
+            return ConfigFilesRequest(
+                specified=self.config,
+                specified_option_name=f"[{self.options_scope}].config",
+                discovery=self.config_discovery,
+                check_existence=["radon.cfg"],
+                check_content={"setup.cfg": b"[radon]"},
+            )
+
+    def radon_cc_args(tool: MetalintTool, files: Tuple[str, ...]):
+        return ["cc"] + ["-s", "--total-average", "--no-assert", "-nb"] + list(files)
+
+    radoncc = make_linter(RadonTool, "radoncc", radon_cc_args)
+
+    def radon_mi_args(tool: MetalintTool, files: Tuple[str, ...]):
+        return ["mi"] + ["-m", "-s"] + list(files)
+
+    radonmi = make_linter(RadonTool, "radonmi", radon_mi_args)
+
+    class VultureTool(MetalintTool):
+        options_scope = "vulture"
+        name = "Vulture"
+        help = """Vulture finds unused code in Python programs"""
+
+        default_version = "vulture==2.5"
+        default_main = ConsoleScript("vulture")
+
+        args = ArgsListOption(example="--min-confidence 95")
+
+    def vulture_args(tool: VultureTool, files: Tuple[str, ...]):
+        return tool.args + files
+
+    vulture = make_linter(VultureTool, "vulture", vulture_args)
+
+    return [
+        *radoncc.rules(),
+        *radonmi.rules(),
+        *vulture.rules(),
+    ]

--- a/src/python/pants/backend/python/helpers/register.py
+++ b/src/python/pants/backend/python/helpers/register.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from experimental.metalint import metalint
+from pants.engine.rules import Rule
+from pants.engine.unions import UnionRule
+
+
+def rules() -> Iterable[Rule | UnionRule]:
+    return (*metalint.rules(),)


### PR DESCRIPTION
I was looking at one of my old projects. It was from before I discovered Pants, so it uses Tox. I was reminded that it is incredibly easy to just run a python package in tox:
```ini
[testenv:radon]
deps = radon
commands = 
    radon cc -s --total-average --no-assert -nb src/
```
I thought it would be great if it were that easy to create a linter in Pants. So I hacked together this prototype!
now it's as simple as
```python
def rules():
    class VultureTool(MetalintTool):
        options_scope = "vulture"
        name = "Vulture"
        help = """Vulture finds unused code in Python programs"""

        default_version = "vulture==2.5"
        default_main = ConsoleScript("vulture")

        args = ArgsListOption(example="--min-confidence 95")

    def vulture_args(tool: VultureTool, files: Tuple[str, ...]):
        return tool.args + files

    vulture = make_linter(VultureTool, "vulture", vulture_args)

    return [
        *vulture.rules(),
    ]
```
This MR follows (reasonably closely) the [Add a linter](https://www.pantsbuild.org/docs/plugins-lint-goal) common task walkthrough.

Initial discussion questions:
1. Do we want this type of helper in Pants?
2. Is this type of helper (a function that generates the rules) the type of helper we want?
3. What features would we need before helpers like this are mergeable?

## Understanding this MR

register.py contains 3 example linters. 2 of them share the same tool, which produces some surprising results but actually works.
`MetalintTool` extends `PythonToolBase` with the fields that make the expected actions (in particular, export and generate-lockfiles) go. This class is 1 part of the basic interface of Metalint. The other component is `make_linter`, which creates all the classes and the rules and shoves them all together into the `Metalint` DTO.

Some of the helpers could also be useful on their own. For example, `make_export_rules` can dynamically generate the boilerplate for the export task.

## What is even happening

`MetalintTool` adds all the fields to make things go.
`Metalint` is a DTO, convenient for gathering all the rules
`make_linter` is the real function here. It accepts a MetalintTool class and an `argv_maker` (which enables the caller to format the invocation arguments as required. This allows passing the right flags and formatting all the filenames, if needed). It optionally accepts the `FieldSet` and `LintTargetsRequest`, as escape hatches. IDK, until Mypy ruined the fun it was an easy include.
`make_export_rules` and `make_lockfile_rules` use a cache to ensure that a tool used in multiple linters only has 1 set of rules generated for it. (It looks like Pants deduplicates rules if they are equal by identity.)
Otherwise it's fairly standard dynamic class generation. The classes themselves are not equal by identity because they are created as variables inside the function, so each invocation of the function creates a new class. It uses a function instead of a class because the classes have dependencies on each other; but all the statements in a class have to be mostly valid on their own, so they can't depend on each other like this (at least AFAIK).

## Known limitations and future work

- tests
- lockfile generation is a lot of a mess, at least internally. The problem is that the lockfile code assumes that we're shipping a lockfile. Which we aren't, since someone is dynamically generating the idea of this lockfile. It still works, although you have to generate lockfiles first.
- does not allow post-processing the result of running the tool. Some tools won't fail your code, but you might want to induce a failure depending on the output. For example, [Radon's Maintainability Index](https://radon.readthedocs.io/en/latest/commandline.html#the-mi-command): you might want to fail if this is too low. I include this here because inserting a postprocess step might be really easy.
- only works with Linters. I think iformatters would be necessary. Ideally we'd also have run targets, although that's maybe less necessary with macros and the experimental_shell_command
- only works with python tools. At a minimum it should work with a binary that the user has on their system. Ideally we'd also build helpers to fetch default_known_versions from popular places, like github releases.
- typing is a bit of a mess, if anyone knows how to get mypy to let you use an arg of type `Type[T]` as a valid type annotation LMK.
