### PR TITLE
Remove unnecessary type parameter from `Get`

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -11,6 +11,11 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 
 See <https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.14.x.md> for the changelog.
 
+### Removed second type parameter from `Get`
+
+`Get` now takes only a single type parameter for the output type: `Get[_Output]`. The input type
+parameter was unused.
+
 ### `FmtRequest` -> `FmtTargetsRequest`
 
 In order to support non-target formatting (like `BUILD` files) we'll be introducing additional `fmt`

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from dataclasses import dataclass
-from typing import Any, Iterable
+from typing import Iterable
 
 from pants.backend.helm.dependency_inference import chart as chart_inference
 from pants.backend.helm.resolve import fetch
@@ -277,7 +277,7 @@ async def find_chart_for_deployment(request: FindHelmDeploymentChart) -> HelmCha
         ),
     )
 
-    find_charts: Iterable[Get[HelmChart, Any]] = [
+    find_charts: Iterable[Get[HelmChart]] = [
         *(
             Get(HelmChart, HelmChartRequest, HelmChartRequest.from_target(tgt))
             for tgt in explicit_targets

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -554,8 +554,9 @@ async def determine_explicitly_provided_setup_kwargs(
                 """
             )
         )
-    setup_kwargs_request = tuple(applicable_setup_kwargs_requests)[0]
-    return await Get(SetupKwargs, SetupKwargsRequest, setup_kwargs_request(target))  # type: ignore[abstract]
+    setup_kwargs_request_type = tuple(applicable_setup_kwargs_requests)[0]
+    setup_kwargs_request: SetupKwargsRequest = setup_kwargs_request_type(target)  # type: ignore[abstract]
+    return await Get(SetupKwargs, SetupKwargsRequest, setup_kwargs_request)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -390,9 +390,7 @@ async def fmt(
             )
         ),
     ]
-    target_batch_results = cast(
-        "tuple[_FmtBatchResult, ...]", await MultiGet(all_requests)  # type: ignore[arg-type]
-    )
+    target_batch_results = cast("tuple[_FmtBatchResult, ...]", await MultiGet(all_requests))
 
     individual_results = list(
         itertools.chain.from_iterable(result.results for result in target_batch_results)

--- a/src/python/pants/engine/internals/.gitignore
+++ b/src/python/pants/engine/internals/.gitignore
@@ -1,3 +1,2 @@
 /native_engine.so
-/native_engine_pyo3.so
 /native_engine.so.metadata

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -723,10 +723,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
 
     def create_live_and_deleted_gets(
         *, filter_by_global_options: bool
-    ) -> tuple[
-        Get[FilteredTargets | Targets, RawSpecsWithoutFileOwners],
-        Get[UnexpandedTargets, RawSpecsWithoutFileOwners],
-    ]:
+    ) -> tuple[Get[FilteredTargets | Targets], Get[UnexpandedTargets],]:
         """Walk up the buildroot looking for targets that would conceivably claim changed sources.
 
         For live files, we use Targets, which causes generated targets to be used rather than their
@@ -741,7 +738,7 @@ async def find_owners(owners_request: OwnersRequest) -> Owners:
             description_of_origin="<owners rule - unused>",
             unmatched_glob_behavior=GlobMatchErrorBehavior.ignore,
         )
-        live_get: Get[FilteredTargets | Targets, RawSpecsWithoutFileOwners] = (
+        live_get: Get[FilteredTargets | Targets] = (
             Get(FilteredTargets, RawSpecsWithoutFileOwners, live_raw_specs)
             if filter_by_global_options
             else Get(Targets, RawSpecsWithoutFileOwners, live_raw_specs)

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -346,10 +346,10 @@ class PyGeneratorResponseBreak:
 _Output = TypeVar("_Output")
 _Input = TypeVar("_Input")
 
-class PyGeneratorResponseGet(Generic[_Output, _Input]):
+class PyGeneratorResponseGet(Generic[_Output]):
     output_type: type[_Output]
-    input_type: type[_Input]
-    input: _Input
+    input_type: type
+    input: Any
 
     @overload
     def __init__(self, output_type: type[_Output], input_arg0: _Input) -> None: ...

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -187,7 +187,7 @@ def test_union_rules() -> None:
     ) in str(exc.value.args[0])
 
 
-def create_outlined_get() -> Get[int, str]:
+def create_outlined_get() -> Get[int]:
     return Get(int, str, "hello")
 
 

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -130,19 +130,19 @@ class AwaitableConstraints:
 # see https://mypy.readthedocs.io/en/stable/runtime_troubles.html#using-classes-that-are-generic-in-stubs-but-not-at-runtime
 if TYPE_CHECKING:
 
-    class _BasePyGeneratorResponseGet(PyGeneratorResponseGet[_Output, _Input]):
+    class _BasePyGeneratorResponseGet(PyGeneratorResponseGet[_Output]):
         pass
 
 else:
 
-    class _BasePyGeneratorResponseGet(Generic[_Output, _Input], PyGeneratorResponseGet):
+    class _BasePyGeneratorResponseGet(Generic[_Output], PyGeneratorResponseGet):
         pass
 
 
-class Awaitable(Generic[_Output, _Input], _BasePyGeneratorResponseGet[_Output, _Input]):
+class Awaitable(Generic[_Output], _BasePyGeneratorResponseGet[_Output]):
     def __await__(
         self,
-    ) -> Generator[Awaitable[_Output, _Input], None, _Output]:
+    ) -> Generator[Awaitable[_Output], None, _Output]:
         """Allow a Get to be `await`ed within an `async` method, returning a strongly-typed result.
 
         The `yield`ed value `self` is interpreted by the engine within
@@ -165,7 +165,7 @@ class Awaitable(Generic[_Output, _Input], _BasePyGeneratorResponseGet[_Output, _
         return cast(_Output, result)
 
 
-class Effect(Generic[_Output, _Input], Awaitable[_Output, _Input]):
+class Effect(Generic[_Output], Awaitable[_Output]):
     """Asynchronous generator API for types which are SideEffecting.
 
     Unlike `Get`s, `Effect`s can cause side-effects (writing files to the workspace, publishing
@@ -175,7 +175,7 @@ class Effect(Generic[_Output, _Input], Awaitable[_Output, _Input]):
     """
 
 
-class Get(Generic[_Output, _Input], Awaitable[_Output, _Input]):
+class Get(Generic[_Output], Awaitable[_Output]):
     """Asynchronous generator API for side-effect-free types.
 
     A Get can be constructed in 2 ways with two variants each:
@@ -222,158 +222,145 @@ _Out7 = TypeVar("_Out7")
 _Out8 = TypeVar("_Out8")
 _Out9 = TypeVar("_Out9")
 
-_In0 = TypeVar("_In0")
-_In1 = TypeVar("_In1")
-_In2 = TypeVar("_In2")
-_In3 = TypeVar("_In3")
-_In4 = TypeVar("_In4")
-_In5 = TypeVar("_In5")
-_In6 = TypeVar("_In6")
-_In7 = TypeVar("_In7")
-_In8 = TypeVar("_In8")
-_In9 = TypeVar("_In9")
-
 
 @overload
-async def MultiGet(__gets: Iterable[Get[_Output, _Input]]) -> tuple[_Output, ...]:  # noqa: F811
+async def MultiGet(__gets: Iterable[Get[_Output]]) -> tuple[_Output, ...]:  # noqa: F811
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Output, _Input],
-    __get1: Get[_Output, _Input],
-    __get2: Get[_Output, _Input],
-    __get3: Get[_Output, _Input],
-    __get4: Get[_Output, _Input],
-    __get5: Get[_Output, _Input],
-    __get6: Get[_Output, _Input],
-    __get7: Get[_Output, _Input],
-    __get8: Get[_Output, _Input],
-    __get9: Get[_Output, _Input],
-    __get10: Get[_Output, _Input],
-    *__gets: Get[_Output, _Input],
+    __get0: Get[_Output],
+    __get1: Get[_Output],
+    __get2: Get[_Output],
+    __get3: Get[_Output],
+    __get4: Get[_Output],
+    __get5: Get[_Output],
+    __get6: Get[_Output],
+    __get7: Get[_Output],
+    __get8: Get[_Output],
+    __get9: Get[_Output],
+    __get10: Get[_Output],
+    *__gets: Get[_Output],
 ) -> tuple[_Output, ...]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
-    __get5: Get[_Out5, _In5],
-    __get6: Get[_Out6, _In6],
-    __get7: Get[_Out7, _In7],
-    __get8: Get[_Out8, _In8],
-    __get9: Get[_Out9, _In9],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
+    __get5: Get[_Out5],
+    __get6: Get[_Out6],
+    __get7: Get[_Out7],
+    __get8: Get[_Out8],
+    __get9: Get[_Out9],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8, _Out9]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
-    __get5: Get[_Out5, _In5],
-    __get6: Get[_Out6, _In6],
-    __get7: Get[_Out7, _In7],
-    __get8: Get[_Out8, _In8],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
+    __get5: Get[_Out5],
+    __get6: Get[_Out6],
+    __get7: Get[_Out7],
+    __get8: Get[_Out8],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
-    __get5: Get[_Out5, _In5],
-    __get6: Get[_Out6, _In6],
-    __get7: Get[_Out7, _In7],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
+    __get5: Get[_Out5],
+    __get6: Get[_Out6],
+    __get7: Get[_Out7],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
-    __get5: Get[_Out5, _In5],
-    __get6: Get[_Out6, _In6],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
+    __get5: Get[_Out5],
+    __get6: Get[_Out6],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
-    __get5: Get[_Out5, _In5],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
+    __get5: Get[_Out5],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
-    __get4: Get[_Out4, _In4],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
+    __get4: Get[_Out4],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0],
-    __get1: Get[_Out1, _In1],
-    __get2: Get[_Out2, _In2],
-    __get3: Get[_Out3, _In3],
+    __get0: Get[_Out0],
+    __get1: Get[_Out1],
+    __get2: Get[_Out2],
+    __get3: Get[_Out3],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0, _In0], __get1: Get[_Out1, _In1], __get2: Get[_Out2, _In2]
+    __get0: Get[_Out0], __get1: Get[_Out1], __get2: Get[_Out2]
 ) -> tuple[_Out0, _Out1, _Out2]:
     ...
 
 
 @overload
