### PR TITLE
`MockGet` expects `input_types` kwarg, not `input_type`

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -9,6 +9,30 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 2.15
 ----
 
+### `MockGet` expects `input_types` kwarg, not `input_type`
+
+It's now possible in Pants 2.15 to use zero arguments or multiple arguments in a `Get`. To support this change, `MockGet` from `run_run_with_mocks()` now expects the kwarg `input_types: tuple[type, ...]` rather than `input_type: type`.
+
+Before:
+
+```python
+MockGet(
+    output_type=LintResult,
+    input_type=LintTargetsRequest,
+    mock=lambda _: LintResult(...),
+)
+```
+
+After:
+
+```python
+MockGet(
+    output_type=LintResult,
+    input_types=(LintTargetsRequest,),
+    mock=lambda _: LintResult(...),
+)
+```
+
 ### Deprecated `Platform.current`
 
 The `Platform` to use will soon become dependent on a `@rule`'s position in the `@rule` graph. To

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-testing.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-testing.md
@@ -83,7 +83,7 @@ Approach 2: `run_rule_with_mocks()` (unit tests for rules)
 
 To use `run_rule_with_mocks`, pass the `@rule` as its first arg, then `rule_args=[arg1, arg2, ...]` in the same order as the arguments to the `@rule`. 
 
-If your `@rule` has any `await Get`s or `await Effect`s, set the argument `mock_gets=[]` with `MockGet`/`MockEffect` objects corresponding to each of them. A `MockGet` takes three arguments: `output_type: Type`, `input_type: Type`, and `mock: Callable[[OutputType], InputType]`, which is a function that takes an instance of the `input_type` and returns an instance of the `output_type`.
+If your `@rule` has any `await Get`s or `await Effect`s, set the argument `mock_gets=[]` with `MockGet`/`MockEffect` objects corresponding to each of them. A `MockGet` takes three arguments: `output_type: type`, `input_types: tuple[type, ...]`, and `mock: Callable[..., InputType]`, which is a function that takes an instance of each of the `input_types` and returns a single instance of the `output_type`. 
 
 For example, given this contrived rule to find all targets with `sources` with a certain filename included (find a "needle in the haystack"):
 
@@ -159,7 +159,7 @@ def test_find_needle_in_haystack() -> None:
         mock_gets=[
             MockGet(
                 output_type=HydratedSources,
-                input_type=HydrateSourcesRequest,
+                input_types=(HydrateSourcesRequest,),
                 mock=mock_hydrate_sources,
             )
         ],

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -162,22 +162,22 @@ def assert_build(
         mock_gets=[
             MockGet(
                 output_type=DockerBuildContext,
-                input_type=DockerBuildContextRequest,
+                input_types=(DockerBuildContextRequest,),
                 mock=build_context_mock,
             ),
             MockGet(
                 output_type=WrappedTarget,
-                input_type=WrappedTargetRequest,
+                input_types=(WrappedTargetRequest,),
                 mock=lambda _: WrappedTarget(tgt),
             ),
             MockGet(
                 output_type=DockerImageTags,
-                input_type=DockerImageTagsRequestPlugin,
+                input_types=(DockerImageTagsRequestPlugin,),
                 mock=lambda _: DockerImageTags(plugin_tags),
             ),
             MockGet(
                 output_type=FallibleProcessResult,
-                input_type=Process,
+                input_types=(Process,),
                 mock=run_process_mock,
             ),
         ],

--- a/src/python/pants/backend/go/goals/BUILD
+++ b/src/python/pants/backend/go/goals/BUILD
@@ -2,4 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={"test_test.py": {"timeout": 120}},
+)

