### PR TITLE
Rename `[environments-preview].aliases` to `[environments-preview].names`

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -96,7 +96,7 @@ root_patterns = [
   "/",
 ]
 
-[environments-preview.aliases]
+[environments-preview.names]
 default_env = "//:default_env"
 # TODO(#7735): Define `//:macos_local_env` after figuring out why our Build Wheels Mac job is
 #  failing when this is set:

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -16,11 +16,11 @@ from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.environments import (
     LOCAL_ENVIRONMENT_MATCHER,
+    EnvironmentRequest,
     EnvironmentsSubsystem,
+    EnvironmentTarget,
     PythonBootstrapBinaryNamesField,
     PythonInterpreterSearchPathsField,
-    ResolvedEnvironmentRequest,
-    ResolvedEnvironmentTarget,
 )
 from pants.engine.environment import Environment
 from pants.engine.rules import Get, collect_rules, rule
@@ -243,8 +243,8 @@ def get_pyenv_root(env: Environment) -> str | None:
 @rule
 async def python_bootstrap(python_bootstrap_subsystem: PythonBootstrapSubsystem) -> PythonBootstrap:
     env_tgt = await Get(
-        ResolvedEnvironmentTarget,
-        ResolvedEnvironmentRequest(LOCAL_ENVIRONMENT_MATCHER, description_of_origin="<infallible>"),
+        EnvironmentTarget,
+        EnvironmentRequest(LOCAL_ENVIRONMENT_MATCHER, description_of_origin="<infallible>"),
     )
     if env_tgt.val is not None:
         interpreter_search_paths = env_tgt.val[PythonInterpreterSearchPathsField].value

--- a/src/python/pants/core/util_rules/environments_integration_test.py
+++ b/src/python/pants/core/util_rules/environments_integration_test.py
@@ -19,7 +19,7 @@ def test_unrecognized_build_file_symbols_during_bootstrap() -> None:
         """
     )
     with setup_tmpdir({"BUILD": build_file}) as tmpdir:
-        args = [f"--environments-preview-aliases={{'env': '{tmpdir}:env'}}", "--plugins=ansicolors"]
+        args = [f"--environments-preview-names={{'env': '{tmpdir}:env'}}", "--plugins=ansicolors"]
         run_pants([*args, "--version"]).assert_success()
         # But then we should error after bootstrapping.
         run_pants([*args, "list", tmpdir]).assert_failure()

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -31,7 +31,7 @@ environment-variable matching APIs to remove ambiguity.
 
 @dataclass(frozen=True)
 class EnvironmentName:
-    """TODO: Replace with `pants.core.util_rules.environments.ResolvedEnvironmentAlias`."""
+    """TODO: Replace with `pants.core.util_rules.environments.EnvironmentName`."""
 
 
 class CompleteEnvironment(FrozenDict):


### PR DESCRIPTION
We decided that `name` is more obvious than `alias`. This also aligns with our use of the term "resolve name".