### PR TITLE
Add IBM to user list.

### DIFF
--- a/build-support/bin/generate_user_list.py
+++ b/build-support/bin/generate_user_list.py
@@ -2,6 +2,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import pkgutil
 from dataclasses import dataclass
 
@@ -32,7 +34,7 @@ NOTE: Please consider adding your company/organization to this list! If you wish
 class Org:
     name: str
     website: str
-    image: str
+    image: str | None
 
 
 # Orgs will be displayed in case-insensitive alphabetical order, but it's useful for human readers
@@ -67,6 +69,7 @@ _orgs = (
         "https://housinganywhere.com/",
         "https://files.readme.io/dd2a703-housinganywhere-small.png",
     ),
+    Org("IBM", "https://www.ibm.com/", None),
     Org("iManage", "https://imanage.com/", "https://files.readme.io/0f7b5f6-imanage-small.png"),
     Org("Lablup", "https://lablup.com/", "https://files.readme.io/a94d375-lablup-small.png"),
     Org("Myst AI", "https://www.myst.ai/", "https://files.readme.io/802d8fa-myst_ai_small.png"),

--- a/build-support/bin/user_list_templates/table.html.mustache
+++ b/build-support/bin/user_list_templates/table.html.mustache
@@ -10,7 +10,7 @@ can be finicky, so be sure to test out changes!
             <td width="50%">
                 <a href="{{ a.website }}" target="_blank">
                     {{#a.image}}
-                        <img src="{{ a.image }}">
+                        <img src="{{ a.image }}" alt="{{ a.name }}">
                     {{/a.image}}
                     {{^a.image}}
                         <span class="org-bigname">{{ a.name }}</span>
@@ -20,7 +20,7 @@ can be finicky, so be sure to test out changes!
             <td width="50%">
                 <a href="{{ b.website }}" target="_blank">
                     {{#b.image}}
-                        <img src="{{ b.image }}">
+                        <img src="{{ b.image }}" alt="{{ b.name }}">
                     {{/b.image}}
                     {{^b.image}}
                         <span class="org-bigname">{{ b.name }}</span>
@@ -29,20 +29,7 @@ can be finicky, so be sure to test out changes!
             </td>
         </tr>
         <tr class="org-name">
-            <td width="50%">
-                <a href="{{ a.website }}" target="_blank">
-                    {{ a.name }}
-                </a>
-                <br>
-                <br>
-                <br>
-                <br>
-            </td>
-            <td width="50%">
-                <a href="{{ b.website }}" target="_blank">
-                    {{ b.name }}
-                </a>
-                <br>
+            <td colspan="2">
                 <br>
                 <br>
                 <br>


### PR DESCRIPTION
We already had the ability to display the company name in large type
instead of the logo, if no logo was provided. However it looks pretty
bad to then repeat the company name in small type underneath it.

In fact, since all logos include the company name as legible text,
and we had already discussed remove the name text as a separate
table row, this change does just that. The name is now used as
alt text for the logo image, if any.