### PR TITLE
Bump release requirements to macos 11.0

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -794,7 +794,7 @@ def build_pex(fetch: bool) -> None:
             "CPython>=3.7,<3.10",
             *(
                 f"--platform={plat}-{abi}"
-                for plat in ("linux_x86_64", "macosx_10.15_x86_64")
+                for plat in ("linux_x86_64", "macosx_11.0_x86_64")
                 for abi in ("cp-37-m", "cp-38-cp38", "cp-39-cp39")
             ),
         ]


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/16317 updated what we're
generating wheels for, so we need to bump the wheels we look for
accordingly.