### PR TITLE
Ban `platforms` and `internal_only` with `pex_from_targets.py` too

### DIFF
--- a/src/python/pants/backend/helm/util_rules/BUILD
+++ b/src/python/pants/backend/helm/util_rules/BUILD
@@ -3,4 +3,9 @@
 
 python_sources()
 
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "post_renderer_test.py": {"timeout": 120},
+    },
+)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -151,6 +151,17 @@ class PexFromTargetsRequest:
         self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
         self.description = description
 
+        if self.internal_only and (self.platforms or self.complete_platforms):
+            raise AssertionError(
+                softwrap(
+                    """
+                    PexFromTargetsRequest set internal_only at the same time as setting
+                    `platforms` and/or `complete_platforms`. Platforms can only be used when
+                    `internal_only=False`.
+                    """
+                )
+            )
+
     def to_interpreter_constraints_request(self) -> InterpreterConstraintsRequest:
         return InterpreterConstraintsRequest(
             addresses=self.addresses,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -180,7 +180,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         platforms: bool,
         include_requirements: bool = True,
         run_against_entire_lockfile: bool = False,
-        expected: PexRequirements | PexRequest | None,
+        expected: PexRequirements | PexRequest,
     ) -> None:
         lockfile_used = mode in (RequirementMode.PEX_LOCKFILE, RequirementMode.NON_PEX_LOCKFILE)
         requirement_constraints_used = mode in (


### PR DESCRIPTION
We already ban `internal_only` and `platforms` in `PexRequest`:

https://github.com/pantsbuild/pants/blob/998992989bbbf48dc1057439fed3b98a47091863/src/python/pants/backend/python/util_rules/pex.py#L217-L247

But we were not eagerly checking this in `PexFromTargetsRequest`. Eagerly checking allows us to simplify reasoning about `pex_from_targets.py` as we now have fewer conditional branches to deal with.

[ci skip-rust]
[ci skip-build-wheels]