### PR TITLE
Replace union hierarchy tricks with direct class traversal

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -467,19 +467,8 @@ class Target:
     @final
     @memoized_classproperty
     def _plugin_field_cls(cls) -> type:
-        # Use the `PluginField` of the first `Target`-subclass ancestor as a base to ours, so that
-        # we inherit the registered fields. E.g. If I inherit from `PythonSourceTarget`, I want all
-        # the registered fields on `PythonSourceTarget` to also be registered for me.
-        baseclass = (
-            object
-            if cast("Type[Target]", cls) is Target
-            else next(
-                base for base in cast("Type[Target]", cls).__bases__ if issubclass(base, Target)
-            )._plugin_field_cls
-        )
-
         @union
-        class PluginField(baseclass):  # type: ignore[misc, valid-type]
+        class PluginField:
             pass
 
         return PluginField
@@ -515,7 +504,15 @@ class Target:
     @final
     @classmethod
     def _find_plugin_fields(cls, union_membership: UnionMembership) -> tuple[type[Field], ...]:
-        return cast(Tuple[Type[Field], ...], tuple(union_membership.get(cls._plugin_field_cls)))
+        result: set[type[Field]] = set()
+        classes = [cls]
+        while classes:
+            cls = classes.pop()
+            classes.extend(cls.__bases__)
+            if issubclass(cls, Target):
+                result.update(union_membership.get(cls._plugin_field_cls))
+
+        return tuple(result)
 
     @final
     @classmethod

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -300,10 +300,6 @@ def test_subclassed_target_inherits_plugin_fields() -> None:
     class CustomFortranTarget(FortranTarget):
         alias = "custom_fortran"
 
-    # Ensure that any `PluginField` is not lost on subclasses.
-    assert issubclass(CustomFortranTarget._plugin_field_cls, FortranTarget._plugin_field_cls)
-    assert issubclass(FortranTarget._plugin_field_cls, Target._plugin_field_cls)
-
     class CustomField(BoolField):
         alias = "custom_field"
         default = False

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -73,15 +73,6 @@ class UnionMembership:
         for rule in rules:
             mapping[rule.union_base].add(rule.union_member)
 
-        # Base union classes inherit the members of any subclasses that are also unions
-        bases = list(mapping.keys())
-        while len(bases) > 0:
-            union_base = bases.pop()
-            for sub_union in union_base.__subclasses__():
-                if is_union(sub_union):
-                    if sub_union not in mapping:
-                        bases.append(sub_union)
-                    mapping[sub_union].update(mapping[union_base])
         return cls(mapping)
 
     def __init__(self, union_rules: Mapping[type, Iterable[type]]) -> None:

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -42,7 +42,7 @@ def test_simple() -> None:
     assert union_membership == UnionMembership(
         {
             Fruit: FrozenOrderedSet([Banana, Apple]),
-            CitrusFruit: FrozenOrderedSet([Orange, Banana, Apple]),
+            CitrusFruit: FrozenOrderedSet([Orange]),
             Vegetable: FrozenOrderedSet([Potato]),
         }
     )


### PR DESCRIPTION
Unions are simple again :tada: 
And we still have Target hierarchies working :tada: 

[ci skip-rust]
[ci skip-build-wheels]