--- a/src/python/pants/backend/project_info/list_targets_test.py
+++ b/src/python/pants/backend/project_info/list_targets_test.py
@@ -35,7 +35,7 @@ def run_goal(targets: list[MockTarget], *, show_documented: bool = False) -> tup
             mock_gets=[
                 MockGet(
                     output_type=UnexpandedTargets,
-                    input_type=Addresses,
+                    input_types=(Addresses,),
                     mock=lambda _: UnexpandedTargets(targets),
                 )
             ],

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -51,14 +51,18 @@ def resolve_config(path: str | None, content: str | None) -> str:
 
     mock_gets = [
         MockGet(
-            output_type=ConfigFiles, input_type=ConfigFilesRequest, mock=mock_find_existing_config
+            output_type=ConfigFiles,
+            input_types=(ConfigFilesRequest,),
+            mock=mock_find_existing_config,
         ),
-        MockGet(output_type=DigestContents, input_type=Digest, mock=mock_read_existing_config),
-        MockGet(output_type=Digest, input_type=CreateDigest, mock=mock_create_final_config),
+        MockGet(output_type=DigestContents, input_types=(Digest,), mock=mock_read_existing_config),
+        MockGet(output_type=Digest, input_types=(CreateDigest,), mock=mock_create_final_config),
     ]
 
     result = run_rule_with_mocks(
-        create_or_update_coverage_config, rule_args=[coverage_subsystem], mock_gets=mock_gets
+        create_or_update_coverage_config,
+        rule_args=[coverage_subsystem],
+        mock_gets=mock_gets,  # type: ignore[arg-type]
     )
     assert result.digest == EMPTY_DIGEST
     assert len(resolved_config) == 1

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -8,6 +8,6 @@ python_tests(
     overrides={
         "local_dists_test.py": {"timeout": 120},
         "pex_from_targets_test.py": {"timeout": 200},
-        "pex_test.py": {"timeout": 400},
+        "pex_test.py": {"timeout": 600},
     },
 )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -229,24 +229,34 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             rule_args=[pex_from_targets_request, python_setup],
             mock_gets=[
                 MockGet(
-                    PexRequirements, _PexRequirementsRequest, lambda _: resolved_pex_requirements
+                    output_type=PexRequirements,
+                    input_types=(_PexRequirementsRequest,),
+                    mock=lambda _: resolved_pex_requirements,
                 ),
                 MockGet(
-                    ChosenPythonResolve, ChosenPythonResolveRequest, lambda _: Mock(lockfile=Mock())
+                    output_type=ChosenPythonResolve,
+                    input_types=(ChosenPythonResolveRequest,),
+                    mock=lambda _: Mock(lockfile=Mock()),
                 ),
                 MockGet(
-                    LoadedLockfile,
-                    LoadedLockfileRequest,
-                    lambda _: (
+                    output_type=LoadedLockfile,
+                    input_types=(LoadedLockfileRequest,),
+                    mock=lambda _: (
                         loaded_lockfile__pex
                         if mode == RequirementMode.PEX_LOCKFILE
                         else loaded_lockfile__not_pex
                     ),
                 ),
                 MockGet(
-                    OptionalPexRequest, _RepositoryPexRequest, lambda _: mock_repository_pex_request
+                    output_type=OptionalPexRequest,
+                    input_types=(_RepositoryPexRequest,),
+                    mock=lambda _: mock_repository_pex_request,
                 ),
-                MockGet(OptionalPex, OptionalPexRequest, lambda _: mock_repository_pex),
+                MockGet(
+                    output_type=OptionalPex,
+                    input_types=(OptionalPexRequest,),
+                    mock=lambda _: mock_repository_pex,
+                ),
             ],
         )
         if expected:

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -629,7 +629,11 @@ def test_determine_pex_python_and_platforms() -> None:
             _determine_pex_python_and_platforms,
             rule_args=[request],
             mock_gets=[
-                MockGet(PythonExecutable, InterpreterConstraints, lambda _: discovered_python)
+                MockGet(
+                    output_type=PythonExecutable,
+                    input_types=(InterpreterConstraints,),
+                    mock=lambda _: discovered_python,
+                )
             ],
         )
         assert result == expected
