### PR TITLE
Document `[python].resolves_to_constraints_file` and `[python].resolves_to_no_binary`

### DIFF
--- a/docs/markdown/Python/python/python-third-party-dependencies.md
+++ b/docs/markdown/Python/python/python-third-party-dependencies.md
@@ -524,6 +524,57 @@ the user:
 indexes.add = ["http://$USERNAME:$PASSWORD@my.custom.repo/index"]
 ```
 
+
+### Constraints files
+
+Sometimes, transitive dependencies of one of your third-party requirements can cause trouble.
+For example, sometimes requirements do not pin their dependencies well enough, and a newer
+version of its transitive dependency is released that breaks the requirement.
+[Constraints files](https://pip.pypa.io/en/stable/user_guide/?highlight=constraints#constraints-files) 
+allow you to pin transitive dependencies to certain versions, overriding the version that
+pip/Pex would normally choose.
+
+Constraints files are configured per-resolve, meaning that the resolves for your user code from
+`[python].resolves` and each Python tool, such as Black and Pytest, can have different
+configuration. Use the option `[python].resolves_to_constraints_file` to map resolve names to
+paths to pip-compatible constraints files. For example:
+
+```toml pants.toml
+[python.resolves_to_constraints_file]
+data-science = "3rdparty/python/data_science_constraints.txt"
+pytest = "3rdparty/python/pytest_constraints.txt"
+```
+```text 3rdparty/python/data_science_constraints.txt
+requests==22.1.0
+urrllib3==4.2
+```
+
+You can also set the key `__default__` to apply the same constraints file to every resolve by
+default, although this is not always useful because resolves often need different constraints.
+
+### `only_binary` and `no_binary`
+
+You can use `[python].resolves_to_only_binary` to avoid using sdists (source distributions) for
+certain requirements, and `[python].resolve_to_no_binary` to avoid using bdists (wheel files) for
+certain requirements.
+
+`only_binary` and `no_binary` are configured per-resolve, meaning that the resolves for your user
+code from `[python].resolves` and each Python tool, such as Black and Pytest, can have different
+configuration. Use the options `[python].resolves_to_only_binary` and 
+`[python].resolves_to_no_binary` to map resolve names to list of Python requirement names.
+For example:
+
+```toml pants.toml
+[python.resolves_to_only_binary]
+data-science = ["numpy"]
+
+[python.resolves_to_no_binary]
+pytest = ["pytest-xdist"]
+mypy_extra_type_stubs = ["django-stubs"]
+```
+
+You can also set the key `__default__` to apply the same value to every resolve by default.
+
 Tip: use `./pants export` to create a virtual environment for IDEs
 ------------------------------------------------------------------
 

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -17,6 +17,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileEntry
@@ -50,7 +51,7 @@ class HelmKubeParserSubsystem(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class HelmKubeParserLockfileSentinel(GenerateToolLockfileSentinel):
+class HelmKubeParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = HelmKubeParserSubsystem.options_scope
 
 

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -21,6 +21,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.system_binaries import CatBinary
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
@@ -59,7 +60,7 @@ class HelmPostRendererSubsystem(PythonToolRequirementsBase):
     default_lockfile_url = git_url(default_lockfile_path)
 
 
-class HelmPostRendererLockfileSentinel(GenerateToolLockfileSentinel):
+class HelmPostRendererLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = HelmPostRendererSubsystem.options_scope
 
 

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -378,7 +378,7 @@ async def setup_user_lockfile_requests(
     )
 
 
-class PoetryLockfileSentinel(GenerateToolLockfileSentinel):
+class PoetryLockfileSentinel(GeneratePythonToolLockfileSentinel):
     resolve_name = PoetrySubsystem.options_scope
 
 

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -250,7 +250,6 @@ def test_multiple_resolves() -> None:
             # Override interpreter constraints for 'b', but use default for 'a'.
             "--python-resolves-to-interpreter-constraints={'b': ['==3.7.*']}",
             "--python-enable-resolves",
-            "--python-lockfile-generator=pex",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )


### PR DESCRIPTION
Also fix some tools that weren't properly declaring they are Python tools, which meant they could not participate in options like `[python].resolves_to_constraints_file`.
 
[ci skip-rust]
[ci skip-build-wheels]