### PR TITLE
Fix `fmt` with no specs

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -9,7 +9,7 @@ import os
 from abc import ABCMeta
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Iterable, Iterator, TypeVar
+from typing import Callable, ClassVar, Iterable, Iterator, TypeVar, cast
 
 from pants.base.specs import Specs
 from pants.core.goals.style_request import (
@@ -374,7 +374,7 @@ async def fmt(
         fmt_subsystem.batch_size,
     )
 
-    target_batch_results = await MultiGet(
+    all_requests = [
         *(
             Get(
                 _FmtBatchResult,
@@ -392,6 +392,9 @@ async def fmt(
                 fmt_subsystem.batch_size,
             )
         ),
+    ]
+    target_batch_results = cast(
+        "tuple[_FmtBatchResult, ...]", await MultiGet(all_requests)  # type: ignore[arg-type]
     )
 
     individual_results = list(

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -318,6 +318,22 @@ def test_only() -> None:
     assert stderr.strip() == "✓ SmalltalkDidNotChange made no changes."
 
 
+def test_no_targets() -> None:
+    rule_runner = fmt_rule_runner(
+        target_types=[FortranTarget, SmalltalkTarget],
+        fmt_targets_request_types=[FortranFmtRequest, SmalltalkSkipRequest, SmalltalkNoopRequest],
+        fmt_build_files_request_types=[BrickyBuildFileFormatter],
+    )
+
+    write_files(rule_runner)
+
+    stderr = run_fmt(
+        rule_runner,
+        target_specs=[],
+    )
+    assert not stderr.strip()
+
+
 def test_message_lists_added_files() -> None:
     input_snapshot = Snapshot._unsafe_create(
         Digest("a" * 64, 1000), ["f.ext", "dir/f.ext"], ["dir"]


### PR DESCRIPTION
Before: `TypeError: MultiGet() missing 1 required positional argument: '__arg0'`
After:  `<nothing>`

And with tests!

[ci skip-rust]
[ci skip-build-wheels]