### PR TITLE
Refactor `create_pex_from_targets` rule with `@rule_helper`

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -47,7 +47,7 @@ from pants.core.goals.generate_lockfiles import NoCompatibleResolveException
 from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import Digest, DigestContents, GlobMatchErrorBehavior, MergeDigests, PathGlobs
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
@@ -357,10 +357,10 @@ class _ConstraintsRepositoryPexRequest:
     repository_pex_request: _RepositoryPexRequest
 
 
-@rule(level=LogLevel.DEBUG)
-async def create_pex_from_targets(
+@rule_helper
+async def _determine_requirements_for_pex_from_targets(
     request: PexFromTargetsRequest, python_setup: PythonSetup
-) -> PexRequest:
+) -> PexRequirements | PexRequest:
     requirements = PexRequirements()
     if request.include_requirements:
         requirements = await Get(PexRequirements, _PexRequirementsRequest(request.addresses))
@@ -437,6 +437,20 @@ async def create_pex_from_targets(
                 LoadedLockfile, LoadedLockfileRequest(chosen_resolve.lockfile)
             )
             requirements = dataclasses.replace(requirements, from_superset=loaded_lockfile)
+
+    return requirements
+
+
+@rule(level=LogLevel.DEBUG)
+async def create_pex_from_targets(
+    request: PexFromTargetsRequest, python_setup: PythonSetup
+) -> PexRequest:
+    requirements_or_pex_request = await _determine_requirements_for_pex_from_targets(
+        request, python_setup
+    )
+    if isinstance(requirements_or_pex_request, PexRequest):
+        return requirements_or_pex_request
+    requirements = requirements_or_pex_request
 
     interpreter_constraints = await Get(
         InterpreterConstraints,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -373,9 +373,7 @@ async def _determine_requirements_for_pex_from_targets(
         chosen_resolve = await Get(
             ChosenPythonResolve, ChosenPythonResolveRequest(request.addresses)
         )
-        loaded_lockfile = await Get(
-            LoadedLockfile, LoadedLockfileRequest(chosen_resolve.lockfile)
-        )
+        loaded_lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(chosen_resolve.lockfile))
         pex_native_subsetting_supported = loaded_lockfile.is_pex_native
         if loaded_lockfile.as_constraints_strings:
             requirements = dataclasses.replace(
@@ -396,47 +394,48 @@ async def _determine_requirements_for_pex_from_targets(
             python_setup.resolve_all_constraints
             and python_setup.requirement_constraints
         )
-        # A non-PEX-native lockfile was used, and so we cannot subset it.
+        # A non-PEX-native lockfile was used, and so we cannot directly subset it from a
+        # LoadedLockfile.
         or not pex_native_subsetting_supported
     )
 
-    if should_request_repository_pex:
-        repository_pex_request = await Get(
-            OptionalPexRequest,
-            _RepositoryPexRequest(
-                request.addresses,
-                hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
-                platforms=request.platforms,
-                complete_platforms=request.complete_platforms,
-                internal_only=request.internal_only,
-                additional_lockfile_args=request.additional_lockfile_args,
-            ),
-        )
-        if should_return_entire_lockfile:
-            if repository_pex_request.maybe_pex_request is None:
-                raise ValueError(
-                    softwrap(
-                        f"""
-                        [python].run_against_entire_lockfile was set, but could not find a
-                        lockfile or constraints file for this target set. See
-                        {doc_url('python-third-party-dependencies')} for details.
-                        """
-                    )
-                )
-            return repository_pex_request.maybe_pex_request
+    if not should_request_repository_pex:
+        if not pex_native_subsetting_supported:
+            return requirements
 
-        repository_pex = await Get(OptionalPex, OptionalPexRequest, repository_pex_request)
-        requirements = dataclasses.replace(requirements, from_superset=repository_pex.maybe_pex)
-    elif python_setup.enable_resolves:
-        # NB: We confirmed above that this is a PEX-native lockfile, so it can be used as a
-        # superset.
         chosen_resolve = await Get(
             ChosenPythonResolve, ChosenPythonResolveRequest(request.addresses)
         )
         loaded_lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(chosen_resolve.lockfile))
