### PR TITLE
Fix process_executor

### DIFF
--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -11,7 +11,7 @@ use testutil::relative_paths;
 use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
-  CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
+  local::KeepSandboxes, CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
   FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Process, ProcessError,
   ProcessMetadata,
 };
@@ -33,7 +33,7 @@ fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
     base_dir.path().to_owned(),
     NamedCaches::new(named_cache_dir),
     ImmutableInputs::new(store.clone(), base_dir.path()).unwrap(),
-    true,
+    KeepSandboxes::Never,
   ));
   (runner, store, base_dir)
 }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -16,7 +16,7 @@ use testutil::{owned_string_vec, relative_paths};
 use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
-  local, CacheName, CommandRunner as CommandRunnerTrait, Context,
+  local, local::KeepSandboxes, CacheName, CommandRunner as CommandRunnerTrait, Context,
   FallibleProcessResultWithPlatform, ImmutableInputs, InputDigests, NamedCaches, Platform, Process,
   ProcessError, RelativePath,
 };
@@ -373,7 +373,7 @@ async fn test_chroot_placeholder() {
   let result = run_command_locally_in_dir(
     Process::new(vec!["/usr/bin/env".to_owned()]).env(env.clone()),
     work_root.clone(),
-    false,
+    KeepSandboxes::Always,
     &mut workunit,
     None,
     None,
@@ -438,7 +438,7 @@ async fn test_directory_preservation() {
   let result = run_command_locally_in_dir(
     process,
     preserved_work_root.clone(),
-    false,
+    KeepSandboxes::Always,
     &mut workunit,
     Some(store),
     Some(executor),
@@ -494,7 +494,7 @@ async fn test_directory_preservation_error() {
   run_command_locally_in_dir(
     Process::new(vec!["doesnotexist".to_owned()]),
     preserved_work_root.clone(),
-    false,
+    KeepSandboxes::Always,
     &mut workunit,
     None,
     None,
@@ -616,7 +616,7 @@ async fn working_directory() {
   let result = run_command_locally_in_dir(
     process,
     work_dir.path().to_owned(),
-    true,
+    KeepSandboxes::Never,
     &mut workunit,
     Some(store),
     Some(executor),
@@ -679,7 +679,7 @@ async fn immutable_inputs() {
   let result = run_command_locally_in_dir(
     process,
     work_dir.path().to_owned(),
-    true,
+    KeepSandboxes::Never,
     &mut workunit,
     Some(store),
     Some(executor),
@@ -770,13 +770,21 @@ async fn run_command_locally(req: Process) -> Result<LocalTestResult, ProcessErr
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
   let work_dir = TempDir::new().unwrap();
   let work_dir_path = work_dir.path().to_owned();
-  run_command_locally_in_dir(req, work_dir_path, true, &mut workunit, None, None).await
+  run_command_locally_in_dir(
+    req,
+    work_dir_path,
+    KeepSandboxes::Never,
+    &mut workunit,
+    None,
+    None,
+  )
+  .await
 }
 
 async fn run_command_locally_in_dir(
   req: Process,
   dir: PathBuf,
-  cleanup: bool,
+  cleanup: KeepSandboxes,
   workunit: &mut RunningWorkunit,
   store: Option<Store>,
   executor: Option<task_executor::Executor>,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,8 +36,8 @@ use std::time::Duration;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches, Platform,
-  ProcessCacheScope, ProcessMetadata,
+  local::KeepSandboxes, CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches,
+  Platform, ProcessCacheScope, ProcessMetadata,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
@@ -339,7 +339,7 @@ async fn main() {
           .unwrap_or_else(NamedCaches::default_path),
       ),
       ImmutableInputs::new(store.clone(), &workdir).unwrap(),
-      true,
+      KeepSandboxes::Never,
     )) as Box<dyn process_execution::CommandRunner>,
   };
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -256,8 +256,10 @@ impl PyExecutionStrategyOptions {
     Self(ExecutionStrategyOptions {
       local_parallelism,
       remote_parallelism,
-      local_keep_sandboxes: process_execution::local::KeepSandboxes::from_str(&local_keep_sandboxes)
-        .unwrap(),
+      local_keep_sandboxes: process_execution::local::KeepSandboxes::from_str(
+        &local_keep_sandboxes,
+      )
+      .unwrap(),
       local_cache,
       local_enable_nailgun,
       remote_cache_read,


### PR DESCRIPTION
This apparently got missed from 8c910d1d7c52a71d09b2e9265ef9aeeec7464443
because it was tagged skip-rust.