### PR TITLE
Add `_environment` field to `python_test`

### DIFF
--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -32,7 +32,6 @@ from pants.core.goals.test import (
     TestResult,
     get_filtered_environment,
 )
-from pants.core.goals.test import rules as core_test_rules
 from pants.core.target_types import FileTarget
 from pants.core.util_rules import source_files
 from pants.engine.fs import DigestContents
@@ -60,7 +59,6 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *source_files.rules(),
             get_filtered_environment,
-            *core_test_rules(),
             QueryRule(TestResult, (GoTestFieldSet,)),
             QueryRule(CoverageReports, (GoCoverageDataCollection,)),
             QueryRule(DigestContents, (Digest,)),

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -31,6 +31,7 @@ from pants.backend.python.util_rules.partition import _find_all_unique_interpret
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import RuntimePackageDependenciesField, TestFieldSet
 from pants.core.util_rules.config_files import ConfigFilesRequest
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
@@ -51,6 +52,7 @@ class PythonTestFieldSet(TestFieldSet):
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVarsField
     xdist_concurrency: PythonTestsXdistConcurrencyField
+    environment: EnvironmentField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -35,6 +35,7 @@ from pants.core.goals.test import (
     TestExtraEnvVarsField,
     TestSubsystem,
 )
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address, Addresses
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -879,6 +880,7 @@ _PYTHON_TEST_MOVED_FIELDS = (
     PythonTestsExtraEnvVarsField,
     InterpreterConstraintsField,
     SkipPythonTestsField,
+    EnvironmentField,
 )
 
 

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -37,9 +37,11 @@ from pants.core.goals.test import (
 )
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     EMPTY_DIGEST,
     EMPTY_FILE_DIGEST,
