### PR TITLE
Use version 2 of Python lockfile metadata for now

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -73,14 +73,13 @@ def _generate(
             //
             // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
             // {{
-            //   "version": 3,
+            //   "version": 2,
             //   "valid_for_interpreter_constraints": [],
             //   "generated_with_requirements": [
             //     "ansicolors{ansicolors_version}"
-            //   ],
-            """
+            //   ]"""
         )
-        + requirement_constraints_str
+        # + requirement_constraints_str
         + dedent(
             """
             // }

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -49,9 +49,7 @@ class PythonLockfileMetadata(LockfileMetadata):
         writing, while still allowing us to support _reading_ older, deprecated metadata versions.
         """
 
-        return PythonLockfileMetadataV3(
-            valid_for_interpreter_constraints, requirements, requirement_constraints
-        )
+        return PythonLockfileMetadataV2(valid_for_interpreter_constraints, requirements)
 
     @classmethod
     def additional_header_attrs(cls, instance: LockfileMetadata) -> dict[Any, Any]:

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -55,14 +55,13 @@ def test_add_header_to_lockfile() -> None:
 #
 # --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 # {
-#   "version": 3,
+#   "version": 2,
 #   "valid_for_interpreter_constraints": [
 #     "CPython>=3.7"
 #   ],
 #   "generated_with_requirements": [
 #     "ansicolors==0.1.0"
-#   ],
-#   "requirement_constraints": []
+#   ]
 # }
 # --- END PANTS LOCKFILE METADATA ---
 dave==3.1.4 \\


### PR DESCRIPTION
V3 of lockfile metadata is not yet stable: we still need to add `--only-binary`, manylinux, indexes, and find links. WIth the release coming today, we should not introduce v3 into the wild yet. (Pants can still understand v3, only won't write it.)

[ci skip-rust]
[ci skip-build-wheels]