### PR TITLE
move creation of named cache directory into NamedCaches

### DIFF
--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -63,8 +63,7 @@ impl NamedCaches {
     for symlink in &symlinks {
       safe_create_dir_all_ioerror(&symlink.dst).map_err(|err| {
         format!(
-          "Error making symlink {} -> {}: {:?}",
-          symlink.src.display(),
+          "Error creating directory {}: {:?}",
           symlink.dst.display(),
           err
         )


### PR DESCRIPTION
Complete a TODO and move creation of the destination directory for named caches into the `NamedCaches::local_paths` function. This is necessary to support the Docker command runner in https://github.com/pantsbuild/pants/pull/16670 which needs to modify the destination symlink to account for difference in paths between the host and container filesystems.

[ci skip-build-wheels]