### PR TITLE
Add `docker_environment` target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,3 +19,9 @@ _local_environment(
     # Avoid system Python interpreters, which tend to be broken on macOS.
     python_interpreter_search_paths=["<PYENV>"],
 )
+
+# Used for experimenting with the new Docker support.
+_docker_environment(
+    name="docker_env",
+    image="python:3.9",
+)

--- a/pants.toml
+++ b/pants.toml
@@ -101,6 +101,7 @@ default_env = "//:default_env"
 # TODO(#7735): Define `//:macos_local_env` after figuring out why our Build Wheels Mac job is
 #  failing when this is set:
 #  https://github.com/pantsbuild/pants/runs/8082954359?check_suite_focus=true#step:9:657
+docker = "//:docker_env"
 
 [tailor]
 build_file_header = """\

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -43,7 +43,7 @@ from pants.core.util_rules import (
     subprocess_environment,
     system_binaries,
 )
-from pants.core.util_rules.environments import LocalEnvironmentTarget
+from pants.core.util_rules.environments import DockerEnvironmentTarget, LocalEnvironmentTarget
 from pants.engine.internals.parametrize import Parametrize
 from pants.goal import anonymous_telemetry, stats_aggregator
 from pants.source import source_root
@@ -94,6 +94,7 @@ def target_types():
         ResourcesGeneratorTarget,
         RelocatedFiles,
         LocalEnvironmentTarget,
+        DockerEnvironmentTarget,
     ]
 
 


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/13682. 

This target serves two purposes:
1. Define what image to use, which we will pass to the new Docker `CommandRunner` when setting up a `Process`.
2. Configure the env vars and search paths to use.

A follow up will allow individual targets to specify which `environment` to use. If set to a `docker_environment` target, then we will propagate the image name to `Process`.

[ci skip-rust]
[ci skip-build-wheels]