### PR TITLE
Welcome community members to consider joining team

### DIFF
--- a/docs/markdown/Getting Help/the-pants-community.md
+++ b/docs/markdown/Getting Help/the-pants-community.md
@@ -3,7 +3,7 @@ title: "The Pants community"
 slug: "the-pants-community"
 hidden: false
 createdAt: "2021-03-13T18:57:07.437Z"
-updatedAt: "2021-08-29T00:28:12.217Z"
+updatedAt: "2022-08-29T00:28:12.217Z"
 ---
 Who is behind Pants?
 --------------------

--- a/docs/markdown/Getting Help/the-pants-community.md
+++ b/docs/markdown/Getting Help/the-pants-community.md
@@ -34,6 +34,11 @@ For some contributions, such as adding new features, the best place to get start
 
 If you want to contribute but don't have a specific plan or idea, we can help you discover some fruitful areas to focus on. There is plenty to do!
 
+> 📘 Interested in joining Pants team?
+> 
+> Welcome, future colleague! Learn more about the team's composition and eligibility criteria by reading below, then post in the #development channel of the [community Slack](doc:getting-started) to express interest in formally joining the [team](doc:team). We love opportunity to usher in new teammates, and are happy to offer mentorship support to community members who request it and have a track record of commitment to the long-term vitality of the project.
+
+
 How is the community structured?
 --------------------------------
 

--- a/docs/markdown/Getting Help/the-pants-community.md
+++ b/docs/markdown/Getting Help/the-pants-community.md
@@ -3,14 +3,14 @@ title: "The Pants community"
 slug: "the-pants-community"
 hidden: false
 createdAt: "2021-03-13T18:57:07.437Z"
-updatedAt: "2021-11-06T00:28:12.217Z"
+updatedAt: "2021-08-29T00:28:12.217Z"
 ---
 Who is behind Pants?
 --------------------
 
 Pants is developed by a community of people who are passionate about improving the craft of software engineering.  We come from diverse backgrounds and interests, but share the goal of creating the best tools to support more effective and enjoyable software development.
 
- Pants Build is registered as a 501c(6) non-profit in California, whose purpose is to maintain the Pants project's assets, such as its CI resources.
+Pants Build is registered as a 501c(6) non-profit in California, whose purpose is to maintain the Pants project's assets, such as its CI resources.
 
 Can I join this community?
 --------------------------
@@ -34,15 +34,14 @@ For some contributions, such as adding new features, the best place to get start
 
 If you want to contribute but don't have a specific plan or idea, we can help you discover some fruitful areas to focus on. There is plenty to do!
 
-> 📘 Interested in joining Pants team?
-> 
-> Welcome, future colleague! Learn more about the team's composition and eligibility criteria by reading below, then post in the #development channel of the [community Slack](doc:getting-started) to express interest in formally joining the [team](doc:team). We love opportunity to usher in new teammates, and are happy to offer mentorship support to community members who request it and have a track record of commitment to the long-term vitality of the project.
-
-
 How is the community structured?
 --------------------------------
 
-We welcome contributions from anyone, and we recognize consistent contribution with special statuses.
+We welcome contributions from anyone, and we recognize consistent contributions with invitation to join the Pants team. 
+
+> 📘 Interested in joining the Pants team?
+> 
+> Welcome, future colleague! Learn more about the team's composition and eligibility criteria by reading below, then post in the #development channel of the [community Slack](doc:getting-started) to express interest in formally joining the [team](doc:team). We love opportunity to usher in new teammates, and are happy to offer mentorship support to community members who request it and have a track record of commitment to the long-term vitality of the project.
 
 ### Maintainers
 
@@ -58,9 +57,9 @@ Contributors do not have any new obligations. For example, you are _not_ expecte
 
 Contributors will be eligible to receive more attention and mentorship in activities like code review. Contributors with a continuing track record of contribution may be nominated to become Maintainers.
 
-### Maintainers Emeritus
+### Former team members
 
-Sometimes a Maintainer may need to step back to less intensive involvement. To recognize their past contributions, they retain the honorary _Emeritus_ status.
+Sometimes a team member may need to step back to less intensive involvement. To recognize their past contributions, a former team member in good standing may be granted the honorary _Maintainer Emeritus_ or _Contributor Emeritus_ status.
 
 ### Officers
 

--- a/docs/markdown/Getting Help/the-pants-community/team.md
+++ b/docs/markdown/Getting Help/the-pants-community/team.md
@@ -6,7 +6,11 @@ hidden: false
 createdAt: "2022-08-15T22:36:48.659Z"
 updatedAt: "2022-08-28T22:13:54.279Z"
 ---
