### PR TITLE
go: support placing resource files in packages (and not just embedding)

### DIFF
--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -31,7 +31,7 @@ from pants.build_graph.address import Address
 from pants.core.goals.test import TestResult, get_filtered_environment
 from pants.core.target_types import ResourceTarget
 from pants.core.util_rules import source_files
-from pants.testutil.rule_runner import QueryRule, RuleRunner, logging
+from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
 @pytest.fixture
@@ -116,7 +116,6 @@ def _assert_test_result_success(test_result: TestResult) -> None:
         )
 
 
-@logging
 def test_embed_in_source_code(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -9,6 +9,7 @@ from typing import Any, Iterable, Mapping
 
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
+from pants.util.strutil import strip_prefix
 
 
 @dataclass(unsafe_hash=True)
@@ -38,12 +39,16 @@ class EmbedConfig:
         self.files = FrozenDict(files)
 
     @classmethod
-    def from_json_dict(cls, d: dict[str, Any]) -> EmbedConfig | None:
+    def from_json_dict(
+        cls, d: dict[str, Any], prefix_to_strip: str | None = None
+    ) -> EmbedConfig | None:
+        patterns = d.get("Patterns", {})
+        files = d.get("Files", {})
+        if prefix_to_strip:
+            files = {key: strip_prefix(value, prefix_to_strip) for key, value in files.items()}
         result = cls(
-            patterns=FrozenDict(
-                {key: tuple(value) for key, value in d.get("Patterns", {}).items()}
-            ),
-            files=FrozenDict(d.get("Files", {})),
+            patterns=FrozenDict({key: tuple(value) for key, value in patterns.items()}),
+            files=FrozenDict(files),
         )
         return result if result else None
 

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 
 from pants.backend.go.go_sources import load_go_binary
@@ -24,7 +25,7 @@ from pants.core.target_types import ResourceSourceField
 from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
+from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -296,36 +297,36 @@ async def setup_first_party_pkg_digest(
     tgt = wrapped_target.target
     pkg_sources = await Get(HydratedSources, HydrateSourcesRequest(tgt[GoPackageSourcesField]))
     sources_digest = pkg_sources.snapshot.digest
+    dir_path = analysis.dir_path if analysis.dir_path else "."
 
     embed_config = None
     test_embed_config = None
     xtest_embed_config = None
 
-    # TODO(#13795): Error if you depend on resources without corresponding embed patterns?
-    if analysis.embed_patterns or analysis.test_embed_patterns or analysis.xtest_embed_patterns:
-        dependencies = await Get(Targets, DependenciesRequest(tgt[Dependencies]))
-        resources_sources = await Get(
-            SourceFiles,
-            SourceFilesRequest(
-                (
-                    t.get(SourcesField)
-                    for t in dependencies
-                    # You can only embed resources located at or below the directory of the
-                    # `go_package`. This is a restriction from Go.
-                    # TODO(#13795): Error if you depend on resources above the go_package?
-                    if t.address.spec_path.startswith(request.address.spec_path)
-                ),
-                for_sources_types=(ResourceSourceField,),
-                # TODO: Switch to True. We need to be confident though that the generated files
-                #  are located below the go_package.
-                enable_codegen=False,
+    # Add `resources` targets to the package.
+    dependencies = await Get(Targets, DependenciesRequest(tgt[Dependencies]))
+    resources_sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(
+            (
+                t.get(SourcesField)
+                for t in dependencies
+                # You can only embed resources located at or below the directory of the
+                # `go_package`. This is a restriction from Go.
+                # TODO(#13795): Error if you depend on resources above the go_package?
+                if t.address.spec_path.startswith(request.address.spec_path)
             ),
-        )
-        resources_digest = await Get(
-            Digest, RemovePrefix(resources_sources.snapshot.digest, request.address.spec_path)
-        )
-        resources_digest = await Get(Digest, AddPrefix(resources_digest, "__resources__"))
+            for_sources_types=(ResourceSourceField,),
+            # TODO: Switch to True. We need to be confident though that the generated files
+            #  are located below the go_package.
+            enable_codegen=False,
+        ),
+    )
+    sources_digest = await Get(
+        Digest, MergeDigests([sources_digest, resources_sources.snapshot.digest])
+    )
 
+    if analysis.embed_patterns or analysis.test_embed_patterns or analysis.xtest_embed_patterns:
         patterns_json = json.dumps(
             {
                 "EmbedPatterns": analysis.embed_patterns,
@@ -333,18 +334,23 @@ async def setup_first_party_pkg_digest(
                 "XTestEmbedPatterns": analysis.xtest_embed_patterns,
             }
         ).encode("utf-8")
-        sources_digest, patterns_json_digest = await MultiGet(
-            Get(Digest, MergeDigests((sources_digest, resources_digest))),
+        patterns_json_digest, sources_digest_for_embedder = await MultiGet(
             Get(Digest, CreateDigest([FileContent("patterns.json", patterns_json)])),
+            Get(Digest, AddPrefix(sources_digest, "__sources__")),
         )
         input_digest = await Get(
-            Digest, MergeDigests((sources_digest, patterns_json_digest, embedder.digest))
+            Digest,
+            MergeDigests((sources_digest_for_embedder, patterns_json_digest, embedder.digest)),
         )
 
         embed_result = await Get(
             FallibleProcessResult,
             Process(
-                ("./embedder", "patterns.json", "__resources__"),
+                (
+                    "./embedder",
+                    "patterns.json",
+                    os.path.normpath(os.path.join("__sources__", dir_path)),
+                ),
                 input_digest=input_digest,
                 description=f"Create embed mapping for {request.address}",
                 level=LogLevel.DEBUG,
@@ -354,12 +360,19 @@ async def setup_first_party_pkg_digest(
             return FallibleFirstPartyPkgDigest(
                 pkg_digest=None,
                 exit_code=embed_result.exit_code,
-                stderr=embed_result.stdout.decode("utf-8"),
+                stderr=embed_result.stdout.decode() + "\n" + embed_result.stderr.decode(),
             )
+
         metadata = json.loads(embed_result.stdout)
-        embed_config = EmbedConfig.from_json_dict(metadata.get("EmbedConfig", {}))
-        test_embed_config = EmbedConfig.from_json_dict(metadata.get("TestEmbedConfig", {}))
-        xtest_embed_config = EmbedConfig.from_json_dict(metadata.get("XTestEmbedConfig", {}))
+        embed_config = EmbedConfig.from_json_dict(
+            metadata.get("EmbedConfig", {}), prefix_to_strip="__sources__/"
+        )
+        test_embed_config = EmbedConfig.from_json_dict(
+            metadata.get("TestEmbedConfig", {}), prefix_to_strip="__sources__/"
+        )
+        xtest_embed_config = EmbedConfig.from_json_dict(
+            metadata.get("XTestEmbedConfig", {}), prefix_to_strip="__sources__/"
+        )
 
     return FallibleFirstPartyPkgDigest(
         FirstPartyPkgDigest(

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -342,20 +342,20 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
     expected_snapshot = rule_runner.make_snapshot(
         {
             **go_sources,
-            **{os.path.join("__resources__", f): content for f, content in resources.items()},
+            **resources,
         }
     )
     assert actual_snapshot == expected_snapshot
 
     assert pkg_digest.embed_config == EmbedConfig(
-        {"grok.txt": ["grok.txt"]}, {"grok.txt": "__resources__/grok.txt"}
+        {"grok.txt": ["grok.txt"]}, {"grok.txt": "grok.txt"}
     )
     assert pkg_digest.test_embed_config == EmbedConfig(
         {"grok.txt": ["grok.txt"], "test_grok.txt": ["test_grok.txt"]},
-        {"grok.txt": "__resources__/grok.txt", "test_grok.txt": "__resources__/test_grok.txt"},
+        {"grok.txt": "grok.txt", "test_grok.txt": "test_grok.txt"},
     )
     assert pkg_digest.xtest_embed_config == EmbedConfig(
-        {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "__resources__/xtest_grok.txt"}
+        {"xtest_grok.txt": ["xtest_grok.txt"]}, {"xtest_grok.txt": "xtest_grok.txt"}
     )
 
 


### PR DESCRIPTION
Support placing resource files into packages just as `.go` files are put into packages (and not just embedding them in the compiled package via `//go:embed` directives). This is necessary to allow placing `.c` files into Go packages for the Cgo support to be added by https://github.com/pantsbuild/pants/pull/16413.

[ci skip-rust]