### PR TITLE
[WIP] go: add "pure" field to go_binary to disable cgo when set

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -29,7 +29,7 @@ from pants.backend.go.util_rules import (
     pkg_analyzer,
     sdk,
     tests_analysis,
-    third_party_pkg,
+    third_party_pkg, context,
 )
 
 
@@ -47,6 +47,7 @@ def rules():
         *coverage.rules(),
         *coverage_output.rules(),
         *cgo.rules(),
+        *context.rules(),
         *third_party_pkg.rules(),
         *go_bootstrap.rules(),
         *goroot.rules(),

--- a/src/python/pants/backend/go/dependency_inference.py
+++ b/src/python/pants/backend/go/dependency_inference.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.go.util_rules.context import GoBuildContext
 from pants.build_graph.address import Address
 from pants.engine.environment import EnvironmentName
 from pants.engine.unions import union
 from pants.util.frozendict import FrozenDict
 
 
-@union(in_scope_types=[EnvironmentName])
+@union(in_scope_types=[EnvironmentName, GoBuildContext])
 @dataclass(frozen=True)
 class GoModuleImportPathsMappingsHook:
     """An entry point for a specific implementation of mapping Go import paths to owning targets.

--- a/src/python/pants/backend/go/goals/debug_goals.py
+++ b/src/python/pants/backend/go/goals/debug_goals.py
@@ -17,6 +17,7 @@ from pants.backend.go.target_types import (
 )
 from pants.backend.go.util_rules import first_party_pkg, third_party_pkg
 from pants.backend.go.util_rules.cgo import CGoCompileRequest, CGoCompileResult
+from pants.backend.go.util_rules.context import GoBuildContext
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
     FallibleFirstPartyPkgDigest,
@@ -193,7 +194,7 @@ async def go_export_cgo_codegen(
     workspace: Workspace,
     golang_subsystem: GolangSubsystem,
 ) -> GoExportCgoCodegen:
-    if not golang_subsystem.cgo_enabled:
+    if not golang_subsystem.cgo_allowed:
         raise ValueError(
             "Nothing to export since cgo is disabled, which is set by the option [golang].cgo_enabled"
         )

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -1,13 +1,14 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import dataclasses
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.go.target_types import GoBinaryMainPackageField, GoBinaryTarget, GoPackageTarget
+from pants.backend.go.target_types import GoBinaryMainPackageField, GoBinaryTarget, GoPackageTarget, GoPureField
 from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.backend.go.util_rules.build_pkg import BuiltGoPackage
 from pants.backend.go.util_rules.build_pkg_target import BuildGoPackageTargetRequest
+from pants.backend.go.util_rules.context import GoBuildContext
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
     FirstPartyPkgAnalysisRequest,
@@ -34,13 +35,21 @@ class GoBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
     main: GoBinaryMainPackageField
     output_path: OutputPathField
+    pure: GoPureField
 
 
 @rule(desc="Package Go binary", level=LogLevel.DEBUG)
-async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
+async def package_go_binary(
+    field_set: GoBinaryFieldSet,
+    go_build_context: GoBuildContext,
+) -> BuiltPackage:
+    if field_set.pure.value:
+        go_build_context = dataclasses.replace(go_build_context, cgo_allowed=False)
+
     main_pkg = await Get(GoBinaryMainPackage, GoBinaryMainPackageRequest(field_set.main))
     main_pkg_analysis = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(main_pkg.address)
+        FallibleFirstPartyPkgAnalysis, {FirstPartyPkgAnalysisRequest(main_pkg.address) : FirstPartyPkgAnalysisRequest,
+                                        go_build_context: GoBuildContext}
     )
     analysis = main_pkg_analysis.analysis
     if not analysis:
@@ -53,25 +62,27 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             f"{GoBinaryTarget.address} target `{field_set.address}` but uses package name `{analysis.name}` "
             "instead of `main`. Go requires that main packages actually use `main` as the package name."
         )
+
+    build_request = BuildGoPackageTargetRequest(main_pkg.address, is_main=True)
     built_package = await Get(
-        BuiltGoPackage, BuildGoPackageTargetRequest(main_pkg.address, is_main=True)
+        BuiltGoPackage, {build_request: BuildGoPackageTargetRequest, go_build_context: GoBuildContext}
     )
     main_pkg_a_file_path = built_package.import_paths_to_pkg_a_files["main"]
     import_config = await Get(
-        ImportConfig, ImportConfigRequest(built_package.import_paths_to_pkg_a_files)
+        ImportConfig, {ImportConfigRequest(built_package.import_paths_to_pkg_a_files) : ImportConfigRequest, go_build_context: GoBuildContext}
     )
     input_digest = await Get(Digest, MergeDigests([built_package.digest, import_config.digest]))
 
     output_filename = PurePath(field_set.output_path.value_or_default(file_ending=None))
+    link_request = LinkGoBinaryRequest(
+        input_digest=input_digest,
+        archives=(main_pkg_a_file_path,),
+        import_config_path=import_config.CONFIG_PATH,
+        output_filename=f"./{output_filename.name}",
+        description=f"Link Go binary for {field_set.address}",
+    )
     binary = await Get(
-        LinkedGoBinary,
-        LinkGoBinaryRequest(
-            input_digest=input_digest,
-            archives=(main_pkg_a_file_path,),
-            import_config_path=import_config.CONFIG_PATH,
-            output_filename=f"./{output_filename.name}",
-            description=f"Link Go binary for {field_set.address}",
-        ),
+        LinkedGoBinary, {link_request: LinkGoBinaryRequest, go_build_context: GoBuildContext}
     )
 
     renamed_output_digest = await Get(Digest, AddPrefix(binary.digest, str(output_filename.parent)))

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -100,12 +100,12 @@ class GolangSubsystem(Subsystem):
         advanced=True,
     )
 
-    cgo_enabled = BoolOption(
-        "--cgo-enabled",
+    cgo_allowed = BoolOption(
+        "--cgo-allowed",
         default=False,
         help=softwrap(
             """\
