### PR TITLE
Add OpenAPI backend as a dependency to the Pants bin

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -250,6 +250,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.java.lint.google_java_format",
         "pants.backend.experimental.kotlin",
         "pants.backend.experimental.kotlin.lint.ktlint",
+        "pants.backend.experimental.openapi",
         "pants.backend.experimental.python",
         "pants.backend.experimental.python.lint.autoflake",
         "pants.backend.experimental.python.lint.pyupgrade",

--- a/src/python/pants/backend/openapi/target_types.py
+++ b/src/python/pants/backend/openapi/target_types.py
@@ -10,6 +10,7 @@ from pants.engine.target import (
     SingleSourceField,
     Target,
     TargetFilesGenerator,
+    generate_multiple_sources_field_help_message,
 )
 
 OPENAPI_FILE_EXTENSIONS = (".json", ".yaml", ".yml")
@@ -48,6 +49,7 @@ class OpenApiDocumentTarget(Target):
 
 class OpenApiDocumentGeneratorField(OpenApiGeneratorField):
     default = tuple(f"openapi{ext}" for ext in OPENAPI_FILE_EXTENSIONS)
+    help = generate_multiple_sources_field_help_message("Example: `sources=['openapi.json']`")
 
 
 class OpenApiDocumentGeneratorTarget(TargetFilesGenerator):
@@ -87,6 +89,7 @@ class OpenApiSourceTarget(Target):
 
 class OpenApiSourceGeneratorField(OpenApiGeneratorField):
     default = tuple(f"*{ext}" for ext in OPENAPI_FILE_EXTENSIONS)
+    help = generate_multiple_sources_field_help_message("Example: `sources=['*.json']`")
 
 
 class OpenApiSourceGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -41,6 +41,7 @@ target(
         "src/python/pants/backend/experimental/kotlin",
         "src/python/pants/backend/experimental/kotlin/debug_goals",
         "src/python/pants/backend/experimental/kotlin/lint/ktlint",
+        "src/python/pants/backend/experimental/openapi",
         "src/python/pants/backend/experimental/python",
         "src/python/pants/backend/experimental/python/lint/autoflake",
         "src/python/pants/backend/experimental/python/lint/pyupgrade",


### PR DESCRIPTION
This adds the newly merged OpenAPI backend to `src/python/pants/bin:plugins`, as requested by @stuhood in #16199.

[ci skip-rust]
[ci skip-build-wheels]
