### PR TITLE
Add --squash and --pull options support for docker build

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -210,7 +210,9 @@ def get_build_options(
                 error_cls=DockerImageOptionValueError,
             )
             yield from target[field_type].options(format)
-        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin) or issubclass(field_type, DockerBuildSkippingOptionFieldMixin):
+        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin) or issubclass(
+            field_type, DockerBuildSkippingOptionFieldMixin
+        ):
             yield from target[field_type].options()
 
     # Target stage

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -210,9 +210,9 @@ def get_build_options(
                 error_cls=DockerImageOptionValueError,
             )
             yield from target[field_type].options(format)
-        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin) or issubclass(
-            field_type, DockerBuildSkippingOptionFieldMixin
-        ):
+        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin):
+            yield from target[field_type].options()
+        elif issubclass(field_type, DockerBuildSkippingOptionFieldMixin):
             yield from target[field_type].options()
 
     # Target stage

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -17,8 +17,8 @@ from pants.backend.docker.registries import DockerRegistries, DockerRegistryOpti
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMixin,
-    DockerBuildSkippingOptionFieldMixin,
-    DockerBuildUnaryOptionFieldMixin,
+    DockerBuildOptionFieldValueMixin,
+    DockerBuildOptionFlagFieldMixin,
     DockerImageContextRootField,
     DockerImageRegistriesField,
     DockerImageRepositoryField,
@@ -210,9 +210,9 @@ def get_build_options(
                 error_cls=DockerImageOptionValueError,
             )
             yield from target[field_type].options(format)
-        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin):
+        elif issubclass(field_type, DockerBuildOptionFieldValueMixin):
             yield from target[field_type].options()
-        elif issubclass(field_type, DockerBuildSkippingOptionFieldMixin):
+        elif issubclass(field_type, DockerBuildOptionFlagFieldMixin):
             yield from target[field_type].options()
 
     # Target stage

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -17,6 +17,8 @@ from pants.backend.docker.registries import DockerRegistries, DockerRegistryOpti
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMixin,
+    DockerBuildSkippingOptionFieldMixin,
+    DockerBuildUnaryOptionFieldMixin,
     DockerImageContextRootField,
     DockerImageRegistriesField,
     DockerImageRepositoryField,
@@ -208,6 +210,8 @@ def get_build_options(
                 error_cls=DockerImageOptionValueError,
             )
             yield from target[field_type].options(format)
+        elif issubclass(field_type, DockerBuildUnaryOptionFieldMixin) or issubclass(field_type, DockerBuildSkippingOptionFieldMixin):
+            yield from target[field_type].options()
 
     # Target stage
     target_stage = None

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -334,7 +334,7 @@ class DockerImageBuildSSHOptionField(DockerBuildOptionFieldMixin, StringSequence
         yield from cast("tuple[str]", self.value)
 
 
-class DockerBuildUnaryOptionFieldMixin(Field):
+class DockerBuildOptionFieldValueMixin(Field):
     """Inherit this mixin class to provide unary options (i.e. option in the form of `--flag=value`)
     to `docker build`."""
 
@@ -345,7 +345,7 @@ class DockerBuildUnaryOptionFieldMixin(Field):
         yield f"{self.docker_build_option}={self.value}"
 
 
-class DockerImageBuildPullOptionField(DockerBuildUnaryOptionFieldMixin, BoolField):
+class DockerImageBuildPullOptionField(DockerBuildOptionFieldValueMixin, BoolField):
     alias = "pull"
     default = True
     help = softwrap(
@@ -358,7 +358,7 @@ class DockerImageBuildPullOptionField(DockerBuildUnaryOptionFieldMixin, BoolFiel
     docker_build_option = "--pull"
 
 
-class DockerBuildSkippingOptionFieldMixin(BoolField, ABC):
+class DockerBuildOptionFlagFieldMixin(BoolField, ABC):
     """Inherit this mixin class to provide optional flags (i.e. add `--flag` only when the value is
     `True`) to `docker build`."""
 
@@ -370,7 +370,7 @@ class DockerBuildSkippingOptionFieldMixin(BoolField, ABC):
             yield f"{self.docker_build_option}"
 
 
-class DockerImageBuildSquashOptionField(DockerBuildSkippingOptionFieldMixin):
+class DockerImageBuildSquashOptionField(DockerBuildOptionFlagFieldMixin):
     alias = "squash"
     default = False
     help = softwrap(

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -25,6 +25,7 @@ from pants.engine.target import (
     BoolField,
     Dependencies,
     DictStringToStringField,
+    Field,
     InvalidFieldException,
     OptionalSingleSourceField,
     StringField,
@@ -333,7 +334,7 @@ class DockerImageBuildSSHOptionField(DockerBuildOptionFieldMixin, StringSequence
         yield from cast("tuple[str]", self.value)
 
 
-class DockerBuildUnaryOptionFieldMixin(ABC):
+class DockerBuildUnaryOptionFieldMixin(Field):
     """Inherit this mixin class to provide unary options (i.e. option in the form of `--flag=value`)
     to `docker build`."""
 

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -334,7 +334,8 @@ class DockerImageBuildSSHOptionField(DockerBuildOptionFieldMixin, StringSequence
 
 
 class DockerBuildUnaryOptionFieldMixin(ABC):
-    """Inherit this mixin class to provide unary options (i.e. option in the form of `--flag=value`) to `docker build`."""
+    """Inherit this mixin class to provide unary options (i.e. option in the form of `--flag=value`)
+    to `docker build`."""
 
     docker_build_option: ClassVar[str]
 
@@ -357,7 +358,9 @@ class DockerImageBuildPullOptionField(DockerBuildUnaryOptionFieldMixin, BoolFiel
 
 
 class DockerBuildSkippingOptionFieldMixin(BoolField, ABC):
-    """Inherit this mixin class to provide optional flags (i.e. add `--flag` only when the value is `True`) to `docker build`."""
+    """Inherit this mixin class to provide optional flags (i.e. add `--flag` only when the value is
+    `True`) to `docker build`."""
+
     docker_build_option: ClassVar[str]
 
     @final
@@ -367,7 +370,7 @@ class DockerBuildSkippingOptionFieldMixin(BoolField, ABC):
 
 
 class DockerImageBuildSquashOptionField(DockerBuildSkippingOptionFieldMixin):
-    alias="squash"
+    alias = "squash"
     default = False
     help = softwrap(
         """


### PR DESCRIPTION
Docker build options had the hardwired behavior of --flag ..values.., so I had to put in new types of mixin to allow --flag=True, and optional --flag

I think I can also get to doing multi-platform build if I add --platform. Will investigate in a follow up commit.

Fixes https://github.com/pantsbuild/pants/issues/16494