### PR TITLE
Docs: improve documentation on Pants handling list options

### DIFF
--- a/docs/markdown/Using Pants/concepts/options.md
+++ b/docs/markdown/Using Pants/concepts/options.md
@@ -206,6 +206,18 @@ listopt = [
 ]
 ```
 
+You can append elements to any existing elements that may have been defined in lower-precedence sources. In this example, having the config file above, there will be a list of three elements at the runtime:
+
+```bash
+./pants --scope-listopt=baz
+```
+
+It is also possible to override any existing list values provided. In this example, having the config file above, there will be a list of one element at the runtime:
+
+```bash
+./pants --scope-listopt="['baz']"
+```
+
 ### Add/remove semantics
 
 List values have some extra semantics:


### PR DESCRIPTION
This PR explains how to override/complement any list values that may have been provided in lower-precedence sources. Current documentation page is [here](https://www.pantsbuild.org/docs/options#list-values).

For example, having

```
[coverage-py]
report = ["xml"]
```

and running

```
./pants test --use-coverage --coverage-py-report=html ::
...
Wrote xml coverage report to `dist/coverage_results`
Wrote html coverage report to `dist/coverage_results`
```

I found this behaviour not obvious, hence the PR.

[ci skip-rust]
[ci skip-build-wheels]