### PR TITLE
Refactor `PythonBootstrap` type

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -10,7 +10,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
 
-class PythonNativeCode(Subsystem):
+class PythonNativeCodeSubsystem(Subsystem):
     options_scope = "python-native-code"
     help = "Options for building native code using Python, e.g. when resolving distributions."
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -30,7 +30,7 @@ from pants.backend.python.util_rules.pex_cli import PexCliProcess, PexPEX
 from pants.backend.python.util_rules.pex_environment import (
     CompletePexEnvironment,
     PexEnvironment,
-    PexRuntimeEnvironment,
+    PexSubsystem,
     PythonExecutable,
 )
 from pants.backend.python.util_rules.pex_requirements import (
@@ -287,7 +287,7 @@ class OptionalPex:
 
 @rule(desc="Find Python interpreter for constraints", level=LogLevel.DEBUG)
 async def find_interpreter(
-    interpreter_constraints: InterpreterConstraints, pex_runtime_env: PexRuntimeEnvironment
+    interpreter_constraints: InterpreterConstraints, pex_subsystem: PexSubsystem
 ) -> PythonExecutable:
     formatted_constraints = " OR ".join(str(constraint) for constraint in interpreter_constraints)
     result = await Get(
@@ -334,7 +334,7 @@ async def find_interpreter(
     )
     path, fingerprint = result.stdout.decode().strip().splitlines()
 
-    if pex_runtime_env.verbosity > 0:
+    if pex_subsystem.verbosity > 0:
         log_output = result.stderr.decode()
         if log_output:
             logger.info("%s", log_output)
@@ -502,10 +502,7 @@ async def _setup_pex_requirements(
 
 @rule(level=LogLevel.DEBUG)
 async def build_pex(
-    request: PexRequest,
-    python_setup: PythonSetup,
-    platform: Platform,
-    pex_runtime_env: PexRuntimeEnvironment,
+    request: PexRequest, python_setup: PythonSetup, platform: Platform, pex_subsystem: PexSubsystem
 ) -> BuildPexResult:
     """Returns a PEX with the given settings."""
     argv = [
@@ -579,7 +576,7 @@ async def build_pex(
     # platform.
     result = await Get(ProcessResult, Process, process)
 
-    if pex_runtime_env.verbosity > 0:
+    if pex_subsystem.verbosity > 0:
         log_output = result.stderr.decode()
         if log_output:
             logger.info("%s", log_output)

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -25,7 +25,7 @@ from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import create_path_env_var, softwrap
 
 
-class PexRuntimeEnvironment(Subsystem):
+class PexSubsystem(Subsystem):
     options_scope = "pex"
     help = "How Pants uses Pex to run Python subprocesses."
 
@@ -160,17 +160,17 @@ class PexEnvironment(EngineAwareReturnType):
 async def find_pex_python(
     python_bootstrap: PythonBootstrap,
     python_binary: PythonBinary,
-    pex_runtime_env: PexRuntimeEnvironment,
+    pex_subsystem: PexSubsystem,
     subprocess_env_vars: SubprocessEnvironmentVars,
     named_caches_dir: NamedCachesDirOption,
 ) -> PexEnvironment:
     return PexEnvironment(
-        path=pex_runtime_env.path(python_bootstrap.environment),
+        path=pex_subsystem.path(python_bootstrap.environment),
         interpreter_search_paths=tuple(python_bootstrap.interpreter_search_paths()),
         subprocess_environment_dict=subprocess_env_vars.vars,
         named_caches_dir=named_caches_dir.val,
         bootstrap_python=PythonExecutable.from_python_binary(python_binary),
-        venv_use_symlinks=pex_runtime_env.venv_use_symlinks,
+        venv_use_symlinks=pex_subsystem.venv_use_symlinks,
     )
 
 


### PR DESCRIPTION
Prework for https://github.com/pantsbuild/pants/pull/16683. We shouldn't be storing `OptionValueContainer` in the `PythonBootstrap` dataclass anymore because values may come from a `local_environment` target instead.

Also renames some subsystem types to end in the name `Subsystem`, for clarity.

[ci skip-rust]
[ci skip-build-wheels]