### PR TITLE
Add `grpc` to default Python module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -73,6 +73,7 @@ DEFAULT_MODULE_MAPPING = {
     "google-cloud-pubsub": ("google.cloud.pubsub_v1", "google.cloud.pubsub"),
     "google-cloud-secret-manager": ("google.cloud.secretmanager",),
     "google-cloud-storage": ("google.cloud.storage",),
+    "grpcio": ("grpc",),
     "ipython": ("IPython",),
     "jack-client": ("jack",),
     "kafka-python": ("kafka",),


### PR DESCRIPTION
[ci skip-rust]