### PR TITLE
Deprecate `Platform.current` in favor of requesting an injected `Platform`

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -9,6 +9,11 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 2.15
 ----
 
+### Deprecated `Platform.current`
+
+The `Platform` to use will soon become dependent on a `@rule`'s position in the `@rule` graph. To
+get the correct `Platform`, a `@rule` should request a `Platform` as a positional argument.
+
 ### Deprecated `convert_dir_literal_to_address_literal` kwarg
 
 The `convert_dir_literal_to_address_literal` keyword argument for `RawSpecs.create()` and

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-codegen.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-codegen.md
@@ -193,10 +193,10 @@ You will likely need to add logic for handling [source roots](doc:source-roots).
 ```python
 @rule
 async def generate_python_from_protobuf(
-    request: GeneratePythonFromProtobufRequest, protoc: Protoc
+    request: GeneratePythonFromProtobufRequest, protoc: Protoc, platform: Platform
 ) -> GeneratedSources:
     download_protoc_get = Get(
-        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)
     )
 
     # Protoc needs all transitive dependencies on `protobuf_libraries` to work properly. It won't

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
@@ -115,14 +115,14 @@ You will need a rule for `fmt` which takes the `FmtRequest` from step 3  (e.g. `
 
 ```python
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
-async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
+async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt, platform: Platform) -> FmtResult:
     if shfmt.skip:
         return FmtResult.skip(formatter_name=request.name)
 
     download_shfmt_get = Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        shfmt.get_request(Platform.current),
+        shfmt.get_request(platform),
     )
 
     # If the user specified `--shfmt-config`, we must search for the file they specified with

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-lint-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-lint-goal.md
@@ -177,7 +177,7 @@ from pants.util.strutil import pluralize
 
 @rule
 async def run_shellcheck(
-    request: ShellcheckRequest, shellcheck: Shellcheck
+    request: ShellcheckRequest, shellcheck: Shellcheck, platform: Platform
 ) -> LintResults:
     if shellcheck.skip:
         return LintResults([], linter_name=request.name)
@@ -185,7 +185,7 @@ async def run_shellcheck(
     download_shellcheck_request = Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        shellcheck.get_request(Platform.current),
+        shellcheck.get_request(platform),
     )
 
     sources_request = Get(

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
@@ -125,7 +125,7 @@ async def demo(shellcheck: Shellcheck, ...) -> Foo:
     shellcheck = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        shellcheck.get_request(Platform.current)
+        shellcheck.get_request(platform)
     )
     result = await Get(
         ProcessResult,

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -19,9 +19,11 @@ class BuildifierRequest(_FmtBuildFilesRequest):
 
 
 @rule(desc="Format with Buildifier", level=LogLevel.DEBUG)
-async def buildfier_fmt(request: BuildifierRequest, buildifier: Buildifier) -> FmtResult:
+async def buildfier_fmt(
+    request: BuildifierRequest, buildifier: Buildifier, platform: Platform
+) -> FmtResult:
     buildifier_tool = await Get(
-        DownloadedExternalTool, ExternalToolRequest, buildifier.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, buildifier.get_request(platform)
     )
     input_digest = await Get(
         Digest,

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -185,6 +185,7 @@ async def setup_full_package_build_request(
     package_mapping: ImportPathToPackages,
     go_protobuf_mapping: GoProtobufImportPathMapping,
     analyzer: PackageAnalyzerSetup,
+    platform: Platform,
 ) -> FallibleBuildGoPackageRequest:
     output_dir = "_generated_files"
     protoc_relpath = "__protoc"
@@ -192,7 +193,7 @@ async def setup_full_package_build_request(
 
     transitive_targets, downloaded_protoc_binary, empty_output_dir = await MultiGet(
         Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
-        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
+        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)),
         Get(Digest, CreateDigest([Directory(output_dir)])),
     )
 
@@ -405,13 +406,14 @@ async def generate_go_from_protobuf(
     request: GenerateGoFromProtobufRequest,
     protoc: Protoc,
     go_protoc_plugin: _SetupGoProtocPlugin,
+    platform: Platform,
 ) -> GeneratedSources:
     output_dir = "_generated_files"
     protoc_relpath = "__protoc"
     protoc_go_plugin_relpath = "__protoc_gen_go"
 
     downloaded_protoc_binary, empty_output_dir, transitive_targets = await MultiGet(
-        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
+        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)),
         Get(Digest, CreateDigest([Directory(output_dir)])),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])),
     )

--- a/src/python/pants/backend/codegen/protobuf/java/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules.py
@@ -64,7 +64,7 @@ class ProtobufJavaGrpcPlugin:
 
 
 @rule
-async def resolve_protobuf_java_grpc_plugin() -> ProtobufJavaGrpcPlugin:
+async def resolve_protobuf_java_grpc_plugin(platform: Platform) -> ProtobufJavaGrpcPlugin:
     lockfile_request = await Get(GenerateJvmLockfileFromTool, GrpcJavaToolLockfileSentinel())
     classpath = await Get(
         ToolClasspath,
@@ -79,7 +79,7 @@ async def resolve_protobuf_java_grpc_plugin() -> ProtobufJavaGrpcPlugin:
         Platform.macos_x86_64: "exe_osx-x86_64",
         Platform.linux_arm64: "exe_linux-aarch_64",
         Platform.linux_x86_64: "exe_linux-x86_64",
-    }[Platform.current]
+    }[platform]
 
     classpath_entries = await Get(DigestEntries, Digest, classpath.digest)
     candidate_plugin_entries = []
@@ -112,9 +112,10 @@ async def generate_java_from_protobuf(
     request: GenerateJavaFromProtobufRequest,
     protoc: Protoc,
     grpc_plugin: ProtobufJavaGrpcPlugin,  # TODO: Don't access grpc plugin unless gRPC codegen is enabled.
+    platform: Platform,
 ) -> GeneratedSources:
     download_protoc_request = Get(
-        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)
     )
 
     output_dir = "_generated_files"

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -45,11 +45,11 @@ class BufFormatRequest(FmtTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG)
-async def setup_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> Process:
+async def setup_buf_format(
+    request: BufFormatRequest, buf: BufSubsystem, platform: Platform
+) -> Process:
     diff_binary = await Get(DiffBinary, DiffBinaryRequest())
-    download_buf_get = Get(
-        DownloadedExternalTool, ExternalToolRequest, buf.get_request(Platform.current)
-    )
+    download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
     binary_shims_get = Get(
         BinaryShims,
         BinaryShimsRequest,

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -40,7 +40,7 @@ class BufLintRequest(LintTargetsRequest):
 
 
 @rule(desc="Lint with buf lint", level=LogLevel.DEBUG)
-async def run_buf(request: BufLintRequest, buf: BufSubsystem) -> LintResults:
+async def run_buf(request: BufLintRequest, buf: BufSubsystem, platform: Platform) -> LintResults:
     if buf.lint_skip:
         return LintResults([], linter_name=request.name)
 
@@ -66,9 +66,7 @@ async def run_buf(request: BufLintRequest, buf: BufSubsystem) -> LintResults:
         ),
     )
 
-    download_buf_get = Get(
-        DownloadedExternalTool, ExternalToolRequest, buf.get_request(Platform.current)
-    )
+    download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
 
     target_sources_stripped, all_sources_stripped, downloaded_buf = await MultiGet(
         target_stripped_sources_request, all_stripped_sources_request, download_buf_get

--- a/src/python/pants/backend/codegen/protobuf/python/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/python/rules.py
@@ -54,9 +54,10 @@ async def generate_python_from_protobuf(
     python_protobuf_subsystem: PythonProtobufSubsystem,
     python_protobuf_mypy_plugin: PythonProtobufMypyPlugin,
     pex_environment: PexEnvironment,
+    platform: Platform,
 ) -> GeneratedSources:
     download_protoc_request = Get(
-        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)
     )
 
     output_dir = "_generated_files"
@@ -125,7 +126,7 @@ async def generate_python_from_protobuf(
         await Get(
             DownloadedExternalTool,
             ExternalToolRequest,
-            grpc_python_plugin.get_request(Platform.current),
+            grpc_python_plugin.get_request(platform),
         )
         if request.protocol_target.get(ProtobufGrpcToggleField).value
         else None

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -106,6 +106,7 @@ async def generate_scala_from_protobuf(
     scalapb: ScalaPBSubsystem,
     shim_classfiles: ScalaPBShimCompiledClassfiles,
     jdk: InternalJdk,
+    platform: Platform,
 ) -> GeneratedSources:
     output_dir = "_generated_files"
     toolcp_relpath = "__toolcp"
@@ -121,7 +122,7 @@ async def generate_scala_from_protobuf(
         transitive_targets,
         inherit_env,
     ) = await MultiGet(
-        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
+        Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(platform)),
         Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
         Get(Digest, CreateDigest([Directory(output_dir)])),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -124,7 +124,7 @@ def assert_build(
             stderr=b"stderr",
             stderr_digest=EMPTY_FILE_DIGEST,
             output_digest=EMPTY_DIGEST,
-            platform=Platform.current,
+            platform=Platform.create_for_localhost(),
             metadata=ProcessResultMetadata(0, "ran_locally", 0),
         )
 

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -49,12 +49,14 @@ def generate_argv(
 
 
 @rule(desc="Lint with Hadolint", level=LogLevel.DEBUG)
-async def run_hadolint(request: HadolintRequest, hadolint: Hadolint) -> LintResults:
+async def run_hadolint(
+    request: HadolintRequest, hadolint: Hadolint, platform: Platform
+) -> LintResults:
     if hadolint.skip:
         return LintResults([], linter_name=request.name)
 
     downloaded_hadolint, config_files = await MultiGet(
-        Get(DownloadedExternalTool, ExternalToolRequest, hadolint.get_request(Platform.current)),
+        Get(DownloadedExternalTool, ExternalToolRequest, hadolint.get_request(platform)),
         Get(ConfigFiles, ConfigFilesRequest, hadolint.config_request()),
     )
 

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -63,9 +63,9 @@ class HelmUnitTestPluginBinding(ExternalHelmPluginBinding[HelmUnitTestSubsystem]
 
 @rule
 def download_unittest_plugin_request(
-    _: HelmUnitTestPluginBinding, subsystem: HelmUnitTestSubsystem
+    _: HelmUnitTestPluginBinding, subsystem: HelmUnitTestSubsystem, platform: Platform
 ) -> ExternalHelmPluginRequest:
-    return ExternalHelmPluginRequest.from_subsystem(subsystem)
+    return ExternalHelmPluginRequest.from_subsystem(subsystem, platform)
 
 
 def rules():

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -109,7 +109,7 @@ class ExternalHelmPlugin(HelmPluginSubsystem, TemplatedExternalTool, metaclass=A
     def download_myplugin_plugin_request(
         _: MyPluginBinding, subsystem: MyHelmPluginSubsystem
     ) -> ExternalHelmPluginRequest:
-        return ExternalHelmPluginRequest.from_subsystem(subsystem)
+        return ExternalHelmPluginRequest.from_subsystem(subsystem, platform)
 
 
     def rules():
@@ -188,8 +188,9 @@ class ExternalHelmPluginRequest(EngineAwareParameter):
     _tool_request: ExternalToolRequest
 
     @classmethod
-    def from_subsystem(cls, subsystem: ExternalHelmPlugin) -> ExternalHelmPluginRequest:
-        platform = Platform.current
+    def from_subsystem(
+        cls, subsystem: ExternalHelmPlugin, platform: Platform
+    ) -> ExternalHelmPluginRequest:
         return cls(
             plugin_name=subsystem.plugin_name,
             platform=platform,
@@ -360,11 +361,11 @@ class HelmProcess:
 
 
 @rule(desc="Download and configure Helm", level=LogLevel.DEBUG)
-async def setup_helm(helm_subsytem: HelmSubsystem, global_plugins: HelmPlugins) -> HelmBinary:
+async def setup_helm(
+    helm_subsytem: HelmSubsystem, global_plugins: HelmPlugins, platform: Platform
+) -> HelmBinary:
     downloaded_binary, empty_dirs_digest = await MultiGet(
-        Get(
-            DownloadedExternalTool, ExternalToolRequest, helm_subsytem.get_request(Platform.current)
-        ),
+        Get(DownloadedExternalTool, ExternalToolRequest, helm_subsytem.get_request(platform)),
         Get(
             Digest,
             CreateDigest(

--- a/src/python/pants/backend/helm/util_rules/tool_test.py
+++ b/src/python/pants/backend/helm/util_rules/tool_test.py
@@ -34,7 +34,9 @@ def test_initialises_basic_helm_binary(rule_runner: RuleRunner) -> None:
     helm_binary = rule_runner.request(HelmBinary, [])
 
     assert helm_binary
-    assert helm_binary.path == f"__helm/{helm_subsystem.generate_exe(Platform.current)}"
+    assert (
+        helm_binary.path == f"__helm/{helm_subsystem.generate_exe(Platform.create_for_localhost())}"
+    )
 
 
 def test_create_helm_process(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -66,18 +66,21 @@ class NpxProcess:
 
 @rule(level=LogLevel.DEBUG)
 async def setup_npx_process(
-    request: NpxProcess, nodejs: NodeJS, named_caches_dir: NamedCachesDirOption
+    request: NpxProcess,
+    nodejs: NodeJS,
+    named_caches_dir: NamedCachesDirOption,
+    platform: Platform,
 ) -> Process:
     # Ensure nodejs is installed
     downloaded_nodejs = await Get(
-        DownloadedExternalTool, ExternalToolRequest, nodejs.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, nodejs.get_request(platform)
     )
 
     input_digest = await Get(Digest, MergeDigests((request.input_digest, downloaded_nodejs.digest)))
 
     # Get reference to npx
     assert nodejs.default_url_platform_mapping is not None
-    plat_str = nodejs.default_url_platform_mapping[Platform.current.value]
+    plat_str = nodejs.default_url_platform_mapping[platform.value]
     nodejs_dir = f"node-{nodejs.version}-{plat_str}"
     # TODO: Investigate if ./{nodejs_dir}/bin/npx can work - as that will be more stable in the long-term
     npx_exe = (

--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -63,6 +63,7 @@ async def count_loc(
     console: Console,
     succinct_code_counter: SuccinctCodeCounter,
     specs_paths: SpecsPaths,
+    platform: Platform,
 ) -> CountLinesOfCode:
     if not specs_paths.files:
         return CountLinesOfCode(exit_code=0)
@@ -72,7 +73,7 @@ async def count_loc(
         Get(
             DownloadedExternalTool,
             ExternalToolRequest,
-            succinct_code_counter.get_request(Platform.current),
+            succinct_code_counter.get_request(platform),
         ),
     )
     input_digest = await Get(Digest, MergeDigests((scc_program.digest, specs_digest)))

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -114,10 +114,8 @@ class PexPEX(DownloadedExternalTool):
 
 
 @rule
-async def download_pex_pex(pex_cli: PexCli) -> PexPEX:
-    pex_pex = await Get(
-        DownloadedExternalTool, ExternalToolRequest, pex_cli.get_request(Platform.current)
-    )
+async def download_pex_pex(pex_cli: PexCli, platform: Platform) -> PexPEX:
+    pex_pex = await Get(DownloadedExternalTool, ExternalToolRequest, pex_cli.get_request(platform))
     return PexPEX(digest=pex_pex.digest, exe=pex_pex.exe)
 
 

--- a/src/python/pants/backend/shell/dependency_inference.py
+++ b/src/python/pants/backend/shell/dependency_inference.py
@@ -94,13 +94,13 @@ PATH_FROM_SHELLCHECK_ERROR = re.compile(r"Not following: (.+) was not specified 
 
 @rule
 async def parse_shell_imports(
-    request: ParseShellImportsRequest, shellcheck: Shellcheck
+    request: ParseShellImportsRequest, shellcheck: Shellcheck, platform: Platform
 ) -> ParsedShellImports:
     # We use Shellcheck to parse for us by running it against each file in isolation, which means
     # that all `source` statements will error. Then, we can extract the problematic paths from the
     # JSON output.
     downloaded_shellcheck = await Get(
-        DownloadedExternalTool, ExternalToolRequest, shellcheck.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, shellcheck.get_request(platform)
     )
     input_digest = await Get(Digest, MergeDigests([request.digest, downloaded_shellcheck.digest]))
     process_result = await Get(

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -38,7 +38,9 @@ class ShellcheckRequest(LintTargetsRequest):
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
-async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> LintResults:
+async def run_shellcheck(
+    request: ShellcheckRequest, shellcheck: Shellcheck, platform: Platform
+) -> LintResults:
     if shellcheck.skip:
         return LintResults([], linter_name=request.name)
 
@@ -66,7 +68,7 @@ async def run_shellcheck(request: ShellcheckRequest, shellcheck: Shellcheck) -> 
     )
 
     download_shellcheck_get = Get(
-        DownloadedExternalTool, ExternalToolRequest, shellcheck.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, shellcheck.get_request(platform)
     )
 
     direct_sources, dependency_sources, downloaded_shellcheck = await MultiGet(

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -37,12 +37,12 @@ class ShfmtRequest(FmtTargetsRequest):
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
-async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt) -> FmtResult:
+async def shfmt_fmt(request: ShfmtRequest, shfmt: Shfmt, platform: Platform) -> FmtResult:
     if shfmt.skip:
         return FmtResult.skip(formatter_name=request.name)
 
     download_shfmt_get = Get(
-        DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(Platform.current)
+        DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(platform)
     )
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, shfmt.config_request(request.snapshot.dirs)

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -126,11 +126,13 @@ class TerraformProcess:
 
 
 @rule
-async def setup_terraform_process(request: TerraformProcess, terraform: TerraformTool) -> Process:
+async def setup_terraform_process(
+    request: TerraformProcess, terraform: TerraformTool, platform: Platform
+) -> Process:
     downloaded_terraform = await Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        terraform.get_request(Platform.current),
+        terraform.get_request(platform),
     )
 
     immutable_input_digests = {"__terraform": downloaded_terraform.digest}

--- a/src/python/pants/base/deprecated.py
+++ b/src/python/pants/base/deprecated.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import inspect
 import logging
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, TypeVar
 
 from packaging.version import InvalidVersion, Version
 
@@ -174,12 +174,15 @@ def deprecated_conditional(
         warn_or_error(removal_version, entity, hint, start_version=start_version)
 
 
+ReturnType = TypeVar("ReturnType")
+
+
 def deprecated(
     removal_version: str,
     hint: str | None = None,
     *,
     start_version: str | None = None,
-):
+) -> Callable[[Callable[..., ReturnType]], Callable[..., ReturnType]]:
     """Mark a function or method as deprecated."""
     validate_deprecation_semver(removal_version, "removal version")
 
@@ -193,7 +196,7 @@ def deprecated(
         def wrapper(*args, **kwargs):
             warn_or_error(
                 removal_version,
-                f"{func.__module__}.{func.__name__}()",
+                f"{func.__module__}.{func.__qualname__}()",
                 hint,
                 start_version=start_version,
             )

--- a/src/python/pants/base/exception_sink_test.py
+++ b/src/python/pants/base/exception_sink_test.py
@@ -64,7 +64,7 @@ def test_set_invalid_log_location():
             "denied:"
         ),
     }
-    assert match(Platform.current, err_str) in str(exc.value)
+    assert match(Platform.create_for_localhost(), err_str) in str(exc.value)
 
 
 def test_log_exception():

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -102,11 +102,11 @@ class ExternalTool(Subsystem, metaclass=ABCMeta):
             return "./path-to/binary
 
     @rule
-    def my_rule(my_external_tool: MyExternalTool) -> Foo:
+    def my_rule(my_external_tool: MyExternalTool, platform: Platform) -> Foo:
         downloaded_tool = await Get(
             DownloadedExternalTool,
             ExternalToolRequest,
-            my_external_tool.get_request(Platform.current)
+            my_external_tool.get_request(platform)
         )
         ...
     """

--- a/src/python/pants/engine/platform.py
+++ b/src/python/pants/engine/platform.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Iterable
 
+from pants.base.deprecated import deprecated
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.util.memo import memoized_classproperty
 from pants.util.osutil import get_normalized_arch_name, get_normalized_os_name
@@ -21,9 +22,24 @@ class Platform(Enum):
     def is_macos(self) -> bool:
         return self in [Platform.macos_arm64, Platform.macos_x86_64]
 
-    # TODO: try to turn all of these accesses into v2 dependency injections!
     @memoized_classproperty
+    @deprecated(
+        "2.16.0.dev1",
+        (
+            "The `Platform` to use is dependent on a `@rule`'s position in the `@rule` graph. "
+            "Request the `Platform` to use as a `@rule` argument to get the appropriate `Platform`."
+        ),
+    )
     def current(cls) -> Platform:
+        return cls.create_for_localhost()
+
+    @classmethod
+    def create_for_localhost(cls) -> Platform:
+        """Creates a Platform instance for localhost.
+
+        This method should never be accessed directly by `@rules`: instead, to get the currently
+        active `Platform`, they should request a `Platform` as a positional argument.
+        """
         return Platform(f"{get_normalized_os_name()}_{get_normalized_arch_name()}")
 
 
@@ -31,7 +47,7 @@ class Platform(Enum):
 # which means replacing this singleton rule with a RootRule populated by an option.
 @rule
 def current_platform() -> Platform:
-    return Platform.current
+    return Platform.create_for_localhost()
 
 
 def rules() -> Iterable[Rule]:

--- a/src/python/pants/engine/platform_test.py
+++ b/src/python/pants/engine/platform_test.py
@@ -8,7 +8,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 def test_platform_on_local_epr_result() -> None:
     rule_runner = RuleRunner(rules=[QueryRule(FallibleProcessResult, (Process,))])
-    this_platform = Platform.current
+    this_platform = Platform.create_for_localhost()
     process = Process(
         argv=("/bin/echo", "test"), description="Run some program that will exit cleanly."
     )

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -244,6 +244,7 @@ async def invoke_coursier_wrapper(
 async def setup_coursier(
     coursier_subsystem: CoursierSubsystem,
     python: PythonBinary,
+    platform: Platform,
 ) -> Coursier:
     repos_args = (
         " ".join(f"-r={shlex.quote(repo)}" for repo in coursier_subsystem.repos) + " --no-default"
@@ -260,7 +261,7 @@ async def setup_coursier(
     downloaded_coursier_get = Get(
         DownloadedExternalTool,
         ExternalToolRequest,
-        coursier_subsystem.get_request(Platform.current),
+        coursier_subsystem.get_request(platform),
     )
     wrapper_scripts_digest_get = Get(
         Digest,


### PR DESCRIPTION
As part of #16721, the `Platform` to use will become dependent on a `@rule`'s position in the `@rule` graph. To get the correct `Platform`, a `@rule` should request a `Platform` as a positional argument.

[ci skip-rust]
[ci skip-build-wheels]