### PR TITLE
Update docs on how to run Pants in CI.

### DIFF
--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -35,14 +35,17 @@ Server compatibility
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
 **SaaS**:
-- [Toolchain](https://www.toolchain.com), designed by several of the lead maintainers of Pants specifically to work seamlessly with it.
+- [Toolchain](https://www.toolchain.com), a remote caching service designed by several of the lead maintainers of Pants specifically to work seamlessly with it.
 
 **Self-hosted**:
 - [BuildBarn](https://github.com/buildbarn/bb-remote-execution)
 - [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm/) 
 - [BuildGrid](https://buildgrid.build/)
 
-**Note**: Setup of a remote execution server is beyond the scope of this documentation. All three server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
+**Note**: Setup of a self-hosted REAPI server is beyond the scope of this documentation. All these server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
+
+There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
+they have not, to our knowledge, been tested with Pants.  Let us know if you have any experience with them!
 
 Resources
 =========

--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -34,6 +34,10 @@ Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
+**SaaS**:
+- [Toolchain](https://www.toolchain.com), designed specifically to work seamlessly with Pants.
+
+**Self-hosted**:
 - [BuildBarn](https://github.com/buildbarn/bb-remote-execution)
 - [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm/) 
 - [BuildGrid](https://buildgrid.build/)

--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -35,7 +35,7 @@ Server compatibility
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
 **SaaS**:
-- [Toolchain](https://www.toolchain.com), designed specifically to work seamlessly with Pants.
+- [Toolchain](https://www.toolchain.com), designed by several of the lead maintainers of Pants specifically to work seamlessly with it.
 
 **Self-hosted**:
 - [BuildBarn](https://github.com/buildbarn/bb-remote-execution)

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -18,34 +18,22 @@ In your CI's config file, we recommend caching these directories:
 
 - `$HOME/.cache/pants/setup`<br>
   This is the Pants bootstrap directory. Cache this against the version, as specified
-  in `pants.toml`.  E.g., if using GitHub Actions you can use:
-  ```yaml
-  path: |
-    ~/.cache/pants/setup
-  key: pants-setup-${{ runner.os }}-${{ hashFiles('pants.toml') }}
-  restore-keys: |
-    pants-setup-${{ runner.os }}-${{ hashFiles('pants.toml') }}
-    pants-setup-${{ runner.os }}-
-  ```
+  in `pants.toml`.  See the [pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml)
+  repo for an example of how to generate an effective cache key for this directory in GitHub Actions.
 - `$HOME/.cache/pants/named_caches`<br>
   Caches used by some underlying tools.  Cache this against the inputs to those tools.
   For the `pants.backend.python` backend, named caches are used by PEX, and therefore
-  its inputs are your lockfiles. For example:
-  ```yaml
-  path: |
-    ~/.cache/pants/named_caches
-  key: named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('python-default.lock') }}
-  restore-keys: |
-    named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('python-default.lock') }}
-    named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-
-    named-caches-${{ runner.os }}-
-  ```
+  its inputs are your lockfiles. Again, see [pantsbuild/example-python]([pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml))
+  for an example.
 
 If you're not using a fine-grained [remote caching](doc:remote-caching-execution) service,
 then you may also want to preserve the local Pants cache at `$HOME/.cache/pants/lmdb_store`.
-This has to be invalidated on any file that can affect any process, e.g., `hashFiles('**/*')`.
+This has to be invalidated on any file that can affect any process, e.g., `hashFiles('**/*')`
+on GitHub Actions.
+
 Computing such a coarse hash, and saving and restoring large directories, can be unwieldy.
 So this may be impractical and slow on medium and large repos.
+
 A [remote cache service](doc:remote-caching-execution) integrates with Pants's fine-grained
 invalidation and avoids these problems, and is recommended for the best CI performance.
 

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -18,9 +18,9 @@ In your CI's config file, we recommend caching these directories:
 - `$HOME/.cache/pants/setup`: The initial bootstrapping of Pants.
 - `$HOME/.cache/pants/named_caches`: Caches used by underlying tools like Pip and PEX.
 
-If you're not using a fine-grained remote caching service, such as the one provided by
-[Toolchain](https://toolchain.com/), the lead sponsor of Pants, then you may also want to
-preserve the local Pants cache:
+If you're not using a fine-grained [remote caching](doc:remote-caching-execution) service, 
+such as the one provided by [Toolchain](https://toolchain.com/), the lead sponsor of Pants, 
+then you may also want to preserve the local Pants cache:
 
 - `$HOME/.cache/pants/lmdb_store`
 

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -24,7 +24,8 @@ preserve the local Pants cache:
 
 - `$HOME/.cache/pants/lmdb_store`
 
-However, this directory gets large quickly, and saving and restoring it can become unwieldy.
+However, this directory gets large quickly, so saving and restoring it can become unwieldy. Hence,
+remote caching typically offers the best performance.
 
 See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) for how to change these cache locations.
 

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -15,9 +15,16 @@ Directories to cache
 
 In your CI's config file, we recommend caching these directories:
 
-- `$HOME/.cache/pants/setup`: the initial bootstrapping of Pants.
-- `$HOME/.cache/pants/named_caches`: caches of tools like pip and PEX.
-- `$HOME/.cache/pants/lmdb_store`: cached content for prior Pants runs, e.g. prior test results.
+- `$HOME/.cache/pants/setup`: The initial bootstrapping of Pants.
+- `$HOME/.cache/pants/named_caches`: Caches used by underlying tools like Pip and PEX.
+
+If you're not using a fine-grained remote caching service, such as the one provided by
+[Toolchain](https://toolchain.com/), the lead sponsor of Pants, then you may also want to
+preserve the local Pants cache:
+
+- `$HOME/.cache/pants/lmdb_store`
+
+However, this directory gets large quickly, and saving and restoring it can become unwieldy.
 
 See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) for how to change these cache locations.
 


### PR DESCRIPTION
Explain where remote caching can come in handy, and why.