### PR TITLE
Deprecate `[python].lockfile_generator`

### DIFF
--- a/docs/markdown/Python/python/python-third-party-dependencies.md
+++ b/docs/markdown/Python/python/python-third-party-dependencies.md
@@ -366,16 +366,16 @@ freezegun==1.2.0 \
   --hash=sha256:e19563d0b05...
 ```
 
-For user lockfiles, set `[python].resolves` to the path of your lockfile(s). Also set
-`[python].resolves_generate_lockfiles` to `False` so that Pants does not expect its metadata header.
-Warning: it will likely be slower to install manually generated user lockfiles than Pex ones
-because Pants cannot as efficiently extract the subset of requirements used for a particular
-task; see the option [`[python].run_against_entire_lockfile`](doc:reference-python). 
+For manually-generated user lockfiles, set `[python].resolves` to the path of your lockfile(s).
+Also set `[python].resolves_generate_lockfiles` to `False` so that Pants does not expect its
+metadata header. Warning: it will likely be slower to install manually generated user lockfiles
+than Pex ones because Pants cannot as efficiently extract the subset of requirements used for a
+particular task; see the option [`[python].run_against_entire_lockfile`](doc:reference-python). 
 
-For tool lockfiles, set `[tool].lockfile` to the path of your lockfile, e.g. `[black].lockfile`.
-Also set `[python].invalid_lockfile_behavior = "error"` so that Pants does not expect metadata
-headers. Note that this option will disable the check for all lockfiles, including user lockfiles,
-which may not be desirable. Feel free to open a
+For manually-generated tool lockfiles, set `[tool].lockfile` to the path of your lockfile, e.g.
+`[black].lockfile`. Also set `[python].invalid_lockfile_behavior = "error"` so that Pants does not
+expect metadata headers. Note that this option will disable the check for all lockfiles, including
+user lockfiles, which may not be desirable. Feel free to open a
 [GitHub issue](https://github.com/pantsbuild/pants/issues/new) if you want more precise control.
 
 Advanced usage

--- a/pants.toml
+++ b/pants.toml
@@ -121,7 +121,6 @@ interpreter_constraints = [">=3.7,<3.10"]
 macos_big_sur_compatibility = true
 resolves = { python-default = "3rdparty/python/user_reqs.lock" }
 enable_resolves = true
-lockfile_generator = "pex"
 
 [python-infer]
 assets = true

--- a/src/python/pants/backend/python/subsystems/poetry.py
+++ b/src/python/pants/backend/python/subsystems/poetry.py
@@ -24,7 +24,7 @@ from pants.util.docutil import git_url
 class PoetrySubsystem(PythonToolRequirementsBase):
     options_scope = "poetry"
     name = "Poetry"
-    help = "Used to generate lockfiles for third-party Python dependencies."
+    help = "Used to generate lockfiles for third-party Python dependencies (deprecated)."
 
     default_version = "poetry==1.1.14"
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -270,8 +270,8 @@ class PythonSetup(Subsystem):
         removal_version="2.15.0.dev0",
         removal_hint=softwrap(
             f"""
-            Pants will soon only support generating lockfiles via the Pex format, given the several
-            limitations of Poetry listed in this option.
+            Pants will soon only support generating lockfiles via the Pex format, as
+            Poetry-generated lockfiles mismatch with Pants's pip-based approach.
 
             If you do not want to use Pex lockfiles, you will still be able to manually generate
             lockfiles, e.g. by manually running `poetry export --dev` on your `poetry.lock`. See

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -391,7 +391,7 @@ class PythonSetup(Subsystem):
             is used on them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary
             for details.
 
-            Note: Only takes effect if you use Pex lockfiles. Set
+            Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
             """
         ),
@@ -407,7 +407,7 @@ class PythonSetup(Subsystem):
             them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-only-binary for
             details.
 
-            Note: Only takes effect if you use Pex lockfiles. Set
+            Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
             """
         ),

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -288,10 +288,10 @@ class PythonSetup(Subsystem):
             Tip: you can incrementally migrate one lockfile at-a-time by dynamically setting the
             option `--python-lockfile-generator`. For example:
 
-              ./pants --python-lockfile-generator=pex generate-lockfiles --resolve=black --resolve=isort
-              ./pants --python-lockfile-generator=poetry generate-lockfiles --resolve=python-default
+              {bin_name()} --python-lockfile-generator=pex generate-lockfiles --resolve=black --resolve=isort
+              {bin_name()} --python-lockfile-generator=poetry generate-lockfiles --resolve=python-default
             """
-        )
+        ),
     )
     resolves_generate_lockfiles = BoolOption(
         default=True,
@@ -312,7 +312,7 @@ class PythonSetup(Subsystem):
 
             Warning: it will likely be slower to install manually generated user lockfiles than Pex
             ones because Pants cannot as efficiently extract the subset of requirements used for a
-            particular task. See the option `[python].run_against_entire_lockfile`. 
+            particular task. See the option `[python].run_against_entire_lockfile`.
             """
         ),
         advanced=True,


### PR DESCRIPTION
Poetry lockfile generation via Pants has several issues, including:

* transitive deps often have bad environment markers
* `[python-repos]` is not hooked up
* `[GLOBAL].ca_certs_path` is not hooked up
* VCS and local requirements don't work
* Poetry writes to a cache not controlled by Pants, due to their bug
* https://github.com/pantsbuild/pants/issues/15315
* https://github.com/pantsbuild/pants/issues/15171
* https://github.com/pantsbuild/pants/issues/14020

Some of these are fixable, whether by the upcoming Poetry 1.2 or by us investing more time. However—given the project's limited resources—it is not beneficial enough to lean into Poetry lockfile generation. Poetry was always seen as a bridge technology while we developed Pex lockfiles, which now meet all of Pantsbuild's requirements.

## Keeps manually generated lockfiles

Users can still manually generate requirements.txt-style lockfiles. This is an important escape hatch if Pex lockfiles don't work for someone, and it eases migration from e.g. Poetry projects still using poetry.lock.

We may want to revisit this decision and require Pex lockfiles in the future, but that is a later decision.

[ci skip-rust]