@@ -704,14 +708,14 @@ def test_setup_pex_requirements() -> None:
             rule_args=[request, create_subsystem(PythonSetup)],
             mock_gets=[
                 MockGet(
-                    LoadedLockfile,
-                    LoadedLockfileRequest,
-                    lambda _: create_loaded_lockfile(is_pex_lock),
+                    output_type=LoadedLockfile,
+                    input_types=(LoadedLockfileRequest,),
+                    mock=lambda _: create_loaded_lockfile(is_pex_lock),
                 ),
                 MockGet(
-                    ResolvePexConfig,
-                    ResolvePexConfigRequest,
-                    lambda _: ResolvePexConfig(
+                    output_type=ResolvePexConfig,
+                    input_types=(ResolvePexConfigRequest,),
+                    mock=lambda _: ResolvePexConfig(
                         indexes=("custom-index",),
                         find_links=("custom-find-links",),
                         manylinux=None,
@@ -721,7 +725,11 @@ def test_setup_pex_requirements() -> None:
                         path_mappings=(),
                     ),
                 ),
-                MockGet(Digest, CreateDigest, lambda _: constraints_digest),
+                MockGet(
+                    output_type=Digest,
+                    input_types=(CreateDigest,),
+                    mock=lambda _: constraints_digest,
+                ),
             ],
         )
         assert result == expected

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -144,7 +144,7 @@ def run_typecheck_rule(
             mock_gets=[
                 MockGet(
                     output_type=CheckResults,
-                    input_type=CheckRequest,
+                    input_types=(CheckRequest,),
                     mock=lambda field_set_collection: field_set_collection.check_results,
                 ),
             ],

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -92,7 +92,7 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
             mock_gets=[
                 MockGet(
                     output_type=ExportResults,
-                    input_type=ExportRequest,
+                    input_types=(ExportRequest,),
                     mock=lambda req: ExportResults(
                         (
                             mock_export(
@@ -112,17 +112,17 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                 ),
                 MockGet(
                     output_type=Digest,
-                    input_type=MergeDigests,
+                    input_types=(MergeDigests,),
                     mock=lambda md: rule_runner.request(Digest, [md]),
                 ),
                 MockGet(
                     output_type=Digest,
-                    input_type=AddPrefix,
+                    input_types=(AddPrefix,),
                     mock=lambda ap: rule_runner.request(Digest, [ap]),
                 ),
                 MockGet(
                     output_type=Environment,
-                    input_type=EnvironmentRequest,
+                    input_types=(EnvironmentRequest,),
                     mock=lambda env: rule_runner.request(Environment, [env]),
                 ),
                 MockEffect(

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -208,42 +208,42 @@ def run_lint_rule(
             mock_gets=[
                 MockGet(
                     output_type=SourceFiles,
-                    input_type=SourceFilesRequest,
+                    input_types=(SourceFilesRequest,),
                     mock=lambda _: SourceFiles(EMPTY_SNAPSHOT, ()),
                 ),
                 MockGet(
                     output_type=LintResults,
-                    input_type=LintTargetsRequest,
+                    input_types=(LintTargetsRequest,),
                     mock=lambda mock_request: mock_request.lint_results,
                 ),
                 MockGet(
                     output_type=LintResults,
-                    input_type=LintFilesRequest,
+                    input_types=(LintFilesRequest,),
                     mock=lambda mock_request: mock_request.lint_results,
                 ),
                 MockGet(
                     output_type=FmtResult,
-                    input_type=FmtTargetsRequest,
+                    input_types=(FmtTargetsRequest,),
                     mock=lambda mock_request: mock_request.fmt_result,
                 ),
                 MockGet(
                     output_type=FmtResult,
-                    input_type=_FmtBuildFilesRequest,
+                    input_types=(_FmtBuildFilesRequest,),
                     mock=lambda mock_request: mock_request.fmt_result,
                 ),
                 MockGet(
                     output_type=FilteredTargets,
-                    input_type=Specs,
+                    input_types=(Specs,),
                     mock=lambda _: FilteredTargets(targets),
                 ),
                 MockGet(
                     output_type=SpecsPaths,
-                    input_type=Specs,
+                    input_types=(Specs,),
                     mock=lambda _: SpecsPaths(("f.txt", "BUILD"), ()),
                 ),
                 MockGet(
                     output_type=Snapshot,
-                    input_type=PathGlobs,
+                    input_types=(PathGlobs,),
                     mock=lambda _: EMPTY_SNAPSHOT,
                 ),
             ],

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -97,22 +97,22 @@ def single_target_run(
             mock_gets=[
                 MockGet(
                     output_type=TargetRootsToFieldSets,
-                    input_type=TargetRootsToFieldSetsRequest,
+                    input_types=(TargetRootsToFieldSetsRequest,),
                     mock=lambda _: TargetRootsToFieldSets({target: [field_set]}),
                 ),
                 MockGet(
                     output_type=WrappedTarget,
-                    input_type=WrappedTargetRequest,
+                    input_types=(WrappedTargetRequest,),
                     mock=lambda _: WrappedTarget(target),
                 ),
                 MockGet(
                     output_type=RunRequest,
-                    input_type=TestRunFieldSet,
+                    input_types=(TestRunFieldSet,),
                     mock=lambda _: create_mock_run_request(rule_runner, program_text),
                 ),
                 MockGet(
                     output_type=RunDebugAdapterRequest,
-                    input_type=TestRunFieldSet,
+                    input_types=(TestRunFieldSet,),
                     mock=lambda _: create_mock_run_debug_adapter_request(rule_runner, program_text),
                 ),
                 MockEffect(

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -231,38 +231,38 @@ def run_test_rule(
             mock_gets=[
                 MockGet(
                     output_type=TargetRootsToFieldSets,
-                    input_type=TargetRootsToFieldSetsRequest,
+                    input_types=(TargetRootsToFieldSetsRequest,),
                     mock=mock_find_valid_field_sets,
                 ),
                 MockGet(
                     output_type=TestResult,
-                    input_type=TestFieldSet,
+                    input_types=(TestFieldSet,),
                     mock=lambda fs: fs.test_result,
                 ),
                 MockGet(
                     output_type=TestDebugRequest,
-                    input_type=TestFieldSet,
+                    input_types=(TestFieldSet,),
                     mock=mock_debug_request,
                 ),
                 MockGet(
                     output_type=TestDebugAdapterRequest,
-                    input_type=TestFieldSet,
+                    input_types=(TestFieldSet,),
                     mock=mock_debug_adapter_request,
                 ),
                 # Merge XML results.
                 MockGet(
                     output_type=Digest,
-                    input_type=MergeDigests,
+                    input_types=(MergeDigests,),
                     mock=lambda _: EMPTY_DIGEST,
                 ),
                 MockGet(
                     output_type=CoverageReports,
-                    input_type=CoverageDataCollection,
+                    input_types=(CoverageDataCollection,),
                     mock=mock_coverage_report_generation,
                 ),
                 MockGet(
                     output_type=OpenFiles,
-                    input_type=OpenFilesRequest,
+                    input_types=(OpenFilesRequest,),
                     mock=lambda _: OpenFiles(()),
                 ),
                 MockEffect(

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -181,7 +181,7 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
             mock_gets=[
                 MockGet(
                     output_type=LoadedLockfile,
-                    input_type=LoadedLockfileRequest,
+                    input_types=(LoadedLockfileRequest,),
                     mock=lambda _: loaded_lock,
                 )
             ],

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -62,12 +62,12 @@ def test_parse_address_family_empty() -> None:
         mock_gets=[
             MockGet(
                 output_type=DigestContents,
-                input_type=PathGlobs,
+                input_types=(PathGlobs,),
                 mock=lambda _: DigestContents([FileContent(path="/dev/null/BUILD", content=b"")]),
             ),
             MockGet(
                 output_type=OptionalAddressFamily,
-                input_type=AddressFamilyDir,
+                input_types=(AddressFamilyDir,),
                 mock=lambda _: OptionalAddressFamily("/dev"),
             ),
         ],
@@ -86,7 +86,7 @@ def run_prelude_parsing_rule(prelude_content: str) -> BuildFilePreludeSymbols:
         mock_gets=[
             MockGet(
                 output_type=DigestContents,
-                input_type=PathGlobs,
+                input_types=(PathGlobs,),
                 mock=lambda _: DigestContents(
                     [FileContent(path="/dev/null/prelude", content=prelude_content.encode())]
                 ),

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -278,7 +278,7 @@ class TestRule:
         res = run_rule_with_mocks(
             a_goal_rule_generator,
             rule_args=[Console()],
-            mock_gets=[MockGet(output_type=A, input_type=str, mock=lambda _: A())],
+            mock_gets=[MockGet(output_type=A, input_types=(str,), mock=lambda _: A())],
         )
         assert res == Example(0)
 

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -53,10 +53,10 @@ def _find_root(
                 mock_gets=[
                     MockGet(
                         output_type=OptionalSourceRoot,
-                        input_type=SourceRootRequest,
+                        input_types=(SourceRootRequest,),
                         mock=_do_find_root,
                     ),
-                    MockGet(output_type=Paths, input_type=PathGlobs, mock=_mock_fs_check),
+                    MockGet(output_type=Paths, input_types=(PathGlobs,), mock=_mock_fs_check),
                 ],
             ),
         )
@@ -232,10 +232,10 @@ def test_all_roots() -> None:
         all_roots,
         rule_args=[source_root_config],
         mock_gets=[
-            MockGet(output_type=Paths, input_type=PathGlobs, mock=provider_rule),
+            MockGet(output_type=Paths, input_types=(PathGlobs,), mock=provider_rule),
             MockGet(
                 output_type=OptionalSourceRoot,
-                input_type=SourceRootRequest,
+                input_types=(SourceRootRequest,),
                 mock=source_root_mock_rule,
             ),
         ],
@@ -270,10 +270,10 @@ def test_all_roots_with_root_at_buildroot() -> None:
         all_roots,
         rule_args=[source_root_config],
         mock_gets=[
-            MockGet(output_type=Paths, input_type=PathGlobs, mock=provider_rule),
+            MockGet(output_type=Paths, input_types=(PathGlobs,), mock=provider_rule),
             MockGet(
                 output_type=OptionalSourceRoot,
-                input_type=SourceRootRequest,
+                input_types=(SourceRootRequest,),
                 mock=lambda req: OptionalSourceRoot(SourceRoot(".")),
             ),
         ],


### PR DESCRIPTION
Follow up to https://github.com/pantsbuild/pants/pull/16668.

[ci skip-rust]