@@ -235,9 +237,14 @@ def run_test_rule(
                     mock=mock_find_valid_field_sets,
                 ),
                 MockGet(
+                    output_type=EnvironmentName,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda _: EnvironmentName(None),
+                ),
+                MockGet(
                     output_type=TestResult,
-                    input_types=(TestFieldSet,),
-                    mock=lambda fs: fs.test_result,
+                    input_types=(TestFieldSet, EnvironmentName),
+                    mock=lambda fs, _env: fs.test_result,
                 ),
                 MockGet(
                     output_type=TestDebugRequest,

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -214,7 +214,7 @@ class EnvironmentTarget:
 
 
 @dataclass(frozen=True)
-class EnvironmentRequest(EngineAwareParameter):
+class EnvironmentNameRequest(EngineAwareParameter):
     f"""Normalize the value into a name from `[environments-preview].names`, such as by
     applying {LOCAL_ENVIRONMENT_MATCHER}."""
 
@@ -290,7 +290,7 @@ async def determine_local_environment(
 
 @rule
 async def resolve_environment_name(
-    request: EnvironmentRequest, environments_subsystem: EnvironmentsSubsystem
+    request: EnvironmentNameRequest, environments_subsystem: EnvironmentsSubsystem
 ) -> EnvironmentName:
     if request.raw_value == LOCAL_ENVIRONMENT_MATCHER:
         local_env_name = await Get(ChosenLocalEnvironmentName, {})
@@ -321,10 +321,10 @@ async def get_target_for_environment_name(
             softwrap(
                 f"""
                 The name `{env_name.val}` is not defined. The name should have been normalized and
-                validated in the rule `EnvironmentRequest -> EnvironmentName`
+                validated in the rule `EnvironmentNameRequest -> EnvironmentName`
                 already. If you directly wrote
                 `Get(EnvironmentTarget, EnvironmentName(my_name))`, refactor to
-                `Get(EnvironmentTarget, EnvironmentRequest(my_name, ...))`.
+                `Get(EnvironmentTarget, EnvironmentNameRequest(my_name, ...))`.
                 """
             )
         )

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -18,6 +18,7 @@ from pants.engine.platform import Platform
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    FieldSet,
     StringField,
     StringSequenceField,
     Target,
@@ -63,6 +64,17 @@ class EnvironmentsSubsystem(Subsystem):
 # -------------------------------------------------------------------------------------------
 
 LOCAL_ENVIRONMENT_MATCHER = "__local__"
+
+
+class EnvironmentField(StringField):
+    alias = "_environment"
+    default = LOCAL_ENVIRONMENT_MATCHER
+    value: str
+    help = softwrap(
+        """
+        TODO(#7735): fill this in.
+        """
+    )
 
 
 class PythonInterpreterSearchPathsField(StringSequenceField):
@@ -221,6 +233,41 @@ class EnvironmentNameRequest(EngineAwareParameter):
     raw_value: str
     description_of_origin: str = dataclasses.field(hash=False, compare=False)
 
+    @classmethod
+    def from_field_set(cls, field_set: FieldSet) -> EnvironmentNameRequest:
+        f"""Return a `EnvironmentNameRequest` with the environment this target should use when built.
+
+        If the FieldSet includes `EnvironmentField` in its class definition, then this method will
+        use the value of that field. Otherwise, it will fall back to `{LOCAL_ENVIRONMENT_MATCHER}`.
+
+        Rules can then use `Get(EnvironmentName, EnvironmentNameRequest,
+        field_set.environment_name_request())` to normalize the environment value, and
+        then pass `{{resulting_environment_name: EnvironmentName}}` into a `Get` to change which
+        environment is used for the subgraph.
+        """
+        for attr in dir(field_set):
+            # Skip what look like dunder methods, which are unlikely to be an
+            # EnvironmentField value on FieldSet class declarations.
+            if attr.startswith("__"):
+                continue
+            val = getattr(field_set, attr)
+            if isinstance(val, EnvironmentField):
+                env_field = val
+                break
+        else:
+            env_field = EnvironmentField(None, address=field_set.address)
+
+        return EnvironmentNameRequest(
+            env_field.value,
+            # Note that if the field was not registered, we will have fallen back to the default
+            # LOCAL_ENVIRONMENT_MATCHER, which we expect to be infallible when normalized. That
+            # implies that the error message using description_of_origin should not trigger, so
+            # it's okay that the field is not actually registered on the target.
+            description_of_origin=(
+                f"the `{env_field.alias}` field from the target {field_set.address}"
+            ),
+        )
+
     def debug_hint(self) -> str:
         return self.raw_value
 
@@ -269,6 +316,8 @@ async def determine_local_environment(
             )
         )
     elif len(compatible_name_and_targets) > 1:
+        # TODO(#7735): Consider if we still want to error when no target is found, given that we
+        #  are now falling back to subsystem values.
         # TODO(#7735): Allow the user to disambiguate what __local__ means via an option.
         raise AmbiguousEnvironmentError(
             softwrap(

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -17,7 +17,7 @@ from pants.core.util_rules.environments import (
     DockerEnvironmentTarget,
     DockerImageField,
     EnvironmentName,
-    EnvironmentRequest,
+    EnvironmentNameRequest,
     EnvironmentTarget,
     LocalEnvironmentTarget,
     NoCompatibleEnvironmentError,
@@ -33,7 +33,7 @@ def rule_runner() -> RuleRunner:
             *environments.rules(),
             QueryRule(AllEnvironmentTargets, []),
             QueryRule(EnvironmentTarget, [EnvironmentName]),
-            QueryRule(EnvironmentName, [EnvironmentRequest]),
+            QueryRule(EnvironmentName, [EnvironmentNameRequest]),
         ],
         target_types=[LocalEnvironmentTarget, DockerEnvironmentTarget],
         singleton_environment=None,
@@ -119,7 +119,7 @@ def test_resolve_environment_name(rule_runner: RuleRunner) -> None:
 
     def get_name(v: str) -> EnvironmentName:
         return rule_runner.request(
-            EnvironmentName, [EnvironmentRequest(v, description_of_origin="foo")]
+            EnvironmentName, [EnvironmentNameRequest(v, description_of_origin="foo")]
         )
 
     # If `--names` is not set, and the local matcher is used, do not choose an environment.


### PR DESCRIPTION
Part of https://github.com/pantsbuild/pants/issues/7735 and https://github.com/pantsbuild/pants/issues/13682.

This allows individual test targets to choose which environment is used during their run, including by using a `docker_environment`. The entire subgraph will be updated appropriately, e.g. we will rediscover `BashBinary` and rebuild the PEXes needed, if relevant.