### PR TITLE
Fix `--process-cleanup` deprecation. (Cherry-pick of #16447)

### DIFF
--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,7 +3,6 @@
 
 from dataclasses import dataclass
 
-from pants.base.deprecated import warn_or_error
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
@@ -11,7 +10,6 @@ from pants.option.global_options import (
     GlobalOptions,
     KeepSandboxes,
     NamedCachesDirOption,
-    ProcessCleanupOption,
     UseDeprecatedPexBinaryRunSemanticsOption,
 )
 from pants.option.options import Options
@@ -58,16 +56,6 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 @rule
 def log_level(global_options: GlobalOptions) -> LogLevel:
     return global_options.level
-
-
-@rule
-def extract_process_cleanup_option(keep_sandboxes: KeepSandboxes) -> ProcessCleanupOption:
-    warn_or_error(
-        removal_version="2.15.0.dev1",
-        entity="ProcessCleanupOption",
-        hint="Instead, use `KeepSandboxes`.",
-    )
-    return ProcessCleanupOption(keep_sandboxes == KeepSandboxes.never)
 
 
 @rule

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1989,7 +1989,12 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         if isinstance(resolved_value, bool):
             # Is `process_cleanup`.
-            return KeepSandboxes.always if resolved_value else KeepSandboxes.on_failure
+            warn_or_error(
+                removal_version="2.15.0.dev1",
+                entity="--process-cleanup",
+                hint="Instead, use `--keep-sandboxes`.",
+            )
+            return KeepSandboxes.never if resolved_value else KeepSandboxes.always
         elif isinstance(resolved_value, KeepSandboxes):
             return resolved_value
         else:
@@ -2085,16 +2090,6 @@ class GlobalOptionsFlags:
                     flags.add(f"--no-{flag[2:]}")
 
         return cls(FrozenOrderedSet(flags), FrozenOrderedSet(short_flags))
-
-
-@dataclass(frozen=True)
-class ProcessCleanupOption:
-    """A wrapper around the global option `process_cleanup`.
-
-    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
-    """
-
-    val: bool
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The deprecation added in #16415 never displayed and the conversion from
the old `--process-cleanup` to the new `--keep-sandboxes` was inverted.

(cherry picked from commit 1453e4c0e438873979777d6c6671e2a825001be7)

[ci skip-rust]
[ci skip-build-wheels]