### PR TITLE
Support removing entries from dict-valued options.

### DIFF
--- a/docs/markdown/Using Pants/concepts/options.md
+++ b/docs/markdown/Using Pants/concepts/options.md
@@ -254,12 +254,15 @@ will set the value to `[3, 4]`.
 > listopt.remove = [3, 4]
 > ```
 > 
-> But note that this only works in Pants's `.toml` config files, not in environment variables or command-line flags.
+> But note that this `.add`/`.remove` affordance only works in Pants's `.toml` config files,
+> not in environment variables or command-line flags.
 
 Dict values
 -----------
 
-Dict values are parsed as Python dict literals on the command-line and environment variables, so you must quote string keys and values, and you may need to apply shell-level quoting and/or escaping, as required.
+Dict values are parsed as Python dict literals on the command-line and environment variables,
+so you must quote string keys and values, and you may need to apply shell-level quoting and/or
+escaping, as required.
 
 ### Command-line flags:
 
@@ -275,7 +278,8 @@ PANTS_SCOPE_DICTOPT="{'foo':1,'bar':2}"
 
 ### Config file entries:
 
-You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table). These are equivalent:
+You can use TOML's [nested table features](https://toml.io/en/v1.0.0#inline-table).
+These are equivalent:
 
 ```toml pants.toml
 [scope]
@@ -300,22 +304,50 @@ dictopt = """{
 
 ### Add/replace semantics
 
-- A value can be preceded by `+`, which will _update_ the value obtained from lower-precedence sources with the entries.
-- Otherwise, the value _replaces_ the one obtained from lower-precendence sources. 
+- A dict literal can be preceded by `+`, which will _update_ the dict value obtained from
+  lower-precedence sources with this literal's entries. If an entry's value is `None`,
+  then the key will be _deleted_ from the value obtained from lower-precedence sources, if present.
+- Otherwise, the dict literal value _replaces_ the one obtained from lower-precendence sources.
 
-For example, if the value of `--dictopt` in `scope` is set to `{'foo', 1, 'bar': 2}` in a config file, then 
+For example, if the value of `--dictopt` in `scope` is set to
+`{'foo': 1, 'bar': 2, 'baz': 3}` in a config file, then
 
 ```bash
-./pants --scope-dictopt="+{'foo':42,'baz':3}"
+./pants --scope-dictopt="+{'foo': 42, 'baz': None}"
 ```
 
-will set the value to `{'foo': 42, 'bar': 2, 'baz': 3}`, and 
+will set the value to `{'foo': 42, 'bar': 2}`, and
 
 ```bash
-./pants --scope-dictopt="{'foo':42,'baz':3}"
+./pants --scope-dictopt="{'foo': 42, 'baz': 3}"
 ```
 
 will set the value to `{'foo': 42, 'baz': 3}`.
+
+> 📘 Add syntax in .toml files
+>
+> The + syntax works in .toml files, but the entire value must be quoted:
+>
+> ```toml pants.toml
+> [scope]
+> dictopt = "+{'foo':42,'baz':3,'qux':None}"
+> ```
+>
+> This means that TOML treats the value as a string, instead of a TOML table.
+>
+> Alternatively, you can use this syntactic sugar, which allows the values to be regular TOML tables:
+>
+> ```toml pants.toml
+> [scope]
+> dictopt.add = {foo = 42, baz = 3, qux = -nan}
+> ```
+>
+> TOML has no none/nil value. So to remove keys, use the value `-nan`.
+>
+> Note that this `.add` affordance only works in Pants's `.toml` config files,
+> not in environment variables or command-line flags.
+
+
 
 Reading individual option values from files
 ===========================================

--- a/src/python/pants/backend/codegen/soap/java/BUILD
+++ b/src/python/pants/backend/codegen/soap/java/BUILD
@@ -5,5 +5,5 @@ python_sources(dependencies=[":lockfiles"])
 
 resources(name="lockfiles", sources=["*.lockfile.txt"])
 
-python_tests(name="tests", dependencies=[":test_resources"])
+python_tests(name="tests", dependencies=[":test_resources"], timeout=120)
 resources(name="test_resources", sources=["*.test.lock"])

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -137,7 +137,7 @@ FILE_1 = ConfigFile(
         [dict_merging]
         dict1.add = {zz = "99"}
         dict2 = "+{'a': 'xx', 'bb': '22'}"
-        dict3.add = {cc = "33", dd = "44"}
+        dict3.add = {cc = "33", dd = "44", bb = -nan}
         dict4 = {ee = "55"}
         """
     ),
