### PR TITLE
`Environment`, `EnvironmentRequest`, and `CompleteEnvironment` now include `Vars` in the name

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -9,6 +9,15 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 2.15
 ----
 
+### `Environment`, `EnvironmentRequest`, and `CompleteEnvironment` now include `Vars` in the name
+
+Before: `Environment`, `EnvironmentRequest`, and `CompleteEnvironment`
+After: `EnvironmentVars`, `EnvironmentVarsRequest`, and `CompleteEnvironmentVars`
+
+The old names still exist as aliases, but we recommend changing to the new values for clarity.
+
+This rename was to avoid ambiguity with the new "environments" mechanism, which lets users specify different options for environments like Linux vs. macOS and running in Docker images.
+
 ### `MockGet` expects `input_types` kwarg, not `input_type`
 
 It's now possible in Pants 2.15 to use zero arguments or multiple arguments in a `Get`. To support this change, `MockGet` from `run_run_with_mocks()` now expects the kwarg `input_types: tuple[type, ...]` rather than `input_type: type`.

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -9,12 +9,15 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 2.15
 ----
 
-### `Environment`, `EnvironmentRequest`, and `CompleteEnvironment` now include `Vars` in the name
+### `Environment`, `EnvironmentRequest`, and `CompleteEnvironment` renamed and moved
 
-Before: `Environment`, `EnvironmentRequest`, and `CompleteEnvironment`
-After: `EnvironmentVars`, `EnvironmentVarsRequest`, and `CompleteEnvironmentVars`
+The types were moved from `pants.engine.environment` to `pants.engine.env_vars`, and now have
+`Vars` in their names:
 
-The old names still exist as aliases, but we recommend changing to the new values for clarity.
+Before: `pants.engine.environment.{Environment,EnvironmentRequest,CompleteEnvironment}`
+After: `pants.engine.env_vars.{EnvironmentVars,EnvironmentVarsRequest,CompleteEnvironmentVars}`
+
+The old names still exist until Pants 2.16 as deprecated aliases.
 
 This rename was to avoid ambiguity with the new "environments" mechanism, which lets users specify different options for environments like Linux vs. macOS and running in Docker images.
 

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
@@ -50,15 +50,16 @@ To populate the temporary directory with files, use the parameter `input_digest:
 
 To set environment variables, use the parameter `env: Mapping[str, str]`. `@rules` are prevented from accessing `os.environ` (it will always be empty) because this reduces reproducibility and breaks caching. Instead, either hardcode the value or add a [`Subsystem` option](doc:rules-api-subsystems) for the environment variable in question, or request the `Environment` type in your `@rule`.
 
-The `Environment` type contains a subset of the environment that Pants was run in, and is requested via a `EnvironmentRequest` that lists the variables to consume.
+The `EnvironmentVars` type contains a subset of the environment that Pants was run in, and is requested via a `EnvironmentVarsRequest` that lists the variables to consume.
 
 ```python
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, rule
+
 
 @rule
 async def partial_env(...) -> Foo:
-    relevant_env = await Get(Environment, EnvironmentRequest(["RELEVANT_VAR", "PATH"]))
+    relevant_env_vars = await Get(EnvironmentVars, EnvironmentVarsRequest(["RELEVANT_VAR", "PATH"]))
     ..
 ```
 

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
@@ -53,7 +53,8 @@ To set environment variables, use the parameter `env: Mapping[str, str]`. `@rule
 The `EnvironmentVars` type contains a subset of the environment that Pants was run in, and is requested via a `EnvironmentVarsRequest` that lists the variables to consume.
 
 ```python
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+
+from pants.engine.env_vars import EnvironmentVarsRequest, EnvironmentVars
 from pants.engine.rules import Get, rule
 
 

--- a/pants.toml
+++ b/pants.toml
@@ -37,6 +37,9 @@ plugins = [
   "toolchain.pants.plugin==0.22.0",
 ]
 
+# Remove once Toolchain plugin is updated.
+ignore_warnings = ["DEPRECATED: `pants.engine.environment"]
+
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the
 # path but not consumed by python, and additionally add the rust code.
 pantsd_invalidation_globs.add = [

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -20,7 +20,7 @@ from pants.core.util_rules import distdir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -20,7 +20,7 @@ from pants.core.util_rules import distdir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -127,7 +127,7 @@ async def generate_scala_from_protobuf(
         Get(Digest, CreateDigest([Directory(output_dir)])),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.protocol_target.address])),
         # Need PATH so that ScalaPB can invoke `mkfifo`.
-        Get(Environment, EnvironmentRequest(requested=["PATH"])),
+        Get(EnvironmentVars, EnvironmentVarsRequest(requested=["PATH"])),
     )
 
     # NB: By stripping the source roots, we avoid having to set the value `--proto_path`

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -14,7 +14,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPaths,
     BinaryPathTest,
 )
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
@@ -122,7 +122,7 @@ async def generate_apache_thrift_sources(
 
 @rule
 async def setup_thrift_tool(apache_thrift: ApacheThriftSubsystem) -> ApacheThriftSetup:
-    env = await Get(Environment, EnvironmentRequest(["PATH"]))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     search_paths = apache_thrift.thrift_search_paths(env)
     all_thrift_binary_paths = await Get(
         BinaryPaths,

--- a/src/python/pants/backend/codegen/thrift/apache/rules.py
+++ b/src/python/pants/backend/codegen/thrift/apache/rules.py
@@ -14,7 +14,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPaths,
     BinaryPathTest,
 )
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult

--- a/src/python/pants/backend/codegen/thrift/apache/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/subsystem.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import OrderedSet
@@ -42,7 +42,7 @@ class ApacheThriftSubsystem(Subsystem):
         ),
     )
 
-    def thrift_search_paths(self, env: Environment) -> tuple[str, ...]:
+    def thrift_search_paths(self, env: EnvironmentVars) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._thrift_search_paths:
                 if entry == "<PATH>":

--- a/src/python/pants/backend/codegen/thrift/apache/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/apache/subsystem.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import OrderedSet

--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -20,7 +20,7 @@ from pants.core.goals.publish import (
     PublishProcesses,
     PublishRequest,
 )
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import Get, collect_rules, rule
 

--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -20,7 +20,7 @@ from pants.core.goals.publish import (
     PublishProcesses,
     PublishRequest,
 )
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import Get, collect_rules, rule
 
@@ -71,7 +71,7 @@ async def push_docker_images(
             ]
         )
 
-    env = await Get(Environment, EnvironmentRequest(options.env_vars))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(options.env_vars))
     skip_push = defaultdict(set)
     jobs: list[PublishPackages] = []
     refs: list[str] = []

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -10,7 +10,7 @@ from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
 

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -10,7 +10,7 @@ from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
 from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
 
