### PR TITLE
Make experimental_shell_command deterministic (Cherry-pick of #16675)

### DIFF
--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -140,7 +140,7 @@ async def prepare_shell_command_process(
                 binary_name=tool,
                 search_path=search_path,
             )
-            for tool in {*tools, *["mkdir", "ln"]}
+            for tool in sorted({*tools, *["mkdir", "ln"]})
             if tool not in BASH_BUILTIN_COMMANDS
         ]
         tool_paths = await MultiGet(


### PR DESCRIPTION
`set` bad, `tuple` good.

[ci skip-rust]