### PR TITLE
Keep `--process-cleanup` until 3.0

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1158,7 +1158,7 @@ class BootstrapOptions:
     process_cleanup = BoolOption(
         default=(DEFAULT_EXECUTION_OPTIONS.keep_sandboxes == KeepSandboxes.never),
         deprecation_start_version="2.15.0.dev1",
-        removal_version="2.17.0.dev1",
+        removal_version="3.0.0.dev0",
         removal_hint="Use the `keep_sandboxes` option instead.",
         help=softwrap(
             """


### PR DESCRIPTION
This is an option that we drilled into our users, so there's a real cost to requiring humans to retrain themselves. It's not very much code for us to keep supporting the old option.

Users will still get a deprecation message when using `--process-cleanups`, which we want.

[ci skip-rust]
[ci skip-build-wheels]