### PR TITLE
Add fix goal

### DIFF
--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -24,9 +24,9 @@ class Fix(Goal):
     subsystem_cls = FixSubsystem
 
 
-# This is it! We're just going to completely piggy-back off fmt for `fix`. Plugins just need to
+# This is it! We're just going to completely piggy-back off `fmt` for `fix`. Plugins just need to
 # register a union implementation which subclasses `FmtTargetsRequest` and sets the class variable
-# `is_fixer` to `True`.
+# `goal_name` to `"fix"`.
 
 
 @goal_rule

--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -1,0 +1,53 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pants.base.specs import Specs
+from pants.core.goals.fmt import FmtSubsystemBase, _fmt_impl
+from pants.core.goals.style_request import only_option_help as make_only_option_help
+from pants.core.goals.style_request import style_batch_size_help
+from pants.engine.console import Console
+from pants.engine.fs import Workspace
+from pants.engine.goal import Goal
+from pants.engine.internals.build_files import BuildFileOptions
+from pants.engine.rules import collect_rules, goal_rule
+from pants.engine.unions import UnionMembership
+
+
+class FixSubsystem(FmtSubsystemBase):
+    name = "fix"
+    help = "Autofix source code."
+    only_option_help = make_only_option_help("fix", "fixer", "autoflake", "pyupgrade")
+    batch_size_option_help = style_batch_size_help(uppercase="Fixer", lowercase="fixer")
+
+
+class Fix(Goal):
+    subsystem_cls = FixSubsystem
+
+
+# This is it! We're just going to completely piggy-back off fmt for `fix`. Plugins just need to
+# register a union implementation which subclasses `FmtTargetsRequest` and sets the class variable
+# `is_fixer` to `True`.
+
+
+@goal_rule
+async def fmt(
+    console: Console,
+    specs: Specs,
+    fix_subsystem: FixSubsystem,
+    build_file_options: BuildFileOptions,
+    workspace: Workspace,
+    union_membership: UnionMembership,
+) -> Fix:
+    result = await _fmt_impl(
+        console=console,
+        specs=specs,
+        subsystem=fix_subsystem,
+        build_file_options=build_file_options,
+        workspace=workspace,
+        union_membership=union_membership,
+    )
+    return Fix(result.exit_code)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/core/goals/fix_smoke_test.py
+++ b/src/python/pants/core/goals/fix_smoke_test.py
@@ -1,0 +1,190 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterable, List
+
+from pants.core.goals.fix import Fix
+from pants.core.goals.fix import rules as fix_rules
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, _FmtBuildFilesRequest
+from pants.core.goals.fmt import rules as fmt_rules
+from pants.core.util_rules import source_files
+from pants.engine.fs import (
+    EMPTY_SNAPSHOT,
+    CreateDigest,
+    Digest,
+    DigestContents,
+    FileContent,
+    Snapshot,
+)
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import FieldSet, SingleSourceField, Target
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner
+
+SMALLTALK_FILE = FileContent("formatted.st", b"y := self size + super size.')\n")
+
+
+class SmalltalkSource(SingleSourceField):
+    pass
+
+
+class SmalltalkTarget(Target):
+    alias = "smalltalk"
+    core_fields = (SmalltalkSource,)
+
+
+@dataclass(frozen=True)
+class SmalltalkFieldSet(FieldSet):
+    required_fields = (SmalltalkSource,)
+
+    source: SmalltalkSource
+
+
+class SmalltalkNoopRequest(FmtTargetsRequest):
+    goal_name = "fix"
+    field_set_type = SmalltalkFieldSet
+    name = "SmalltalkDidNotChange"
+
+
+@rule
+async def smalltalk_noop(request: SmalltalkNoopRequest) -> FmtResult:
+    assert request.snapshot != EMPTY_SNAPSHOT
+    return FmtResult(
+        input=request.snapshot,
+        output=request.snapshot,
+        stdout="",
+        stderr="",
+        formatter_name=request.name,
+    )
+
+
+class SmalltalkSkipRequest(FmtTargetsRequest):
+    goal_name = "fix"
+    field_set_type = SmalltalkFieldSet
+    name = "SmalltalkSkipped"
+
+
+@rule
+async def smalltalk_skip(request: SmalltalkSkipRequest) -> FmtResult:
+    assert request.snapshot != EMPTY_SNAPSHOT
+    return FmtResult.skip(formatter_name=request.name)
+
+
+class BrickyBuildFileFormatter(_FmtBuildFilesRequest):
+    """Ensures all non-comment lines only consist of the word 'brick'."""
+
+    goal_name = "fix"
+    name = "BrickyBobby"
+
+
+@rule
+async def fix_with_bricky(request: BrickyBuildFileFormatter) -> FmtResult:
+    def brickify(contents: bytes) -> bytes:
+        content_str = contents.decode("ascii")
+        new_lines = []
+        for line in content_str.splitlines(keepends=True):
+            if not line.startswith("#"):
+                line = re.sub(r"[a-zA-Z_]+", "brick", line)
+            new_lines.append(line)
+        return "".join(new_lines).encode()
+
+    digest_contents = await Get(DigestContents, Digest, request.snapshot.digest)
+    new_contents = [
+        dataclasses.replace(file_content, content=brickify(file_content.content))
+        for file_content in digest_contents
+    ]
+    output_snapshot = await Get(Snapshot, CreateDigest(new_contents))
+
+    return FmtResult(
+        input=request.snapshot,
+        output=output_snapshot,
+        stdout="",
+        stderr="",
+        formatter_name=request.name,
+    )
+
+
+def run_fix(
+    rule_runner: RuleRunner,
+    *,
+    target_specs: List[str],
+    only: list[str] | None = None,
+    extra_args: Iterable[str] = (),
+) -> str:
+    result = rule_runner.run_goal_rule(
+        Fix,
+        args=[f"--only={repr(only or [])}", *target_specs, *extra_args],
+    )
+    assert result.exit_code == 0
+    assert not result.stdout
+    return result.stderr
+
+
+def write_files(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                smalltalk(name='s1', source="st1.st")
+                smalltalk(name='s2', source="formatted.st")
+                """,
+            ),
+            "st1.st": "y := self size + super size.')",
+            "formatted.st": "y := self size + super size.')\n",
+        },
+    )
+
+
+def test_smoke() -> None:
+    """Just smoke test `fix`, as it really is just a shim around `fmt`."""
+    rule_runner = RuleRunner(
+        rules=[
+            *collect_rules(),
+            *source_files.rules(),
+            *fmt_rules(),
+            *fix_rules(),
+            UnionRule(FmtTargetsRequest, SmalltalkSkipRequest),
+            UnionRule(FmtTargetsRequest, SmalltalkNoopRequest),
+            UnionRule(_FmtBuildFilesRequest, BrickyBuildFileFormatter),
+        ],
+        target_types=[SmalltalkTarget],
+    )
+
+    write_files(rule_runner)
+
+    stderr = run_fix(rule_runner, target_specs=["::"])
+
+    assert stderr == dedent(
+        """\
+
+        + BrickyBobby made changes.
+        ✓ SmalltalkDidNotChange made no changes.
+        """
+    )
+
+    smalltalk_file = Path(rule_runner.build_root, SMALLTALK_FILE.path)
+    build_file = Path(rule_runner.build_root, "BUILD")
+    assert smalltalk_file.is_file()
+    assert smalltalk_file.read_text() == SMALLTALK_FILE.content.decode()
+    assert build_file.is_file()
+    assert build_file.read_text() == dedent(
+        """\
+        brick(brick='brick1', brick="brick1.brick")
+        brick(brick='brick2', brick="brick.brick")
+        """
+    )
+
+    write_files(rule_runner)
+    stderr = run_fix(
+        rule_runner,
+        target_specs=["::"],
+        only=[SmalltalkNoopRequest.name],
+    )
+    assert stderr.strip() == "✓ SmalltalkDidNotChange made no changes."


### PR DESCRIPTION
Fixes #13504 by adding a new `fix` goal, which piggybacks off of `fmt` pretty heavily.
`fmt` itself has been tweaked slightly to allow the piggybacking.

Will be shifting the existing `experimental` Python "fixers" in a later PR.