### PR TITLE
Auto-detect Helm chart source roots

### DIFF
--- a/docs/markdown/Helm/helm-deployments.md
+++ b/docs/markdown/Helm/helm-deployments.md
@@ -69,10 +69,6 @@ There are quite a few things to notice in the previous example:
 * One of those value files (`common-values.yaml`) provides with default values that are common to all deployments.
 * Each deployment uses an additional `xxx-override.yaml` file with values that are specific to the given deployment.
 
-> 📘 Source roots
-> 
-> Don't forget to configure your source roots such that each of the shown files in the previous example sit at their respective source root level.
-
 The `helm_deployment` target has many additional fields including the target kubernetes namespace, adding inline override values (similar to using helm's `--set` arg) and many others. Please run `./pants help helm_deployment` to see all the posibilities.
 
 Dependencies with `docker_image` targets

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -25,7 +25,7 @@ backend_packages = [
 ]
 ```
 
-In the case in which you may have more than one chart in the same repository, it is important that you configure your Pants' source roots in a way that Pants recognises each of your chart folders as a source root. In the following example `foo` and `bar` are Helm charts, so we give Pants a source root pattern to consider `src/helm/foo` and `src/helm/bar` as source roots.
+In the case in which you may have more than one chart in the same repository, the Helm backend is capable of auto-detecting the root folder of your Helm charts taking the chart definition file `Chart.yaml` as the reference for that root. Nonetheless, it is recommended that you configure your Pants' source roots in a way that Pants recognises each of your chart folders as a source root. In the following example `foo` and `bar` are Helm charts, so we give Pants a source root pattern to consider `src/helm/foo` and `src/helm/bar` as source roots.
 
 ```yaml src/helm/foo/Chart.yaml
 apiVersion: v2

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -48,6 +48,8 @@ root_patterns = [
 ]
 ```
 
+You can verify this by running the `./pants roots` command and and checking that the folders `src/helm/foo` and `src/helm/bar` are listed.
+
 Adding `helm_chart` targets
 ---------------------------
 

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -25,7 +25,7 @@ backend_packages = [
 ]
 ```
 
-In the case in which you may have more than one chart in the same repository, the Helm backend is capable of auto-detecting the root folder of your Helm charts taking the chart definition file `Chart.yaml` as the reference for that root. Nonetheless, it is recommended that you configure your Pants' source roots in a way that Pants recognises each of your chart folders as a source root. In the following example `foo` and `bar` are Helm charts, so we give Pants a source root pattern to consider `src/helm/foo` and `src/helm/bar` as source roots.
+In the case in which you may have more than one chart in the same repository, the Helm backend is capable of auto-detecting the root folder of your Helm charts taking the chart definition file `Chart.yaml` as the reference for that root. Nonetheless, it is recommended that you configure your Pants' source roots in a way that Pants recognises each of your chart folders as a source root. In the following example `foo` and `bar` are Helm charts, so we tell Pants to use a marker filename to identify the source roots of those charts.
 
 ```yaml src/helm/foo/Chart.yaml
 apiVersion: v2
@@ -41,11 +41,7 @@ version: 0.1.0
 ```
 ```toml pants.toml
 [source]
-root_patterns = [
-  ...
-  "src/helm/*",
-  ...
-]
+marker_filenames = ["Chart.yaml"]
 ```
 
 You can verify this by running the `./pants roots` command and and checking that the folders `src/helm/foo` and `src/helm/bar` are listed.

--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -25,7 +25,7 @@ backend_packages = [
 ]
 ```
 
-In the case in which you may have more than one chart in the same repository, the Helm backend is capable of auto-detecting the root folder of your Helm charts taking the chart definition file `Chart.yaml` as the reference for that root. Nonetheless, it is recommended that you configure your Pants' source roots in a way that Pants recognises each of your chart folders as a source root. In the following example `foo` and `bar` are Helm charts, so we tell Pants to use a marker filename to identify the source roots of those charts.
+If you have more than one Helm chart in the same repository, organise them such that each of them lives in a separate folder with the chart definition file (`Chart.yaml`) at their root. The Helm backend is capable of auto-detecting the root folder of your Helm charts taking the chart definition file `Chart.yaml` as the reference for that root. 
 
 ```yaml src/helm/foo/Chart.yaml
 apiVersion: v2
@@ -39,12 +39,6 @@ description: Bar Helm chart
 name: bar
 version: 0.1.0
 ```
-```toml pants.toml
-[source]
-marker_filenames = ["Chart.yaml"]
-```
-
-You can verify this by running the `./pants roots` command and and checking that the folders `src/helm/foo` and `src/helm/bar` are listed.
 
 Adding `helm_chart` targets
 ---------------------------

--- a/src/python/pants/backend/helm/dependency_inference/chart.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart.py
@@ -17,6 +17,7 @@ from pants.backend.helm.target_types import (
     HelmChartTarget,
 )
 from pants.backend.helm.target_types import rules as helm_target_types_rules
+from pants.backend.helm.util_rules import chart_metadata
 from pants.backend.helm.util_rules.chart_metadata import HelmChartDependency, HelmChartMetadata
 from pants.engine.addresses import Address
 from pants.engine.internals.selectors import Get, MultiGet
@@ -162,5 +163,6 @@ def rules():
         *collect_rules(),
         *artifacts.rules(),
         *helm_target_types_rules(),
+        *chart_metadata.rules(),
         UnionRule(InferDependenciesRequest, InferHelmChartDependenciesRequest),
     ]

--- a/src/python/pants/backend/helm/dependency_inference/chart_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart_test.py
@@ -36,12 +36,6 @@ def rule_runner() -> RuleRunner:
             QueryRule(InferredDependencies, (InferHelmChartDependenciesRequest,)),
         ],
     )
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options(
-        [
-            f"--source-root-patterns={repr(source_root_patterns)}",
-        ]
-    )
     return rule_runner
 
 

--- a/src/python/pants/backend/helm/dependency_inference/chart_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/chart_test.py
@@ -25,7 +25,7 @@ from pants.util.strutil import bullet_list
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         target_types=[HelmArtifactTarget, HelmChartTarget],
         rules=[
             *artifacts.rules(),
@@ -36,13 +36,20 @@ def rule_runner() -> RuleRunner:
             QueryRule(InferredDependencies, (InferHelmChartDependenciesRequest,)),
         ],
     )
+    source_root_patterns = ("/src/*",)
+    rule_runner.set_options(
+        [
+            f"--source-root-patterns={repr(source_root_patterns)}",
+        ]
+    )
+    return rule_runner
 
 
 def test_build_first_party_mapping(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/BUILD": "helm_chart(name='foo')",
-            "src/Chart.yaml": dedent(
+            "src/foo/BUILD": "helm_chart(name='foo')",
+            "src/foo/Chart.yaml": dedent(
                 """\
                 apiVersion: v2
                 name: chart-name
@@ -52,7 +59,7 @@ def test_build_first_party_mapping(rule_runner: RuleRunner) -> None:
         }
     )
 
-    tgt = rule_runner.get_target(Address("src", target_name="foo"))
+    tgt = rule_runner.get_target(Address("src/foo", target_name="foo"))
     mapping = rule_runner.request(FirstPartyHelmChartMapping, [])
     assert mapping["chart-name"] == tgt.address
 
@@ -135,13 +142,6 @@ def test_infer_chart_dependencies(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options(
-        [
-            f"--source-root-patterns={repr(source_root_patterns)}",
-        ]
-    )
-
     tgt = rule_runner.get_target(Address("src/foo", target_name="foo"))
     inferred_deps = rule_runner.request(
         InferredDependencies,
@@ -184,9 +184,6 @@ def test_disambiguate_chart_dependencies(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
-
     tgt = rule_runner.get_target(Address("src/foo", target_name="foo"))
     inferred_deps = rule_runner.request(
         InferredDependencies,
@@ -214,9 +211,6 @@ def test_raise_error_when_unknown_dependency_is_found(rule_runner: RuleRunner) -
             ),
         }
     )
-
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
 
     tgt = rule_runner.get_target(Address("src/foo", target_name="foo"))
 

--- a/src/python/pants/backend/helm/dependency_inference/unittest_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/unittest_test.py
@@ -92,9 +92,6 @@ def test_injects_parent_chart(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_roots = ["src/*"]
-    rule_runner.set_options([f"--source-roots-patterns={repr(source_roots)}"])
-
     chart1_tgt = rule_runner.get_target(Address("src/chart1", target_name="chart1"))
     chart1_unittest_tgt = rule_runner.get_target(Address("src/chart1/tests", target_name="tests"))
 

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -19,6 +19,7 @@ from pants.backend.helm.target_types import (
 from pants.backend.helm.testutil import HELM_CHART_FILE
 from pants.backend.helm.util_rules.tool import HelmBinary
 from pants.core.goals.deploy import DeployProcess
+from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
@@ -30,6 +31,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmArtifactTarget, HelmChartTarget, HelmDeploymentTarget, DockerImageTarget],
         rules=[
             *helm_deploy_rules(),
+            *stripped_source_files.rules(),
             QueryRule(HelmBinary, ()),
             QueryRule(DeployProcess, (DeployHelmDeploymentFieldSet,)),
         ],

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -108,6 +108,17 @@ def test_run_helm_deploy(rule_runner: RuleRunner) -> None:
 
     helm = rule_runner.request(HelmBinary, [])
 
+    expected_value_files_order = [
+        "common.yaml",
+        "bar.yaml",
+        "foo.yaml",
+        "bar-override.yaml",
+        "subdir/bar.yaml",
+        "subdir/foo.yaml",
+        "subdir/foo-override.yaml",
+        "subdir/last.yaml",
+    ]
+
     assert deploy_process.process
     assert deploy_process.process.process.argv == (
         helm.path,
@@ -124,7 +135,7 @@ def test_run_helm_deploy(rule_runner: RuleRunner) -> None:
         "--post-renderer",
         "./post_renderer_wrapper.sh",
         "--values",
-        "common.yaml,bar.yaml,foo.yaml,bar-override.yaml,subdir/bar.yaml,subdir/foo.yaml,subdir/foo-override.yaml,subdir/last.yaml",
+        ",".join([f"__values/{filename}" for filename in expected_value_files_order]),
         "--set",
         "key=foo",
         "--set",

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -96,14 +96,12 @@ def test_run_helm_deploy(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_root_patterns = ["/src/*"]
     deploy_args = ["--kubeconfig", "./kubeconfig"]
     deploy_process = _run_deployment(
         rule_runner,
         "src/deployment",
         "foo",
         args=[
-            f"--source-root-patterns={repr(source_root_patterns)}",
             f"--helm-args={repr(deploy_args)}",
         ],
     )
@@ -137,7 +135,9 @@ def test_run_helm_deploy(rule_runner: RuleRunner) -> None:
         "--post-renderer",
         "./post_renderer_wrapper.sh",
         "--values",
-        ",".join([f"__values/{filename}" for filename in expected_value_files_order]),
+        ",".join(
+            [f"__values/src/deployment/{filename}" for filename in expected_value_files_order]
+        ),
         "--set",
         "key=foo",
         "--set",

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -19,7 +19,7 @@ from pants.backend.helm.target_types import (
 from pants.backend.helm.testutil import HELM_CHART_FILE
 from pants.backend.helm.util_rules.tool import HelmBinary
 from pants.core.goals.deploy import DeployProcess
-from pants.core.util_rules import stripped_source_files
+from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
 from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmArtifactTarget, HelmChartTarget, HelmDeploymentTarget, DockerImageTarget],
         rules=[
             *helm_deploy_rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             QueryRule(HelmBinary, ()),
             QueryRule(DeployProcess, (DeployHelmDeploymentFieldSet,)),
         ],

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -46,7 +46,7 @@ async def run_helm_lint(request: HelmLintRequest, helm_subsystem: HelmSubsystem)
     logger.debug(f"Linting {pluralize(len(charts), 'chart')}...")
 
     def create_process(chart: HelmChart, field_set: HelmLintFieldSet) -> HelmProcess:
-        argv = ["lint", chart.path]
+        argv = ["lint", chart.name]
 
         strict: bool = field_set.lint_strict.value or helm_subsystem.lint_strict
         if strict:
@@ -54,7 +54,7 @@ async def run_helm_lint(request: HelmLintRequest, helm_subsystem: HelmSubsystem)
 
         return HelmProcess(
             argv,
-            input_digest=chart.snapshot.digest,
+            extra_immutable_input_digests=chart.immutable_input_digests,
             description=f"Linting chart: {chart.info.name}",
         )
 

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Sequence
+from typing import Iterable
 
 import pytest
 
@@ -52,14 +52,11 @@ def run_helm_lint(
     rule_runner: RuleRunner,
     targets: list[Target],
     *,
-    source_root_patterns: Sequence[str] = ("/",),
     extra_options: Iterable[str] = [],
 ) -> tuple[LintResult, ...]:
     field_sets = [HelmLintFieldSet.create(tgt) for tgt in targets]
 
-    opts = [f"--source-root-patterns={repr(source_root_patterns)}"]
-    opts.extend(extra_options)
-    rule_runner.set_options(opts)
+    rule_runner.set_options(extra_options)
 
     lint_results = rule_runner.request(LintResults, [HelmLintRequest(field_sets)])
     return lint_results.results
@@ -172,13 +169,13 @@ def test_one_lint_result_per_chart(rule_runner: RuleRunner) -> None:
             "src/chart2/templates/service.yaml": K8S_SERVICE_TEMPLATE,
         }
     )
-    source_root_patterns = ("src/*",)
 
     chart1_target = rule_runner.get_target(Address("src/chart1", target_name="chart1"))
     chart2_target = rule_runner.get_target(Address("src/chart2", target_name="chart2"))
 
     lint_results = run_helm_lint(
-        rule_runner, [chart1_target, chart2_target], source_root_patterns=source_root_patterns
+        rule_runner,
+        [chart1_target, chart2_target],
     )
     assert len(lint_results) == 2
     assert lint_results[0].exit_code == 0
@@ -198,10 +195,9 @@ def test_skip_lint(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_root_patterns = ("src/*",)
-
     chart_target = rule_runner.get_target(Address("src/chart", target_name="chart"))
     lint_results = run_helm_lint(
-        rule_runner, [chart_target], source_root_patterns=source_root_patterns
+        rule_runner,
+        [chart_target],
     )
     assert len(lint_results) == 0

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -22,7 +22,7 @@ from pants.backend.helm.testutil import (
 from pants.backend.helm.util_rules import chart, sources
 from pants.build_graph.address import Address
 from pants.core.goals.lint import LintResult, LintResults
-from pants.core.util_rules import config_files, stripped_source_files
+from pants.core.util_rules import config_files, source_files
 from pants.engine.rules import QueryRule, SubsystemRule
 from pants.engine.target import Target
 from pants.source.source_root import rules as source_root_rules
@@ -37,7 +37,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *chart.rules(),
             *helm_lint_rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             *source_root_rules(),
             *sources.rules(),
             *target_types_rules(),

--- a/src/python/pants/backend/helm/goals/package.py
+++ b/src/python/pants/backend/helm/goals/package.py
@@ -12,15 +12,7 @@ from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
 from pants.backend.helm.util_rules.chart_metadata import HelmChartMetadata
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
-from pants.engine.fs import (
-    AddPrefix,
-    CreateDigest,
-    Digest,
-    Directory,
-    MergeDigests,
-    RemovePrefix,
-    Snapshot,
-)
+from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, RemovePrefix, Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -56,14 +48,14 @@ async def run_helm_package(field_set: HelmPackageFieldSet) -> BuiltPackage:
         Get(Digest, CreateDigest([Directory(result_dir)])),
     )
 
-    input_digest = await Get(Digest, MergeDigests([chart.snapshot.digest, result_digest]))
     process_output_file = os.path.join(result_dir, f"{chart.info.artifact_name}.tgz")
 
     process_result = await Get(
         ProcessResult,
         HelmProcess(
-            argv=["package", chart.path, "-d", result_dir],
-            input_digest=input_digest,
+            argv=["package", chart.name, "-d", result_dir],
+            input_digest=result_digest,
+            extra_immutable_input_digests=chart.immutable_input_digests,
             output_files=(process_output_file,),
             description=f"Packaging Helm chart: {field_set.address.spec_path}",
         ),

--- a/src/python/pants/backend/helm/goals/package_test.py
+++ b/src/python/pants/backend/helm/goals/package_test.py
@@ -48,8 +48,6 @@ def rule_runner() -> RuleRunner:
 
 
 def _assert_build_package(rule_runner: RuleRunner, *, chart_name: str, chart_version: str) -> None:
-    rule_runner.set_options(["--source-root-patterns=['src/*']"])
-
     target = rule_runner.get_target(Address(f"src/{chart_name}", target_name=chart_name))
     field_set = HelmPackageFieldSet.create(target)
 

--- a/src/python/pants/backend/helm/goals/package_test.py
+++ b/src/python/pants/backend/helm/goals/package_test.py
@@ -21,7 +21,7 @@ from pants.backend.helm.testutil import (
 from pants.backend.helm.util_rules import chart, sources, tool
 from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage
-from pants.core.util_rules import config_files, external_tool, stripped_source_files
+from pants.core.util_rules import config_files, external_tool, source_files
 from pants.engine.rules import QueryRule, SubsystemRule
 from pants.source.source_root import rules as source_root_rules
 from pants.testutil.rule_runner import RuleRunner
@@ -37,7 +37,7 @@ def rule_runner() -> RuleRunner:
             *tool.rules(),
             *chart.rules(),
             *package.rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             *source_root_rules(),
             *sources.rules(),
             *target_types_rules(),

--- a/src/python/pants/backend/helm/resolve/fetch.py
+++ b/src/python/pants/backend/helm/resolve/fetch.py
@@ -78,6 +78,20 @@ class FetchHelmArfifactsRequest(EngineAwareParameter):
         return f"{self.description_of_origin}: fetch {pluralize(len(self.field_sets), 'artifact')}"
 
 
+@dataclass(frozen=True)
+class _StripHelmArtifactPrefixRequest:
+    artifact: ResolvedHelmArtifact
+    digest: Digest
+
+
+@rule
+async def _strip_prefix_from_fetched_artifact(request: _StripHelmArtifactPrefixRequest) -> Digest:
+    subset_digest = await Get(
+        Digest, DigestSubset(request.digest, PathGlobs([os.path.join(request.artifact.name, "**")]))
+    )
+    return await Get(Digest, RemovePrefix(subset_digest, request.artifact.name))
+
+
 @rule(desc="Fetch third party Helm Chart artifacts", level=LogLevel.DEBUG)
 async def fetch_helm_artifacts(request: FetchHelmArfifactsRequest) -> FetchedHelmArtifacts:
     download_prefix = "__downloads"
@@ -122,7 +136,7 @@ async def fetch_helm_artifacts(request: FetchHelmArfifactsRequest) -> FetchedHel
 
     # Avoid capturing the tarball that has been downloaded by Helm during the pull.
     artifact_snapshots = await MultiGet(
-        Get(Snapshot, DigestSubset(digest, PathGlobs([os.path.join(artifact.name, "**")])))
+        Get(Snapshot, _StripHelmArtifactPrefixRequest(artifact, digest))
         for artifact, digest in zip(artifacts, stripped_artifact_digests)
     )
 

--- a/src/python/pants/backend/helm/resolve/fetch_test.py
+++ b/src/python/pants/backend/helm/resolve/fetch_test.py
@@ -78,4 +78,4 @@ def test_download_artifacts(rule_runner: RuleRunner) -> None:
     assert len(fetched_artifacts) == len(expected_artifacts)
     for fetched, expected in zip(fetched_artifacts, expected_artifacts):
         assert fetched.artifact == expected
-        assert f"{expected.name}/Chart.yaml" in fetched.snapshot.files
+        assert "Chart.yaml" in fetched.snapshot.files

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -21,7 +21,7 @@ from pants.backend.helm.target_types import (
 )
 from pants.backend.helm.util_rules import tool
 from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
-from pants.backend.helm.util_rules.sources import HelmChartSourceRootRequest
+from pants.backend.helm.util_rules.sources import HelmChartSourceRoot, HelmChartSourceRootRequest
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.core.goals.test import (
     TestDebugAdapterRequest,
@@ -44,7 +44,6 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionRule
-from pants.source.source_root import SourceRoot
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -90,7 +89,9 @@ async def run_helm_unittest(
     chart_target = chart_targets[0]
     chart, chart_root, test_files = await MultiGet(
         Get(HelmChart, HelmChartRequest, HelmChartRequest.from_target(chart_target)),
-        Get(SourceRoot, HelmChartSourceRootRequest(chart_target[HelmChartMetaSourceField])),
+        Get(
+            HelmChartSourceRoot, HelmChartSourceRootRequest(chart_target[HelmChartMetaSourceField])
+        ),
         Get(
             SourceFiles,
             SourceFilesRequest(

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -21,7 +21,7 @@ from pants.backend.helm.target_types import (
 )
 from pants.backend.helm.util_rules import tool
 from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
-from pants.backend.helm.util_rules.sources import HelmChartSourceRoot, HelmChartSourceRootRequest
+from pants.backend.helm.util_rules.sources import HelmChartRoot, HelmChartRootRequest
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.core.goals.test import (
     TestDebugAdapterRequest,
@@ -89,9 +89,7 @@ async def run_helm_unittest(
     chart_target = chart_targets[0]
     chart, chart_root, test_files = await MultiGet(
         Get(HelmChart, HelmChartRequest, HelmChartRequest.from_target(chart_target)),
-        Get(
-            HelmChartSourceRoot, HelmChartSourceRootRequest(chart_target[HelmChartMetaSourceField])
-        ),
+        Get(HelmChartRoot, HelmChartRootRequest(chart_target[HelmChartMetaSourceField])),
         Get(
             SourceFiles,
             SourceFilesRequest(

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -19,7 +19,7 @@ from pants.backend.helm.target_types import (
     HelmUnitTestTimeoutField,
 )
 from pants.backend.helm.util_rules import tool
-from pants.backend.helm.util_rules.chart import AddDigestToChart, HelmChart, HelmChartRequest
+from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.core.goals.test import (
     TestDebugAdapterRequest,
@@ -32,7 +32,7 @@ from pants.core.target_types import ResourceSourceField
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.addresses import Address
-from pants.engine.fs import RemovePrefix, Snapshot
+from pants.engine.fs import AddPrefix, Digest, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.process import FallibleProcessResult, ProcessCacheScope
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -104,10 +104,14 @@ async def run_helm_unittest(
         ),
     )
 
-    chart_with_tests = await Get(HelmChart, AddDigestToChart(chart, source_files.snapshot.digest))
-
     reports_dir = "__reports_dir"
     reports_file = os.path.join(reports_dir, f"{field_set.address.path_safe_spec}.xml")
+
+    merged_digests = await Get(
+        Digest,
+        MergeDigests([chart.snapshot.digest, source_files.snapshot.digest]),
+    )
+    input_digest = await Get(Digest, AddPrefix(merged_digests, chart.name))
 
     # Cache test runs only if they are successful, or not at all if `--test-force`.
     cache_scope = (
@@ -130,7 +134,7 @@ async def run_helm_unittest(
                 chart.name,
             ],
             description=f"Running Helm unittest suite {field_set.address}",
-            extra_immutable_input_digests=chart_with_tests.immutable_input_digests,
+            input_digest=input_digest,
             cache_scope=cache_scope,
             timeout_seconds=field_set.timeout.calculate_from_global_options(test_subsystem),
             output_directories=(reports_dir,),

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -17,7 +17,7 @@ from pants.backend.helm.testutil import (
 )
 from pants.backend.helm.util_rules import chart
 from pants.core.goals.test import TestResult
-from pants.core.util_rules import external_tool, stripped_source_files
+from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Address
 from pants.engine.rules import QueryRule
 from pants.source.source_root import rules as source_root_rules
@@ -32,7 +32,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *chart.rules(),
             *unittest_rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             *source_root_rules(),
             *target_types_rules(),
             QueryRule(TestResult, (HelmUnitTestFieldSet,)),

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -225,20 +225,6 @@ async def get_helm_chart(request: HelmChartRequest, subsystem: HelmSubsystem) ->
     return HelmChart(address=request.field_set.address, info=chart_info, snapshot=chart_snapshot)
 
 
-@dataclass(frozen=True)
-class AddDigestToChart:
-    chart: HelmChart
-    digest: Digest
-
-
-@rule
-async def add_digest_to_chart(request: AddDigestToChart) -> HelmChart:
-    merged_snapshot = await Get(
-        Snapshot, MergeDigests([request.chart.snapshot.digest, request.digest])
-    )
-    return dataclasses.replace(request.chart, snapshot=merged_snapshot)
-
-
 class MissingHelmDeploymentChartError(ValueError):
     def __init__(self, address: Address) -> None:
         super().__init__(

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -43,8 +43,9 @@ from pants.engine.fs import (
     PathGlobs,
     Snapshot,
 )
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import DependenciesRequest, ExplicitlyProvidedDependencies, Target, Targets
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import pluralize, softwrap
@@ -65,8 +66,12 @@ class HelmChart:
     artifact: ResolvedHelmArtifact | None = None
 
     @property
-    def path(self) -> str:
+    def name(self) -> str:
         return self.info.name
+
+    @property
+    def immutable_input_digests(self) -> FrozenDict[str, Digest]:
+        return FrozenDict({self.name: self.snapshot.digest})
 
 
 @dataclass(frozen=True)
@@ -89,8 +94,7 @@ async def create_chart_from_artifact(fetched_artifact: FetchedHelmArtifact) -> H
         HelmChartMetadata,
         ParseHelmChartMetadataDigest(
             fetched_artifact.snapshot.digest,
-            description_of_origin=fetched_artifact.address.spec,
-            prefix=fetched_artifact.artifact.name,
+            description_of_origin=f"the `helm_artifact` {fetched_artifact.address.spec}",
         ),
     )
     return HelmChart(
@@ -99,6 +103,15 @@ async def create_chart_from_artifact(fetched_artifact: FetchedHelmArtifact) -> H
         fetched_artifact.snapshot,
         artifact=fetched_artifact.artifact,
     )
+
+
+@rule_helper
+async def _merge_subchart_digests(charts: Iterable[HelmChart]) -> Digest:
+    prefixed_chart_digests = await MultiGet(
+        Get(Digest, AddPrefix(chart.snapshot.digest, chart.name)) for chart in charts
+    )
+    merged_digests = await Get(Digest, MergeDigests(prefixed_chart_digests))
+    return await Get(Digest, AddPrefix(merged_digests, "charts"))
 
 
 @rule(desc="Collect all source code and subcharts of a Helm Chart", level=LogLevel.DEBUG)
@@ -147,10 +160,7 @@ async def get_helm_chart(request: HelmChartRequest, subsystem: HelmSubsystem) ->
             )
         )
 
-        merged_subcharts = await Get(
-            Digest, MergeDigests([chart.snapshot.digest for chart in subcharts])
-        )
-        subcharts_digest = await Get(Digest, AddPrefix(merged_subcharts, "charts"))
+        subcharts_digest = await _merge_subchart_digests(subcharts)
 
         # Update subchart dependencies in the metadata and re-render it.
         remotes = subsystem.remotes()
@@ -208,12 +218,25 @@ async def get_helm_chart(request: HelmChartRequest, subsystem: HelmSubsystem) ->
     )
 
     # Merge all digests that conform chart's content.
-    content_digest = await Get(
-        Digest, MergeDigests([metadata_digest, sources_without_metadata, subcharts_digest])
+    chart_snapshot = await Get(
+        Snapshot, MergeDigests([metadata_digest, sources_without_metadata, subcharts_digest])
     )
 
-    chart_snapshot = await Get(Snapshot, AddPrefix(content_digest, chart_info.name))
     return HelmChart(address=request.field_set.address, info=chart_info, snapshot=chart_snapshot)
+
+
+@dataclass(frozen=True)
+class AddDigestToChart:
+    chart: HelmChart
+    digest: Digest
+
+
+@rule
+async def add_digest_to_chart(request: AddDigestToChart) -> HelmChart:
+    merged_snapshot = await Get(
+        Snapshot, MergeDigests([request.chart.snapshot.digest, request.digest])
+    )
+    return dataclasses.replace(request.chart, snapshot=merged_snapshot)
 
 
 class MissingHelmDeploymentChartError(ValueError):

--- a/src/python/pants/backend/helm/util_rules/chart_metadata.py
+++ b/src/python/pants/backend/helm/util_rules/chart_metadata.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import yaml
 
 from pants.backend.helm.target_types import HelmChartMetaSourceField
-from pants.backend.helm.util_rules.sources import HelmChartSourceRoot, HelmChartSourceRootRequest
+from pants.backend.helm.util_rules.sources import HelmChartRoot, HelmChartRootRequest
 from pants.backend.helm.utils.yaml import snake_case_attr_dict
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.engine.engine_aware import EngineAwareParameter
@@ -256,7 +256,7 @@ async def parse_chart_metadata_from_digest(
 @rule
 async def parse_chart_metadata_from_field(field: HelmChartMetaSourceField) -> HelmChartMetadata:
     chart_root, source_files = await MultiGet(
-        Get(HelmChartSourceRoot, HelmChartSourceRootRequest(field)),
+        Get(HelmChartRoot, HelmChartRootRequest(field)),
         Get(
             HydratedSources,
             HydrateSourcesRequest(

--- a/src/python/pants/backend/helm/util_rules/chart_metadata_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_metadata_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import pytest
@@ -74,21 +73,6 @@ def test_parse_metadata_digest(rule_runner: RuleRunner, chart_contents: str) -> 
 
     assert_metadata(non_prefixed_metadata, chart_dict)
 
-    prefix = "foo"
-    prefixed_digest = rule_runner.request(
-        Digest, [CreateDigest([FileContent(os.path.join(prefix, "Chart.yml"), chart_bytes)])]
-    )
-    prefixed_metadata = rule_runner.request(
-        HelmChartMetadata,
-        [
-            ParseHelmChartMetadataDigest(
-                prefixed_digest, description_of_origin="test_parse_metadata_digest", prefix="*"
-            )
-        ],
-    )
-
-    assert_metadata(prefixed_metadata, chart_dict)
-
 
 def test_raises_error_if_more_than_one_metadata_file(rule_runner: RuleRunner) -> None:
     digest = rule_runner.request(
@@ -98,9 +82,6 @@ def test_raises_error_if_more_than_one_metadata_file(rule_runner: RuleRunner) ->
                 [
                     FileContent("Chart.yaml", HELM_CHART_FILE_V1_FULL.encode()),
                     FileContent("Chart.yml", HELM_CHART_FILE_V2_FULL.encode()),
-                    FileContent(
-                        os.path.join("foo", "Chart.yaml"), HELM_CHART_FILE_V1_FULL.encode()
-                    ),
                 ]
             )
         ],
@@ -113,7 +94,6 @@ def test_raises_error_if_more_than_one_metadata_file(rule_runner: RuleRunner) ->
                 ParseHelmChartMetadataDigest(
                     digest,
                     description_of_origin="test_raises_error_if_more_than_one_metadata_file",
-                    prefix="**",
                 )
             ],
         )

--- a/src/python/pants/backend/helm/util_rules/chart_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_test.py
@@ -277,33 +277,6 @@ def test_chart_metadata_is_updated_with_explicit_dependencies(rule_runner: RuleR
     assert new_metadata == expected_metadata
 
 
-def test_wrong_source_roots_results_in_error(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "src/chart/BUILD": "helm_chart()",
-            "src/chart/Chart.yaml": dedent(
-                """\
-                apiVersion: v2
-                name: chart
-                version: 0.1.0
-                """
-            ),
-            "src/chart1/values.yaml": HELM_VALUES_FILE,
-        }
-    )
-
-    source_root_patterns = ("/src",)
-    rule_runner.set_options(
-        [
-            f"--source-root-patterns={repr(source_root_patterns)}",
-        ]
-    )
-
-    target = rule_runner.get_target(Address("src/chart", target_name="chart"))
-    with pytest.raises(ExecutionError):
-        rule_runner.request(HelmChart, [HelmChartRequest.from_target(target)])
-
-
 def test_obtain_chart_from_deployment(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/helm/util_rules/chart_test.py
+++ b/src/python/pants/backend/helm/util_rules/chart_test.py
@@ -117,9 +117,6 @@ def test_gathers_local_subchart_sources_using_explicit_dependency(rule_runner: R
         }
     )
 
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
-
     target = rule_runner.get_target(Address("src/chart2", target_name="chart2"))
     helm_chart = rule_runner.request(HelmChart, [HelmChartRequest.from_target(target)])
 
@@ -168,13 +165,6 @@ def test_gathers_all_subchart_sources_inferring_dependencies(rule_runner: RuleRu
                 """
             ),
         }
-    )
-
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options(
-        [
-            f"--source-root-patterns={repr(source_root_patterns)}",
-        ]
     )
 
     expected_metadata = HelmChartMetadata(
@@ -239,13 +229,6 @@ def test_chart_metadata_is_updated_with_explicit_dependencies(rule_runner: RuleR
         }
     )
 
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options(
-        [
-            f"--source-root-patterns={repr(source_root_patterns)}",
-        ]
-    )
-
     expected_metadata = HelmChartMetadata(
         name="chart2",
         api_version="v2",
@@ -302,9 +285,6 @@ def test_obtain_chart_from_deployment(rule_runner: RuleRunner) -> None:
         }
     )
 
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
-
     first_party_target = rule_runner.get_target(Address("src/deploy", target_name="first_party"))
     third_party_target = rule_runner.get_target(Address("src/deploy", target_name="3rd_party"))
 
@@ -348,9 +328,6 @@ def test_fail_when_more_than_one_chart_is_found_for_a_deployment(rule_runner: Ru
             ),
         }
     )
-
-    source_root_patterns = ("/src/*",)
-    rule_runner.set_options([f"--source-root-patterns={repr(source_root_patterns)}"])
 
     target = rule_runner.get_target(Address("src/quxx"))
     field_set = HelmDeploymentFieldSet.create(target)

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -28,7 +28,7 @@ from pants.backend.helm.util_rules.renderer import (
 )
 from pants.backend.helm.util_rules.renderer_test import _read_file_from_digest
 from pants.backend.helm.util_rules.tool import HelmProcess
-from pants.core.util_rules import stripped_source_files
+from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
 from pants.engine.process import ProcessResult
 from pants.engine.rules import QueryRule
@@ -41,7 +41,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, HelmDeploymentTarget, DockerImageTarget],
         rules=[
             *infer_deployment.rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             *post_renderer.rules(),
             QueryRule(HelmPostRenderer, (HelmDeploymentPostRendererRequest,)),
             QueryRule(RenderedHelmFiles, (HelmDeploymentRequest,)),

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -28,6 +28,7 @@ from pants.backend.helm.util_rules.renderer import (
 )
 from pants.backend.helm.util_rules.renderer_test import _read_file_from_digest
 from pants.backend.helm.util_rules.tool import HelmProcess
+from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address
 from pants.engine.process import ProcessResult
 from pants.engine.rules import QueryRule
@@ -40,6 +41,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, HelmDeploymentTarget, DockerImageTarget],
         rules=[
             *infer_deployment.rules(),
+            *stripped_source_files.rules(),
             *post_renderer.rules(),
             QueryRule(HelmPostRenderer, (HelmDeploymentPostRendererRequest,)),
             QueryRule(RenderedHelmFiles, (HelmDeploymentRequest,)),

--- a/src/python/pants/backend/helm/util_rules/renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/renderer_test.py
@@ -113,7 +113,7 @@ def test_sort_deployment_files_alphabetically(rule_runner: RuleRunner) -> None:
     )
 
     render_process = rule_runner.request(InteractiveProcess, [render_request])
-    assert "a.yaml,b.yaml" in render_process.process.argv
+    assert "__values/a.yaml,__values/b.yaml" in render_process.process.argv
 
 
 def test_sort_deployment_files_as_given(rule_runner: RuleRunner) -> None:
@@ -136,7 +136,7 @@ def test_sort_deployment_files_as_given(rule_runner: RuleRunner) -> None:
     )
 
     render_process = rule_runner.request(InteractiveProcess, [render_request])
-    assert "b.yaml,a.yaml" in render_process.process.argv
+    assert "__values/b.yaml,__values/a.yaml" in render_process.process.argv
 
 
 def test_renders_files(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/renderer_test.py
@@ -20,7 +20,7 @@ from pants.backend.helm.util_rules.renderer import (
     HelmDeploymentRequest,
     RenderedHelmFiles,
 )
-from pants.core.util_rules import external_tool, stripped_source_files
+from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents, DigestSubset, PathGlobs
 from pants.engine.internals.native_engine import Digest
@@ -35,7 +35,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, HelmDeploymentTarget],
         rules=[
             *external_tool.rules(),
-            *stripped_source_files.rules(),
+            *source_files.rules(),
             *renderer.rules(),
             QueryRule(InteractiveProcess, (HelmDeploymentRequest,)),
             QueryRule(RenderedHelmFiles, (HelmDeploymentRequest,)),
@@ -113,7 +113,10 @@ def test_sort_deployment_files_alphabetically(rule_runner: RuleRunner) -> None:
     )
 
     render_process = rule_runner.request(InteractiveProcess, [render_request])
-    assert "__values/a.yaml,__values/b.yaml" in render_process.process.argv
+    assert (
+        "__values/src/deployment/a.yaml,__values/src/deployment/b.yaml"
+        in render_process.process.argv
+    )
 
 
 def test_sort_deployment_files_as_given(rule_runner: RuleRunner) -> None:
@@ -136,7 +139,10 @@ def test_sort_deployment_files_as_given(rule_runner: RuleRunner) -> None:
     )
 
     render_process = rule_runner.request(InteractiveProcess, [render_request])
-    assert "__values/b.yaml,__values/a.yaml" in render_process.process.argv
+    assert (
+        "__values/src/deployment/b.yaml,__values/src/deployment/a.yaml"
+        in render_process.process.argv
+    )
 
 
 def test_renders_files(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/sources.py
+++ b/src/python/pants/backend/helm/util_rules/sources.py
@@ -29,7 +29,7 @@ from pants.engine.target import (
 
 
 @dataclass(frozen=True)
-class HelmChartSourceRootRequest(EngineAwareParameter):
+class HelmChartRootRequest(EngineAwareParameter):
     source: HelmChartMetaSourceField
 
     def debug_hint(self) -> str | None:
@@ -37,12 +37,12 @@ class HelmChartSourceRootRequest(EngineAwareParameter):
 
 
 @dataclass(frozen=True)
-class HelmChartSourceRoot:
+class HelmChartRoot:
     path: str
 
 
 @rule(desc="Detect Helm chart source root")
-async def find_chart_source_root(request: HelmChartSourceRootRequest) -> HelmChartSourceRoot:
+async def find_chart_source_root(request: HelmChartRootRequest) -> HelmChartRoot:
     source = await Get(
         HydratedSources,
         HydrateSourcesRequest(
@@ -51,7 +51,7 @@ async def find_chart_source_root(request: HelmChartSourceRootRequest) -> HelmCha
     )
     assert len(source.snapshot.files) == 1
 
-    return HelmChartSourceRoot(os.path.dirname(source.snapshot.files[0]))
+    return HelmChartRoot(os.path.dirname(source.snapshot.files[0]))
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,7 @@ class HelmChartSourceFiles:
 
 @rule_helper
 async def _strip_chart_source_root(
-    source_files: SourceFiles, chart_root: HelmChartSourceRoot
+    source_files: SourceFiles, chart_root: HelmChartRoot
 ) -> Snapshot:
     if not source_files.snapshot.files:
         return source_files.snapshot
@@ -155,7 +155,7 @@ async def _strip_chart_source_root(
 @rule
 async def get_helm_source_files(request: HelmChartSourceFilesRequest) -> HelmChartSourceFiles:
     chart_root, dependencies = await MultiGet(
-        Get(HelmChartSourceRoot, HelmChartSourceRootRequest(request.field_set.chart)),
+        Get(HelmChartRoot, HelmChartRootRequest(request.field_set.chart)),
         Get(Targets, DependenciesRequest(request.field_set.dependencies)),
     )
 

--- a/src/python/pants/backend/helm/util_rules/sources.py
+++ b/src/python/pants/backend/helm/util_rules/sources.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 
 from pants.backend.helm.target_types import (
@@ -11,16 +12,46 @@ from pants.backend.helm.target_types import (
     HelmChartSourcesField,
 )
 from pants.core.target_types import FileSourceField, ResourceSourceField
-from pants.core.util_rules import stripped_source_files
-from pants.core.util_rules.source_files import SourceFilesRequest
-from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.fs import MergeDigests, Snapshot
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import DependenciesRequest, SourcesField, Target, Targets
+from pants.core.util_rules import source_files
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
+from pants.engine.internals.native_engine import RemovePrefix
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
+from pants.engine.target import (
+    DependenciesRequest,
+    HydratedSources,
+    HydrateSourcesRequest,
+    SourcesField,
+    Target,
+    Targets,
+)
+from pants.source.source_root import SourceRoot
 
 
 @dataclass(frozen=True)
-class HelmChartSourceFilesRequest:
+class HelmChartSourceRootRequest(EngineAwareParameter):
+    source: HelmChartMetaSourceField
+
+    def debug_hint(self) -> str | None:
+        return self.source.address.spec
+
+
+@rule(desc="Detect Helm chart source root")
+async def find_chart_source_root(request: HelmChartSourceRootRequest) -> SourceRoot:
+    source = await Get(
+        HydratedSources,
+        HydrateSourcesRequest(
+            request.source, for_sources_types=[HelmChartMetaSourceField], enable_codegen=True
+        ),
+    )
+    assert len(source.snapshot.files) == 1
+
+    return SourceRoot(os.path.dirname(source.snapshot.files[0]))
+
+
+@dataclass(frozen=True)
+class HelmChartSourceFilesRequest(EngineAwareParameter):
     field_set: HelmChartFieldSet
     include_resources: bool
     include_files: bool
@@ -76,18 +107,55 @@ class HelmChartSourceFilesRequest:
             types.append(FileSourceField)
         return tuple(types)
 
+    def debug_hint(self) -> str | None:
+        return self.field_set.address.spec
+
 
 @dataclass(frozen=True)
 class HelmChartSourceFiles:
     snapshot: Snapshot
+    unrooted_files: tuple[str, ...]
+
+
+@rule_helper
+async def _strip_chart_source_root(source_files: SourceFiles, source_root: SourceRoot) -> Snapshot:
+    if not source_files.snapshot.files:
+        return source_files.snapshot
+
+    if source_files.unrooted_files:
+        rooted_files = set(source_files.snapshot.files) - set(source_files.unrooted_files)
+        rooted_files_snapshot = await Get(
+            Snapshot, DigestSubset(source_files.snapshot.digest, PathGlobs(rooted_files))
+        )
+    else:
+        rooted_files_snapshot = source_files.snapshot
+
+    resulting_snapshot = await Get(
+        Snapshot, RemovePrefix(rooted_files_snapshot.digest, source_root.path)
+    )
+    if source_files.unrooted_files:
+        # Add unrooted files back in
+        unrooted_digest = await Get(
+            Digest,
+            DigestSubset(source_files.snapshot.digest, PathGlobs(source_files.unrooted_files)),
+        )
+        resulting_snapshot = await Get(
+            Snapshot, MergeDigests([resulting_snapshot.digest, unrooted_digest])
+        )
+
+    return resulting_snapshot
 
 
 @rule
 async def get_helm_source_files(request: HelmChartSourceFilesRequest) -> HelmChartSourceFiles:
-    dependencies = await Get(Targets, DependenciesRequest(request.field_set.dependencies))
+    source_root, dependencies = await MultiGet(
+        Get(SourceRoot, HelmChartSourceRootRequest(request.field_set.chart)),
+        Get(Targets, DependenciesRequest(request.field_set.dependencies)),
+    )
+
     source_files, original_sources = await MultiGet(
         Get(
-            StrippedSourceFiles,
+            SourceFiles,
             SourceFilesRequest(
                 sources_fields=[
                     *request.sources_fields,
@@ -102,15 +170,22 @@ async def get_helm_source_files(request: HelmChartSourceFilesRequest) -> HelmCha
             ),
         ),
         Get(
-            StrippedSourceFiles,
+            SourceFiles,
             SourceFilesRequest([request.field_set.sources], enable_codegen=False),
         ),
     )
+
+    stripped_source_files = await _strip_chart_source_root(source_files, source_root)
+    stripped_original_sources = await _strip_chart_source_root(original_sources, source_root)
+
     all_files_snapshot = await Get(
-        Snapshot, MergeDigests([source_files.snapshot.digest, original_sources.snapshot.digest])
+        Snapshot, MergeDigests([stripped_source_files.digest, stripped_original_sources.digest])
     )
-    return HelmChartSourceFiles(snapshot=all_files_snapshot)
+    return HelmChartSourceFiles(
+        snapshot=all_files_snapshot,
+        unrooted_files=(*source_files.unrooted_files, *original_sources.unrooted_files),
+    )
 
 
 def rules():
-    return [*collect_rules(), *stripped_source_files.rules()]
+    return [*collect_rules(), *source_files.rules()]

--- a/src/python/pants/backend/helm/util_rules/sources_test.py
+++ b/src/python/pants/backend/helm/util_rules/sources_test.py
@@ -20,13 +20,13 @@ from pants.backend.helm.util_rules import sources
 from pants.backend.helm.util_rules.sources import (
     HelmChartSourceFiles,
     HelmChartSourceFilesRequest,
+    HelmChartSourceRoot,
     HelmChartSourceRootRequest,
 )
 from pants.build_graph.address import Address
 from pants.core.target_types import FilesGeneratorTarget, ResourcesGeneratorTarget
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
-from pants.source.source_root import SourceRoot
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -36,7 +36,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, ResourcesGeneratorTarget, FilesGeneratorTarget],
         rules=[
             *sources.rules(),
-            QueryRule(SourceRoot, (HelmChartSourceRootRequest,)),
+            QueryRule(HelmChartSourceRoot, (HelmChartSourceRootRequest,)),
             QueryRule(HelmChartSourceFiles, (HelmChartSourceFilesRequest,)),
         ],
     )
@@ -53,7 +53,9 @@ def test_auto_detect_chart_source_root(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("src/main/helm/chart"))
     field_set = HelmChartFieldSet.create(tgt)
 
-    source_root = rule_runner.request(SourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
+    source_root = rule_runner.request(
+        HelmChartSourceRoot, [HelmChartSourceRootRequest(field_set.chart)]
+    )
     assert source_root.path == "src/main/helm/chart"
 
 
@@ -71,7 +73,7 @@ def test_can_not_auto_detect_source_root(rule_runner: RuleRunner) -> None:
         ExecutionError,
         match="The 'chart' field in target src:src must have 1 file, but it had 0 files",
     ):
-        rule_runner.request(SourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
+        rule_runner.request(HelmChartSourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
 
 
 def test_source_templates_are_always_included(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/sources_test.py
+++ b/src/python/pants/backend/helm/util_rules/sources_test.py
@@ -18,10 +18,10 @@ from pants.backend.helm.testutil import (
 )
 from pants.backend.helm.util_rules import sources
 from pants.backend.helm.util_rules.sources import (
+    HelmChartRoot,
+    HelmChartRootRequest,
     HelmChartSourceFiles,
     HelmChartSourceFilesRequest,
-    HelmChartSourceRoot,
-    HelmChartSourceRootRequest,
 )
 from pants.build_graph.address import Address
 from pants.core.target_types import FilesGeneratorTarget, ResourcesGeneratorTarget
@@ -36,7 +36,7 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, ResourcesGeneratorTarget, FilesGeneratorTarget],
         rules=[
             *sources.rules(),
-            QueryRule(HelmChartSourceRoot, (HelmChartSourceRootRequest,)),
+            QueryRule(HelmChartRoot, (HelmChartRootRequest,)),
             QueryRule(HelmChartSourceFiles, (HelmChartSourceFilesRequest,)),
         ],
     )
@@ -53,9 +53,7 @@ def test_auto_detect_chart_source_root(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("src/main/helm/chart"))
     field_set = HelmChartFieldSet.create(tgt)
 
-    source_root = rule_runner.request(
-        HelmChartSourceRoot, [HelmChartSourceRootRequest(field_set.chart)]
-    )
+    source_root = rule_runner.request(HelmChartRoot, [HelmChartRootRequest(field_set.chart)])
     assert source_root.path == "src/main/helm/chart"
 
 
@@ -73,7 +71,7 @@ def test_can_not_auto_detect_source_root(rule_runner: RuleRunner) -> None:
         ExecutionError,
         match="The 'chart' field in target src:src must have 1 file, but it had 0 files",
     ):
-        rule_runner.request(HelmChartSourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
+        rule_runner.request(HelmChartRoot, [HelmChartRootRequest(field_set.chart)])
 
 
 def test_source_templates_are_always_included(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/helm/util_rules/sources_test.py
+++ b/src/python/pants/backend/helm/util_rules/sources_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 
 import pytest
 
-from pants.backend.helm.target_types import HelmChartTarget
+from pants.backend.helm.target_types import HelmChartFieldSet, HelmChartTarget
 from pants.backend.helm.testutil import (
     HELM_CHART_FILE,
     HELM_TEMPLATE_HELPERS_FILE,
@@ -17,10 +17,16 @@ from pants.backend.helm.testutil import (
     K8S_SERVICE_TEMPLATE,
 )
 from pants.backend.helm.util_rules import sources
-from pants.backend.helm.util_rules.sources import HelmChartSourceFiles, HelmChartSourceFilesRequest
+from pants.backend.helm.util_rules.sources import (
+    HelmChartSourceFiles,
+    HelmChartSourceFilesRequest,
+    HelmChartSourceRootRequest,
+)
 from pants.build_graph.address import Address
 from pants.core.target_types import FilesGeneratorTarget, ResourcesGeneratorTarget
+from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule
+from pants.source.source_root import SourceRoot
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -30,9 +36,42 @@ def rule_runner() -> RuleRunner:
         target_types=[HelmChartTarget, ResourcesGeneratorTarget, FilesGeneratorTarget],
         rules=[
             *sources.rules(),
+            QueryRule(SourceRoot, (HelmChartSourceRootRequest,)),
             QueryRule(HelmChartSourceFiles, (HelmChartSourceFilesRequest,)),
         ],
     )
+
+
+def test_auto_detect_chart_source_root(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/main/helm/chart/BUILD": "helm_chart()",
+            "src/main/helm/chart/Chart.yaml": HELM_CHART_FILE,
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("src/main/helm/chart"))
+    field_set = HelmChartFieldSet.create(tgt)
+
+    source_root = rule_runner.request(SourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
+    assert source_root.path == "src/main/helm/chart"
+
+
+def test_can_not_auto_detect_source_root(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": "helm_chart()",
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("src"))
+    field_set = HelmChartFieldSet.create(tgt)
+
+    with pytest.raises(
+        ExecutionError,
+        match="The 'chart' field in target src:src must have 1 file, but it had 0 files",
+    ):
+        rule_runner.request(SourceRoot, [HelmChartSourceRootRequest(field_set.chart)])
 
 
 def test_source_templates_are_always_included(rule_runner: RuleRunner) -> None:
@@ -121,3 +160,4 @@ def test_source_templates_includes(
         assert "resource.xml" in source_files.snapshot.files
     if include_files:
         assert "file.txt" in source_files.snapshot.files
+        assert "file.txt" in source_files.unrooted_files

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -215,7 +215,7 @@ class HelmPlugin(EngineAwareReturnType):
         return self.info.version
 
     def level(self) -> LogLevel | None:
-        return LogLevel.INFO
+        return LogLevel.DEBUG
 
     def message(self) -> str | None:
         return f"Materialized Helm plugin {self.name} with version {self.version} for {self.platform} platform."

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -36,7 +36,7 @@ from pants.engine.fs import (
     PathGlobs,
     RemovePrefix,
 )
-from pants.engine.internals.native_engine import AddPrefix, MergeDigests, Snapshot
+from pants.engine.internals.native_engine import EMPTY_DIGEST, AddPrefix, MergeDigests, Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -332,8 +332,8 @@ class HelmProcess:
         self,
         argv: Iterable[str],
         *,
-        input_digest: Digest,
         description: str,
+        input_digest: Digest = EMPTY_DIGEST,
         level: LogLevel = LogLevel.INFO,
         output_directories: Iterable[str] | None = None,
         output_files: Iterable[str] | None = None,


### PR DESCRIPTION
~Enforces the configuration of source root patterns that make the `Chart.yaml` file live at the root of any `helm_chart` target by erroring when this is not the case. This aligns the behaviour with the current documentation and gives an unequivocal result to new users of the backend.~

Auto-detects the Helm chart source root using the `Chart.yaml` of each chart as marker file. This prevents misconfiguration of the source patterns and unexpected behaviour of some Helm commands when those source roots are not the right ones.

In addition to this, now the Helm chart sources are used as immutable input digests in all of the Helm processes.

Closes #16493.

[ci skip-rust]
[ci skip-build-wheels]