### PR TITLE
Perform address mapping on a per-deployment basis

### DIFF
--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -78,7 +78,7 @@ async def analyse_deployment(request: AnalyseHelmDeploymentRequest) -> HelmDeplo
     parsed_manifests = await MultiGet(
         Get(
             ParsedKubeManifest,
-            ParseKubeManifestRequest(owner=request.field_set.address, file=entry),
+            ParseKubeManifestRequest(file=entry),
         )
         for entry in rendered_entries
         if isinstance(entry, FileEntry)

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -6,16 +6,13 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import PurePath
+from typing import Any
 
 from pants.backend.docker.target_types import AllDockerImageTargets
 from pants.backend.docker.target_types import rules as docker_target_types_rules
 from pants.backend.helm.subsystems import k8s_parser
 from pants.backend.helm.subsystems.k8s_parser import ParsedKubeManifest, ParseKubeManifestRequest
-from pants.backend.helm.target_types import (
-    AllHelmDeploymentTargets,
-    HelmDeploymentDependenciesField,
-    HelmDeploymentFieldSet,
-)
+from pants.backend.helm.target_types import HelmDeploymentFieldSet
 from pants.backend.helm.target_types import rules as helm_target_types_rules
 from pants.backend.helm.util_rules import renderer
 from pants.backend.helm.util_rules.renderer import (
@@ -25,17 +22,16 @@ from pants.backend.helm.util_rules.renderer import (
 )
 from pants.backend.helm.utils.yaml import FrozenYamlIndex, MutableYamlIndex
 from pants.engine.addresses import Address
+from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import Digest, DigestEntries, FileEntry
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     DependenciesRequest,
     ExplicitlyProvidedDependencies,
-    FieldSet,
     InferDependenciesRequest,
     InferredDependencies,
 )
 from pants.engine.unions import UnionRule
-from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize, softwrap
@@ -44,7 +40,15 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class HelmDeploymentReport:
+class AnalyseHelmDeploymentRequest(EngineAwareParameter):
+    field_set: HelmDeploymentFieldSet
+
+    def debug_hint(self) -> str | None:
+        return self.field_set.address.spec
+
+
+@dataclass(frozen=True)
+class HelmDeploymentReport(EngineAwareReturnType):
     address: Address
     image_refs: FrozenYamlIndex[str]
 
@@ -52,15 +56,21 @@ class HelmDeploymentReport:
     def all_image_refs(self) -> FrozenOrderedSet[str]:
         return FrozenOrderedSet(self.image_refs.values())
 
+    def level(self) -> LogLevel | None:
+        return LogLevel.DEBUG
+
+    def metadata(self) -> dict[str, Any] | None:
+        return {"address": self.address, "image_refs": self.image_refs}
+
 
 @rule(desc="Analyse Helm deployment", level=LogLevel.DEBUG)
-async def analyse_deployment(field_set: HelmDeploymentFieldSet) -> HelmDeploymentReport:
+async def analyse_deployment(request: AnalyseHelmDeploymentRequest) -> HelmDeploymentReport:
     rendered_deployment = await Get(
         RenderedHelmFiles,
         HelmDeploymentRequest(
             cmd=HelmDeploymentCmd.RENDER,
-            field_set=field_set,
-            description=f"Rendering Helm deployment {field_set.address}",
+            field_set=request.field_set,
+            description=f"Rendering Helm deployment {request.field_set.address}",
         ),
     )
 
@@ -68,7 +78,7 @@ async def analyse_deployment(field_set: HelmDeploymentFieldSet) -> HelmDeploymen
     parsed_manifests = await MultiGet(
         Get(
             ParsedKubeManifest,
-            ParseKubeManifestRequest(file=entry),
+            ParseKubeManifestRequest(owner=request.field_set.address, file=entry),
         )
         for entry in rendered_entries
         if isinstance(entry, FileEntry)
@@ -85,11 +95,21 @@ async def analyse_deployment(field_set: HelmDeploymentFieldSet) -> HelmDeploymen
                 item=image_ref,
             )
 
-    return HelmDeploymentReport(address=field_set.address, image_refs=image_refs_index.frozen())
+    return HelmDeploymentReport(
+        address=request.field_set.address, image_refs=image_refs_index.frozen()
+    )
 
 
 @dataclass(frozen=True)
-class FirstPartyHelmDeploymentMappings:
+class FirstPartyHelmDeploymentMappingRequest(EngineAwareParameter):
+    field_set: HelmDeploymentFieldSet
+
+    def debug_hint(self) -> str | None:
+        return self.field_set.address.spec
+
+
+@dataclass(frozen=True)
+class FirstPartyHelmDeploymentMapping:
     """A mapping between `helm_deployment` target addresses and tuples made up of a Docker image
     reference and a `docker_image` target address.
 
@@ -97,23 +117,17 @@ class FirstPartyHelmDeploymentMappings:
     the locations in which the Docker image refs appear in the deployment files.
     """
 
-    deployment_to_docker_addresses: FrozenDict[Address, FrozenYamlIndex[tuple[str, Address]]]
-
-    def docker_addresses_referenced_by(self, address: Address) -> list[tuple[str, Address]]:
-        if address not in self.deployment_to_docker_addresses:
-            return []
-        return list(self.deployment_to_docker_addresses[address].values())
+    address: Address
+    indexed_docker_addresses: FrozenYamlIndex[tuple[str, Address]]
 
 
 @rule
-async def first_party_helm_deployment_mappings(
-    deployment_targets: AllHelmDeploymentTargets, docker_targets: AllDockerImageTargets
-) -> FirstPartyHelmDeploymentMappings:
-    field_sets = [HelmDeploymentFieldSet.create(tgt) for tgt in deployment_targets]
-    all_deployments_info = await MultiGet(
-        Get(HelmDeploymentReport, HelmDeploymentFieldSet, field_set) for field_set in field_sets
+async def first_party_helm_deployment_mapping(
+    request: FirstPartyHelmDeploymentMappingRequest, docker_targets: AllDockerImageTargets
+) -> FirstPartyHelmDeploymentMapping:
+    deployment_report = await Get(
+        HelmDeploymentReport, AnalyseHelmDeploymentRequest(request.field_set)
     )
-
     docker_target_addresses = {tgt.address.spec: tgt.address for tgt in docker_targets}
 
     def lookup_docker_addreses(image_ref: str) -> tuple[str, Address] | None:
@@ -122,38 +136,32 @@ async def first_party_helm_deployment_mappings(
             return image_ref, addr
         return None
 
-    # Builds a mapping between `helm_deployment` addresses and a YAML index of `docker_image` addresses.
-    address_mapping = {
-        fs.address: info.image_refs.transform_values(lookup_docker_addreses)
-        for fs, info in zip(field_sets, all_deployments_info)
-    }
-    return FirstPartyHelmDeploymentMappings(
-        deployment_to_docker_addresses=FrozenDict(address_mapping)
+    return FirstPartyHelmDeploymentMapping(
+        address=request.field_set.address,
+        indexed_docker_addresses=deployment_report.image_refs.transform_values(
+            lookup_docker_addreses
+        ),
     )
 
 
-@dataclass(frozen=True)
-class HelmDeploymentDependenciesInferenceFieldSet(FieldSet):
-    required_fields = (HelmDeploymentDependenciesField,)
-
-    dependencies: HelmDeploymentDependenciesField
-
-
 class InferHelmDeploymentDependenciesRequest(InferDependenciesRequest):
-    infer_from = HelmDeploymentDependenciesInferenceFieldSet
+    infer_from = HelmDeploymentFieldSet
 
 
 @rule(desc="Find the dependencies needed by a Helm deployment")
 async def inject_deployment_dependencies(
-    request: InferHelmDeploymentDependenciesRequest, mapping: FirstPartyHelmDeploymentMappings
+    request: InferHelmDeploymentDependenciesRequest,
 ) -> InferredDependencies:
-    explicitly_provided_deps = await Get(
-        ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)
+    explicitly_provided_deps, mapping = await MultiGet(
+        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
+        Get(
+            FirstPartyHelmDeploymentMapping,
+            FirstPartyHelmDeploymentMappingRequest(request.field_set),
+        ),
     )
-    candidate_docker_addresses = mapping.docker_addresses_referenced_by(request.field_set.address)
 
     dependencies: OrderedSet[Address] = OrderedSet()
-    for imager_ref, candidate_address in candidate_docker_addresses:
+    for imager_ref, candidate_address in mapping.indexed_docker_addresses.values():
         matches = frozenset([candidate_address]).difference(explicitly_provided_deps.includes)
         explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
             matches,

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -149,10 +149,10 @@ async def parse_kube_manifest(
                     softwrap(
                         f"""Unexpected output from k8s parser when parsing file {request.file.path}:
 
-                    {line}
-                    """
+                        {line}
+                        """
+                    )
                 )
-            )
 
             image_refs.append((int(parts[0]), YamlPath.parse(parts[1]), parts[2]))
 

--- a/src/python/pants/backend/helm/subsystems/k8s_parser_test.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser_test.py
@@ -12,6 +12,7 @@ from pants.backend.helm.subsystems import k8s_parser
 from pants.backend.helm.subsystems.k8s_parser import ParsedKubeManifest, ParseKubeManifestRequest
 from pants.backend.helm.testutil import K8S_POD_FILE
 from pants.backend.helm.utils.yaml import YamlPath
+from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, DigestEntries, FileContent, FileEntry
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
@@ -40,7 +41,8 @@ def test_parser_can_run(rule_runner: RuleRunner) -> None:
     file_entries = rule_runner.request(DigestEntries, [file_digest])
 
     parsed_manifest = rule_runner.request(
-        ParsedKubeManifest, [ParseKubeManifestRequest(cast(FileEntry, file_entries[0]))]
+        ParsedKubeManifest,
+        [ParseKubeManifestRequest(owner=Address("foo"), file=cast(FileEntry, file_entries[0]))],
     )
 
     expected_image_refs = [
@@ -70,7 +72,8 @@ def test_parser_returns_no_image_refs(rule_runner: RuleRunner) -> None:
     file_entries = rule_runner.request(DigestEntries, [file_digest])
 
     parsed_manifest = rule_runner.request(
-        ParsedKubeManifest, [ParseKubeManifestRequest(cast(FileEntry, file_entries[0]))]
+        ParsedKubeManifest,
+        [ParseKubeManifestRequest(owner=Address("foo"), file=cast(FileEntry, file_entries[0]))],
     )
 
     assert len(parsed_manifest.found_image_refs) == 0

--- a/src/python/pants/backend/helm/subsystems/k8s_parser_test.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser_test.py
@@ -12,7 +12,6 @@ from pants.backend.helm.subsystems import k8s_parser
 from pants.backend.helm.subsystems.k8s_parser import ParsedKubeManifest, ParseKubeManifestRequest
 from pants.backend.helm.testutil import K8S_POD_FILE
 from pants.backend.helm.utils.yaml import YamlPath
-from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, DigestEntries, FileContent, FileEntry
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
@@ -42,7 +41,7 @@ def test_parser_can_run(rule_runner: RuleRunner) -> None:
 
     parsed_manifest = rule_runner.request(
         ParsedKubeManifest,
-        [ParseKubeManifestRequest(owner=Address("foo"), file=cast(FileEntry, file_entries[0]))],
+        [ParseKubeManifestRequest(file=cast(FileEntry, file_entries[0]))],
     )
 
     expected_image_refs = [
@@ -73,7 +72,7 @@ def test_parser_returns_no_image_refs(rule_runner: RuleRunner) -> None:
 
     parsed_manifest = rule_runner.request(
         ParsedKubeManifest,
-        [ParseKubeManifestRequest(owner=Address("foo"), file=cast(FileEntry, file_entries[0]))],
+        [ParseKubeManifestRequest(file=cast(FileEntry, file_entries[0]))],
     )
 
     assert len(parsed_manifest.found_image_refs) == 0

--- a/src/python/pants/backend/helm/subsystems/post_renderer_main.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer_main.py
@@ -120,6 +120,13 @@ def main(args: list[str]) -> None:
 
             output_manifest_map[source_filename].append(dump_yaml_data(yaml, manifest_yaml))
 
+    # Include in the output the files that didn't require any replacement
+    remaining_files = set(input_manifest_map.keys()) - set(output_manifest_map.keys())
+    for remaining_file in remaining_files:
+        input_file = input_manifest_map.get(remaining_file)
+        if input_file:
+            output_manifest_map[remaining_file] = input_file
+
     print_manifests(output_manifest_map)
 
 

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -59,6 +59,16 @@ def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
                 """
             ),
             "src/mychart/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            "src/mychart/templates/configmap.yaml": dedent(
+                """\
+              apiVersion: v1
+              kind: ConfigMap
+              metadata:
+                name: foo-config
+              data:
+                foo_key: foo_value
+              """
+            ),
             "src/mychart/templates/pod.yaml": dedent(
                 """\
                 {{- $root := . -}}
@@ -192,6 +202,7 @@ def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
         ],
     )
     assert "mychart/templates/pod.yaml" in rendered_output.snapshot.files
+    assert "mychart/templates/configmap.yaml" in rendered_output.snapshot.files
 
     rendered_pod_file = _read_file_from_digest(
         rule_runner, digest=rendered_output.snapshot.digest, filename="mychart/templates/pod.yaml"

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -150,6 +150,7 @@ class RenderedHelmFiles(EngineAwareReturnType):
     address: Address
     chart: HelmChart
     snapshot: Snapshot
+    post_processed: bool
 
     def level(self) -> LogLevel | None:
         return LogLevel.DEBUG
@@ -166,7 +167,7 @@ class RenderedHelmFiles(EngineAwareReturnType):
         return {"content": self.snapshot}
 
     def metadata(self) -> dict[str, Any] | None:
-        return {"address": self.address, "chart": self.chart}
+        return {"address": self.address, "chart": self.chart, "post_processed": self.post_processed}
 
 
 @rule_helper
@@ -391,7 +392,10 @@ async def run_renderer(process_wrapper: _HelmDeploymentProcessWrapper) -> Render
         )
 
     return RenderedHelmFiles(
-        address=process_wrapper.address, chart=process_wrapper.chart, snapshot=output_snapshot
+        address=process_wrapper.address,
+        chart=process_wrapper.chart,
+        snapshot=output_snapshot,
+        post_processed=process_wrapper.uses_post_renderer,
     )
 
 


### PR DESCRIPTION
When testing the new `helm_deployment` target with full scale real deployments a few things were observed:

- The Helm backend used to calculate the mappings of Pants addresses to Docker images for all targets even if only one was requested
- Because inferring the dependencies of a deployment requires a full rendering of the charts, this required requesting a `WrappedTarget` to be able to obtain an instance of the `HelmDeploymentFieldSet` suitable for the rendering process.
- The inference field set did not react to changes in the deployment sources or its inline values, which is the way we are recommending in the documentation on how to make use of this feature.

To address these issues, this PR makes following changes:
- First party mappings are calculated on a per-fieldset basis. This prevents execesive processing in the cases in which just a subset of targets has been passed through the command line.
- The dependency inference field set used for deployments is now a `HelmDeploymentFieldSet`, so no need to rely on `WrappedTarget`.