### PR TITLE
Optimize `CreateDigest` implementation.

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -366,6 +366,23 @@ impl Store {
   }
 
   ///
+  /// A convenience method for storing batches of small files.
+  ///
+  /// NB: This method should not be used for large blobs: prefer to stream them from their source
+  /// using `store_file`.
+  ///
+  pub async fn store_file_bytes_batch(
+    &self,
+    items: Vec<(Option<Digest>, Bytes)>,
+    initial_lease: bool,
+  ) -> Result<Vec<Digest>, String> {
+    self
+      .local
+      .store_bytes_batch(EntryType::File, items, initial_lease)
+      .await
+  }
+
+  ///
   /// Store a file locally by streaming its contents.
   ///
   pub async fn store_file<F, R>(

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -470,13 +470,12 @@ fn create_digest_to_digest(
 
   let store = context.core.store();
   async move {
+    // The digests returned here are already in the `file_digests` map.
+    let _ = store.store_file_bytes_batch(bytes_to_store, true).await?;
     let trie = DigestTrie::from_path_stats(path_stats, &file_digests)?;
-    let store_trie = store.record_digest_trie(trie, true);
-    let store_bytes = store.store_file_bytes_batch(bytes_to_store, true);
-    let (trie_digest, _) = try_join!(store_trie, store_bytes)?;
 
     let gil = Python::acquire_gil();
-    let value = Snapshot::store_directory_digest(gil.python(), trie_digest)?;
+    let value = Snapshot::store_directory_digest(gil.python(), trie.into())?;
     Ok(value)
   }
   .boxed()


### PR DESCRIPTION
Closes #16570

* Use a `DigestTrie` to create all snapshots at once, instead of creating them individually
* Store all in-memory file contents in a single (batched) call, instead of storing them individually

[ci skip-build-wheels]

---

I restored the benchmark script from #14569 to test this. The results seem almost too good to be true, but here they are 🤔 

| size | create_digest_before | create_digest_after |
| --- | --- | --- |
| 20000 | 608 | 130 |
| 40000 | 1164 | 268 |
| 60000 | 2260 | 475 |
| 80000 | 3582 | 674 |
| 100000 | 5085 | 862 |
| 120000 | 6765 | 1057 |
| 140000 | 8818 | 1067 |
| 160000 | 10752 | 1361 |
| 180000 | 12619 | 1604 |

Somebody should probably double-check those numbers 😅 I'll re-run on my machine to sanity-check it as well