### PR TITLE
Support adding to dict-valued options in config files.

### DIFF
--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -43,7 +43,7 @@ class DockerRegistryOptions:
             extra_image_tags=tuple(
                 d.get("extra_image_tags", DockerRegistryOptions.extra_image_tags)
             ),
-            repository=Parser.to_value_type(d.get("repository"), str, None, None),
+            repository=Parser.to_value_type(d.get("repository"), str, None),
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2450,9 +2450,8 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
         `{bin_name()} dependencies` or `{bin_name()} peek` on this target to get the final
         result.
 
-        See {doc_url('targets#target-addresses')} and {doc_url('targets#target-generation')} for
-        more about how addresses are formed, including for generated targets. You can also run
-        `{bin_name()} list ::` to find all addresses in your project, or
+        See {doc_url('targets')} for more about how addresses are formed, including for generated
+        targets. You can also run `{bin_name()} list ::` to find all addresses in your project, or
         `{bin_name()} list dir:` to find all addresses defined in that directory.
 
         If the target is in the same BUILD file, you can leave off the BUILD file path, e.g.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2452,7 +2452,7 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
 
         See {doc_url('targets')} for more about how addresses are formed, including for generated
         targets. You can also run `{bin_name()} list ::` to find all addresses in your project, or
-        `{bin_name()} list dir:` to find all addresses defined in that directory.
+        `{bin_name()} list dir` to find all addresses defined in that directory.
 
         If the target is in the same BUILD file, you can leave off the BUILD file path, e.g.
         `:tgt` instead of `helloworld/subdir:tgt`. For generated first-party addresses, use

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from functools import partial
 from types import SimpleNamespace
 from typing import Any, Dict, Iterable, List, Mapping, Union, cast
 
@@ -23,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 # A dict with optional override seed values for buildroot, pants_workdir, and pants_distdir.
-SeedValues = Dict[str, Value]
+SeedValues = Mapping[str, Value]
 
 
 class ConfigSource(Protocol):
@@ -163,7 +162,7 @@ class Config:
 
 
 _TomlPrimitive = Union[bool, int, float, str]
-_TomlValue = Union[_TomlPrimitive, List[_TomlPrimitive]]
+_TomlValue = Union[_TomlPrimitive, List[_TomlPrimitive], Dict[str, _TomlPrimitive]]
 
 
 @dataclass(frozen=True)
@@ -172,16 +171,6 @@ class _ConfigValues:
 
     path: str
     section_to_values: dict[str, dict[str, Any]]
-
-    @staticmethod
-    def _is_an_option(option_value: _TomlValue | dict) -> bool:
-        """Determine if the value is actually an option belonging to that section.
-
-        This handles the special syntax of `my_list_option.add` and `my_list_option.remove`.
-        """
-        if isinstance(option_value, dict):
-            return "add" in option_value or "remove" in option_value
-        return True
 
     def _possibly_interpolate_value(
         self,
@@ -193,10 +182,10 @@ class _ConfigValues:
     ) -> str:
         """For any values with %(foo)s, substitute it with the corresponding value from DEFAULT or
         the same section."""
+        # TODO(benjy): I wonder if we can abuse ConfigParser to do this for us?
 
         def format_str(value: str) -> str:
