### PR TITLE
Add `PexRequirements.req_strings_from_requirement_fields()`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -357,10 +357,9 @@ async def setup_user_lockfile_requests(
 
     return UserGenerateLockfiles(
         GeneratePythonLockfile(
-            requirements=PexRequirements.create_from_requirement_fields(
-                resolve_to_requirements_fields[resolve],
-                constraints_strings=(),
-            ).req_strings,
+            requirements=PexRequirements.req_strings_from_requirement_fields(
+                resolve_to_requirements_fields[resolve]
+            ),
             interpreter_constraints=InterpreterConstraints(
                 python_setup.resolves_to_interpreter_constraints.get(
                     resolve, python_setup.interpreter_constraints

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -868,14 +868,13 @@ async def get_requirements(
     direct_deps_with_excl = direct_deps_chained.difference(transitive_excludes)
 
     req_strs = list(
-        PexRequirements.create_from_requirement_fields(
+        PexRequirements.req_strings_from_requirement_fields(
             (
                 tgt[PythonRequirementsField]
                 for tgt in direct_deps_with_excl
                 if tgt.has_field(PythonRequirementsField)
             ),
-            constraints_strings=(),
-        ).req_strings
+        )
     )
 
     # Add the requirements on any exported targets on which we depend.

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -220,10 +220,9 @@ async def flake8_first_party_plugins(flake8: Flake8) -> Flake8FirstPartyPlugins:
     )
 
     return Flake8FirstPartyPlugins(
-        requirement_strings=PexRequirements.create_from_requirement_fields(
+        requirement_strings=PexRequirements.req_strings_from_requirement_fields(
             requirements_fields,
-            constraints_strings=(),
-        ).req_strings,
+        ),
         interpreter_constraints_fields=FrozenOrderedSet(interpreter_constraints_fields),
         sources_digest=prefixed_sources,
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -220,10 +220,9 @@ async def pylint_first_party_plugins(pylint: Pylint) -> PylintFirstPartyPlugins:
     )
 
     return PylintFirstPartyPlugins(
-        requirement_strings=PexRequirements.create_from_requirement_fields(
+        requirement_strings=PexRequirements.req_strings_from_requirement_fields(
             requirements_fields,
-            constraints_strings=(),
-        ).req_strings,
+        ),
         interpreter_constraints_fields=FrozenOrderedSet(interpreter_constraints_fields),
         sources_digest=prefixed_sources,
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -268,18 +268,17 @@ async def mypy_first_party_plugins(
         TransitiveTargets, TransitiveTargetsRequest(plugin_target_addresses)
     )
 
-    requirements = PexRequirements.create_from_requirement_fields(
+    requirements = PexRequirements.req_strings_from_requirement_fields(
         (
             plugin_tgt[PythonRequirementsField]
             for plugin_tgt in transitive_targets.closure
             if plugin_tgt.has_field(PythonRequirementsField)
         ),
-        constraints_strings=(),
     )
 
     sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(transitive_targets.closure))
     return MyPyFirstPartyPlugins(
-        requirement_strings=requirements.req_strings,
+        requirement_strings=requirements,
         sources_digest=sources.source_files.snapshot.digest,
         source_roots=sources.source_roots,
     )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -573,13 +573,10 @@ async def _setup_constraints_repository_pex(
 
     transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses))
 
-    requirements = PexRequirements.create_from_requirement_fields(
-        (
-            tgt[PythonRequirementsField]
-            for tgt in transitive_targets.closure
-            if tgt.has_field(PythonRequirementsField)
-        ),
-        constraints_strings=(str(constraint) for constraint in global_requirement_constraints),
+    req_strings = PexRequirements.req_strings_from_requirement_fields(
+        tgt[PythonRequirementsField]
+        for tgt in transitive_targets.closure
+        if tgt.has_field(PythonRequirementsField)
     )
 
     # In requirement strings, Foo_-Bar.BAZ and foo-bar-baz refer to the same project. We let
@@ -590,7 +587,7 @@ async def _setup_constraints_repository_pex(
     name_req_projects = set()
     constraints_file_reqs = set(global_requirement_constraints)
 
-    for req_str in requirements.req_strings:
+    for req_str in req_strings:
         req = PipRequirement.parse(req_str)
         if req.url:
             url_reqs.add(req)

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -270,6 +270,14 @@ class PexRequirements:
         field_requirements = {str(python_req) for field in fields for python_req in field.value}
         return PexRequirements(field_requirements, constraints_strings=constraints_strings)
 
+    @classmethod
+    def req_strings_from_requirement_fields(
+        cls, fields: Iterable[PythonRequirementsField]
+    ) -> FrozenOrderedSet[str]:
+        """A convenience when you only need the raw requirement strings from fields and don't need
+        to consider things like constraints or resolves."""
+        return cls.create_from_requirement_fields(fields, constraints_strings=()).req_strings
+
     def __bool__(self) -> bool:
         return bool(self.req_strings)
 


### PR DESCRIPTION
In several places, we create `PexRequirements` solely to immediately extract out the raw parsed strings. 

However, we made all call sites unnecessarily deal with `constraint_strings`, which has no impact on the operation. Soon, as part of the per-resolve config project at https://docs.google.com/document/d/1HAvpSNvNAHreFfvTAXavZGka-A3WWvPuH0sMjGUCo48/edit#, we would also likely have made the call sites think about `resolve_name`. Instead, we avoid that confusion.

[ci skip-rust]
[ci skip-build-wheels]