### PR TITLE
Add `[mypy].extra_type_stubs_lockfile`

### DIFF
--- a/docs/markdown/Python/python-goals/python-check-goal.md
+++ b/docs/markdown/Python/python-goals/python-check-goal.md
@@ -123,11 +123,16 @@ python_sources(name="lib")
 
 You can install third-party type stubs (e.g. `types-requests`) like [normal Python requirements](doc:python-third-party-dependencies). Pants will infer a dependency on both the type stub and the actual dependency, e.g. both `types-requests` and `requests`, which you can confirm by running `./pants dependencies path/to/f.py`.
 
-You can also install the type stub via the option `[mypy].extra_type_stubs`, which ensures the stubs are only used when running MyPy and are not included when, for example, [packaging a PEX](doc:python-package-goal).
+You can also install the type stub via the option `[mypy].extra_type_stubs`, which ensures
+the stubs are only used when running MyPy and are not included when, for example,
+[packaging a PEX](doc:python-package-goal). We recommend also setting
+`[mypy].extra_type_stubs_lockfile` for more reproducible builds and better supply-chain security.
 
 ```toml pants.toml
 [mypy]
 extra_type_stubs = ["types-requests==2.25.12"]
+# Set this to a path, then run `./pants generate-lockfiles --resolve=mypy-extra-type-stubs`. 
+extra_type_stubs_lockfile = "3rdparty/python/mypy_extra_type_stubs.lock
 ```
 
 ### Add a third-party plugin

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -21,7 +21,7 @@ from pants.engine.fs import Digest, FileContent
 from pants.option.errors import OptionsError
 from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import bin_name, doc_url
+from pants.util.docutil import bin_name
 from pants.util.strutil import softwrap
 
 
@@ -82,15 +82,16 @@ class PythonToolRequirementsBase(Subsystem):
             {cls.default_lockfile_url} for the default lockfile contents.
 
             Set to the string `{NO_TOOL_LOCKFILE}` to opt out of using a lockfile. We
-            do not recommend this, though, as lockfiles are essential for reproducible builds.
+            do not recommend this, though, as lockfiles are essential for reproducible builds and
+            supply-chain security.
 
             To use a custom lockfile, set this option to a file path relative to the
             build root, then run `{bin_name()} generate-lockfiles --resolve={cls.options_scope}`.
 
