### PR TITLE
Deprecate `[python].only_binary` and `[python].no_binary` in favor of more powerful `[python].resolves_to_only_binary` and `[python].resolves_to_no_binary`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -159,8 +159,8 @@ class _PipArgsAndConstraintsSetup:
     args: tuple[str, ...]
     digest: Digest
     constraints: FrozenOrderedSet[PipRequirement]
-    only_binary: set[str]
-    no_binary: set[str]
+    only_binary: tuple[str, ...]
+    no_binary: tuple[str, ...]
 
 
 @rule_helper
@@ -207,8 +207,8 @@ async def generate_lockfile(
     python_setup: PythonSetup,
 ) -> GenerateLockfileResult:
     requirement_constraints: FrozenOrderedSet[PipRequirement] = FrozenOrderedSet()
-    only_binary = set()
-    no_binary = set()
+    only_binary: tuple[str, ...] = ()
+    no_binary: tuple[str, ...] = ()
 
     if req.use_pex:
         pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
@@ -318,8 +318,8 @@ async def generate_lockfile(
         valid_for_interpreter_constraints=req.interpreter_constraints,
         requirements={PipRequirement.parse(i) for i in req.requirements},
         requirement_constraints=set(requirement_constraints),
-        only_binary=only_binary,
-        no_binary=no_binary,
+        only_binary=set(only_binary),
+        no_binary=set(no_binary),
     )
     lockfile_with_header = metadata.add_header_to_lockfile(
         initial_lockfile_digest_contents[0].content,

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -14,7 +14,7 @@ from pants.backend.python.goals.lockfile import (
 )
 from pants.backend.python.goals.lockfile import rules as lockfile_rules
 from pants.backend.python.goals.lockfile import setup_user_lockfile_requests
-from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.subsystems.setup import RESOLVE_OPTION_KEY__DEFAULT, PythonSetup
 from pants.backend.python.target_types import PythonRequirementTarget
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -110,11 +110,12 @@ def test_poetry_lockfile_generation(rule_runner: RuleRunner) -> None:
 def test_pex_lockfile_generation(
     rule_runner: RuleRunner, no_binary: bool, only_binary: bool
 ) -> None:
-    args = []
+    args = ["--python-resolves={'test': 'foo.lock'}"]
+    no_binary_arg = f"{{'{RESOLVE_OPTION_KEY__DEFAULT}': ['ansicolors']}}"
     if no_binary:
-        args.append("--python-no-binary=ansicolors")
+        args.append(f"--python-resolves-to-no-binary={no_binary_arg}")
     if only_binary:
-        args.append("--python-only-binary=ansicolors")
+        args.append(f"--python-resolves-to-only-binary={no_binary_arg}")
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
 
     lock_entry = json.loads(_generate(rule_runner=rule_runner, use_pex=True))
@@ -161,7 +162,7 @@ def test_constraints_file(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
             "--python-resolves={'test': 'foo.lock'}",
-            "--python-resolves-to-constraints-file={'test': 'constraints.txt'}",
+            f"--python-resolves-to-constraints-file={{'{RESOLVE_OPTION_KEY__DEFAULT}': 'constraints.txt'}}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
-from typing import Iterable, Iterator, Optional, TypeVar, cast
+from typing import Iterable, Iterator, List, Optional, TypeVar, cast
 
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.option.option_types import (
@@ -243,7 +243,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_no_binary = DictOption[list[str]](
+    _resolves_to_no_binary = DictOption[List[str]](
         help=softwrap(
             f"""
             When generating a resolve's lockfile, do not use binary packages (i.e. wheels) for
@@ -269,7 +269,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_only_binary = DictOption[list[str]](
+    _resolves_to_only_binary = DictOption[List[str]](
         help=softwrap(
             f"""
             When generating a resolve's lockfile, do not use source packages (i.e. sdists) for

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
-from typing import Iterable, Iterator, Optional, cast
+from typing import Iterable, Iterator, Optional, TypeVar, cast
 
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.option.option_types import (
@@ -36,6 +36,11 @@ class InvalidLockfileBehavior(enum.Enum):
 class LockfileGenerator(enum.Enum):
     PEX = "pex"
     POETRY = "poetry"
+
+
+RESOLVE_OPTION_KEY__DEFAULT = "__default__"
+
+_T = TypeVar("_T")
 
 
 class PythonSetup(Subsystem):
@@ -215,7 +220,7 @@ class PythonSetup(Subsystem):
     )
     _resolves_to_constraints_file = DictOption[str](
         help=softwrap(
-            """
+            f"""
             When generating a resolve's lockfile, use a constraints file to pin the version of
             certain requirements. This is particularly useful to pin the versions of transitive
             dependencies of your direct requirements.
@@ -226,10 +231,63 @@ class PythonSetup(Subsystem):
             Expects a dictionary of resolve names from `[python].resolves` and Python tools (e.g.
             `black` and `pytest`) to file paths for
             constraints files. For example,
-            `{'data-science': '3rdparty/data-science-constraints.txt'}`.
+            `{{'data-science': '3rdparty/data-science-constraints.txt'}}`.
             If a resolve is not set in the dictionary, it will not use a constraints file.
 
-            You can use the key `__default__` to set a default value for all resolves.
+            You can use the key `{RESOLVE_OPTION_KEY__DEFAULT}` to set a default value for all
+            resolves.
+
+            Note: Only takes effect if you use Pex lockfiles. Use the default
+            `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
+            """
+        ),
+        advanced=True,
+    )
+    _resolves_to_no_binary = DictOption[list[str]](
+        help=softwrap(
+            f"""
+            When generating a resolve's lockfile, do not use binary packages (i.e. wheels) for
+            these 3rdparty project names.
+
+            Expects a dictionary of resolve names from `[python].resolves` and Python tools (e.g.
+            `black` and `pytest`) to lists of project names. For example,
+            `{{'data-science': ['requests', 'numpy']}}`. If a resolve is not set in the dictionary,
+            it will have no restrictions on binary packages.
+
+            You can use the key `{RESOLVE_OPTION_KEY__DEFAULT}` to set a default value for all
+            resolves.
+
+            For each resolve's value, you can use the value `:all:` to disable all binary packages.
+
+            Note that some packages are tricky to compile and may fail to install when this option
+            is used on them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary
+            for details.
+
+            Note: Only takes effect if you use Pex lockfiles. Use the default
+            `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
+            """
+        ),
+        advanced=True,
+    )
+    _resolves_to_only_binary = DictOption[list[str]](
+        help=softwrap(
+            f"""
+            When generating a resolve's lockfile, do not use source packages (i.e. sdists) for
+            these 3rdparty project names, e.g `['django', 'requests']`.
+
+            Expects a dictionary of resolve names from `[python].resolves` and Python tools (e.g.
+            `black` and `pytest`) to lists of project names. For example,
+            `{{'data-science': ['requests', 'numpy']}}`. If a resolve is not set in the dictionary,
+            it will have no restrictions on source packages.
+
+            You can use the key `{RESOLVE_OPTION_KEY__DEFAULT}` to set a default value for all
+            resolves.
+
+            For each resolve's value, you can use the value `:all:` to disable all source packages.
+
+            Packages without binary distributions will fail to install when this option is used on
+            them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-only-binary for
+            details.
 
             Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
@@ -423,6 +481,15 @@ class PythonSetup(Subsystem):
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
             """
         ),
+        removal_version="2.15.0.dev0",
+        removal_hint=softwrap(
+            f"""
+            Use `[python].resolves_to_no_binary`, which allows you to set `--no-binary` on a
+            per-resolve basis for more flexibility. To keep this option's behavior, set
+            `[python].resolves_to_no_binary` with the key `{RESOLVE_OPTION_KEY__DEFAULT}` and the
+            value you used on this option.
+            """
+        ),
     )
     only_binary = StrListOption(
         help=softwrap(
@@ -437,6 +504,15 @@ class PythonSetup(Subsystem):
 
             Note: Only takes effect if you use Pex lockfiles. Use the default
             `[python].lockfile_generator = "pex"` and run the `generate-lockfiles` goal.
+            """
+        ),
+        removal_version="2.15.0.dev0",
+        removal_hint=softwrap(
+            f"""
+            Use `[python].resolves_to_only_binary`, which allows you to set `--only-binary` on a
+            per-resolve basis for more flexibility. To keep this option's behavior, set
+            `[python].resolves_to_only_binary` with the key `{RESOLVE_OPTION_KEY__DEFAULT}` and the
+            value you used on this option.
             """
         ),
     )
@@ -562,28 +638,91 @@ class PythonSetup(Subsystem):
             )
         return result
 
-    @memoized_method
-    def resolves_to_constraints_file(
-        self, all_python_tool_resolve_names: tuple[str, ...]
-    ) -> dict[str, str]:
+    def _resolves_to_option_helper(
+        self,
+        option_value: dict[str, _T],
+        option_name: str,
+        all_python_tool_resolve_names: tuple[str, ...],
+    ) -> dict[str, _T]:
         all_valid_resolves = {*self.resolves, *all_python_tool_resolve_names}
-        unrecognized_resolves = set(self._resolves_to_constraints_file.keys()) - {
-            "__default__",
+        unrecognized_resolves = set(option_value.keys()) - {
+            RESOLVE_OPTION_KEY__DEFAULT,
             *all_valid_resolves,
         }
         if unrecognized_resolves:
             raise UnrecognizedResolveNamesError(
                 sorted(unrecognized_resolves),
-                all_valid_resolves,
-                description_of_origin="the option `[python].resolves_to_constraints_file`",
+                {*all_valid_resolves, RESOLVE_OPTION_KEY__DEFAULT},
+                description_of_origin=f"the option `[python].{option_name}`",
             )
-        default_val = self._resolves_to_constraints_file.get("__default__")
+        default_val = option_value.get(RESOLVE_OPTION_KEY__DEFAULT)
         if not default_val:
-            return self._resolves_to_constraints_file
-        return {
-            resolve: self._resolves_to_constraints_file.get(resolve, default_val)
-            for resolve in all_valid_resolves
-        }
+            return option_value
+        return {resolve: option_value.get(resolve, default_val) for resolve in all_valid_resolves}
+
+    @memoized_method
+    def resolves_to_constraints_file(
+        self, all_python_tool_resolve_names: tuple[str, ...]
+    ) -> dict[str, str]:
+        return self._resolves_to_option_helper(
+            self._resolves_to_constraints_file,
+            "resolves_to_constraints_file",
+            all_python_tool_resolve_names,
+        )
+
+    @memoized_method
+    def resolves_to_no_binary(
+        self, all_python_tool_resolve_names: tuple[str, ...]
+    ) -> dict[str, list[str]]:
+        if self.no_binary:
+            if self._resolves_to_no_binary:
+                raise ValueError(
+                    softwrap(
+                        """
+                        Conflicting options used. You used the new, preferred
+                        `[python].resolves_to_no_binary`, but also used the deprecated
+                        `[python].no_binary`.
+
+                        Please use only one of these (preferably `[python].resolves_to_no_binary`).
+                        """
+                    )
+                )
+            return {
+                resolve: list(self.no_binary)
+                for resolve in {*self.resolves, *all_python_tool_resolve_names}
+            }
+        return self._resolves_to_option_helper(
+            self._resolves_to_no_binary,
+            "resolves_to_no_binary",
+            all_python_tool_resolve_names,
+        )
+
+    @memoized_method
+    def resolves_to_only_binary(
+        self, all_python_tool_resolve_names: tuple[str, ...]
+    ) -> dict[str, list[str]]:
+        if self.only_binary:
+            if self._resolves_to_only_binary:
+                raise ValueError(
+                    softwrap(
+                        """
+                        Conflicting options used. You used the new, preferred
+                        `[python].resolves_to_only_binary`, but also used the deprecated
+                        `[python].only_binary`.
+
+                        Please use only one of these (preferably `[python].resolves_to_only_binary`).
+                        """
+                    )
+                )
+            return {
+                resolve: list(self.only_binary)
+                for resolve in {*self.resolves, *all_python_tool_resolve_names}
+            }
+        return self._resolves_to_option_helper(
+            self._resolves_to_only_binary,
+            "resolves_to_only_binary",
+            all_python_tool_resolve_names,
+        )
 
     def resolve_all_constraints_was_set_explicitly(self) -> bool:
         return not self.options.is_default("resolve_all_constraints")

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -430,7 +430,7 @@ async def _setup_pex_requirements(
                 lockfile.original_lockfile,
                 request.requirements.complete_req_strings,
                 python_setup,
-                resolve_config.constraints_file,
+                resolve_config,
             )
 
         return _BuildPexRequirementsSetup(
@@ -468,7 +468,7 @@ async def _setup_pex_requirements(
                 loaded_lockfile.original_lockfile,
                 request.requirements.req_strings,
                 python_setup,
-                resolve_config.constraints_file,
+                resolve_config,
             )
 
         return _BuildPexRequirementsSetup(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -298,6 +298,8 @@ class ResolvePexConfig:
     """Configuration from `[python]` that impacts how the resolve is created."""
 
     constraints_file: ResolvePexConstraintsFile | None
+    only_binary: tuple[str, ...]
+    no_binary: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -318,6 +320,17 @@ async def determine_resolve_pex_config(
         sentinel.resolve_name
         for sentinel in union_membership.get(GenerateToolLockfileSentinel)
         if issubclass(sentinel, GeneratePythonToolLockfileSentinel)
+    )
+
+    no_binary = (
+        python_setup.resolves_to_no_binary(all_python_tool_resolve_names).get(request.resolve_name)
+        or []
+    )
+    only_binary = (
+        python_setup.resolves_to_only_binary(all_python_tool_resolve_names).get(
+            request.resolve_name
+        )
+        or []
     )
 
     constraints_file: ResolvePexConstraintsFile | None = None
@@ -360,7 +373,11 @@ async def determine_resolve_pex_config(
             _constraints_digest, _constraints_file_path, FrozenOrderedSet(constraints)
         )
 
-    return ResolvePexConfig(constraints_file=constraints_file)
+    return ResolvePexConfig(
+        constraints_file=constraints_file,
+        no_binary=tuple(no_binary),
+        only_binary=tuple(only_binary),
+    )
 
 
 def should_validate_metadata(

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -83,8 +83,8 @@ def test_invalid_lockfile_behavior_option() -> None:
 
 
 @pytest.mark.parametrize(
-    "is_default_lock,invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file," +
-    "invalid_only_binary,invalid_no_binary,uses_source_plugins,uses_project_ic",
+    "is_default_lock,invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file,"
+    + "invalid_only_binary,invalid_no_binary,uses_source_plugins,uses_project_ic",
     [
         (
             is_default_lock,
@@ -144,7 +144,7 @@ def test_validate_tool_lockfiles(
                 ),
             ),
             no_binary=("not-sdist" if invalid_no_binary else "sdist",),
-            only_binary=("not-bdist" if invalid_only_binary else "bdist",)
+            only_binary=("not-bdist" if invalid_only_binary else "bdist",),
         ),
     )
 
@@ -187,13 +187,25 @@ def test_validate_tool_lockfiles(
 @pytest.mark.parametrize(
     "invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file,invalid_only_binary,invalid_no_binary",
     [
-        (invalid_reqs, invalid_interpreter_constraints, invalid_constraints_file, invalid_only_binary, invalid_no_binary)
+        (
+            invalid_reqs,
+            invalid_interpreter_constraints,
+            invalid_constraints_file,
+            invalid_only_binary,
+            invalid_no_binary,
+        )
         for invalid_reqs in (True, False)
         for invalid_interpreter_constraints in (True, False)
         for invalid_constraints_file in (True, False)
         for invalid_only_binary in (True, False)
         for invalid_no_binary in (True, False)
-        if (invalid_reqs or invalid_interpreter_constraints or invalid_constraints_file or invalid_only_binary or invalid_no_binary)
+        if (
+            invalid_reqs
+            or invalid_interpreter_constraints
+            or invalid_constraints_file
+            or invalid_only_binary
+            or invalid_no_binary
+        )
     ],
 )
 def test_validate_user_lockfiles(

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -13,6 +13,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.lockfile_metadata import PythonLockfileMetadataV3
 from pants.backend.python.util_rules.pex_requirements import (
     Lockfile,
+    ResolvePexConfig,
     ResolvePexConstraintsFile,
     ToolCustomLockfile,
     ToolDefaultLockfile,
@@ -31,6 +32,8 @@ METADATA = PythonLockfileMetadataV3(
     InterpreterConstraints(["==3.8.*"]),
     {PipRequirement.parse("ansicolors"), PipRequirement.parse("requests")},
     requirement_constraints={PipRequirement.parse("abc")},
+    only_binary={"bdist"},
+    no_binary={"sdist"},
 )
 
 
@@ -80,13 +83,16 @@ def test_invalid_lockfile_behavior_option() -> None:
 
 
 @pytest.mark.parametrize(
-    "is_default_lock,invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file,uses_source_plugins,uses_project_ic",
+    "is_default_lock,invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file," +
+    "invalid_only_binary,invalid_no_binary,uses_source_plugins,uses_project_ic",
     [
         (
             is_default_lock,
             invalid_reqs,
             invalid_interpreter_constraints,
             invalid_constraints_file,
+            invalid_only_binary,
+            invalid_no_binary,
             source_plugins,
             project_ics,
         )
@@ -94,6 +100,8 @@ def test_invalid_lockfile_behavior_option() -> None:
         for invalid_reqs in (True, False)
         for invalid_interpreter_constraints in (True, False)
         for invalid_constraints_file in (True, False)
+        for invalid_only_binary in (True, False)
+        for invalid_no_binary in (True, False)
         for source_plugins in (True, False)
         for project_ics in (True, False)
         if (invalid_reqs or invalid_interpreter_constraints or invalid_constraints_file)
@@ -104,6 +112,8 @@ def test_validate_tool_lockfiles(
     invalid_reqs: bool,
     invalid_interpreter_constraints: bool,
     invalid_constraints_file: bool,
+    invalid_only_binary: bool,
+    invalid_no_binary: bool,
     uses_source_plugins: bool,
     uses_project_ic: bool,
     caplog,
@@ -125,10 +135,16 @@ def test_validate_tool_lockfiles(
         requirements,
         req_strings,
         create_python_setup(InvalidLockfileBehavior.warn),
-        constraints_file=ResolvePexConstraintsFile(
-            EMPTY_DIGEST,
-            "c.txt",
-            FrozenOrderedSet({PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}),
+        ResolvePexConfig(
+            ResolvePexConstraintsFile(
+                EMPTY_DIGEST,
+                "c.txt",
+                FrozenOrderedSet(
+                    {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
+                ),
+            ),
+            no_binary=("not-sdist" if invalid_no_binary else "sdist",),
+            only_binary=("not-bdist" if invalid_only_binary else "bdist",)
         ),
     )
 
@@ -157,6 +173,8 @@ def test_validate_tool_lockfiles(
     )
 
     contains("The constraints file at c.txt has changed", if_=invalid_constraints_file)
+    contains("The `only_binary` arguments have changed", if_=invalid_only_binary)
+    contains("The `no_binary` arguments have changed", if_=invalid_no_binary)
 
     contains(
         "To generate a custom lockfile based on your current configuration", if_=is_default_lock
@@ -167,19 +185,23 @@ def test_validate_tool_lockfiles(
 
 
 @pytest.mark.parametrize(
-    "invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file",
+    "invalid_reqs,invalid_interpreter_constraints,invalid_constraints_file,invalid_only_binary,invalid_no_binary",
     [
-        (invalid_reqs, invalid_interpreter_constraints, invalid_constraints_file)
+        (invalid_reqs, invalid_interpreter_constraints, invalid_constraints_file, invalid_only_binary, invalid_no_binary)
         for invalid_reqs in (True, False)
         for invalid_interpreter_constraints in (True, False)
         for invalid_constraints_file in (True, False)
-        if (invalid_reqs or invalid_interpreter_constraints or invalid_constraints_file)
+        for invalid_only_binary in (True, False)
+        for invalid_no_binary in (True, False)
+        if (invalid_reqs or invalid_interpreter_constraints or invalid_constraints_file or invalid_only_binary or invalid_no_binary)
     ],
 )
 def test_validate_user_lockfiles(
     invalid_reqs: bool,
     invalid_interpreter_constraints: bool,
     invalid_constraints_file: bool,
+    invalid_only_binary: bool,
+    invalid_no_binary: bool,
     caplog,
 ) -> None:
     runtime_interpreter_constraints = (
@@ -207,10 +229,16 @@ def test_validate_user_lockfiles(
         lockfile,
         req_strings,
         create_python_setup(InvalidLockfileBehavior.warn),
-        constraints_file=ResolvePexConstraintsFile(
-            EMPTY_DIGEST,
-            "c.txt",
-            FrozenOrderedSet({PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}),
+        ResolvePexConfig(
+            ResolvePexConstraintsFile(
+                EMPTY_DIGEST,
+                "c.txt",
+                FrozenOrderedSet(
+                    {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
+                ),
+            ),
+            no_binary=("not-sdist" if invalid_no_binary else "sdist",),
+            only_binary=("not-bdist" if invalid_only_binary else "bdist",),
         ),
     )
 
@@ -226,6 +254,8 @@ def test_validate_user_lockfiles(
     contains("The targets use interpreter constraints", if_=invalid_interpreter_constraints)
 
     contains("The constraints file at c.txt has changed", if_=invalid_constraints_file)
+    contains("The `only_binary` arguments have changed", if_=invalid_only_binary)
+    contains("The `no_binary` arguments have changed", if_=invalid_no_binary)
 
     contains("./pants generate-lockfiles --resolve=a`")
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -615,6 +615,8 @@ def test_setup_pex_requirements() -> None:
                     ResolvePexConfigRequest,
                     lambda _: ResolvePexConfig(
                         constraints_file=None,
+                        only_binary=(),
+                        no_binary=(),
                     ),
                 ),
                 MockGet(Digest, CreateDigest, lambda _: constraints_digest),
@@ -746,6 +748,8 @@ def test_lockfile_validation(rule_runner: RuleRunner) -> None:
         valid_for_interpreter_constraints=InterpreterConstraints(),
         requirements=set(),
         requirement_constraints=set(),
+        only_binary=set(),
+        no_binary=set(),
     ).add_header_to_lockfile(b"", regenerate_command="regen", delimeter="#")
     rule_runner.write_files({"lock.txt": lock_content.decode()})
 

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -146,6 +146,8 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
         valid_for_interpreter_constraints=InterpreterConstraints(["==2.7.*"]),
         requirements=set(),
         requirement_constraints=set(),
+        only_binary=set(),
+        no_binary=set(),
     )
 
     def assert_ics(


### PR DESCRIPTION
Part of the per-resolve config project at https://docs.google.com/document/d/1HAvpSNvNAHreFfvTAXavZGka-A3WWvPuH0sMjGUCo48/edit. 

We already with multiple resolves allow you to have conflicting versions of the same requirement, e.g. Django 2 vs Django 3. So, it's useful to also allow those resolves to set different options for `--no-binary` and `--only-binary`, as you might only need it for certain versions of a project or for certain contexts.

This only works with Pex lockfiles, with similar reasoning to why we closed https://github.com/pantsbuild/pants/pull/16476.

This adds the options to the lockfile header, making progress on https://github.com/pantsbuild/pants/issues/12832. 