### PR TITLE
Adds `binary_name` field to PyOxidizer support

### DIFF
--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 from pants.backend.python.packaging.pyoxidizer.config import PyOxidizerConfig
 from pants.backend.python.packaging.pyoxidizer.subsystem import PyOxidizer
 from pants.backend.python.packaging.pyoxidizer.target_types import (
+    PyOxidizerBinaryNameField,
     PyOxidizerConfigSourceField,
     PyOxidizerDependenciesField,
     PyOxidizerEntryPointField,
@@ -58,6 +59,7 @@ logger = logging.getLogger(__name__)
 class PyOxidizerFieldSet(PackageFieldSet):
     required_fields = (PyOxidizerDependenciesField,)
 
+    binary_name: PyOxidizerBinaryNameField
     entry_point: PyOxidizerEntryPointField
     dependencies: PyOxidizerDependenciesField
     unclassified_resources: PyOxidizerUnclassifiedResources
@@ -132,7 +134,7 @@ async def package_pyoxidizer_binary(
         config_template = digest_contents[0].content.decode("utf-8")
 
     config = PyOxidizerConfig(
-        executable_name=field_set.address.target_name,
+        executable_name=field_set.binary_name.value or field_set.address.target_name,
         entry_point=field_set.entry_point.value,
         wheels=wheel_paths,
         template=config_template,

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -28,13 +28,24 @@ class PyOxidizerOutputPathField(OutputPathField):
         Regardless of whether you use the default or set this field, the path will end with
         PyOxidizer's file format of `<platform>/{{debug,release}}/install/<binary_name>`, where
         `platform` is a Rust platform triplet like `aarch-64-apple-darwin` and `binary_name` is
-        the `name` of the `pyoxidizer_target`. So, using the default for this field, the target
+        the value of the `binary_name` field. So, using the default for this field, the target
         `src/python/project:bin` might have a final path like
         `src.python.project/bin/aarch-64-apple-darwin/release/bin`.
 
         When running `{bin_name()} package`, this path will be prefixed by `--distdir` (e.g. `dist/`).
 
         Warning: setting this value risks naming collisions with other package targets you may have.
+        """
+    )
+
+
+class PyOxidizerBinaryNameField(OutputPathField):
+    alias = "binary_name"
+    default = None
+    help = softwrap(
+        """
+        The name of the binary that will be output by PyOxidizer. If not set, this will default
+        to the name of this target.
         """
     )
 
@@ -122,6 +133,7 @@ class PyOxidizerTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         PyOxidizerOutputPathField,
+        PyOxidizerBinaryNameField,
         PyOxidizerConfigSourceField,
         PyOxidizerDependenciesField,
         PyOxidizerEntryPointField,


### PR DESCRIPTION
This came up while working on Pants pyoxidized support -- it didn't make sense to call the target `pants`, so adding an extra config field made sense here.