### PR TITLE
increase LMDB size to fix a test on Apple M1

### DIFF
--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -12,7 +12,7 @@ fn new_store(shard_count: u8) -> (ShardedLmdb, TempDir) {
   let tempdir = TempDir::new().unwrap();
   let s = ShardedLmdb::new(
     tempdir.path().to_owned(),
-    10_000_000,
+    15_000_000,
     Executor::new(),
     DEFAULT_LEASE_TIME,
     shard_count,


### PR DESCRIPTION
Tests in src/rust/engine/sharded_lmdb/src/tests.rs were failing on my M1 Macbook Pro. Increase the maximum size of the LMDB instance used in those tests.

[ci skip-build-wheels]