### PR TITLE
Fix list of passthrough arguments for Helm deployments

### DIFF
--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -16,10 +16,10 @@ from pants.util.strutil import bullet_list, softwrap
 
 _VALID_PASSTHROUGH_FLAGS = [
     "--atomic",
-    "--dry-run",
+    "--cleanup-on-fail",
     "--debug",
+    "--dry-run",
     "--force",
-    "--replace",
     "--wait",
     "--wait-for-jobs",
 ]


### PR DESCRIPTION
When reviewing the list of valid passthrough flags initially set for Helm deployments it was found that it was not fully correct, as it included an argument for the Helm command `template` (instead of the `upgrade` command, used in the deployment process) and was missing one.

This PR amends that list.

[ci skip-rust]
[ci skip-build-wheels]