### PR TITLE
Optimize struct sizes to reduce allocation overhead

### DIFF
--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -141,7 +141,7 @@ rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", default_features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }
-smallvec = "1"
+smallvec = { version = "1", features=["union"] }
 stdio = { path = "stdio" }
 store = { path = "fs/store" }
 serde_json = "1.0"

--- a/src/rust/engine/rule_graph/Cargo.toml
+++ b/src/rust/engine/rule_graph/Cargo.toml
@@ -12,7 +12,7 @@ indexmap = "1.9"
 internment = "0.6"
 log = "0.4"
 petgraph = "0.6"
-smallvec = "1"
+smallvec = { version = "1", features=["union"] }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4"
 parking_lot = "0.12"
 petgraph = "0.6"
 rand = "0.8"
-smallvec = "1"
+smallvec = { version = "1", features=["union"] }
 strum = "0.24"
 strum_macros = "0.24"
 tokio = { version = "1.16", features = ["rt", "sync"] }


### PR DESCRIPTION
Use the [`union` feature](https://docs.rs/smallvec/latest/smallvec/#union) of the `smallvec` crate, which makes each `SmallVec` one word smaller.

[ci skip-build-wheels]