### PR TITLE
Pass the `__local__` environment target to all goals

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/BUILD
+++ b/src/python/pants/backend/codegen/avro/java/BUILD
@@ -5,6 +5,10 @@ python_sources(dependencies=[":lockfile"])
 
 resource(name="lockfile", source="avro-tools.default.lockfile.txt")
 
-python_tests(name="tests", dependencies=[":test_lockfiles"])
+python_tests(
+    name="tests",
+    dependencies=[":test_lockfiles"],
+    overrides={"rules_integration_test.py": {"timeout": 120}},
+)
 
 resources(name="test_lockfiles", sources=["*.test.lock"])

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -11,7 +11,8 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironment, EnvironmentName
+from pants.core.util_rules.environments import determine_bootstrap_environment
+from pants.engine.environment import CompleteEnvironment
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import PySessionCancellationLatch
 from pants.engine.internals.scheduler import ExecutionError
@@ -206,7 +207,10 @@ class LocalPantsRunner:
     def _get_workunits_callbacks(self) -> tuple[WorkunitsCallback, ...]:
         # Load WorkunitsCallbacks by requesting WorkunitsCallbackFactories, and then constructing
         # a per-run instance of each WorkunitsCallback.
-        params = Params(self.union_membership, EnvironmentName(None))
+        params = Params(
+            self.union_membership,
+            determine_bootstrap_environment(self.graph_session.scheduler_session),
+        )
         (workunits_callback_factories,) = self.graph_session.scheduler_session.product_request(
             WorkunitsCallbackFactories, [params]
         )

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -206,7 +206,7 @@ class LocalPantsRunner:
     def _get_workunits_callbacks(self) -> tuple[WorkunitsCallback, ...]:
         # Load WorkunitsCallbacks by requesting WorkunitsCallbackFactories, and then constructing
         # a per-run instance of each WorkunitsCallback.
