### PR TITLE
Add missing `help` message to experimental backends (Cherry-pick of #16403)

### DIFF
--- a/src/python/pants/backend/codegen/soap/target_types.py
+++ b/src/python/pants/backend/codegen/soap/target_types.py
@@ -11,6 +11,7 @@ from pants.engine.target import (
     Target,
     TargetFilesGenerator,
     Targets,
+    generate_multiple_sources_field_help_message,
 )
 from pants.util.logging import LogLevel
 
@@ -55,6 +56,9 @@ class WsdlSourceTarget(Target):
 class WsdlSourcesGeneratingSourcesField(MultipleSourcesField):
     default = ("*.wsdl",)
     expected_file_extensions = (".wsdl",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['utils.wsdl', 'models/*.wsdl', '!ignore_me.wsdl']`"
+    )
 
 
 class WsdlSourcesGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/backend/javascript/target_types.py
+++ b/src/python/pants/backend/javascript/target_types.py
@@ -10,6 +10,7 @@ from pants.engine.target import (
     SingleSourceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 
 JS_FILE_EXTENSIONS = (".js",)
@@ -40,6 +41,9 @@ class JSSourceTarget(Target):
 
 class JSSourcesGeneratorSourcesField(JSGeneratorSourcesField):
     default = tuple(f"*{ext}" for ext in JS_FILE_EXTENSIONS)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['utils.js', 'subdir/*.js', '!ignore_me.js']`"
+    )
 
 
 class JSSourcesGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/backend/swift/target_types.py
+++ b/src/python/pants/backend/swift/target_types.py
@@ -10,6 +10,7 @@ from pants.engine.target import (
     SingleSourceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 
 SWIFT_FILE_EXTENSIONS = (".swift",)
@@ -40,6 +41,9 @@ class SwiftSourceTarget(Target):
 
 class SwiftSourcesGeneratorSourcesField(SwiftGeneratorSourcesField):
     default = tuple(f"*{ext}" for ext in SWIFT_FILE_EXTENSIONS)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `sources=['utils.swift', 'subdir/*.swift', '!ignore_me.swift']`"
+    )
 
 
 class SwiftSourcesGeneratorTarget(TargetFilesGenerator):


### PR DESCRIPTION
Missing from https://github.com/pantsbuild/pants/pull/15633.

[ci skip-rust]
[ci skip-build-wheels]