-Pants open source project has had many team members in over a decade. The current team is comprised of elected Contributors and Maintainers, who are nominated based on [criteria](docs:the-pants-community#how-is-the-community-structured) including demonstrated commitment to the project and a track record of contributions to the project and community. Interested in joining our team? Learn more on [The Pants Community](docs:the-pants-community) page.
+> 📘 Interested in joining Pants team?
+>
+> Welcome, future colleague! Learn more about the team's composition and eligibility criteria on the [Pants Community](docs:the-pants-community) page, then post in the #development channel of the [community Slack](doc:getting-started) to express interest in joining the team. We love opportunity to usher in new teammates, and are happy to offer mentorship support to community members who request it and have a track record of commitment to the long-term vitality of the project.
+
+Pants open source project has had many team members in over a decade. The current team is comprised of elected Contributors and Maintainers, who are nominated based on [criteria](docs:the-pants-community#how-is-the-community-structured) including demonstrated commitment to the project and a track record of contributions to the project and community.
 
 Maintainers
 -----------

--- a/docs/markdown/Getting Help/the-pants-community/team.md
+++ b/docs/markdown/Getting Help/the-pants-community/team.md
@@ -4,7 +4,7 @@ slug: "team"
 excerpt: ""
 hidden: false
 createdAt: "2022-08-15T22:36:48.659Z"
-updatedAt: "2021-08-29T00:28:12.217Z"
+updatedAt: "2022-08-29T00:28:12.217Z"
 ---
 Pants open source project has had many team members in over a decade. The current team is comprised of elected Contributors and Maintainers, who are nominated based on [criteria](docs:the-pants-community#how-is-the-community-structured) including demonstrated commitment to the project and a track record of contributions to the project and community.
 

--- a/docs/markdown/Getting Help/the-pants-community/team.md
+++ b/docs/markdown/Getting Help/the-pants-community/team.md
@@ -4,15 +4,17 @@ slug: "team"
 excerpt: ""
 hidden: false
 createdAt: "2022-08-15T22:36:48.659Z"
-updatedAt: "2022-08-28T22:13:54.279Z"
+updatedAt: "2021-08-29T00:28:12.217Z"
 ---
-> 📘 Interested in joining Pants team?
+Pants open source project has had many team members in over a decade. The current team is comprised of elected Contributors and Maintainers, who are nominated based on [criteria](docs:the-pants-community#how-is-the-community-structured) including demonstrated commitment to the project and a track record of contributions to the project and community.
+
+> 📘 Interested in joining the Pants team?
 >
 > Welcome, future colleague! Learn more about the team's composition and eligibility criteria on the [Pants Community](docs:the-pants-community) page, then post in the #development channel of the [community Slack](doc:getting-started) to express interest in joining the team. We love opportunity to usher in new teammates, and are happy to offer mentorship support to community members who request it and have a track record of commitment to the long-term vitality of the project.
 
-Pants open source project has had many team members in over a decade. The current team is comprised of elected Contributors and Maintainers, who are nominated based on [criteria](docs:the-pants-community#how-is-the-community-structured) including demonstrated commitment to the project and a track record of contributions to the project and community.
+## Current Team
 
-Maintainers
+### Maintainers
 -----------
 
 | **NAME**                   | **PROUDEST CONTRIBUTION**                                                                             |
@@ -35,7 +37,7 @@ Maintainers
 | **Tom Dyas**               | Adding the Golang backend and getting remote execution to work with more servers.                     |
 | **Yi Cheng**               | Adding coursier integration to v.1                                                                    |
 
-Contributors
+### Contributors
 ------------
 
 | **NAME**               | **PROUDEST CONTRIBUTION **                                                                               |
@@ -55,9 +57,11 @@ Contributors
 
 ***
 
+## Emeritus
+
 When team members retire from the team in good standing, they are designated emeritus. We are grateful for the many past contributons by our emeritus team members, whose collective work created the strong foundations that modern Pants stands on. We are honored to have had the opportunity to collaborate with them as teammates.
 
-Maintainers Emeritus
+### Maintainers Emeritus
 --------------------
 
 | **NAME**              | **PROUDEST CONTRIBUTION**                                                           |
@@ -84,7 +88,7 @@ Maintainers Emeritus
 | **Travis Crawford**   |                                                                                     |
 | **Yujie Chen**        |                                                                                     |
 
-Contributors Emeritus
+### Contributors Emeritus
 ---------------------
 
 | **NAME**             | **PROUDEST CONTRIBUTION**                                               |


### PR DESCRIPTION
The docs describe eligibility but do not indicate how candidates are identified. Up to now, candidates have generally been identified by team members, who reach out to the candidate to assess whether they'd be interested in being nominated. This PR explicitely invites community members to consider joining formally joining the team, and identifies the first step for making their interest known — so that we can begin to identify/cultivate prospective team members earlier, and guide them toward contributions that would support their goal of becoming a team member.