### PR TITLE
Use Markdown h3 for ToC support (Cherry-pick of #15964)

### DIFF
--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -1,5 +1,7 @@
 <div style="color: purple">
-  <h3><code>{{config_key}}</code></h3>
+
+### `{{config_key}}`
+
   <code>{{comma_separated_display_args}}</code><br>
   <code>{{env_var}}</code><br>
 </div>


### PR DESCRIPTION
Fixes #15959.

[ci skip-rust]
[ci skip-build-wheels]
