### PR TITLE
Use `PipRequirement` for `only_binary` and `no_binary` lockfile metadata

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -300,8 +300,13 @@ async def generate_lockfile(
     initial_lockfile_digest_contents = await Get(DigestContents, Digest, result.output_digest)
     metadata = PythonLockfileMetadata.new(
         valid_for_interpreter_constraints=req.interpreter_constraints,
-        # TODO(#12314) Improve error message on `Requirement.parse`
-        requirements={PipRequirement.parse(i) for i in req.requirements},
+        requirements={
+            PipRequirement.parse(
+                i,
+                description_of_origin=f"the lockfile {req.lockfile_dest} for the resolve {req.resolve_name}",
+            )
+            for i in req.requirements
+        },
         indexes=set(pip_args_setup.resolve_config.indexes),
         find_links=set(pip_args_setup.resolve_config.find_links),
         manylinux=pip_args_setup.resolve_config.manylinux,

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -36,8 +36,8 @@ def test_metadata_header_round_trip() -> None:
         find_links={"find-links"},
         manylinux="manylinux2014",
         requirement_constraints={PipRequirement.parse("constraint")},
-        only_binary={"bdist"},
-        no_binary={"sdist"},
+        only_binary={PipRequirement.parse("bdist")},
+        no_binary={PipRequirement.parse("sdist")},
     )
     serialized_lockfile = input_metadata.add_header_to_lockfile(
         b"req1==1.0", regenerate_command="./pants lock", delimeter="#"
@@ -99,8 +99,8 @@ dave==3.1.4 \\
         find_links={"find-links"},
         manylinux=None,
         requirement_constraints={PipRequirement.parse("constraint")},
-        only_binary={"bdist"},
-        no_binary={"sdist"},
+        only_binary={PipRequirement.parse("bdist")},
+        no_binary={PipRequirement.parse("sdist")},
     )
     result = metadata.add_header_to_lockfile(
         input_lockfile, regenerate_command="./pants lock", delimeter="#"
@@ -298,8 +298,8 @@ def test_is_valid_for_v3_metadata(is_tool: bool) -> None:
         find_links={"find-links"},
         manylinux=None,
         requirement_constraints={PipRequirement.parse("c1")},
-        only_binary={"bdist"},
-        no_binary={"sdist"},
+        only_binary={PipRequirement.parse("bdist")},
+        no_binary={PipRequirement.parse("sdist")},
     ).is_valid_for(
         is_tool=is_tool,
         expected_invalidation_digest="",
@@ -310,8 +310,8 @@ def test_is_valid_for_v3_metadata(is_tool: bool) -> None:
         find_links={"different-find-links"},
         manylinux="manylinux2014",
         requirement_constraints={PipRequirement.parse("c2")},
-        only_binary={"not-bdist"},
-        no_binary={"not-sdist"},
+        only_binary={PipRequirement.parse("not-bdist")},
+        no_binary={PipRequirement.parse("not-sdist")},
     )
     assert result.failure_reasons == {
         InvalidPythonLockfileReason.CONSTRAINTS_FILE_MISMATCH,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -302,8 +302,8 @@ class ResolvePexConfig:
     find_links: tuple[str, ...]
     manylinux: str | None
     constraints_file: ResolvePexConstraintsFile | None
-    only_binary: tuple[str, ...]
-    no_binary: tuple[str, ...]
+    only_binary: FrozenOrderedSet[PipRequirement]
+    no_binary: FrozenOrderedSet[PipRequirement]
 
     def indexes_and_find_links_and_manylinux_pex_args(self) -> Iterator[str]:
         # NB: In setting `--no-pypi`, we rely on the default value of `[python-repos].indexes`
@@ -350,8 +350,8 @@ async def determine_resolve_pex_config(
             find_links=python_repos.repos,
             manylinux=python_setup.manylinux,
             constraints_file=None,
-            no_binary=(),
-            only_binary=(),
+            no_binary=FrozenOrderedSet(),
+            only_binary=FrozenOrderedSet(),
         )
 
     all_python_tool_resolve_names = tuple(
@@ -416,8 +416,8 @@ async def determine_resolve_pex_config(
         find_links=python_repos.repos,
         manylinux=python_setup.manylinux,
         constraints_file=constraints_file,
-        no_binary=tuple(no_binary),
-        only_binary=tuple(only_binary),
+        no_binary=FrozenOrderedSet(no_binary),
+        only_binary=FrozenOrderedSet(only_binary),
     )
 
 

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -35,8 +35,8 @@ METADATA = PythonLockfileMetadataV3(
     find_links={"find-links"},
     manylinux=None,
     requirement_constraints={PipRequirement.parse("abc")},
-    only_binary={"bdist"},
-    no_binary={"sdist"},
+    only_binary={PipRequirement.parse("bdist")},
+    no_binary={PipRequirement.parse("sdist")},
 )
 
 
@@ -149,8 +149,12 @@ def test_validate_tool_lockfiles(
                     {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
                 ),
             ),
-            no_binary=("not-sdist" if invalid_no_binary else "sdist",),
-            only_binary=("not-bdist" if invalid_only_binary else "bdist",),
+            no_binary=FrozenOrderedSet(
+                [PipRequirement.parse("not-sdist" if invalid_no_binary else "sdist")]
+            ),
+            only_binary=FrozenOrderedSet(
+                [PipRequirement.parse("not-bdist" if invalid_only_binary else "bdist")]
+            ),
         ),
     )
 
@@ -273,8 +277,12 @@ def test_validate_user_lockfiles(
                     {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
                 ),
             ),
-            no_binary=("not-sdist" if invalid_no_binary else "sdist",),
-            only_binary=("not-bdist" if invalid_only_binary else "bdist",),
+            no_binary=FrozenOrderedSet(
+                [PipRequirement.parse("not-sdist" if invalid_no_binary else "sdist")]
+            ),
+            only_binary=FrozenOrderedSet(
+                [PipRequirement.parse("not-bdist" if invalid_only_binary else "bdist")]
+            ),
         ),
     )
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -65,6 +65,7 @@ from pants.testutil.rule_runner import (
     run_rule_with_mocks,
 )
 from pants.util.dirutil import safe_rmtree
+from pants.util.ordered_set import FrozenOrderedSet
 
 
 @pytest.fixture
@@ -613,8 +614,8 @@ def test_setup_pex_requirements() -> None:
                         find_links=("custom-find-links",),
                         manylinux=None,
                         constraints_file=None,
-                        only_binary=(),
-                        no_binary=(),
+                        only_binary=FrozenOrderedSet(),
+                        no_binary=FrozenOrderedSet(),
                     ),
                 ),
                 MockGet(Digest, CreateDigest, lambda _: constraints_digest),


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16527.

Also adds `description_of_origin` to several lockfile related places using `PipRequirement.parse()`.