### PR TITLE
Implement a batched local lookup for missing fingerprints.

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -1,6 +1,6 @@
 use super::{EntryType, ShrinkBehavior};
 
-use std::collections::BinaryHeap;
+use std::collections::{BinaryHeap, HashSet};
 use std::fmt::Debug;
 use std::io::{self, Read};
 use std::path::Path;
@@ -338,18 +338,41 @@ impl ByteStore {
       .await
   }
 
-  pub async fn exists(&self, entry_type: EntryType, digest: Digest) -> Result<bool, String> {
-    if digest == EMPTY_DIGEST {
-      // Avoid I/O for this case. This allows some client-provided operations (like merging
-      // snapshots) to work without needing to first store the empty snapshot.
-      return Ok(true);
-    }
+  ///
+  /// Given a collection of Digests (digests),
+  /// returns the set of digests from that collection not present in the
+  /// underlying LMDB store.
+  ///
+  pub async fn get_missing_digests(
+    &self,
+    entry_type: EntryType,
+    digests: HashSet<Digest>,
+  ) -> Result<HashSet<Digest>, String> {
+    let fingerprints_to_check = digests
+      .iter()
+      .filter_map(|digest| {
+        // Avoid I/O for this case. This allows some client-provided operations (like
+        // merging snapshots) to work without needing to first store the empty snapshot.
+        if *digest == EMPTY_DIGEST {
+          None
+        } else {
+          Some(digest.hash)
+        }
+      })
+      .collect::<Vec<_>>();
 
     let dbs = match entry_type {
       EntryType::Directory => self.inner.directory_dbs.clone(),
       EntryType::File => self.inner.file_dbs.clone(),
     }?;
-    dbs.exists(digest.hash).await
+
+    let missing = dbs.get_missing_fingerprints(fingerprints_to_check).await?;
+
+    let missing = digests
+      .into_iter()
+      .filter(|digest| *digest != EMPTY_DIGEST && missing.contains(&digest.hash))
+      .collect::<HashSet<_>>();
+    Ok(missing)
   }
 
   ///

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -366,11 +366,11 @@ impl ByteStore {
       EntryType::File => self.inner.file_dbs.clone(),
     }?;
 
-    let missing = dbs.get_missing_fingerprints(fingerprints_to_check).await?;
+    let existing = dbs.exists_batch(fingerprints_to_check).await?;
 
     let missing = digests
       .into_iter()
-      .filter(|digest| *digest != EMPTY_DIGEST && missing.contains(&digest.hash))
+      .filter(|digest| *digest != EMPTY_DIGEST && !existing.contains(&digest.hash))
       .collect::<HashSet<_>>();
     Ok(missing)
   }


### PR DESCRIPTION
Closes #16400

The structure of the new `exists_batch` function is based on the existing `store_bytes_batch`.

[ci skip-build-wheels]