### PR TITLE
Improve performance of `Owners` rule (#16563)

### DIFF
--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -25,7 +25,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 
 
@@ -36,10 +36,8 @@ class PutativeJavaTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    tests_filespec = Filespec(includes=list(JavaTestsGeneratorSourcesField.default))
-    test_filenames = set(
-        matches_filespec(tests_filespec, paths=[os.path.basename(path) for path in paths])
-    )
+    tests_filespec_matcher = FilespecMatcher(JavaTestsGeneratorSourcesField.default, ())
+    test_filenames = set(tests_filespec_matcher.matches([os.path.basename(path) for path in paths]))
     test_files = {path for path in paths if os.path.basename(path) in test_filenames}
     sources_files = set(paths) - test_files
     return {JunitTestsGeneratorTarget: test_files, JavaSourcesGeneratorTarget: sources_files}

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -25,7 +25,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 
 
@@ -36,12 +36,12 @@ class PutativeKotlinTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    junit_filespec = Filespec(includes=list(KotlinJunitTestsGeneratorSourcesField.default))
+    junit_filespec_matcher = FilespecMatcher(KotlinJunitTestsGeneratorSourcesField.default, ())
     junit_files = {
         path
         for path in paths
         if os.path.basename(path)
-        in set(matches_filespec(junit_filespec, paths=[os.path.basename(path) for path in paths]))
+        in set(junit_filespec_matcher.matches([os.path.basename(path) for path in paths]))
     }
     sources_files = set(paths) - junit_files
     return {

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -39,7 +39,7 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule, rule_helper
 from pants.engine.target import Target, UnexpandedTargets
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
 from pants.util.logging import LogLevel
 
@@ -53,13 +53,13 @@ class PutativePythonTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    tests_filespec = Filespec(includes=list(PythonTestsGeneratingSourcesField.default))
-    test_utils_filespec = Filespec(includes=list(PythonTestUtilsGeneratingSourcesField.default))
+    tests_filespec_matcher = FilespecMatcher(PythonTestsGeneratingSourcesField.default, ())
+    test_utils_filespec_matcher = FilespecMatcher(PythonTestUtilsGeneratingSourcesField.default, ())
 
     path_to_file_name = {path: os.path.basename(path) for path in paths}
-    test_file_names = set(matches_filespec(tests_filespec, paths=path_to_file_name.values()))
+    test_file_names = set(tests_filespec_matcher.matches(list(path_to_file_name.values())))
     test_util_file_names = set(
-        matches_filespec(test_utils_filespec, paths=path_to_file_name.values())
+        test_utils_filespec_matcher.matches(list(path_to_file_name.values()))
     )
 
     test_files = {

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -27,7 +27,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 
 
@@ -38,21 +38,19 @@ class PutativeScalaTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    scalatest_filespec = Filespec(includes=list(ScalatestTestsGeneratorSourcesField.default))
-    junit_filespec = Filespec(includes=list(ScalaJunitTestsGeneratorSourcesField.default))
+    scalatest_filespec_matcher = FilespecMatcher(ScalatestTestsGeneratorSourcesField.default, ())
+    junit_filespec_matcher = FilespecMatcher(ScalaJunitTestsGeneratorSourcesField.default, ())
     scalatest_files = {
         path
         for path in paths
         if os.path.basename(path)
-        in set(
-            matches_filespec(scalatest_filespec, paths=[os.path.basename(path) for path in paths])
-        )
+        in set(scalatest_filespec_matcher.matches([os.path.basename(path) for path in paths]))
     }
     junit_files = {
         path
         for path in paths
         if os.path.basename(path)
-        in set(matches_filespec(junit_filespec, paths=[os.path.basename(path) for path in paths]))
+        in set(junit_filespec_matcher.matches([os.path.basename(path) for path in paths]))
     }
     sources_files = set(paths) - scalatest_files - junit_files
     return {

--- a/src/python/pants/backend/shell/tailor.py
+++ b/src/python/pants/backend/shell/tailor.py
@@ -25,7 +25,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 
 
@@ -36,10 +36,8 @@ class PutativeShellTargetsRequest(PutativeTargetsRequest):
 
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
-    tests_filespec = Filespec(includes=list(Shunit2TestsGeneratorSourcesField.default))
-    test_filenames = set(
-        matches_filespec(tests_filespec, paths=[os.path.basename(path) for path in paths])
-    )
+    tests_filespec_matcher = FilespecMatcher(Shunit2TestsGeneratorSourcesField.default, ())
+    test_filenames = set(tests_filespec_matcher.matches([os.path.basename(path) for path in paths]))
     test_files = {path for path in paths if os.path.basename(path) in test_filenames}
     sources_files = set(paths) - test_files
     return {Shunit2TestsGeneratorTarget: test_files, ShellSourcesGeneratorTarget: sources_files}

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -43,7 +43,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, union
 from pants.option.global_options import GlobalOptions
 from pants.option.option_types import BoolOption, DictOption, StrListOption, StrOption
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -367,8 +367,8 @@ class TailorSubsystem(GoalSubsystem):
     def validate_build_file_name(self, build_file_patterns: tuple[str, ...]) -> None:
         """Check that the specified BUILD file name works with the repository's BUILD file
         patterns."""
-        filespec = Filespec(includes=list(build_file_patterns))
-        if not bool(matches_filespec(filespec, paths=[self.build_file_name])):
+        filespec_matcher = FilespecMatcher(build_file_patterns, ())
+        if not bool(filespec_matcher.matches([self.build_file_name])):
             raise ValueError(
                 f"The option `[{self.options_scope}].build_file_name` is set to "
                 f"`{self.build_file_name}`, which is not compatible with "
@@ -380,13 +380,14 @@ class TailorSubsystem(GoalSubsystem):
     def filter_by_ignores(
         self, putative_targets: Iterable[PutativeTarget], build_file_ignores: tuple[str, ...]
     ) -> Iterator[PutativeTarget]:
-        ignore_paths_filespec = Filespec(includes=[*self.ignore_paths, *build_file_ignores])
+        ignore_paths_filespec_matcher = FilespecMatcher(
+            (*self.ignore_paths, *build_file_ignores), ()
+        )
         for ptgt in putative_targets:
             is_ignored_file = bool(
-                matches_filespec(
-                    ignore_paths_filespec,
-                    paths=[os.path.join(ptgt.path, self.build_file_name)],
-                )
+                ignore_paths_filespec_matcher.matches(
+                    [os.path.join(ptgt.path, self.build_file_name)]
+                ),
             )
             if is_ignored_file:
                 continue

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -34,7 +34,7 @@ from pants.engine.internals.build_files import extract_build_file_options
 from pants.engine.rules import Get, QueryRule, rule
 from pants.engine.target import MultipleSourcesField, Target
 from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec, matches_filespec
+from pants.source.filespec import FilespecMatcher
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.pytest_util import no_exception
 from pants.testutil.rule_runner import RuleRunner
@@ -79,11 +79,9 @@ async def find_fortran_targets(
     all_fortran_files = await Get(Paths, PathGlobs, req.path_globs("*.f90"))
     unowned_shell_files = set(all_fortran_files.files) - set(all_owned_sources)
 
-    tests_filespec = Filespec(includes=list(FortranTestsSources.default))
+    tests_filespec_matcher = FilespecMatcher(FortranTestsSources.default, ())
     test_filenames = set(
-        matches_filespec(
-            tests_filespec, paths=[os.path.basename(path) for path in unowned_shell_files]
-        )
+        tests_filespec_matcher.matches([os.path.basename(path) for path in unowned_shell_files])
     )
     test_files = {path for path in unowned_shell_files if os.path.basename(path) in test_filenames}
     sources_files = set(unowned_shell_files) - test_files

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -93,7 +93,6 @@ from pants.option.global_options import (
     OwnersNotFoundBehavior,
     UnmatchedBuildFileGlobs,
 )
-from pants.source.filespec import matches_filespec
 from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -787,7 +786,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
 
         for candidate_tgt, bfa in zip(candidate_tgts, build_file_addresses):
             matching_files = set(
-                matches_filespec(candidate_tgt.get(SourcesField).filespec, paths=sources_set)
+                candidate_tgt.get(SourcesField).filespec_matcher.matches(list(sources_set))
             )
             # Also consider secondary ownership, meaning it's not a `SourcesField` field with
             # primary ownership, but the target still should match the file. We can't use
@@ -799,7 +798,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
             )
             for secondary_owner_field in secondary_owner_fields:
                 matching_files.update(
-                    matches_filespec(secondary_owner_field.filespec, paths=sources_set)
+                    *secondary_owner_field.filespec_matcher.matches(list(sources_set))
                 )
             if not matching_files and bfa.rel_path not in sources_set:
                 continue

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -8,7 +8,6 @@ from typing import Any, Generic, Iterable, Sequence, TextIO, Tuple, TypeVar, ove
 
 from typing_extensions import Protocol
 
-from pants.engine.fs import PathGlobs
 from pants.engine.internals.scheduler import Workunit, _PathGlobsAndRootCollection
 from pants.engine.internals.session import SessionValues
 from pants.engine.process import InteractiveProcessResult
@@ -149,15 +148,18 @@ class RemovePrefix:
     def __hash__(self) -> int: ...
     def __repr__(self) -> str: ...
 
+class FilespecMatcher:
+    def __init__(self, includes: Sequence[str], excludes: Sequence[str]) -> None: ...
+    def __eq__(self, other: FilespecMatcher | Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    def matches(self, paths: Sequence[str]) -> list[str]: ...
+
 EMPTY_DIGEST: Digest
 EMPTY_FILE_DIGEST: FileDigest
 EMPTY_SNAPSHOT: Snapshot
 
 def default_cache_path() -> str: ...
-
-# TODO: Really, `paths` should be `Sequence[str]`. Fix and update call sites so that we don't
-#  cast to `tuple()` when not necessary.
-def match_path_globs(path_globs: PathGlobs, paths: tuple[str, ...]) -> str: ...
 
 # ------------------------------------------------------------------------------
 # Workunits

--- a/src/python/pants/source/filespec.py
+++ b/src/python/pants/source/filespec.py
@@ -7,8 +7,10 @@ from typing import Iterable
 
 from typing_extensions import TypedDict
 
-from pants.engine.fs import PathGlobs
-from pants.engine.internals import native_engine
+from pants.base.deprecated import deprecated
+from pants.engine.internals.native_engine import (
+    FilespecMatcher as FilespecMatcher,  # explicit re-export
+)
 
 
 class _IncludesDict(TypedDict, total=True):
@@ -26,11 +28,7 @@ class Filespec(_IncludesDict, total=False):
     excludes: list[str]
 
 
+@deprecated("2.15.0.dev0", "Use `FilespecMatcher().matches()` instead", start_version="2.14.0.dev5")
 def matches_filespec(spec: Filespec, *, paths: Iterable[str]) -> tuple[str, ...]:
-    include_patterns = spec["includes"]
-    exclude_patterns = [f"!{e}" for e in spec.get("excludes", [])]
-    return tuple(
-        native_engine.match_path_globs(
-            PathGlobs((*include_patterns, *exclude_patterns)), tuple(paths)
-        )
-    )
+    matcher = FilespecMatcher(spec["includes"], spec.get("excludes", []))
+    return tuple(matcher.matches(tuple(paths)))

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -6,7 +6,7 @@ from typing import Tuple
 import pytest
 
 from pants.engine.fs import PathGlobs, Snapshot
-from pants.source.filespec import matches_filespec
+from pants.source.filespec import FilespecMatcher, matches_filespec
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -19,7 +19,9 @@ def assert_rule_match(
     rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...], *, should_match: bool
 ) -> None:
     # Confirm in-memory behavior.
-    matched_filespec = matches_filespec({"includes": [glob]}, paths=paths)
+    matched_filespec = tuple(FilespecMatcher([glob], ()).matches(paths))
+    deprecated_matched_filespec = matches_filespec({"includes": [glob]}, paths=paths)
+    assert matched_filespec == deprecated_matched_filespec
     if should_match:
         assert matched_filespec == paths
     else:

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -245,25 +245,9 @@ pub struct PreparedPathGlobs {
   pub(crate) exclude: Arc<GitignoreStyleExcludes>,
   strict_match_behavior: StrictGlobMatching,
   conjunction: GlobExpansionConjunction,
-  patterns: Vec<glob::Pattern>,
 }
 
 impl PreparedPathGlobs {
-  fn parse_patterns_from_include(
-    include: &[PathGlobIncludeEntry],
-  ) -> Result<Vec<glob::Pattern>, String> {
-    include
-      .iter()
-      .map(|pattern| {
-        PathGlob::normalize_pattern(&pattern.input.0).and_then(|components| {
-          let normalized_pattern: PathBuf = components.into_iter().collect();
-          Pattern::new(normalized_pattern.to_str().unwrap())
-            .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", pattern.input.0, e))
-        })
-      })
-      .collect::<Result<Vec<_>, String>>()
-  }
-
   pub fn create(
     globs: Vec<String>,
     strict_match_behavior: StrictGlobMatching,
@@ -281,14 +265,12 @@ impl PreparedPathGlobs {
     }
     let include = PathGlob::spread_filespecs(include_globs)?;
     let exclude = GitignoreStyleExcludes::create(exclude_globs)?;
-    let patterns = PreparedPathGlobs::parse_patterns_from_include(&include)?;
 
     Ok(PreparedPathGlobs {
       include,
       exclude,
       strict_match_behavior,
       conjunction,
-      patterns,
     })
   }
 
@@ -301,32 +283,62 @@ impl PreparedPathGlobs {
       })
       .collect();
 
-    let patterns = PreparedPathGlobs::parse_patterns_from_include(include.as_slice())?;
     Ok(PreparedPathGlobs {
       include,
       // An empty exclude becomes EMPTY_IGNORE.
       exclude: GitignoreStyleExcludes::create(vec![])?,
       strict_match_behavior: StrictGlobMatching::Ignore,
       conjunction: GlobExpansionConjunction::AllMatch,
-      patterns,
     })
+  }
+}
+
+/// Allows checking in-memory if paths match the patterns.
+#[derive(Debug)]
+pub struct FilespecMatcher {
+  includes: Vec<Pattern>,
+  excludes: Arc<GitignoreStyleExcludes>,
+}
+
+impl FilespecMatcher {
+  pub fn new(includes: Vec<String>, excludes: Vec<String>) -> Result<Self, String> {
+    let includes = includes
+      .iter()
+      .map(|glob| {
+        PathGlob::normalize_pattern(glob).and_then(|components| {
+          let normalized_pattern: PathBuf = components.into_iter().collect();
+          Pattern::new(normalized_pattern.to_str().unwrap())
+            .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", glob, e))
+        })
+      })
+      .collect::<Result<Vec<_>, String>>()?;
+    let excludes = GitignoreStyleExcludes::create(excludes)?;
+    Ok(Self { includes, excludes })
   }
 
   ///
-  /// Matches these PreparedPathGlobs against the given paths.
+  /// Matches the patterns against the given paths.
   ///
   /// NB: This implementation is independent from GlobMatchingImplementation::expand, and must be
-  /// kept in sync via unit tests (in particular: the python FilespecTest) in order to allow for
+  /// kept in sync via unit tests (in particular: the python filespec_test.py) in order to allow for
   /// owners detection of deleted files (see #6790 and #5636 for more info). The lazy filesystem
   /// traversal in expand is (currently) too expensive to use for that in-memory matching (such as
   /// via MemFS).
   ///
   pub fn matches(&self, path: &Path) -> bool {
-    self
-      .patterns
+    let matches_includes = self
+      .includes
       .iter()
-      .any(|pattern| pattern.matches_path_with(path, *PATTERN_MATCH_OPTIONS))
-      && !self.exclude.is_ignored_path(path, false)
+      .any(|pattern| pattern.matches_path_with(path, *PATTERN_MATCH_OPTIONS));
+    matches_includes && !self.excludes.is_ignored_path(path, false)
+  }
+
+  pub fn include_globs(&self) -> &[Pattern] {
+    self.includes.as_slice()
+  }
+
+  pub fn exclude_globs(&self) -> &[String] {
+    self.excludes.patterns.as_slice()
   }
 }
 

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::directory::{
   DigestTrie, DirectoryDigest, EMPTY_DIGEST_TREE, EMPTY_DIRECTORY_DIGEST,
 };
 pub use crate::glob_matching::{
-  GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB, SINGLE_STAR_GLOB,
+  FilespecMatcher, GlobMatching, PathGlob, PreparedPathGlobs, DOUBLE_STAR_GLOB, SINGLE_STAR_GLOB,
 };
 
 use std::cmp::min;
@@ -292,29 +292,6 @@ impl GitignoreStyleExcludes {
     match self.gitignore.matched_path_or_any_parents(path, is_dir) {
       ::ignore::Match::None | ::ignore::Match::Whitelist(_) => false,
       ::ignore::Match::Ignore(_) => true,
-    }
-  }
-
-  ///
-  /// Find out if a path has any ignore patterns for files/paths in its tree.
-  ///
-  /// Used by the IntermediateGlobbedFilesAndDirectories in snapshot_ops.rs,
-  /// to check if it may optimize the snapshot subset operation on this tree,
-  /// or need to check for excluded files/directories.
-  ///
-  pub fn maybe_is_parent_of_ignored_path(&self, path: &Path) -> bool {
-    match path.to_str() {
-      None => true,
-      Some(s) => {
-        for pattern in self.exclude_patterns().iter() {
-          if pattern.starts_with(s) || s.starts_with(pattern) {
-            // In case the pattern is shorter than path, we are inside a ignored tree, so both
-            // parent and child of ignored paths.
-            return true;
-          }
-        }
-        false
-      }
     }
   }
 }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -13,7 +13,7 @@ use pyo3::prelude::*;
 use pyo3::types::{PyIterator, PyString, PyTuple, PyType};
 
 use fs::{
-  DirectoryDigest, GlobExpansionConjunction, PathGlobs, PreparedPathGlobs, StrictGlobMatching,
+  DirectoryDigest, FilespecMatcher, GlobExpansionConjunction, PathGlobs, StrictGlobMatching,
   EMPTY_DIRECTORY_DIGEST,
 };
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
@@ -28,12 +28,12 @@ pub(crate) fn register(m: &PyModule) -> PyResult<()> {
   m.add_class::<PyMergeDigests>()?;
   m.add_class::<PyAddPrefix>()?;
   m.add_class::<PyRemovePrefix>()?;
+  m.add_class::<PyFilespecMatcher>()?;
 
   m.add("EMPTY_DIGEST", PyDigest(EMPTY_DIRECTORY_DIGEST.clone()))?;
   m.add("EMPTY_FILE_DIGEST", PyFileDigest(EMPTY_DIGEST))?;
   m.add("EMPTY_SNAPSHOT", PySnapshot(Snapshot::empty()))?;
 
-  m.add_function(wrap_pyfunction!(match_path_globs, m)?)?;
   m.add_function(wrap_pyfunction!(default_cache_path, m)?)?;
   Ok(())
 }
@@ -385,17 +385,6 @@ impl PyRemovePrefix {
 
 struct PyPathGlobs(PathGlobs);
 
-impl PyPathGlobs {
-  fn parse(self) -> PyResult<PreparedPathGlobs> {
-    self.0.clone().parse().map_err(|e| {
-      PyValueError::new_err(format!(
-        "Failed to parse PathGlobs: {:?}\n\nError: {}",
-        self.0, e
-      ))
-    })
-  }
-}
-
 impl<'source> FromPyObject<'source> for PyPathGlobs {
   fn extract(obj: &'source PyAny) -> PyResult<Self> {
     let globs: Vec<String> = obj.getattr("globs")?.extract()?;
@@ -426,21 +415,65 @@ impl<'source> FromPyObject<'source> for PyPathGlobs {
   }
 }
 
-#[pyfunction]
-fn match_path_globs(
-  py_path_globs: PyPathGlobs,
-  paths: Vec<String>,
-  py: Python,
-) -> PyResult<Vec<String>> {
-  py.allow_threads(|| {
-    let path_globs = py_path_globs.parse()?;
-    Ok(
-      paths
-        .into_iter()
-        .filter(|p| path_globs.matches(Path::new(p)))
-        .collect(),
-    )
-  })
+// -----------------------------------------------------------------------------
+// FilespecMatcher
+// -----------------------------------------------------------------------------
+
+#[pyclass(name = "FilespecMatcher")]
+#[derive(Debug)]
+pub struct PyFilespecMatcher(FilespecMatcher);
+
+#[pymethods]
+impl PyFilespecMatcher {
+  #[new]
+  fn __new__(includes: Vec<String>, excludes: Vec<String>, py: Python) -> PyResult<Self> {
+    // Parsing the globs has shown up in benchmarks
+    // (https://github.com/pantsbuild/pants/issues/16122), so we use py.allow_threads().
+    let matcher =
+      py.allow_threads(|| FilespecMatcher::new(includes, excludes).map_err(PyValueError::new_err))?;
+    Ok(Self(matcher))
+  }
+
+  fn __hash__(&self) -> u64 {
+    let mut s = DefaultHasher::new();
+    self.0.include_globs().hash(&mut s);
+    self.0.exclude_globs().hash(&mut s);
+    s.finish()
+  }
+
+  fn __repr__(&self) -> String {
+    let includes = self
+      .0
+      .include_globs()
+      .iter()
+      .map(|pattern| pattern.to_string())
+      .join(", ");
+    let excludes = self.0.exclude_globs().join(", ");
+    format!("FilespecMatcher(includes=['{includes}'], excludes=[{excludes}])",)
+  }
+
+  fn __richcmp__(&self, other: &PyFilespecMatcher, op: CompareOp, py: Python) -> PyObject {
+    match op {
+      CompareOp::Eq => (self.0.include_globs() == other.0.include_globs()
+        && self.0.exclude_globs() == other.0.exclude_globs())
+      .into_py(py),
+      CompareOp::Ne => (self.0.include_globs() != other.0.include_globs()
+        || self.0.exclude_globs() != other.0.exclude_globs())
+      .into_py(py),
+      _ => py.NotImplemented(),
+    }
+  }
+
+  fn matches(&self, paths: Vec<String>, py: Python) -> PyResult<Vec<String>> {
+    py.allow_threads(|| {
+      Ok(
+        paths
+          .into_iter()
+          .filter(|p| self.0.matches(Path::new(p)))
+          .collect(),
+      )
+    })
+  }
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Possibly will close https://github.com/pantsbuild/pants/issues/16122.

@stuhood found in https://github.com/pantsbuild/pants/issues/16122#issuecomment-1183598289 that we were spending substantial time in Rust parsing the same globs in the stateless function `matches_filespec`.

This improves the situation by introducing `FilespecsMatcher`, which allows us to persist the globs parsing over time. Crucially, `FilespecsMatcher` eagerly parses the globs in its constructor, unlike `PathGlobs` currently being lazy. Then, we  use a `@memoized_method` on each `SourcesField` instance to avoid ever creating the matcher more than necessary.

Before:

```
❯ hyperfine -w 2 -r 10 './pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled dependencies ::'
  Time (mean ± σ):      6.562 s ±  0.153 s    [User: 7.354 s, System: 1.516 s]
  Range (min … max):    6.420 s …  6.878 s    10 runs
```

After:

```
❯ hyperfine -w 2 -r 10 './pants --no-pantsd --no-buildsense-enable --no-anonymous-telemetry-enabled dependencies ::'
  Time (mean ± σ):      6.460 s ±  0.065 s    [User: 7.301 s, System: 1.447 s]
  Range (min … max):    6.340 s …  6.576 s    10 runs
```

(Note, we expect the performance to be better in repos with the shape described at https://github.com/pantsbuild/pants/issues/16122#issuecomment-1183598289)

## Relationship to `PathGlobs`

We also considered changing `PathGlobs` to eagerly parse, and then defining `PathGlobs.matches()`, rather than introducing the new type `FilespecsMatcher`.

I believe `FilespecsMatcher` is a clearer API: it is only used for in-memory checks if globs match paths, whereas `PathGlobs` is used for on-disk.

Notably, the Rust code only overlaps in how the exclude patterns are ignored. So, making this split allows us to simplify `PathGlobs`.

A downside of having separate types is it's harder to share the duplicate parsing of the exclude patterns. This seems fine, given that the include patterns are separate code paths.

(See https://github.com/pantsbuild/pants/issues/16564 for improving `PathGlobs` to also eagerly parse.)
