### PR TITLE
[internal] remove `_unfreeze_instance` and replace with `with x._unfrozen()`

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -239,12 +239,11 @@ class AsyncFieldMixin(Field):
         super().__init__(raw_value, address)
         # We must temporarily unfreeze the field, but then we refreeze to continue avoiding
         # subclasses from adding arbitrary fields.
-        self._unfreeze_instance()  # type: ignore[attr-defined]
-        # N.B.: We store the address here and not in the Field base class, because the memory usage
-        # of storing this value in every field was shown to be excessive / lead to performance
-        # issues.
-        self.address = address
-        self._freeze_instance()  # type: ignore[attr-defined]
+        with self._unfrozen():  # type: ignore[attr-defined]
+            # N.B.: We store the address here and not in the Field base class, because the memory usage
+            # of storing this value in every field was shown to be excessive / lead to performance
+            # issues.
+            self.address = address
 
     def __repr__(self) -> str:
         return (

--- a/src/python/pants/util/meta.py
+++ b/src/python/pants/util/meta.py
@@ -123,9 +123,6 @@ def frozen_after_init(cls: C) -> C:
     def freeze_instance(self) -> None:
         self._is_frozen = True
 
-    def unfreeze_instance(self) -> None:
-        self._is_frozen = False
-
     @contextmanager
     def unfrozen(self) -> Iterator:
         old_is_frozen = self._is_frozen
@@ -149,7 +146,6 @@ def frozen_after_init(cls: C) -> C:
         prev_setattr(self, key, value)  # type: ignore[call-arg]
 
     cls._freeze_instance = freeze_instance
-    cls._unfreeze_instance = unfreeze_instance
     cls._unfrozen = unfrozen
     cls.__init__ = new_init
     cls.__setattr__ = new_setattr  # type: ignore[assignment]

--- a/src/python/pants/util/meta_test.py
+++ b/src/python/pants/util/meta_test.py
@@ -256,10 +256,9 @@ def test_add_new_field_after_init() -> None:
     with pytest.raises(FrozenInstanceError):
         test.y = "abc"  # type: ignore[attr-defined]
 
-    test._unfreeze_instance()  # type: ignore[attr-defined]
-    test.y = "abc"  # type: ignore[attr-defined]
+    with test._unfrozen():  # type: ignore[attr-defined]
+        test.y = "abc"  # type: ignore[attr-defined]
 
-    test._freeze_instance()  # type: ignore[attr-defined]
     with pytest.raises(FrozenInstanceError):
         test.z = "abc"  # type: ignore[attr-defined]
 
@@ -274,10 +273,9 @@ def test_explicitly_call_setattr_after_init() -> None:
     with pytest.raises(FrozenInstanceError):
         setattr(test, "x", 1)
 
-    test._unfreeze_instance()  # type: ignore[attr-defined]
-    setattr(test, "x", 1)
+    with test._unfrozen():  # type: ignore[attr-defined]
+        setattr(test, "x", 1)
 
-    test._freeze_instance()  # type: ignore[attr-defined]
     with pytest.raises(FrozenInstanceError):
         test.y = "abc"  # type: ignore[attr-defined]
 


### PR DESCRIPTION
Following #16863, this removes other uses of `_unfreeze_instance` and replaces them with the `_unfrozen()` context manager