### PR TITLE
Make `FilespecMatcher` case-sensitive (Cherry-pick of #16673)

### DIFF
--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -92,6 +92,10 @@ def test_valid_matches(rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...
         # Dirs.
         ("dist/", ("not_dist", "cdist", "dist.py", "dist/dist")),
         ("build-support/*.venv/", ("build-support/rbt.venv.but_actually_a_file",)),
+        # Case sensitivity
+        ("A", ("a",)),
+        ("a", ("A",)),
+        ("**/BUILD", ("src/rust/build.rs",)),
     ],
 )
 def test_invalid_matches(rule_runner: RuleRunner, glob: str, paths: Tuple[str, ...]) -> None:

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -36,8 +36,9 @@ lazy_static! {
   pub static ref DOUBLE_STAR_GLOB: Pattern = Pattern::new(*DOUBLE_STAR).unwrap();
   static ref MISSING_GLOB_SOURCE: GlobParsedSource = GlobParsedSource(String::from(""));
   static ref PATTERN_MATCH_OPTIONS: MatchOptions = MatchOptions {
+    case_sensitive: true,
     require_literal_separator: true,
-    ..MatchOptions::default()
+    require_literal_leading_dot: false,
   };
 }
 


### PR DESCRIPTION
This is why sensitivity training is so important...

[ci skip-build-wheels]