### PR TITLE
Fix `LintGoal.activated()` to consider `fmt` goal

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -192,7 +192,14 @@ class LintSubsystem(GoalSubsystem):
 
     @classmethod
     def activated(cls, union_membership: UnionMembership) -> bool:
-        return LintTargetsRequest in union_membership or LintFilesRequest in union_membership
+        return bool(
+            {
+                LintTargetsRequest,
+                LintFilesRequest,
+                FmtTargetsRequest,
+                _FmtBuildFilesRequest,
+            }.intersection(union_membership.union_rules.keys())
+        )
 
     only = StrListOption(
         help=only_option_help("lint", "linter", "flake8", "shellcheck"),


### PR DESCRIPTION
This shouldn't actually matter because `regex-lint` is always activated. But it's good to fix the modeling.

[ci skip-rust]
[ci skip-build-wheels]