### PR TITLE
Add support for inferring dependencies used in type context bounds (Cherry-pick of #16709)

### DIFF
--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -372,9 +372,10 @@ class SourceAnalysisTraverser extends Traverser {
       })
     }
 
-    case Type.Param(mods, _name, _tparams, bounds, _vbounds, _cbounds) => {
+    case Type.Param(mods, _name, _tparams, bounds, _vbounds, cbounds) => {
       visitMods(mods)
       extractNamesFromTypeTree(bounds).foreach(recordConsumedSymbol(_))
+      cbounds.flatMap(extractNamesFromTypeTree(_)).foreach(recordConsumedSymbol(_))
     }
 
     case Ctor.Primary(mods, _name, params_list) => {

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -655,3 +655,25 @@ def test_type_constaint(rule_runner: RuleRunner) -> None:
         "foo.E",
         "foo.F",
     ]
+
+
+def test_type_context_bounds(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """\
+            package foo
+
+            class Foo[F[_] : Functor]
+
+            class Bar {
+                def doSomething[F[_] : Applicative]() = ()
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == [
+        "foo.Applicative",
+        "foo.Functor",
+    ]


### PR DESCRIPTION
Closes #16708

[ci skip-rust]
[ci skip-build-wheels]