### PR TITLE
Further `--process-cleanup` deprecation tweaks

### DIFF
--- a/src/python/pants/engine/internals/options_parsing.py
+++ b/src/python/pants/engine/internals/options_parsing.py
@@ -3,6 +3,7 @@
 
 from dataclasses import dataclass
 
+from pants.base.deprecated import warn_or_error
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
@@ -10,6 +11,7 @@ from pants.option.global_options import (
     GlobalOptions,
     KeepSandboxes,
     NamedCachesDirOption,
+    ProcessCleanupOption,
     UseDeprecatedPexBinaryRunSemanticsOption,
 )
 from pants.option.options import Options
@@ -56,6 +58,16 @@ def scope_options(scope: Scope, options: _Options) -> ScopedOptions:
 @rule
 def log_level(global_options: GlobalOptions) -> LogLevel:
     return global_options.level
+
+
+@rule
+def extract_process_cleanup_option(keep_sandboxes: KeepSandboxes) -> ProcessCleanupOption:
+    warn_or_error(
+        removal_version="2.15.0.dev1",
+        entity="ProcessCleanupOption",
+        hint="Instead, use `KeepSandboxes`.",
+    )
+    return ProcessCleanupOption(keep_sandboxes == KeepSandboxes.never)
 
 
 @rule

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -23,7 +23,7 @@ from pants.base.build_environment import (
     is_in_container,
     pants_version,
 )
-from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options, warn_or_error
+from pants.base.deprecated import deprecated_conditional, resolve_conflicting_options
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals.native_engine import PyExecutor
@@ -1935,12 +1935,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         if isinstance(resolved_value, bool):
             # Is `process_cleanup`.
-            warn_or_error(
-                removal_version="2.15.0.dev1",
-                entity="--process-cleanup",
-                hint="Instead, use `--keep-sandboxes`.",
-            )
-            return KeepSandboxes.never if resolved_value else KeepSandboxes.always
+            return KeepSandboxes.always if resolved_value else KeepSandboxes.on_failure
         elif isinstance(resolved_value, KeepSandboxes):
             return resolved_value
         else:
@@ -2036,6 +2031,16 @@ class GlobalOptionsFlags:
                     flags.add(f"--no-{flag[2:]}")
 
         return cls(FrozenOrderedSet(flags), FrozenOrderedSet(short_flags))
+
+
+@dataclass(frozen=True)
+class ProcessCleanupOption:
+    """A wrapper around the global option `process_cleanup`.
+
+    Prefer to use this rather than requesting `GlobalOptions` for more precise invalidation.
+    """
+
+    val: bool
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1158,7 +1158,7 @@ class BootstrapOptions:
     process_cleanup = BoolOption(
         default=(DEFAULT_EXECUTION_OPTIONS.keep_sandboxes == KeepSandboxes.never),
         deprecation_start_version="2.15.0.dev1",
-        removal_version="2.16.0.dev1",
+        removal_version="2.17.0.dev1",
         removal_hint="Use the `keep_sandboxes` option instead.",
         help=softwrap(
             """
@@ -1935,7 +1935,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         if isinstance(resolved_value, bool):
             # Is `process_cleanup`.
-            return KeepSandboxes.always if resolved_value else KeepSandboxes.on_failure
+            return KeepSandboxes.never if resolved_value else KeepSandboxes.always
         elif isinstance(resolved_value, KeepSandboxes):
             return resolved_value
         else:


### PR DESCRIPTION
Restores the plugin API deprecation from #16447, moves the deprecation start back to `2.15.0.dev1`, and bumps the deprecation end to `2.17.0.dev1`, since the flag is widely used.

[ci skip-rust]
[ci skip-build-wheels]