@@ -158,7 +158,7 @@ FILE_1 = ConfigFile(
         "dict_merging": {
             "dict1": "+{'zz': '99'}",
             "dict2": "+{'a': 'xx', 'bb': '22'}",
-            "dict3": "+{'cc': '33', 'dd': '44'}",
+            "dict3": "+{'cc': '33', 'dd': '44', 'bb': None}",
             "dict4": "{'ee': '55'}",
         },
     },
@@ -196,7 +196,7 @@ _expected_combined_values: dict[str, dict[str, list[str]]] = {
     "dict_merging": {
         "dict1": ["{}", "+{'zz': '99'}"],
         "dict2": ["{'a': '1', 'b': '2'}", "+{'a': 'xx', 'bb': '22'}"],
-        "dict3": ["+{'c': '3', 'd': '4'}", "+{'cc': '33', 'dd': '44'}"],
+        "dict3": ["+{'c': '3', 'd': '4'}", "+{'cc': '33', 'dd': '44', 'bb': None}"],
         "dict4": ["{'e': '5'}", "{'ee': '55'}"],
     },
 }

--- a/src/python/pants/option/custom_types.py
+++ b/src/python/pants/option/custom_types.py
@@ -276,6 +276,7 @@ class ListValueComponent:
                       a string representation of a list or tuple (possibly prefixed by + or -
                       indicating modification instead of replacement), or any allowed member_type.
                       May also be a comma-separated sequence of modifications.
+        :param member_type: The expected type of members of the list.
         """
         if isinstance(value, cls):  # Ensure idempotency.
             return value

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -206,7 +206,7 @@ class _ListOptionBase(
     _OptionBase["tuple[_ListMemberT, ...]", "tuple[_ListMemberT, ...]"],
     Generic[_ListMemberT],
 ):
-    """Descriptor base for a  subsystem option of  ahomogenous list of some type.
+    """Descriptor base for a  subsystem option of a homogenous list of some type.
 
     Don't use this class directly, instead use one of the conrete classes below.
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -167,6 +167,9 @@ class OptionsBootstrapper:
             # https://github.com/pantsbuild/pants/pull/13228#discussion_r728223889
             alias_vals = post_bootstrap_config.get("cli", "alias")
             val = DictValueComponent.merge([DictValueComponent.create(v) for v in alias_vals]).val
+            # The options system uses None as a sentinel for "delete this key" when merging option
+            # values across sources. We bypass that mechanism, so we must filter ourselves here.
+            val = {k: v for (k, v) in val.items() if v is not None}
             alias = CliAlias.from_dict(val)
 
             args = alias.expand_args(tuple(args))

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -399,6 +399,7 @@ class TestOptionsBootstrapper:
                     [cli.alias]
                     pyupgrade = "--backend-packages=pants.backend.python.lint.pyupgrade fmt"
                     green = "lint test"
+                    unaliased = "this_should_be_unaliased"
                     """
             )
         )
@@ -408,7 +409,7 @@ class TestOptionsBootstrapper:
             dedent(
                 """\
                     [cli]
-                    alias.add = {green = "lint test --force check"}
+                    alias.add = {green = "lint test --force check", unaliased = -nan}
                     """
             )
         )
@@ -428,7 +429,7 @@ class TestOptionsBootstrapper:
             f"'{config0.as_posix()}','{config1.as_posix()}','{config2.as_posix()}']"
         )
         ob = OptionsBootstrapper.create(
-            env={}, args=[config_arg, "pyupgrade", "green"], allow_pantsrc=False
+            env={}, args=[config_arg, "pyupgrade", "green", "unaliased"], allow_pantsrc=False
         )
         assert (
             config_arg,
@@ -438,6 +439,7 @@ class TestOptionsBootstrapper:
             "test",
             "--force",
             "check",
+            "unaliased",
         ) == ob.args
         assert (
             "<ignored>",

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1042,6 +1042,17 @@ class OptionsTest(unittest.TestCase):
             flags='--dicty=\'+{"e": "f"}\'',
             expected={**all_args, "e": "f"},
         )
+        check(
+            config_val='+{"c": "d"}',
+            flags="--dicty='+{\"a\": None}'",
+            expected=specified_args,
+        )
+        check(
+            config_val='+{"c": "d", "a": None}',
+            config2_val='+{"c": None}',
+            flags='--dicty=\'+{"e": "f"}\'',
+            expected={"e": "f"},
+        )
 
         # Check that highest rank wins if we have multiple values for the same key.
         check(config_val='+{"a": "b+", "c": "d"}', expected={"a": "b+", "c": "d"})


### PR DESCRIPTION
This is signaled by setting the value to `None` (or to `-nan` in TOML files). 

Having a `.remove` affordance in config files would be overly complicated, and this gets the job done nicely with minimal changes.
