### PR TITLE
Don't register non-union subclasses of unions as union members

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -467,9 +467,9 @@ class Target:
     @final
     @memoized_classproperty
     def _plugin_field_cls(cls) -> type:
-        # NB: We ensure that each Target subtype has its own `PluginField` class so that
-        # registering a plugin field doesn't leak across target types.
-
+        # Use the `PluginField` of the first `Target`-subclass ancestor as a base to ours, so that
+        # we inherit the registered fields. E.g. If I inherit from `PythonSourceTarget`, I want all
+        # the registered fields on `PythonSourceTarget` to also be registered for me.
         baseclass = (
             object
             if cast("Type[Target]", cls) is Target

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -72,14 +72,16 @@ class UnionMembership:
         mapping: DefaultDict[type, OrderedSet[type]] = defaultdict(OrderedSet)
         for rule in rules:
             mapping[rule.union_base].add(rule.union_member)
-        # Subclassed union bases should inherit the superclass's union members.
+
+        # Base union classes inherit the members of any subclasses that are also unions
         bases = list(mapping.keys())
         while len(bases) > 0:
             union_base = bases.pop()
             for sub_union in union_base.__subclasses__():
-                if sub_union not in mapping:
-                    bases.append(sub_union)
-                mapping[sub_union].update(mapping[union_base])
+                if is_union(sub_union):
+                    if sub_union not in mapping:
+                        bases.append(sub_union)
+                    mapping[sub_union].update(mapping[union_base])
         return cls(mapping)
 
     def __init__(self, union_rules: Mapping[type, Iterable[type]]) -> None:

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -5,17 +5,42 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.ordered_set import FrozenOrderedSet
 
 
-def test_union_membership_from_rules() -> None:
+def test_simple() -> None:
     @union
-    class Base:
+    class Fruit:
         pass
 
-    class A:
+    class Banana(Fruit):
         pass
 
-    class B:
+    class Apple(Fruit):
         pass
 
-    assert UnionMembership.from_rules([UnionRule(Base, A), UnionRule(Base, B)]) == UnionMembership(
-        {Base: FrozenOrderedSet([A, B])}
+    @union
+    class CitrusFruit(Fruit):
+        pass
+
+    class Orange(CitrusFruit):
+        pass
+
+    @union
+    class Vegetable:
+        pass
+
+    class Potato:  # Doesn't _have_ to inherit from the union
+        pass
+
+    assert UnionMembership.from_rules(
+        [
+            UnionRule(Fruit, Banana),
+            UnionRule(Fruit, Apple),
+            UnionRule(CitrusFruit, Orange),
+            UnionRule(Vegetable, Potato),
+        ]
+    ) == UnionMembership(
+        {
+            Fruit: FrozenOrderedSet([Banana, Apple]),
+            CitrusFruit: FrozenOrderedSet([Orange, Banana, Apple]),
+            Vegetable: FrozenOrderedSet([Potato]),
+        }
     )

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -30,14 +30,16 @@ def test_simple() -> None:
     class Potato:  # Doesn't _have_ to inherit from the union
         pass
 
-    assert UnionMembership.from_rules(
+    union_membership = UnionMembership.from_rules(
         [
             UnionRule(Fruit, Banana),
             UnionRule(Fruit, Apple),
             UnionRule(CitrusFruit, Orange),
             UnionRule(Vegetable, Potato),
         ]
-    ) == UnionMembership(
+    )
+
+    assert union_membership == UnionMembership(
         {
             Fruit: FrozenOrderedSet([Banana, Apple]),
             CitrusFruit: FrozenOrderedSet([Orange, Banana, Apple]),


### PR DESCRIPTION
Before:
```
>>> print(union_membership.get(BlackRequest))
FrozenOrderedSet([<class 'pants.backend.python.lint.autoflake.rules.AutoflakeRequest'>, <class 'pants.backend.python.lint.black.rules.BlackRequest'>, <class 'pants.backend.python.lint.docformatter.rules.DocformatterRequest'>, <class 'pants.backend.python.lint.isort.rules.IsortRequest'>, <class 'pants.backend.shell.lint.shfmt.rules.ShfmtRequest'>, <class 'pants.backend.go.lint.gofmt.rules.GofmtRequest'>, <class 'pants.backend.java.lint.google_java_format.rules.GoogleJavaFormatRequest'>, <class 'pants.backend.scala.lint.scalafmt.rules.ScalafmtRequest'>])
```

After:
```
>>> print(union_membership.get(BlackRequest))
FrozenOrderedSet([])
```

This was introduced in https://github.com/pantsbuild/pants/pull/15876 which was first in 2.14.