### PR TITLE
Support Docker custom tags via plugin hook

### DIFF
--- a/src/python/pants/backend/helm/util_rules/post_renderer.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer.py
@@ -53,7 +53,7 @@ async def _obtain_custom_image_tags(
     address: Address, union_membership: UnionMembership
 ) -> DockerImageTags:
     wrapped_target = await Get(
-        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infalible>")
+        WrappedTarget, WrappedTargetRequest(address, description_of_origin="<infallible>")
     )
 
     image_tags_requests = union_membership.get(DockerImageTagsRequest)


### PR DESCRIPTION
In #16077 we added support to provide with additional Docker image tags via a custom union rule. However the Helm backend was not making use of that rule and therefore any tags provided in that way would be ignored when resolving Docker image references in Helm's post-renderer.

This PR adds support for retrieving the image tags that end users may provide using that mechanism.

[ci skip-rust]

[ci skip-build-wheels]