### PR TITLE
Allow removing headers from lockfile

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -73,9 +73,7 @@ class ClangFormatLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_clangformat_lockfile(
     _: ClangFormatLockfileSentinel, clangformat: ClangFormat, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        clangformat, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(clangformat, python_setup=python_setup)
 
 
 class ClangFormatExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -99,9 +99,7 @@ def setup_mypy_protobuf_lockfile(
     mypy_protobuf: PythonProtobufMypyPlugin,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        mypy_protobuf, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(mypy_protobuf, python_setup=python_setup)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -65,9 +65,7 @@ def setup_lockfile_request(
     dockerfile_parser: DockerfileParser,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        dockerfile_parser, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(dockerfile_parser, python_setup=python_setup)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -61,9 +61,7 @@ def setup_k8s_parser_lockfile_request(
     post_renderer: HelmKubeParserSubsystem,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        post_renderer, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(post_renderer, python_setup=python_setup)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -70,9 +70,7 @@ def setup_postrenderer_lockfile_request(
     post_renderer: HelmPostRendererSubsystem,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        post_renderer, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(post_renderer, python_setup=python_setup)
 
 
 _HELM_POST_RENDERER_TOOL = "__pants_helm_post_renderer.py"

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -237,9 +237,7 @@ class CoveragePyLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_coverage_lockfile(
     _: CoveragePyLockfileSentinel, coverage: CoverageSubsystem, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        coverage, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(coverage, python_setup=python_setup)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -72,7 +72,7 @@ class GeneratePythonLockfile(GenerateLockfile):
         subsystem: PythonToolRequirementsBase,
         interpreter_constraints: InterpreterConstraints | None = None,
         *,
-        use_pex: bool,
+        python_setup: PythonSetup,
         extra_requirements: Iterable[str] = (),
     ) -> GeneratePythonLockfile:
         """Create a request for a dedicated lockfile for the tool.
@@ -81,6 +81,7 @@ class GeneratePythonLockfile(GenerateLockfile):
         rather than the option `--interpreter-constraints`, you must pass the arg
         `interpreter_constraints`.
         """
+        use_pex = python_setup.generate_lockfiles_with_pex
         if not subsystem.uses_custom_lockfile:
             return cls(
                 requirements=FrozenOrderedSet(),
@@ -396,9 +397,7 @@ async def setup_poetry_lockfile(
     # No matter what venv (Python) Poetry lives in, it can still create locks for projects with
     # a disjoint set of Pythons as implied by the project's `python` requirement; so we need not
     # account for user resolve ICs.
-    return GeneratePythonLockfile.from_tool(
-        poetry_subsystem, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(poetry_subsystem, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -57,6 +57,7 @@ def _generate(
                 resolve_name="test",
                 lockfile_dest="test.lock",
                 use_pex=use_pex,
+                with_headers=True,
             )
         ],
     )
@@ -265,6 +266,7 @@ def test_multiple_resolves() -> None:
             resolve_name="a",
             lockfile_dest="a.lock",
             use_pex=True,
+            with_headers=True,
         ),
         GeneratePythonLockfile(
             requirements=FrozenOrderedSet(["b"]),
@@ -272,5 +274,6 @@ def test_multiple_resolves() -> None:
             resolve_name="b",
             lockfile_dest="b.lock",
             use_pex=True,
+            with_headers=True,
         ),
     }

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -54,9 +54,7 @@ class AutoflakeLockfileSentinel(GeneratePythonToolLockfileSentinel):
 async def setup_autoflake_lockfile(
     _: AutoflakeLockfileSentinel, autoflake: Autoflake, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        autoflake, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(autoflake, python_setup=python_setup)
 
 
 class AutoflakeExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -120,15 +120,13 @@ async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not bandit.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            bandit, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(bandit, python_setup=python_setup)
 
     constraints = await _bandit_interpreter_constraints(python_setup)
     return GeneratePythonLockfile.from_tool(
         bandit,
         constraints,
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -116,14 +116,10 @@ async def setup_black_lockfile(
     _: BlackLockfileSentinel, black: Black, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not black.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            black, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(black, python_setup=python_setup)
 
     constraints = await _black_interpreter_constraints(black, python_setup)
-    return GeneratePythonLockfile.from_tool(
-        black, constraints, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(black, constraints, python_setup=python_setup)
 
 
 class BlackExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -47,9 +47,7 @@ class DocformatterLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_lockfile_request(
     _: DocformatterLockfileSentinel, docformatter: Docformatter, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        docformatter, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(docformatter, python_setup=python_setup)
 
 
 class DocformatterExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -300,16 +300,14 @@ async def setup_flake8_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not flake8.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            flake8, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(flake8, python_setup=python_setup)
 
     constraints = await _flake8_interpreter_constraints(first_party_plugins, python_setup)
     return GeneratePythonLockfile.from_tool(
         flake8,
         constraints,
         extra_requirements=first_party_plugins.requirement_strings,
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -113,7 +113,7 @@ class IsortLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_isort_lockfile(
     _: IsortLockfileSentinel, isort: Isort, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(isort, use_pex=python_setup.generate_lockfiles_with_pex)
+    return GeneratePythonLockfile.from_tool(isort, python_setup=python_setup)
 
 
 class IsortExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -293,16 +293,14 @@ async def setup_pylint_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not pylint.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            pylint, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(pylint, python_setup=python_setup)
 
     constraints = await _pylint_interpreter_constraints(first_party_plugins, python_setup)
     return GeneratePythonLockfile.from_tool(
         pylint,
         constraints,
         extra_requirements=first_party_plugins.requirement_strings,
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -50,9 +50,7 @@ class PyUpgradeLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_pyupgrade_lockfile(
     _: PyUpgradeLockfileSentinel, pyupgrade: PyUpgrade, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        pyupgrade, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(pyupgrade, python_setup=python_setup)
 
 
 class PyUpgradeExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -111,7 +111,7 @@ class YapfLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_yapf_lockfile(
     _: YapfLockfileSentinel, yapf: Yapf, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(yapf, use_pex=python_setup.generate_lockfiles_with_pex)
+    return GeneratePythonLockfile.from_tool(yapf, python_setup=python_setup)
 
 
 class YapfExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -49,9 +49,7 @@ class PyoxidizerLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_lockfile_request(
     _: PyoxidizerLockfileSentinel, pyoxidizer: PyOxidizer, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        pyoxidizer, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(pyoxidizer, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -91,9 +91,7 @@ class DebugPyLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_debugpy_lockfile(
     _: DebugPyLockfileSentinel, debugpy: DebugPy, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        debugpy, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(debugpy, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -71,9 +71,7 @@ async def setup_ipython_lockfile(
     _: IPythonLockfileSentinel, ipython: IPython, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not ipython.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            ipython, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(ipython, python_setup=python_setup)
 
     # IPython is often run against the whole repo (`./pants repl ::`), but it is possible to run
     # on subsets of the codebase with disjoint interpreter constraints, such as
@@ -94,7 +92,7 @@ async def setup_ipython_lockfile(
     return GeneratePythonLockfile.from_tool(
         ipython,
         constraints or InterpreterConstraints(python_setup.interpreter_constraints),
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -39,9 +39,7 @@ class LambdexLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_lambdex_lockfile(
     _: LambdexLockfileSentinel, lambdex: Lambdex, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        lambdex, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(lambdex, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -274,15 +274,13 @@ async def setup_pytest_lockfile(
     _: PytestLockfileSentinel, pytest: PyTest, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not pytest.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            pytest, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(pytest, python_setup=python_setup)
 
     constraints = await _pytest_interpreter_constraints(python_setup)
     return GeneratePythonLockfile.from_tool(
         pytest,
         constraints,
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -617,6 +617,15 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
+    add_headers_to_lockfile = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            Should headers that describe how to regenerate the lock file be added to the lock file
+            """
+        ),
+        advanced=True,
+    )
 
     @property
     def generate_lockfiles_with_pex(self) -> bool:

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -65,9 +65,7 @@ async def setup_setuptools_lockfile(
     _: SetuptoolsLockfileSentinel, setuptools: Setuptools, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not setuptools.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            setuptools, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(setuptools, python_setup=python_setup)
 
     all_tgts = await Get(AllTargets, AllTargetsRequest())
     transitive_targets_per_python_dist = await MultiGet(
@@ -84,7 +82,7 @@ async def setup_setuptools_lockfile(
     return GeneratePythonLockfile.from_tool(
         setuptools,
         constraints or InterpreterConstraints(python_setup.interpreter_constraints),
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -41,9 +41,7 @@ class SetuptoolsSCMLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_setuptools_scm_lockfile(
     _: SetuptoolsSCMLockfileSentinel, setuptools_scm: SetuptoolsSCM, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        setuptools_scm, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(setuptools_scm, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -118,7 +118,7 @@ class TwineLockfileSentinel(GeneratePythonToolLockfileSentinel):
 def setup_twine_lockfile(
     _: TwineLockfileSentinel, twine: TwineSubsystem, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(twine, use_pex=python_setup.generate_lockfiles_with_pex)
+    return GeneratePythonLockfile.from_tool(twine, python_setup=python_setup)
 
 
 def rules():

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -382,16 +382,14 @@ async def setup_mypy_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not mypy.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(
-            mypy, use_pex=python_setup.generate_lockfiles_with_pex
-        )
+        return GeneratePythonLockfile.from_tool(mypy, python_setup=python_setup)
 
     constraints = await _mypy_interpreter_constraints(mypy, python_setup)
     return GeneratePythonLockfile.from_tool(
         mypy,
         constraints,
         extra_requirements=first_party_plugins.requirement_strings,
-        use_pex=python_setup.generate_lockfiles_with_pex,
+        python_setup=python_setup,
     )
 
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -411,6 +411,7 @@ async def setup_mypy_extra_type_stubs_lockfile(
             resolve_name=request.resolve_name,
             lockfile_dest=mypy.extra_type_stubs_lockfile,
             use_pex=use_pex,
+            with_headers=python_setup.add_headers_to_lockfile,
         )
 
     # While MyPy will run in partitions, we need a set of constraints that works with every
@@ -437,6 +438,7 @@ async def setup_mypy_extra_type_stubs_lockfile(
         resolve_name=request.resolve_name,
         lockfile_dest=mypy.extra_type_stubs_lockfile,
         use_pex=use_pex,
+        with_headers=python_setup.add_headers_to_lockfile,
     )
 
 

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -63,9 +63,7 @@ def setup_lockfile_request(
     hcl2_parser: TerraformHcl2Parser,
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(
-        hcl2_parser, use_pex=python_setup.generate_lockfiles_with_pex
-    )
+    return GeneratePythonLockfile.from_tool(hcl2_parser, python_setup=python_setup)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
For pex based lock files, adding those headers makes the lockfile a non-standard json file which makes it harder to process it by tools that expect json (like pex, for example). 
So this PR adds the option to opt out of having those headers.


Fixes: https://github.com/pantsbuild/pants/issues/15740