### PR TITLE
Render `experimental_(run_)shell_command` at Debug level.

### DIFF
--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -231,6 +231,7 @@ async def prepare_shell_command_process(
         output_files=output_files,
         timeout_seconds=timeout,
         working_directory=working_directory,
+        level=LogLevel.DEBUG,
     )
 
 


### PR DESCRIPTION
#16825 describes a case where the actual execution of a process takes a long time, but because the process is not marked at least `DEBUG` level, what ends up rendering is the parent `Scheduling: $process` workunit (which is always DEBUG for now due to #14680).

[ci skip-build-wheels]