### PR TITLE
Fix equality implementation in ordered_set

### DIFF
--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -62,7 +62,9 @@ class _AbstractOrderedSet(AbstractSet[T]):
         """Returns True if other is the same type with the same elements and same order."""
         if not isinstance(other, self.__class__):
             return NotImplemented
-        return all(x == y for x, y in itertools.zip_longest(self._items, other._items))
+        return len(self._items) == len(other._items) and all(
+            x == y for x, y in zip(self._items, other._items)
+        )
 
     def __or__(self: _TAbstractOrderedSet, other: Iterable[T]) -> _TAbstractOrderedSet:  # type: ignore[override]
         return self.union(other)

--- a/src/python/pants/util/ordered_set_test.py
+++ b/src/python/pants/util/ordered_set_test.py
@@ -57,6 +57,7 @@ def test_equality(cls: OrderedSetCls) -> None:
     assert set1 == cls([1, 2])
     assert set1 == cls([1, 1, 2, 2])
 
+    assert set1 != cls([1, 2, None])
     assert set1 != cls([2, 1])
     assert set1 != [2, 1]
     assert set1 != [2, 1, 1]


### PR DESCRIPTION
The current implementation of `_AbstractOrderedSet.__eq__` uses `zip_longest`, which fills the smaller iterable with `None`.
This was probably done to handle sets of different sizes, but causes  `Ordered([1]) == Ordered([1, None])`, which is incorrect.
The changed implementation first compares the length of both sets and then compares all respective pairs of elements using `zip`.