### PR TITLE
 go:  analyze imports paths by module to enable multiple go_mod targets (Cherry pick of #16386)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -14,10 +14,18 @@ from pants.backend.codegen.protobuf.target_types import (
     AllProtobufTargets,
     ProtobufGrpcToggleField,
     ProtobufSourceField,
+    ProtobufSourcesGeneratorTarget,
+    ProtobufSourceTarget,
 )
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_type_rules import ImportPathToPackages
-from pants.backend.go.target_types import GoPackageSourcesField
+from pants.backend.go.dependency_inference import (
+    GoImportPathsMappingAddressSet,
+    GoModuleImportPathsMapping,
+    GoModuleImportPathsMappings,
+    GoModuleImportPathsMappingsHook,
+)
+from pants.backend.go.target_type_rules import GoImportPathMappingRequest
+from pants.backend.go.target_types import GoOwningGoModAddressField, GoPackageSourcesField
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -36,10 +44,8 @@ from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
 )
-from pants.backend.go.util_rules.first_party_pkg import (
-    FallibleFirstPartyPkgAnalysis,
-    FirstPartyPkgAnalysisRequest,
-)
+from pants.backend.go.util_rules.first_party_pkg import FallibleFirstPartyPkgAnalysis
+from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.backend.python.util_rules import pex
@@ -65,13 +71,10 @@ from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
-    FieldSet,
     GeneratedSources,
     GenerateSourcesRequest,
     HydratedSources,
     HydrateSourcesRequest,
-    InferDependenciesRequest,
-    InferredDependencies,
     SourcesPaths,
     SourcesPathsRequest,
     TransitiveTargets,
@@ -118,17 +121,15 @@ def parse_go_package_option(content_raw: bytes) -> str | None:
     return None
 
 
-@dataclass(frozen=True)
-class GoProtobufImportPathMapping:
-    """Maps import paths of Go Protobuf packages to the addresses."""
-
-    mapping: FrozenDict[str, tuple[Address, ...]]
+class ProtobufGoModuleImportPathsMappingsHook(GoModuleImportPathsMappingsHook):
+    pass
 
 
 @rule(desc="Map import paths for all Go Protobuf targets.", level=LogLevel.DEBUG)
 async def map_import_paths_of_all_go_protobuf_targets(
-    targets: AllProtobufTargets,
-) -> GoProtobufImportPathMapping:
+    _request: ProtobufGoModuleImportPathsMappingsHook,
+    all_protobuf_targets: AllProtobufTargets,
+) -> GoModuleImportPathsMappings:
     sources = await MultiGet(
         Get(
             HydratedSources,
@@ -138,28 +139,57 @@ async def map_import_paths_of_all_go_protobuf_targets(
                 enable_codegen=True,
             ),
         )
-        for tgt in targets
+        for tgt in all_protobuf_targets
     )
 
     all_contents = await MultiGet(
         Get(DigestContents, Digest, source.snapshot.digest) for source in sources
     )
 
-    go_protobuf_targets: dict[str, set[Address]] = defaultdict(set)
-    for tgt, contents in zip(targets, all_contents):
+    go_protobuf_mapping_metadata = []
+    owning_go_mod_gets = []
+    for tgt, contents in zip(all_protobuf_targets, all_contents):
         if not contents:
             continue
         if len(contents) > 1:
             raise AssertionError(
                 f"Protobuf target `{tgt.address}` mapped to more than one source file."
             )
+
         import_path = parse_go_package_option(contents[0].content)
         if not import_path:
             continue
-        go_protobuf_targets[import_path].add(tgt.address)
 
