### PR TITLE
Replace union hierarchy tricks with direct class traversal (Cherry-pick of #16657)

### DIFF
--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -300,10 +300,6 @@ def test_subclassed_target_inherits_plugin_fields() -> None:
     class CustomFortranTarget(FortranTarget):
         alias = "custom_fortran"
 
-    # Ensure that any `PluginField` is not lost on subclasses.
-    assert issubclass(CustomFortranTarget._plugin_field_cls, FortranTarget._plugin_field_cls)
-    assert issubclass(FortranTarget._plugin_field_cls, Target._plugin_field_cls)
-
     class CustomField(BoolField):
         alias = "custom_field"
         default = False

--- a/src/python/pants/engine/unions.py
+++ b/src/python/pants/engine/unions.py
@@ -72,14 +72,7 @@ class UnionMembership:
         mapping: DefaultDict[type, OrderedSet[type]] = defaultdict(OrderedSet)
         for rule in rules:
             mapping[rule.union_base].add(rule.union_member)
-        # Subclassed union bases should inherit the superclass's union members.
-        bases = list(mapping.keys())
-        while len(bases) > 0:
-            union_base = bases.pop()
-            for sub_union in union_base.__subclasses__():
-                if sub_union not in mapping:
-                    bases.append(sub_union)
-                mapping[sub_union].update(mapping[union_base])
+
         return cls(mapping)
 
     def __init__(self, union_rules: Mapping[type, Iterable[type]]) -> None:

--- a/src/python/pants/engine/unions_test.py
+++ b/src/python/pants/engine/unions_test.py
@@ -5,17 +5,44 @@ from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.ordered_set import FrozenOrderedSet
 
 
-def test_union_membership_from_rules() -> None:
+def test_simple() -> None:
     @union
-    class Base:
+    class Fruit:
         pass
 
-    class A:
+    class Banana(Fruit):
         pass
 
-    class B:
+    class Apple(Fruit):
         pass
 
-    assert UnionMembership.from_rules([UnionRule(Base, A), UnionRule(Base, B)]) == UnionMembership(
-        {Base: FrozenOrderedSet([A, B])}
+    @union
+    class CitrusFruit(Fruit):
+        pass
+
+    class Orange(CitrusFruit):
+        pass
+
+    @union
+    class Vegetable:
+        pass
+
+    class Potato:  # Doesn't _have_ to inherit from the union
+        pass
+
+    union_membership = UnionMembership.from_rules(
+        [
+            UnionRule(Fruit, Banana),
+            UnionRule(Fruit, Apple),
+            UnionRule(CitrusFruit, Orange),
+            UnionRule(Vegetable, Potato),
+        ]
+    )
+
+    assert union_membership == UnionMembership(
+        {
+            Fruit: FrozenOrderedSet([Banana, Apple]),
+            CitrusFruit: FrozenOrderedSet([Orange]),
+            Vegetable: FrozenOrderedSet([Potato]),
+        }
     )


### PR DESCRIPTION
Unions are simple again :tada:
And we still have Target hierarchies working :tada:

[ci skip-rust]
[ci skip-build-wheels]