### PR TITLE
`docker_image` comes from `Process` struct, rather than the `CommandRunner`

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -64,7 +64,6 @@ class Process:
     concurrency_available: int
     cache_scope: ProcessCacheScope
     platform: str | None
-    docker_image: str | None
 
     def __init__(
         self,

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -64,6 +64,7 @@ class Process:
     concurrency_available: int
     cache_scope: ProcessCacheScope
     platform: str | None
+    docker_image: str | None
 
     def __init__(
         self,
@@ -85,6 +86,7 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         platform: Platform | None = None,
+        docker_image: str | None = None,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -132,6 +134,7 @@ class Process:
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
         self.platform = platform.value if platform is not None else None
+        self.docker_image = docker_image
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -86,7 +86,6 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         platform: Platform | None = None,
-        docker_image: str | None = None,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -134,7 +133,8 @@ class Process:
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
         self.platform = platform.value if platform is not None else None
-        self.docker_image = docker_image
+        # TODO(#7735): Figure out how this should be set by callers, e.g. automatically.
+        self.docker_image = None
 
 
 @dataclass(frozen=True)

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -33,7 +33,6 @@ pub struct CommandRunner {
   named_caches: NamedCaches,
   immutable_inputs: ImmutableInputs,
   keep_sandboxes: KeepSandboxes,
-  image: String,
 }
 
 impl CommandRunner {
@@ -44,7 +43,6 @@ impl CommandRunner {
     named_caches: NamedCaches,
     immutable_inputs: ImmutableInputs,
     keep_sandboxes: KeepSandboxes,
-    image: String,
   ) -> Result<Self, String> {
     let docker = Docker::connect_with_local_defaults()
       .map_err(|err| format!("Failed to connect to local Docker: {err}"))?;
@@ -56,7 +54,6 @@ impl CommandRunner {
       named_caches,
       immutable_inputs,
       keep_sandboxes,
-      image,
     })
   }
 }
@@ -224,6 +221,10 @@ impl CapturedWorkdir for CommandRunner {
         )
       })?;
 
+    let image = req
+      .docker_image
+      .ok_or("docker_image not set on the Process, but the Docker CommandRunner was used.")?;
+
     // DOCKER-TODO: Set creation options so we can set platform.
 
     let config = bollard::container::Config {
@@ -249,7 +250,7 @@ impl CapturedWorkdir for CommandRunner {
         init: Some(true),
         ..bollard_stubs::models::HostConfig::default()
       }),
-      image: Some(self.image.clone()),
+      image: Some(image),
       attach_stdout: Some(true),
       attach_stderr: Some(true),
       ..bollard::container::Config::default()

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -663,6 +663,7 @@ async fn immutable_inputs() {
   .unwrap();
   process.timeout = Some(Duration::from_secs(1));
   process.description = "confused-cat".to_string();
+  process.docker_image = Some(IMAGE.to_string());
 
   let result = run_command_via_docker_in_dir(
     &docker,
@@ -722,7 +723,6 @@ async fn run_command_via_docker_in_dir(
     named_caches,
     immutable_inputs,
     cleanup,
-    IMAGE.to_string(),
   )?;
   let original = runner.run(Context::default(), workunit, req.into()).await?;
   let stdout_bytes = store

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -534,6 +534,9 @@ pub struct Process {
   pub platform_constraint: Option<Platform>,
 
   pub cache_scope: ProcessCacheScope,
+
+  /// The docker image to run the process with.
+  pub docker_image: Option<String>,
 }
 
 impl Process {
@@ -564,6 +567,7 @@ impl Process {
       execution_slot_variable: None,
       concurrency_available: 0,
       cache_scope: ProcessCacheScope::Successful,
+      docker_image: None,
     }
   }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -89,6 +89,7 @@ async fn make_execute_request() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let want_command = remexec::Command {
@@ -166,6 +167,7 @@ async fn make_execute_request_with_instance_name() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let want_command = remexec::Command {
@@ -256,6 +258,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let mut want_command = remexec::Command {
@@ -493,6 +496,7 @@ async fn make_execute_request_with_timeout() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let want_command = remexec::Command {
@@ -598,6 +602,7 @@ async fn make_execute_request_using_immutable_inputs() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -455,6 +455,7 @@ async fn make_request_from_flat_args(
     execution_slot_variable: None,
     concurrency_available: args.command.concurrency_available.unwrap_or(0),
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let metadata = ProcessMetadata {
@@ -548,6 +549,7 @@ async fn extract_request_from_action_digest(
     jdk_home: None,
     platform_constraint: None,
     cache_scope: ProcessCacheScope::Always,
+    docker_image: None,
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -359,6 +359,8 @@ impl ExecuteProcess {
         None
       };
 
+    let docker_image = externs::getattr_as_optional_string(value, "docker_image");
+
     Ok(process_execution::Process {
       argv: externs::getattr(value, "argv").unwrap(),
       env,
@@ -375,6 +377,7 @@ impl ExecuteProcess {
       execution_slot_variable,
       concurrency_available,
       cache_scope,
+      docker_image,
     })
   }
 


### PR DESCRIPTION
Otherwise, we would need to create a distinct CommandRunner per n Docker images the user defines.

A follow up (https://github.com/pantsbuild/pants/pull/16755) will update our Python code to actually set `docker_image`, and another will wire up our `run_wrapped_node` logic to consume Docker when `docker_image` is set. For now, the field does nothing.