-            Enable Cgos support, which allows Go and C code to interact. This option must be enabled for any
+            Enable Cgo support, which allows Go and C code to interact. This option must be enabled for any
             packages making use of Cgo to actually be compiled with Cgo support.
 
             TODO: Future Pants changes may also require enabling Cgo via fields on relevant Go targets.

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -22,7 +22,7 @@ from pants.engine.target import (
     Target,
     TargetGenerator,
     ValidNumbers,
-    generate_multiple_sources_field_help_message,
+    generate_multiple_sources_field_help_message, TriBoolField,
 )
 from pants.util.strutil import softwrap
 
@@ -230,6 +230,19 @@ class GoBinaryDependenciesField(Dependencies):
     alias = "_dependencies"
 
 
+class GoPureField(BoolField):
+    alias = "pure"
+    help = softwrap(
+        """
+        Controls whether Pants will build "pure" Go binaries with only Go code. That is, Cgo support will be disabled
+        for all packages which comprise the binary, regardless of whether they are first-party or third-party code.
+        
+        Setting this field to `True` is the equivalent of setting the `CGO_ENABLED` environment variable to `0`
+        when using `go build`. 
+        """
+    )
+
+
 class GoBinaryTarget(Target):
     alias = "go_binary"
     core_fields = (
@@ -237,6 +250,7 @@ class GoBinaryTarget(Target):
         OutputPathField,
         GoBinaryMainPackageField,
         GoBinaryDependenciesField,
+        GoPureField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -12,7 +12,7 @@ from pathlib import PurePath
 from typing import Iterable
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
-from pants.backend.go.util_rules import cgo_binaries, cgo_pkgconfig
+from pants.backend.go.util_rules import cgo_binaries, cgo_pkgconfig, context
 from pants.backend.go.util_rules.cgo_binaries import CGoBinaryPathRequest
 from pants.backend.go.util_rules.cgo_pkgconfig import (
     CGoPkgConfigFlagsRequest,
@@ -876,4 +876,5 @@ def rules():
         *collect_rules(),
         *cgo_binaries.rules(),
         *cgo_pkgconfig.rules(),
+        *context.rules(),
     )

--- a/src/python/pants/backend/go/util_rules/context.py
+++ b/src/python/pants/backend/go/util_rules/context.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.engine.rules import collect_rules, rule
+
+
+@dataclass(frozen=True)
+class GoBuildContext:
+    """Build-related options. Those options are centralized in this dataclass so that configuration options can be
+    merged with any override values from relevant target fields."""
+    cgo_allowed: bool
+
+
+@rule
+async def go_global_context(golang_subsystem: GolangSubsystem) -> GoBuildContext:
+    return GoBuildContext(cgo_allowed=golang_subsystem.cgo_allowed)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -14,6 +14,7 @@ from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import pkg_analyzer
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
+from pants.backend.go.util_rules.context import GoBuildContext
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.go_mod import (
     GoModInfo,
@@ -240,7 +241,7 @@ async def compute_first_party_package_import_path(
 async def analyze_first_party_package(
     request: FirstPartyPkgAnalysisRequest,
     analyzer: PackageAnalyzerSetup,
-    golang_subsystem: GolangSubsystem,
+    go_build_context: GoBuildContext,
 ) -> FallibleFirstPartyPkgAnalysis:
     wrapped_target, import_path_info, owning_go_mod = await MultiGet(
         Get(
@@ -267,7 +268,7 @@ async def analyze_first_party_package(
             input_digest=input_digest,
             description=f"Determine metadata for {request.address}",
             level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
+            env={"CGO_ENABLED": "1" if go_build_context.cgo_allowed else "0"},
         ),
     )
     return FallibleFirstPartyPkgAnalysis.from_process_result(

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -16,6 +16,7 @@ from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoB
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import pkg_analyzer
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
+from pants.backend.go.util_rules.context import GoBuildContext
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
@@ -271,7 +272,7 @@ def _freeze_json_dict(d: dict[Any, Any]) -> FrozenDict[str, Any]:
 async def analyze_go_third_party_module(
     request: AnalyzeThirdPartyModuleRequest,
     analyzer: PackageAnalyzerSetup,
-    golang_subsystem: GolangSubsystem,
+    go_build_context: GoBuildContext,
 ) -> AnalyzedThirdPartyModule:
     # Download the module.
     download_result = await Get(
@@ -338,7 +339,7 @@ async def analyze_go_third_party_module(
             },
             description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
             level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
+            env={"CGO_ENABLED": "1" if go_build_context.cgo_allowed else "0"},
         ),
     )
 


### PR DESCRIPTION
Add a `pure` field to `go_binary` which disables cgo when set. I.e., the binary is built "purely" with Go sources.

Introduces `GoBuildContext` to carry build-related options like whether to permit cgo or not (and eventually compiler flags to use etc.)

[ci skip-rust]

[ci skip-build-wheels]