### PR TITLE
Automatically set `docker_image` for every Process based on current Environment

### DIFF
--- a/src/python/pants/backend/explorer/browser.py
+++ b/src/python/pants/backend/explorer/browser.py
@@ -6,13 +6,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.core.util_rules.system_binaries import OpenBinary
+from pants.engine.environment import EnvironmentName
 from pants.engine.explorer import RequestState
-from pants.engine.process import (
-    Process,
-    ProcessCacheScope,
-    ProcessConfigFromEnvironment,
-    ProcessResult,
-)
+from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import QueryRule, collect_rules, rule
 from pants.util.logging import LogLevel
 
@@ -55,5 +51,5 @@ async def get_browser(request: BrowserRequest, open_binary: OpenBinary) -> Brows
 def rules():
     return (
         *collect_rules(),
-        QueryRule(ProcessResult, (Process, ProcessConfigFromEnvironment)),
+        QueryRule(ProcessResult, (Process, EnvironmentName)),
     )

--- a/src/python/pants/backend/explorer/browser.py
+++ b/src/python/pants/backend/explorer/browser.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 
 from pants.core.util_rules.system_binaries import OpenBinary
 from pants.engine.explorer import RequestState
-from pants.engine.process import Process, ProcessCacheScope, ProcessResult
+from pants.engine.process import (
+    Process,
+    ProcessCacheScope,
+    ProcessConfigFromEnvironment,
+    ProcessResult,
+)
 from pants.engine.rules import QueryRule, collect_rules, rule
 from pants.util.logging import LogLevel
 
@@ -50,5 +55,5 @@ async def get_browser(request: BrowserRequest, open_binary: OpenBinary) -> Brows
 def rules():
     return (
         *collect_rules(),
-        QueryRule(ProcessResult, (Process,)),
+        QueryRule(ProcessResult, (Process, ProcessConfigFromEnvironment)),
     )

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -11,6 +11,7 @@ from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName as EnvironmentName
 from pants.engine.internals.graph import WrappedTargetForBootstrap
+from pants.engine.internals.native_engine import ProcessConfigFromEnvironment
 from pants.engine.internals.scheduler import SchedulerSession
 from pants.engine.internals.selectors import Params
 from pants.engine.platform import Platform
@@ -352,6 +353,14 @@ async def get_target_for_environment_name(
             )
         )
     return EnvironmentTarget(tgt)
+
+
+@rule
+def extract_process_config_from_environment(tgt: EnvironmentTarget) -> ProcessConfigFromEnvironment:
+    docker_image = (
+        tgt.val[DockerImageField].value if tgt.val and tgt.val.has_field(DockerImageField) else None
+    )
+    return ProcessConfigFromEnvironment(docker_image=docker_image)
 
 
 def rules():

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -10,7 +10,7 @@ from typing_extensions import Protocol
 
 from pants.engine.internals.scheduler import Workunit, _PathGlobsAndRootCollection
 from pants.engine.internals.session import SessionValues
-from pants.engine.process import InteractiveProcessResult
+from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 
 # TODO: black and flake8 disagree about the content of this file:
 #   see https://github.com/psf/black/issues/1548
@@ -326,7 +326,7 @@ def session_poll_workunits(
     scheduler: PyScheduler, session: PySession, max_log_verbosity_level: int
 ) -> tuple[tuple[Workunit, ...], tuple[Workunit, ...]]: ...
 def session_run_interactive_process(
-    session: PySession, InteractiveProcess
+    session: PySession, process: InteractiveProcess, process_config: ProcessConfigFromEnvironment
 ) -> InteractiveProcessResult: ...
 def session_get_metrics(session: PySession) -> dict[str, int]: ...
 def session_get_observation_histograms(

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -162,6 +162,24 @@ EMPTY_SNAPSHOT: Snapshot
 def default_cache_path() -> str: ...
 
 # ------------------------------------------------------------------------------
+# Process
+# ------------------------------------------------------------------------------
+
+class ProcessConfigFromEnvironment:
+    """Settings from the current Environment for how a `Process` should be run.
+
+    Note that most values from the Environment are instead set via changing the arguments `argv` and
+    `env` in the `Process` constructor.
+    """
+
+    def __init__(self, *, docker_image: str | None) -> None: ...
+    def __eq__(self, other: ProcessConfigFromEnvironment | Any) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __repr__(self) -> str: ...
+    @property
+    def docker_image(self) -> str | None: ...
+
+# ------------------------------------------------------------------------------
 # Workunits
 # ------------------------------------------------------------------------------
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -11,6 +11,9 @@ from typing import Iterable, Mapping
 
 from pants.engine.engine_aware import SideEffecting
 from pants.engine.fs import EMPTY_DIGEST, Digest, FileDigest
+from pants.engine.internals.native_engine import (  # noqa: F401
+    ProcessConfigFromEnvironment as ProcessConfigFromEnvironment,
+)
 from pants.engine.internals.session import RunId
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
@@ -131,8 +134,6 @@ class Process:
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
         self.platform = platform.value if platform is not None else None
-        # TODO(#7735): Figure out how this should be set by callers, e.g. automatically.
-        self.docker_image = None
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -139,6 +139,7 @@ def test_cache_scope_always(rule_runner: RuleRunner) -> None:
     )
     result_one = rule_runner.request(FallibleProcessResult, [process])
     rule_runner.new_session("session two")
