### PR TITLE
Add `[flake8].extra_files` to allow configuring plugins like Bandit

### DIFF
--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -68,7 +68,7 @@ async def flake8_lint_partition(
         PathGlobs(
             globs=flake8.extra_files,
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin="the option flake8.extra_files",
+            description_of_origin="the option [flake8].extra_files",
         ),
     )
     # Ensure that the empty report dir exists.

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -185,21 +185,26 @@ def test_skip(rule_runner: RuleRunner) -> None:
 
 
 def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
+    # Test extra_files option
     rule_runner.write_files(
-        {"f.py": "'constant' and 'constant2'\n", "BUILD": "python_sources(name='t')"}
+        {
+            "f.py": "assert None == 1\n",
+            ".bandit": 'skips: ["B101"]\n',
+            "BUILD": "python_sources(name='t')",
+        }
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_flake8(
         rule_runner,
         [tgt],
         extra_args=[
-            "--flake8-extra-requirements=flake8-pantsbuild>=2.0,<3",
+            "--flake8-extra-requirements=flake8-bandit==3.0.0",
             "--flake8-lockfile=<none>",
+            "--flake8-extra-files=['.bandit']",
         ],
     )
     assert len(result) == 1
-    assert result[0].exit_code == 1
-    assert "f.py:1:1: PB11" in result[0].stdout
+    assert result[0].exit_code == 0
 
 
 def test_report_file(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -188,8 +188,8 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
     # Test extra_files option
     rule_runner.write_files(
         {
-            "f.py": "assert None == 1\n",
-            ".bandit": 'skips: ["B101"]\n',
+            "f.py": "assert 1 == 1\n",
+            ".bandit": "[bandit]\nskips: B101\n",
             "BUILD": "python_sources(name='t')",
         }
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -43,6 +43,7 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
+    FileListOption,
     FileOption,
     SkipOption,
     TargetListOption,
@@ -93,6 +94,11 @@ class Flake8(PythonToolBase):
             this option if the config is located in a non-standard location.
             """
         ),
+    )
+    extra_files = FileListOption(
+        default=None,
+        advanced=True,
+        help="Path to extra YAML config files used by flake8 plugins like `flake8-bandit`.",
     )
     config_discovery = BoolOption(
         default=True,

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -98,7 +98,10 @@ class Flake8(PythonToolBase):
     extra_files = FileListOption(
         default=None,
         advanced=True,
-        help="Path to extra YAML config files used by flake8 plugins like `flake8-bandit`.",
+        help=softwrap(
+            """Paths to extra files to include in the sandbox. This can be useful for Flake8 plugins,
+            like including config files for the `flake8-bandit` plugin."""
+        ),
     )
     config_discovery = BoolOption(
         default=True,


### PR DESCRIPTION
Adds a new option for passing config files used by`flake8` plugin.

Fixes https://github.com/pantsbuild/pants/issues/15225

[ci skip-rust]
[ci skip-build-wheels]
