### PR TITLE
Change `write_reports` to take a mapping

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Iterable, cast
 
@@ -182,15 +183,15 @@ async def check(
         Get(CheckResults, CheckRequest, request) for request in requests if request.field_sets
     )
 
-    def get_name(res: CheckResults) -> str:
-        return res.checker_name
+    results_by_tool: dict[str, list[CheckResult]] = defaultdict(list)
+    for results in all_results:
+        results_by_tool[results.checker_name].extend(results.results)
 
     write_reports(
-        all_results,
+        results_by_tool,
         workspace,
         dist_dir,
         goal_name=CheckSubsystem.name,
-        get_name=get_name,
     )
 
     exit_code = 0

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import itertools
 import logging
 import os
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Callable, ClassVar, Iterable, Iterator, TypeVar, cast
 
@@ -463,12 +464,15 @@ async def lint(
     def get_name(res: LintResults) -> str:
         return res.linter_name
 
+    results_by_tool: dict[str, list[LintResult]] = defaultdict(list)
+    for results in all_results:
+        results_by_tool[get_name(results)].extend(results.results)
+
     write_reports(
-        all_results,
+        results_by_tool,
         workspace,
         dist_dir,
         goal_name=LintSubsystem.name,
-        get_name=get_name,
     )
 
     _print_results(

--- a/src/python/pants/core/goals/style_request_test.py
+++ b/src/python/pants/core/goals/style_request_test.py
@@ -1,6 +1,9 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
+from collections import defaultdict
 from pathlib import Path
 
 import pytest
@@ -59,22 +62,22 @@ def test_write_reports() -> None:
         checker_name="partition_duplicate",
     )
 
-    def get_name(res: CheckResults) -> str:
-        return res.checker_name
+    results_by_name: dict[str, list[CheckResult]] = defaultdict(list)
+    for results in (
+        no_results,
+        empty_results,
+        single_results,
+        duplicate_results,
+        partition_results,
+        partition_duplicate_results,
+    ):
+        results_by_name[results.checker_name].extend(results.results)
 
     write_reports(
-        (
-            no_results,
-            empty_results,
-            single_results,
-            duplicate_results,
-            partition_results,
-            partition_duplicate_results,
-        ),
+        results_by_name,
         Workspace(rule_runner.scheduler, _enforce_effects=False),
         DistDir(Path("dist")),
         goal_name="check",
-        get_name=get_name,
     )
 
     check_dir = Path(rule_runner.build_root, "dist", "check")


### PR DESCRIPTION
This preps a future change to `lint.py` in which `LintResults` no longer exists, only `LintResult`.

[ci skip-rust]
[ci skip-build-wheels]