+    rule_runner.set_options([])
     result_two = rule_runner.request(FallibleProcessResult, [process])
     assert result_one is result_two
 
@@ -151,7 +152,9 @@ def test_cache_scope_successful(rule_runner: RuleRunner) -> None:
         description="success",
     )
     result_one = rule_runner.request(FallibleProcessResult, [process])
+
     rule_runner.new_session("session one")
+    rule_runner.set_options([])
     result_two = rule_runner.request(FallibleProcessResult, [process])
     assert result_one is result_two
 
@@ -163,7 +166,9 @@ def test_cache_scope_successful(rule_runner: RuleRunner) -> None:
     )
     result_three = rule_runner.request(FallibleProcessResult, [process])
     result_four = rule_runner.request(FallibleProcessResult, [process])
+
     rule_runner.new_session("session two")
+    rule_runner.set_options([])
     result_five = rule_runner.request(FallibleProcessResult, [process])
     assert result_three is result_four
     assert result_four != result_five
@@ -197,6 +202,7 @@ def test_cache_scope_per_restart() -> None:
     success_cache_failure_res1 = run1(success_cache_failure)
 
     runner_one.new_session("new session")
+    runner_one.set_options([])
     always_cache_success_res2 = run1(always_cache_success)
     always_cache_failure_res2 = run1(always_cache_failure)
     success_cache_success_res2 = run1(success_cache_success)
@@ -229,7 +235,9 @@ def test_cache_scope_per_session(rule_runner: RuleRunner) -> None:
     result_one = rule_runner.request(FallibleProcessResult, [process])
     result_two = rule_runner.request(FallibleProcessResult, [process])
     assert result_one is result_two
+
     rule_runner.new_session("next attempt")
+    rule_runner.set_options([])
     result_three = rule_runner.request(FallibleProcessResult, [process])
     # Should re-run in a new Session.
     assert result_one != result_three

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -26,7 +26,7 @@ from pants.engine.environment import CompleteEnvironment, EnvironmentName
 from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import native_engine
-from pants.engine.internals.native_engine import PyExecutor
+from pants.engine.internals.native_engine import ProcessConfigFromEnvironment, PyExecutor
 from pants.engine.internals.scheduler import ExecutionError, Scheduler, SchedulerSession
 from pants.engine.internals.selectors import Effect, Get, Params
 from pants.engine.internals.session import SessionValues
@@ -504,7 +504,9 @@ class RuleRunner:
         )
 
     def run_interactive_process(self, request: InteractiveProcess) -> InteractiveProcessResult:
-        return native_engine.session_run_interactive_process(self.scheduler.py_session, request)
+        return native_engine.session_run_interactive_process(
+            self.scheduler.py_session, request, ProcessConfigFromEnvironment(docker_image=None)
+        )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -38,7 +38,7 @@ use pyo3::prelude::{
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple, PyType};
 use pyo3::{create_exception, IntoPy, PyAny, PyRef};
 use regex::Regex;
