### PR TITLE
Add `ResolvedEnvironmentRequest` and refactor `environments.py`

### DIFF
--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -15,10 +15,12 @@ from pants.base.build_environment import get_buildroot
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.environments import (
-    ChosenLocalEnvironment,
+    ChosenLocalEnvironmentAlias,
     EnvironmentsSubsystem,
     PythonBootstrapBinaryNamesField,
     PythonInterpreterSearchPathsField,
+    ResolvedEnvironmentAlias,
+    ResolvedEnvironmentTarget,
 )
 from pants.engine.environment import Environment
 from pants.engine.rules import Get, collect_rules, rule
@@ -240,11 +242,16 @@ def get_pyenv_root(env: Environment) -> str | None:
 
 @rule
 async def python_bootstrap(
-    python_bootstrap_subsystem: PythonBootstrapSubsystem, chosen_environment: ChosenLocalEnvironment
+    python_bootstrap_subsystem: PythonBootstrapSubsystem,
+    chosen_environment: ChosenLocalEnvironmentAlias,
 ) -> PythonBootstrap:
-    if chosen_environment.tgt:
-        interpreter_search_paths = chosen_environment.tgt[PythonInterpreterSearchPathsField].value
-        interpreter_names = chosen_environment.tgt[PythonBootstrapBinaryNamesField].value
+    if chosen_environment.val:
+        env_tgt = await Get(
+            ResolvedEnvironmentTarget, ResolvedEnvironmentAlias(chosen_environment.val)
+        )
+        assert env_tgt.val is not None
+        interpreter_search_paths = env_tgt.val[PythonInterpreterSearchPathsField].value
+        interpreter_names = env_tgt.val[PythonBootstrapBinaryNamesField].value
         for opt in ("search_path", "names"):
             python_bootstrap_subsystem.error_if_environment_mechanism_ambiguity(opt)
     else:

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -7,16 +7,19 @@ from textwrap import dedent
 
 import pytest
 
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, ResolveError
 from pants.core.util_rules import environments
 from pants.core.util_rules.environments import (
+    LOCAL_ENVIRONMENT_MATCHER,
     AllEnvironmentTargets,
     AmbiguousEnvironmentError,
     ChosenLocalEnvironmentAlias,
     LocalEnvironmentTarget,
     NoCompatibleEnvironmentError,
     ResolvedEnvironmentAlias,
+    ResolvedEnvironmentRequest,
     ResolvedEnvironmentTarget,
+    UnrecognizedEnvironmentError,
 )
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
@@ -29,6 +32,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(AllEnvironmentTargets, []),
             QueryRule(ChosenLocalEnvironmentAlias, []),
             QueryRule(ResolvedEnvironmentTarget, [ResolvedEnvironmentAlias]),
+            QueryRule(ResolvedEnvironmentAlias, [ResolvedEnvironmentRequest]),
         ],
         target_types=[LocalEnvironmentTarget],
     )
@@ -88,3 +92,56 @@ def test_choose_local_environment(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--environments-preview-aliases={'e1': '//:e1', 'e2': '//:e2'}"])
     with engine_error(AmbiguousEnvironmentError):
         get_env()
+
+
+def test_resolve_environment_alias(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                _local_environment(name='local')
+                # Intentionally set this to no platforms so that it cannot be autodiscovered.
+                _local_environment(name='hardcoded', compatible_platforms=[])
+                """
+            )
+        }
+    )
+
+    def get_alias(v: str) -> ResolvedEnvironmentAlias:
+        return rule_runner.request(
+            ResolvedEnvironmentAlias, [ResolvedEnvironmentRequest(v, description_of_origin="foo")]
+        )
+
+    # If `--aliases` is not set, and the local matcher is used, do not choose an environment.
+    assert get_alias(LOCAL_ENVIRONMENT_MATCHER).val is None
+    # Else, error for unrecognized aliases.
+    with engine_error(UnrecognizedEnvironmentError):
+        get_alias("hardcoded")
+
+    rule_runner.set_options(
+        ["--environments-preview-aliases={'local': '//:local', 'hardcoded': '//:hardcoded'}"]
+    )
+    assert get_alias(LOCAL_ENVIRONMENT_MATCHER).val == "local"
+    assert get_alias("hardcoded").val == "hardcoded"
+    with engine_error(UnrecognizedEnvironmentError):
+        get_alias("fake")
+
+
+def test_resolve_environment_tgt(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"BUILD": "_local_environment(name='env')"})
+    rule_runner.set_options(
+        ["--environments-preview-aliases={'env': '//:env', 'bad-address': '//:fake'}"]
+    )
+
+    def get_tgt(v: str | None) -> ResolvedEnvironmentTarget:
+        return rule_runner.request(ResolvedEnvironmentTarget, [ResolvedEnvironmentAlias(v)])
+
+    assert get_tgt(None).val is None
+
+    # If the alias is not defined, error.
+    with engine_error(AssertionError):
+        get_tgt("bad")
+
+    assert get_tgt("env").val == LocalEnvironmentTarget({}, Address("", target_name="env"))
+    with engine_error(ResolveError):
+        get_tgt("bad-address")


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/7735.

The new `ResolvedEnvironmentRequest`, `ResolvedEnvironmentAlias`, and `ResolvedEnvironmentTarget` types give the functionality needed for individual targets to change what environment is used, rather than it always being the same global environment.

Intentionally, those types are agnostic to the Target API, even though usually the value will come from an upcoming `EnvironmentField`.

As explained in a comment, the `ResolvedEnvironmentAlias` type exists so that we can have finer-grained param keys with the rule graph.