### PR TITLE
Allow for `./pants help _underscored_target`

### DIFF
--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -507,11 +507,7 @@ class HelpInfoExtracter:
             {
                 alias: target_type_info_for(target_type)
                 for alias, target_type in registered_target_types.aliases_to_types.items()
-                if (
-                    not alias.startswith("_")
-                    and target_type.removal_version is None
-                    and alias != target_type.deprecated_alias
-                )
+                if (target_type.removal_version is None and alias != target_type.deprecated_alias)
             }
         )
 

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -33,7 +33,8 @@ def test_help_advanced_global() -> None:
 def test_help_targets() -> None:
     pants_run = run_pants(["help", "targets"])
     pants_run.assert_success()
-    assert "archive          A ZIP or TAR file containing loose files" in pants_run.stdout
+    lines = [" ".join(line.split()) for line in pants_run.stdout.splitlines()]
+    assert "archive A ZIP or TAR file containing loose files" in lines
     assert "to get help for a specific target" in pants_run.stdout
 
 

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -34,7 +34,7 @@ def test_help_targets() -> None:
     pants_run = run_pants(["help", "targets"])
     pants_run.assert_success()
     lines = [" ".join(line.split()) for line in pants_run.stdout.splitlines()]
-    assert "archive A ZIP or TAR file containing loose files" in lines
+    assert "archive A ZIP or TAR file containing loose files and code packages." in lines
     assert "to get help for a specific target" in pants_run.stdout
 
 

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -269,6 +269,8 @@ class HelpPrinter(MaybeColor):
         for alias, target_type_info in sorted(
             self._all_help_info.name_to_target_type_info.items(), key=lambda x: x[0]
         ):
+            if alias.startswith("_"):
+                continue
             alias_str = self.maybe_cyan(f"{alias}".ljust(chars_before_description))
             summary = self._format_summary_description(
                 target_type_info.summary, chars_before_description


### PR DESCRIPTION
This allows users to request help for undocumented targets, but it does not appear in `./pants help targets`