### PR TITLE
Add `[environment].aliases` and `compatible_platforms` field

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,7 @@ _local_environment(
 
 _local_environment(
     name="macos_local_env",
+    compatible_platforms=["macos_arm64", "macos_x86_64"],
     # Avoid system Python interpreters, which tend to be broken on macOS.
     python_interpreter_search_paths=["<PYENV>"],
 )

--- a/pants.toml
+++ b/pants.toml
@@ -98,15 +98,9 @@ root_patterns = [
 
 [environments-preview.aliases]
 default_env = "//:default_env"
-
-[environments-preview.platforms_to_local_environment]
-linux_arm64 = "//:default_env"
-linux_x86_64 = "//:default_env"
-# TODO(#7735): Set to `//:macos_local_env` after figuring out why our Build Wheels Mac job is
+# TODO(#7735): Define `//:macos_local_env` after figuring out why our Build Wheels Mac job is
 #  failing when this is set:
 #  https://github.com/pantsbuild/pants/runs/8082954359?check_suite_focus=true#step:9:657
-macos_arm64 = "//:default_env"
-macos_x86_64 = "//:default_env"
 
 [tailor]
 build_file_header = """\

--- a/pants.toml
+++ b/pants.toml
@@ -96,6 +96,9 @@ root_patterns = [
   "/",
 ]
 
+[environments-preview.aliases]
+default_env = "//:default_env"
+
 [environments-preview.platforms_to_local_environment]
 linux_arm64 = "//:default_env"
 linux_x86_64 = "//:default_env"

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -10,8 +10,6 @@ from pants.engine.platform import Platform
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
-    AsyncFieldMixin,
-    StringField,
     StringSequenceField,
     Target,
     WrappedTarget,
@@ -54,26 +52,6 @@ class EnvironmentsSubsystem(Subsystem):
 # -------------------------------------------------------------------------------------------
 # Environment targets
 # -------------------------------------------------------------------------------------------
-
-LOCAL_ENVIRONMENT_MATCHER = "__local__"
-
-
-class EnvironmentField(StringField, AsyncFieldMixin):
-    alias = "_environment"
-    default = LOCAL_ENVIRONMENT_MATCHER
-    value: str
-    help = softwrap(
-        f"""
-        What environment to use from the option `[environments-preview].aliases` when building
-        this target.
-
-        Use the special string `{LOCAL_ENVIRONMENT_MATCHER}` for Pants to automatically choose the
-        environment based on the current platform. Otherwise, use a key from the option
-        `[environments-preview].aliases` to force that environment to be used.
-
-        Pants will error if the specified environment is not compatible with the current platform.
-        """
-    )
 
 
 class CompatiblePlatformsField(StringSequenceField):
@@ -167,29 +145,13 @@ class AmbiguousEnvironmentError(Exception):
     pass
 
 
-class UnrecognizedEnvironmentError(Exception):
-    pass
-
-
 class AllEnvironments(FrozenDict[str, LocalEnvironmentTarget]):
     """A mapping of environment aliases to their corresponding environment target."""
 
 
 @dataclass(frozen=True)
 class ChosenLocalEnvironment:
-    f"""Which environment target {LOCAL_ENVIRONMENT_MATCHER} resolves to."""
-
     tgt: LocalEnvironmentTarget | None
-
-
-@dataclass(frozen=True)
-class EnvironmentForTarget:
-    env_tgt: LocalEnvironmentTarget | None
-
-
-@dataclass(frozen=True)
-class EnvironmentForTargetRequest:
-    environment_field: EnvironmentField
 
 
 @rule
@@ -222,7 +184,7 @@ async def determine_all_environments(
 
 
 @rule
-async def determine_local_environment(
+async def choose_local_environment(
     platform: Platform,
     all_environments: AllEnvironments,
 ) -> ChosenLocalEnvironment:
@@ -257,7 +219,7 @@ async def determine_local_environment(
                 Multiple `_local_environment` targets from `[environments-preview].aliases`
                 are compatible with the current platform `{platform.value}`, so it is ambiguous
                 which to use: {sorted(tgt.address.spec for tgt in compatible_targets)}
-
+    
                 To fix, either adjust the `{CompatiblePlatformsField.alias}` field from those
                 targets so that only one includes the value `{platform.value}`, or change
                 `[environments-preview].aliases` so that it does not define some of those targets.
@@ -265,26 +227,6 @@ async def determine_local_environment(
             )
         )
     return ChosenLocalEnvironment(compatible_targets[0])
-
-
-@rule
-async def determine_environment_for_target(
-    request: EnvironmentForTargetRequest,
-) -> EnvironmentForTarget:
-    requested_env = request.environment_field.value
-    if requested_env == LOCAL_ENVIRONMENT_MATCHER:
-        local_env = await Get(ChosenLocalEnvironment, {})
-        return EnvironmentForTarget(local_env.tgt)
-    all_envs = await Get(AllEnvironments, {})
-    if requested_env not in all_envs:
-        raise UnrecognizedEnvironmentError(
-            softwrap(
-                """
-                TODO(#7735)
-                """
-            )
-        )
-    return EnvironmentForTarget(all_envs[requested_env])
 
 
 def rules():

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.platform import Platform
@@ -176,10 +177,8 @@ async def determine_all_environments(
     )
     # TODO(#7735): validate the correct target type is used?
     return AllEnvironments(
-        {
-            alias: wrapped_tgt.target
-            for alias, wrapped_tgt in zip(environments_subsystem.aliases.keys(), wrapped_targets)
-        }
+        (alias, cast(LocalEnvironmentTarget, wrapped_tgt.target))
+        for alias, wrapped_tgt in zip(environments_subsystem.aliases.keys(), wrapped_targets)
     )
 
 
@@ -219,7 +218,7 @@ async def choose_local_environment(
                 Multiple `_local_environment` targets from `[environments-preview].aliases`
                 are compatible with the current platform `{platform.value}`, so it is ambiguous
                 which to use: {sorted(tgt.address.spec for tgt in compatible_targets)}
-    
+
                 To fix, either adjust the `{CompatiblePlatformsField.alias}` field from those
                 targets so that only one includes the value `{platform.value}`, or change
                 `[environments-preview].aliases` so that it does not define some of those targets.

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -11,10 +11,12 @@ from pants.build_graph.address import Address
 from pants.core.util_rules import environments
 from pants.core.util_rules.environments import (
     AllEnvironments,
+    AmbiguousEnvironmentError,
     ChosenLocalEnvironment,
     LocalEnvironmentTarget,
+    NoCompatibleEnvironmentError,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
 
 @pytest.fixture
@@ -56,27 +58,29 @@ def test_choose_local_environment(rule_runner: RuleRunner) -> None:
         {
             "BUILD": dedent(
                 """\
-                _local_environment(name='local_env')
+                _local_environment(name='e1')
+                _local_environment(name='e2')
+                _local_environment(name='not-compatible', compatible_platforms=[])
                 """
             )
         }
     )
-    # If `--platforms-to-local-environments` is not set, do not choose an environment.
-    assert rule_runner.request(ChosenLocalEnvironment, []).tgt is None
 
-    rule_runner.set_options(
-        [
-            # Note that we cannot inject the `Platform` to an arbitrary value: it will use the
-            # platform of the test executor. So, we use the same environment for all platforms.
-            (
-                "--environments-preview-platforms-to-local-environment="
-                + "{'macos_arm64': '//:local_env', "
-                + "'macos_x86_64': '//:local_env', "
-                + "'linux_arm64': '//:local_env', "
-                + "'linux_x86_64': '//:local_env'}"
-            ),
-        ]
-    )
-    assert rule_runner.request(ChosenLocalEnvironment, []).tgt == LocalEnvironmentTarget(
-        {}, Address("", target_name="local_env")
-    )
+    def get_env() -> ChosenLocalEnvironment:
+        return rule_runner.request(ChosenLocalEnvironment, [])
+
+    # If `--aliases` is not set, do not choose an environment.
+    assert get_env().tgt is None
+
+    rule_runner.set_options(["--environments-preview-aliases={'e': '//:e1'}"])
+    assert get_env().tgt == LocalEnvironmentTarget({}, Address("", target_name="e1"))
+
+    # Error if `--aliases` set, but no compatible platforms
+    rule_runner.set_options(["--environments-preview-aliases={'e': '//:not-compatible'}"])
+    with engine_error(NoCompatibleEnvironmentError):
+        get_env()
+
+    # Error if >1 compatible targets.
+    rule_runner.set_options(["--environments-preview-aliases={'e1': '//:e1', 'e2': '//:e2'}"])
+    with engine_error(AmbiguousEnvironmentError):
+        get_env()

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -10,7 +10,7 @@ import pytest
 from pants.build_graph.address import Address
 from pants.core.util_rules import environments
 from pants.core.util_rules.environments import (
-    AllEnvironments,
+    AllEnvironmentTargets,
     AmbiguousEnvironmentError,
     ChosenLocalEnvironment,
     LocalEnvironmentTarget,
@@ -24,7 +24,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *environments.rules(),
-            QueryRule(AllEnvironments, []),
+            QueryRule(AllEnvironmentTargets, []),
             QueryRule(ChosenLocalEnvironment, []),
         ],
         target_types=[LocalEnvironmentTarget],
@@ -44,8 +44,8 @@ def test_all_environments(rule_runner: RuleRunner) -> None:
         }
     )
     rule_runner.set_options(["--environments-preview-aliases={'e1': '//:e1', 'e2': '//:e2'}"])
-    result = rule_runner.request(AllEnvironments, [])
-    assert result == AllEnvironments(
+    result = rule_runner.request(AllEnvironmentTargets, [])
+    assert result == AllEnvironmentTargets(
         {
             "e1": LocalEnvironmentTarget({}, Address("", target_name="e1")),
             "e2": LocalEnvironmentTarget({}, Address("", target_name="e2")),

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -9,7 +9,11 @@ import pytest
 
 from pants.build_graph.address import Address
 from pants.core.util_rules import environments
-from pants.core.util_rules.environments import ChosenLocalEnvironment, LocalEnvironmentTarget
+from pants.core.util_rules.environments import (
+    AllEnvironments,
+    ChosenLocalEnvironment,
+    LocalEnvironmentTarget,
+)
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -18,9 +22,32 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *environments.rules(),
+            QueryRule(AllEnvironments, []),
             QueryRule(ChosenLocalEnvironment, []),
         ],
         target_types=[LocalEnvironmentTarget],
+    )
+
+
+def test_all_environments(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                _local_environment(name='e1')
+                _local_environment(name='e2')
+                _local_environment(name='no-alias')
+                """
+            )
+        }
+    )
+    rule_runner.set_options(["--environments-preview-aliases={'e1': '//:e1', 'e2': '//:e2'}"])
+    result = rule_runner.request(AllEnvironments, [])
+    assert result == AllEnvironments(
+        {
+            "e1": LocalEnvironmentTarget({}, Address("", target_name="e1")),
+            "e2": LocalEnvironmentTarget({}, Address("", target_name="e2")),
+        }
     )
 
 


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/7735 and the design doc at https://docs.google.com/document/d/1vXRHWK7ZjAIp2BxWLwRYm1QOKDeXx02ONQWvXDloxkg/edit?usp=sharing.

A followup PR will allow individual targets to set the `environment` field, which means that you can run part of your codebase with different environments than others. 

For the `environment` field to work, we decided environments should have an "alias", which is a logical name the user defines, like `[python].resolves`. This is for two reasons:

1. We need the user to statically define which `local_environment` targets are valid. We can't auto-discover via `AllTargets` because it would result in a rule graph cycle.
2. We want to let users override which environment is used via the options system, e.g. redefine what `centos6` points to. They need to be able to do this without rewriting BUILD files.

The `environment` field will default to `__local__`, where Pants auto-detects which environment to use based on the platform. This means adding a `compatible_platforms` field so that you can, for example, have a Linux-only environment and macOS-only environment. In a followup, we also likely want to add `[environments].local_override` to instruct Pants which value to use with `__local__`.