-            # Because dictionaries use the symbols `{}`, we must proactively escape the symbols so
-            # that .format() does not try to improperly interpolate.
+            # Escape embedded { and } characters, so that .format() does not act on them.
             escaped_str = value.replace("{", "{{").replace("}", "}}")
             new_style_format_str = re.sub(
                 pattern=r"%\((?P<interpolated>[a-zA-Z_0-9.]+)\)s",
@@ -224,49 +213,6 @@ class _ConfigValues:
 
         return recursively_format_str(raw_value)
 
-    def _stringify_val(
-        self,
-        raw_value: _TomlValue,
-        *,
-        option: str,
-        section: str,
-        section_values: dict,
-        interpolate: bool = True,
-        list_prefix: str | None = None,
-    ) -> str:
-        # We convert all values to strings, which allows us to treat them uniformly with
-        # env vars and cmd-line flags in parser.py.
-        possibly_interpolate = partial(
-            self._possibly_interpolate_value,
-            option=option,
-            section=section,
-            section_values=section_values,
-        )
-        if isinstance(raw_value, str):
-            return possibly_interpolate(raw_value) if interpolate else raw_value
-
-        if isinstance(raw_value, list):
-
-            def stringify_list_member(member: _TomlPrimitive) -> str:
-                if not isinstance(member, str):
-                    return str(member)
-                interpolated_member = possibly_interpolate(member) if interpolate else member
-                return f'"{interpolated_member}"'
-
-            list_members = ", ".join(stringify_list_member(member) for member in raw_value)
-            return f"{list_prefix or ''}[{list_members}]"
-
-        return str(raw_value)
-
-    def _stringify_val_without_interpolation(self, raw_value: _TomlValue) -> str:
-        return self._stringify_val(
-            raw_value,
-            option="",
-            section="",
-            section_values={},
-            interpolate=False,
-        )
-
     def get_value(self, section: str, option: str) -> str | None:
         section_values = self.section_to_values.get(section)
         if section_values is None:
@@ -274,32 +220,39 @@ class _ConfigValues:
         if option not in section_values:
             return None
 
-        stringify = partial(
-            self._stringify_val,
-            option=option,
-            section=section,
-            section_values=section_values,
-        )
+        def stringify(raw_val: _TomlValue, prefix: str = "") -> str:
+            string_val = self._possibly_interpolate_value(
+                raw_value=str(raw_val),
+                option=option,
+                section=section,
+                section_values=section_values or {},
+            )
+            return f"{prefix}{string_val}"
 
         option_value = section_values[option]
         if not isinstance(option_value, dict):
             return stringify(option_value)
 
-        # Handle dict options, along with the special `my_list_option.add` and
-        # `my_list_option.remove` syntax. We only treat `add` and `remove` as the special list
-        # syntax if the values are lists to reduce the risk of incorrectly special casing.
-        has_add = isinstance(option_value.get("add"), list)
-        has_remove = isinstance(option_value.get("remove"), list)
-        if not has_add and not has_remove:
-            return stringify(option_value)
+        # Handle dict options, along with the special `my_dict_option.add`, `my_list_option.add` and
+        # `my_list_option.remove` syntax. We only treat `add` and `remove` as the special syntax
+        # if the values have the approprate type, to reduce the risk of incorrectly special casing.
+        has_add_dict = isinstance(option_value.get("add"), dict)
+        has_add_list = isinstance(option_value.get("add"), list)
+        has_remove_list = isinstance(option_value.get("remove"), list)
 
-        add_val = stringify(option_value["add"], list_prefix="+") if has_add else "[]"
-        remove_val = stringify(option_value["remove"], list_prefix="-") if has_remove else "[]"
-        if has_add and has_remove:
-            return f"{add_val},{remove_val}"
-        if has_add:
-            return add_val
-        return remove_val
+        if has_add_dict:
+            return stringify(option_value["add"], prefix="+")
+
+        if has_add_list or has_remove_list:
+            add_val = stringify(option_value["add"], prefix="+") if has_add_list else "[]"
+            remove_val = stringify(option_value["remove"], prefix="-") if has_remove_list else "[]"
+            if has_add_list and has_remove_list:
+                return f"{add_val},{remove_val}"
+            if has_add_list:
+                return add_val
+            return remove_val
+
+        return stringify(option_value)
 
     @property
     def defaults(self) -> dict[str, Any]:

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -2,10 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import unittest
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import Dict
+
+import pytest
 
 from pants.engine.fs import FileContent
 from pants.option.config import Config, TomlSerializer
@@ -14,11 +15,12 @@ from pants.option.config import Config, TomlSerializer
 @dataclass(frozen=True)
 class ConfigFile:
     content: str
-    default_values: Dict
+    unexpanded_default_values: Dict
+    expanded_default_values: Dict
     expected_options: Dict
 
 
-FILE_1 = ConfigFile(
+FILE_0 = ConfigFile(
     content=dedent(
         """
         [DEFAULT]
@@ -51,7 +53,7 @@ FILE_1 = ConfigFile(
         # Make sure we don't misinterpret `add` and `remove` as list options.
         add = 0
         remove = 0
-        nested = { nested_key = 'foo' }
+        nested = { nested_key = '%(answer)s!' }
 
         [list_merging]
         list1 = []
@@ -59,9 +61,23 @@ FILE_1 = ConfigFile(
         list3.add = [3, 4]
         list4.remove = [5]
         list5 = [6, 7]
+
+        [dict_merging]
+        dict1 = {}
+        dict2 = {a = "1", b = "2"}
+        dict3.add = {c = "3", d = "4"}
+        dict4 = {e = "5"}
         """
     ),
-    default_values={
+    unexpanded_default_values={
+        "name": "%(env.NAME)s",
+        "answer": 42,
+        "scale": 1.2,
+        "path": "/a/b/%(answer)s",
+        "embed": "%(path)s::%(name)s",
+        "disclaimer": "Let it be known\nthat.",
+    },
+    expanded_default_values={
         "name": "foo",
         "answer": 42,
         "scale": 1.2,
@@ -70,14 +86,14 @@ FILE_1 = ConfigFile(
         "disclaimer": "Let it be known\nthat.",
     },
     expected_options={
-        "a": {"list": '["1", "2", "3", "42"]', "list2": "+[7, 8, 9]", "list3": '-["x", "y", "z"]'},
+        "a": {"list": "['1', '2', '3', '42']", "list2": "+[7, 8, 9]", "list3": "-['x', 'y', 'z']"},
         "b": {"preempt": "True"},
         "c": {
             "name": "overridden_from_default",
             "interpolated_from_section": "overridden_from_default is interpolated",
             "recursively_interpolated_from_section": "overridden_from_default is interpolated (again)",
         },
-        "d": {"dict_val": "{'add': 0, 'remove': 0, 'nested': {'nested_key': 'foo'}"},
+        "d": {"dict_val": "{'add': 0, 'remove': 0, 'nested': {'nested_key': '42!'}}"},
         "list_merging": {
             "list1": "[]",
             "list2": "[1, 2]",
@@ -85,11 +101,17 @@ FILE_1 = ConfigFile(
             "list4": "-[5]",
             "list5": "[6, 7]",
         },
+        "dict_merging": {
+            "dict1": "{}",
+            "dict2": "{'a': '1', 'b': '2'}",
+            "dict3": "+{'c': '3', 'd': '4'}",
+            "dict4": "{'e': '5'}",
+        },
     },
 )
 
 
-FILE_2 = ConfigFile(
+FILE_1 = ConfigFile(
     content=dedent(
         """
         [a]
@@ -111,9 +133,16 @@ FILE_2 = ConfigFile(
         list3.remove = [4, 55]
         list4 = [66]
         list6.add = [77, 88]
+
+        [dict_merging]
+        dict1.add = {zz = "99"}
+        dict2 = "+{'a': 'xx', 'bb': '22'}"
+        dict3.add = {cc = "33", dd = "44"}
+        dict4 = {ee = "55"}
         """
     ),
-    default_values={},
+    unexpanded_default_values={},
+    expanded_default_values={},
     expected_options={
         "a": {"fast": "True"},
         "b": {"preempt": "False"},
@@ -126,98 +155,113 @@ FILE_2 = ConfigFile(
             "list4": "[66]",
             "list6": "+[77, 88]",
         },
+        "dict_merging": {
+            "dict1": "+{'zz': '99'}",
+            "dict2": "+{'a': 'xx', 'bb': '22'}",
+            "dict3": "+{'cc': '33', 'dd': '44'}",
+            "dict4": "{'ee': '55'}",
+        },
     },
 )
 
 
-def _setup_config() -> Config:
-    parsed_config = Config.load(
-        file_contents=[
-            FileContent("file1.toml", FILE_1.content.encode()),
-            FileContent("file2.toml", FILE_2.content.encode()),
+_expected_combined_values: dict[str, dict[str, list[str]]] = {
+    "a": {
+        "list": ["['1', '2', '3', '42']"],
+        "list2": ["+[7, 8, 9]"],
+        "list3": ["-['x', 'y', 'z']"],
+        "fast": ["True"],
+    },
+    "b": {"preempt": ["True", "False"]},
+    "c": {
+        "name": ["overridden_from_default"],
+        "interpolated_from_section": ["overridden_from_default is interpolated"],
+        "recursively_interpolated_from_section": [
+            "overridden_from_default is interpolated (again)"
         ],
-        seed_values={"buildroot": "fake_buildroot"},
-        env={"NAME": "foo"},
+    },
+    "d": {
+        "dict_val": ["{'add': 0, 'remove': 0, 'nested': {'nested_key': '42!'}}"],
+        "list": ["+[0, 1],-[8, 9]"],
+    },
+    "empty_section": {},
+    "list_merging": {
+        "list1": ["[]", "[11, 22]"],
+        "list2": ["[1, 2]", "+[33]"],
+        "list3": ["+[3, 4]", "+[8, 9],-[4, 55]"],
+        "list4": ["-[5]", "[66]"],
+        "list5": ["[6, 7]"],
+        "list6": ["+[77, 88]"],
+    },
+    "dict_merging": {
+        "dict1": ["{}", "+{'zz': '99'}"],
+        "dict2": ["{'a': '1', 'b': '2'}", "+{'a': 'xx', 'bb': '22'}"],
+        "dict3": ["+{'c': '3', 'd': '4'}", "+{'cc': '33', 'dd': '44'}"],
+        "dict4": ["{'e': '5'}", "{'ee': '55'}"],
+    },
+}
+
+
+_seed_values = {"buildroot": "fake_buildroot"}
+_env = {"NAME": "foo"}
+_default_seed_values = Config._determine_seed_values(seed_values=_seed_values, env=_env)
+
+
+def test_empty() -> None:
+    config = Config.load([])
+    assert config.sources() == []
+
+
+@pytest.mark.parametrize("filedata", [FILE_0, FILE_1])
+def test_individual_file_parsing(filedata: ConfigFile) -> None:
+    config = Config.load(
+        file_contents=[
+            FileContent("file.toml", filedata.content.encode()),
+        ],
+        seed_values=_seed_values,
+        env=_env,
     )
-    assert ["file1.toml", "file2.toml"] == parsed_config.sources()
-    return parsed_config
+    assert ["file.toml"] == config.sources()
+    for section, section_data in filedata.expected_options.items():
+        for key, val in section_data.items():
+            values_list = config.get(section, key)
+            assert values_list, f"for section {section}, key {key}"
+            assert values_list[0] == val
+
+    # The raw unexpanded defaults, as returned by _ConfigValues.defaults, are used in
+    # `options_bootstrapper.py` to ignore default values when validating options, so we
+    # test that those values make sense here.
+    assert config.values[0].defaults == {
+        **_default_seed_values,
+        **filedata.unexpanded_default_values,
+    }
 
 
-class ConfigTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.config = _setup_config()
-        self.default_seed_values = Config._determine_seed_values(
-            seed_values={"buildroot": "fake_buildroot"},
-            env={"NAME": "foo"},
-        )
-        self.expected_combined_values: dict[str, dict[str, list[str]]] = {
-            "a": {
-                "list": ['["1", "2", "3", "42"]'],
-                "list2": ["+[7, 8, 9]"],
-                "list3": ['-["x", "y", "z"]'],
-                "fast": ["True"],
-            },
-            "b": {"preempt": ["True", "False"]},
-            "c": {
-                "name": ["overridden_from_default"],
-                "interpolated_from_section": ["overridden_from_default is interpolated"],
-                "recursively_interpolated_from_section": [
-                    "overridden_from_default is interpolated (again)"
-                ],
-            },
-            "d": {
-                "dict_val": ["{'add': 0, 'remove': 0, 'nested': {'nested_key': 'foo'}}"],
-                "list": ["+[0, 1],-[8, 9]"],
-            },
-            "empty_section": {},
-            "list_merging": {
-                "list1": ["[]", "[11, 22]"],
-                "list2": ["[1, 2]", "+[33]"],
-                "list3": ["+[3, 4]", "+[8, 9],-[4, 55]"],
-                "list4": ["-[5]", "[66]"],
-                "list5": ["[6, 7]"],
-                "list6": ["+[77, 88]"],
-            },
-        }
+def test_merged_config() -> None:
+    config = Config.load(
+        file_contents=[
+            FileContent("file1.toml", FILE_0.content.encode()),
+            FileContent("file2.toml", FILE_1.content.encode()),
+        ],
+        seed_values=_seed_values,
+        env=_env,
+    )
+    assert ["file1.toml", "file2.toml"] == config.sources()
 
-    def test_default_values(self) -> None:
-        # This is used in `options_bootstrapper.py` to ignore default values when validating options.
-        file1_values = self.config.values[0]
-        file2_values = self.config.values[1]
-        # NB: string interpolation should only happen when calling _ConfigValues.get_value(). The
-        # values for _ConfigValues.defaults are not yet interpolated.
-        default_file1_values_unexpanded = {
-            **FILE_1.default_values,
-            "name": "%(env.NAME)s",
-            "path": "/a/b/%(answer)s",
-            "embed": "%(path)s::%(name)s",
-        }
-        assert file1_values.defaults == {
-            **self.default_seed_values,
-            **default_file1_values_unexpanded,
-        }
-        assert file2_values.defaults == self.default_seed_values
+    # Check the DEFAULT section
+    # N.B.: All values read from config files are read as str and only later converted by the
+    # options parser to the expected destination type; so we ensure we're comparing strings here.
+    for option, value in _default_seed_values.items():
+        # Both config files have the seed values.
+        assert config.get(section="DEFAULT", option=option) == [str(value), str(value)]
+    for option, value in FILE_0.expanded_default_values.items():
+        # Only FILE_1 has explicit DEFAULT values.
+        assert config.get(section="DEFAULT", option=option) == [str(value)]
 
-    def test_get(self) -> None:
-        # Check the DEFAULT section
-        # N.B.: All values read from config files are read as str and only later converted by the
-        # options parser to the expected destination type; so we ensure we're comparing strings
-        # here.
-        for option, value in self.default_seed_values.items():
-            # Both config files have the seed values.
-            assert self.config.get(section="DEFAULT", option=option) == [str(value), str(value)]
-        for option, value in FILE_1.default_values.items():
-            # Only FILE_1 has explicit DEFAULT values.
-            assert self.config.get(section="DEFAULT", option=option) == [str(value)]
-
-        # Check the combined values.
-        for section, section_values in self.expected_combined_values.items():
-            for option, value_list in section_values.items():
-                assert self.config.get(section=section, option=option) == value_list
-
-    def test_empty(self) -> None:
-        config = Config.load([])
-        assert config.sources() == []
+    # Check the combined values.
+    for section, expected_section_values in _expected_combined_values.items():
+        for option, value_list in expected_section_values.items():
+            assert config.get(section=section, option=option) == value_list, f"in section {section}"
 
 
 def test_toml_serializer() -> None:

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -14,14 +14,13 @@ from pants.base.build_environment import get_default_pants_config_file, pants_ve
 from pants.base.exceptions import BuildConfigurationError
 from pants.option.alias import CliAlias
 from pants.option.config import Config
-from pants.option.custom_types import ListValueComponent
+from pants.option.custom_types import DictValueComponent, ListValueComponent
 from pants.option.global_options import BootstrapOptions, GlobalOptions
 from pants.option.option_types import collect_options_info
 from pants.option.options import Options
 from pants.option.scope import GLOBAL_SCOPE, ScopeInfo
 from pants.option.subsystem import Subsystem
 from pants.util.dirutil import read_file
-from pants.util.eval import parse_expression
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import ensure_text
@@ -167,12 +166,8 @@ class OptionsBootstrapper:
             # stuhood: This could potentially break the rust client when aliases are used:
             # https://github.com/pantsbuild/pants/pull/13228#discussion_r728223889
             alias_vals = post_bootstrap_config.get("cli", "alias")
-            alias_dict = parse_expression(
-                name="cli.alias",
-                val=alias_vals[-1] if alias_vals else "{}",
-                acceptable_types=dict,
-            )
-            alias = CliAlias.from_dict(alias_dict)
+            val = DictValueComponent.merge([DictValueComponent.create(v) for v in alias_vals]).val
+            alias = CliAlias.from_dict(val)
 
             args = alias.expand_args(tuple(args))
             bargs = cls._get_bootstrap_args(args)

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -391,28 +391,66 @@ class TestOptionsBootstrapper:
         logdir = ob.get_bootstrap_options().for_global_scope().logdir
         assert "logdir1" == logdir
 
-    def test_alias_pyupgrade(self, tmp_path: Path) -> None:
-        config = tmp_path / "config"
-        config.write_text(
+    def test_alias(self, tmp_path: Path) -> None:
+        config0 = tmp_path / "config0"
+        config0.write_text(
             dedent(
                 """\
                     [cli.alias]
                     pyupgrade = "--backend-packages=pants.backend.python.lint.pyupgrade fmt"
+                    green = "lint test"
                     """
             )
         )
 
-        config_arg = f"--pants-config-files=['{config.as_posix()}']"
-        ob = OptionsBootstrapper.create(env={}, args=[config_arg, "pyupgrade"], allow_pantsrc=False)
+        config1 = tmp_path / "config1"
+        config1.write_text(
+            dedent(
+                """\
+                    [cli]
+                    alias.add = {green = "lint test --force check"}
+                    """
+            )
+        )
 
+        config2 = tmp_path / "config2"
+        config2.write_text(
+            dedent(
+                """\
+                    [cli]
+                    alias = "+{'shell': 'repl'}"
+                    """
+            )
+        )
+
+        config_arg = (
+            f"--pants-config-files=["
+            f"'{config0.as_posix()}','{config1.as_posix()}','{config2.as_posix()}']"
+        )
+        ob = OptionsBootstrapper.create(
+            env={}, args=[config_arg, "pyupgrade", "green"], allow_pantsrc=False
+        )
         assert (
             config_arg,
             "--backend-packages=pants.backend.python.lint.pyupgrade",
             "fmt",
+            "lint",
+            "test",
+            "--force",
+            "check",
         ) == ob.args
-
         assert (
             "<ignored>",
             config_arg,
             "--backend-packages=pants.backend.python.lint.pyupgrade",
+        ) == ob.bootstrap_args
+
+        ob = OptionsBootstrapper.create(env={}, args=[config_arg, "shell"], allow_pantsrc=False)
+        assert (
+            config_arg,
+            "repl",
+        ) == ob.args
+        assert (
+            "<ignored>",
+            config_arg,
         ) == ob.bootstrap_args

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -299,9 +299,7 @@ class Parser:
             if not ("default" in nkwargs and isinstance(nkwargs["default"], RankedValue)):
                 type_arg = nkwargs.get("type", str)
                 member_type = nkwargs.get("member_type", str)
-                default_val = self.to_value_type(
-                    nkwargs.get("default"), type_arg, member_type, dest
-                )
+                default_val = self.to_value_type(nkwargs.get("default"), type_arg, member_type)
                 if isinstance(default_val, (ListValueComponent, DictValueComponent)):
                     default_val = default_val.val
                 nkwargs["default"] = RankedValue(Rank.HARDCODED, default_val)
@@ -422,7 +420,7 @@ class Parser:
             if isinstance(default_value, str) and type_arg != str:
                 # attempt to parse default value, for correctness..
                 # custom function types may implement their own validation
-                default_value = self.to_value_type(default_value, type_arg, member_type, "")
+                default_value = self.to_value_type(default_value, type_arg, member_type)
                 if hasattr(default_value, "val"):
                     default_value = default_value.val
 
@@ -502,7 +500,7 @@ class Parser:
             raise ParseError(str(error))
 
     @classmethod
-    def to_value_type(cls, val_str, type_arg, member_type, dest):
+    def to_value_type(cls, val_str, type_arg, member_type):
         """Convert a string to a value of the option's type."""
         if val_str is None:
             return None
@@ -550,7 +548,7 @@ class Parser:
         member_type = kwargs.get("member_type", str)
 
         def to_value_type(val_str):
-            return self.to_value_type(val_str, type_arg, member_type, dest)
+            return self.to_value_type(val_str, type_arg, member_type)
 
         # Helper function to expand a fromfile=True value string, if needed.
         # May return a string or a dict/list decoded from a json/yaml file.


### PR DESCRIPTION
Previously you could use the "+" prefix on a stringified dict to add to the value across different sources (flag, env var, config, default), but this did not work across multiple config files. Instead, the last config file would stomp the values in previous ones.

This change:

- Adds support for "+" across config files.
- Also supports using the ".add" affordance, similar to list-valued options, so that the value can be a toml map instead of a stringified python dict. Note that, unlike with lists, "add" could actually be a valid dict key, in which case we will do the wrong thing. In that case, the escape hatch is to use "+" with a stringified value. 
- Ensures that the above works for `cli.alias`, which we special-case in the options bootstrapper.
- Streamlines some of the config machinery. In particular, simplifies how we do interpolation. Instead of interpolating individual values in lists and then manually stringifying them, we interpolate after stringification. This is safe in practice, as for `%(name)s` to span two list items, `name` would have to contain forbidden characters like a quote or double-quote.
- As a byproduct of the above, adds support for interpolation inside dicts, following the same post-stringification principle.

Fixes #15922 

[ci skip-rust]

[ci skip-build-wheels]