### PR TITLE
Deprecate remote_auth_plugin option - plugins can use entry points now.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1382,11 +1382,11 @@ class BootstrapOptions:
         removal_version="2.16.0.dev1",
         removal_hint=softwrap(
             """
-            Remote auth plugins should now provide the function by implementing an entry point called remote_auth. 
+            Remote auth plugins should now provide the function by implementing an entry point called remote_auth.
 
-            If you are developing a plugin, switch to using an entry point. 
+            If you are developing a plugin, switch to using an entry point.
 
-            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option 
+            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option
             and now only need the plugin to be included in [GLOBAL].plugins
             """
         ),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1384,7 +1384,8 @@ class BootstrapOptions:
             """
             Remote auth plugins should now provide the function by implementing an entry point called remote_auth. 
             If you are developing a plugin, switch to using an entry point. 
-            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option and now only need the plugin to be included in [GLOBAL].plugins
+            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option 
+            and now only need the plugin to be included in [GLOBAL].plugins
             """
         ),
         help=softwrap(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1381,7 +1381,11 @@ class BootstrapOptions:
         deprecation_start_version="2.15.0.dev2",
         removal_version="2.16.0.dev1",
         removal_hint=softwrap(
-            "Remote auth plugins should now provide the function by implementing an entry point called remote_auth. If you are developing a plugin, switch to using an entry point. If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option and now only need the plugin to be included in [GLOBAL].plugins"
+            """
+            Remote auth plugins should now provide the function by implementing an entry point called remote_auth. 
+            If you are developing a plugin, switch to using an entry point. 
+            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option and now only need the plugin to be included in [GLOBAL].plugins
+            """
         ),
         help=softwrap(
             """

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1378,7 +1378,7 @@ class BootstrapOptions:
     remote_auth_plugin = StrOption(
         default=None,
         advanced=True,
-        deprecation_start_version="2.15.0.dev1",
+        deprecation_start_version="2.15.0.dev2",
         removal_version="2.16.0.dev1",
         removal_hint="Remote Auth plugins should use provide the function via the `remote_auth` entry point.",
         help=softwrap(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1378,6 +1378,9 @@ class BootstrapOptions:
     remote_auth_plugin = StrOption(
         default=None,
         advanced=True,
+        deprecation_start_version="2.15.0.dev1",
+        removal_version="2.16.0.dev1",
+        removal_hint="Remote Auth plugins should use provide the function via the `remote_auth` entry point.",
         help=softwrap(
             """
             Path to a plugin to dynamically configure remote caching and execution options.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1380,7 +1380,9 @@ class BootstrapOptions:
         advanced=True,
         deprecation_start_version="2.15.0.dev2",
         removal_version="2.16.0.dev1",
-        removal_hint="Remote Auth plugins should use provide the function via the `remote_auth` entry point.",
+        removal_hint=softwrap(
+            "Remote auth plugins should now provide the function by implementing an entry point called remote_auth. If you are developing a plugin, switch to using an entry point. If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option and now only need the plugin to be included in [GLOBAL].plugins"
+        ),
         help=softwrap(
             """
             Path to a plugin to dynamically configure remote caching and execution options.

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1383,7 +1383,9 @@ class BootstrapOptions:
         removal_hint=softwrap(
             """
             Remote auth plugins should now provide the function by implementing an entry point called remote_auth. 
+
             If you are developing a plugin, switch to using an entry point. 
+
             If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option 
             and now only need the plugin to be included in [GLOBAL].plugins
             """


### PR DESCRIPTION
Follow up for https://github.com/pantsbuild/pants/pull/16212