### PR TITLE
docker: upgrade bollard crate for bug fix

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -178,11 +178,10 @@ dependencies = [
 [[package]]
 name = "bollard"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82e7850583ead5f8bbef247e2a3c37a19bd576e8420cd262a6711921827e1e5"
+source = "git+https://github.com/fussybeaver/bollard.git?rev=2e10fe31076a6e298697fc6e31fa3676b7498b6c#2e10fe31076a6e298697fc6e31fa3676b7498b6c"
 dependencies = [
  "base64",
- "bollard-stubs",
+ "bollard-stubs 1.42.0-rc.4",
  "bytes",
  "futures-core",
  "futures-util",
@@ -208,6 +207,15 @@ name = "bollard-stubs"
 version = "1.42.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed59b5c00048f48d7af971b71f800fdf23e858844a6f9e4d32ca72e9399e7864"
+dependencies = [
+ "serde",
+ "serde_with",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.42.0-rc.4"
+source = "git+https://github.com/fussybeaver/bollard.git?rev=2e10fe31076a6e298697fc6e31fa3676b7498b6c#2e10fe31076a6e298697fc6e31fa3676b7498b6c"
 dependencies = [
  "serde",
  "serde_with",
@@ -2282,7 +2290,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "bollard",
- "bollard-stubs",
+ "bollard-stubs 1.42.0-rc.3",
  "bytes",
  "cache",
  "concrete_time",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 async-stream = "0.3"
 async-trait = "0.1"
 async-lock = "2.5"
-bollard = "0.13"
+bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2e10fe31076a6e298697fc6e31fa3676b7498b6c" }
 bollard-stubs = "1.42.0-rc.3"
 walkdir = "2"
 protos = { path = "../protos" }

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -551,7 +551,7 @@ impl ContainerCache {
 
     let config = bollard::container::Config {
       entrypoint: Some(vec!["/bin/sh".to_string()]),
-      host_config: Some(bollard_stubs::models::HostConfig {
+      host_config: Some(bollard::service::HostConfig {
         binds: Some(vec![
           format!("{}:{}", work_dir_base, SANDBOX_BASE_PATH_IN_CONTAINER),
           // DOCKER-TODO: Consider making this bind mount read-only.
@@ -566,7 +566,7 @@ impl ContainerCache {
         ]),
         // The init process ensures that child processes are properly reaped.
         init: Some(true),
-        ..bollard_stubs::models::HostConfig::default()
+        ..bollard::service::HostConfig::default()
       }),
       image: Some(image.clone()),
       tty: Some(true),


### PR DESCRIPTION
Upgrade the `bollard` crate which is used by the Docker command runner to pick up a bug fix in decoding errors returned by the Docker daemon. Some errors may not have been actually decoded in the prior release. 

https://github.com/fussybeaver/bollard/commit/a1fad80acf71f8ec5af476095377b76608bcc8a0 is the specific commit we want but pin to latest development version until a release is made.

[ci skip-build-wheels]