### PR TITLE
fix `cargo install` invocation

### DIFF
--- a/build-support/bin/check_rust_target_headers.sh
+++ b/build-support/bin/check_rust_target_headers.sh
@@ -2,7 +2,7 @@
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-"${REPO_ROOT}/cargo" install cargo-ensure-prefix --locked "=0.1.7"
+"${REPO_ROOT}/cargo" install cargo-ensure-prefix --locked --version "=0.1.7"
 
 if ! out="$("${REPO_ROOT}/cargo" ensure-prefix \
   --manifest-path="${REPO_ROOT}/src/rust/engine/Cargo.toml" \


### PR DESCRIPTION
adds the missing `--version` flag,

fixes seeing (if cargo-ensure-prefix wasn't installed, it too would fail with a much more confusing error)
```
    Updating crates.io index
     Ignored package `cargo-ensure-prefix v0.1.7` is already installed, use --force to override
error: could not find `=0.1.7` in registry `crates-io` with version `*`
     Summary Successfully installed cargo-ensure-prefix! Failed to install =0.1.7 (see error(s) above).
error: some crates failed to install

```
now, looks like:
```
     Ignored package `cargo-ensure-prefix v0.1.7` is already installed, use --force to override
```