### PR TITLE
Increase the timeout for the docker timeout test.

### DIFF
--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -563,11 +563,11 @@ async fn timeout() {
   let argv = vec![
     SH_PATH.to_string(),
     "-c".to_owned(),
-    "/bin/echo -n 'Calculating...'; /bin/sleep 2; /bin/echo -n 'European Burmese'".to_string(),
+    "/bin/echo -n 'Calculating...'; /bin/sleep 5; /bin/echo -n 'European Burmese'".to_string(),
   ];
 
   let mut process = Process::new(argv);
-  process.timeout = Some(Duration::from_millis(100));
+  process.timeout = Some(Duration::from_millis(500));
   process.description = "sleepy-cat".to_string();
   process.docker_image = Some(IMAGE.to_owned());
 


### PR DESCRIPTION
See #16855. The timeout is applied only after we have successfully opened an output stream from the process, so the hypothesis with this test is that the process just runs more slowly under docker, and needs longer to get to the point where it can render output.

Fixes #16855.

[ci skip-build-wheels]