### PR TITLE
Rename `FmtRequest` to `FmtTargetsRequest` (plus some `fix` refactoring)

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -11,6 +11,13 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 
 See <https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.14.x.md> for the changelog.
 
+### `FmtRequest` -> `FmtTargetsRequest`
+
+In order to support non-target formatting (like `BUILD` files) we'll be introducing additional `fmt`
+request types. Therefore `FmtRequest` has been renamed to `FmtTargetsRequest` to reflect the behavior.
+
+This change also matches `lint`, which uses `LintTargetsRequest`.
+
 ### Optional Option flag name
 
 Pants 2.14 adds support for deducing the flag name from the attribute name when declaring `XOption`s.
@@ -125,7 +132,7 @@ You can also now specify multiple globs, e.g. `req.path_globs("*.py", "*.pyi")`.
 
 ### Banned short option names like `-x`
 
-You must now use a long option name when [defining options](doc:rules-api-subsystems). You can also now only specify a single option name per option. 
+You must now use a long option name when [defining options](doc:rules-api-subsystems). You can also now only specify a single option name per option.
 
 (These changes allowed us to introduce ignore specs, like `./pants list :: -ignore_me::`.)
 

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -10,7 +10,7 @@ from typing import Iterable
 from pants.backend.cc.lint.clangformat.subsystem import ClangFormat
 from pants.backend.cc.target_types import CCSourceField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.process import ProcessResult
@@ -30,7 +30,7 @@ class ClangFormatFmtFieldSet(FieldSet):
     sources: CCSourceField
 
 
-class ClangFormatRequest(FmtRequest):
+class ClangFormatRequest(FmtTargetsRequest):
     field_set_type = ClangFormatFmtFieldSet
     name = ClangFormat.options_scope
 
@@ -88,5 +88,5 @@ async def clangformat_fmt(request: ClangFormatRequest, clangformat: ClangFormat)
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        UnionRule(FmtRequest, ClangFormatRequest),
+        UnionRule(FmtTargetsRequest, ClangFormatRequest),
     )

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -8,7 +8,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufDependenciesField,
     ProtobufSourceField,
 )
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.system_binaries import (
     BinaryShims,
@@ -39,7 +39,7 @@ class BufFieldSet(FieldSet):
         return tgt.get(SkipBufFormatField).value
 
 
-class BufFormatRequest(FmtRequest):
+class BufFormatRequest(FmtTargetsRequest):
     field_set_type = BufFieldSet
     name = "buf-format"
 
@@ -97,5 +97,5 @@ async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtRes
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, BufFormatRequest),
+        UnionRule(FmtTargetsRequest, BufFormatRequest),
     ]

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -11,7 +11,7 @@ from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
@@ -34,7 +34,7 @@ class GofmtFieldSet(FieldSet):
         return tgt.get(SkipGofmtField).value
 
 
-class GofmtRequest(FmtRequest):
+class GofmtRequest(FmtTargetsRequest):
     field_set_type = GofmtFieldSet
     name = GofmtSubsystem.options_scope
 
@@ -66,5 +66,5 @@ def rules():
     return [
         *collect_rules(),
         *goroot.rules(),
-        UnionRule(FmtRequest, GofmtRequest),
+        UnionRule(FmtTargetsRequest, GofmtRequest),
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.java.lint.google_java_format.skip_field import SkipGoogleJavaFormatField
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.target_types import JavaSourceField
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -36,7 +36,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
         return tgt.get(SkipGoogleJavaFormatField).value
 
 
-class GoogleJavaFormatRequest(FmtRequest):
+class GoogleJavaFormatRequest(FmtTargetsRequest):
     field_set_type = GoogleJavaFormatFieldSet
     name = GoogleJavaFormatSubsystem.options_scope
 
@@ -111,6 +111,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        UnionRule(FmtRequest, GoogleJavaFormatRequest),
+        UnionRule(FmtTargetsRequest, GoogleJavaFormatRequest),
         UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -10,7 +10,7 @@ from typing import Iterable
 from pants.backend.javascript.lint.prettier.subsystem import Prettier
 from pants.backend.javascript.subsystems.nodejs import NpxProcess
 from pants.backend.javascript.target_types import JSSourceField
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.process import ProcessResult
@@ -30,7 +30,7 @@ class PrettierFmtFieldSet(FieldSet):
     sources: JSSourceField
 
 
-class PrettierFmtRequest(FmtRequest):
+class PrettierFmtRequest(FmtTargetsRequest):
     field_set_type = PrettierFmtFieldSet
     name = Prettier.options_scope
 
@@ -79,5 +79,5 @@ async def prettier_fmt(request: PrettierFmtRequest, prettier: Prettier) -> FmtRe
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        UnionRule(FmtRequest, PrettierFmtRequest),
+        UnionRule(FmtTargetsRequest, PrettierFmtRequest),
     )

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.kotlin.lint.ktlint.skip_field import SkipKtlintField
 from pants.backend.kotlin.lint.ktlint.subsystem import KtlintSubsystem
 from pants.backend.kotlin.target_types import KotlinSourceField
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -36,7 +36,7 @@ class KtlintFieldSet(FieldSet):
         return tgt.get(SkipKtlintField).value
 
 
