### PR TITLE
Update release helper to know about macos 10.15 and 11 wheels.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -1225,13 +1225,13 @@ def check_pants_wheels_present(check_dir: str | Path) -> None:
         if not local_files:
             missing_packages.append(package.name)
             continue
-        if is_cross_platform(local_files) and len(local_files) != 7:
+        if is_cross_platform(local_files) and len(local_files) != 10:
             formatted_local_files = "\n    ".join(sorted(f.name for f in local_files))
             missing_packages.append(
                 softwrap(
                     f"""
-                    {package.name}. Expected 7 wheels ({{cp37m, cp38, cp39}} x
-                    {{macosx-x86_64, linux-x86_64}} + cp39-macosx-arm64),
+                    {package.name}. Expected 10 wheels ({{cp37m, cp38, cp39}} x
+                    {{macosx10.15-x86_64, macosx11-x86_64, linux-x86_64}} + cp39-macosx-arm64),
                     but found {len(local_files)}:\n    {formatted_local_files}
                     """
                 )


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]