### PR TITLE
go: extract package name from analysis

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -345,6 +345,7 @@ async def setup_full_package_build_request(
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path=request.import_path,
+            pkg_name=analysis.name,
             digest=gen_sources.digest,
             dir_path=analysis.dir_path,
             go_file_names=analysis.go_files,

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -53,6 +53,7 @@ async def setup_go_binary(request: LoadedGoBinaryRequest) -> LoadedGoBinary:
         BuiltGoPackage,
         BuildGoPackageRequest(
             import_path="main",
+            pkg_name="main",
             dir_path="",
             digest=source_digest,
             go_file_names=tuple(fc.path for fc in file_contents),

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -261,6 +261,7 @@ async def run_go_tests(
 
         xtest_pkg_build_request = BuildGoPackageRequest(
             import_path=f"{import_path}_test",
+            pkg_name=f"{pkg_analysis.name}_test",
             digest=pkg_digest.digest,
             dir_path=pkg_analysis.dir_path,
             go_file_names=pkg_analysis.xtest_go_files,
@@ -307,6 +308,7 @@ async def run_go_tests(
         FallibleBuiltGoPackage,
         BuildGoPackageRequest(
             import_path="main",
+            pkg_name="main",
             digest=testmain_input_digest,
             dir_path="",
             go_file_names=(GeneratedTestMain.TEST_MAIN_FILE, *coverage_setup_files),

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -133,6 +133,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
 def test_build_invalid_package(rule_runner: RuleRunner) -> None:
     request = BuildGoPackageRequest(
         import_path="example.com/assembly",
+        pkg_name="main",
         dir_path="",
         go_file_names=("add_amd64.go", "add_arm64.go"),
         digest=rule_runner.make_snapshot(

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -39,6 +39,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self,
         *,
         import_path: str,
+        pkg_name: str,
         digest: Digest,
         dir_path: str,
         go_file_names: tuple[str, ...],
@@ -56,6 +57,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         """
 
         self.import_path = import_path
+        self.pkg_name = pkg_name
         self.digest = digest
         self.dir_path = dir_path
         self.go_file_names = go_file_names
@@ -68,6 +70,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self._hashcode = hash(
             (
                 self.import_path,
+                self.pkg_name,
                 self.digest,
                 self.dir_path,
                 self.go_file_names,
@@ -86,6 +89,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         return (
             f"{self.__class__}("
             f"import_path={repr(self.import_path)}, "
+            f"pkg_name={self.pkg_name}, "
             f"digest={self.digest}, "
             f"dir_path={self.dir_path}, "
             f"go_file_names={self.go_file_names}, "
@@ -107,6 +111,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         return (
             self._hashcode == other._hashcode
             and self.import_path == other.import_path
+            and self.pkg_name == other.pkg_name
             and self.digest == other.digest
             and self.dir_path == other.dir_path
             and self.go_file_names == other.go_file_names

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -152,6 +152,7 @@ async def setup_build_go_package_target_request(
         _first_party_pkg_digest = _maybe_first_party_pkg_digest.pkg_digest
 
         digest = _first_party_pkg_digest.digest
+        pkg_name = _first_party_pkg_analysis.name
         import_path = _first_party_pkg_analysis.import_path
         dir_path = _first_party_pkg_analysis.dir_path
         minimum_go_version = _first_party_pkg_analysis.minimum_go_version
@@ -187,6 +188,7 @@ async def setup_build_go_package_target_request(
             raise _third_party_pkg_info.error
 
         dir_path = _third_party_pkg_info.dir_path
+        pkg_name = _third_party_pkg_info.name
         digest = _third_party_pkg_info.digest
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
@@ -223,6 +225,7 @@ async def setup_build_go_package_target_request(
     result = BuildGoPackageRequest(
         digest=digest,
         import_path="main" if request.is_main else import_path,
+        pkg_name=pkg_name,
         dir_path=dir_path,
         go_file_names=go_file_names,
         s_file_names=s_file_names,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -74,6 +74,7 @@ async def generate_from_file(request: GoCodegenBuildFilesRequest) -> FallibleBui
     return FallibleBuildGoPackageRequest(
         request=BuildGoPackageRequest(
             import_path="codegen.com/gen",
+            pkg_name="gen",
             digest=digest,
             dir_path="codegen",
             go_file_names=("f.go",),

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -69,6 +69,7 @@ def assert_built(
 def test_build_pkg(rule_runner: RuleRunner) -> None:
     transitive_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep/transitive",
+        pkg_name="transitive",
         dir_path="dep/transitive",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
@@ -92,6 +93,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
     )
     direct_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep",
+        pkg_name="dep",
         dir_path="dep",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
@@ -115,6 +117,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
     )
     main = BuildGoPackageRequest(
         import_path="example.com/foo",
+        pkg_name="foo",
         dir_path="",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
@@ -160,6 +163,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
 def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     invalid_dep = BuildGoPackageRequest(
         import_path="example.com/foo/dep",
+        pkg_name="dep",
         dir_path="dep",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot({"dep/f.go": "invalid!!!"}).digest,
@@ -169,13 +173,14 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     )
     main = BuildGoPackageRequest(
         import_path="example.com/foo",
+        pkg_name="main",
         dir_path="",
         go_file_names=("f.go",),
         digest=rule_runner.make_snapshot(
             {
                 "f.go": dedent(
                     """\
-                    package foo
+                    package main
 
                     import "example.com/foo/dep"
 

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -74,6 +74,7 @@ class FirstPartyPkgAnalysis:
     """
 
     import_path: str
+    name: str
     dir_path: str
 
     imports: tuple[str, ...]
@@ -163,6 +164,7 @@ class FallibleFirstPartyPkgAnalysis:
         analysis = FirstPartyPkgAnalysis(
             dir_path=dir_path,
             import_path=import_path,
+            name=metadata["Name"],
             imports=tuple(metadata.get("Imports", [])),
             test_imports=tuple(metadata.get("TestImports", [])),
             xtest_imports=tuple(metadata.get("XTestImports", [])),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -52,6 +52,7 @@ class ThirdPartyPkgAnalysis:
     """
 
     import_path: str
+    name: str
 
     digest: Digest
     dir_path: str
@@ -435,6 +436,7 @@ async def analyze_go_third_party_package(
     analysis = ThirdPartyPkgAnalysis(
         digest=package_digest,
         import_path=import_path,
+        name=request.pkg_json.get("Name") or import_path.rpartition("/")[-1],
         dir_path=request.package_path,
         imports=tuple(request.pkg_json.get("Imports", ())),
         go_files=tuple(request.pkg_json.get("GoFiles", ())),
@@ -585,6 +587,7 @@ def maybe_raise_or_create_error_or_create_failed_pkg_info(
         )
         return None, ThirdPartyPkgAnalysis(
             import_path=import_path,
+            name="",
             dir_path="",
             digest=EMPTY_DIGEST,
             imports=(),


### PR DESCRIPTION
Extract the package name returned by the package analyzer and make it available to Go rules. This will be needed for the Cgo support to be added by https://github.com/pantsbuild/pants/pull/16413.

[ci skip-rust]