### PR TITLE
Fix docker invalidation bug. (cherrypick #16419)

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -94,6 +94,7 @@ def assert_build(
     def build_context_mock(request: DockerBuildContextRequest) -> DockerBuildContext:
         return DockerBuildContext.create(
             snapshot=build_context_snapshot,
+            upstream_image_ids=[],
             dockerfile_info=DockerfileInfo(
                 request.address,
                 digest=EMPTY_DIGEST,
@@ -445,6 +446,7 @@ def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
             {
                 "INHERIT": "from Pants env",
                 "VAR": "value",
+                "__UPSTREAM_IMAGE_IDS": "",
             }
         )
 
@@ -486,6 +488,7 @@ def test_docker_build_args(rule_runner: RuleRunner) -> None:
         assert process.env == FrozenDict(
             {
                 "INHERIT": "from Pants env",
+                "__UPSTREAM_IMAGE_IDS": "",
             }
         )
 
@@ -582,6 +585,7 @@ def test_docker_extra_build_args_field(rule_runner: RuleRunner) -> None:
         assert process.env == FrozenDict(
             {
                 "FROM_ENV": "env value",
+                "__UPSTREAM_IMAGE_IDS": "",
             }
         )
 

--- a/src/python/pants/backend/docker/package_types.py
+++ b/src/python/pants/backend/docker/package_types.py
@@ -11,12 +11,17 @@ from pants.util.strutil import bullet_list, pluralize
 
 @dataclass(frozen=True)
 class BuiltDockerImage(BuiltPackageArtifact):
+    # We don't really want a default for this field, but the superclass has a field with
+    # a default, so all subsequent fields must have one too. The `create()` method below
+    # will ensure that this field is properly populated in practice.
+    image_id: str = ""
     tags: tuple[str, ...] = ()
 
     @classmethod
     def create(cls, image_id: str, tags: tuple[str, ...]) -> BuiltDockerImage:
-        tags_string = tags[0] if len(tags) == 1 else (f"\n{bullet_list(tags)}")
+        tags_string = tags[0] if len(tags) == 1 else f"\n{bullet_list(tags)}"
         return cls(
+            image_id=image_id,
             tags=tags,
             relpath=None,
             extra_log_lines=(

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -88,6 +88,8 @@ class DockerBinary(BinaryPath):
             env=self._get_process_environment(env),
             input_digest=digest,
             immutable_input_digests=self.extra_input_digests,
+            # We must run the docker build commands every time, even if nothing has changed,
+            # in case the user ran `docker image rm` outside of Pants.
             cache_scope=ProcessCacheScope.PER_SESSION,
         )
 


### PR DESCRIPTION
Assume a "child" image that depends on a "parent" image
(via a FROM command).

Previously, the child image building Process had no mention
of the parent image's unique ID. So, even though we would re-run
the parent building process every time (because it was set
to PER_SESSION scope in #13464), Pants would not know that the
child building process depended on the parent building process
completing first (and creating the new parent image as a side effect).

Now we write a dummy file containing the ids of all upstream images
into the context in which a child image build is executed. This
causes the child building process to invalidate correctly.

Note that we still need the PER_SESSION scope because we have
to re-run all image build processes even when there were no changes at
all, in case the user did a `docker image rm`.

This highlights the complications and dangers of interacting with
a stateful external daemon like docker.

[ci skip-rust]

[ci skip-build-wheels]