### PR TITLE
Replace `--[no-]process-cleanup` with `--keep-sandboxes={always,never,on_failure}` (Cherry-pick of #16415)

### DIFF
--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -27,19 +27,21 @@ Setting the option `--pex-verbosity=9` can help debug exceptions that occur when
 
 Once you have this stack trace, we recommend copying it into Pastebin or a GitHub Gist, then opening a GitHub issue or posting on Slack. Someone from the Pants team would be happy to help. See [Getting Help](doc:getting-help).
 
-Debug tip: inspect the sandbox with `--no-process-cleanup`
+Debug tip: inspect the sandbox with `--keep-sandboxes`
 ----------------------------------------------------------
 
 Pants runs most processes in a hermetic sandbox (temporary directory), which allows for safely caching and running multiple processes in parallel. 
 
-Use the option `--no-process-cleanup` for Pants to log the paths to these sandboxes, and to keep them around after the run. You can then inspect them to check if the files you are expecting are present.
+Use the option `--keep-sandboxes=always` for Pants to log the paths to these sandboxes, and to keep them around after the run. You can then inspect them to check if the files you are expecting are present.
 
 ```bash
-./pants --no-process-cleanup lint src/project/app.py
+./pants --keep-sandboxes=always lint src/project/app.py
 ...
 21:26:13.55 [INFO] preserving local process execution dir `"/private/var/folders/hm/qjjq4w3n0fsb07kp5bxbn8rw0000gn/T/process-executionQgIOjb"` for "Run isort on 1 file."
 ...
 ```
+
+You can also pass `--keep-sandboxes=on_failure`, to preserve only the sandboxes of failing processes.
 
 There is even a `__run.sh` script in the directory that will run the process using the same argv and environment that Pants would use.
 

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
@@ -38,7 +38,7 @@ The process will run in a temporary directory and is hermetic, meaning that it c
 
 > 📘 Debugging a `Process`
 > 
-> Setting the [`--no-process-cleanup`](docs:rules-api-tips#debugging-look-inside-the-chroot) flag will cause the sandboxes of `Process`es to be preserved and logged to the console for inspection.
+> Setting the [`--keep-sandboxes=always`](docs:rules-api-tips#debugging-look-inside-the-chroot) flag will cause the sandboxes of `Process`es to be preserved and logged to the console for inspection.
 > 
 > It can be very helpful while editing `Process` definitions!
 

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-tips.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-tips.md
@@ -61,12 +61,12 @@ Pants will also memoize in-memory the evaluation of all `@rule`s. This means tha
 Debugging: Look inside the chroot
 ---------------------------------
 
-When Pants runs most processes, it runs in a `chroot` (temporary directory). Usually, this gets cleaned up after the `Process` finishes. You can instead run `./pants --no-process-cleanup`, which will keep around the folder.
+When Pants runs most processes, it runs in a `chroot` (temporary directory). Usually, this gets cleaned up after the `Process` finishes. You can instead pass `--keep-sandboxes=always` to keep those directories for all processes, or `--keep-sandboxes=on_failure` to keep those directories for only processes which have failed.
 
 Pants will log the path to the chroot, e.g.:
 
 ```
-▶ ./pants --no-process-cleanup test src/python/pants/util/strutil_test.py
+▶ ./pants --keep-sandboxes=always test src/python/pants/util/strutil_test.py
 ...
 12:29:45.08 [INFO] preserving local process execution dir `"/private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/process-executionN9Kdk0"` for "Test binary /Users/pantsbuild/.pyenv/shims/python3."
 ...

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -40,7 +40,7 @@ from pants.engine.process import FallibleProcessResult, Process, ProcessExecutio
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionRule
-from pants.option.global_options import GlobalOptions, ProcessCleanupOption
+from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.util.strutil import bullet_list
 
 logger = logging.getLogger(__name__)
@@ -233,7 +233,7 @@ async def build_docker_image(
     options: DockerOptions,
     global_options: GlobalOptions,
     docker: DockerBinary,
-    process_cleanup: ProcessCleanupOption,
+    keep_sandboxes: KeepSandboxes,
 ) -> BuiltPackage:
     """Build a Docker image using `docker build`."""
     context, wrapped_target = await MultiGet(
@@ -290,7 +290,7 @@ async def build_docker_image(
             result.stdout,
             result.stderr,
             process.description,
-            process_cleanup=process_cleanup.val,
+            keep_sandboxes=keep_sandboxes,
         )
 
     image_id = parse_image_id_from_docker_build_output(result.stdout, result.stderr)

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -53,7 +53,7 @@ from pants.engine.process import (
     ProcessResultMetadata,
 )
 from pants.engine.target import InvalidFieldException, WrappedTarget, WrappedTargetRequest
-from pants.option.global_options import GlobalOptions, ProcessCleanupOption
+from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.pytest_util import assert_logged, no_exception
 from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
@@ -146,7 +146,7 @@ def assert_build(
             docker_options,
             global_options,
             DockerBinary("/dummy/docker"),
-            ProcessCleanupOption(True),
+            KeepSandboxes.never,
         ],
         mock_gets=[
             MockGet(

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -21,7 +21,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
-from pants.option.global_options import ProcessCleanupOption
+from pants.option.global_options import KeepSandboxes
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -53,7 +53,7 @@ class JavaParserCompiledClassfiles:
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleJavaSourceDependencyAnalysisResult,
-    process_cleanup: ProcessCleanupOption,
+    keep_sandboxes: KeepSandboxes,
 ) -> JavaSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -68,7 +68,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Java source dependency analysis failed.",
-        process_cleanup=process_cleanup.val,
+        keep_sandboxes=keep_sandboxes,
     )
 
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -21,7 +21,7 @@ from pants.jvm.jdk_rules import InternalJdk, JdkEnvironment, JdkRequest, JvmProc
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
-from pants.option.global_options import ProcessCleanupOption
+from pants.option.global_options import KeepSandboxes
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -207,7 +207,7 @@ async def analyze_kotlin_source_dependencies(
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleKotlinSourceDependencyAnalysisResult,
-    process_cleanup: ProcessCleanupOption,
+    keep_sandboxes: KeepSandboxes,
 ) -> KotlinSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -222,7 +222,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Kotlin source dependency analysis failed.",
-        process_cleanup=process_cleanup.val,
+        keep_sandboxes=keep_sandboxes,
     )
 
 

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -49,7 +49,7 @@ from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure,
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
-from pants.option.global_options import ProcessCleanupOption
+from pants.option.global_options import KeepSandboxes
 from pants.option.option_types import (
     BoolOption,
     EnumListOption,
@@ -494,7 +494,7 @@ async def generate_coverage_reports(
     coverage_setup: CoverageSetup,
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
-    process_cleanup: ProcessCleanupOption,
+    keep_sandboxes: KeepSandboxes,
     distdir: DistDir,
 ) -> CoverageReports:
     """Takes all Python test results and generates a single coverage report."""
@@ -573,7 +573,7 @@ async def generate_coverage_reports(
                 res.stdout,
                 res.stderr,
                 proc.description,
-                process_cleanup=process_cleanup.val,
+                keep_sandboxes=keep_sandboxes,
             )
 
     # In practice if one result triggers --fail-under, they all will, but no need to rely on that.

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -35,7 +35,7 @@ from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
-from pants.option.global_options import ProcessCleanupOption
+from pants.option.global_options import KeepSandboxes
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -292,7 +292,7 @@ async def analyze_scala_source_dependencies(
 @rule(level=LogLevel.DEBUG)
 async def resolve_fallible_result_to_analysis(
     fallible_result: FallibleScalaSourceDependencyAnalysisResult,
-    process_cleanup: ProcessCleanupOption,
+    keep_sandboxes: KeepSandboxes,
 ) -> ScalaSourceDependencyAnalysis:
     # TODO(#12725): Just convert directly to a ProcessResult like this:
     # result = await Get(ProcessResult, FallibleProcessResult, fallible_result.process_result)
@@ -307,7 +307,7 @@ async def resolve_fallible_result_to_analysis(
         fallible_result.process_result.stdout,
         fallible_result.process_result.stderr,
         "Scala source dependency analysis failed.",
-        process_cleanup=process_cleanup.val,
+        keep_sandboxes=keep_sandboxes,
     )
 
 

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -25,7 +25,7 @@ from pants.engine.target import (
     WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, union
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.option.option_types import ArgsListOption, BoolOption
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
@@ -111,14 +111,17 @@ class RunSubsystem(GoalSubsystem):
     cleanup = BoolOption(
         "--cleanup",
         default=True,
+        deprecation_start_version="2.15.0.dev1",
+        removal_version="2.16.0.dev1",
+        removal_hint="Use the global `keep_sandboxes` option instead.",
         help=softwrap(
             """
             Whether to clean up the temporary directory in which the binary is chrooted.
             Set this to false to retain the directory, e.g., for debugging.
 
-            Note that setting the global --process-cleanup option to false will also conserve
-            this directory, along with those of all other processes that Pants executes.
-            This option is more selective and controls just the target binary's directory.
+            Note that setting the global --keep-sandboxes option may also conserve this directory,
+            along with those of all other processes that Pants executes. This option is more
+            selective and controls just the target binary's directory.
             """
         ),
     )
@@ -170,8 +173,11 @@ async def run(
         WrappedTarget, WrappedTargetRequest(field_set.address, description_of_origin="<infallible>")
     )
     restartable = wrapped_target.target.get(RestartableField).value
-    # Cleanup is the default, so we want to preserve the chroot if either option is off.
-    cleanup = run_subsystem.cleanup and global_options.process_cleanup
+    keep_sandboxes = (
+        global_options.keep_sandboxes
+        if run_subsystem.options.is_default("cleanup")
+        else (KeepSandboxes.never if run_subsystem.cleanup else KeepSandboxes.always)
+    )
 
     if run_subsystem.debug_adapter:
         logger.info(
@@ -191,7 +197,7 @@ async def run(
             input_digest=request.digest,
             run_in_workspace=True,
             restartable=restartable,
-            cleanup=cleanup,
+            keep_sandboxes=keep_sandboxes,
             immutable_input_digests=request.immutable_input_digests,
             append_only_caches=request.append_only_caches,
         ),

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -27,7 +27,7 @@ from pants.engine.target import (
     WrappedTarget,
     WrappedTargetRequest,
 )
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptions, KeepSandboxes
 from pants.testutil.option_util import create_goal_subsystem, create_subsystem
 from pants.testutil.rule_runner import (
     MockEffect,
@@ -86,7 +86,9 @@ def single_target_run(
                     port="5678",
                 ),
                 create_subsystem(
-                    GlobalOptions, pants_workdir=rule_runner.pants_workdir, process_cleanup=True
+                    GlobalOptions,
+                    pants_workdir=rule_runner.pants_workdir,
+                    keep_sandboxes=KeepSandboxes.never,
                 ),
                 workspace,
                 BuildRoot(),

--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,11 +3,13 @@
 
 from dataclasses import dataclass
 
+from pants.base.deprecated import warn_or_error
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
 from pants.option.global_options import (
     GlobalOptions,
+    KeepSandboxes,
     NamedCachesDirOption,
     ProcessCleanupOption,
     UseDeprecatedPexBinaryRunSemanticsOption,
@@ -59,8 +61,18 @@ def log_level(global_options: GlobalOptions) -> LogLevel:
 
 
 @rule
-def extract_process_cleanup_option(global_options: GlobalOptions) -> ProcessCleanupOption:
-    return ProcessCleanupOption(global_options.process_cleanup)
+def extract_process_cleanup_option(keep_sandboxes: KeepSandboxes) -> ProcessCleanupOption:
+    warn_or_error(
+        removal_version="2.15.0.dev1",
+        entity="ProcessCleanupOption",
+        hint="Instead, use `KeepSandboxes`.",
+    )
+    return ProcessCleanupOption(keep_sandboxes == KeepSandboxes.never)
+
+
+@rule
+def extract_keep_sandboxes(global_options: GlobalOptions) -> KeepSandboxes:
+    return GlobalOptions.resolve_keep_sandboxes(global_options.options)
 
 
 @rule

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -203,7 +203,7 @@ class Scheduler:
             local_cache=execution_options.local_cache,
             remote_cache_read=execution_options.remote_cache_read,
             remote_cache_write=execution_options.remote_cache_write,
-            local_cleanup=execution_options.process_cleanup,
+            local_keep_sandboxes=execution_options.keep_sandboxes.value,
             local_parallelism=execution_options.process_execution_local_parallelism,
             local_enable_nailgun=execution_options.process_execution_local_enable_nailgun,
             remote_parallelism=execution_options.process_execution_remote_parallelism,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -119,6 +119,17 @@ class CacheContentBehavior(Enum):
     defer = "defer"
 
 
+class KeepSandboxes(Enum):
+    """An enum for the global option `keep_sandboxes`.
+
+    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
+    """
+
+    always = "always"
+    on_failure = "on_failure"
+    never = "never"
+
+
 @enum.unique
 class AuthPluginState(Enum):
     OK = "ok"
@@ -353,7 +364,7 @@ class ExecutionOptions:
     remote_instance_name: str | None
     remote_ca_certs_path: str | None
 
-    process_cleanup: bool
+    keep_sandboxes: KeepSandboxes
     local_cache: bool
     process_execution_local_parallelism: int
     process_execution_local_enable_nailgun: bool
@@ -398,7 +409,7 @@ class ExecutionOptions:
             remote_instance_name=dynamic_remote_options.instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
             # Process execution setup.
-            process_cleanup=bootstrap_options.process_cleanup,
+            keep_sandboxes=GlobalOptions.resolve_keep_sandboxes(bootstrap_options),
             local_cache=bootstrap_options.local_cache,
             process_execution_local_parallelism=bootstrap_options.process_execution_local_parallelism,
             process_execution_remote_parallelism=dynamic_remote_options.parallelism,
@@ -487,7 +498,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     process_execution_local_parallelism=CPU_COUNT,
     process_execution_remote_parallelism=128,
     process_execution_cache_namespace=None,
-    process_cleanup=True,
+    keep_sandboxes=KeepSandboxes.never,
     local_cache=True,
     cache_content_behavior=CacheContentBehavior.fetch,
     process_execution_local_enable_nailgun=True,
@@ -1076,13 +1087,30 @@ class BootstrapOptions:
     )
     process_cleanup = BoolOption(
         "--process-cleanup",
-        default=DEFAULT_EXECUTION_OPTIONS.process_cleanup,
+        default=(DEFAULT_EXECUTION_OPTIONS.keep_sandboxes == KeepSandboxes.never),
+        deprecation_start_version="2.15.0.dev1",
+        removal_version="2.16.0.dev1",
+        removal_hint="Use the `keep_sandboxes` option instead.",
         help=softwrap(
             """
             If false, Pants will not clean up local directories used as chroots for running
             processes. Pants will log their location so that you can inspect the chroot, and
             run the `__run.sh` script to recreate the process using the same argv and
             environment variables used by Pants. This option is useful for debugging.
+            """
+        ),
+    )
+    keep_sandboxes = EnumOption(
+        "--keep-sandboxes",
+        default=DEFAULT_EXECUTION_OPTIONS.keep_sandboxes,
+        help=softwrap(
+            """
+            Controls whether Pants will clean up local directories used as chroots for running
+            processes.
+
+            Pants will log their location so that you can inspect the chroot, and run the
+            `__run.sh` script to recreate the process using the same argv and environment variables
+            used by Pants. This option is useful for debugging.
             """
         ),
     )
@@ -1945,6 +1973,27 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             raise TypeError(
                 f"Unexpected option value for `cache_content_behavior`: {resolved_value}"
             )
+
+    @staticmethod
+    def resolve_keep_sandboxes(
+        bootstrap_options: OptionValueContainer,
+    ) -> KeepSandboxes:
+        resolved_value = resolve_conflicting_options(
+            old_option="process_cleanup",
+            new_option="keep_sandboxes",
+            old_scope="",
+            new_scope="",
+            old_container=bootstrap_options,
+            new_container=bootstrap_options,
+        )
+
+        if isinstance(resolved_value, bool):
+            # Is `process_cleanup`.
+            return KeepSandboxes.always if resolved_value else KeepSandboxes.on_failure
+        elif isinstance(resolved_value, KeepSandboxes):
+            return resolved_value
+        else:
+            raise TypeError(f"Unexpected option value for `keep_sandboxes`: {resolved_value}")
 
     @staticmethod
     def compute_pants_ignore(buildroot, global_options):

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -92,6 +92,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -127,6 +128,8 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
             be removed in. You must also set `removal_hint`.
         :param removal_hint: If the option is deprecated, provides a message to display to the
             user when running `help`.
+        :param deprecation_start_version: If the option is deprecated, sets the version at which the
+            deprecation will begin. Must be less than the `removal_version`.
         """
         self = super().__new__(cls)
         self._flag_names = (flag_name,)
@@ -145,6 +148,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
                 "mutually_exclusive_group": mutually_exclusive_group,
                 "removal_hint": removal_hint,
                 "removal_version": removal_version,
+                "deprecation_start_version": deprecation_start_version,
             }.items()
             if v is not None
         }
@@ -220,6 +224,7 @@ class _ListOptionBase(
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -240,6 +245,7 @@ class _ListOptionBase(
             mutually_exclusive_group=mutually_exclusive_group,
             removal_hint=removal_hint,
             removal_version=removal_version,
+            deprecation_start_version=deprecation_start_version,
         )
         return instance
 
@@ -435,6 +441,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -459,6 +466,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -483,6 +491,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -505,6 +514,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         mutually_exclusive_group=None,
         removal_version=None,
         removal_hint=None,
+        deprecation_start_version=None,
         # Internal bells/whistles
         daemon=None,
         fingerprint=None,
@@ -522,6 +532,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
             mutually_exclusive_group=mutually_exclusive_group,
             removal_version=removal_version,
             removal_hint=removal_hint,
+            deprecation_start_version=deprecation_start_version,
             daemon=daemon,
             fingerprint=fingerprint,
         )
@@ -573,6 +584,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -597,6 +609,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -620,6 +633,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -642,6 +656,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         mutually_exclusive_group=None,
         removal_version=None,
         removal_hint=None,
+        deprecation_start_version=None,
         # Internal bells/whistles
         daemon=None,
         fingerprint=None,
@@ -659,6 +674,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
             mutually_exclusive_group=mutually_exclusive_group,
             removal_version=removal_version,
             removal_hint=removal_hint,
+            deprecation_start_version=deprecation_start_version,
             daemon=daemon,
             fingerprint=fingerprint,
         )
@@ -723,6 +739,7 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
         removal_hint: str | None = None,
+        deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -742,6 +759,7 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
             mutually_exclusive_group=mutually_exclusive_group,
             removal_hint=removal_hint,
             removal_version=removal_version,
+            deprecation_start_version=deprecation_start_version,
         )
 
     def _convert_(self, val: Any) -> dict[str, _ValueT]:

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -206,7 +206,7 @@ class RuleRunner:
             root_dir = Path(mkdtemp(prefix="RuleRunner."))
             print(f"Preserving rule runner temporary directories at {root_dir}.", file=sys.stderr)
             bootstrap_args.extend(
-                ["--no-process-cleanup", f"--local-execution-root-dir={root_dir}"]
+                ["--keep-sandboxes=always", f"--local-execution-root-dir={root_dir}"]
             )
             build_root = (root_dir / "BUILD_ROOT").resolve()
             build_root.mkdir()

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -106,7 +106,7 @@ pub struct RemotingOptions {
 pub struct ExecutionStrategyOptions {
   pub local_parallelism: usize,
   pub remote_parallelism: usize,
-  pub local_cleanup: bool,
+  pub local_keep_sandboxes: local::KeepSandboxes,
   pub local_cache: bool,
   pub local_enable_nailgun: bool,
   pub remote_cache_read: bool,
@@ -216,7 +216,7 @@ impl Core {
         local_execution_root_dir.to_path_buf(),
         named_caches.clone(),
         immutable_inputs.clone(),
-        exec_strategy_opts.local_cleanup,
+        exec_strategy_opts.local_keep_sandboxes,
       );
 
       let runner: Box<dyn CommandRunner> = if exec_strategy_opts.local_enable_nailgun {

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -244,7 +244,7 @@ impl PyExecutionStrategyOptions {
   fn __new__(
     local_parallelism: usize,
     remote_parallelism: usize,
-    local_cleanup: bool,
+    local_keep_sandboxes: String,
     local_cache: bool,
     local_enable_nailgun: bool,
     remote_cache_read: bool,
@@ -256,7 +256,8 @@ impl PyExecutionStrategyOptions {
     Self(ExecutionStrategyOptions {
       local_parallelism,
       remote_parallelism,
-      local_cleanup,
+      local_keep_sandboxes: process_execution::local::KeepSandboxes::from_str(&local_keep_sandboxes)
+        .unwrap(),
       local_cache,
       local_enable_nailgun,
       remote_cache_read,


### PR DESCRIPTION
For the purposes of debugging an intermittent issue (such as a crash which occurs only in certain conditions in CI), `--no-process-cleanup` is too big of a hammer. To support capturing the sandboxes for only failing processes, this change replaces the `--[no-]process-cleanup` option with `--keep-sandboxes={always,never,on_failure}`.

[ci skip-rust]
[ci skip-build-wheels]
