### PR TITLE
Refactor `build_pex` rule with `@rule_helper`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -58,7 +58,7 @@ from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import HydratedSources, HydrateSourcesRequest, SourcesField, Targets
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -354,24 +354,16 @@ class BuildPexResult:
         return Pex(digest=self.digest, name=self.pex_filename, python=self.python)
 
 
-@rule(level=LogLevel.DEBUG)
-async def build_pex(
-    request: PexRequest,
-    python_setup: PythonSetup,
-    python_repos: PythonRepos,
-    platform: Platform,
-    pex_runtime_env: PexRuntimeEnvironment,
-) -> BuildPexResult:
-    """Returns a PEX with the given settings."""
-    argv = [
-        "--output-file",
-        request.output_filename,
-        "--no-emit-warnings",
-        *python_setup.manylinux_pex_args,
-        *request.additional_args,
-    ]
+@dataclass
+class _BuildPexPythonSetup:
+    python: PythonExecutable | None
+    argv: list[str]
 
+
+@rule_helper
+async def _determine_pex_python_and_platforms(request: PexRequest) -> _BuildPexPythonSetup:
     python: PythonExecutable | None = None
+    argv = []
 
     # NB: If `--platform` is specified, this signals that the PEX should not be built locally.
     # `--interpreter-constraint` only makes sense in the context of building locally. These two
@@ -399,25 +391,25 @@ async def build_pex(
     if python:
         argv.extend(["--python", python.path])
 
-    if request.main is not None:
-        argv.extend(request.main.iter_pex_args())
+    return _BuildPexPythonSetup(python, argv)
 
-    # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path
-    #  requirements, which could lead to problems. Support shading python binaries.
-    #  See: https://github.com/pantsbuild/pants/issues/9206
-    if request.pex_path:
-        argv.extend(["--pex-path", ":".join(pex.name for pex in request.pex_path)])
 
-    source_dir_name = "source_files"
-    argv.append(f"--sources-directory={source_dir_name}")
-    sources_digest_as_subdir = await Get(
-        Digest, AddPrefix(request.sources or EMPTY_DIGEST, source_dir_name)
-    )
+@dataclass
+class _BuildPexRequirementsSetup:
+    digests: list[Digest]
+    argv: list[str]
+    concurrency_available: int
 
-    # Include any additional arguments and input digests required by the requirements.
-    requirements_digests = []
+
+@rule_helper
+async def _setup_pex_requirements(
+    request: PexRequest, python_repos: PythonRepos, python_setup: PythonSetup
+) -> _BuildPexRequirementsSetup:
+    digests = []
+    argv = []
     pex_lock_resolver_args = [*python_repos.pex_args]
     pip_resolver_args = [*python_repos.pex_args, "--resolver-version", "pip-2020-resolver"]
+
     if isinstance(request.requirements, EntireLockfile):
         lockfile, resolve_config = await MultiGet(
             Get(LoadedLockfile, LoadedLockfileRequest(request.requirements.lockfile)),
@@ -427,7 +419,7 @@ async def build_pex(
             ),
         )
         concurrency_available = lockfile.requirement_estimate
-        requirements_digests.append(lockfile.lockfile_digest)
+        digests.append(lockfile.lockfile_digest)
         if lockfile.is_pex_native:
             argv.extend(["--lock", lockfile.lockfile_path])
             argv.extend(pex_lock_resolver_args)
@@ -454,7 +446,7 @@ async def build_pex(
         if isinstance(request.requirements.from_superset, Pex):
             repository_pex = request.requirements.from_superset
             argv.extend(["--pex-repository", repository_pex.name])
-            requirements_digests.append(repository_pex.digest)
+            digests.append(repository_pex.digest)
         elif isinstance(request.requirements.from_superset, LoadedLockfile):
             loaded_lockfile = request.requirements.from_superset
             resolve_config = await Get(
@@ -464,7 +456,7 @@ async def build_pex(
             # NB: This is also validated in the constructor.
             assert loaded_lockfile.is_pex_native
             if request.requirements.req_strings:
-                requirements_digests.append(loaded_lockfile.lockfile_digest)
+                digests.append(loaded_lockfile.lockfile_digest)
                 argv.extend(["--lock", loaded_lockfile.lockfile_path])
                 argv.extend(pex_lock_resolver_args)
 
@@ -485,13 +477,55 @@ async def build_pex(
             if request.requirements.constraints_strings:
                 constraints_file = "__constraints.txt"
                 constraints_content = "\n".join(request.requirements.constraints_strings)
-                requirements_digests.append(
+                digests.append(
                     await Get(
                         Digest,
                         CreateDigest([FileContent(constraints_file, constraints_content.encode())]),
                     )
                 )
                 argv.extend(["--constraints", constraints_file])
+
+    return _BuildPexRequirementsSetup(digests, argv, concurrency_available)
+
+
+@rule(level=LogLevel.DEBUG)
+async def build_pex(
+    request: PexRequest,
+    python_setup: PythonSetup,
+    python_repos: PythonRepos,
+    platform: Platform,
+    pex_runtime_env: PexRuntimeEnvironment,
+) -> BuildPexResult:
+    """Returns a PEX with the given settings."""
+    argv = [
+        "--output-file",
+        request.output_filename,
+        "--no-emit-warnings",
+        *python_setup.manylinux_pex_args,
+        *request.additional_args,
+    ]
+
+    pex_python_setup = await _determine_pex_python_and_platforms(request)
+    argv.extend(pex_python_setup.argv)
+
+    if request.main is not None:
+        argv.extend(request.main.iter_pex_args())
+
+    # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path
+    #  requirements, which could lead to problems. Support shading python binaries.
+    #  See: https://github.com/pantsbuild/pants/issues/9206
+    if request.pex_path:
+        argv.extend(["--pex-path", ":".join(pex.name for pex in request.pex_path)])
+
+    source_dir_name = "source_files"
+    argv.append(f"--sources-directory={source_dir_name}")
+    sources_digest_as_subdir = await Get(
+        Digest, AddPrefix(request.sources or EMPTY_DIGEST, source_dir_name)
+    )
+
+    # Include any additional arguments and input digests required by the requirements.
+    requirements_setup = await _setup_pex_requirements(request, python_repos, python_setup)
+    argv.extend(requirements_setup.argv)
 
     merged_digest = await Get(
         Digest,
@@ -500,7 +534,7 @@ async def build_pex(
                 request.complete_platforms.digest,
                 sources_digest_as_subdir,
                 request.additional_inputs,
-                *requirements_digests,
+                *requirements_setup.digests,
                 *(pex.digest for pex in request.pex_path),
             )
         ),
@@ -517,14 +551,14 @@ async def build_pex(
     process = await Get(
         Process,
         PexCliProcess(
-            python=python,
+            python=pex_python_setup.python,
             subcommand=(),
             extra_args=argv,
             additional_input_digest=merged_digest,
             description=_build_pex_description(request),
             output_files=output_files,
             output_directories=output_directories,
-            concurrency_available=concurrency_available,
+            concurrency_available=requirements_setup.concurrency_available,
         ),
     )
 
@@ -549,7 +583,10 @@ async def build_pex(
     )
 
     return BuildPexResult(
-        result=result, pex_filename=request.output_filename, digest=digest, python=python
+        result=result,
+        pex_filename=request.output_filename,
+        digest=digest,
+        python=pex_python_setup.python,
     )
 
 


### PR DESCRIPTION
This allows us to leverage early returns & inlining variables. It also allows creating comprehensive unit tests.