### PR TITLE
Remove deprecated `use_deprecated_directory_cli_args_semantics` option

### DIFF
--- a/src/python/pants/backend/explorer/graphql/query/targets.py
+++ b/src/python/pants/backend/explorer/graphql/query/targets.py
@@ -166,9 +166,7 @@ class QueryTargetsMixin:
         req = GraphQLContext.request_state_from_info(info).product_request
         specs = (
             specs_parser.parse_specs(
-                query.specs,
-                convert_dir_literal_to_address_literal=False,
-                description_of_origin="GraphQL targets `query.specs`",
+                query.specs, description_of_origin="GraphQL targets `query.specs`"
             )
             if query is not None and query.specs
             else None

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -136,7 +136,7 @@ def test_python_dependencies(rule_runner: RuleRunner) -> None:
     assert_deps = partial(assert_dependencies, rule_runner)
 
     assert_deps(
-        specs=["some/other/target"],
+        specs=["some/other/target:target"],
         transitive=False,
         expected=["some/other/target/a.py"],
     )
@@ -146,7 +146,7 @@ def test_python_dependencies(rule_runner: RuleRunner) -> None:
         expected=["3rdparty/python:req2", "some/target/a.py"],
     )
     assert_deps(
-        specs=["some/other/target"],
+        specs=["some/other/target:target"],
         transitive=True,
         expected=[
             "3rdparty/python:req1",

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -20,7 +20,6 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
-from pants.option.global_options import GlobalOptions
 from pants.option.option_types import StrOption
 
 
@@ -80,9 +79,7 @@ def find_paths_breadth_first(
 
 
 @goal_rule
-async def paths(
-    console: Console, paths_subsystem: PathsSubsystem, global_options: GlobalOptions
-) -> PathsGoal:
+async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
 
     path_from = paths_subsystem.from_
     path_to = paths_subsystem.to
@@ -95,7 +92,6 @@ async def paths(
 
     specs_parser = SpecsParser()
 
-    convert_dir_literals = global_options.use_deprecated_directory_cli_args_semantics
     from_tgts, to_tgts = await MultiGet(
         Get(
             Targets,
@@ -103,7 +99,6 @@ async def paths(
             specs_parser.parse_specs(
                 [path_from],
                 description_of_origin="the option `--paths-from`",
-                convert_dir_literal_to_address_literal=convert_dir_literals,
             ),
         ),
         Get(
@@ -112,7 +107,6 @@ async def paths(
             specs_parser.parse_specs(
                 [path_to],
                 description_of_origin="the option `--paths-to`",
-                convert_dir_literal_to_address_literal=convert_dir_literals,
             ),
         ),
     )

--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -114,10 +114,6 @@ class DirLiteralSpec(Spec):
     def __str__(self) -> str:
         return self.directory
 
-    def to_address_literal(self) -> AddressLiteralSpec:
-        """For now, `dir` can also be shorthand for `dir:dir`."""
-        return AddressLiteralSpec(path_component=self.directory)
-
     def matches_target_residence_dir(self, residence_dir: str) -> bool:
         return residence_dir == self.directory
 
@@ -253,7 +249,7 @@ class RawSpecs:
         specs: Iterable[Spec],
         *,
         description_of_origin: str,
-        convert_dir_literal_to_address_literal: bool,
+        convert_dir_literal_to_address_literal: bool = False,
         unmatched_glob_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.error,
         filter_by_global_options: bool = False,
         from_change_detection: bool = False,
@@ -278,10 +274,7 @@ class RawSpecs:
             elif isinstance(spec, FileGlobSpec):
                 file_globs.append(spec)
             elif isinstance(spec, DirLiteralSpec):
-                if convert_dir_literal_to_address_literal:
-                    address_literals.append(spec.to_address_literal())
-                else:
-                    dir_literals.append(spec)
+                dir_literals.append(spec)
             elif isinstance(spec, DirGlobSpec):
                 dir_globs.append(spec)
             elif isinstance(spec, RecursiveGlobSpec):

--- a/src/python/pants/base/specs_parser.py
+++ b/src/python/pants/base/specs_parser.py
@@ -116,7 +116,7 @@ class SpecsParser:
         specs: Iterable[str],
         *,
         description_of_origin: str,
-        convert_dir_literal_to_address_literal: bool,
+        convert_dir_literal_to_address_literal: bool = False,
         unmatched_glob_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.error,
     ) -> Specs:
         include_specs = []
@@ -131,14 +131,12 @@ class SpecsParser:
         includes = RawSpecs.create(
             include_specs,
             description_of_origin=description_of_origin,
-            convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
             unmatched_glob_behavior=unmatched_glob_behavior,
             filter_by_global_options=True,
         )
         ignores = RawSpecs.create(
             ignore_specs,
             description_of_origin=description_of_origin,
-            convert_dir_literal_to_address_literal=convert_dir_literal_to_address_literal,
             unmatched_glob_behavior=unmatched_glob_behavior,
             # By setting the below to False, we will end up matching some targets
             # that cannot have been resolved by the include specs. For example, if the user runs

--- a/src/python/pants/bsp/util_rules/targets.py
+++ b/src/python/pants/bsp/util_rules/targets.py
@@ -137,9 +137,7 @@ class _ParseOneBSPMappingRequest:
 async def parse_one_bsp_mapping(request: _ParseOneBSPMappingRequest) -> BSPBuildTargetInternal:
     specs_parser = SpecsParser()
     specs = specs_parser.parse_specs(
-        request.definition.addresses,
-        description_of_origin=f"the BSP mapping {request.name}",
-        convert_dir_literal_to_address_literal=False,
+        request.definition.addresses, description_of_origin=f"the BSP mapping {request.name}"
     ).includes
     return BSPBuildTargetInternal(request.name, specs, request.definition)
 

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -10,7 +10,6 @@ from textwrap import dedent
 
 import pytest
 
-from pants.base.specs import AddressLiteralSpec, DirLiteralSpec, FileLiteralSpec, RawSpecs
 from pants.core.goals import tailor
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -26,7 +25,6 @@ from pants.core.goals.tailor import (
     default_sources_for_target_type,
     group_by_dir,
     make_content_str,
-    specs_to_dirs,
 )
 from pants.core.util_rules import source_files
 from pants.engine.fs import DigestContents, FileContent, PathGlobs, Paths
@@ -429,54 +427,6 @@ def test_group_by_dir() -> None:
         "foo/bar": {"__init__.ext", "baz1.ext", "baz1_test.ext", "baz2.ext"},
         "foo/bar/qux": {"quux1.ext"},
     } == group_by_dir(paths)
-
-
-def test_specs_to_dirs() -> None:
-    assert specs_to_dirs(RawSpecs(description_of_origin="tests")) == ("",)
-    assert specs_to_dirs(
-        RawSpecs(
-            address_literals=(AddressLiteralSpec("src/python/foo"),), description_of_origin="tests"
-        )
-    ) == ("src/python/foo",)
-    assert specs_to_dirs(
-        RawSpecs(dir_literals=(DirLiteralSpec("src/python/foo"),), description_of_origin="tests")
-    ) == ("src/python/foo",)
-    assert specs_to_dirs(
-        RawSpecs(
-            address_literals=(
-                AddressLiteralSpec("src/python/foo"),
-                AddressLiteralSpec("src/python/bar"),
-            ),
-            description_of_origin="tests",
-        )
-    ) == ("src/python/foo", "src/python/bar")
-
-    with pytest.raises(ValueError):
-        specs_to_dirs(
-            RawSpecs(
-                file_literals=(FileLiteralSpec("src/python/foo.py"),), description_of_origin="tests"
-            )
-        )
-
-    with pytest.raises(ValueError):
-        specs_to_dirs(
-            RawSpecs(
-                address_literals=(AddressLiteralSpec("src/python/bar", "tgt"),),
-                description_of_origin="tests",
-            )
-        )
-
-    with pytest.raises(ValueError):
-        specs_to_dirs(
-            RawSpecs(
-                address_literals=(
-                    AddressLiteralSpec(
-                        "src/python/bar", target_component=None, generated_component="gen"
-                    ),
-                ),
-                description_of_origin="tests",
-            )
-        )
 
 
 def test_tailor_rule_write_mode(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -927,9 +927,7 @@ def test_streaming_workunits_expanded_specs(run_tracker: RunTracker) -> None:
         }
     )
     specs = SpecsParser().parse_specs(
-        ["src/python/somefiles::", "src/python/others/b.py"],
-        convert_dir_literal_to_address_literal=False,
-        description_of_origin="tests",
+        ["src/python/somefiles::", "src/python/others/b.py"], description_of_origin="tests"
     )
 
     class Callback(WorkunitsCallback):

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -903,7 +903,7 @@ def assert_generated(
         # TODO: Adjust the `TransitiveTargets` API to expose the complete mapping.
         #   see https://github.com/pantsbuild/pants/issues/11270
         specs = SpecsParser(rule_runner.build_root).parse_specs(
-            ["::"], convert_dir_literal_to_address_literal=False, description_of_origin="tests"
+            ["::"], description_of_origin="tests"
         )
         addresses = rule_runner.request(Addresses, [specs])
         dependency_mapping = rule_runner.request(

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -153,7 +153,6 @@ def resolve_raw_specs_without_file_owners(
     specs_obj = RawSpecs.create(
         specs,
         filter_by_global_options=True,
-        convert_dir_literal_to_address_literal=False,
         unmatched_glob_behavior=(
             GlobMatchErrorBehavior.ignore if ignore_nonexistent else GlobMatchErrorBehavior.error
         ),
@@ -533,7 +532,6 @@ def resolve_raw_specs_with_only_file_owners(
     specs_obj = RawSpecs.create(
         specs,
         filter_by_global_options=True,
-        convert_dir_literal_to_address_literal=True,
         unmatched_glob_behavior=(
             GlobMatchErrorBehavior.ignore if ignore_nonexistent else GlobMatchErrorBehavior.error
         ),
@@ -641,7 +639,6 @@ def test_resolve_addresses_from_raw_specs(rule_runner: RuleRunner) -> None:
     multiple_files_specs = ["multiple_files/f2.txt", "multiple_files:multiple_files"]
     specs = SpecsParser(rule_runner.build_root).parse_specs(
         [*no_interaction_specs, *multiple_files_specs],
-        convert_dir_literal_to_address_literal=False,
         description_of_origin="tests",
     )
 
@@ -672,9 +669,7 @@ def test_resolve_addresses_from_specs(rule_runner: RuleRunner) -> None:
     )
 
     def assert_resolved(specs: Iterable[str], expected: set[str]) -> None:
-        specs_obj = SpecsParser().parse_specs(
-            specs, convert_dir_literal_to_address_literal=False, description_of_origin="tests"
-        )
+        specs_obj = SpecsParser().parse_specs(specs, description_of_origin="tests")
         result = rule_runner.request(Addresses, [specs_obj])
         assert {addr.spec for addr in result} == expected
 
@@ -805,9 +800,7 @@ def test_resolve_specs_paths(rule_runner: RuleRunner) -> None:
     def assert_paths(
         specs: Iterable[str], expected_files: set[str], expected_dirs: set[str]
     ) -> None:
-        specs_obj = SpecsParser().parse_specs(
-            specs, convert_dir_literal_to_address_literal=False, description_of_origin="tests"
-        )
+        specs_obj = SpecsParser().parse_specs(specs, description_of_origin="tests")
         result = rule_runner.request(SpecsPaths, [specs_obj])
         assert set(result.files) == expected_files
         assert set(result.dirs) == expected_dirs
@@ -914,11 +907,7 @@ def test_find_valid_field_sets(caplog) -> None:
             [
                 request,
                 Specs(
-                    includes=RawSpecs.create(
-                        specs,
-                        convert_dir_literal_to_address_literal=True,
-                        description_of_origin="tests",
-                    ),
+                    includes=RawSpecs.create(specs, description_of_origin="tests"),
                     ignores=RawSpecs(description_of_origin="tests"),
                 ),
             ],

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -35,9 +35,6 @@ def calculate_specs(
         options.specs,
         description_of_origin="CLI arguments",
         unmatched_glob_behavior=unmatched_cli_globs,
-        convert_dir_literal_to_address_literal=(
-            global_options.use_deprecated_directory_cli_args_semantics
-        ),
     )
 
     changed_options = ChangedOptions.from_options(options.for_scope("changed"))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1710,36 +1710,6 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         advanced=True,
     )
 
-    use_deprecated_directory_cli_args_semantics = BoolOption(
-        default=False,
-        help=softwrap(
-            f"""
-            If true, Pants will use the old, deprecated semantics for directory arguments like
-            `{bin_name()} test dir`: directories are shorthand for the target `dir:dir`, i.e. the
-            target that leaves off `name=`.
-
-            If false, Pants will use the new semantics: directory arguments will match all files
-            and targets in the directory, e.g. `{bin_name()} test dir` will run all tests in `dir`.
-
-            This also impacts the behavior of the `tailor` goal. If this option is true,
-            `{bin_name()} tailor dir` will run over `dir` and all recursive sub-directories. If
-            false, specifying a directory will only add targets for that directory.
-            """
-        ),
-        removal_version="2.15.0.dev0",
-        removal_hint=softwrap(
-            f"""
-            If `use_deprecated_directory_cli_args_semantics` is already set explicitly to `false`,
-            simply delete the option from `pants.toml` because `false` is now the default.
-
-            If set to true, removing the option will cause directory arguments like `{bin_name()}
-            test project/dir` to now match all files and targets in the directory, whereas before
-            it matched the target `project/dir:dir`. To keep the old semantics, use the explicit
-            address syntax.
-            """
-        ),
-    )
-
     use_deprecated_pex_binary_run_semantics = BoolOption(
         default=False,
         help=softwrap(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -336,9 +336,7 @@ class RuleRunner:
             [GlobalOptions.get_scope_info(), goal.subsystem_cls.get_scope_info()]
         ).specs
         specs = SpecsParser(self.build_root).parse_specs(
-            raw_specs,
-            convert_dir_literal_to_address_literal=True,
-            description_of_origin="RuleRunner.run_goal_rule()",
+            raw_specs, description_of_origin="RuleRunner.run_goal_rule()"
         )
 
         stdout, stderr = StringIO(), StringIO()


### PR DESCRIPTION
Directories on the CLI now never mean the target `dir:dir`.

[ci skip-rust]
[ci skip-build-wheels]