### PR TITLE
Simplify rule graph setup for the Python and core backends

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -12,6 +12,7 @@ from pants.backend.python.goals.coverage_py import (
     CoverageSubsystem,
     PytestCoverageData,
 )
+from pants.backend.python.subsystems import pytest
 from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.subsystems.pytest import PyTest, PythonTestFieldSet
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -475,6 +476,7 @@ async def setup_runtime_packages(request: RuntimePackagesPluginRequest) -> Pytes
 def rules():
     return [
         *collect_rules(),
+        *pytest.rules(),
         UnionRule(TestFieldSet, PythonTestFieldSet),
         UnionRule(PytestPluginSetupRequest, RuntimePackagesPluginRequest),
     ]

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -17,9 +17,7 @@ from pants.backend.python.goals.coverage_py import create_or_update_coverage_con
 from pants.backend.python.goals.pytest_runner import PytestPluginSetup, PytestPluginSetupRequest
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.pytest import PythonTestFieldSet
-from pants.backend.python.subsystems.pytest import rules as pytest_subsystem_rules
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.subsystems.setuptools import rules as setuptools_rules
 from pants.backend.python.target_types import (
     PexBinary,
     PythonDistribution,
@@ -57,7 +55,6 @@ def rule_runner() -> RuleRunner:
             build_runtime_package_dependencies,
             create_or_update_coverage_config,
             *pytest_runner.rules(),
-            *pytest_subsystem_rules(),
             *pex_from_targets.rules(),
             *dependency_inference_rules.rules(),
             *distdir.rules(),
@@ -67,7 +64,6 @@ def rule_runner() -> RuleRunner:
             *target_types_rules.rules(),
             *local_dists.rules(),
             *setup_py.rules(),
-            *setuptools_rules(),
             QueryRule(TestResult, (PythonTestFieldSet,)),
             QueryRule(TestDebugRequest, (PythonTestFieldSet,)),
             QueryRule(TestDebugAdapterRequest, (PythonTestFieldSet,)),

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
+from pants.backend.python.subsystems import ipython
 from pants.backend.python.subsystems.ipython import IPython
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
@@ -197,6 +198,7 @@ async def create_ipython_repl_request(
 def rules():
     return [
         *collect_rules(),
+        *ipython.rules(),
         UnionRule(ReplImplementation, PythonRepl),
         UnionRule(ReplImplementation, IPythonRepl),
     ]

--- a/src/python/pants/backend/python/goals/repl_integration_test.py
+++ b/src/python/pants/backend/python/goals/repl_integration_test.py
@@ -9,7 +9,6 @@ import pytest
 
 from pants.backend.codegen.protobuf.target_types import ProtobufSourceTarget
 from pants.backend.python.goals import repl as python_repl
-from pants.backend.python.subsystems.ipython import rules as ipython_subsystem_rules
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     PythonRequirementTarget,
@@ -38,7 +37,6 @@ def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
             *repl_rules(),
-            *ipython_subsystem_rules(),
             *python_repl.rules(),
             *pex_from_targets.rules(),
             *local_dists.rules(),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -29,7 +29,7 @@ from pants.backend.python.macros.pipenv_requirements import PipenvRequirementsTa
 from pants.backend.python.macros.poetry_requirements import PoetryRequirementsTargetGenerator
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
-from pants.backend.python.subsystems import debugpy, ipython, pytest, python_native_code, setuptools
+from pants.backend.python.subsystems import debugpy
 from pants.backend.python.target_types import (
     PexBinariesGeneratorTarget,
     PexBinary,
@@ -45,8 +45,6 @@ from pants.backend.python.util_rules import (
     ancestor_files,
     local_dists,
     pex,
-    pex_cli,
-    pex_environment,
     pex_from_targets,
     python_sources,
 )
@@ -60,30 +58,27 @@ def build_file_aliases():
 
 def rules():
     return (
-        *ancestor_files.rules(),
+        *target_types_rules.rules(),
+        # Subsystems
         *coverage_py.rules(),
         *debugpy.rules(),
+        # Util rules
+        *ancestor_files.rules(),
         *dependency_inference_rules.rules(),
-        *export.rules(),
-        *ipython.rules(),
-        *local_dists.rules(),
-        *lockfile.rules(),
-        *package_pex_binary.rules(),
         *pex.rules(),
-        *pex_cli.rules(),
-        *pex_environment.rules(),
         *pex_from_targets.rules(),
-        *pytest.rules(),
-        *pytest_runner.rules(),
-        *python_native_code.rules(),
         *python_sources.rules(),
+        # Goals
+        *package_pex_binary.rules(),
+        *pytest_runner.rules(),
         *repl.rules(),
         *run_pex_binary.rules(),
         *run_python_source.rules(),
         *setup_py.rules(),
-        *setuptools.rules(),
         *tailor.rules(),
-        *target_types_rules.rules(),
+        *local_dists.rules(),
+        *export.rules(),
+        *lockfile.rules(),
         # Macros.
         *pipenv_requirements.rules(),
         *poetry_requirements.rules(),

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -4,7 +4,6 @@
 import os
 from typing import Dict
 
-from pants.engine.rules import collect_rules
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import safe_shlex_join, safe_shlex_split
@@ -32,7 +31,3 @@ class PythonNativeCodeSubsystem(Subsystem):
             "CPPFLAGS": safe_shlex_join(self.cpp_flags),
             "LDFLAGS": safe_shlex_join(self.ld_flags),
         }
-
-
-def rules():
-    return collect_rules()

--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -11,6 +11,7 @@ from typing import Any, Mapping
 
 import toml
 
+from pants.backend.python.subsystems import setuptools
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -325,4 +326,4 @@ def distutils_repr(obj) -> str:
 
 
 def rules():
-    return (*collect_rules(), *pex_rules())
+    return (*collect_rules(), *setuptools.rules(), *pex_rules())

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -8,6 +8,7 @@ import os
 from abc import ABCMeta
 from dataclasses import dataclass
 
+from pants.core.util_rules import distdir
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, MergeDigests, Workspace
@@ -149,4 +150,4 @@ async def package_asset(workspace: Workspace, dist_dir: DistDir) -> Package:
 
 
 def rules():
-    return collect_rules()
+    return (*collect_rules(), *distdir.rules())

--- a/src/python/pants/core/goals/publish_test.py
+++ b/src/python/pants/core/goals/publish_test.py
@@ -9,18 +9,18 @@ from textwrap import dedent
 
 import pytest
 
+from pants.backend.python.goals import setup_py
 from pants.backend.python.macros.python_artifact import PythonArtifact
-from pants.backend.python.register import rules as python_rules
 from pants.backend.python.target_types import PythonDistribution, PythonSourcesGeneratorTarget
+from pants.backend.python.target_types_rules import rules as python_target_type_rules
+from pants.core.goals import package, publish
 from pants.core.goals.publish import (
     Publish,
     PublishFieldSet,
     PublishPackages,
     PublishProcesses,
     PublishRequest,
-    rules,
 )
-from pants.core.register import rules as core_rules
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import rule
 from pants.engine.target import StringSequenceField
@@ -68,9 +68,10 @@ async def mock_publish(request: MockPublishRequest) -> PublishProcesses:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *core_rules(),
-            *python_rules(),
-            *rules(),
+            *package.rules(),
+            *publish.rules(),
+            *setup_py.rules(),
+            *python_target_type_rules(),
             mock_publish,
             PythonDistribution.register_plugin_field(MockRepositoriesField),
             *PublishTestFieldSet.rules(),

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -36,7 +36,6 @@ from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import (
     archive,
     config_files,
-    distdir,
     external_tool,
     source_files,
     stripped_source_files,
@@ -71,7 +70,6 @@ def rules():
         *anonymous_telemetry.rules(),
         *archive.rules(),
         *config_files.rules(),
-        *distdir.rules(),
         *external_tool.rules(),
         *git.rules(),
         *source_files.rules(),


### PR DESCRIPTION
In another PR, I had a rule graph issue. This is prework to fix that by leveraging a principle we've done before: files register their direct dependencies.