### PR TITLE
Load environment variables from Docker image

### DIFF
--- a/src/python/pants/engine/env_vars.py
+++ b/src/python/pants/engine/env_vars.py
@@ -7,8 +7,6 @@ import re
 from dataclasses import dataclass
 from typing import Dict, Optional, Sequence
 
-from pants.engine.internals.session import SessionValues
-from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
@@ -93,26 +91,3 @@ class EnvironmentVars(FrozenDict[str, str]):
     `CompleteEnvironmentVars`, as it represents a filtered/relevant subset of the environment, rather
     than the entire unfiltered environment.
     """
-
-
-@rule
-def complete_environment_vars(session_values: SessionValues) -> CompleteEnvironmentVars:
-    return session_values[CompleteEnvironmentVars]
-
-
-@rule
-def environment_vars_subset(
-    session_values: SessionValues, request: EnvironmentVarsRequest
-) -> EnvironmentVars:
-    return EnvironmentVars(
-        session_values[CompleteEnvironmentVars]
-        .get_subset(
-            requested=tuple(request.requested),
-            allowed=(None if request.allowed is None else tuple(request.allowed)),
-        )
-        .items()
-    )
-
-
-def rules():
-    return collect_rules()

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -3,9 +3,18 @@
 
 from __future__ import annotations
 
-from pants.core.util_rules.environments import DockerPlatformField, EnvironmentTarget
+from pants.core.util_rules.environments import (
+    DockerImageField,
+    DockerPlatformField,
+    EnvironmentTarget,
+)
+from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
+from pants.engine.internals.session import SessionValues
 from pants.engine.platform import Platform
-from pants.engine.rules import collect_rules, rule
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+from pants.util.logging import LogLevel
+from pants.util.strutil import softwrap
 
 
 @rule
@@ -13,6 +22,44 @@ def current_platform(env_tgt: EnvironmentTarget) -> Platform:
     if env_tgt.val is None or not env_tgt.val.has_field(DockerPlatformField):
         return Platform.create_for_localhost()
     return Platform(env_tgt.val[DockerPlatformField].normalized_value)
+
+
+@rule
+async def complete_environment_vars(
+    session_values: SessionValues, env_tgt: EnvironmentTarget
+) -> CompleteEnvironmentVars:
+    if not env_tgt.val or not env_tgt.val.has_field(DockerImageField):
+        return session_values[CompleteEnvironmentVars]
+    env_process_result = await Get(
+        ProcessResult,
+        Process(
+            ["env"],
+            description=softwrap(
+                f"""
+                Extract environment variables from the Docker image
+                {env_tgt.val[DockerImageField].value}
+                """
+            ),
+            level=LogLevel.DEBUG,
+        ),
+    )
+    result = {}
+    for line in env_process_result.stdout.decode("utf-8").splitlines():
+        k, v = line.split("=", maxsplit=1)
+        result[k] = v
+    return CompleteEnvironmentVars(result)
+
+
+@rule
+def environment_vars_subset(
+    complete_env_vars: CompleteEnvironmentVars, request: EnvironmentVarsRequest
+) -> EnvironmentVars:
+    return EnvironmentVars(
+        complete_env_vars.get_subset(
+            requested=tuple(request.requested),
+            allowed=(None if request.allowed is None else tuple(request.allowed)),
+        ).items()
+    )
 
 
 def rules():

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -33,7 +33,7 @@ async def complete_environment_vars(
     env_process_result = await Get(
         ProcessResult,
         Process(
-            ["env"],
+            ["env", "-0"],
             description=softwrap(
                 f"""
                 Extract environment variables from the Docker image
@@ -44,7 +44,9 @@ async def complete_environment_vars(
         ),
     )
     result = {}
-    for line in env_process_result.stdout.decode("utf-8").splitlines():
+    for line in env_process_result.stdout.decode("utf-8").rstrip().split("\0"):
+        if not line:
+            continue
         k, v = line.split("=", maxsplit=1)
         result[k] = v
     return CompleteEnvironmentVars(result)

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -22,7 +22,9 @@ def test_docker_complete_env_vars() -> None:
             "BUILD": dedent(
                 """\
                 _docker_environment(
-                    name='docker', image='centos:7.9.2009', platform='linux_x86_64'
+                    name='docker',
+                    image='centos@sha256:a1801b843b1bfaf77c501e7a6d3f709401a1e0c83863037fa3aab063a7fdb9dc',
+                    platform='linux_x86_64',
                 )
                 """
             )
