### PR TITLE
Update docs on how to run Pants in CI. (Cherry-pick of #16503)

### DIFF
--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -34,11 +34,18 @@ Server compatibility
 
 In order to use remote caching or remote execution, Pants will need access to a server that complies with REAPI. Pants is known to work with:
 
+**SaaS**:
+- [Toolchain](https://www.toolchain.com), a remote caching service designed by several of the lead maintainers of Pants specifically to work seamlessly with it.
+
+**Self-hosted**:
 - [BuildBarn](https://github.com/buildbarn/bb-remote-execution)
 - [Buildfarm](https://github.com/bazelbuild/bazel-buildfarm/) 
 - [BuildGrid](https://buildgrid.build/)
 
-**Note**: Setup of a remote execution server is beyond the scope of this documentation. All three server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
+**Note**: Setup of a self-hosted REAPI server is beyond the scope of this documentation. All these server projects have support channels on the BuildTeamWorld Slack. [Go here to obtain an invite to that Slack.](https://bit.ly/2SG1amT)
+
+There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
+they have not, to our knowledge, been tested with Pants.  Let us know if you have any experience with them!
 
 Resources
 =========

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -15,15 +15,34 @@ Directories to cache
 
 In your CI's config file, we recommend caching these directories:
 
-- `$HOME/.cache/pants/setup`: the initial bootstrapping of Pants.
-- `$HOME/.cache/pants/named_caches`: caches of tools like pip and PEX.
-- `$HOME/.cache/pants/lmdb_store`: cached content for prior Pants runs, e.g. prior test results.
+
+- `$HOME/.cache/pants/setup`<br>
+  This is the Pants bootstrap directory. Cache this against the version, as specified
+  in `pants.toml`.  See the [pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml)
+  repo for an example of how to generate an effective cache key for this directory in GitHub Actions.
+- `$HOME/.cache/pants/named_caches`<br>
+  Caches used by some underlying tools.  Cache this against the inputs to those tools.
+  For the `pants.backend.python` backend, named caches are used by PEX, and therefore
+  its inputs are your lockfiles. Again, see [pantsbuild/example-python]([pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml))
+  for an example.
+
+If you're not using a fine-grained [remote caching](doc:remote-caching-execution) service,
+then you may also want to preserve the local Pants cache at `$HOME/.cache/pants/lmdb_store`.
+This has to be invalidated on any file that can affect any process, e.g., `hashFiles('**/*')`
+on GitHub Actions.
+
+Computing such a coarse hash, and saving and restoring large directories, can be unwieldy.
+So this may be impractical and slow on medium and large repos.
+
+A [remote cache service](doc:remote-caching-execution) integrates with Pants's fine-grained
+invalidation and avoids these problems, and is recommended for the best CI performance.
 
 See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) for how to change these cache locations.
 
 > 📘 Nuking the cache when too big
 > 
-> In CI, the cache must be uploaded and downloaded every run. This takes time, so there is a tradeoff where too large of a cache will slow down your CI.
+> In CI, the cache must be uploaded and downloaded every run. This takes time, so there is a tradeoff where too
+> large a cache will slow down your CI.
 > 
 > You can use this script to nuke the cache when it gets too big:
 > 
@@ -37,8 +56,7 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >     rm -rf ${path}
 >   fi
 > }
-> 
-> nuke_if_too_big ~/.cache/pants/lmdb_store 2048
+>
 > nuke_if_too_big ~/.cache/pants/setup 256
 > nuke_if_too_big ~/.cache/pants/named_caches 1024
 > ```
@@ -58,7 +76,8 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 
 > 👍 Remote caching
 > 
-> Rather than storing your cache with your CI provider, remote caching stores the cache in the cloud, using gRPC and the open-source Remote Execution API for low-latency and fine-grained caching. 
+> Rather than storing your cache with your CI provider, remote caching stores the cache in the cloud,
+> using gRPC and the open-source Remote Execution API for low-latency and fine-grained caching.
 > 
 > This brings several benefits over local caching:
 > 
@@ -67,12 +86,14 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >   - No download and upload stage for your cache. 
 >   - No need to "nuke" your cache when it gets too big.
 > 
-> See [Remote Caching](doc:remote-caching) for more information.
+> See [Remote Caching and Execution](doc:remote-caching-execution) for more information.
 
 Recommended commands
 --------------------
 
-With both approaches, you may want to shard the input targets into multiple CI jobs, for increased parallelism. See [Advanced Target Selection](doc:advanced-target-selection#sharding-the-input-targets). (This is typically less necessary when using [remote caching](doc:remote-caching).)
+With both approaches, you may want to shard the input targets into multiple CI jobs, for increased parallelism.
+See [Advanced Target Selection](doc:advanced-target-selection#sharding-the-input-targets). 
+(This is typically less necessary when using [remote caching](doc:remote-caching-execution).)
 
 ### Approach #1: only run over changed files
 


### PR DESCRIPTION
Explain where remote caching can come in handy, and why.
