### PR TITLE
Fix deprecation to use FilespecMatcher in fmt.py

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -25,7 +25,7 @@ python_tests(
             "tags": ["platform_specific_behavior"],
             "timeout": 300,
         },
-        "run_pex_binary_integration_test.py": {"timeout": 400},
+        "run_pex_binary_integration_test.py": {"timeout": 600},
         "run_python_source_integration_test.py": {"timeout": 180},
         "setup_py_integration_test.py": {
             "dependencies": ["testprojects/src/python:native_directory"],

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -38,7 +38,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule, ru
 from pants.engine.target import FieldSet, FilteredTargets, SourcesField, Target, Targets
 from pants.engine.unions import UnionMembership, union
 from pants.option.option_types import IntOption, StrListOption
-from pants.source.filespec import matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.collections import partition_sequentially
 from pants.util.logging import LogLevel
 from pants.util.meta import frozen_after_init
@@ -360,13 +360,10 @@ async def fmt(
     )
 
     targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
-    specified_build_files = matches_filespec(
-        {
-            "includes": [os.path.join("**", p) for p in build_file_options.patterns],
-            "excludes": list(build_file_options.ignores),
-        },
-        paths=specs_paths.files,
-    )
+    specified_build_files = FilespecMatcher(
+        includes=[os.path.join("**", p) for p in build_file_options.patterns],
+        excludes=build_file_options.ignores,
+    ).matches(specs_paths.files)
 
     targets_to_request_types = _batch_targets(
         fmt_target_request_types,


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/16563.

[ci skip-rust]