### PR TITLE
Add `__default__` symbol to `[python].resolves_to_constraints_file`

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -229,8 +229,7 @@ class PythonSetup(Subsystem):
             `{'data-science': '3rdparty/data-science-constraints.txt'}`.
             If a resolve is not set in the dictionary, it will not use a constraints file.
 
-            You can use the key `__all__` to use the same constraints file for all resolves.
-            Entries for specific resolves will override the `__all__` default.
+            You can use the key `__default__` to set a default value for all resolves.
 
             Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
@@ -569,7 +568,7 @@ class PythonSetup(Subsystem):
     ) -> dict[str, str]:
         all_valid_resolves = {*self.resolves, *all_python_tool_resolve_names}
         unrecognized_resolves = set(self._resolves_to_constraints_file.keys()) - {
-            "__all__",
+            "__default__",
             *all_valid_resolves,
         }
         if unrecognized_resolves:
@@ -578,7 +577,7 @@ class PythonSetup(Subsystem):
                 all_valid_resolves,
                 description_of_origin="the option `[python].resolves_to_constraints_file`",
             )
-        default_val = self._resolves_to_constraints_file.get("__all__")
+        default_val = self._resolves_to_constraints_file.get("__default__")
         if not default_val:
             return self._resolves_to_constraints_file
         return {

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -229,6 +229,9 @@ class PythonSetup(Subsystem):
             `{'data-science': '3rdparty/data-science-constraints.txt'}`.
             If a resolve is not set in the dictionary, it will not use a constraints file.
 
+            You can use the key `__all__` to use the same constraints file for all resolves.
+            Entries for specific resolves will override the `__all__` default.
+
             Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
             """
@@ -562,17 +565,26 @@ class PythonSetup(Subsystem):
 
     @memoized_method
     def resolves_to_constraints_file(
-        self, all_tool_resolve_names: tuple[str, ...]
+        self, all_python_tool_resolve_names: tuple[str, ...]
     ) -> dict[str, str]:
-        all_valid_resolves = {*self.resolves, *all_tool_resolve_names}
-        unrecognized_resolves = set(self._resolves_to_constraints_file.keys()) - all_valid_resolves
+        all_valid_resolves = {*self.resolves, *all_python_tool_resolve_names}
+        unrecognized_resolves = set(self._resolves_to_constraints_file.keys()) - {
+            "__all__",
+            *all_valid_resolves,
+        }
         if unrecognized_resolves:
             raise UnrecognizedResolveNamesError(
                 sorted(unrecognized_resolves),
                 all_valid_resolves,
                 description_of_origin="the option `[python].resolves_to_constraints_file`",
             )
-        return self._resolves_to_constraints_file
+        default_val = self._resolves_to_constraints_file.get("__all__")
+        if not default_val:
+            return self._resolves_to_constraints_file
+        return {
+            resolve: self._resolves_to_constraints_file.get(resolve, default_val)
+            for resolve in all_valid_resolves
+        }
 
     def resolve_all_constraints_was_set_explicitly(self) -> bool:
         return not self.options.is_default("resolve_all_constraints")

--- a/src/python/pants/backend/python/subsystems/setup_test.py
+++ b/src/python/pants/backend/python/subsystems/setup_test.py
@@ -21,3 +21,21 @@ def test_resolves_to_interpreter_constraints_validation() -> None:
     assert create({"a": ["==3.7.*"]}) == {"a": ("==3.7.*",)}
     with pytest.raises(UnrecognizedResolveNamesError):
         create({"fake": []})
+
+
+def test_resolves_to_constraints_file() -> None:
+    def create(resolves_to_constraints_file: dict[str, str]) -> dict[str, str]:
+        return create_subsystem(
+            PythonSetup,
+            resolves={"a": "a.lock"},
+            resolves_to_constraints_file=resolves_to_constraints_file,
+        ).resolves_to_constraints_file(all_python_tool_resolve_names=("tool1", "tool2"))
+
+    assert create({"a": "c1.txt", "tool1": "c2.txt"}) == {"a": "c1.txt", "tool1": "c2.txt"}
+    assert create({"__all__": "c.txt", "tool2": "override.txt"}) == {
+        "a": "c.txt",
+        "tool1": "c.txt",
+        "tool2": "override.txt",
+    }
+    with pytest.raises(UnrecognizedResolveNamesError):
+        create({"fake": "c.txt"})

--- a/src/python/pants/backend/python/subsystems/setup_test.py
+++ b/src/python/pants/backend/python/subsystems/setup_test.py
@@ -32,7 +32,7 @@ def test_resolves_to_constraints_file() -> None:
         ).resolves_to_constraints_file(all_python_tool_resolve_names=("tool1", "tool2"))
 
     assert create({"a": "c1.txt", "tool1": "c2.txt"}) == {"a": "c1.txt", "tool1": "c2.txt"}
-    assert create({"__all__": "c.txt", "tool2": "override.txt"}) == {
+    assert create({"__default__": "c.txt", "tool2": "override.txt"}) == {
         "a": "c.txt",
         "tool1": "c.txt",
         "tool2": "override.txt",


### PR DESCRIPTION
As proposed in the per-resolve config design doc at https://docs.google.com/document/d/1HAvpSNvNAHreFfvTAXavZGka-A3WWvPuH0sMjGUCo48/edit#, `__default__` is important for boilerplate reduction.

We go with the name `__default__` for alignment with `__defaults__` from BUILD files.

[ci skip-rust]
[ci skip-build-wheels]