### PR TITLE
"switched" command runner

### DIFF
--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -31,7 +31,6 @@ pub(crate) const IMMUTABLE_INPUTS_PATH_IN_CONTAINER: &str = "/pants-immutable-in
 
 /// `CommandRunner` that executes processes using a local Docker client.
 pub struct CommandRunner {
-  inner: Box<dyn crate::CommandRunner>,
   docker: OnceCell<Docker>,
   store: Store,
   executor: Executor,
@@ -127,7 +126,6 @@ async fn pull_image(docker: &Docker, image: &str, policy: ImagePullPolicy) -> Re
 
 impl CommandRunner {
   pub fn new(
-    inner: Box<dyn crate::CommandRunner>,
     store: Store,
     executor: Executor,
     work_dir_base: PathBuf,
@@ -137,7 +135,6 @@ impl CommandRunner {
     image_pull_policy: ImagePullPolicy,
   ) -> Result<Self, String> {
     Ok(CommandRunner {
-      inner,
       docker: OnceCell::new(),
       store,
       executor,
@@ -197,7 +194,6 @@ impl CommandRunner {
 impl fmt::Debug for CommandRunner {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
     f.debug_struct("docker::CommandRunner")
-      .field("inner", &self.inner)
       .finish_non_exhaustive()
   }
 }
@@ -207,13 +203,9 @@ impl super::CommandRunner for CommandRunner {
   async fn run(
     &self,
     context: Context,
-    workunit: &mut RunningWorkunit,
+    _workunit: &mut RunningWorkunit,
     req: Process,
   ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
-    if req.docker_image.is_none() {
-      return self.inner.run(context, workunit, req).await;
-    }
-
     let req_debug_repr = format!("{:#?}", req);
     in_workunit!(
       "run_local_process_via_docker",

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -83,7 +83,7 @@ async fn runner_errors_if_docker_image_not_set() {
   if let ProcessError::Unclassified(msg) = err {
     assert!(msg.contains("Failed to pull Docker image"));
   } else {
-    panic!("expected value: {:?}", err)
+    panic!("unexpected value: {:?}", err)
   }
 
   // Otherwise, if docker_image is not set, use the local runner.
@@ -95,7 +95,7 @@ async fn runner_errors_if_docker_image_not_set() {
       msg.contains("docker_image not set on the Process, but the Docker CommandRunner was used")
     );
   } else {
-    panic!("expected value: {:?}", err)
+    panic!("unexpected value: {:?}", err)
   }
 }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -54,6 +54,8 @@ pub mod cache;
 #[cfg(test)]
 mod cache_tests;
 
+pub mod switched;
+
 pub mod children;
 
 pub mod docker;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -875,6 +875,18 @@ pub trait CommandRunner: Send + Sync + Debug {
   ) -> Result<FallibleProcessResultWithPlatform, ProcessError>;
 }
 
+#[async_trait]
+impl<T: CommandRunner + ?Sized> CommandRunner for Box<T> {
+  async fn run(
+    &self,
+    context: Context,
+    workunit: &mut RunningWorkunit,
+    req: Process,
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
+    (**self).run(context, workunit, req).await
+  }
+}
+
 // TODO(#8513) possibly move to the MEPR struct, or to the hashing crate?
 pub fn digest(process: &Process, metadata: &ProcessMetadata) -> Digest {
   let (_, _, execute_request) =

--- a/src/rust/engine/process_execution/src/switched.rs
+++ b/src/rust/engine/process_execution/src/switched.rs
@@ -103,7 +103,7 @@ mod tests {
     if let ProcessError::Unclassified(msg) = &err {
       assert_eq!(msg, "left");
     } else {
-      panic!("expected value: {:?}", err)
+      panic!("unexpected value: {:?}", err)
     }
 
     let req = Process::new(vec!["not-left".to_string()]);
@@ -114,7 +114,7 @@ mod tests {
     if let ProcessError::Unclassified(msg) = &err {
       assert_eq!(msg, "right");
     } else {
-      panic!("expected value: {:?}", err)
+      panic!("unexpected value: {:?}", err)
     }
   }
 }

--- a/src/rust/engine/process_execution/src/switched.rs
+++ b/src/rust/engine/process_execution/src/switched.rs
@@ -1,0 +1,120 @@
+// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt;
+use std::fmt::Formatter;
+
+use async_trait::async_trait;
+use workunit_store::RunningWorkunit;
+
+use crate::{CommandRunner, Context, FallibleProcessResultWithPlatform, Process, ProcessError};
+
+pub struct SwitchedCommandRunner<F> {
+  true_runner: Box<dyn CommandRunner>,
+  false_runner: Box<dyn CommandRunner>,
+  predicate: F,
+}
+
+impl<F> fmt::Debug for SwitchedCommandRunner<F> {
+  fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    f.debug_struct("SwitchedCommandRunner")
+      .finish_non_exhaustive()
+  }
+}
+
+impl<F> SwitchedCommandRunner<F>
+where
+  F: Fn(&Process) -> bool + Send + Sync,
+{
+  pub fn new(
+    true_runner: Box<dyn CommandRunner>,
+    false_runner: Box<dyn CommandRunner>,
+    predicate: F,
+  ) -> Self {
+    Self {
+      true_runner,
+      false_runner,
+      predicate,
+    }
+  }
+}
+
+#[async_trait]
+impl<F> CommandRunner for SwitchedCommandRunner<F>
+where
+  F: Fn(&Process) -> bool + Send + Sync,
+{
+  async fn run(
+    &self,
+    context: Context,
+    workunit: &mut RunningWorkunit,
+    req: Process,
+  ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
+    if (self.predicate)(&req) {
+      self.true_runner.run(context, workunit, req).await
+    } else {
+      self.false_runner.run(context, workunit, req).await
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use async_trait::async_trait;
+  use workunit_store::{RunningWorkunit, WorkunitStore};
+
+  use crate::switched::SwitchedCommandRunner;
+  use crate::CommandRunner;
+  use crate::{Context, FallibleProcessResultWithPlatform, Process, ProcessError};
+
+  #[derive(Debug)]
+  struct MockCommandRunner(Result<FallibleProcessResultWithPlatform, ProcessError>);
+
+  #[async_trait]
+  impl CommandRunner for MockCommandRunner {
+    async fn run(
+      &self,
+      _context: Context,
+      _workunit: &mut RunningWorkunit,
+      _req: Process,
+    ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
+      self.0.clone()
+    }
+  }
+
+  #[tokio::test]
+  async fn switched_command_runner() {
+    let (_, mut workunit) = WorkunitStore::setup_for_tests();
+
+    let left = Box::new(MockCommandRunner(Err(ProcessError::Unclassified(
+      "left".to_string(),
+    ))));
+    let right = Box::new(MockCommandRunner(Err(ProcessError::Unclassified(
+      "right".to_string(),
+    ))));
+
+    let runner = SwitchedCommandRunner::new(left, right, |req| req.argv.get(0).unwrap() == "left");
+
+    let req = Process::new(vec!["left".to_string()]);
+    let err = runner
+      .run(Context::default(), &mut workunit, req)
+      .await
+      .expect_err("expected error");
+    if let ProcessError::Unclassified(msg) = &err {
+      assert_eq!(msg, "left");
+    } else {
+      panic!("expected value: {:?}", err)
+    }
+
+    let req = Process::new(vec!["not-left".to_string()]);
+    let err = runner
+      .run(Context::default(), &mut workunit, req)
+      .await
+      .expect_err("expected error");
+    if let ProcessError::Unclassified(msg) = &err {
+      assert_eq!(msg, "right");
+    } else {
+      panic!("expected value: {:?}", err)
+    }
+  }
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -258,9 +258,9 @@ impl Core {
         docker::ImagePullPolicy::OnlyIfLatestOrMissing,
       )?);
 
-      let runner =
-        SwitchedCommandRunner::new(docker_runner, runner, |req| req.docker_image.is_some());
-      let runner = Box::new(runner) as _;
+      let runner = Box::new(SwitchedCommandRunner::new(docker_runner, runner, |req| {
+        req.docker_image.is_some()
+      }));
 
       (runner, exec_strategy_opts.local_parallelism)
     };

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -25,6 +25,7 @@ use graph::{self, EntryId, Graph, InvalidationResult, NodeContext};
 use hashing::Digest;
 use log::info;
 use parking_lot::Mutex;
+use process_execution::switched::SwitchedCommandRunner;
 use process_execution::{
   self, bounded, docker, local, nailgun, remote, remote_cache, CacheContentBehavior, CommandRunner,
   ImmutableInputs, NamedCaches, Platform, ProcessMetadata, RemoteCacheWarningsBehavior,
@@ -246,8 +247,7 @@ impl Core {
 
       // Note that the Docker command runner is only used if the Process sets docker_image. So,
       // it's safe to always create this command runner.
-      let runner = Box::new(docker::CommandRunner::new(
-        runner,
+      let docker_runner = Box::new(docker::CommandRunner::new(
         local_runner_store.clone(),
         executor.clone(),
         local_execution_root_dir.to_path_buf(),
@@ -257,6 +257,10 @@ impl Core {
         // TODO(#16767): Allow users to specify this via an option.
         docker::ImagePullPolicy::OnlyIfLatestOrMissing,
       )?);
+
+      let runner =
+        SwitchedCommandRunner::new(docker_runner, runner, |req| req.docker_image.is_some());
+      let runner = Box::new(runner) as _;
 
       (runner, exec_strategy_opts.local_parallelism)
     };


### PR DESCRIPTION
Introduce `SwitchedCommandRunner` which uses a predicate to choose between two command runners. Then use `SwitchedCommandRunner` to switch between the `docker::CommandRunner` and whatever other local command runner is configured.

This allows `docker::CommandRunner` to no longer know about any other command runners, thereby re-introducing better encapsulation to `docker::CommandRunner`.

Closes https://github.com/pantsbuild/pants/issues/16788