### PR TITLE
[internal] Shell completions fix for Bash

### DIFF
--- a/build-support/bin/generate_completions.py
+++ b/build-support/bin/generate_completions.py
@@ -12,12 +12,12 @@ BASH_COMPLETION_TEMPLATE = """# DO NOT EDIT.
 
 function pants_completions()
 {{
-    readonly PANTS_GOALS="\\
+    local -r PANTS_GOALS="\\
         {goals}"
 
     {goal_options}
 
-    readonly PANTS_GLOBAL_OPTIONS="\\
+    local -r PANTS_GLOBAL_OPTIONS="\\
         {global_options}"
 
     local current_word previous_word previous_goal
@@ -60,15 +60,11 @@ function get_previous_goal()
     echo $previous_goal
 }}
 
-# TODO: Need to create a separate .zsh script instead of this
-autoload -U +X bashcompinit && bashcompinit
-autoload -Uz compinit && compinit
-
 complete -o default -o bashdefault -F pants_completions pants
 """
 
 GOAL_OPTIONS_TEMPLATE = """
-    readonly PANTS_{name}_OPTIONS="\\
+    local -r PANTS_{name}_OPTIONS="\\
         {options}"
 """
 


### PR DESCRIPTION
Fixed a couple of Bash-centric bugs.
- Removed calling `compinit` from the script (test code, should be called by user's `zshrc` - see below)
- Changed `readonly` to `local -r` so that bash doesn't complain on completion usage

Tested on MacOS 12.5 and Debian Bullseye with the following workflow:

```bash
python3 build-support/bin/generate_completions.py > complete.bash
source ./complete.bash

./pants <TAB>
```

On MacOS, in the current terminal (or in your `~/.zshrc`), you'll need to add the following:

```bash
autoload -Uz compinit bashcompinit
compinit
bashcompinit
```

See https://zsh.sourceforge.io/Doc/Release/Completion-System.html or https://docs.brew.sh/Shell-Completion for more examples of these functions.

[ci skip-rust]
[ci skip-build-wheels]