### PR TITLE
Mention team meetings as a Contributor permission

### DIFF
--- a/docs/markdown/Getting Help/the-pants-community.md
+++ b/docs/markdown/Getting Help/the-pants-community.md
@@ -47,9 +47,9 @@ Pants has a core group of [_Maintainers_](doc:maintainers): trusted people with 
 
 Anyone who has made a few contributions of any kind, and has an ongoing interest in the Pants project, may be nominated by a Maintainer to become a _Contributor_. 
 
-Contributors may be granted extra permissions, such as the ability to assign issues and to fully participate in monthly contributor meetings. These permissions stop short of full Maintainer permissions, such as not yet getting write access to the repository.
+Contributors are granted extra permissions, such as the ability to assign issues and participating in monthly team meetings (with the Maintainers and Contributors). These permissions stop short of full Maintainer permissions, such as not yet getting write access to the repository.
 
-Contributors do not have any new obligations. For example, you are _not_ expected to make a certain number of changes. However, contributors are expected to respect their extra permissions.
+Contributors do not have any new obligations. For example, you are _not_ expected to make a certain number of changes. However, Contributors are expected to respect their extra permissions.
 
 Contributors will be eligible to receive more attention and mentorship in activities like code review. Contributors with a continuing track record of contribution may be nominated to become Maintainers.
 

--- a/docs/markdown/Getting Help/the-pants-community.md
+++ b/docs/markdown/Getting Help/the-pants-community.md
@@ -47,7 +47,11 @@ Pants has a core group of [_Maintainers_](doc:maintainers): trusted people with 
 
 Anyone who has made a few contributions of any kind, and has an ongoing interest in the Pants project, may be nominated by a Maintainer to become a _Contributor_. 
 
-Contributors may be granted extra permissions, such as the ability to assign issues, but these stop short of full Maintainer permissions. Contributors do not have any new obligations—for example, you are _not_ expected to make a certain number of changes. However, contributors are expected to respect their extra permissions. Contributors will be eligible to receive more attention and mentorship in activities like code review. Contributors with a continuing track record of contribution may be nominated to become Maintainers.
+Contributors may be granted extra permissions, such as the ability to assign issues and to fully participate in monthly contributor meetings. These permissions stop short of full Maintainer permissions, such as not yet getting write access to the repository.
+
+Contributors do not have any new obligations. For example, you are _not_ expected to make a certain number of changes. However, contributors are expected to respect their extra permissions.
+
+Contributors will be eligible to receive more attention and mentorship in activities like code review. Contributors with a continuing track record of contribution may be nominated to become Maintainers.
 
 ### Maintainers Emeritus
 

--- a/docs/markdown/Getting Help/the-pants-community/maintainers.md
+++ b/docs/markdown/Getting Help/the-pants-community/maintainers.md
@@ -46,6 +46,20 @@ New maintainers should be:
   - to the [pants-maintainers@ Google Group](https://groups.google.com/g/pants-maintainers)
   - to [`MAINTAINERS.md`](https://github.com/pantsbuild/pants/blob/main/MAINTAINERS.md)
   - to the [Slack #maintainers-confidential room](doc:getting-help#slack)
+  - to the [Meet the Team page](doc:team), with their proudest contribution
+- Welcomed:
+  - on the [pants-devel@ Google Group](https://groups.google.com/g/pants-devel)
+  - in the [Slack #announce room](doc:getting-help#slack)
+  - by [@pantsbuild on Twitter](https://twitter.com/pantsbuild)
+
+Contributor onboarding
+----------------------
+
+New Contributors should be:
+
+- Added:
+  - to the [Contributors Github team](https://github.com/orgs/pantsbuild/teams/contributors)
+  - to the [Meet the Team page](doc:team), with their proudest contribution
 - Welcomed:
   - on the [pants-devel@ Google Group](https://groups.google.com/g/pants-devel)
   - in the [Slack #announce room](doc:getting-help#slack)


### PR DESCRIPTION
The team meetings are a new development. We haven't yet formally decided if we are comfortable with anyone attending/observing, but either way, fully participating (e.g. presenting) is intended to be for Maintainers and Contributors. 

[ci skip-rust]
[ci skip-build-wheels]