### PR TITLE
`GenerateToolLockfileSentinel` encouraged to use language-specific subclasses

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -45,6 +45,19 @@ likely include the relevant `Dependencies` subclass. Likewise for pre-2.14 `Infe
 Note that in most cases, you no longer need to request the target in your rule code, and should rely
 on `FieldSet`'s mechanisms for matching targets and getting field values.
 
+### `GenerateToolLockfileSentinel` encouraged to use language-specific subclasses
+
+Rather than directly subclassing `GenerateToolLockfileSentinel`, we encourage you to subclass
+`GeneratePythonToolLockfileSentinel` and `GenerateJvmToolLockfileSentinel`. This is so that we can
+distinguish what language a tool belongs to, which is used for options like
+`[python].resolves_to_constraints_file` to validate which resolve names are recognized. 
+
+Things will still work if you do not make this change, other than the new options not recognizing
+your tool.
+
+However, keep the `UnionRule` the same, i.e. with the first argument still
+`GenerateToolLockfileSentinel`.
+
 2.13
 ----
 

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -8,7 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -62,7 +65,7 @@ class ClangFormat(PythonToolBase):
         )
 
 
-class ClangFormatLockfileSentinel(GenerateToolLockfileSentinel):
+class ClangFormatLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = ClangFormat.options_scope
 
 

--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -53,7 +53,7 @@ from pants.jvm.dependency_inference.artifact_mapper import (
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField, PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
@@ -66,7 +66,7 @@ class GenerateJavaFromAvroRequest(GenerateSourcesRequest):
     output = JavaSourceField
 
 
-class AvroToolLockfileSentinel(GenerateToolLockfileSentinel):
+class AvroToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = AvroSubsystem.options_scope
 
 

--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -42,7 +42,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
@@ -53,7 +53,7 @@ class GenerateJavaFromProtobufRequest(GenerateSourcesRequest):
     output = JavaSourceField
 
 
-class GrpcJavaToolLockfileSentinel(GenerateToolLockfileSentinel):
+class GrpcJavaToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = JavaProtobufGrpcSubsystem.options_scope
 
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -11,7 +11,10 @@ from pants.backend.codegen.protobuf.target_types import (
 from pants.backend.codegen.utils import find_python_runtime_library_or_raise_error
 from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
@@ -86,7 +89,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class MypyProtobufLockfileSentinel(GenerateToolLockfileSentinel):
+class MypyProtobufLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = PythonProtobufMypyPlugin.options_scope
 
 

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -50,7 +50,7 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, GatherJvmCoordinatesRequest
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
@@ -62,7 +62,7 @@ class GenerateScalaFromProtobufRequest(GenerateSourcesRequest):
     output = ScalaSourceField
 
 
-class ScalapbcToolLockfileSentinel(GenerateToolLockfileSentinel):
+class ScalapbcToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = ScalaPBSubsystem.options_scope
 
 

--- a/src/python/pants/backend/codegen/soap/java/rules.py
+++ b/src/python/pants/backend/codegen/soap/java/rules.py
@@ -41,7 +41,7 @@ from pants.jvm import jdk_rules
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
@@ -52,7 +52,7 @@ class GenerateJavaFromWsdlRequest(GenerateSourcesRequest):
     output = JavaSourceField
 
 
-class JaxWsToolsLockfileSentinel(GenerateToolLockfileSentinel):
+class JaxWsToolsLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = JaxWsTools.options_scope
 
 

--- a/src/python/pants/backend/codegen/thrift/scrooge/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/rules.py
@@ -26,7 +26,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
 from pants.util.logging import LogLevel
@@ -44,7 +44,7 @@ class GeneratedScroogeThriftSources:
     snapshot: Snapshot
 
 
-class ScroogeToolLockfileSentinel(GenerateToolLockfileSentinel):
+class ScroogeToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = ScroogeSubsystem.options_scope
 
 

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -11,7 +11,10 @@ from pathlib import PurePath
 from pants.backend.docker.target_types import DockerImageSourceField
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
@@ -52,7 +55,7 @@ class DockerfileParser(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class DockerfileParserLockfileSentinel(GenerateToolLockfileSentinel):
+class DockerfileParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = DockerfileParser.options_scope
 
 

--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -20,7 +20,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.option.global_options import KeepSandboxes
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 _LAUNCHER_BASENAME = "PantsJavaParserLauncher.java"
 
 
-class JavaParserToolLockfileSentinel(GenerateToolLockfileSentinel):
+class JavaParserToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = "java-parser"
 
 

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -18,7 +18,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -41,7 +41,7 @@ class GoogleJavaFormatRequest(FmtRequest):
     name = GoogleJavaFormatSubsystem.options_scope
 
 
-class GoogleJavaFormatToolLockfileSentinel(GenerateToolLockfileSentinel):
+class GoogleJavaFormatToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = GoogleJavaFormatSubsystem.options_scope
 
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -20,7 +20,7 @@ from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.option.global_options import KeepSandboxes
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -29,7 +29,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 _PARSER_KOTLIN_VERSION = "1.6.20"
 
 
-class KotlinParserToolLockfileSentinel(GenerateToolLockfileSentinel):
+class KotlinParserToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = "kotlin-parser"
 
 

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -18,7 +18,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve import jvm_tool
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -41,7 +41,7 @@ class KtlintRequest(FmtRequest):
     name = KtlintSubsystem.options_scope
 
 
-class KtlintToolLockfileSentinel(GenerateToolLockfileSentinel):
+class KtlintToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = KtlintSubsystem.options_scope
 
 

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -13,7 +13,10 @@ from typing import Any, MutableMapping, cast
 import toml
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -226,7 +229,7 @@ class CoverageSubsystem(PythonToolBase):
         )
 
 
-class CoveragePyLockfileSentinel(GenerateToolLockfileSentinel):
+class CoveragePyLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = CoverageSubsystem.options_scope
 
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -44,12 +44,22 @@ from pants.core.goals.generate_lockfiles import (
     WrappedGenerateLockfile,
 )
 from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
-from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, MergeDigests
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    DigestContents,
+    DigestEntries,
+    FileContent,
+    FileEntry,
+    GlobMatchErrorBehavior,
+    MergeDigests,
+    PathGlobs,
+)
 from pants.engine.internals.native_engine import FileDigest
 from pants.engine.process import ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import AllTargets
-from pants.engine.unions import UnionRule
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -389,6 +399,55 @@ async def setup_poetry_lockfile(
     return GeneratePythonLockfile.from_tool(
         poetry_subsystem, use_pex=python_setup.generate_lockfiles_with_pex
     )
+
+
+@rule
+async def determine_resolve_pex_config(
+    request: ResolvePexConfigRequest, python_setup: PythonSetup, union_membership: UnionMembership
+) -> ResolvePexConfig:
+    all_python_tool_resolve_names = tuple(
+        sentinel.resolve_name
+        for sentinel in union_membership.get(GenerateToolLockfileSentinel)
+        if issubclass(sentinel, GeneratePythonToolLockfileSentinel)
+    )
+
+    constraints_file: tuple[Digest, FileEntry] | None = None
+    _constraints_file_path = python_setup.resolves_to_constraints_file(
+        all_python_tool_resolve_names
+    ).get(request.resolve_name)
+    if _constraints_file_path:
+        _constraints_origin = softwrap(
+            f"""
+            the option `[python].resolves_to_constraints_file` for the resolve
+            '{request.resolve_name}'
+            """
+        )
+        _constraints_path_globs = PathGlobs(
+            [_constraints_file_path] if _constraints_file_path else [],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=_constraints_origin,
+        )
+        _constraints_digest, _constraints_digest_entries = await MultiGet(
+            Get(Digest, PathGlobs, _constraints_path_globs),
+            Get(DigestEntries, PathGlobs, _constraints_path_globs),
+        )
+
+        if len(_constraints_digest_entries) != 1:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    Expected only one file from {_constraints_origin}, but matched:
+                    {_constraints_digest_entries}
+
+                    Did you use a glob like `*`?
+                    """
+                )
+            )
+        _constraints_file_entry = next(iter(_constraints_digest_entries))
+        assert isinstance(_constraints_file_entry, FileEntry)
+        constraints_file = (_constraints_digest, _constraints_file_entry)
+
+    return ResolvePexConfig(constraints_file=constraints_file)
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -58,6 +58,10 @@ from pants.util.strutil import softwrap
 logger = logging.getLogger(__name__)
 
 
+class GeneratePythonToolLockfileSentinel(GenerateToolLockfileSentinel):
+    pass
+
+
 @dataclass(frozen=True)
 class GeneratePythonLockfile(GenerateLockfile):
     requirements: FrozenOrderedSet[str]

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -43,7 +46,7 @@ class Autoflake(PythonToolBase):
     export = ExportToolOption()
 
 
-class AutoflakeLockfileSentinel(GenerateToolLockfileSentinel):
+class AutoflakeLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Autoflake.options_scope
 
 

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.lint.bandit.skip_field import SkipBanditField
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -100,7 +103,7 @@ async def _bandit_interpreter_constraints(python_setup: PythonSetup) -> Interpre
     return constraints or InterpreterConstraints(python_setup.interpreter_constraints)
 
 
-class BanditLockfileSentinel(GenerateToolLockfileSentinel):
+class BanditLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Bandit.options_scope
 
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -8,7 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.lint.black.skip_field import SkipBlackField
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -101,7 +104,7 @@ async def _black_interpreter_constraints(
     return constraints
 
 
-class BlackLockfileSentinel(GenerateToolLockfileSentinel):
+class BlackLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Black.options_scope
 
 

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -4,7 +4,10 @@
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -36,7 +39,7 @@ class Docformatter(PythonToolBase):
     export = ExportToolOption()
 
 
-class DocformatterLockfileSentinel(GenerateToolLockfileSentinel):
+class DocformatterLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Docformatter.options_scope
 
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -269,7 +272,7 @@ async def _flake8_interpreter_constraints(
 # --------------------------------------------------------------------------------------
 
 
-class Flake8LockfileSentinel(GenerateToolLockfileSentinel):
+class Flake8LockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Flake8.options_scope
 
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -8,7 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -102,7 +105,7 @@ class Isort(PythonToolBase):
         )
 
 
-class IsortLockfileSentinel(GenerateToolLockfileSentinel):
+class IsortLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Isort.options_scope
 
 

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -10,7 +10,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.lint.pylint.skip_field import SkipPylintField
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -271,7 +274,7 @@ async def _pylint_interpreter_constraints(
 # --------------------------------------------------------------------------------------
 
 
-class PylintLockfileSentinel(GenerateToolLockfileSentinel):
+class PylintLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Pylint.options_scope
 
 

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -39,7 +42,7 @@ class PyUpgrade(PythonToolBase):
     export = ExportToolOption()
 
 
-class PyUpgradeLockfileSentinel(GenerateToolLockfileSentinel):
+class PyUpgradeLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = PyUpgrade.options_scope
 
 

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -8,7 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -100,7 +103,7 @@ class Yapf(PythonToolBase):
         )
 
 
-class YapfLockfileSentinel(GenerateToolLockfileSentinel):
+class YapfLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Yapf.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
@@ -80,7 +83,7 @@ class DebugPy(PythonToolBase):
         )
 
 
-class DebugPyLockfileSentinel(GenerateToolLockfileSentinel):
+class DebugPyLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = DebugPy.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 import itertools
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript, InterpreterConstraintsField
@@ -51,7 +54,7 @@ class IPython(PythonToolBase):
     )
 
 
-class IPythonLockfileSentinel(GenerateToolLockfileSentinel):
+class IPythonLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = IPython.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -28,7 +31,7 @@ class Lambdex(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class LambdexLockfileSentinel(GenerateToolLockfileSentinel):
+class LambdexLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Lambdex.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -12,7 +12,10 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -238,7 +241,7 @@ async def _pytest_interpreter_constraints(python_setup: PythonSetup) -> Interpre
     return constraints or InterpreterConstraints(python_setup.interpreter_constraints)
 
 
-class PytestLockfileSentinel(GenerateToolLockfileSentinel):
+class PytestLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = PyTest.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -39,8 +39,8 @@ class PythonToolRequirementsBase(Subsystem):
     # If this tool does not mix with user requirements (e.g. Flake8 and Isort, but not Pylint and
     # Pytest), you should set this to True.
     #
-    # You also need to subclass `GenerateToolLockfileSentinel` and create a rule that goes from
-    # it -> GeneratePythonLockfile by calling `GeneratePythonLockfile.from_python_tool()`.
+    # You also need to subclass `GeneratePythonToolLockfileSentinel` and create a rule that goes
+    # from it -> GeneratePythonLockfile by calling `GeneratePythonLockfile.from_python_tool()`.
     # Register the UnionRule.
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -5,7 +5,10 @@ import itertools
 from dataclasses import dataclass
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonProvidesField
@@ -45,7 +48,7 @@ class Setuptools(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class SetuptoolsLockfileSentinel(GenerateToolLockfileSentinel):
+class SetuptoolsLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = Setuptools.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
@@ -30,7 +33,7 @@ class SetuptoolsSCM(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class SetuptoolsSCMLockfileSentinel(GenerateToolLockfileSentinel):
+class SetuptoolsSCMLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = SetuptoolsSCM.options_scope
 
 

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -7,7 +7,10 @@ import os
 from pathlib import Path
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import ConsoleScript
@@ -107,7 +110,7 @@ class TwineSubsystem(PythonToolBase):
         return CreateDigest((FileContent(chrooted_ca_certs_path, ca_certs_content),))
 
 
-class TwineLockfileSentinel(GenerateToolLockfileSentinel):
+class TwineLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = TwineSubsystem.options_scope
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -10,7 +10,10 @@ from typing import Iterable
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
@@ -312,7 +315,7 @@ async def _mypy_interpreter_constraints(
 # --------------------------------------------------------------------------------------
 
 
-class MyPyLockfileSentinel(GenerateToolLockfileSentinel):
+class MyPyLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = MyPy.options_scope
 
 

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -16,17 +16,21 @@ from pants.backend.python.util_rules.lockfile_metadata import (
     PythonLockfileMetadata,
     PythonLockfileMetadataV2,
 )
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.lockfile_metadata import InvalidLockfileError, LockfileMetadataValidation
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
     CreateDigest,
     Digest,
     DigestContents,
+    DigestEntries,
     FileContent,
     FileEntry,
     GlobMatchErrorBehavior,
     PathGlobs,
 )
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.unions import UnionMembership
 from pants.util.docutil import bin_name, doc_url
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
@@ -270,6 +274,12 @@ class PexRequirements:
         return bool(self.req_strings)
 
 
+# NB: This is defined here so that our rule for ResolvePexConfigRequest -> ResolvePexConfig
+# can avoid an import cycle. We re-export this out of goals/lockfile.py.
+class GeneratePythonToolLockfileSentinel(GenerateToolLockfileSentinel):
+    pass
+
+
 @dataclass(frozen=True)
 class ResolvePexConfig:
     """Configuration from `[python]` that impacts how the resolve is created."""
@@ -285,10 +295,62 @@ class ResolvePexConfig:
 
 
 @dataclass(frozen=True)
-class ResolvePexConfigRequest:
+class ResolvePexConfigRequest(EngineAwareParameter):
     """Find all configuration from `[python]` that impacts how the resolve is created."""
 
     resolve_name: str
+
+    def debug_hint(self) -> str:
+        return self.resolve_name
+
+
+@rule
+async def determine_resolve_pex_config(
+    request: ResolvePexConfigRequest, python_setup: PythonSetup, union_membership: UnionMembership
+) -> ResolvePexConfig:
+    all_python_tool_resolve_names = tuple(
+        sentinel.resolve_name
+        for sentinel in union_membership.get(GenerateToolLockfileSentinel)
+        if issubclass(sentinel, GeneratePythonToolLockfileSentinel)
+    )
+
+    constraints_file: tuple[Digest, FileEntry] | None = None
+    _constraints_file_path = python_setup.resolves_to_constraints_file(
+        all_python_tool_resolve_names
+    ).get(request.resolve_name)
+    if _constraints_file_path:
+        _constraints_origin = softwrap(
+            f"""
+            the option `[python].resolves_to_constraints_file` for the resolve
+            '{request.resolve_name}'
+            """
+        )
+        _constraints_path_globs = PathGlobs(
+            [_constraints_file_path] if _constraints_file_path else [],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=_constraints_origin,
+        )
+        _constraints_digest, _constraints_digest_entries = await MultiGet(
+            Get(Digest, PathGlobs, _constraints_path_globs),
+            Get(DigestEntries, PathGlobs, _constraints_path_globs),
+        )
+
+        if len(_constraints_digest_entries) != 1:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    Expected only one file from {_constraints_origin}, but matched:
+                    {_constraints_digest_entries}
+
+                    Did you use a glob like `*`?
+                    """
+                )
+            )
+        _constraints_file_entry = next(iter(_constraints_digest_entries))
+        assert isinstance(_constraints_file_entry, FileEntry)
+        constraints_file = (_constraints_digest, _constraints_file_entry)
+
+    return ResolvePexConfig(constraints_file=constraints_file)
 
 
 def should_validate_metadata(

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -32,7 +32,7 @@ from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.option.global_options import KeepSandboxes
@@ -47,7 +47,7 @@ _PARSER_SCALA_VERSION = "2.13.8"
 _PARSER_SCALA_BINARY_VERSION = _PARSER_SCALA_VERSION.rpartition(".")[0]
 
 
-class ScalaParserToolLockfileSentinel(GenerateToolLockfileSentinel):
+class ScalaParserToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = "scala-parser"
 
 

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -30,7 +30,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -54,7 +54,7 @@ class ScalafmtRequest(FmtRequest):
     name = ScalafmtSubsystem.options_scope
 
 
-class ScalafmtToolLockfileSentinel(GenerateToolLockfileSentinel):
+class ScalafmtToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = ScalafmtSubsystem.options_scope
 
 

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -33,7 +33,7 @@ from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmDependenciesField, JvmJdkField
 from pants.util.logging import LogLevel
@@ -54,7 +54,7 @@ class ScalatestTestFieldSet(TestFieldSet):
     dependencies: JvmDependenciesField
 
 
-class ScalatestToolLockfileSentinel(GenerateToolLockfileSentinel):
+class ScalatestToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = Scalatest.options_scope
 
 

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -7,7 +7,10 @@ from dataclasses import dataclass
 from pathlib import PurePath
 
 from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.goals.lockfile import (
+    GeneratePythonLockfile,
+    GeneratePythonToolLockfileSentinel,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
@@ -50,7 +53,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class TerraformHcl2ParserLockfileSentinel(GenerateToolLockfileSentinel):
+class TerraformHcl2ParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = TerraformHcl2Parser.options_scope
 
 

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -62,9 +62,12 @@ class GenerateToolLockfileSentinel:
     Each language ecosystem should set up a union member of `GenerateLockfile`, like
     `GeneratePythonLockfile`, as explained in that class's docstring.
 
-    Then, each tool should subclass `GenerateToolLockfileSentinel` and set up a rule that goes from the
+    Each language ecosystem should also subclass `GenerateToolLockfileSentinel`, e.g.
+    `GeneratePythonToolLockfileSentinel`. The subclass does not need to do anything - it is only used to know which language ecosystems tools correspond to.
+
+    Then, each tool should subclass their language ecosystem's subclass of `GenerateToolLockfileSentinel` and set up a rule that goes from the
     subclass -> the language's lockfile request, e.g. BlackLockfileSentinel ->
-    GeneratePythonLockfile. Register a union rule for the `GenerateToolLockfileSentinel` subclass.
+    GeneratePythonLockfile. Register `UnionRule(GenerateToolLockfileSentinel, MySubclass)`.
     """
 
     resolve_name: ClassVar[str]

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from pants.build_graph.address import Address, AddressInput
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE
+from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.engine.addresses import Addresses
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
@@ -154,6 +154,10 @@ async def gather_coordinates_for_jvm_lockfile(
         )
 
     return ArtifactRequirements(requirements)
+
+
+class GenerateJvmToolLockfileSentinel(GenerateToolLockfileSentinel):
+    pass
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -14,7 +14,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -22,7 +22,7 @@ _STRIP_JAR_BASENAME = "StripJar.java"
 _OUTPUT_PATH = "__stripped_jars"
 
 
-class StripJarToolLockfileSentinel(GenerateToolLockfileSentinel):
+class StripJarToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = "strip-jar"
 
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -33,7 +33,7 @@ from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import (
     JunitTestSourceField,
@@ -59,7 +59,7 @@ class JunitTestFieldSet(TestFieldSet):
     dependencies: JvmDependenciesField
 
 
-class JunitToolLockfileSentinel(GenerateToolLockfileSentinel):
+class JunitToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = JUnit.options_scope
 
 


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16443, which is necessary for the per-resolve config project from https://docs.google.com/document/d/1HAvpSNvNAHreFfvTAXavZGka-A3WWvPuH0sMjGUCo48/edit# to work properly. See https://github.com/pantsbuild/pants/pull/16420#discussion_r940559986. 

As discussed on the ticket, this is not a very elegant solution. But we don't have the rule graph introspection mechanism necessary to automagically figure out what type each tool is, and that also seems brittle.

As explained in this PR's updated docs, plugin authors don't have to technically make this change.

[ci skip-rust]
[ci skip-build-wheels]