### PR TITLE
Remove orphaned `Get` parsing code.

### DIFF
--- a/src/python/pants/engine/internals/selectors_test.py
+++ b/src/python/pants/engine/internals/selectors_test.py
@@ -1,90 +1,23 @@
 # Copyright 2016 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import ast
 import re
-from typing import Any, Callable, Tuple
+from dataclasses import dataclass
+from typing import Callable
 
 import pytest
 
-from pants.engine.internals.selectors import AwaitableConstraints, Get, GetParseError, MultiGet
+from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.unions import union
-
-
-def parse_get_types(get: str) -> Tuple[str, str, bool]:
-    call_node = ast.parse(get).body[0].value  # type: ignore[attr-defined]
-    signature = AwaitableConstraints.signature_from_call_node(call_node, source_file_name="test.py")
-    assert signature
-    return signature
-
-
-def test_parse_get_types_valid() -> None:
-    assert parse_get_types("Get(O, I, input)") == ("O", "I", False)
-    assert parse_get_types("Get(O, I())") == ("O", "I", False)
-    assert parse_get_types("Effect(O, I, input)") == ("O", "I", True)
-    assert parse_get_types("Effect(O, I())") == ("O", "I", True)
-
-
-def assert_parse_get_types_fails(get: str, *, expected_explanation: str) -> None:
-    with pytest.raises(GetParseError) as exc:
-        parse_get_types(get)
-    assert str(exc.value) == f"Invalid Get. {expected_explanation} Failed for {get} in test.py."
-
-
-def test_parse_get_types_wrong_number_args() -> None:
-    assert_parse_get_types_fails(
-        "Get()",
-        expected_explanation="Expected either two or three arguments, but got 0 arguments.",
-    )
-    assert_parse_get_types_fails(
-        "Get(O, I1, I2(), I3.create())",
-        expected_explanation="Expected either two or three arguments, but got 4 arguments.",
-    )
-
-
-def test_parse_get_types_invalid_output_type() -> None:
-    assert_parse_get_types_fails(
-        "Get(O(), I, input)",
-        expected_explanation=(
-            "The first argument should be the output type, like `Digest` or `ProcessResult`."
-        ),
-    )
-
-
-def test_parse_get_types_invalid_input() -> None:
-    assert_parse_get_types_fails(
-        "Get(O, I)",
-        expected_explanation=(
-            "Because you are using the shorthand form Get(OutputType, InputType(constructor args), "
-            "the second argument should be a constructor call, like `MergeDigest(...)` or "
-            "`Process(...)`."
-        ),
-    )
-    assert_parse_get_types_fails(
-        "Get(O, I.create())",
-        expected_explanation=(
-            "Because you are using the shorthand form Get(OutputType, InputType(constructor args), "
-            "the second argument should be a top-level constructor function call, like "
-            "`MergeDigest(...)` or `Process(...)`, rather than a method call."
-        ),
-    )
-    assert_parse_get_types_fails(
-        "Get(O, I(), input)",
-        expected_explanation=(
-            "Because you are using the longhand form Get(OutputType, InputType, "
-            "input), the second argument should be a type, like `MergeDigests` or "
-            "`Process`."
-        ),
-    )
 
 
 class AClass:
     pass
 
 
+@dataclass(frozen=True)
 class BClass:
-    def __eq__(self, other: Any):
-        return type(self) == type(other)
+    pass
 
 
 def test_create_get() -> None:


### PR DESCRIPTION
This logic now lives in `rule_visitor.py` (and is tested there).

[ci skip-build-wheels]
[ci skip-rust]