### PR TITLE
Mark `[python].requirement_constraints` as deprecated (but not planned for removal)

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -428,6 +428,20 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
+
+    __constraints_deprecation_msg = softwrap(
+        f"""
+        We encourage instead migrating to `[python].enable_resolves` and `[python].resolves`,
+        which is an improvement over this option. The `[python].resolves` feature ensures that
+        your lockfiles are fully comprehensive, i.e. include all transitive dependencies;
+        uses hashes for better supply chain security; and supports advanced features like VCS
+        and local requirements, along with options `[python].resolves_to_only_binary`.
+
+        To migrate, stop setting `[python].requirement_constraints` and
+        `[python].resolve_all_constraints`, and instead set `[python].enable_resolves` to
+        `true`. Then, run `{bin_name()} generate-lockfiles`.
+        """
+    )
     requirement_constraints = FileOption(
         default=None,
         help=softwrap(
@@ -449,6 +463,8 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
         mutually_exclusive_group="lockfile",
+        removal_version="3.0.0.dev0",
+        removal_hint=__constraints_deprecation_msg,
     )
     _resolve_all_constraints = BoolOption(
         default=True,
@@ -466,6 +482,8 @@ class PythonSetup(Subsystem):
             """
         ),
         advanced=True,
+        removal_version="3.0.0.dev0",
+        removal_hint=__constraints_deprecation_msg,
     )
     no_binary = StrListOption(
         help=softwrap(

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -450,7 +450,7 @@ class PythonSetup(Subsystem):
         advanced=True,
         mutually_exclusive_group="lockfile",
     )
-    resolve_all_constraints = BoolOption(
+    _resolve_all_constraints = BoolOption(
         default=True,
         help=softwrap(
             """
@@ -755,15 +755,29 @@ class PythonSetup(Subsystem):
             ).items()
         }
 
-    def resolve_all_constraints_was_set_explicitly(self) -> bool:
-        return not self.options.is_default("resolve_all_constraints")
-
     @property
     def manylinux(self) -> str | None:
         manylinux = cast(Optional[str], self.resolver_manylinux)
         if manylinux is None or manylinux.lower() in ("false", "no", "none"):
             return None
         return manylinux
+
+    @property
+    def resolve_all_constraints(self) -> bool:
+        if (
+            self._resolve_all_constraints
+            and not self.options.is_default("resolve_all_constraints")
+            and not self.requirement_constraints
+        ):
+            raise ValueError(
+                softwrap(
+                    """
+                    `[python].resolve_all_constraints` is enabled, so
+                    `[python].requirement_constraints` must also be set.
+                    """
+                )
+            )
+        return self._resolve_all_constraints
 
     @property
     def scratch_dir(self):


### PR DESCRIPTION
We decided in Slack to not plan to remove this mechanism until Pants 3.0. While we strongly encourage using `[python].resolves` instead, we don't want to _force_ users to migrate. We only want to _encourage_ migration.

This PR also refactors `pex_from_targets.py` so that the impact of the old code is even better isolated. Note that we will always need to keep around a lot of the relevant code with how to subset via `--repository-pex` because we decided to support manually managed `requirements.txt`-style locks.