### PR TITLE
Have `run` run `__main__.py` for non-zipapp PEXs (Cherry-pick of #16568)

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -25,7 +25,7 @@ python_tests(
             "tags": ["platform_specific_behavior"],
             "timeout": 300,
         },
-        "run_pex_binary_integration_test.py": {"timeout": 400},
+        "run_pex_binary_integration_test.py": {"timeout": 600},
         "run_python_source_integration_test.py": {"timeout": 180},
         "setup_py_integration_test.py": {
             "dependencies": ["testprojects/src/python:native_directory"],

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -9,7 +9,7 @@ from pants.backend.python.goals.run_helper import (
     _create_python_source_run_request,
 )
 from pants.backend.python.subsystems.debugpy import DebugPy
-from pants.backend.python.target_types import PexBinaryDefaults
+from pants.backend.python.target_types import PexBinaryDefaults, PexLayout
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.core.goals.package import BuiltPackage
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
@@ -31,6 +31,9 @@ async def create_pex_binary_run_request(
         built_pex = await Get(BuiltPackage, PexBinaryFieldSet, field_set)
         relpath = built_pex.artifacts[0].relpath
         assert relpath is not None
+        if field_set.layout.value != PexLayout.ZIPAPP.value:
+            relpath = os.path.join(relpath, "__main__.py")
+
         return RunRequest(
             digest=built_pex.digest,
             args=[os.path.join("{chroot}", relpath)],


### PR DESCRIPTION
Fixes #16562. 

Note I had to refactor tests to avoid 400s timeout. Bumping timeout seemed like a bandaid. Note in 2.15, we'll eliminate the `use_deprecated_semantics_args` parameterization and greatly reduce # of tests.


[ci skip-rust]
[ci skip-build-wheels]