@@ -32,6 +34,6 @@ def test_docker_complete_env_vars() -> None:
     result = rule_runner.request(CompleteEnvironmentVars, [])
     assert dict(result) == {
         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "HOSTNAME": "cba3dbdb7962",
+        "HOSTNAME": "85277b717746",
         "HOME": "/root",
     }

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -1,0 +1,34 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.core.util_rules.environments import DockerEnvironmentTarget
+from pants.engine.env_vars import CompleteEnvironmentVars
+from pants.engine.environment import EnvironmentName
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+def test_docker_complete_env_vars() -> None:
+    rule_runner = RuleRunner(
+        rules=[QueryRule(CompleteEnvironmentVars, [])],
+        target_types=[DockerEnvironmentTarget],
+        singleton_environment=EnvironmentName("docker"),
+    )
+    rule_runner.write_files(
+        {"BUILD": "_docker_environment(name='docker', image='centos:7.9.2009')"}
+    )
+    rule_runner.set_options(["--environments-preview-names={'docker': '//:docker'}"])
+    result = rule_runner.request(CompleteEnvironmentVars, [])
+    assert dict(result) == {
+        "PATH": "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOSTNAME": "a02a9770c54a",
+        "LANG": "C.UTF-8",
+        "GPG_KEY": "E3FF2839C048B25C084DEBE9B26995E310250568",
+        "PYTHON_VERSION": "3.9.14",
+        "PYTHON_PIP_VERSION": "22.0.4",
+        "PYTHON_SETUPTOOLS_VERSION": "58.1.0",
+        "PYTHON_GET_PIP_URL": "https://github.com/pypa/get-pip/raw/5eaac1050023df1f5c98b173b248c260023f2278/public/get-pip.py",
+        "PYTHON_GET_PIP_SHA256": "5aefe6ade911d997af080b315ebcb7f882212d070465df544e1175ac2be519b4",
+        "HOME": "/root",
+    }

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -31,9 +31,12 @@ def test_docker_complete_env_vars() -> None:
         }
     )
     rule_runner.set_options(["--environments-preview-names={'docker': '//:docker'}"])
-    result = rule_runner.request(CompleteEnvironmentVars, [])
+    result = dict(rule_runner.request(CompleteEnvironmentVars, []))
+
+    # HOSTNAME is not deterministic across machines, so we don't care about the value.
+    assert "HOSTNAME" in result
+    result.pop("HOSTNAME")
     assert dict(result) == {
         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "HOSTNAME": "85277b717746",
         "HOME": "/root",
     }

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+
 from pants.core.util_rules.environments import DockerEnvironmentTarget
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.environment import EnvironmentName
@@ -16,19 +18,20 @@ def test_docker_complete_env_vars() -> None:
         singleton_environment=EnvironmentName("docker"),
     )
     rule_runner.write_files(
-        {"BUILD": "_docker_environment(name='docker', image='centos:7.9.2009')"}
+        {
+            "BUILD": dedent(
+                """\
+                _docker_environment(
+                    name='docker', image='centos:7.9.2009', platform='linux_x86_64'
+                )
+                """
+            )
+        }
     )
     rule_runner.set_options(["--environments-preview-names={'docker': '//:docker'}"])
     result = rule_runner.request(CompleteEnvironmentVars, [])
     assert dict(result) == {
-        "PATH": "/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "HOSTNAME": "a02a9770c54a",
-        "LANG": "C.UTF-8",
-        "GPG_KEY": "E3FF2839C048B25C084DEBE9B26995E310250568",
-        "PYTHON_VERSION": "3.9.14",
-        "PYTHON_PIP_VERSION": "22.0.4",
-        "PYTHON_SETUPTOOLS_VERSION": "58.1.0",
-        "PYTHON_GET_PIP_URL": "https://github.com/pypa/get-pip/raw/5eaac1050023df1f5c98b173b248c260023f2278/public/get-pip.py",
-        "PYTHON_GET_PIP_SHA256": "5aefe6ade911d997af080b315ebcb7f882212d070465df544e1175ac2be519b4",
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOSTNAME": "cba3dbdb7962",
         "HOME": "/root",
     }

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -16,7 +16,7 @@ from pants.bsp.protocol import BSPHandlerMapping
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.core.util_rules import environments, system_binaries
 from pants.core.util_rules.environments import determine_bootstrap_environment
-from pants.engine import desktop, env_vars, fs, process
+from pants.engine import desktop, fs, process
 from pants.engine.console import Console
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, Snapshot, Workspace
@@ -262,7 +262,6 @@ class EngineInitializer:
                 *collect_rules(locals()),
                 *build_files.rules(),
                 *fs.rules(),
-                *env_vars.rules(),
                 *desktop.rules(),
                 *git_rules(),
                 *graph.rules(),


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16754.

We simply run the `env` process. We could alternatively run `docker inspect`, but this is much easier to implement and this strategy will work for remote execution environments too.

--

Note that we do _not_ strip environment variables for Docker images, unlike local processes! This is because we will be guaranteed that every user has the exact same environment, so there is no need to strip environment variables; whereas for local processes, we need to strip in an attempt to reduce Works On My Machine issues.

Still, we need to extract out the `CompleteEnvironmentVars` at the start of the run so that rules can augment and override certain values, such as the `[test].extra_env_vars` option.

This key detail is what makes our `Process` to run `env` possible.

[ci skip-rust]
[ci skip-build-wheels]