### PR TITLE
Skip CI for user list changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -755,7 +755,7 @@ jobs:
       name: Get changed files
       uses: tj-actions/changed-files@v23.1
       with:
-        files_ignore: docs/**
+        files_ignore: docs/**|build-support/bin/generate_user_list.py
         files_ignore_separator: '|'
     - id: docs_only_check
       if: steps.files.outputs.any_changed != 'true'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -82,7 +82,7 @@ def _docs_only_cond(docs_only: bool) -> str:
 def is_docs_only() -> Jobs:
     """Check if this change only involves docs."""
     linux_x86_64_helper = Helper(Platform.LINUX_X86_64)
-    docs_files = ["docs/**"]
+    docs_files = ["docs/**", "build-support/bin/generate_user_list.py"]
     return {
         "docs_only_check": {
             "name": "Check for docs-only change",


### PR DESCRIPTION
Nothing runs or tests changes to that file, which is not part of Pants and is only used to generate the user list on the website, and therefore its changes are unrelated to the health or stability of Pants itself.