-        params = Params(self.union_membership, EnvironmentName())
+        params = Params(self.union_membership, EnvironmentName(None))
         (workunits_callback_factories,) = self.graph_session.scheduler_session.product_request(
             WorkunitsCallbackFactories, [params]
         )

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -15,8 +15,6 @@ from pants.base.build_environment import get_buildroot
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.environments import (
-    LOCAL_ENVIRONMENT_MATCHER,
-    EnvironmentRequest,
     EnvironmentsSubsystem,
     EnvironmentTarget,
     PythonBootstrapBinaryNamesField,
@@ -241,11 +239,9 @@ def get_pyenv_root(env: Environment) -> str | None:
 
 
 @rule
-async def python_bootstrap(python_bootstrap_subsystem: PythonBootstrapSubsystem) -> PythonBootstrap:
-    env_tgt = await Get(
-        EnvironmentTarget,
-        EnvironmentRequest(LOCAL_ENVIRONMENT_MATCHER, description_of_origin="<infallible>"),
-    )
+async def python_bootstrap(
+    python_bootstrap_subsystem: PythonBootstrapSubsystem, env_tgt: EnvironmentTarget
+) -> PythonBootstrap:
     if env_tgt.val is not None:
         interpreter_search_paths = env_tgt.val[PythonInterpreterSearchPathsField].value
         interpreter_names = env_tgt.val[PythonBootstrapBinaryNamesField].value

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -9,7 +9,6 @@ from typing import cast
 
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.environment import ChosenLocalEnvironmentName as ChosenLocalEnvironmentName
 from pants.engine.environment import EnvironmentName as EnvironmentName
 from pants.engine.internals.graph import WrappedTargetForBootstrappingOnly
 from pants.engine.internals.scheduler import SchedulerSession
@@ -199,6 +198,13 @@ class UnrecognizedEnvironmentError(Exception):
 
 class AllEnvironmentTargets(FrozenDict[str, Target]):
     """A mapping of environment names to their corresponding environment target."""
+
+
+@dataclass(frozen=True)
+class ChosenLocalEnvironmentName:
+    """Which environment name from `[environments-preview].names` that __local__ resolves to."""
+
+    val: str | None
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -180,9 +180,7 @@ class DockerEnvironmentTarget(Target):
 def determine_bootstrap_environment(session: SchedulerSession) -> EnvironmentName:
     local_env = cast(
         ChosenLocalEnvironmentName,
-        session.product_request(
-            ChosenLocalEnvironmentName, [Params(Platform.create_for_localhost())]
-        )[0],
+        session.product_request(ChosenLocalEnvironmentName, [Params()])[0],
     )
     return EnvironmentName(local_env.val)
 
@@ -236,8 +234,9 @@ async def determine_all_environments(
 
 @rule
 async def determine_local_environment(
-    platform: Platform, all_environment_targets: AllEnvironmentTargets
+    all_environment_targets: AllEnvironmentTargets,
 ) -> ChosenLocalEnvironmentName:
+    platform = Platform.create_for_localhost()
     if not all_environment_targets:
         return ChosenLocalEnvironmentName(None)
     compatible_name_and_targets = [
@@ -350,4 +349,4 @@ async def get_target_for_environment_name(
 
 
 def rules():
-    return (*collect_rules(), QueryRule(ChosenLocalEnvironmentName, [Platform]))
+    return (*collect_rules(), QueryRule(ChosenLocalEnvironmentName, []))

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -10,7 +10,7 @@ from typing import cast
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName as EnvironmentName
-from pants.engine.internals.graph import WrappedTargetForBootstrappingOnly
+from pants.engine.internals.graph import WrappedTargetForBootstrap
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
 from pants.engine.platform import Platform
@@ -336,7 +336,7 @@ async def get_target_for_environment_name(
         ),
     )
     wrapped_target = await Get(
-        WrappedTargetForBootstrappingOnly,
+        WrappedTargetForBootstrap,
         WrappedTargetRequest(address, description_of_origin=_description_of_origin),
     )
     tgt = wrapped_target.val

--- a/src/python/pants/core/util_rules/environments_integration_test.py
+++ b/src/python/pants/core/util_rules/environments_integration_test.py
@@ -14,12 +14,18 @@ def test_unrecognized_build_file_symbols_during_bootstrap() -> None:
     # we special-case the bootstrap scheduler.
     build_file = dedent(
         """\
-        bad_tgt_type(name='bad')
-        _local_environment(name='env', bad_field=123)
+        # This target type's backend is not loaded during plugin resolution.
+        shell_sources(name='shell')
+
+        # TODO(#7735): Once we migrate the Shell backend to use environments, add one of its
+        #  plugin fields here
+        _local_environment(name='env')
         """
     )
     with setup_tmpdir({"BUILD": build_file}) as tmpdir:
-        args = [f"--environments-preview-names={{'env': '{tmpdir}:env'}}", "--plugins=ansicolors"]
-        run_pants([*args, "--version"]).assert_success()
-        # But then we should error after bootstrapping.
-        run_pants([*args, "list", tmpdir]).assert_failure()
+        args = [
+            "--backend-packages=pants.backend.shell",
+            f"--environments-preview-names={{'env': '{tmpdir}:env'}}",
+            "--plugins=ansicolors",
+        ]
+        run_pants([*args, "list", tmpdir]).assert_success()

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -32,11 +32,11 @@ def rule_runner() -> RuleRunner:
         rules=[
             *environments.rules(),
             QueryRule(AllEnvironmentTargets, []),
-            QueryRule(ChosenLocalEnvironmentName, []),
             QueryRule(EnvironmentTarget, [EnvironmentName]),
             QueryRule(EnvironmentName, [EnvironmentRequest]),
         ],
         target_types=[LocalEnvironmentTarget, DockerEnvironmentTarget],
+        singleton_environment=None,
     )
 
 
@@ -84,6 +84,7 @@ def test_choose_local_environment(rule_runner: RuleRunner) -> None:
 
     def get_env() -> EnvironmentTarget:
         name = rule_runner.request(ChosenLocalEnvironmentName, [])
+        print(name)
         return rule_runner.request(EnvironmentTarget, [EnvironmentName(name.val)])
 
     # If `--names` is not set, do not choose an environment.

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -84,7 +84,6 @@ def test_choose_local_environment(rule_runner: RuleRunner) -> None:
 
     def get_env() -> EnvironmentTarget:
         name = rule_runner.request(ChosenLocalEnvironmentName, [])
-        print(name)
         return rule_runner.request(EnvironmentTarget, [EnvironmentName(name.val)])
 
     # If `--names` is not set, do not choose an environment.

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -13,6 +13,7 @@ from pants.core.util_rules.environments import (
     LOCAL_ENVIRONMENT_MATCHER,
     AllEnvironmentTargets,
     AmbiguousEnvironmentError,
+    ChosenLocalEnvironmentName,
     DockerEnvironmentTarget,
     DockerImageField,
     EnvironmentName,
@@ -22,7 +23,6 @@ from pants.core.util_rules.environments import (
     NoCompatibleEnvironmentError,
     UnrecognizedEnvironmentError,
 )
-from pants.engine.environment import ChosenLocalEnvironmentName
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
 

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -13,7 +13,6 @@ from pants.core.util_rules.environments import (
     LOCAL_ENVIRONMENT_MATCHER,
     AllEnvironmentTargets,
     AmbiguousEnvironmentError,
-    ChosenLocalEnvironmentName,
     DockerEnvironmentTarget,
     DockerImageField,
     EnvironmentName,
@@ -23,6 +22,7 @@ from pants.core.util_rules.environments import (
     NoCompatibleEnvironmentError,
     UnrecognizedEnvironmentError,
 )
+from pants.engine.environment import ChosenLocalEnvironmentName
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
 

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -1,11 +1,13 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
 
 import logging
 import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Sequence
 
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.internals.session import SessionValues
 from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
@@ -30,8 +32,19 @@ environment-variable matching APIs to remove ambiguity.
 
 
 @dataclass(frozen=True)
-class EnvironmentName:
-    """TODO: Replace with `pants.core.util_rules.environments.EnvironmentName`."""
+class EnvironmentName(EngineAwareParameter):
+    f"""The normalized name for an environment, from `[environments-preview].names`, after
+    applying things like the __local__ matcher.
+
+    Note that we have this type, rather than only `EnvironmentTarget`, for a more efficient
+    rule graph. This node impacts the equality of many downstream nodes, so we want its identity
+    to only be a single string, rather than a Target instance.
+    """
+
+    val: str | None
+
+    def debug_hint(self) -> str:
+        return self.val or "<none>"
 
 
 class CompleteEnvironment(FrozenDict):

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -30,21 +30,37 @@ If the second use case gains steam as #13682 proceeds, we should move and rename
 environment-variable matching APIs to remove ambiguity.
 """
 
+# ----------------------------------------------------------------------
+# Environments mechanism
+# ----------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class EnvironmentName(EngineAwareParameter):
-    f"""The normalized name for an environment, from `[environments-preview].names`, after
-    applying things like the __local__ matcher.
+    """The normalized name for an environment, from `[environments-preview].names`, after applying
+    things like the __local__ matcher.
 
-    Note that we have this type, rather than only `EnvironmentTarget`, for a more efficient
-    rule graph. This node impacts the equality of many downstream nodes, so we want its identity
-    to only be a single string, rather than a Target instance.
+    Note that we have this type, rather than only `EnvironmentTarget`, for a more efficient rule
+    graph. This node impacts the equality of many downstream nodes, so we want its identity to only
+    be a single string, rather than a Target instance.
     """
 
     val: str | None
 
     def debug_hint(self) -> str:
         return self.val or "<none>"
+
+
+@dataclass(frozen=True)
+class ChosenLocalEnvironmentName:
+    """Which environment name from `[environments-preview].names` that __local__ resolves to."""
+
+    val: str | None
+
+
+# ----------------------------------------------------------------------
+# Environments variables
+# ----------------------------------------------------------------------
 
 
 class CompleteEnvironment(FrozenDict):

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -51,13 +51,6 @@ class EnvironmentName(EngineAwareParameter):
         return self.val or "<none>"
 
 
-@dataclass(frozen=True)
-class ChosenLocalEnvironmentName:
-    """Which environment name from `[environments-preview].names` that __local__ resolves to."""
-
-    val: str | None
-
-
 # ----------------------------------------------------------------------
 # Environments variables
 # ----------------------------------------------------------------------

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -32,11 +32,6 @@ from pants.util.strutil import softwrap
 
 
 @dataclass(frozen=True)
-class IgnoreUnrecognizedBuildFileSymbols:
-    val: bool
-
-
-@dataclass(frozen=True)
 class BuildFileOptions:
     patterns: tuple[str, ...]
     ignores: tuple[str, ...] = ()

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -362,7 +362,7 @@ async def resolve_target(
 
 
 @dataclass(frozen=True)
-class WrappedTargetForBootstrappingOnly:
+class WrappedTargetForBootstrap:
     """Used to avoid a rule graph cycle when evaluating bootstrap targets.
 
     This does not work with target generation and parametrization. It also ignores any unrecognized
@@ -380,7 +380,7 @@ async def resolve_target_for_bootstrapping(
     request: WrappedTargetRequest,
     registered_target_types: RegisteredTargetTypes,
     union_membership: UnionMembership,
-) -> WrappedTargetForBootstrappingOnly:
+) -> WrappedTargetForBootstrap:
     target_adaptor, target_type = await _determine_target_adaptor_and_type(
         request.address,
         registered_target_types,
@@ -393,7 +393,7 @@ async def resolve_target_for_bootstrapping(
         union_membership=union_membership,
         ignore_unrecognized_fields=True,
     )
-    return WrappedTargetForBootstrappingOnly(target)
+    return WrappedTargetForBootstrap(target)
 
 
 @rule

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -24,7 +24,6 @@ from pants.engine.addresses import (
 from pants.engine.collection import Collection
 from pants.engine.fs import EMPTY_SNAPSHOT, GlobMatchErrorBehavior, PathGlobs, Paths, Snapshot
 from pants.engine.internals import native_engine
-from pants.engine.internals.build_files import IgnoreUnrecognizedBuildFileSymbols
 from pants.engine.internals.native_engine import AddressParseException
 from pants.engine.internals.parametrize import Parametrize, _TargetParametrization
 from pants.engine.internals.parametrize import (  # noqa: F401
@@ -170,20 +169,13 @@ def warn_deprecated_field_type(field_type: type[Field]) -> None:
     )
 
 
-@rule
-async def resolve_target_parametrizations(
-    request: _TargetParametrizationsRequest,
-    registered_target_types: RegisteredTargetTypes,
-    union_membership: UnionMembership,
-    target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
-    unmatched_build_file_globs: UnmatchedBuildFileGlobs,
-    ignore_unrecognized_build_file_symbols: IgnoreUnrecognizedBuildFileSymbols,
-) -> _TargetParametrizations:
-    address = request.address
-
+@rule_helper
+async def _determine_target_adaptor_and_type(
+    address: Address, registered_target_types: RegisteredTargetTypes, *, description_of_origin: str
+) -> tuple[TargetAdaptor, type[Target]]:
     target_adaptor = await Get(
         TargetAdaptor,
-        TargetAdaptorRequest(address, description_of_origin=request.description_of_origin),
+        TargetAdaptorRequest(address, description_of_origin=description_of_origin),
     )
     target_type = registered_target_types.aliases_to_types.get(target_adaptor.type_alias, None)
     if target_type is None:
@@ -196,6 +188,21 @@ async def resolve_target_parametrizations(
         and not address.is_generated_target
     ):
         warn_deprecated_target_type(target_type)
+    return target_adaptor, target_type
+
+
+@rule
+async def resolve_target_parametrizations(
+    request: _TargetParametrizationsRequest,
+    registered_target_types: RegisteredTargetTypes,
+    union_membership: UnionMembership,
+    target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,
+    unmatched_build_file_globs: UnmatchedBuildFileGlobs,
+) -> _TargetParametrizations:
+    address = request.address
+    target_adaptor, target_type = await _determine_target_adaptor_and_type(
+        address, registered_target_types, description_of_origin=request.description_of_origin
+    )
 
     target = None
     parametrizations: list[_TargetParametrization] = []
@@ -300,7 +307,6 @@ async def resolve_target_parametrizations(
                         parameterized_address,
                         name_explicitly_set=target_adaptor.name_explicitly_set,
                         union_membership=union_membership,
-                        ignore_unrecognized_fields=ignore_unrecognized_build_file_symbols.val,
                     ),
                 )
                 for parameterized_address, parameterized_fields in (first, *rest)
@@ -313,7 +319,6 @@ async def resolve_target_parametrizations(
                 address,
                 name_explicitly_set=target_adaptor.name_explicitly_set,
                 union_membership=union_membership,
-                ignore_unrecognized_fields=ignore_unrecognized_build_file_symbols.val,
             )
             parametrizations.append(_TargetParametrization(target, FrozenDict()))
 
@@ -354,6 +359,41 @@ async def resolve_target(
             )
         )
     return WrappedTarget(target)
+
+
+@dataclass(frozen=True)
+class WrappedTargetForBootstrappingOnly:
+    """Used to avoid a rule graph cycle when evaluating bootstrap targets.
+
+    This does not work with target generation and parametrization. It also ignores any unrecognized
+    fields in the target, to accommodate plugin fields which are not yet registered during
+    bootstrapping.
+
+    This should only be used by bootstrapping code.
+    """
+
+    val: Target
+
+
+@rule
+async def resolve_target_for_bootstrapping(
+    request: WrappedTargetRequest,
+    registered_target_types: RegisteredTargetTypes,
+    union_membership: UnionMembership,
+) -> WrappedTargetForBootstrappingOnly:
+    target_adaptor, target_type = await _determine_target_adaptor_and_type(
+        request.address,
+        registered_target_types,
+        description_of_origin=request.description_of_origin,
+    )
+    target = target_type(
+        target_adaptor.kwargs,
+        request.address,
+        name_explicitly_set=target_adaptor.name_explicitly_set,
+        union_membership=union_membership,
+        ignore_unrecognized_fields=True,
+    )
+    return WrappedTargetForBootstrappingOnly(target)
 
 
 @rule

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
 from pants.base.specs import Specs
+from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.engine.addresses import Addresses
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, DigestContents, FileDigest, Snapshot
@@ -103,7 +104,11 @@ class StreamingWorkunitContext:
         """Return a dict containing the canonicalized addresses of the specs for this run, and what
         files they expand to."""
 
-        params = Params(self._specs, self._options_bootstrapper, EnvironmentName(None))
+        params = Params(
+            self._specs,
+            self._options_bootstrapper,
+            determine_bootstrap_environment(self._scheduler),
+        )
         request = self._scheduler.execution_request([(Addresses, params), (Targets, params)])
         unexpanded_addresses, expanded_targets = self._scheduler.execute(request)
 

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -103,7 +103,7 @@ class StreamingWorkunitContext:
         """Return a dict containing the canonicalized addresses of the specs for this run, and what
         files they expand to."""
 
-        params = Params(self._specs, self._options_bootstrapper, EnvironmentName())
+        params = Params(self._specs, self._options_bootstrapper, EnvironmentName(None))
         request = self._scheduler.execution_request([(Addresses, params), (Targets, params)])
         unexpanded_addresses, expanded_targets = self._scheduler.execute(request)
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -15,6 +15,7 @@ from pants.base.specs import Specs
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.util_rules import environments, system_binaries
+from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.engine import desktop, environment, fs, platform, process
 from pants.engine.console import Console
 from pants.engine.environment import EnvironmentName
@@ -124,6 +125,7 @@ class GraphSession:
         """
 
         workspace = Workspace(self.scheduler_session)
+        env_name = determine_bootstrap_environment(self.scheduler_session)
 
         for goal in goals:
             goal_product = self.goal_map[goal]
@@ -133,7 +135,7 @@ class GraphSession:
             if not goal_product.subsystem_cls.activated(union_membership):
                 continue
             # NB: Keep this in sync with the property `goal_param_types`.
-            params = Params(specs, self.console, workspace, EnvironmentName(None))
+            params = Params(specs, self.console, workspace, env_name)
             logger.debug(f"requesting {goal_product} to satisfy execution of `{goal}` goal")
             try:
                 exit_code = self.scheduler_session.run_goal_rule(

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -21,7 +21,6 @@ from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import build_files, graph, options_parsing, specs_rules
-from pants.engine.internals.build_files import IgnoreUnrecognizedBuildFileSymbols
 from pants.engine.internals.native_engine import PyExecutor, PySessionCancellationLatch
 from pants.engine.internals.parser import Parser
 from pants.engine.internals.scheduler import Scheduler, SchedulerSession
@@ -134,7 +133,7 @@ class GraphSession:
             if not goal_product.subsystem_cls.activated(union_membership):
                 continue
             # NB: Keep this in sync with the property `goal_param_types`.
-            params = Params(specs, self.console, workspace, EnvironmentName())
+            params = Params(specs, self.console, workspace, EnvironmentName(None))
             logger.debug(f"requesting {goal_product} to satisfy execution of `{goal}` goal")
             try:
                 exit_code = self.scheduler_session.run_goal_rule(
@@ -238,10 +237,6 @@ class EngineInitializer:
                 object_aliases=build_configuration.registered_aliases,
                 ignore_unrecognized_symbols=ignore_unrecognized_build_file_symbols,
             )
-
-        @rule
-        def ignore_unrecognized_build_file_symbols_singleton() -> IgnoreUnrecognizedBuildFileSymbols:
-            return IgnoreUnrecognizedBuildFileSymbols(ignore_unrecognized_build_file_symbols)
 
         @rule
         def build_configuration_singleton() -> BuildConfiguration:

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -17,7 +17,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
-from pants.core.util_rules.environments import EnvironmentRequest, LOCAL_ENVIRONMENT_MATCHER
+from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.environment import CompleteEnvironment, EnvironmentName
 from pants.engine.internals.selectors import Params
@@ -157,7 +157,7 @@ class PluginResolver:
                 }
             ),
         )
-        params = Params(request, EnvironmentName(None))
+        params = Params(request, determine_bootstrap_environment(session))
         return cast(
             ResolvedPluginDistributions,
             session.product_request(ResolvedPluginDistributions, [params])[0],

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -17,6 +17,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
+from pants.core.util_rules.environments import EnvironmentRequest, LOCAL_ENVIRONMENT_MATCHER
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.environment import CompleteEnvironment, EnvironmentName
 from pants.engine.internals.selectors import Params
@@ -156,7 +157,7 @@ class PluginResolver:
                 }
             ),
         )
-        params = Params(request, EnvironmentName())
+        params = Params(request, EnvironmentName(None))
         return cast(
             ResolvedPluginDistributions,
             session.product_request(ResolvedPluginDistributions, [params])[0],

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -68,7 +68,7 @@ def calculate_specs(
 
     changed_request = ChangedRequest(changed_files, changed_options.dependees)
     (changed_addresses,) = session.product_request(
-        ChangedAddresses, [Params(changed_request, options_bootstrapper, EnvironmentName())]
+        ChangedAddresses, [Params(changed_request, options_bootstrapper, EnvironmentName(None))]
     )
     logger.debug("changed addresses: %s", changed_addresses)
 

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from pants.base.specs import AddressLiteralSpec, FileLiteralSpec, RawSpecs, Specs
 from pants.base.specs_parser import SpecsParser
+from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.core.util_rules.system_binaries import GitBinary, GitBinaryRequest
 from pants.engine.addresses import AddressInput
 from pants.engine.environment import EnvironmentName
@@ -68,7 +69,8 @@ def calculate_specs(
 
     changed_request = ChangedRequest(changed_files, changed_options.dependees)
     (changed_addresses,) = session.product_request(
-        ChangedAddresses, [Params(changed_request, options_bootstrapper, EnvironmentName(None))]
+        ChangedAddresses,
+        [Params(changed_request, options_bootstrapper, determine_bootstrap_environment(session))],
     )
     logger.debug("changed addresses: %s", changed_addresses)
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -197,7 +197,7 @@ class RuleRunner:
         bootstrap_args: Iterable[str] = (),
         extra_session_values: dict[Any, Any] | None = None,
         max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
-        singleton_environment: EnvironmentName | None = EnvironmentName(),
+        singleton_environment: EnvironmentName | None = EnvironmentName(None),
     ) -> None:
 
         bootstrap_args = [*bootstrap_args]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16770.

Now, we dynamically determine what environment target to use at the root of the graph, and inject the value. This will always be the `__local__` target, or `None` if no targets are defined. That is, it cannot be a `docker_environment` etc. Then, callers can change the value to be a different environment by using `Get()` to inject a different `EnvironmentName` `Param`.

To avoid a rule graph cycle, this adds `WrappedTargetForBootstrap`.