### PR TITLE
docker: attempt to fix intermittently uncaptured output

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
  "rustls-pemfile 0.2.1",
  "tokio",
  "tokio-rustls 0.22.0",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tonic",
  "tonic-build",
  "tower",
@@ -1221,7 +1221,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tracing",
 ]
 
@@ -1807,7 +1807,7 @@ dependencies = [
  "futures",
  "log",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -2286,6 +2286,7 @@ dependencies = [
  "concrete_time",
  "deepsize",
  "derivative",
+ "env_logger",
  "fs",
  "futures",
  "grpc_util",
@@ -3497,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3557,7 +3558,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3591,7 +3592,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-stream",
- "tokio-util 0.6.9",
+ "tokio-util 0.6.10",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2317,6 +2317,7 @@ dependencies = [
  "testutil",
  "tokio",
  "tokio-rustls 0.23.4",
+ "tokio-stream",
  "tokio-util 0.7.2",
  "tonic",
  "tryfuture",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -34,6 +34,7 @@ tempfile = "3"
 concrete_time = { path = "../concrete_time" }
 tokio = { version = "1.16", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
+tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec"] }
 uname = "0.1.1"
 uuid = { version = "1.1", features = ["v4"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -55,6 +55,7 @@ tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots
 tryfuture = { path = "../tryfuture" }
 
 [dev-dependencies]
+env_logger = "0.9"
 maplit = "1.0.1"
 mock = { path = "../testutil/mock" }
 parking_lot = "0.12"

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -611,7 +611,7 @@ async fn working_directory() {
   process.output_directories = relative_paths(&["roland.ext"]).collect::<BTreeSet<_>>();
   process.input_digests =
     InputDigests::with_input_files(TestDirectory::nested().directory_digest());
-  process.timeout = Some(Duration::from_secs(1));
+  process.timeout = Some(Duration::from_secs(5));
   process.description = "confused-cat".to_string();
   process.docker_image = Some(IMAGE.to_owned());
 
@@ -639,6 +639,7 @@ async fn working_directory() {
 
 #[tokio::test]
 async fn immutable_inputs() {
+  let _ = env_logger::try_init().unwrap();
   let docker = setup_docker!();
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
 
@@ -681,7 +682,7 @@ async fn immutable_inputs() {
   )
   .await
   .unwrap();
-  process.timeout = Some(Duration::from_secs(1));
+  process.timeout = Some(Duration::from_secs(5));
   process.description = "confused-cat".to_string();
   process.docker_image = Some(IMAGE.to_string());
 


### PR DESCRIPTION
A WIP non-working attempt to fix https://github.com/pantsbuild/pants/issues/16749 by trying to consume any remaining output from the container's output stream. Times out in tests because Docker does not close the output stream even after the container has exited.