-    return GoProtobufImportPathMapping(
-        FrozenDict({ip: tuple(addrs) for ip, addrs in go_protobuf_targets.items()})
+        owning_go_mod_gets.append(Get(OwningGoMod, OwningGoModRequest(tgt.address)))
+        go_protobuf_mapping_metadata.append((import_path, tgt.address))
+
+    owning_go_mod_targets = await MultiGet(owning_go_mod_gets)
+
+    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+
+    for owning_go_mod, (import_path, address) in zip(
+        owning_go_mod_targets, go_protobuf_mapping_metadata
+    ):
+        import_paths_by_module[owning_go_mod.address][import_path].add(address)
+
+    return GoModuleImportPathsMappings(
+        FrozenDict(
+            {
+                go_mod_addr: GoModuleImportPathsMapping(
+                    mapping=FrozenDict(
+                        {
+                            import_path: GoImportPathsMappingAddressSet(
+                                addresses=tuple(sorted(addresses)), infer_all=True
+                            )
+                            for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                )
+                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
+            }
+        )
     )
 
 
@@ -182,8 +212,6 @@ async def setup_full_package_build_request(
     request: _SetupGoProtobufPackageBuildRequest,
     protoc: Protoc,
     go_protoc_plugin: _SetupGoProtocPlugin,
-    package_mapping: ImportPathToPackages,
-    go_protobuf_mapping: GoProtobufImportPathMapping,
     analyzer: PackageAnalyzerSetup,
 ) -> FallibleBuildGoPackageRequest:
     output_dir = "_generated_files"
@@ -194,6 +222,11 @@ async def setup_full_package_build_request(
         Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses)),
         Get(DownloadedExternalTool, ExternalToolRequest, protoc.get_request(Platform.current)),
         Get(Digest, CreateDigest([Directory(output_dir)])),
+    )
+
+    go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(transitive_targets.roots[0].address))
+    package_mapping = await Get(
+        GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
     )
 
     all_sources = await Get(
@@ -317,25 +350,23 @@ async def setup_full_package_build_request(
         candidate_addresses = package_mapping.mapping.get(dep_import_path)
         if candidate_addresses:
             # TODO: Use explicit dependencies to disambiguate? This should never happen with Go backend though.
-            if len(candidate_addresses) > 1:
-                return FallibleBuildGoPackageRequest(
-                    request=None,
-                    import_path=request.import_path,
-                    exit_code=result.exit_code,
-                    stderr=textwrap.dedent(
-                        f"""
-                        Multiple addresses match import of `{dep_import_path}`.
+            if candidate_addresses.infer_all:
+                dep_build_request_addrs.extend(candidate_addresses.addresses)
+            else:
+                if len(candidate_addresses.addresses) > 1:
+                    return FallibleBuildGoPackageRequest(
+                        request=None,
+                        import_path=request.import_path,
+                        exit_code=result.exit_code,
+                        stderr=textwrap.dedent(
+                            f"""
+                            Multiple addresses match import of `{dep_import_path}`.
 
-                        addresses: {', '.join(str(a) for a in candidate_addresses)}
-                        """
-                    ).strip(),
-                )
-            dep_build_request_addrs.extend(candidate_addresses)
-
-        # Infer dependencies on other generated Go sources.
-        go_protobuf_candidate_addresses = go_protobuf_mapping.mapping.get(dep_import_path)
-        if go_protobuf_candidate_addresses:
-            dep_build_request_addrs.extend(go_protobuf_candidate_addresses)
+                            addresses: {', '.join(str(a) for a in candidate_addresses.addresses)}
+                            """
+                        ).strip(),
+                    )
+                dep_build_request_addrs.extend(candidate_addresses.addresses)
 
     dep_build_requests = await MultiGet(
         Get(BuildGoPackageRequest, BuildGoPackageTargetRequest(addr))
@@ -359,7 +390,6 @@ async def setup_full_package_build_request(
 @rule
 async def setup_build_go_package_request_for_protobuf(
     request: GoCodegenBuildProtobufRequest,
-    protobuf_package_mapping: GoProtobufImportPathMapping,
 ) -> FallibleBuildGoPackageRequest:
     # Hydrate the protobuf source to parse for the Go import path.
     sources = await Get(HydratedSources, HydrateSourcesRequest(request.target[ProtobufSourceField]))
@@ -374,10 +404,15 @@ async def setup_build_go_package_request_for_protobuf(
             stderr=f"No import path was set in Protobuf file via `option go_package` directive for {request.target.address}.",
         )
 
+    go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.target.address))
+    package_mapping = await Get(
+        GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
+    )
+
     # Request the full build of the package. This indirection is necessary so that requests for two or more
     # Protobuf files in the same Go package result in a single cacheable rule invocation.
-    protobuf_target_addrs_for_import_path = protobuf_package_mapping.mapping.get(import_path)
-    if not protobuf_target_addrs_for_import_path:
+    protobuf_target_addrs_set_for_import_path = package_mapping.mapping.get(import_path)
+    if not protobuf_target_addrs_set_for_import_path:
         return FallibleBuildGoPackageRequest(
             request=None,
             import_path=import_path,
@@ -393,7 +428,7 @@ async def setup_build_go_package_request_for_protobuf(
     return await Get(
         FallibleBuildGoPackageRequest,
         _SetupGoProtobufPackageBuildRequest(
-            addresses=protobuf_target_addrs_for_import_path,
+            addresses=protobuf_target_addrs_set_for_import_path.addresses,
             import_path=import_path,
         ),
     )
@@ -589,59 +624,14 @@ async def setup_go_protoc_plugin(platform: Platform) -> _SetupGoProtocPlugin:
     return _SetupGoProtocPlugin(plugin_digest)
 
 
-@dataclass(frozen=True)
-class GoProtobufDependenciesInferenceFieldSet(FieldSet):
-    required_fields = (GoPackageSourcesField,)
-
-    sources: GoPackageSourcesField
-
-
-class InferGoProtobufDependenciesRequest(InferDependenciesRequest):
-    infer_from = GoProtobufDependenciesInferenceFieldSet
-
-
-@rule(
-    desc="Infer dependencies on Protobuf sources for first-party Go packages", level=LogLevel.DEBUG
-)
-async def infer_go_dependencies(
-    request: InferGoProtobufDependenciesRequest,
-    go_protobuf_mapping: GoProtobufImportPathMapping,
-) -> InferredDependencies:
-    address = request.field_set.address
-    maybe_pkg_analysis = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(address)
-    )
-    if maybe_pkg_analysis.analysis is None:
-        _logger.error(
-            softwrap(
-                f"""
-                Failed to analyze {maybe_pkg_analysis.import_path} for dependency inference:
-
-                {maybe_pkg_analysis.stderr}
-                """
-            )
-        )
-        return InferredDependencies([])
-    pkg_analysis = maybe_pkg_analysis.analysis
-
-    inferred_dependencies: list[Address] = []
-    for import_path in (
-        *pkg_analysis.imports,
-        *pkg_analysis.test_imports,
-        *pkg_analysis.xtest_imports,
-    ):
-        candidate_addresses = go_protobuf_mapping.mapping.get(import_path, ())
-        inferred_dependencies.extend(candidate_addresses)
-
-    return InferredDependencies(inferred_dependencies)
-
-
 def rules():
     return (
         *collect_rules(),
         UnionRule(GenerateSourcesRequest, GenerateGoFromProtobufRequest),
         UnionRule(GoCodegenBuildRequest, GoCodegenBuildProtobufRequest),
-        UnionRule(InferDependenciesRequest, InferGoProtobufDependenciesRequest),
+        UnionRule(GoModuleImportPathsMappingsHook, ProtobufGoModuleImportPathsMappingsHook),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(GoOwningGoModAddressField),
+        ProtobufSourceTarget.register_plugin_field(GoOwningGoModAddressField),
         # Rules needed for this to pass src/python/pants/init/load_backends_integration_test.py:
         *assembly.rules(),
         *build_pkg.rules(),

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -14,6 +14,7 @@ from pants.backend.go.target_types import (
 )
 from pants.backend.go.util_rules import (
     assembly,
+    binary,
     build_pkg,
     build_pkg_target,
     coverage,
@@ -38,6 +39,7 @@ def target_types():
 def rules():
     return [
         *assembly.rules(),
+        *binary.rules(),
         *build_pkg.rules(),
         *build_pkg_target.rules(),
         *check.rules(),

--- a/src/python/pants/backend/go/dependency_inference.py
+++ b/src/python/pants/backend/go/dependency_inference.py
@@ -1,0 +1,49 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.build_graph.address import Address
+from pants.engine.environment import EnvironmentName
+from pants.engine.unions import union
+from pants.util.frozendict import FrozenDict
+
+
+@union(in_scope_types=[EnvironmentName])
+@dataclass(frozen=True)
+class GoModuleImportPathsMappingsHook:
+    """An entry point for a specific implementation of mapping Go import paths to owning targets.
+
+    All implementations will be merged together. The core Go dependency inference rules will request
+    the `GoModuleImportPathsMappings` type using implementations of this union.
+    """
+
+
+@dataclass(frozen=True)
+class GoImportPathsMappingAddressSet:
+    addresses: tuple[Address, ...]
+    infer_all: bool
+
+
+@dataclass(frozen=True)
+class GoModuleImportPathsMapping:
+    """Maps import paths (as strings) to one or more addresses of targets providing those import
+    path(s) for a single Go module."""
+
+    mapping: FrozenDict[str, GoImportPathsMappingAddressSet]
+
+
+@dataclass(frozen=True)
+class GoModuleImportPathsMappings:
+    """Import path mappings for all Go modules in the repository.
+
+    This type is requested from plugins which provide implementations for the GoCodegenBuildRequest
+    union and then merged.
+    """
+
+    modules: FrozenDict[Address, GoModuleImportPathsMapping]
+
+
+class AllGoModuleImportPathsMappings(GoModuleImportPathsMappings):
+    pass

--- a/src/python/pants/backend/go/dependency_inference.py
+++ b/src/python/pants/backend/go/dependency_inference.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.build_graph.address import Address
-from pants.engine.environment import EnvironmentName
 from pants.engine.unions import union
 from pants.util.frozendict import FrozenDict
 
 
-@union(in_scope_types=[EnvironmentName])
+@union
 @dataclass(frozen=True)
 class GoModuleImportPathsMappingsHook:
     """An entry point for a specific implementation of mapping Go import paths to owning targets.

--- a/src/python/pants/backend/go/dependency_inference_test.py
+++ b/src/python/pants/backend/go/dependency_inference_test.py
@@ -1,0 +1,124 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.goals.test import GoTestFieldSet
+from pants.backend.go.goals.test import rules as test_rules
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    tests_analysis,
+    third_party_pkg,
+)
+from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.build_graph.address import Address
+from pants.core.goals.test import TestResult, get_filtered_environment
+from pants.core.util_rules import source_files
+from pants.engine.process import ProcessResult
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *test_rules(),
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *first_party_pkg.rules(),
+            *go_mod.rules(),
+            *link.rules(),
+            *sdk.rules(),
+            *target_type_rules.rules(),
+            *tests_analysis.rules(),
+            *third_party_pkg.rules(),
+            *source_files.rules(),
+            get_filtered_environment,
+            QueryRule(TestResult, (GoTestFieldSet,)),
+            QueryRule(ProcessResult, (GoSdkProcess,)),
+        ],
+        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget],
+    )
+    rule_runner.set_options(["--go-test-args=-v"], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_multiple_go_mod_support(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": dedent(
+                """\
+            go_mod(name="mod")
+            go_package()
+            """
+            ),
+            "foo/go.mod": "module foo",
+            "foo/add.go": dedent(
+                """\
+            package foo
+            func add(x, y int) int {
+              return x + y
+            }
+            """
+            ),
+            "foo/add_test.go": dedent(
+                """\
+            package foo
+            import "testing"
+            func TestFoo(t *testing.T) {
+              if add(2, 3) != 5 {
+                t.Fail()
+              }
+            }
+            """
+            ),
+            "bar/BUILD": dedent(
+                """\
+            go_mod(name="mod")
+            go_package()
+            """
+            ),
+            "bar/go.mod": "module bar",
+            "bar/add.go": dedent(
+                """\
+            package bar
+            func add(x, y int) int {
+              return x + y
+            }
+            """
+            ),
+            "bar/add_test.go": dedent(
+                """\
+            package bar
+            import "testing"
+            func TestBar(t *testing.T) {
+              if add(2, 3) != 5 {
+                t.Fail()
+              }
+            }
+            """
+            ),
+        }
+    )
+    tgt = rule_runner.get_target(Address("foo"))
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    assert result.exit_code == 0
+    assert "PASS: TestFoo" in result.stdout
+
+    tgt = rule_runner.get_target(Address("bar"))
+    result = rule_runner.request(TestResult, [GoTestFieldSet.create(tgt)])
+    assert result.exit_code == 0
+    assert "PASS: TestBar" in result.stdout

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -4,11 +4,8 @@
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.go.target_types import (
-    GoBinaryMainPackage,
-    GoBinaryMainPackageField,
-    GoBinaryMainPackageRequest,
-)
+from pants.backend.go.target_types import GoBinaryMainPackageField, GoBinaryTarget, GoPackageTarget
+from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.backend.go.util_rules.build_pkg import BuiltGoPackage
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.go.target_types import GoBinaryMainPackageField, GoBinaryTarget, GoPackageTarget
+from pants.backend.go.target_types import GoBinaryMainPackageField
 from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.backend.go.util_rules.build_pkg import BuiltGoPackage
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -10,13 +10,12 @@ from pathlib import PurePath
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_types import (
-    GoBinaryMainPackage,
     GoBinaryMainPackageField,
-    GoBinaryMainPackageRequest,
     GoBinaryTarget,
     GoModTarget,
     GoPackageTarget,
 )
+from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.base.specs import AncestorGlobSpec, RawSpecs
 from pants.core.goals.tailor import (
     AllOwnedSources,

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -7,11 +7,14 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 
+from pants.backend.go.dependency_inference import (
+    AllGoModuleImportPathsMappings,
+    GoImportPathsMappingAddressSet,
+    GoModuleImportPathsMapping,
+    GoModuleImportPathsMappings,
+    GoModuleImportPathsMappingsHook,
+)
 from pants.backend.go.target_types import (
-    GoBinaryDependenciesField,
-    GoBinaryMainPackage,
-    GoBinaryMainPackageField,
-    GoBinaryMainPackageRequest,
     GoImportPathField,
     GoModSourcesField,
     GoModTarget,
@@ -26,7 +29,12 @@ from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgImportPath,
     FirstPartyPkgImportPathRequest,
 )
-from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
+from pants.backend.go.util_rules.go_mod import (
+    GoModInfo,
+    GoModInfoRequest,
+    OwningGoMod,
+    OwningGoModRequest,
+)
 from pants.backend.go.util_rules.import_analysis import GoStdLibImports
 from pants.backend.go.util_rules.third_party_pkg import (
     AllThirdPartyPackages,
@@ -34,13 +42,12 @@ from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
 )
-from pants.base.specs import DirGlobSpec, RawSpecs
-from pants.build_graph.address import ResolveError
 from pants.core.target_types import (
     TargetGeneratorSourcesHelperSourcesField,
     TargetGeneratorSourcesHelperTarget,
 )
-from pants.engine.addresses import Address, AddressInput
+from pants.engine.addresses import Address
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -51,10 +58,6 @@ from pants.engine.target import (
     GenerateTargetsRequest,
     InferDependenciesRequest,
     InferredDependencies,
-    InvalidFieldException,
-    Targets,
-    WrappedTarget,
-    WrappedTargetRequest,
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.frozendict import FrozenDict
@@ -63,43 +66,126 @@ from pants.util.logging import LogLevel
 logger = logging.getLogger(__name__)
 
 
-class AllGoTargets(Targets):
+@dataclass(frozen=True)
+class GoImportPathMappingRequest(EngineAwareParameter):
+    go_mod_address: Address
+
+    def debug_hint(self) -> str | None:
+        return str(self.go_mod_address)
+
+
+class FirstPartyGoModuleImportPathsMappingsHook(GoModuleImportPathsMappingsHook):
     pass
 
 
-@rule(desc="Find all Go targets in project", level=LogLevel.DEBUG)
-def find_all_go_targets(tgts: AllTargets) -> AllGoTargets:
-    return AllGoTargets(
-        t for t in tgts if t.has_field(GoImportPathField) or t.has_field(GoPackageSourcesField)
+@rule(desc="Analyze and map Go import paths for all modules.", level=LogLevel.DEBUG)
+async def go_map_import_paths_by_module(
+    _request: FirstPartyGoModuleImportPathsMappingsHook,
+    all_targets: AllTargets,
+) -> GoModuleImportPathsMappings:
+    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
+        lambda: defaultdict(set)
     )
 
+    candidate_go_source_targets = [
+        tgt
+        for tgt in all_targets
+        if tgt.has_field(GoImportPathField) or tgt.has_field(GoPackageSourcesField)
+    ]
 
-@dataclass(frozen=True)
-class ImportPathToPackages:
-    mapping: FrozenDict[str, tuple[Address, ...]]
+    owning_go_mod_targets = await MultiGet(
+        Get(OwningGoMod, OwningGoModRequest(tgt.address)) for tgt in candidate_go_source_targets
+    )
 
-
-@rule(desc="Map all Go targets to their import paths", level=LogLevel.DEBUG)
-async def map_import_paths_to_packages(go_tgts: AllGoTargets) -> ImportPathToPackages:
-    mapping: dict[str, list[Address]] = defaultdict(list)
-    first_party_addresses = []
+    first_party_gets_metadata = []
     first_party_gets = []
-    for tgt in go_tgts:
+
+    for tgt, owning_go_mod in zip(candidate_go_source_targets, owning_go_mod_targets):
         if tgt.has_field(GoImportPathField):
             import_path = tgt[GoImportPathField].value
-            mapping[import_path].append(tgt.address)
-        else:
-            first_party_addresses.append(tgt.address)
+            import_paths_by_module[owning_go_mod.address][import_path].add(tgt.address)
+        elif tgt.has_field(GoPackageSourcesField):
+            first_party_gets_metadata.append((tgt.address, owning_go_mod))
             first_party_gets.append(
                 Get(FirstPartyPkgImportPath, FirstPartyPkgImportPathRequest(tgt.address))
             )
 
     first_party_import_paths = await MultiGet(first_party_gets)
-    for import_path_info, addr in zip(first_party_import_paths, first_party_addresses):
-        mapping[import_path_info.import_path].append(addr)
+    for import_path_info, (addr, owning_go_mod) in zip(
+        first_party_import_paths, first_party_gets_metadata
+    ):
+        import_paths_by_module[owning_go_mod.address][import_path_info.import_path].add(addr)
 
-    frozen_mapping = FrozenDict({ip: tuple(tgts) for ip, tgts in mapping.items()})
-    return ImportPathToPackages(frozen_mapping)
+    return GoModuleImportPathsMappings(
+        FrozenDict(
+            {
+                go_mod_addr: GoModuleImportPathsMapping(
+                    mapping=FrozenDict(
+                        {
+                            import_path: GoImportPathsMappingAddressSet(
+                                addresses=tuple(sorted(addresses)), infer_all=False
+                            )
+                            for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                )
+                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
+            }
+        )
+    )
+
+
+@rule(desc="Analyze Go import paths for all modules.", level=LogLevel.DEBUG)
+async def go_merge_import_paths_analysis(
+    union_membership: UnionMembership,
+) -> AllGoModuleImportPathsMappings:
+    import_path_mappers = union_membership.get(GoModuleImportPathsMappingsHook)
+    all_results = await MultiGet(
+        Get(GoModuleImportPathsMappings, GoModuleImportPathsMappingsHook, impl())
+        for impl in import_path_mappers
+    )
+
+    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+    infer_all_by_module: dict[Address, dict[str, bool]] = defaultdict(lambda: defaultdict(bool))
+
+    # Merge all of the mappings together.
+    for result in all_results:
+        for go_mod_address, mapping in result.modules.items():
+            imports_paths_for_module = import_paths_by_module[go_mod_address]
+            for import_path, address_set in mapping.mapping.items():
+                for address in address_set.addresses:
+                    imports_paths_for_module[import_path].add(address)
+                if address_set.infer_all:
+                    infer_all_by_module[go_mod_address][import_path] = True
+
+    return AllGoModuleImportPathsMappings(
+        FrozenDict(
+            {
+                go_mod_addr: GoModuleImportPathsMapping(
+                    mapping=FrozenDict(
+                        {
+                            import_path: GoImportPathsMappingAddressSet(
+                                addresses=tuple(sorted(addresses)),
+                                infer_all=infer_all_by_module[go_mod_addr][import_path],
+                            )
+                            for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                )
+                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
+            }
+        )
+    )
+
+
+@rule(desc="Map Go targets owned by module to import paths", level=LogLevel.DEBUG)
+async def map_import_paths_to_packages(
+    request: GoImportPathMappingRequest,
+    module_import_path_mappings: AllGoModuleImportPathsMappings,
+) -> GoModuleImportPathsMapping:
+    return module_import_path_mappings.modules[request.go_mod_address]
 
 
 @dataclass(frozen=True)
@@ -117,8 +203,12 @@ class InferGoPackageDependenciesRequest(InferDependenciesRequest):
 async def infer_go_dependencies(
     request: InferGoPackageDependenciesRequest,
     std_lib_imports: GoStdLibImports,
-    package_mapping: ImportPathToPackages,
 ) -> InferredDependencies:
+    go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.field_set.address))
+    package_mapping = await Get(
+        GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
+    )
+
     addr = request.field_set.address
     maybe_pkg_analysis = await Get(
         FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr)
@@ -131,7 +221,7 @@ async def infer_go_dependencies(
         return InferredDependencies([])
     pkg_analysis = maybe_pkg_analysis.analysis
 
-    inferred_dependencies = []
+    inferred_dependencies: list[Address] = []
     for import_path in (
         *pkg_analysis.imports,
         *pkg_analysis.test_imports,
@@ -142,14 +232,23 @@ async def infer_go_dependencies(
         # Avoid a dependency cycle caused by external test imports of this package (i.e., "xtest").
         if import_path == pkg_analysis.import_path:
             continue
-        candidate_packages = package_mapping.mapping.get(import_path, ())
-        if len(candidate_packages) > 1:
-            # TODO(#12761): Use ExplicitlyProvidedDependencies for disambiguation.
-            logger.warning(
-                f"Ambiguous mapping for import path {import_path} on packages at addresses: {candidate_packages}"
-            )
-        elif len(candidate_packages) == 1:
-            inferred_dependencies.append(candidate_packages[0])
+        candidate_packages = package_mapping.mapping.get(import_path)
+        if candidate_packages:
+            if candidate_packages.infer_all:
+                inferred_dependencies.extend(candidate_packages.addresses)
+            else:
+                if len(candidate_packages.addresses) > 1:
+                    # TODO(#12761): Use ExplicitlyProvidedDependencies for disambiguation.
+                    logger.warning(
+                        f"Ambiguous mapping for import path {import_path} on packages at addresses: {candidate_packages}"
+                    )
+                elif len(candidate_packages.addresses) == 1:
+                    inferred_dependencies.append(candidate_packages.addresses[0])
+                else:
+                    logger.debug(
+                        f"Unable to infer dependency for import path '{import_path}' "
+                        f"in go_package at address '{addr}'."
+                    )
         else:
             logger.debug(
                 f"Unable to infer dependency for import path '{import_path}' "
@@ -175,11 +274,15 @@ class InferGoThirdPartyPackageDependenciesRequest(InferDependenciesRequest):
 async def infer_go_third_party_package_dependencies(
     request: InferGoThirdPartyPackageDependenciesRequest,
     std_lib_imports: GoStdLibImports,
-    package_mapping: ImportPathToPackages,
 ) -> InferredDependencies:
     addr = request.field_set.address
     go_mod_address = addr.maybe_convert_to_target_generator()
-    go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
+
+    package_mapping, go_mod_info = await MultiGet(
+        Get(GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_address)),
+        Get(GoModInfo, GoModInfoRequest(go_mod_address)),
+    )
+
     pkg_info = await Get(
         ThirdPartyPkgAnalysis,
         ThirdPartyPkgAnalysisRequest(
@@ -187,19 +290,28 @@ async def infer_go_third_party_package_dependencies(
         ),
     )
 
-    inferred_dependencies = []
+    inferred_dependencies: list[Address] = []
     for import_path in pkg_info.imports:
         if import_path in std_lib_imports:
             continue
 
         candidate_packages = package_mapping.mapping.get(import_path, ())
-        if len(candidate_packages) > 1:
-            # TODO(#12761): Use ExplicitlyProvidedDependencies for disambiguation.
-            logger.warning(
-                f"Ambiguous mapping for import path {import_path} on packages at addresses: {candidate_packages}"
-            )
-        elif len(candidate_packages) == 1:
-            inferred_dependencies.append(candidate_packages[0])
+        if candidate_packages:
+            if candidate_packages.infer_all:
+                inferred_dependencies.extend(candidate_packages.addresses)
+            else:
+                if len(candidate_packages.addresses) > 1:
+                    # TODO(#12761): Use ExplicitlyProvidedDependencies for disambiguation.
+                    logger.warning(
+                        f"Ambiguous mapping for import path {import_path} on packages at addresses: {candidate_packages}"
+                    )
+                elif len(candidate_packages.addresses) == 1:
+                    inferred_dependencies.append(candidate_packages.addresses[0])
+                else:
+                    logger.debug(
+                        f"Unable to infer dependency for import path '{import_path}' "
+                        f"in go_third_party_package at address '{addr}'."
+                    )
         else:
             logger.debug(
                 f"Unable to infer dependency for import path '{import_path}' "
@@ -262,98 +374,6 @@ async def generate_targets_from_go_mod(
     return GeneratedTargets(request.generator, result)
 
 
-# -----------------------------------------------------------------------------------------------
-# The `main` field for `go_binary`
-# -----------------------------------------------------------------------------------------------
-
-
-@rule(desc="Determine first-party package used by `go_binary` target", level=LogLevel.DEBUG)
-async def determine_main_pkg_for_go_binary(
-    request: GoBinaryMainPackageRequest,
-) -> GoBinaryMainPackage:
-    addr = request.field.address
-    if request.field.value:
-        description_of_origin = (
-            f"the `{request.field.alias}` field from the target {request.field.address}"
-        )
-        specified_address = await Get(
-            Address,
-            AddressInput,
-            AddressInput.parse(
-                request.field.value,
-                relative_to=addr.spec_path,
-                description_of_origin=description_of_origin,
-            ),
-        )
-        wrapped_specified_tgt = await Get(
-            WrappedTarget,
-            WrappedTargetRequest(specified_address, description_of_origin=description_of_origin),
-        )
-        if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
-            raise InvalidFieldException(
-                f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
-                "a `go_package` target, but was the address for a "
-                f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
-                "Hint: you should normally not specify this field so that Pants will find the "
-                "`go_package` target for you."
-            )
-        return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
-
-    candidate_targets = await Get(
-        Targets,
-        RawSpecs(
-            dir_globs=(DirGlobSpec(addr.spec_path),),
-            description_of_origin="the `go_binary` dependency inference rule",
-        ),
-    )
-    relevant_pkg_targets = [
-        tgt
-        for tgt in candidate_targets
-        if tgt.has_field(GoPackageSourcesField) and tgt.residence_dir == addr.spec_path
-    ]
-    if len(relevant_pkg_targets) == 1:
-        return GoBinaryMainPackage(relevant_pkg_targets[0].address)
-
-    if not relevant_pkg_targets:
-        raise ResolveError(
-            f"The target {addr} requires that there is a `go_package` "
-            f"target defined in its directory {addr.spec_path}, but none were found.\n\n"
-            "To fix, add a target like `go_package()` or `go_package(name='pkg')` to the BUILD "
-            f"file in {addr.spec_path}."
-        )
-    raise ResolveError(
-        f"There are multiple `go_package` targets for the same directory of the "
-        f"target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
-        "package.\n\n"
-        f"To fix, please either set the `main` field for `{addr} or remove these "
-        "`go_package` targets so that only one remains: "
-        f"{sorted(tgt.address.spec for tgt in relevant_pkg_targets)}"
-    )
-
-
-@dataclass(frozen=True)
-class GoBinaryMainDependencyInferenceFieldSet(FieldSet):
-    required_fields = (GoBinaryDependenciesField, GoBinaryMainPackageField)
-
-    dependencies: GoBinaryDependenciesField
-    main_package: GoBinaryMainPackageField
-
-
-class InferGoBinaryMainDependencyRequest(InferDependenciesRequest):
-    infer_from = GoBinaryMainDependencyInferenceFieldSet
-
-
-@rule
-async def infer_go_binary_main_dependency(
-    request: InferGoBinaryMainDependencyRequest,
-) -> InferredDependencies:
-    main_pkg = await Get(
-        GoBinaryMainPackage,
-        GoBinaryMainPackageRequest(request.field_set.main_package),
-    )
-    return InferredDependencies([main_pkg.address])
-
-
 def rules():
     return (
         *collect_rules(),
@@ -361,6 +381,6 @@ def rules():
         *import_analysis.rules(),
         UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),
         UnionRule(InferDependenciesRequest, InferGoThirdPartyPackageDependenciesRequest),
-        UnionRule(InferDependenciesRequest, InferGoBinaryMainDependencyRequest),
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoModRequest),
+        UnionRule(GoModuleImportPathsMappingsHook, FirstPartyGoModuleImportPathsMappingsHook),
     )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -8,14 +8,8 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_type_rules import (
-    GoBinaryMainDependencyInferenceFieldSet,
-    InferGoBinaryMainDependencyRequest,
-)
 from pants.backend.go.target_types import (
-    GoBinaryMainPackage,
     GoBinaryMainPackageField,
-    GoBinaryMainPackageRequest,
     GoBinaryTarget,
     GoImportPathField,
     GoModTarget,
@@ -31,6 +25,12 @@ from pants.backend.go.util_rules import (
     link,
     sdk,
     third_party_pkg,
+)
+from pants.backend.go.util_rules.binary import (
+    GoBinaryMainDependencyInferenceFieldSet,
+    GoBinaryMainPackage,
+    GoBinaryMainPackageRequest,
+    InferGoBinaryMainDependencyRequest,
 )
 from pants.build_graph.address import Address, ResolveError
 from pants.core.target_types import (

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -4,14 +4,12 @@
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass
 from typing import Iterable, Optional, Sequence, Tuple
 
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.core.goals.test import TestExtraEnvVarsField, TestTimeoutField
 from pants.engine.addresses import Address
-from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
@@ -226,19 +224,6 @@ class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     value: str
 
 
-@dataclass(frozen=True)
-class GoBinaryMainPackage:
-    address: Address
-
-
-@dataclass(frozen=True)
-class GoBinaryMainPackageRequest(EngineAwareParameter):
-    field: GoBinaryMainPackageField
-
-    def debug_hint(self) -> str:
-        return self.field.address.spec
-
-
 class GoBinaryDependenciesField(Dependencies):
     # This is only used to inject a dependency from the `GoBinaryMainPackageField`. Users should
     # add any explicit dependencies to the `go_package`.
@@ -255,3 +240,24 @@ class GoBinaryTarget(Target):
         RestartableField,
     )
     help = "A Go binary."
+
+
+# -----------------------------------------------------------------------------------------------
+# Support for codegen targets that need to specify an owning go_mod target
+# -----------------------------------------------------------------------------------------------
+
+
+class GoOwningGoModAddressField(StringField):
+    alias = "go_mod_address"
+    help = softwrap(
+        """
+        Address of the `go_mod` target representing the Go module that this target is part of.
+
+        This field is similar to the `resolve` field used in the Python and JVM backends. If a codegen
+        target such as `protobuf_sources` will be used in multiple Go modules, then you should use
+        the `parametrize` built-in to parametrize that `protobuf_sources` target for each Go module.
+
+        If there is a single `go_mod` target in the repository, then this field defaults to the address
+        for that single `go_mod` target.
+        """
+    )

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -1,0 +1,134 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.target_types import (
+    GoBinaryDependenciesField,
+    GoBinaryMainPackageField,
+    GoPackageSourcesField,
+)
+from pants.base.specs import DirGlobSpec, RawSpecs
+from pants.build_graph.address import Address, AddressInput, ResolveError
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    FieldSet,
+    InferDependenciesRequest,
+    InferredDependencies,
+    InvalidFieldException,
+    Targets,
+    WrappedTarget,
+    WrappedTargetRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+
+@dataclass(frozen=True)
+class GoBinaryMainPackage:
+    address: Address
+
+
+@dataclass(frozen=True)
+class GoBinaryMainPackageRequest(EngineAwareParameter):
+    field: GoBinaryMainPackageField
+
+    def debug_hint(self) -> str:
+        return self.field.address.spec
+
+
+@rule(desc="Determine first-party package used by `go_binary` target", level=LogLevel.DEBUG)
+async def determine_main_pkg_for_go_binary(
+    request: GoBinaryMainPackageRequest,
+) -> GoBinaryMainPackage:
+    addr = request.field.address
+    if request.field.value:
+        description_of_origin = (
+            f"the `{request.field.alias}` field from the target {request.field.address}"
+        )
+        specified_address = await Get(
+            Address,
+            AddressInput,
+            AddressInput.parse(
+                request.field.value,
+                relative_to=addr.spec_path,
+                description_of_origin=description_of_origin,
+            ),
+        )
+        wrapped_specified_tgt = await Get(
+            WrappedTarget,
+            WrappedTargetRequest(specified_address, description_of_origin=description_of_origin),
+        )
+        if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
+            raise InvalidFieldException(
+                f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
+                "a `go_package` target, but was the address for a "
+                f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
+                "Hint: you should normally not specify this field so that Pants will find the "
+                "`go_package` target for you."
+            )
+        return GoBinaryMainPackage(wrapped_specified_tgt.target.address)
+
+    candidate_targets = await Get(
+        Targets,
+        RawSpecs(
+            dir_globs=(DirGlobSpec(addr.spec_path),),
+            description_of_origin="the `go_binary` dependency inference rule",
+        ),
+    )
+    relevant_pkg_targets = [
+        tgt
+        for tgt in candidate_targets
+        if tgt.has_field(GoPackageSourcesField) and tgt.residence_dir == addr.spec_path
+    ]
+    if len(relevant_pkg_targets) == 1:
+        return GoBinaryMainPackage(relevant_pkg_targets[0].address)
+
+    if not relevant_pkg_targets:
+        raise ResolveError(
+            f"The target {addr} requires that there is a `go_package` "
+            f"target defined in its directory {addr.spec_path}, but none were found.\n\n"
+            "To fix, add a target like `go_package()` or `go_package(name='pkg')` to the BUILD "
+            f"file in {addr.spec_path}."
+        )
+    raise ResolveError(
+        f"There are multiple `go_package` targets for the same directory of the "
+        f"target {addr}: {addr.spec_path}. It is ambiguous what to use as the `main` "
+        "package.\n\n"
+        f"To fix, please either set the `main` field for `{addr} or remove these "
+        "`go_package` targets so that only one remains: "
+        f"{sorted(tgt.address.spec for tgt in relevant_pkg_targets)}"
+    )
+
+
+@dataclass(frozen=True)
+class GoBinaryMainDependencyInferenceFieldSet(FieldSet):
+    required_fields = (GoBinaryDependenciesField, GoBinaryMainPackageField)
+
+    dependencies: GoBinaryDependenciesField
+    main_package: GoBinaryMainPackageField
+
+
+class InferGoBinaryMainDependencyRequest(InferDependenciesRequest):
+    infer_from = GoBinaryMainDependencyInferenceFieldSet
+
+
+@rule
+async def infer_go_binary_main_dependency(
+    request: InferGoBinaryMainDependencyRequest,
+) -> InferredDependencies:
+    main_pkg = await Get(
+        GoBinaryMainPackage,
+        GoBinaryMainPackageRequest(request.field_set.main_package),
+    )
+    return InferredDependencies([main_pkg.address])
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(InferDependenciesRequest, InferGoBinaryMainDependencyRequest),
+    )

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -7,23 +7,36 @@ import logging
 import os
 from dataclasses import dataclass
 
-from pants.backend.go.target_types import GoModSourcesField
+from pants.backend.go.target_types import (
+    GoBinaryMainPackageField,
+    GoModDependenciesField,
+    GoModSourcesField,
+    GoModTarget,
+    GoOwningGoModAddressField,
+    GoPackageSourcesField,
+    GoThirdPartyPackageDependenciesField,
+)
+from pants.backend.go.util_rules import binary
+from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.base.specs import AncestorGlobSpec, RawSpecs
-from pants.build_graph.address import Address
+from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest
 from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import (
+    AllUnexpandedTargets,
     HydratedSources,
     HydrateSourcesRequest,
     InvalidTargetException,
+    Targets,
     UnexpandedTargets,
     WrappedTarget,
     WrappedTargetRequest,
 )
 from pants.util.docutil import bin_name
+from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
 
@@ -41,8 +54,32 @@ class OwningGoMod:
     address: Address
 
 
+@dataclass(frozen=True)
+class NearestAncestorGoModRequest(EngineAwareParameter):
+    address: Address
+
+    def debug_hint(self) -> str | None:
+        return self.address.spec
+
+
+@dataclass(frozen=True)
+class NearestAncestorGoModResult:
+    address: Address
+
+
+class AllGoModTargets(Targets):
+    pass
+
+
+@rule(desc="Find all `go_mod` targets in project", level=LogLevel.DEBUG)
+async def find_all_go_mod_targets(targets: AllUnexpandedTargets) -> AllGoModTargets:
+    return AllGoModTargets(tgt for tgt in targets if tgt.has_field(GoModDependenciesField))
+
+
 @rule
-async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
+async def find_nearest_ancestor_go_mod(
+    request: NearestAncestorGoModRequest,
+) -> NearestAncestorGoModResult:
     # We don't expect `go_mod` targets to be generated, so we can use UnexpandedTargets.
     candidate_targets = await Get(
         UnexpandedTargets,
@@ -58,14 +95,120 @@ async def find_nearest_go_mod(request: OwningGoModRequest) -> OwningGoMod:
         key=lambda tgt: tgt.address.spec_path,
         reverse=True,
     )
+
     if not go_mod_targets:
         raise InvalidTargetException(
             f"The target {request.address} does not have a `go_mod` target in its BUILD file or "
             "any ancestor BUILD files. To fix, please make sure your project has a `go.mod` file "
             f"and add a `go_mod` target (you can run `{bin_name()} tailor` to do this)."
         )
-    nearest_go_mod_target = go_mod_targets[0]
-    return OwningGoMod(nearest_go_mod_target.address)
+
+    return NearestAncestorGoModResult(go_mod_targets[0].address)
+
+
+@rule_helper
+async def _find_explict_owning_go_mod_address(
+    address: Address,
+    field: GoOwningGoModAddressField,
+    alias: str,
+    all_go_mod_targets: AllGoModTargets,
+) -> Address:
+    # If no value is specified, then see if there is only one `go_mod` target in this repository.
+    if field.value is None:
+        # If so, that is the default.
+        if len(all_go_mod_targets) == 1:
+            return all_go_mod_targets[0].address
+
+        # Otherwise error and inform user to specify the owning `go_mod` target's address.
+        if not all_go_mod_targets:
+            raise InvalidTargetException(
+                f"The `{alias}` target `{address}` requires that the address of an owning `{GoModTarget.alias}` "
+                f"target be given via the `{GoOwningGoModAddressField.alias}` field since it is "
+                "a dependency of a Go target. However, there are no `go_mod` targets in this repository."
+            )
+
+        raise InvalidTargetException(
+            f"The `{alias}` target `{address}` requires that the address of an owning `{GoModTarget.alias}` "
+            f"target be given via the `{GoOwningGoModAddressField.alias}` field since it is "
+            "a dependency of a Go target. However, there are multiple `go_mod` targets in this repository "
+            "which makes the choice of which `go_mod` target to use ambiguous. Please specify which of the "
+            "following addresses to use or consider using the `parametrize` builtin to specify more than "
+            "one of these addresses if this target will be used in multiple Go modules: "
+            f"{', '.join([str(tgt.address) for tgt in all_go_mod_targets])}"
+        )
+
+    # If a value is specified, then resolve it as an address.
+    address_input = AddressInput.parse(
+        field.value,
+        relative_to=address.spec_path,
+        description_of_origin=f"the `{GoOwningGoModAddressField.alias}` field of target `{address}`",
+    )
+    candidate_go_mod_address = await Get(Address, AddressInput, address_input)
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            candidate_go_mod_address,
+            description_of_origin=f"the `{GoOwningGoModAddressField.alias}` field of target `{address}`",
+        ),
+    )
+    if not wrapped_target.target.has_field(GoModDependenciesField):
+        raise InvalidTargetException(
+            f"The `{alias}` target `{address}` requires that the address of an owning `{GoModTarget.alias}` "
+            f"target be given via the `{GoOwningGoModAddressField.alias}` field since it is "
+            f"a dependency of a Go target. However, the provided address `{field.value}` does not refer to "
+            f"a `{GoModTarget.alias}` target. Please specify which of the following addresses to use or consider "
+            "using the `parametrize` builtin to specify more than one of these addresses if this target will be "
+            f"used in multiple Go modules: {', '.join([str(tgt.address) for tgt in all_go_mod_targets])}"
+        )
+    return candidate_go_mod_address
+
+
+@rule
+async def find_owning_go_mod(
+    request: OwningGoModRequest, all_go_mod_targets: AllGoModTargets
+) -> OwningGoMod:
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(request.address, description_of_origin="the `OwningGoMod` rule"),
+    )
+    target = wrapped_target.target
+
+    if target.has_field(GoModDependenciesField):
+        return OwningGoMod(request.address)
+
+    if target.has_field(GoPackageSourcesField):
+        nearest_go_mod_result = await Get(
+            NearestAncestorGoModResult, NearestAncestorGoModRequest(request.address)
+        )
+        return OwningGoMod(nearest_go_mod_result.address)
+
+    if target.has_field(GoThirdPartyPackageDependenciesField):
+        # For `go_third_party_package` targets, use the generator which is the owning `go_mod` target.
+        generator_address = target.address.maybe_convert_to_target_generator()
+        return OwningGoMod(generator_address)
+
+    if target.has_field(GoBinaryMainPackageField):
+        main_pkg = await Get(
+            GoBinaryMainPackage, GoBinaryMainPackageRequest(target.get(GoBinaryMainPackageField))
+        )
+        owning_go_mod_for_main_pkg = await Get(OwningGoMod, OwningGoModRequest(main_pkg.address))
+        return owning_go_mod_for_main_pkg
+
+    if target.has_field(GoOwningGoModAddressField):
+        # Otherwise, find any explicitly defined go_mod address (e.g., for `protobuf_sources` targets).
+        explicit_go_mod_address = await _find_explict_owning_go_mod_address(
+            address=request.address,
+            field=target.get(GoOwningGoModAddressField),
+            alias=target.alias,
+            all_go_mod_targets=all_go_mod_targets,
+        )
+        return OwningGoMod(explicit_go_mod_address)
+
+    raise AssertionError(
+        f"Internal error: Unable to determine how to determine the owning `{GoModTarget.alias}` target "
+        f"for `{target.alias}` target `{target.address}`. Please file an issue at "
+        "https://github.com/pantsbuild/pants/issues/new."
+    )
 
 
 @dataclass(frozen=True)
@@ -126,4 +269,7 @@ async def determine_go_mod_info(
 
 
 def rules():
-    return collect_rules()
+    return (
+        *collect_rules(),
+        *binary.rules(),
+    )

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -680,7 +680,6 @@ class Target:
             )
         return result
 
-    @final
     @classmethod
     def register_plugin_field(cls, field: Type[Field]) -> UnionRule:
         """Register a new field on the target type.
@@ -1045,6 +1044,14 @@ class TargetGenerator(Target):
                 "`TargetGenerator.copied_field`. `Dependencies` fields should be "
                 "`TargetGenerator.moved_field`s, to avoid redundant graph edges."
             )
+
+    @classmethod
+    def register_plugin_field(cls, field: Type[Field], *, copy_field: bool = False) -> UnionRule:
+        if copy_field:
+            cls.copied_fields = cls.copied_fields + (field,)
+        else:
+            cls.moved_fields = cls.moved_fields + (field,)
+        return super().register_plugin_field(field)
 
 
 class TargetFilesGenerator(TargetGenerator):


### PR DESCRIPTION
The package mapping from import path to addresses (`ImportPathToPackages`) was global to the entire repository and not split by Go module. This prevented using multiple Go modules in a single repository. This PR solves the issue by introducing `GoImportPathMappingRequest` which allows the package mapping to be requested per module.

That per-module mapping relies on a repository-wide mapping available as `AllGoModuleImportPathsMappings`. The `GoModuleImportPathsMappingsHook` union allows plugins to provide their own import path mappings. For example, this support is now used by the protobuf/go codegen backend to supply import paths from generated protobuf code, meaning that the Go backend is able to infer dependencies between Go code and protobuf code automatically.

Fixes https://github.com/pantsbuild/pants/issues/13114.

[ci skip-rust]