-        requirements = dataclasses.replace(requirements, from_superset=loaded_lockfile)
+        return dataclasses.replace(requirements, from_superset=loaded_lockfile)
 
-    return requirements
+    # Else, request the repository PEX and possibly subset it.
+    repository_pex_request = await Get(
+        OptionalPexRequest,
+        _RepositoryPexRequest(
+            request.addresses,
+            hardcoded_interpreter_constraints=request.hardcoded_interpreter_constraints,
+            platforms=request.platforms,
+            complete_platforms=request.complete_platforms,
+            internal_only=request.internal_only,
+            additional_lockfile_args=request.additional_lockfile_args,
+        ),
+    )
+    if should_return_entire_lockfile:
+        if repository_pex_request.maybe_pex_request is None:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    [python].run_against_entire_lockfile was set, but could not find a
+                    lockfile or constraints file for this target set. See
+                    {doc_url('python-third-party-dependencies')} for details.
+                    """
+                )
+            )
+        return repository_pex_request.maybe_pex_request
+
+    repository_pex = await Get(OptionalPex, OptionalPexRequest, repository_pex_request)
+    return dataclasses.replace(requirements, from_superset=repository_pex.maybe_pex)
 
 
 @rule(level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -10,11 +10,13 @@ from enum import Enum
 from pathlib import Path, PurePath
 from textwrap import dedent
 from typing import Iterable, List, Mapping, cast
+from unittest.mock import Mock
 
 import pytest
 
 from pants.backend.python import target_types_rules
 from pants.backend.python.subsystems import setuptools
+from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.target_types import (
     PexLayout,
@@ -24,16 +26,26 @@ from pants.backend.python.target_types import (
     PythonTestTarget,
 )
 from pants.backend.python.util_rules import pex_from_targets, pex_test_utils
-from pants.backend.python.util_rules.pex import Pex, PexPlatforms, PexRequest
+from pants.backend.python.util_rules.pex import (
+    OptionalPex,
+    OptionalPexRequest,
+    Pex,
+    PexPlatforms,
+    PexRequest,
+)
 from pants.backend.python.util_rules.pex_from_targets import (
     ChosenPythonResolve,
     ChosenPythonResolveRequest,
     GlobalRequirementConstraints,
     PexFromTargetsRequest,
+    _determine_requirements_for_pex_from_targets,
+    _PexRequirementsRequest,
+    _RepositoryPexRequest,
 )
 from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
+    LoadedLockfileRequest,
     LockfileContent,
     PexRequirements,
 )
@@ -42,7 +54,14 @@ from pants.build_graph.address import Address
 from pants.core.goals.generate_lockfiles import NoCompatibleResolveException
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Snapshot
-from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+from pants.testutil.option_util import create_subsystem
+from pants.testutil.rule_runner import (
+    MockGet,
+    QueryRule,
+    RuleRunner,
+    engine_error,
+    run_rule_with_mocks,
+)
 from pants.util.contextutil import pushd
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import softwrap
@@ -130,6 +149,204 @@ def test_choose_compatible_resolve(rule_runner: RuleRunner) -> None:
     ):
         choose_resolve(
             [Address("invalid", target_name="req"), Address("invalid", target_name="dep")]
+        )
+
+
+def test_determine_requirements_for_pex_from_targets() -> None:
+    class RequirementMode(Enum):
+        PEX_LOCKFILE = 1
+        NON_PEX_LOCKFILE = 2
+        # Note that enable_resolves is mutually exclusive with requirement_constraints.
+        CONSTRAINTS_RESOLVE_ALL = 3
+        CONSTRAINTS_NO_RESOLVE_ALL = 4
+        NO_LOCKS = 5
+
+    req_strings = ["req1", "req2"]
+    global_requirement_constraints = ["constraint1", "constraint2"]
+
+    loaded_lockfile__pex = Mock(is_pex_native=True, as_constraints_strings=None)
+    loaded_lockfile__not_pex = Mock(is_pex_native=False, as_constraints_strings=req_strings)
+
+    repository_pex_request__lockfile = Mock()
+    repository_pex_request__constraints = Mock()
+
+    repository_pex__lockfile = Mock()
+    repository_pex__constraints = Mock()
+
+    def assert_setup(
+        mode: RequirementMode,
+        *,
+        include_requirements: bool = True,
+        internal_only: bool = True,
+        run_against_entire_lockfile: bool = False,
+        expected: PexRequirements | PexRequest,
+    ) -> None:
+        lockfile_used = mode in (RequirementMode.PEX_LOCKFILE, RequirementMode.NON_PEX_LOCKFILE)
+        requirement_constraints_used = mode in (
+            RequirementMode.CONSTRAINTS_RESOLVE_ALL,
+            RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
+        )
+
+        python_setup = create_subsystem(
+            PythonSetup,
+            enable_resolves=lockfile_used,
+            run_against_entire_lockfile=run_against_entire_lockfile,
+            resolve_all_constraints=mode != RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
+            requirement_constraints="foo.constraints" if requirement_constraints_used else None,
+        )
+        pex_from_targets_request = Mock(
+            include_requirements=include_requirements,
+            internal_only=internal_only,
+            addresses=Addresses(),
+        )
+        resolved_pex_requirements = PexRequirements(
+            req_strings,
+            constraints_strings=(
+                global_requirement_constraints if requirement_constraints_used else ()
+            ),
+        )
+
+        if lockfile_used:
+            mock_repository_pex_request = OptionalPexRequest(
+                maybe_pex_request=repository_pex_request__lockfile
+            )
+            mock_repository_pex = OptionalPex(maybe_pex=repository_pex__lockfile)
+        elif mode == RequirementMode.CONSTRAINTS_RESOLVE_ALL:
+            mock_repository_pex_request = OptionalPexRequest(
+                maybe_pex_request=repository_pex_request__constraints
+            )
+            mock_repository_pex = OptionalPex(maybe_pex=repository_pex__constraints)
+        else:
+            mock_repository_pex_request = OptionalPexRequest(maybe_pex_request=None)
+            mock_repository_pex = OptionalPex(maybe_pex=None)
+
+        requirements_or_pex_request = run_rule_with_mocks(
+            _determine_requirements_for_pex_from_targets,
+            rule_args=[pex_from_targets_request, python_setup],
+            mock_gets=[
+                MockGet(
+                    PexRequirements, _PexRequirementsRequest, lambda _: resolved_pex_requirements
+                ),
+                MockGet(
+                    ChosenPythonResolve, ChosenPythonResolveRequest, lambda _: Mock(lockfile=Mock())
+                ),
+                MockGet(
+                    LoadedLockfile,
+                    LoadedLockfileRequest,
+                    lambda _: (
+                        loaded_lockfile__pex
+                        if mode == RequirementMode.PEX_LOCKFILE
+                        else loaded_lockfile__not_pex
+                    ),
+                ),
+                MockGet(
+                    OptionalPexRequest, _RepositoryPexRequest, lambda _: mock_repository_pex_request
+                ),
+                MockGet(OptionalPex, OptionalPexRequest, lambda _: mock_repository_pex),
+            ],
+        )
+        assert requirements_or_pex_request == expected
+
+    # If include_requirements is False, no matter what, early return.
+    for mode in RequirementMode:
+        assert_setup(mode, include_requirements=False, expected=PexRequirements())
+
+    # Pex lockfiles: usually, return PexRequirements with from_superset as the LoadedLockfile.
+    #   Except for when run_against_entire_lockfile is set and it's an internal_only Pex, then
+    #   return PexRequest.
+    for internal_only in (False, True):
+        assert_setup(
+            RequirementMode.PEX_LOCKFILE,
+            internal_only=internal_only,
+            expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
+        )
+    assert_setup(
+        RequirementMode.PEX_LOCKFILE,
+        internal_only=False,
+        run_against_entire_lockfile=True,
+        expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
+    )
+    assert_setup(
+        RequirementMode.PEX_LOCKFILE,
+        internal_only=True,
+        run_against_entire_lockfile=True,
+        expected=repository_pex_request__lockfile,
+    )
+
+    # Non-Pex lockfiles: except for when run_against_entire_lockfile is applicable, return
+    # PexRequirements with from_superset as the lockfile repository Pex and constraint_strings as
+    # the lockfile's requirements.
+    for internal_only in (False, True):
+        assert_setup(
+            RequirementMode.NON_PEX_LOCKFILE,
+            internal_only=internal_only,
+            expected=PexRequirements(
+                req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
+            ),
+        )
+    assert_setup(
+        RequirementMode.NON_PEX_LOCKFILE,
+        internal_only=False,
+        run_against_entire_lockfile=True,
+        expected=PexRequirements(
+            req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
+        ),
+    )
+    assert_setup(
+        RequirementMode.NON_PEX_LOCKFILE,
+        internal_only=True,
+        run_against_entire_lockfile=True,
+        expected=repository_pex_request__lockfile,
+    )
+
+    # Constraints file with resolve_all_constraints: except for when run_against_entire_lockfile
+    #   is applicable, return PexRequirements with from_superset as the constraints repository Pex
+    #   and constraint_strings as the global constraints.
+    for internal_only in (False, True):
+        assert_setup(
+            RequirementMode.CONSTRAINTS_RESOLVE_ALL,
+            internal_only=internal_only,
+            expected=PexRequirements(
+                req_strings,
+                constraints_strings=global_requirement_constraints,
+                from_superset=repository_pex__constraints,
+            ),
+        )
+    assert_setup(
+        RequirementMode.CONSTRAINTS_RESOLVE_ALL,
+        internal_only=False,
+        run_against_entire_lockfile=True,
+        expected=PexRequirements(
+            req_strings,
+            constraints_strings=global_requirement_constraints,
+            from_superset=repository_pex__constraints,
+        ),
+    )
+    assert_setup(
+        RequirementMode.CONSTRAINTS_RESOLVE_ALL,
+        internal_only=True,
+        run_against_entire_lockfile=True,
+        expected=repository_pex_request__constraints,
+    )
+
+    # Constraints file without resolve_all_constraints: always PexRequirements with
+    #   constraint_strings as the global constraints. run_against_entire_lockfile is banned.
+    for internal_only in (False, True):
+        assert_setup(
+            RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
+            internal_only=internal_only,
+            expected=PexRequirements(
+                req_strings, constraints_strings=global_requirement_constraints
+            ),
+        )
+
+    # No constraints and lockfiles: return PexRequirements without modification.
+    #   run_against_entire_lockfile is banned.
+    for internal_only in (False, True):
+        assert_setup(
+            RequirementMode.NO_LOCKS,
+            internal_only=internal_only,
+            expected=PexRequirements(req_strings),
         )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -93,7 +93,7 @@ class LoadedLockfile:
     is_pex_native: bool
     # If !is_pex_native, the lockfile parsed as constraints strings, for use when the lockfile
     # needs to be subsetted (see #15031, ##12222).
-    constraints_strings: FrozenOrderedSet[str] | None
+    as_constraints_strings: FrozenOrderedSet[str] | None
     # The original file or file content (which may not have identical content to the output
     # `lockfile_digest`).
     original_lockfile: Lockfile | LockfileContent

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -582,7 +582,7 @@ def test_setup_pex_requirements() -> None:
             metadata=None,
             requirement_estimate=2,
             is_pex_native=is_pex_lock,
-            constraints_strings=None,
+            as_constraints_strings=None,
             original_lockfile=lockfile_obj,
         )
 

--- a/src/python/pants/backend/scala/test/BUILD
+++ b/src/python/pants/backend/scala/test/BUILD
@@ -3,5 +3,12 @@
 
 python_sources()
 
-python_tests(name="tests", dependencies=[":test_resources"])
+python_tests(
+    name="tests",
+    dependencies=[":test_resources"],
+    overrides={
+        "scalatest_test.py": {"timeout": 120},
+    },
+)
+
 resources(name="test_resources", sources=["*.test.lock"])

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -168,7 +168,7 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
             metadata=metadata,
             requirement_estimate=1,
             is_pex_native=True,
-            constraints_strings=None,
+            as_constraints_strings=None,
             original_lockfile=Lockfile(
                 "black.lock", file_path_description_of_origin="foo", resolve_name="black"
             ),


### PR DESCRIPTION
Similar to https://github.com/pantsbuild/pants/pull/16465, the rule_helper allows us to leverage early returns & inlining variables. It also allows creating comprehensive unit tests.