### PR TITLE
Fix `CacheContentBehavior::Defer` with a remote cache

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1195,8 +1195,8 @@ class BootstrapOptions:
             fetching it.
 
             The `defer` behavior, on the other hand, will neither fetch nor validate the cache
-            content before calling a cache hit a hit. This "defers" actually consuming the cache
-            entry until a consumer consumes it.
+            content before calling a cache hit a hit. This "defers" actually fetching the cache
+            entry until Pants needs it (which may be never).
 
             The `defer` mode is the most network efficient (because it will completely skip network
             requests in many cases), followed by the `validate` mode (since it can still skip

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -479,7 +479,7 @@ impl Core {
     )?;
 
     let store = if (exec_strategy_opts.remote_cache_read || exec_strategy_opts.remote_cache_write)
-      && remoting_opts.cache_content_behavior == CacheContentBehavior::Defer
+      && remoting_opts.cache_content_behavior == CacheContentBehavior::Fetch
     {
       // In remote cache mode with eager fetching, the only interaction with the remote CAS
       // should be through the remote cache code paths. Thus, the store seen by the rest of the


### PR DESCRIPTION
`CacheContentBehavior::{Fetch,Defer}` were incorrectly, respectively 1) still using a remote store, 2) not using a remote store.

Fix a swapped condition, and improve test coverage to confirm that those cases can successfully hit.

[ci skip-build-wheels]