### PR TITLE
Drop unused `protobuf` dep in `brfs`.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -229,7 +229,6 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.12.1",
- "protobuf",
  "protos",
  "store",
  "task_executor",
@@ -2413,15 +2412,6 @@ checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
  "prost",
-]
-
-[[package]]
-name = "protobuf"
-version = "2.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
-dependencies = [
- "bytes",
 ]
 
 [[package]]

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -18,7 +18,6 @@ hashing = { path = "../../hashing" }
 libc = "0.2.126"
 log = "0.4.17"
 parking_lot = "0.12"
-protobuf = { version = "2.27.1", features = ["with-bytes"] }
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.3"


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]