-async def MultiGet(
-    __get0: Get[_Out0, _In0], __get1: Get[_Out1, _In1]
-) -> tuple[_Out0, _Out1]:  # noqa: F811
+async def MultiGet(__get0: Get[_Out0], __get1: Get[_Out1]) -> tuple[_Out0, _Out1]:  # noqa: F811
     ...
 
 
 async def MultiGet(  # noqa: F811
-    __arg0: Iterable[Get[_Output, _Input]] | Get[_Out0, _In0],
-    __arg1: Get[_Out1, _In1] | None = None,
-    __arg2: Get[_Out2, _In2] | None = None,
-    __arg3: Get[_Out3, _In3] | None = None,
-    __arg4: Get[_Out4, _In4] | None = None,
-    __arg5: Get[_Out5, _In5] | None = None,
-    __arg6: Get[_Out6, _In6] | None = None,
-    __arg7: Get[_Out7, _In7] | None = None,
-    __arg8: Get[_Out8, _In8] | None = None,
-    __arg9: Get[_Out9, _In9] | None = None,
-    *__args: Get[_Output, _Input],
+    __arg0: Iterable[Get[_Output]] | Get[_Out0],
+    __arg1: Get[_Out1] | None = None,
+    __arg2: Get[_Out2] | None = None,
+    __arg3: Get[_Out3] | None = None,
+    __arg4: Get[_Out4] | None = None,
+    __arg5: Get[_Out5] | None = None,
+    __arg6: Get[_Out6] | None = None,
+    __arg7: Get[_Out7] | None = None,
+    __arg8: Get[_Out8] | None = None,
+    __arg9: Get[_Out9] | None = None,
+    *__args: Get[_Output],
 ) -> (
     tuple[_Output, ...]
     | tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8, _Out9]
@@ -615,8 +602,8 @@ async def MultiGet(  # noqa: F811
             Unexpected MultiGet argument types: {', '.join(map(str, likely_args_exlicitly_passed))}
 
             A MultiGet can be constructed in two ways:
-            1. MultiGet(Iterable[Get[T]]) -> Tuple[T, ...]
-            2. MultiGet(Get[T1], Get[T2], ...) -> Tuple[T1, T2, ...]
+            1. MultiGet(Iterable[Get[T]]) -> Tuple[T]
+            2. MultiGet(Get[T1]], ...) -> Tuple[T1, T2, ...]
 
             The 1st form is intended for homogenous collections of Gets and emulates an
             async `for ...` comprehension used to iterate over the collection in parallel and


### PR DESCRIPTION
Remove the unnecessary generic `_Input` type parameter from `Get`, since that field is never consumed by python code.

[ci skip-rust]
[ci skip-build-wheels]