### PR TITLE
Fix `IndexError` when codegen is missing expected `python_requirement` targets

### DIFF
--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -236,6 +236,9 @@ def softwrap(text: str) -> str:
             width, use trailing backlashes to line-continue the line. Because we squash multiple
             spaces, this will "just work".)
     """
+    if not text:
+        return text
+
     # If callers didnt use a leading "\" thats OK.
     if text[0] == "\n":
         text = text[1:]


### PR DESCRIPTION
This code could result in calling `softwrap("")`, which causes an exception unnecessarily.

https://github.com/pantsbuild/pants/blob/9a6e8d3c98ab1d0435feb5ad98c0013b2720284b/src/python/pants/backend/codegen/utils.py#L46-L57

[ci skip-rust]
[ci skip-build-wheels]