-class KtlintRequest(FmtRequest):
+class KtlintRequest(FmtTargetsRequest):
     field_set_type = KtlintFieldSet
     name = KtlintSubsystem.options_scope
 
@@ -95,6 +95,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        UnionRule(FmtRequest, KtlintRequest),
+        UnionRule(FmtTargetsRequest, KtlintRequest),
         UnionRule(GenerateToolLockfileSentinel, KtlintToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -8,7 +8,7 @@ from pants.backend.python.lint.autoflake.subsystem import Autoflake
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
@@ -30,7 +30,7 @@ class AutoflakeFieldSet(FieldSet):
         return tgt.get(SkipAutoflakeField).value
 
 
-class AutoflakeRequest(FmtRequest):
+class AutoflakeRequest(FmtTargetsRequest):
     field_set_type = AutoflakeFieldSet
     name = Autoflake.options_scope
 
@@ -63,6 +63,6 @@ async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtR
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, AutoflakeRequest),
+        UnionRule(FmtTargetsRequest, AutoflakeRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.target_types import InterpreterConstraintsField, Pytho
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
@@ -34,7 +34,7 @@ class BlackFieldSet(FieldSet):
         return tgt.get(SkipBlackField).value
 
 
-class BlackRequest(FmtRequest):
+class BlackRequest(FmtTargetsRequest):
     field_set_type = BlackFieldSet
     name = Black.options_scope
 
@@ -113,6 +113,6 @@ async def black_fmt(request: BlackRequest, black: Black, python_setup: PythonSet
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, BlackRequest),
+        UnionRule(FmtTargetsRequest, BlackRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -8,7 +8,7 @@ from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
@@ -30,7 +30,7 @@ class DocformatterFieldSet(FieldSet):
         return tgt.get(SkipDocformatterField).value
 
 
-class DocformatterRequest(FmtRequest):
+class DocformatterRequest(FmtTargetsRequest):
     field_set_type = DocformatterFieldSet
     name = Docformatter.options_scope
 
@@ -62,6 +62,6 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, DocformatterRequest),
+        UnionRule(FmtTargetsRequest, DocformatterRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -10,7 +10,7 @@ from pants.backend.python.lint.isort.subsystem import Isort
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, PexResolveInfo, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
@@ -33,7 +33,7 @@ class IsortFieldSet(FieldSet):
         return tgt.get(SkipIsortField).value
 
 
-class IsortRequest(FmtRequest):
+class IsortRequest(FmtTargetsRequest):
     field_set_type = IsortFieldSet
     name = Isort.options_scope
 
@@ -100,6 +100,6 @@ async def isort_fmt(request: IsortRequest, isort: Isort) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, IsortRequest),
+        UnionRule(FmtTargetsRequest, IsortRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -9,7 +9,7 @@ from pants.backend.python.lint.pyupgrade.subsystem import PyUpgrade
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import FallibleProcessResult
@@ -31,7 +31,7 @@ class PyUpgradeFieldSet(FieldSet):
         return tgt.get(SkipPyUpgradeField).value
 
 
-class PyUpgradeRequest(FmtRequest):
+class PyUpgradeRequest(FmtTargetsRequest):
     field_set_type = PyUpgradeFieldSet
     name = PyUpgrade.options_scope
 
@@ -61,6 +61,6 @@ async def pyupgrade_fmt(request: PyUpgradeRequest, pyupgrade: PyUpgrade) -> FmtR
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, PyUpgradeRequest),
+        UnionRule(FmtTargetsRequest, PyUpgradeRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -8,7 +8,7 @@ from pants.backend.python.lint.yapf.subsystem import Yapf
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
@@ -31,7 +31,7 @@ class YapfFieldSet(FieldSet):
         return tgt.get(SkipYapfField).value
 
 
-class YapfRequest(FmtRequest):
+class YapfRequest(FmtTargetsRequest):
     field_set_type = YapfFieldSet
     name = Yapf.options_scope
 
@@ -73,6 +73,6 @@ async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, YapfRequest),
+        UnionRule(FmtTargetsRequest, YapfRequest),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -11,7 +11,7 @@ from pants.backend.scala.lint.scalafmt.skip_field import SkipScalafmtField
 from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.tailor import group_by_dir
 from pants.engine.fs import (
@@ -49,7 +49,7 @@ class ScalafmtFieldSet(FieldSet):
         return tgt.get(SkipScalafmtField).value
 
 
-class ScalafmtRequest(FmtRequest):
+class ScalafmtRequest(FmtTargetsRequest):
     field_set_type = ScalafmtFieldSet
     name = ScalafmtSubsystem.options_scope
 
@@ -276,6 +276,6 @@ def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(FmtRequest, ScalafmtRequest),
+        UnionRule(FmtTargetsRequest, ScalafmtRequest),
         UnionRule(GenerateToolLockfileSentinel, ScalafmtToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.shell.lint.shfmt.skip_field import SkipShfmtField
 from pants.backend.shell.lint.shfmt.subsystem import Shfmt
 from pants.backend.shell.target_types import ShellSourceField
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -31,7 +31,7 @@ class ShfmtFieldSet(FieldSet):
         return tgt.get(SkipShfmtField).value
 
 
-class ShfmtRequest(FmtRequest):
+class ShfmtRequest(FmtTargetsRequest):
     field_set_type = ShfmtFieldSet
     name = Shfmt.options_scope
 
@@ -81,5 +81,5 @@ async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtRequest, ShfmtRequest),
+        UnionRule(FmtTargetsRequest, ShfmtRequest),
     ]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -7,7 +7,7 @@ from pants.backend.terraform.style import StyleSetup, StyleSetupRequest
 from pants.backend.terraform.target_types import TerraformFieldSet
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.tool import rules as tool_rules
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules import external_tool
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
@@ -29,7 +29,7 @@ class TfFmtSubsystem(Subsystem):
     skip = SkipOption("fmt", "lint")
 
 
-class TffmtRequest(FmtRequest):
+class TffmtRequest(FmtTargetsRequest):
     field_set_type = TerraformFieldSet
     name = TfFmtSubsystem.options_scope
 
@@ -81,5 +81,5 @@ def rules():
         *collect_rules(),
         *external_tool.rules(),
         *tool_rules(),
-        UnionRule(FmtRequest, TffmtRequest),
+        UnionRule(FmtTargetsRequest, TffmtRequest),
     ]