@@ -19,7 +19,7 @@ async def docker_image_run_request(
     field_set: DockerFieldSet, docker: DockerBinary, options: DockerOptions
 ) -> RunRequest:
     env, image = await MultiGet(
-        Get(Environment, EnvironmentRequest(options.env_vars)),
+        Get(EnvironmentVars, EnvironmentVarsRequest(options.env_vars)),
         Get(BuiltPackage, PackageFieldSet, field_set),
     )
     tag = cast(BuiltDockerImage, image.artifacts[0]).tags[0]

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from pants.backend.docker.registries import DockerRegistries
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.option.option_types import (
     BoolOption,
     DictOption,

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any
 
 from pants.backend.docker.registries import DockerRegistries
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.option.option_types import (
     BoolOption,
     DictOption,
@@ -234,7 +234,7 @@ class DockerOptions(Subsystem):
         return DockerRegistries.from_dict(self._registries)
 
     @memoized_method
-    def executable_search_path(self, env: Environment) -> tuple[str, ...]:
+    def executable_search_path(self, env: EnvironmentVars) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._executable_search_paths:
                 if entry == "<PATH>":

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -17,7 +17,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
@@ -128,7 +128,7 @@ class DockerBinaryRequest:
 async def find_docker(
     docker_request: DockerBinaryRequest, docker_options: DockerOptions
 ) -> DockerBinary:
-    env = await Get(Environment, EnvironmentRequest(["PATH"]))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     search_path = docker_options.executable_search_path(env)
     request = BinaryPathRequest(
         binary_name="docker",

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -17,7 +17,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule

--- a/src/python/pants/backend/docker/util_rules/docker_build_env.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_env.py
@@ -13,7 +13,7 @@ from pants.backend.docker.util_rules.docker_build_args import (
     DockerBuildArgsRequest,
 )
 from pants.backend.docker.utils import KeyValueSequenceUtil
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Target
 
@@ -31,14 +31,14 @@ class DockerBuildEnvironmentError(ValueError):
 
 @dataclass(frozen=True)
 class DockerBuildEnvironment:
-    environment: Environment
+    environment: EnvironmentVars
 
     @classmethod
     def create(
         cls,
         env: Mapping[str, str],
     ) -> DockerBuildEnvironment:
-        return cls(Environment(env))
+        return cls(EnvironmentVars(env))
 
     def __getitem__(self, key: str) -> str:
         try:
@@ -67,7 +67,7 @@ async def docker_build_environment_vars(
         *{build_arg for build_arg in build_args if "=" not in build_arg},
         *docker_options.env_vars,
     )
-    env = await Get(Environment, EnvironmentRequest(tuple(env_vars)))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(tuple(env_vars)))
     return DockerBuildEnvironment.create(env)
 
 

--- a/src/python/pants/backend/docker/util_rules/docker_build_env.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_env.py
@@ -13,7 +13,7 @@ from pants.backend.docker.util_rules.docker_build_args import (
     DockerBuildArgsRequest,
 )
 from pants.backend.docker.utils import KeyValueSequenceUtil
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Target
 

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -46,7 +46,7 @@ from pants.core.goals.test import (
 )
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -46,7 +46,7 @@ from pants.core.goals.test import (
 )
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
@@ -347,7 +347,7 @@ async def run_go_tests(
     # located. See https://dave.cheney.net/2016/05/10/test-fixtures-in-go.
     working_dir = field_set.address.spec_path
     field_set_extra_env_get = Get(
-        Environment, EnvironmentRequest(field_set.extra_env_vars.value or ())
+        EnvironmentVars, EnvironmentVarsRequest(field_set.extra_env_vars.value or ())
     )
     binary_with_prefix, files_sources, field_set_extra_env = await MultiGet(
         Get(Digest, AddPrefix(binary.digest, working_dir)),

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import os
 
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 import os
 
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -228,7 +228,7 @@ class GolangSubsystem(Subsystem):
         return tuple(sorted(set(self._subprocess_env_vars)))
 
     @memoized_method
-    def cgo_tool_search_paths(self, env: Environment) -> tuple[str, ...]:
+    def cgo_tool_search_paths(self, env: EnvironmentVars) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._cgo_tool_search_paths:
                 if entry == "<PATH>":

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -29,7 +29,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathTest,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
     DigestContents,
@@ -324,7 +324,10 @@ async def _cc(
     wrapper_script = await Get(CGoCompilerWrapperScript, CGoCompilerWrapperScriptRequest())
     compiler_args_result, env, input_digest = await MultiGet(
         Get(SetupCompilerCmdResult, SetupCompilerCmdRequest((compiler_path.path,), work_dir)),
-        Get(Environment, EnvironmentRequest(golang_subsystem.env_vars_to_pass_to_subprocesses)),
+        Get(
+            EnvironmentVars,
+            EnvironmentVarsRequest(golang_subsystem.env_vars_to_pass_to_subprocesses),
+        ),
         Get(Digest, MergeDigests([input_digest, wrapper_script.digest])),
     )
     replaced_flags = _replace_srcdir_in_flags(flags, work_dir)
@@ -369,7 +372,7 @@ async def _gccld(
     # TODO(#16830): Select CXX if any C++ code is present.
     compiler_args_result, env = await MultiGet(
         Get(SetupCompilerCmdResult, SetupCompilerCmdRequest((compiler_path.path,), obj_dir_path)),
-        Get(Environment, EnvironmentRequest(["PATH"])),
+        Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"])),
     )
 
     args = [*compiler_args_result.args, "-o", outfile, *objs, *flags]

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -29,7 +29,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathTest,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
     DigestContents,

--- a/src/python/pants/backend/go/util_rules/cgo_binaries.py
+++ b/src/python/pants/backend/go/util_rules/cgo_binaries.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathTest,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 

--- a/src/python/pants/backend/go/util_rules/cgo_binaries.py
+++ b/src/python/pants/backend/go/util_rules/cgo_binaries.py
@@ -12,7 +12,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathTest,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 
@@ -30,7 +30,7 @@ class CGoBinaryPathRequest(EngineAwareParameter):
 async def find_cgo_binary_path(
     request: CGoBinaryPathRequest, golang_subsystem: GolangSubsystem
 ) -> BinaryPath:
-    env = await Get(Environment, EnvironmentRequest(["PATH"]))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     path_request = BinaryPathRequest(
         binary_name=request.binary_name,
         search_path=golang_subsystem.cgo_tool_search_paths(env),

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 
@@ -21,7 +21,7 @@ class GoBootstrap:
     EXTRA_ENV_VAR_NAMES = ("PATH",)
 
     raw_go_search_paths: tuple[str, ...]
-    environment: Environment
+    environment: EnvironmentVars
     asdf_standard_tool_paths: tuple[str, ...]
     asdf_local_tool_paths: tuple[str, ...]
 
@@ -42,7 +42,7 @@ class GoBootstrap:
         return tuple(expanded)
 
     @staticmethod
-    def get_environment_paths(env: Environment) -> list[str]:
+    def get_environment_paths(env: EnvironmentVars) -> list[str]:
         """Returns a list of paths specified by the PATH env var."""
         pathstr = env.get("PATH")
         if pathstr:

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 

--- a/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
@@ -8,7 +8,7 @@ from typing import Mapping
 from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
 from pants.backend.go.util_rules.go_bootstrap import rules as go_bootstrap_rules
 from pants.core.util_rules.asdf_test import fake_asdf_root, materialize_indices
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -96,7 +96,7 @@ def test_expand_search_paths() -> None:
         )
         rule_runner.set_session_values(
             {
-                CompleteEnvironment: CompleteEnvironment(
+                CompleteEnvironmentVars: CompleteEnvironmentVars(
                     {
                         "HOME": home_dir,
                         "PATH": "/env/path1:/env/path2",

--- a/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
@@ -8,7 +8,7 @@ from typing import Mapping
 from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
 from pants.backend.go.util_rules.go_bootstrap import rules as go_bootstrap_rules
 from pants.core.util_rules.asdf_test import fake_asdf_root, materialize_indices
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -11,7 +11,7 @@ from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.util_rules.system_binaries import BashBinary
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -11,7 +11,7 @@ from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.util_rules.system_binaries import BashBinary
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform
@@ -113,7 +113,10 @@ async def setup_go_sdk_process(
 ) -> Process:
     input_digest, env_vars = await MultiGet(
         Get(Digest, MergeDigests([go_sdk_run.digest, request.input_digest])),
-        Get(Environment, EnvironmentRequest(golang_subsystem.env_vars_to_pass_to_subprocesses)),
+        Get(
+            EnvironmentVars,
+            EnvironmentVarsRequest(golang_subsystem.env_vars_to_pass_to_subprocesses),
+        ),
     )
     maybe_replace_sandbox_root_env = (
         {GoSdkRunSetup.SANDBOX_ROOT_ENV: "1"} if request.replace_sandbox_root_in_args else {}

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -24,7 +24,7 @@ from pants.backend.helm.value_interpolation import HelmEnvironmentInterpolationV
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     EMPTY_SNAPSHOT,

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -24,7 +24,7 @@ from pants.backend.helm.value_interpolation import HelmEnvironmentInterpolationV
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     EMPTY_SNAPSHOT,
@@ -177,7 +177,7 @@ class RenderedHelmFiles(EngineAwareReturnType):
 async def _build_interpolation_context(helm_subsystem: HelmSubsystem) -> InterpolationContext:
     interpolation_context: dict[str, dict[str, str] | InterpolationValue] = {}
 
-    env = await Get(Environment, EnvironmentRequest(helm_subsystem.extra_env_vars))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(helm_subsystem.extra_env_vars))
     interpolation_context["env"] = HelmEnvironmentInterpolationValue(env)
 
     return InterpolationContext.from_dict(interpolation_context)

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -25,7 +25,7 @@ from pants.core.util_rules.external_tool import (
 from pants.engine import process
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.environment import Environment, EnvironmentName, EnvironmentRequest
+from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     AddPrefix,
@@ -427,7 +427,7 @@ async def setup_helm(
         _HELM_DATA_DIR: data_subset_digest,
     }
 
-    local_env = await Get(Environment, EnvironmentRequest(["HOME", "PATH"]))
+    local_env = await Get(EnvironmentVars, EnvironmentVarsRequest(["HOME", "PATH"]))
     return HelmBinary(
         path=helm_path,
         helm_env=helm_env,
@@ -440,7 +440,9 @@ async def setup_helm(
 async def helm_process(
     request: HelmProcess, helm_binary: HelmBinary, helm_subsytem: HelmSubsystem
 ) -> Process:
-    global_extra_env = await Get(Environment, EnvironmentRequest(helm_subsytem.extra_env_vars))
+    global_extra_env = await Get(
+        EnvironmentVars, EnvironmentVarsRequest(helm_subsytem.extra_env_vars)
+    )
 
     # Helm binary's setup parameters go last to prevent end users overriding any of its values.
 

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -25,7 +25,8 @@ from pants.core.util_rules.external_tool import (
 from pants.engine import process
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
-from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     EMPTY_DIGEST,
     AddPrefix,

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -17,7 +17,7 @@ from pants.core.goals.publish import (
     PublishRequest,
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, Digest, MergeDigests, Snapshot
 from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -112,9 +112,9 @@ def twine_env_suffix(repo: str) -> str:
     return f"_{repo[1:]}".replace("-", "_").upper() if repo.startswith("@") else ""
 
 
-def twine_env_request(repo: str) -> EnvironmentRequest:
+def twine_env_request(repo: str) -> EnvironmentVarsRequest:
     suffix = twine_env_suffix(repo)
-    req = EnvironmentRequest(
+    req = EnvironmentVarsRequest(
         [
             f"{var}{suffix}"
             for var in [
@@ -127,12 +127,12 @@ def twine_env_request(repo: str) -> EnvironmentRequest:
     return req
 
 
-def twine_env(env: Environment, repo: str) -> Environment:
+def twine_env(env: EnvironmentVars, repo: str) -> EnvironmentVars:
     suffix = twine_env_suffix(repo)
     if not suffix:
         return env
 
-    return Environment({key.rsplit(suffix, maxsplit=1)[0]: value for key, value in env.items()})
+    return EnvironmentVars({key.rsplit(suffix, maxsplit=1)[0]: value for key, value in env.items()})
 
 
 @rule
@@ -185,7 +185,7 @@ async def twine_upload(
     )
     pex_proc_requests = []
     twine_envs = await MultiGet(
-        Get(Environment, EnvironmentRequest, twine_env_request(repo))
+        Get(EnvironmentVars, EnvironmentVarsRequest, twine_env_request(repo))
         for repo in request.field_set.repositories.value
     )
 

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -17,7 +17,7 @@ from pants.core.goals.publish import (
     PublishRequest,
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, Digest, MergeDigests, Snapshot
 from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -41,7 +41,8 @@ from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
-from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -41,7 +41,7 @@ from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
-from pants.engine.environment import Environment, EnvironmentName, EnvironmentRequest
+from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     CreateDigest,
@@ -218,7 +218,7 @@ async def setup_pytest_for_target(
     field_set_source_files_get = Get(SourceFiles, SourceFilesRequest([request.field_set.source]))
 
     field_set_extra_env_get = Get(
-        Environment, EnvironmentRequest(request.field_set.extra_env_vars.value or ())
+        EnvironmentVars, EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ())
     )
 
     (

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -57,7 +57,8 @@ from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, Package
 from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
-from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -57,7 +57,7 @@ from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, Package
 from pants.core.target_types import FileSourceField, ResourceSourceField
 from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
-from pants.engine.environment import Environment, EnvironmentName, EnvironmentRequest
+from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     AddPrefix,
     CreateDigest,
@@ -431,9 +431,11 @@ async def package_python_dist(
     sdist_config_settings = dist_tgt.get(SDistConfigSettingsField).value or FrozenDict()
     backend_env_vars = dist_tgt.get(BuildBackendEnvVarsField).value
     if backend_env_vars:
-        extra_build_time_env = await Get(Environment, EnvironmentRequest(sorted(backend_env_vars)))
+        extra_build_time_env = await Get(
+            EnvironmentVars, EnvironmentVarsRequest(sorted(backend_env_vars))
+        )
     else:
-        extra_build_time_env = Environment()
+        extra_build_time_env = EnvironmentVars()
 
     interpreter_constraints = InterpreterConstraints.create_from_targets(
         transitive_targets.closure, python_setup

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -13,7 +13,7 @@ from pants.core.util_rules import subprocess_environment, system_binaries
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.core.util_rules.system_binaries import BinaryPath, PythonBinary
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.engine.rules import collect_rules, rule
 from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
@@ -65,7 +65,7 @@ class PexSubsystem(Subsystem):
     )
 
     @memoized_method
-    def path(self, env: Environment) -> tuple[str, ...]:
+    def path(self, env: EnvironmentVars) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._executable_search_paths:
                 if entry == "<PATH>":

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -13,7 +13,7 @@ from pants.core.util_rules import subprocess_environment, system_binaries
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.core.util_rules.system_binaries import BinaryPath, PythonBinary
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import collect_rules, rule
 from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -23,7 +23,7 @@ from pants.core.goals.test import (
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
     FallibleProcessResult,
@@ -127,7 +127,7 @@ async def setup_scalatest_for_target(
         extra_jvm_args.extend(jvm.debug_args)
 
     field_set_extra_env = await Get(
-        Environment, EnvironmentRequest(request.field_set.extra_env_vars.value or ())
+        EnvironmentVars, EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ())
     )
 
     process = JvmProcess(

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -23,7 +23,7 @@ from pants.core.goals.test import (
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
     FallibleProcessResult,

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -32,7 +32,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
 )
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     AddPrefix,
@@ -133,7 +133,7 @@ async def prepare_shell_command_process(
                 f"Must provide any `tools` used by the `{shell_command.alias}` {shell_command.address}."
             )
 
-        env = await Get(Environment, EnvironmentRequest(["PATH"]))
+        env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
         search_path = shell_setup.executable_search_path(env)
         tool_requests = [
             BinaryPathRequest(
@@ -164,7 +164,7 @@ async def prepare_shell_command_process(
                     rationale=f"execute `{shell_command.alias}` {shell_command.address}",
                 )
 
-    extra_env = await Get(Environment, EnvironmentRequest(extra_env_vars))
+    extra_env = await Get(EnvironmentVars, EnvironmentVarsRequest(extra_env_vars))
     command_env.update(extra_env)
 
     transitive_targets = await Get(

--- a/src/python/pants/backend/shell/shell_command.py
+++ b/src/python/pants/backend/shell/shell_command.py
@@ -32,7 +32,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
 )
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     EMPTY_DIGEST,
     AddPrefix,

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.option.option_types import BoolOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.option.option_types import BoolOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.memo import memoized_method
@@ -46,7 +46,7 @@ class ShellSetup(Subsystem):
     )
 
     @memoized_method
-    def executable_search_path(self, env: Environment) -> tuple[str, ...]:
+    def executable_search_path(self, env: EnvironmentVars) -> tuple[str, ...]:
         def iter_path_entries():
             for entry in self._executable_search_path:
                 if entry == "<PATH>":

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -34,7 +34,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPaths,
 )
 from pants.engine.addresses import Address
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -140,7 +140,7 @@ async def determine_shunit2_shell(
             )
         tgt_shell = parse_result
 
-    env = await Get(Environment, EnvironmentRequest(["PATH"]))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     path_request = BinaryPathRequest(
         binary_name=tgt_shell.name,
         search_path=shell_setup.executable_search_path(env),
@@ -174,7 +174,7 @@ async def setup_shunit2_for_target(
             BuiltPackageDependencies,
             BuildPackageDependenciesRequest(request.field_set.runtime_package_dependencies),
         ),
-        Get(Environment, EnvironmentRequest(["PATH"])),
+        Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"])),
     )
 
     dependencies_source_files_request = Get(

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -34,7 +34,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPaths,
 )
 from pants.engine.addresses import Address
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
     Digest,

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -11,7 +11,7 @@ from typing import Dict, Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, ExitCode
 from pants.bin.local_pants_runner import LocalPantsRunner
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PySessionCancellationLatch
 from pants.init.logging import stdio_destination
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/src/python/pants/bin/daemon_pants_runner.py
+++ b/src/python/pants/bin/daemon_pants_runner.py
@@ -11,7 +11,7 @@ from typing import Dict, Tuple
 
 from pants.base.exiter import PANTS_FAILED_EXIT_CODE, ExitCode
 from pants.bin.local_pants_runner import LocalPantsRunner
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PySessionCancellationLatch
 from pants.init.logging import stdio_destination
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -126,7 +126,7 @@ class DaemonPantsRunner:
             )
 
             # Run using the pre-warmed Session.
-            complete_env = CompleteEnvironment(env)
+            complete_env = CompleteEnvironmentVars(env)
             scheduler, options_initializer = self._core.prepare(options_bootstrapper, complete_env)
             runner = LocalPantsRunner.create(
                 complete_env,

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -12,7 +12,7 @@ from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.util_rules.environments import determine_bootstrap_environment
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import PySessionCancellationLatch
 from pants.engine.internals.scheduler import ExecutionError

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -12,7 +12,7 @@ from pants.base.specs import Specs
 from pants.base.specs_parser import SpecsParser
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.util_rules.environments import determine_bootstrap_environment
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import PySessionCancellationLatch
 from pants.engine.internals.scheduler import ExecutionError
@@ -63,7 +63,7 @@ class LocalPantsRunner:
         options_initializer: OptionsInitializer,
         options_bootstrapper: OptionsBootstrapper,
         build_config: BuildConfiguration,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
         run_id: str,
         options: Options,
         scheduler: GraphScheduler | None = None,
@@ -98,7 +98,7 @@ class LocalPantsRunner:
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: options_bootstrapper,
-                    CompleteEnvironment: env,
+                    CompleteEnvironmentVars: env,
                 }
             ),
             cancellation_latch=cancellation_latch,
@@ -107,7 +107,7 @@ class LocalPantsRunner:
     @classmethod
     def create(
         cls,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
         options_bootstrapper: OptionsBootstrapper,
         options_initializer: OptionsInitializer | None = None,
         scheduler: GraphScheduler | None = None,

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -10,7 +10,7 @@ from typing import List, Mapping
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import ExitCode
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.init.util import init_workdir
 from pants.option.option_value_container import OptionValueContainer
@@ -97,6 +97,6 @@ class PantsRunner:
                 log_location=init_workdir(global_bootstrap_options), pantsd_instance=False
             )
             runner = LocalPantsRunner.create(
-                env=CompleteEnvironment(self.env), options_bootstrapper=options_bootstrapper
+                env=CompleteEnvironmentVars(self.env), options_bootstrapper=options_bootstrapper
             )
             return runner.run(start_time)

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -10,7 +10,7 @@ from typing import List, Mapping
 
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import ExitCode
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.init.logging import initialize_stdio, stdio_destination
 from pants.init.util import init_workdir
 from pants.option.option_value_container import OptionValueContainer

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -17,7 +17,7 @@ from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPConnection
 from pants.bsp.util_rules.lifecycle import BSP_VERSION, BSPLanguageSupport
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.session import SessionValues
 from pants.engine.unions import UnionMembership
 from pants.goal.builtin_goal import BuiltinGoal
@@ -116,7 +116,7 @@ class BSPGoal(BuiltinGoal):
                 union_membership=union_membership,
             )
         current_session_values = graph_session.scheduler_session.py_session.session_values
-        env = current_session_values[CompleteEnvironment]
+        env = current_session_values[CompleteEnvironmentVars]
         return self._setup_bsp_connection(
             union_membership=union_membership, env=env, options=goal_options
         )
@@ -149,7 +149,7 @@ class BSPGoal(BuiltinGoal):
 
         # Determine which environment variables to set in the BSP runner script.
         # TODO: Consider whether some of this logic could be shared with
-        #  `pants.engine.environment.CompleteEnvironment.get_subset`.
+        #  `pants.engine.environment.CompleteEnvironmentVars.get_subset`.
         run_script_env_lines: list[str] = []
         for env_var in options.runner_env_vars:
             if "=" in env_var:

--- a/src/python/pants/bsp/goal.py
+++ b/src/python/pants/bsp/goal.py
@@ -17,7 +17,7 @@ from pants.bsp.context import BSPContext
 from pants.bsp.protocol import BSPConnection
 from pants.bsp.util_rules.lifecycle import BSP_VERSION, BSPLanguageSupport
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.session import SessionValues
 from pants.engine.unions import UnionMembership
 from pants.goal.builtin_goal import BuiltinGoal

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -11,7 +11,7 @@ from pants.base.build_root import BuildRoot
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.environment import Environment, EnvironmentName, EnvironmentRequest
+from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Effect, Get, MultiGet
@@ -126,7 +126,7 @@ async def export(
     merged_digest = await Get(Digest, MergeDigests(prefixed_digests))
     dist_digest = await Get(Digest, AddPrefix(merged_digest, output_dir))
     workspace.write_digest(dist_digest)
-    environment = await Get(Environment, EnvironmentRequest(["PATH"]))
+    environment = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     for result in flattened_results:
         result_dir = os.path.join(output_dir, result.reldir)
         digest_root = os.path.join(build_root.path, result_dir)

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -11,7 +11,8 @@ from pants.base.build_root import BuildRoot
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.environment import EnvironmentName, EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.selectors import Effect, Get, MultiGet

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -19,7 +19,7 @@ from pants.core.goals.export import (
 )
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.addresses import Address
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -19,7 +19,7 @@ from pants.core.goals.export import (
 )
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.addresses import Address
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule
@@ -121,9 +121,9 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                     mock=lambda ap: rule_runner.request(Digest, [ap]),
                 ),
                 MockGet(
-                    output_type=Environment,
-                    input_types=(EnvironmentRequest,),
-                    mock=lambda env: rule_runner.request(Environment, [env]),
+                    output_type=EnvironmentVars,
+                    input_types=(EnvironmentVarsRequest,),
+                    mock=lambda env: rule_runner.request(EnvironmentVars, [env]),
                 ),
                 MockEffect(
                     output_type=InteractiveProcessResult,
@@ -141,7 +141,7 @@ def test_run_export_rule() -> None:
         rules=[
             UnionRule(ExportRequest, MockExportRequest),
             QueryRule(Digest, [CreateDigest]),
-            QueryRule(Environment, [EnvironmentRequest]),
+            QueryRule(EnvironmentVars, [EnvironmentVarsRequest]),
             QueryRule(InteractiveProcessResult, [InteractiveProcess]),
         ],
         target_types=[MockTarget],

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -9,7 +9,7 @@ from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple
 
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
-from pants.engine.environment import CompleteEnvironment, EnvironmentName
+from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
 from pants.engine.fs import Digest
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -99,7 +99,7 @@ async def run_repl(
     repl_subsystem: ReplSubsystem,
     specified_targets: FilteredTargets,
     union_membership: UnionMembership,
-    complete_env: CompleteEnvironment,
+    complete_env: CompleteEnvironmentVars,
 ) -> Repl:
     # TODO: When we support multiple languages, detect the default repl to use based
     #  on the targets.  For now we default to the python repl.

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -9,7 +9,8 @@ from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple
 
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
-from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
+from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -10,7 +10,7 @@ from typing import Iterable, Mapping, Optional, Tuple
 
 from pants.base.build_root import BuildRoot
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
-from pants.engine.environment import CompleteEnvironment, EnvironmentName
+from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
@@ -150,7 +150,7 @@ async def run(
     global_options: GlobalOptions,
     workspace: Workspace,
     build_root: BuildRoot,
-    complete_env: CompleteEnvironment,
+    complete_env: CompleteEnvironmentVars,
 ) -> Run:
     targets_to_valid_field_sets = await Get(
         TargetRootsToFieldSets,

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -10,7 +10,8 @@ from typing import Iterable, Mapping, Optional, Tuple
 
 from pants.base.build_root import BuildRoot
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
-from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
+from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -20,7 +20,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.session import RunId

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -20,7 +20,7 @@ from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.desktop import OpenFiles, OpenFilesRequest
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, Digest, FileDigest, MergeDigests, Snapshot, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.internals.session import RunId
@@ -674,12 +674,14 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
 
 @dataclass(frozen=True)
 class TestExtraEnv:
-    env: Environment
+    env: EnvironmentVars
 
 
 @rule
 async def get_filtered_environment(test_subsystem: TestSubsystem) -> TestExtraEnv:
-    return TestExtraEnv(await Get(Environment, EnvironmentRequest(test_subsystem.extra_env_vars)))
+    return TestExtraEnv(
+        await Get(EnvironmentVars, EnvironmentVarsRequest(test_subsystem.extra_env_vars))
+    )
 
 
 # -------------------------------------------------------------------------------------------

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -20,7 +20,7 @@ from pants.core.util_rules.environments import (
     PythonBootstrapBinaryNamesField,
     PythonInterpreterSearchPathsField,
 )
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
@@ -106,7 +106,7 @@ class PythonBootstrap:
 
     interpreter_names: tuple[str, ...]
     raw_interpreter_search_paths: tuple[str, ...]
-    environment: Environment
+    environment: EnvironmentVars
     asdf_standard_tool_paths: tuple[str, ...]
     asdf_local_tool_paths: tuple[str, ...]
 
@@ -123,7 +123,7 @@ class PythonBootstrap:
     def _expand_interpreter_search_paths(
         cls,
         interpreter_search_paths: Sequence[str],
-        env: Environment,
+        env: EnvironmentVars,
         asdf_standard_tool_paths: tuple[str, ...],
         asdf_local_tool_paths: tuple[str, ...],
     ):
@@ -160,7 +160,7 @@ class PythonBootstrap:
         return expanded
 
     @staticmethod
-    def get_environment_paths(env: Environment):
+    def get_environment_paths(env: EnvironmentVars):
         """Returns a list of paths specified by the PATH env var."""
         pathstr = env.get("PATH")
         if pathstr:
@@ -194,7 +194,7 @@ class PythonBootstrap:
         return standard_path_token, local_path_token
 
     @staticmethod
-    def get_pyenv_paths(env: Environment, *, pyenv_local: bool = False) -> list[str]:
+    def get_pyenv_paths(env: EnvironmentVars, *, pyenv_local: bool = False) -> list[str]:
         """Returns a list of paths to Python interpreters managed by pyenv.
 
         :param env: The environment to use to look up pyenv.
@@ -236,7 +236,7 @@ class PythonBootstrap:
         return paths
 
 
-def get_pyenv_root(env: Environment) -> str | None:
+def get_pyenv_root(env: EnvironmentVars) -> str | None:
     """See https://github.com/pyenv/pyenv#environment-variables."""
     from_env = env.get("PYENV_ROOT")
     if from_env:

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -20,7 +20,7 @@ from pants.core.util_rules.environments import (
     PythonBootstrapBinaryNamesField,
     PythonInterpreterSearchPathsField,
 )
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -10,7 +10,7 @@ from pants.core.subsystems.python_bootstrap import PythonBootstrap, get_pyenv_ro
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.asdf_test import fake_asdf_root, get_asdf_paths
-from pants.engine.environment import EnvironmentVars
+from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import environment_as, temporary_dir

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -10,7 +10,7 @@ from pants.core.subsystems.python_bootstrap import PythonBootstrap, get_pyenv_ro
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.asdf_test import fake_asdf_root, get_asdf_paths
-from pants.engine.environment import Environment
+from pants.engine.environment import EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import environment_as, temporary_dir
@@ -59,7 +59,9 @@ def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> List[
 
 
 def test_get_environment_paths() -> None:
-    paths = PythonBootstrap.get_environment_paths(Environment({"PATH": "foo/bar:baz:/qux/quux"}))
+    paths = PythonBootstrap.get_environment_paths(
+        EnvironmentVars({"PATH": "foo/bar:baz:/qux/quux"})
+    )
     assert ["foo/bar", "baz", "/qux/quux"] == paths
 
 
@@ -74,9 +76,9 @@ def test_get_pyenv_root() -> None:
     default_root = f"{home}/.pyenv"
     explicit_root = f"{home}/explicit"
 
-    assert explicit_root == get_pyenv_root(Environment({"PYENV_ROOT": explicit_root}))
-    assert default_root == get_pyenv_root(Environment({"HOME": home}))
-    assert get_pyenv_root(Environment({})) is None
+    assert explicit_root == get_pyenv_root(EnvironmentVars({"PYENV_ROOT": explicit_root}))
+    assert default_root == get_pyenv_root(EnvironmentVars({"HOME": home}))
+    assert get_pyenv_root(EnvironmentVars({})) is None
 
 
 def test_get_pyenv_paths() -> None:
@@ -88,9 +90,9 @@ def test_get_pyenv_paths() -> None:
         expected_paths,
         expected_local_paths,
     ):
-        paths = PythonBootstrap.get_pyenv_paths(Environment({"PYENV_ROOT": pyenv_root}))
+        paths = PythonBootstrap.get_pyenv_paths(EnvironmentVars({"PYENV_ROOT": pyenv_root}))
         local_paths = PythonBootstrap.get_pyenv_paths(
-            Environment({"PYENV_ROOT": pyenv_root}), pyenv_local=True
+            EnvironmentVars({"PYENV_ROOT": pyenv_root}), pyenv_local=True
         )
     assert expected_paths == paths
     assert expected_local_paths == local_paths

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -10,7 +10,7 @@ from pathlib import Path, PurePath
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import _uncacheable_rule, collect_rules, rule_helper
 from pants.util.strutil import softwrap
@@ -32,7 +32,7 @@ class AsdfToolPathsRequest:
 @dataclass(frozen=True)
 class AsdfToolPathsResult:
     tool_name: str
-    env: Environment
+    env: EnvironmentVars
     standard_tool_paths: tuple[str, ...] = ()
     local_tool_paths: tuple[str, ...] = ()
 
@@ -44,7 +44,7 @@ async def _resolve_asdf_tool_paths(
     tool_description: str,
     tool_env_name: str,
     bin_relpath: str,
-    env: Environment,
+    env: EnvironmentVars,
     local: bool,
 ) -> tuple[str, ...]:
     asdf_dir = get_asdf_data_dir(env)
@@ -195,7 +195,7 @@ async def resolve_asdf_tool_paths(
         "HOME",
         *request.extra_env_var_names,
     ]
-    env = await Get(Environment, EnvironmentRequest(env_vars_to_request))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(env_vars_to_request))
 
     standard_tool_paths: tuple[str, ...] = ()
     if request.resolve_standard:
@@ -229,7 +229,7 @@ async def resolve_asdf_tool_paths(
     )
 
 
-def get_asdf_data_dir(env: Environment) -> PurePath | None:
+def get_asdf_data_dir(env: EnvironmentVars) -> PurePath | None:
     """Returns the location of asdf's installed tool versions.
 
     See https://asdf-vm.com/manage/configuration.html#environment-variables.

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -10,7 +10,7 @@ from pathlib import Path, PurePath
 
 from pants.base.build_environment import get_buildroot
 from pants.base.build_root import BuildRoot
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import _uncacheable_rule, collect_rules, rule_helper
 from pants.util.strutil import softwrap

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -8,7 +8,7 @@ from typing import Iterable, Mapping, Sequence, TypeVar
 
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
-from pants.engine.environment import CompleteEnvironmentVars, EnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import temporary_dir

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -8,7 +8,7 @@ from typing import Iterable, Mapping, Sequence, TypeVar
 
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
-from pants.engine.environment import CompleteEnvironment, Environment
+from pants.engine.environment import CompleteEnvironmentVars, EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.contextutil import temporary_dir
@@ -70,9 +70,11 @@ def test_get_asdf_dir() -> None:
     default_root = home / ".asdf"
     explicit_root = home / "explicit"
 
-    assert explicit_root == get_asdf_data_dir(Environment({"ASDF_DATA_DIR": f"{explicit_root}"}))
-    assert default_root == get_asdf_data_dir(Environment({"HOME": f"{home}"}))
-    assert get_asdf_data_dir(Environment({})) is None
+    assert explicit_root == get_asdf_data_dir(
+        EnvironmentVars({"ASDF_DATA_DIR": f"{explicit_root}"})
+    )
+    assert default_root == get_asdf_data_dir(EnvironmentVars({"HOME": f"{home}"}))
+    assert get_asdf_data_dir(EnvironmentVars({})) is None
 
 
 def get_asdf_paths(
@@ -85,7 +87,7 @@ def get_asdf_paths(
 ) -> AsdfToolPathsResult:
     rule_runner.set_session_values(
         {
-            CompleteEnvironment: CompleteEnvironment(env),
+            CompleteEnvironmentVars: CompleteEnvironmentVars(env),
         }
     )
     return rule_runner.request(

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
@@ -51,7 +51,9 @@ async def get_subprocess_environment(
     subproc_env: SubprocessEnvironment,
 ) -> SubprocessEnvironmentVars:
     return SubprocessEnvironmentVars(
-        await Get(Environment, EnvironmentRequest(subproc_env.env_vars_to_pass_to_subprocesses))
+        await Get(
+            EnvironmentVars, EnvironmentVarsRequest(subproc_env.env_vars_to_pass_to_subprocesses)
+        )
     )
 
 

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Iterable, Tuple
 
 from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.platform import Platform
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import Get, collect_rules, rule

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 from typing import Iterable, Tuple
 
 from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.platform import Platform
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import Get, collect_rules, rule
@@ -36,7 +36,7 @@ class OpenFiles:
 async def find_open_program(
     request: OpenFilesRequest,
     plat: Platform,
-    complete_env: CompleteEnvironment,
+    complete_env: CompleteEnvironmentVars,
 ) -> OpenFiles:
     open_program_name = "open" if plat.is_macos else "xdg-open"
     open_program_paths = await Get(

--- a/src/python/pants/engine/env_vars.py
+++ b/src/python/pants/engine/env_vars.py
@@ -1,3 +1,6 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
 import re

--- a/src/python/pants/engine/env_vars.py
+++ b/src/python/pants/engine/env_vars.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence
+
+from pants.engine.internals.session import SessionValues
+from pants.engine.rules import collect_rules, rule
+from pants.util.frozendict import FrozenDict
+from pants.util.meta import frozen_after_init
+from pants.util.ordered_set import FrozenOrderedSet
+
+name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
+shorthand_re = re.compile(r"([A-Za-z_]\w*)")
+
+
+class CompleteEnvironmentVars(FrozenDict):
+    """CompleteEnvironmentVars contains all environment variables from the current Pants process.
+
+    NB: Consumers should almost always prefer to consume the `EnvironmentVars` type, which is
+    filtered to a relevant subset of the environment.
+    """
+
+    def get_subset(
+        self, requested: Sequence[str], *, allowed: Optional[Sequence[str]] = None
+    ) -> FrozenDict[str, str]:
+        """Extract a subset of named env vars.
+
+        Given a list of extra environment variable specifiers as strings, filter the contents of
+        the Pants environment to only those variables.
+
+        Each variable can be specified either as a name or as a name=value pair.
+        In the former case, the value for that name is taken from this env. In the latter
+        case the specified value overrides the value in this env.
+
+        If `allowed` is specified, the requested variable names must be in that list, or an error
+        will be raised.
+        """
+        allowed_set = None if allowed is None else set(allowed)
+        env_var_subset: Dict[str, str] = {}
+
+        def check_and_set(name: str, value: Optional[str]):
+            if allowed_set is not None and name not in allowed_set:
+                raise ValueError(
+                    f"{name} is not in the list of variable names that are allowed to be set. "
+                    f"Must be one of {','.join(sorted(allowed_set))}."
+                )
+            if value is not None:
+                env_var_subset[name] = value
+
+        for env_var in requested:
+            name_value_match = name_value_re.match(env_var)
+            if name_value_match:
+                check_and_set(name_value_match[1], name_value_match[2])
+            elif shorthand_re.match(env_var):
+                check_and_set(env_var, self.get(env_var))
+            else:
+                raise ValueError(
+                    f"An invalid variable was requested via the --test-extra-env-var "
+                    f"mechanism: {env_var}"
+                )
+
+        return FrozenDict(env_var_subset)
+
+
+@frozen_after_init
+@dataclass(unsafe_hash=True)
+class EnvironmentVarsRequest:
+    """Requests a subset of the variables set in the environment.
+
+    Requesting only the relevant subset of the environment reduces invalidation caused by unrelated
+    changes.
+    """
+
+    requested: FrozenOrderedSet[str]
+    allowed: Optional[FrozenOrderedSet[str]]
+
+    def __init__(self, requested: Sequence[str], allowed: Optional[Sequence[str]] = None):
+        self.requested = FrozenOrderedSet(requested)
+        self.allowed = None if allowed is None else FrozenOrderedSet(allowed)
+
+
+class EnvironmentVars(FrozenDict[str, str]):
+    """A subset of the variables set in the environment.
+
+    Accesses to `os.environ` cannot be accurately tracked, so @rules that need access to the
+    environment should use APIs from this module instead.
+
+    Wherever possible, the `EnvironmentVars` type should be consumed rather than the
+    `CompleteEnvironmentVars`, as it represents a filtered/relevant subset of the environment, rather
+    than the entire unfiltered environment.
+    """
+
+
+@rule
+def complete_environment_vars(session_values: SessionValues) -> CompleteEnvironmentVars:
+    return session_values[CompleteEnvironmentVars]
+
+
+@rule
+def environment_vars_subset(
+    session_values: SessionValues, request: EnvironmentVarsRequest
+) -> EnvironmentVars:
+    return EnvironmentVars(
+        session_values[CompleteEnvironmentVars]
+        .get_subset(
+            requested=tuple(request.requested),
+            allowed=(None if request.allowed is None else tuple(request.allowed)),
+        )
+        .items()
+    )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.base.deprecated import warn_or_error
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 
@@ -24,6 +25,28 @@ class EnvironmentName(EngineAwareParameter):
         return self.val or "<none>"
 
 
-CompleteEnvironment = CompleteEnvironmentVars
-EnvironmentRequest = EnvironmentVarsRequest
-Environment = EnvironmentVars
+def __getattr__(name):
+    if name == "EnvironmentName":
+        return EnvironmentName
+    if name == "CompleteEnvironment":
+        warn_or_error(
+            "2.16.0.dev0",
+            "`pants.engine.environment.CompleteEnvironment`",
+            "Use `pants.engine.env_vars.CompleteEnvironmentVars",
+        )
+        return CompleteEnvironmentVars
+    if name == "EnvironmentRequest":
+        warn_or_error(
+            "2.16.0.dev0",
+            "`pants.engine.environment.EnvironmentRequest`",
+            "Use `pants.engine.env_vars.EnvironmentVarsRequest",
+        )
+        return EnvironmentVarsRequest
+    if name == "Environment":
+        warn_or_error(
+            "2.16.0.dev0",
+            "`pants.engine.environment.Environment`",
+            "Use `pants.engine.env_vars.EnvironmentVars",
+        )
+        return EnvironmentVars
+    raise AttributeError(name)

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -2,37 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import logging
-import re
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence
 
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.session import SessionValues
-from pants.engine.rules import collect_rules, rule
-from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
-from pants.util.ordered_set import FrozenOrderedSet
-
-logger = logging.getLogger(__name__)
-
-name_value_re = re.compile(r"([A-Za-z_]\w*)=(.*)")
-shorthand_re = re.compile(r"([A-Za-z_]\w*)")
-
-
-"""
-TODO: This module currently contains two concepts:
-
-1. environment variable matching (CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest)
-2. the new "environment" concept from #13682.
-
-If the second use case gains steam as #13682 proceeds, we should move and rename the
-environment-variable matching APIs to remove ambiguity.
-"""
-
-# ----------------------------------------------------------------------
-# Environments mechanism
-# ----------------------------------------------------------------------
+from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 
 
 @dataclass(frozen=True)
@@ -51,116 +24,6 @@ class EnvironmentName(EngineAwareParameter):
         return self.val or "<none>"
 
 
-# ----------------------------------------------------------------------
-# Environment variables
-# ----------------------------------------------------------------------
-
-
-class CompleteEnvironmentVars(FrozenDict):
-    """CompleteEnvironmentVars contains all environment variables from the current Pants process.
-
-    NB: Consumers should almost always prefer to consume the `EnvironmentVars` type, which is
-    filtered to a relevant subset of the environment.
-    """
-
-    def get_subset(
-        self, requested: Sequence[str], *, allowed: Optional[Sequence[str]] = None
-    ) -> FrozenDict[str, str]:
-        """Extract a subset of named env vars.
-
-        Given a list of extra environment variable specifiers as strings, filter the contents of
-        the Pants environment to only those variables.
-
-        Each variable can be specified either as a name or as a name=value pair.
-        In the former case, the value for that name is taken from this env. In the latter
-        case the specified value overrides the value in this env.
-
-        If `allowed` is specified, the requested variable names must be in that list, or an error
-        will be raised.
-        """
-        allowed_set = None if allowed is None else set(allowed)
-        env_var_subset: Dict[str, str] = {}
-
-        def check_and_set(name: str, value: Optional[str]):
-            if allowed_set is not None and name not in allowed_set:
-                raise ValueError(
-                    f"{name} is not in the list of variable names that are allowed to be set. "
-                    f"Must be one of {','.join(sorted(allowed_set))}."
-                )
-            if value is not None:
-                env_var_subset[name] = value
-
-        for env_var in requested:
-            name_value_match = name_value_re.match(env_var)
-            if name_value_match:
-                check_and_set(name_value_match[1], name_value_match[2])
-            elif shorthand_re.match(env_var):
-                check_and_set(env_var, self.get(env_var))
-            else:
-                raise ValueError(
-                    f"An invalid variable was requested via the --test-extra-env-var "
-                    f"mechanism: {env_var}"
-                )
-
-        return FrozenDict(env_var_subset)
-
-
 CompleteEnvironment = CompleteEnvironmentVars
-
-
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class EnvironmentVarsRequest:
-    """Requests a subset of the variables set in the environment.
-
-    Requesting only the relevant subset of the environment reduces invalidation caused by unrelated
-    changes.
-    """
-
-    requested: FrozenOrderedSet[str]
-    allowed: Optional[FrozenOrderedSet[str]]
-
-    def __init__(self, requested: Sequence[str], allowed: Optional[Sequence[str]] = None):
-        self.requested = FrozenOrderedSet(requested)
-        self.allowed = None if allowed is None else FrozenOrderedSet(allowed)
-
-
 EnvironmentRequest = EnvironmentVarsRequest
-
-
-class EnvironmentVars(FrozenDict[str, str]):
-    """A subset of the variables set in the environment.
-
-    Accesses to `os.environ` cannot be accurately tracked, so @rules that need access to the
-    environment should use APIs from this module instead.
-
-    Wherever possible, the `EnvironmentVars` type should be consumed rather than the
-    `CompleteEnvironmentVars`, as it represents a filtered/relevant subset of the environment, rather
-    than the entire unfiltered environment.
-    """
-
-
 Environment = EnvironmentVars
-
-
-@rule
-def complete_environment_vars(session_values: SessionValues) -> CompleteEnvironmentVars:
-    return session_values[CompleteEnvironmentVars]
-
-
-@rule
-def environment_vars_subset(
-    session_values: SessionValues, request: EnvironmentVarsRequest
-) -> EnvironmentVars:
-    return EnvironmentVars(
-        session_values[CompleteEnvironmentVars]
-        .get_subset(
-            requested=tuple(request.requested),
-            allowed=(None if request.allowed is None else tuple(request.allowed)),
-        )
-        .items()
-    )
-
-
-def rules():
-    return collect_rules()

--- a/src/python/pants/engine/environment_test.py
+++ b/src/python/pants/engine/environment_test.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 import pytest
 
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 
 
 @pytest.mark.parametrize(
@@ -22,14 +22,14 @@ from pants.engine.environment import CompleteEnvironment
     ],
 )
 def test_complete_environment(input_strs: List[str], expected: Dict[str, str]) -> None:
-    pants_env = CompleteEnvironment({"A": "a", "B": "b", "C": "c"})
+    pants_env = CompleteEnvironmentVars({"A": "a", "B": "b", "C": "c"})
 
     subset = pants_env.get_subset(input_strs)
     assert dict(subset) == expected
 
 
 def test_invalid_variable() -> None:
-    pants_env = CompleteEnvironment()
+    pants_env = CompleteEnvironmentVars()
 
     with pytest.raises(ValueError) as exc:
         pants_env.get_subset(["3INVALID=doesn't matter"])

--- a/src/python/pants/engine/environment_test.py
+++ b/src/python/pants/engine/environment_test.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 import pytest
 
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -16,7 +16,7 @@ from pants.bsp.protocol import BSPHandlerMapping
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.util_rules import environments, system_binaries
 from pants.core.util_rules.environments import determine_bootstrap_environment
-from pants.engine import desktop, environment, fs, platform, process
+from pants.engine import desktop, env_vars, fs, platform, process
 from pants.engine.console import Console
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
@@ -262,7 +262,7 @@ class EngineInitializer:
                 *collect_rules(locals()),
                 *build_files.rules(),
                 *fs.rules(),
-                *environment.rules(),
+                *env_vars.rules(),
                 *desktop.rules(),
                 *git_rules(),
                 *graph.rules(),

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -12,7 +12,7 @@ from typing import Iterator
 import pkg_resources
 
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.help.flag_error_help_printer import FlagErrorHelpPrinter
 from pants.init.bootstrap_scheduler import BootstrapScheduler

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -12,7 +12,7 @@ from typing import Iterator
 import pkg_resources
 
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.help.flag_error_help_printer import FlagErrorHelpPrinter
 from pants.init.bootstrap_scheduler import BootstrapScheduler
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 def _initialize_build_configuration(
     plugin_resolver: PluginResolver,
     options_bootstrapper: OptionsBootstrapper,
-    env: CompleteEnvironment,
+    env: CompleteEnvironmentVars,
 ) -> BuildConfiguration:
     """Initialize a BuildConfiguration for the given OptionsBootstrapper.
 
@@ -103,7 +103,11 @@ class OptionsInitializer:
         self._plugin_resolver = PluginResolver(self._bootstrap_scheduler)
 
     def build_config_and_options(
-        self, options_bootstrapper: OptionsBootstrapper, env: CompleteEnvironment, *, raise_: bool
+        self,
+        options_bootstrapper: OptionsBootstrapper,
+        env: CompleteEnvironmentVars,
+        *,
+        raise_: bool,
     ) -> tuple[BuildConfiguration, Options]:
         build_config = _initialize_build_configuration(
             self._plugin_resolver, options_bootstrapper, env
@@ -114,7 +118,11 @@ class OptionsInitializer:
 
     @contextmanager
     def handle_unknown_flags(
-        self, options_bootstrapper: OptionsBootstrapper, env: CompleteEnvironment, *, raise_: bool
+        self,
+        options_bootstrapper: OptionsBootstrapper,
+        env: CompleteEnvironmentVars,
+        *,
+        raise_: bool,
     ) -> Iterator[None]:
         """If there are any unknown flags, print "Did you mean?" and possibly error."""
         try:

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -19,7 +19,8 @@ from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.engine.collection import DeduplicatedCollection
-from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
+from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.environment import EnvironmentName
 from pants.engine.internals.selectors import Params
 from pants.engine.internals.session import SessionValues
 from pants.engine.process import ProcessCacheScope, ProcessResult

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -19,7 +19,7 @@ from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.util_rules.environments import determine_bootstrap_environment
 from pants.engine.collection import DeduplicatedCollection
-from pants.engine.environment import CompleteEnvironment, EnvironmentName
+from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
 from pants.engine.internals.selectors import Params
 from pants.engine.internals.session import SessionValues
 from pants.engine.process import ProcessCacheScope, ProcessResult
@@ -128,7 +128,7 @@ class PluginResolver:
     def resolve(
         self,
         options_bootstrapper: OptionsBootstrapper,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
     ) -> WorkingSet:
         """Resolves any configured plugins and adds them to the working_set."""
 
@@ -145,7 +145,7 @@ class PluginResolver:
     def _resolve_plugins(
         self,
         options_bootstrapper: OptionsBootstrapper,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
         request: PluginsRequest,
     ) -> ResolvedPluginDistributions:
         session = self._scheduler.scheduler.new_session(
@@ -153,7 +153,7 @@ class PluginResolver:
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: options_bootstrapper,
-                    CompleteEnvironment: env,
+                    CompleteEnvironmentVars: env,
                 }
             ),
         )

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -20,7 +20,7 @@ from pants.core.goals.test import (
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
     FallibleProcessResult,

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -20,7 +20,7 @@ from pants.core.goals.test import (
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Addresses
-from pants.engine.environment import Environment, EnvironmentRequest
+from pants.engine.environment import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
     FallibleProcessResult,
@@ -129,7 +129,7 @@ async def setup_junit_for_target(
         extra_jvm_args.extend(jvm.debug_args)
 
     field_set_extra_env = await Get(
-        Environment, EnvironmentRequest(request.field_set.extra_env_vars.value or ())
+        EnvironmentVars, EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ())
     )
 
     process = JvmProcess(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -25,7 +25,7 @@ from pants.base.build_environment import (
 )
 from pants.base.deprecated import resolve_conflicting_options
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.option.custom_types import memory_size
 from pants.option.errors import OptionsError

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -25,7 +25,7 @@ from pants.base.build_environment import (
 )
 from pants.base.deprecated import resolve_conflicting_options
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.option.custom_types import memory_size
 from pants.option.errors import OptionsError
@@ -306,7 +306,7 @@ class DynamicRemoteOptions:
     def from_options(
         cls,
         full_options: Options,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
         prior_result: AuthPluginResult | None = None,
         remote_auth_plugin_func: Callable | None = None,
     ) -> tuple[DynamicRemoteOptions, AuthPluginResult | None]:
@@ -370,7 +370,7 @@ class DynamicRemoteOptions:
         cls,
         bootstrap_options: OptionValueContainer,
         full_options: Options,
-        env: CompleteEnvironment,
+        env: CompleteEnvironmentVars,
         prior_result: AuthPluginResult | None,
         remote_auth_plugin_func_from_entry_point: Callable | None,
     ) -> tuple[DynamicRemoteOptions, AuthPluginResult | None]:

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pants.base.build_environment import get_buildroot
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import DynamicRemoteOptions, GlobalOptions

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 import pytest
 
 from pants.base.build_environment import get_buildroot
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import DynamicRemoteOptions, GlobalOptions
@@ -40,7 +40,7 @@ def create_dynamic_remote_options(
     if plugin:
         args.append(f"--remote-auth-plugin={plugin}")
     ob = create_options_bootstrapper(args)
-    env = CompleteEnvironment({})
+    env = CompleteEnvironmentVars({})
     _build_config, options = OptionsInitializer(ob).build_config_and_options(ob, env, raise_=False)
     return DynamicRemoteOptions.from_options(
         options, env, remote_auth_plugin_func=_build_config.remote_auth_plugin_func

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -11,7 +11,7 @@ from typing import Iterator
 from typing_extensions import Protocol
 
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
 from pants.init.options_initializer import OptionsInitializer
@@ -118,7 +118,7 @@ class PantsDaemonCore:
             raise e
 
     def prepare(
-        self, options_bootstrapper: OptionsBootstrapper, env: CompleteEnvironment
+        self, options_bootstrapper: OptionsBootstrapper, env: CompleteEnvironmentVars
     ) -> tuple[GraphScheduler, OptionsInitializer]:
         """Get a scheduler for the given options_bootstrapper.
 

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -11,7 +11,7 @@ from typing import Iterator
 from typing_extensions import Protocol
 
 from pants.build_graph.build_configuration import BuildConfiguration
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
 from pants.init.options_initializer import OptionsInitializer

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -33,7 +33,7 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addresses import Address
 from pants.engine.console import Console
-from pants.engine.environment import CompleteEnvironment, EnvironmentName
+from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
 from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import native_engine
@@ -255,7 +255,7 @@ class RuleRunner:
         build_config_builder.register_target_types("_dummy_for_test_", target_types or ())
         self.build_config = build_config_builder.create()
 
-        self.environment = CompleteEnvironment({})
+        self.environment = CompleteEnvironmentVars({})
         self.options_bootstrapper = create_options_bootstrapper(args=bootstrap_args)
         self.extra_session_values = extra_session_values or {}
         self.max_workunit_verbosity = max_workunit_verbosity
@@ -311,7 +311,7 @@ class RuleRunner:
             session_values=SessionValues(
                 {
                     OptionsBootstrapper: self.options_bootstrapper,
-                    CompleteEnvironment: self.environment,
+                    CompleteEnvironmentVars: self.environment,
                     **self.extra_session_values,
                 }
             ),
@@ -384,7 +384,7 @@ class RuleRunner:
     ) -> None:
         """Update the engine session with new options and/or environment variables.
 
-        The environment variables will be used to set the `CompleteEnvironment`, which is the
+        The environment variables will be used to set the `CompleteEnvironmentVars`, which is the
         environment variables captured by the parent Pants process. Some rules use this to be able
         to read arbitrary env vars. Any options that start with `PANTS_` will also be used to set
         options.
@@ -399,7 +399,7 @@ class RuleRunner:
             **(env or {}),
         }
         self.options_bootstrapper = create_options_bootstrapper(args=args, env=env)
-        self.environment = CompleteEnvironment(env)
+        self.environment = CompleteEnvironmentVars(env)
         self._set_new_session(self.scheduler.scheduler)
 
     def set_session_values(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -33,7 +33,8 @@ from pants.build_graph.build_configuration import BuildConfiguration
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.engine.addresses import Address
 from pants.engine.console import Console
-from pants.engine.environment import CompleteEnvironmentVars, EnvironmentName
+from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import native_engine

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -3,7 +3,7 @@
 
 import unittest
 
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -17,7 +17,7 @@ class OptionsInitializerTest(unittest.TestCase):
             allow_pantsrc=False,
         )
 
-        env = CompleteEnvironment({})
+        env = CompleteEnvironmentVars({})
         with self.assertRaises(ExecutionError):
             OptionsInitializer(options_bootstrapper).build_config_and_options(
                 options_bootstrapper, env, raise_=True
@@ -30,7 +30,7 @@ class OptionsInitializerTest(unittest.TestCase):
             args=["--backend-packages=[]", "--no-watch-filesystem", "--loop"],
             allow_pantsrc=False,
         )
-        env = CompleteEnvironment({})
+        env = CompleteEnvironmentVars({})
         with self.assertRaises(ExecutionError) as exc:
             OptionsInitializer(ob).build_config_and_options(ob, env, raise_=True)
         self.assertIn(

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -21,7 +21,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.util_rules import external_tool
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessResult
@@ -181,7 +181,7 @@ def plugin_resolution(
         args = [f"--pants-config-files=['{configpath}']"]
 
         options_bootstrapper = OptionsBootstrapper.create(env=env, args=args, allow_pantsrc=False)
-        complete_env = CompleteEnvironment(
+        complete_env = CompleteEnvironmentVars(
             {**{k: os.environ[k] for k in ["PATH", "HOME", "PYENV_ROOT"] if k in os.environ}, **env}
         )
         bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper)

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -21,7 +21,7 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.core.util_rules import external_tool
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessResult

--- a/tests/python/pants_test/pantsd/test_pants_daemon_core.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon_core.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.environment import CompleteEnvironmentVars
+from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices

--- a/tests/python/pants_test/pantsd/test_pants_daemon_core.py
+++ b/tests/python/pants_test/pantsd/test_pants_daemon_core.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.engine.environment import CompleteEnvironment
+from pants.engine.environment import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
 from pants.pantsd.pants_daemon_core import PantsDaemonCore
 from pants.pantsd.service.pants_service import PantsServices
@@ -13,7 +13,7 @@ def test_prepare_scheduler() -> None:
     def create_services(bootstrap_options, graph_scheduler):
         return PantsServices()
 
-    env = CompleteEnvironment({})
+    env = CompleteEnvironmentVars({})
     core = PantsDaemonCore(
         create_options_bootstrapper([]),
         PyExecutor(core_threads=2, max_threads=4),


### PR DESCRIPTION
This avoids ambiguity with the new `Environment` mechanism.

We can't outright remove the old names because it breaks the Toolchain plugin used by pantsbuild/pants. At the same time, I don't know how to pull off deprecating the old aliases? Using a subclass means it would be a distinct type, which the engine does not like.