-            As explained at {doc_url('python-third-party-dependencies')}, lockfile generation
-            via `generate-lockfiles` does not always work and you may want to manually generate
-            the lockfile. You will want to set `[python].invalid_lockfile_behavior = 'ignore'` so
-            that Pants does not complain about missing lockfile headers.
+            Alternatively, you can set this option to the path to a custom lockfile using pip's
+            requirements.txt-style, ideally with `--hash`. Set
+            `[python].invalid_lockfile_behavior = 'ignore'` so that Pants does not complain about
+            missing lockfile headers.
             """
         ),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/mypyc.py
+++ b/src/python/pants/backend/python/typecheck/mypy/mypyc.py
@@ -15,7 +15,6 @@ from pants.backend.python.typecheck.mypy.subsystem import (
 from pants.backend.python.util_rules import pex_from_targets
 from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
-from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import BoolField, Target
 from pants.engine.unions import UnionRule
@@ -70,15 +69,9 @@ async def get_mypyc_build_environment(
         ),
     )
     extra_type_stubs_pex_get = Get(
-        Pex,
-        PexRequest(
-            output_filename="extra_type_stubs.pex",
-            internal_only=True,
-            requirements=PexRequirements(mypy.extra_type_stubs),
-            interpreter_constraints=request.interpreter_constraints,
-        ),
+        Pex, PexRequest, mypy.extra_type_stubs_pex_request(request.interpreter_constraints)
     )
-    (mypy_pex, requirements_pex, extra_type_stubs_pex) = await MultiGet(
+    mypy_pex, requirements_pex, extra_type_stubs_pex = await MultiGet(
         mypy_pex_get, requirements_pex_get, extra_type_stubs_pex_get
     )
     return DistBuildEnvironment(

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -30,7 +30,6 @@ from pants.backend.python.util_rules.pex import (
     VenvPexProcess,
 )
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
-from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -177,13 +176,7 @@ async def mypy_typecheck_partition(
         ),
     )
     extra_type_stubs_pex_get = Get(
-        Pex,
-        PexRequest(
-            output_filename="extra_type_stubs.pex",
-            internal_only=True,
-            requirements=PexRequirements(mypy.extra_type_stubs),
-            interpreter_constraints=partition.interpreter_constraints,
-        ),
+        Pex, PexRequest, mypy.extra_type_stubs_pex_request(partition.interpreter_constraints)
     )
 
     mypy_pex_get = Get(

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -283,6 +283,81 @@ def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/app.py:4" in result[0].stdout
 
 
+def test_extra_type_stubs_lockfile(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            f"{PACKAGE}/app.py": dedent(
+                """\
+                from pkg_resources import Requirement
+
+                assert Requirement(123) == 123
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_sources()",
+            "stubs.lock": dedent(
+                """
+                {
+                  "allow_builds": true,
+                  "allow_prereleases": false,
+                  "allow_wheels": true,
+                  "build_isolation": true,
+                  "constraints": [],
+                  "locked_resolves": [
+                    {
+                      "locked_requirements": [
+                        {
+                          "artifacts": [
+                            {
+                              "algorithm": "sha256",
+                              "hash": "f568830d82b48783a0df00646bc84effeddb4886bf0f19708fbbadeb552b6ece",
+                              "url": "https://files.pythonhosted.org/packages/ff/62/7de9f8c8378e46ec7dc68257cd9577c65d2c0b3dd4abc31ae92e97fa98e8/types_setuptools-63.4.0-py3-none-any.whl"
+                            }
+                          ],
+                          "project_name": "types-setuptools",
+                          "requires_dists": [],
+                          "requires_python": null,
+                          "version": "63.4"
+                        }
+                      ],
+                      "platform_tag": null
+                    }
+                  ],
+                  "path_mappings": {},
+                  "pex_version": "2.1.103",
+                  "prefer_older_binary": false,
+                  "requirements": [
+                    "types-setuptools"
+                  ],
+                  "requires_python": [
+                    "==3.9.*"
+                  ],
+                  "resolver_version": "pip-2020-resolver",
+                  "style": "universal",
+                  "target_systems": [
+                    "linux",
+                    "mac"
+                  ],
+                  "transitive": true,
+                  "use_pep517": null
+                }
+                """
+            ),
+        }
+    )
+    result = run_mypy(
+        rule_runner,
+        [rule_runner.get_target(Address(PACKAGE, relative_file_path="app.py"))],
+        extra_args=[
+            "--mypy-extra-type-stubs==types-setuptools",
+            "--mypy-extra-type-stubs-lockfile=stubs.lock",
+            "--python-invalid-lockfile-behavior=ignore",
+        ],
+    )
+    assert len(result) == 1
+    assert result[0].exit_code == 1
+    assert f"{PACKAGE}/app.py:3" in result[0].stdout
+
+
 def test_transitive_dependencies(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -23,14 +23,21 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.typecheck.mypy.skip_field import SkipMyPyField
+from pants.backend.python.util_rules import partition
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex_requirements import PexRequirements
+from pants.backend.python.util_rules.pex import PexRequest
+from pants.backend.python.util_rules.pex_requirements import (
+    EntireLockfile,
+    PexRequirements,
+    ToolCustomLockfile,
+)
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import NO_TOOL_LOCKFILE, GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
+from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
 from pants.engine.rules import Get, collect_rules, rule, rule_helper
@@ -49,9 +56,10 @@ from pants.option.option_types import (
     FileOption,
     SkipOption,
     StrListOption,
+    StrOption,
     TargetListOption,
 )
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import bin_name, doc_url, git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
@@ -154,6 +162,26 @@ class MyPy(PythonToolBase):
 
             Expects a list of pip-style requirement strings, like
             `['types-requests==2.25.9']`.
+
+            We recommend also enabling `[mypy].extra_type_stubs_lockfile` for a more reproducible
+            build and less supply-chain security risk.
+            """
+        ),
+    )
+    extra_type_stubs_lockfile = StrOption(
+        advanced=True,
+        # Note that there is no default lockfile, as by default, extra_type_stubs is empty.
+        default=NO_TOOL_LOCKFILE,
+        help=softwrap(
+            f"""
+            Path to a lockfile for the option `[mypy].extra_type_stubs`.
+
+            Set to the string `{NO_TOOL_LOCKFILE}` to opt out of using a lockfile. We
+            do not recommend this if you use `[mypy].extra_type_stubs`, though, as lockfiles are
+            essential for reproducible builds and supply-chain security.
+
+            To use a lockfile, set this option to a file path relative to the
+            build root, then run `{bin_name()} generate-lockfiles --resolve=mypy-extra-type-stubs`.
             """
         ),
     )
@@ -175,6 +203,31 @@ class MyPy(PythonToolBase):
             self._source_plugins,
             owning_address=None,
             description_of_origin=f"the option `[{self.options_scope}].source_plugins`",
+        )
+
+    def extra_type_stubs_pex_request(
+        self, interpreter_constraints: InterpreterConstraints
+    ) -> PexRequest:
+        requirements: PexRequirements | EntireLockfile
+        if self.extra_type_stubs_lockfile == NO_TOOL_LOCKFILE:
+            requirements = PexRequirements(self.extra_type_stubs)
+        else:
+            tool_lockfile = ToolCustomLockfile(
+                file_path=self.extra_type_stubs_lockfile,
+                file_path_description_of_origin=(
+                    f"the option `[{self.options_scope}].extra_type_stubs_lockfile`"
+                ),
+                lockfile_hex_digest=calculate_invalidation_digest(self.extra_type_stubs),
+                resolve_name=self.options_scope,
+                uses_project_interpreter_constraints=True,
+                uses_source_plugins=False,
+            )
+            requirements = EntireLockfile(tool_lockfile, complete_req_strings=self.extra_type_stubs)
+        return PexRequest(
+            output_filename="extra_type_stubs.pex",
+            internal_only=True,
+            requirements=requirements,
+            interpreter_constraints=interpreter_constraints,
         )
 
     def check_and_warn_if_python_version_configured(self, config: FileContent | None) -> bool:
@@ -310,7 +363,7 @@ async def _mypy_interpreter_constraints(
 
 
 # --------------------------------------------------------------------------------------
-# Lockfile
+# Lockfiles
 # --------------------------------------------------------------------------------------
 
 
@@ -339,6 +392,53 @@ async def setup_mypy_lockfile(
         constraints,
         extra_requirements=first_party_plugins.requirement_strings,
         use_pex=python_setup.generate_lockfiles_with_pex,
+    )
+
+
+class MyPyExtraTypeStubsLockfileSentinel(GeneratePythonToolLockfileSentinel):
+    resolve_name = "mypy-extra-type-stubs"
+
+
+@rule(desc="Set up lockfile request for [mypy].extra_type_stubs", level=LogLevel.DEBUG)
+async def setup_mypy_extra_type_stubs_lockfile(
+    request: MyPyExtraTypeStubsLockfileSentinel,
+    mypy: MyPy,
+    python_setup: PythonSetup,
+) -> GeneratePythonLockfile:
+    use_pex = python_setup.generate_lockfiles_with_pex
+    if mypy.extra_type_stubs_lockfile == NO_TOOL_LOCKFILE:
+        return GeneratePythonLockfile(
+            requirements=FrozenOrderedSet(),
+            interpreter_constraints=InterpreterConstraints(),
+            resolve_name=request.resolve_name,
+            lockfile_dest=mypy.extra_type_stubs_lockfile,
+            use_pex=use_pex,
+        )
+
+    # While MyPy will run in partitions, we need a set of constraints that works with every
+    # partition.
+    #
+    # This first finds the ICs of each partition. Then, it ORs all unique resulting interpreter
+    # constraints. The net effect is that every possible Python interpreter used will be covered.
+    all_tgts = await Get(AllTargets, AllTargetsRequest())
+    all_field_sets = [
+        MyPyFieldSet.create(tgt) for tgt in all_tgts if MyPyFieldSet.is_applicable(tgt)
+    ]
+    resolve_and_interpreter_constraints_to_coarsened_targets = (
+        await partition._by_interpreter_constraints_and_resolve(all_field_sets, python_setup)
+    )
+    unique_constraints = {
+        ics for resolve, ics in resolve_and_interpreter_constraints_to_coarsened_targets.keys()
+    }
+    interpreter_constraints = InterpreterConstraints(
+        itertools.chain.from_iterable(unique_constraints)
+    ) or InterpreterConstraints(python_setup.interpreter_constraints)
+    return GeneratePythonLockfile(
+        requirements=FrozenOrderedSet(mypy.extra_type_stubs),
+        interpreter_constraints=interpreter_constraints,
+        resolve_name=request.resolve_name,
+        lockfile_dest=mypy.extra_type_stubs_lockfile,
+        use_pex=use_pex,
     )
 
 
@@ -375,5 +475,6 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         UnionRule(GenerateToolLockfileSentinel, MyPyLockfileSentinel),
+        UnionRule(GenerateToolLockfileSentinel, MyPyExtraTypeStubsLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, MyPyExportSentinel),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -218,7 +218,7 @@ class MyPy(PythonToolBase):
                     f"the option `[{self.options_scope}].extra_type_stubs_lockfile`"
                 ),
                 lockfile_hex_digest=calculate_invalidation_digest(self.extra_type_stubs),
-                resolve_name=self.options_scope,
+                resolve_name=MyPyExtraTypeStubsLockfileSentinel.resolve_name,
                 uses_project_interpreter_constraints=True,
                 uses_source_plugins=False,
             )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -14,6 +14,7 @@ from pants.backend.python.typecheck.mypy import skip_field, subsystem
 from pants.backend.python.typecheck.mypy.subsystem import (
     MyPy,
     MyPyConfigFile,
+    MyPyExtraTypeStubsLockfileSentinel,
     MyPyFirstPartyPlugins,
     MyPyLockfileSentinel,
 )
@@ -40,6 +41,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(MyPyConfigFile, []),
             QueryRule(MyPyFirstPartyPlugins, []),
             QueryRule(GeneratePythonLockfile, [MyPyLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [MyPyExtraTypeStubsLockfileSentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, PythonRequirementTarget, GenericTarget],
     )
@@ -246,4 +248,71 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
         MyPy.default_interpreter_constraints,
         extra_args=["--mypy-source-plugins=project"],
         extra_expected_requirements=["ansicolors"],
+    )
+
+
+def test_setup_extra_type_stubs_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None:
+    global_constraint = "==3.9.*"
+
+    def assert_lockfile_request(build_file: str, expected_ics: list[str]) -> None:
+        rule_runner.write_files({"project/BUILD": build_file, "project/f.py": ""})
+        rule_runner.set_options(
+            ["--mypy-extra-type-stubs-lockfile=lockfile.txt"],
+            env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
+            env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+        )
+        lockfile_request = rule_runner.request(
+            GeneratePythonLockfile, [MyPyExtraTypeStubsLockfileSentinel()]
+        )
+        assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
+
+    assert_lockfile_request("python_sources()", [global_constraint])
+    assert_lockfile_request("python_sources(interpreter_constraints=['==2.7.*'])", ["==2.7.*"])
+    assert_lockfile_request(
+        "python_sources(interpreter_constraints=['==2.7.*', '==3.8.*'])", ["==2.7.*", "==3.8.*"]
+    )
+
+    # If no Python targets in repo, fall back to global [python] constraints.
+    assert_lockfile_request("target()", [global_constraint])
+
+    # Ignore targets that are skipped.
+    assert_lockfile_request(
+        dedent(
+            """\
+            python_sources(name='a', interpreter_constraints=['==2.7.*'])
+            python_sources(name='b', interpreter_constraints=['==3.8.*'], skip_mypy=True)
+            """
+        ),
+        ["==2.7.*"],
+    )
+
+    # If there are multiple distinct ICs in the repo, we OR them because the lockfile needs to be
+    # compatible with every target.
+    assert_lockfile_request(
+        dedent(
+            """\
+            python_sources(name='a', interpreter_constraints=['==2.7.*'])
+            python_sources(name='b', interpreter_constraints=['==3.8.*'])
+            """
+        ),
+        ["==2.7.*", "==3.8.*"],
+    )
+    assert_lockfile_request(
+        dedent(
+            """\
+            python_sources(name='a', interpreter_constraints=['==2.7.*', '==3.8.*'])
+            python_sources(name='b', interpreter_constraints=['>=3.8'])
+            """
+        ),
+        ["==2.7.*", "==3.8.*", ">=3.8"],
+    )
+    assert_lockfile_request(
+        dedent(
+            """\
+            python_sources(name='a')
+            python_sources(name='b', interpreter_constraints=['==2.7.*'])
+            python_sources(name='c', interpreter_constraints=['>=3.8'])
+            """
+        ),
+        ["==2.7.*", global_constraint, ">=3.8"],
     )

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Iterable, Mapping, TypeVar
+from typing import Mapping, Sequence, TypeVar
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
@@ -20,7 +20,7 @@ FS = TypeVar("FS", bound=FieldSet)
 
 @rule_helper
 async def _by_interpreter_constraints_and_resolve(
-    field_sets: Iterable[FS],
+    field_sets: Sequence[FS],
     python_setup: PythonSetup,
 ) -> Mapping[
     tuple[ResolveName, InterpreterConstraints],


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/15455.

Beyond it generally being useful for `[mypy].extra_type_stubs` to have a lockfile, it is important that we have a defined resolve name for the option so that the per-resolve options like `[python].resolves_to_constraints_file` can work: https://docs.google.com/document/d/1HAvpSNvNAHreFfvTAXavZGka-A3WWvPuH0sMjGUCo48/edit#heading=h.n451mfzergzm.

[ci skip-rust]
[ci skip-build-wheels]