--- a/src/python/pants/backend/terraform/style.py
+++ b/src/python/pants/backend/terraform/style.py
@@ -11,7 +11,7 @@ from typing import Iterable
 from pants.backend.terraform.tool import TerraformProcess
 from pants.build_graph.address import Address
 from pants.core.goals.check import CheckRequest
-from pants.core.goals.fmt import FmtRequest
+from pants.core.goals.fmt import FmtTargetsRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
@@ -24,10 +24,10 @@ from pants.util.strutil import pluralize
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 class StyleSetupRequest:
-    request: FmtRequest | CheckRequest
+    request: FmtTargetsRequest | CheckRequest
     args: tuple[str, ...]
 
-    def __init__(self, request: FmtRequest | CheckRequest, args: Iterable[str]):
+    def __init__(self, request: FmtTargetsRequest | CheckRequest, args: Iterable[str]):
         self.request = request
         self.args = tuple(args)
 
@@ -50,7 +50,7 @@ async def setup_terraform_style(setup_request: StyleSetupRequest) -> StyleSetup:
 
     source_files_snapshot = (
         setup_request.request.snapshot
-        if isinstance(setup_request.request, FmtRequest)
+        if isinstance(setup_request.request, FmtTargetsRequest)
         else await Get(
             Snapshot, MergeDigests(sfs.snapshot.digest for sfs in source_files_by_field_set)
         )

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from textwrap import dedent
 from typing import List, Type
 
-from pants.core.goals.fmt import Fmt, FmtRequest, FmtResult
+from pants.core.goals.fmt import Fmt, FmtResult, FmtTargetsRequest
 from pants.core.goals.fmt import rules as fmt_rules
 from pants.core.util_rules import source_files
 from pants.engine.fs import (
@@ -46,7 +46,7 @@ class FortranFieldSet(FieldSet):
     sources: FortranSource
 
 
-class FortranFmtRequest(FmtRequest):
+class FortranFmtRequest(FmtTargetsRequest):
     field_set_type = FortranFieldSet
     name = "FortranConditionallyDidChange"
 
@@ -77,7 +77,7 @@ class SmalltalkFieldSet(FieldSet):
     source: SmalltalkSource
 
 
-class SmalltalkNoopRequest(FmtRequest):
+class SmalltalkNoopRequest(FmtTargetsRequest):
     field_set_type = SmalltalkFieldSet
     name = "SmalltalkDidNotChange"
 
@@ -94,7 +94,7 @@ async def smalltalk_noop(request: SmalltalkNoopRequest) -> FmtResult:
     )
 
 
-class SmalltalkSkipRequest(FmtRequest):
+class SmalltalkSkipRequest(FmtTargetsRequest):
     field_set_type = SmalltalkFieldSet
     name = "SmalltalkSkipped"
 
@@ -107,14 +107,14 @@ def smalltalk_skip(request: SmalltalkSkipRequest) -> FmtResult:
 
 def fmt_rule_runner(
     target_types: List[Type[Target]],
-    fmt_request_types: List[Type[FmtRequest]],
+    fmt_request_types: List[Type[FmtTargetsRequest]],
 ) -> RuleRunner:
     return RuleRunner(
         rules=[
             *collect_rules(),
             *source_files.rules(),
             *fmt_rules(),
-            *(UnionRule(FmtRequest, frt) for frt in fmt_request_types),
+            *(UnionRule(FmtTargetsRequest, frt) for frt in fmt_request_types),
         ],
         target_types=target_types,
     )

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Any, ClassVar, Iterable, Iterator, Type, TypeVar, cast
 
 from pants.base.specs import Specs
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.style_request import (
     StyleRequest,
     determine_specified_tool_names,
@@ -268,7 +268,9 @@ async def lint(
     lint_target_request_types = cast(
         "Iterable[type[LintTargetsRequest]]", union_membership.get(LintTargetsRequest)
     )
-    fmt_target_request_types = cast("Iterable[type[FmtRequest]]", union_membership.get(FmtRequest))
+    fmt_target_request_types = cast(
+        "Iterable[type[FmtTargetsRequest]]", union_membership.get(FmtTargetsRequest)
+    )
     file_request_types = cast(
         "Iterable[type[LintFilesRequest]]", union_membership[LintFilesRequest]
     )
@@ -326,7 +328,7 @@ async def lint(
         request_type(batch) for request_type, batch in batch_by_type(lint_target_request_types)
     )
 
-    fmt_requests: Iterable[FmtRequest] = ()
+    fmt_requests: Iterable[FmtTargetsRequest] = ()
     if not lint_subsystem.skip_formatters:
         batched_fmt_request_pairs = batch_by_type(fmt_target_request_types)
         all_fmt_source_batches = await MultiGet(
@@ -360,7 +362,7 @@ async def lint(
 
     all_requests = [
         *(Get(LintResults, LintTargetsRequest, request) for request in lint_target_requests),
-        *(Get(FmtResult, FmtRequest, request) for request in fmt_requests),
+        *(Get(FmtResult, FmtTargetsRequest, request) for request in fmt_requests),
         *(Get(LintResults, LintFilesRequest, request) for request in file_requests),
     ]
     all_batch_results = cast(

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -12,7 +12,7 @@ from typing import Iterable, Optional, Sequence, Tuple, Type
 import pytest
 
 from pants.base.specs import Specs
-from pants.core.goals.fmt import FmtRequest, FmtResult
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.lint import (
     AmbiguousRequestNamesError,
     Lint,
@@ -127,7 +127,7 @@ class MockFilesRequest(LintFilesRequest):
         return LintResults([LintResult(0, "", "")], linter_name=self.name)
 
 
-class MockFmtRequest(FmtRequest):
+class MockFmtRequest(FmtTargetsRequest):
     field_set_type = MockLinterFieldSet
 
 
@@ -162,7 +162,7 @@ def run_lint_rule(
     rule_runner: RuleRunner,
     *,
     lint_request_types: Sequence[Type[LintTargetsRequest]],
-    fmt_request_types: Sequence[Type[FmtRequest]] = (),
+    fmt_request_types: Sequence[Type[FmtTargetsRequest]] = (),
     targets: list[Target],
     run_files_linter: bool = False,
     batch_size: int = 128,
@@ -173,7 +173,7 @@ def run_lint_rule(
         {
             LintTargetsRequest: lint_request_types,
             LintFilesRequest: [MockFilesRequest] if run_files_linter else [],
-            FmtRequest: fmt_request_types,
+            FmtTargetsRequest: fmt_request_types,
         }
     )
     lint_subsystem = create_goal_subsystem(
@@ -211,7 +211,7 @@ def run_lint_rule(
                 ),
                 MockGet(
                     output_type=FmtResult,
-                    input_type=FmtRequest,
+                    input_type=FmtTargetsRequest,
                     mock=lambda mock_request: mock_request.fmt_result,
                 ),
                 MockGet(


### PR DESCRIPTION
This is prepwork for dissolving `update-build-files` from #13504, as well as #16480. No semantic changes have been made, just renaming and refactoring.

Note that `FmtResult` hasn't been renamed, as it isn't target-specific.

Commits are useful to review :smile: 

[ci skip-rust]
[ci skip-build-wheels]