-use rule_graph::{self, RuleGraph};
+use rule_graph::{self, DependencyKey, RuleGraph};
 use task_executor::Executor;
 use workunit_store::{
   ArtifactOutput, ObservationMetric, UserMetadataItem, Workunit, WorkunitState, WorkunitStore,
@@ -46,6 +46,7 @@ use workunit_store::{
 };
 
 use crate::externs::fs::{possible_store_missing_digest, PyFileDigest};
+use crate::externs::process::PyProcessConfigFromEnvironment;
 use crate::{
   externs, nodes, Context, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination,
   Failure, Function, Intrinsic, Intrinsics, Key, LocalStoreOptions, Params, RemotingOptions, Rule,
@@ -983,21 +984,26 @@ fn session_run_interactive_process(
   py: Python,
   py_session: &PySession,
   interactive_process: PyObject,
+  process_config_from_environment: PyProcessConfigFromEnvironment,
 ) -> PyO3Result<PyObject> {
   let core = py_session.0.core();
   let context = Context::new(core.clone(), py_session.0.clone());
   let interactive_process: Value = interactive_process.into();
+  let process_config = Value::new(process_config_from_environment.into_py(py));
   py.allow_threads(|| {
     core.executor.clone().block_on(nodes::maybe_side_effecting(
       true,
       &Arc::new(std::sync::atomic::AtomicBool::new(true)),
       core.intrinsics.run(
-        &Intrinsic::new(
-          core.types.interactive_process_result,
-          core.types.interactive_process,
-        ),
+        &Intrinsic {
+          product: core.types.interactive_process_result,
+          inputs: vec![
+            DependencyKey::new(core.types.interactive_process),
+            DependencyKey::new(core.types.process_config_from_environment),
+          ],
+        },
         context,
-        vec![interactive_process],
+        vec![interactive_process, process_config],
       ),
     ))
   })

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -58,6 +58,7 @@ fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
   externs::address::register(py, m)?;
   externs::fs::register(m)?;
   externs::nailgun::register(py, m)?;
+  externs::process::register(m)?;
   externs::scheduler::register(m)?;
   externs::testutil::register(m)?;
   externs::workunits::register(m)?;
@@ -214,6 +215,9 @@ impl PyTypes {
       platform: TypeId::new(platform),
       process: TypeId::new(process),
       process_result: TypeId::new(process_result),
+      process_config_from_environment: TypeId::new(
+        py.get_type::<externs::process::PyProcessConfigFromEnvironment>(),
+      ),
       process_result_metadata: TypeId::new(process_result_metadata),
       coroutine: TypeId::new(coroutine),
       session_values: TypeId::new(session_values),

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -29,6 +29,7 @@ mod interface;
 #[cfg(test)]
 mod interface_tests;
 pub mod nailgun;
+pub mod process;
 pub mod scheduler;
 mod stdio;
 pub mod testutil;

--- a/src/rust/engine/src/externs/process.rs
+++ b/src/rust/engine/src/externs/process.rs
@@ -1,0 +1,59 @@
+// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use pyo3::basic::CompareOp;
+use pyo3::prelude::*;
+
+pub(crate) fn register(m: &PyModule) -> PyResult<()> {
+  m.add_class::<PyProcessConfigFromEnvironment>()?;
+
+  Ok(())
+}
+
+#[pyclass(name = "ProcessConfigFromEnvironment")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PyProcessConfigFromEnvironment {
+  pub docker_image: Option<String>,
+}
+
+#[pymethods]
+impl PyProcessConfigFromEnvironment {
+  #[new]
+  fn __new__(docker_image: Option<String>) -> Self {
+    Self { docker_image }
+  }
+
+  fn __hash__(&self) -> u64 {
+    let mut s = DefaultHasher::new();
+    self.docker_image.hash(&mut s);
+    s.finish()
+  }
+
+  fn __repr__(&self) -> String {
+    format!(
+      "ProcessConfigFromEnvironment(docker_image={})",
+      self.docker_image.as_ref().unwrap_or(&"None".to_owned())
+    )
+  }
+
+  fn __richcmp__(
+    &self,
+    other: &PyProcessConfigFromEnvironment,
+    op: CompareOp,
+    py: Python,
+  ) -> PyObject {
+    match op {
+      CompareOp::Eq => (self == other).into_py(py),
+      CompareOp::Ne => (self != other).into_py(py),
+      _ => py.NotImplemented(),
+    }
+  }
+
+  #[getter]
+  fn docker_image(&self) -> Option<String> {
+    self.docker_image.clone()
+  }
+}

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -515,6 +515,9 @@ fn interactive_process(
         .unwrap();
       (py_interactive_process.extract().unwrap(), py_process, process_config)
     });
+    if let Some(docker_image) = process_config.docker_image {
+      panic!("InteractiveProcess should not run with a docker environment, but set to {docker_image}")
+    }
     let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;
     let (run_in_workspace, restartable, keep_sandboxes) = Python::with_gil(|py| {
       let py_interactive_process_obj = py_interactive_process.to_object(py);

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -22,6 +22,7 @@ pub struct Types {
   pub download_file: TypeId,
   pub platform: TypeId,
   pub process: TypeId,
+  pub process_config_from_environment: TypeId,
   pub process_result: TypeId,
   pub process_result_metadata: TypeId,
   pub coroutine: TypeId,


### PR DESCRIPTION
Follow up to https://github.com/pantsbuild/pants/pull/16758.

Rather than individual `Process` constructor calls setting `docker_image` like in https://github.com/pantsbuild/pants/pull/16755, I believe we need this to be automatic. If `EnvironmentName` points to a docker env, then it would be wrong to run with `docker_image=None`, which implies running locally. You would run locally, but with the Environment for the Docker image, which is wrong.

Most of the time, we expect `docker_image` will still end up being `None` because the majority of Pants's rule graph still runs with the local environment chosen.