### PR TITLE
Preserve stdio when a local process times out. (Cherry-pick of #16841)

### DIFF
--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -110,14 +110,14 @@ def test_output_digest(rule_runner: RuleRunner, working_directory) -> None:
 
 def test_timeout(rule_runner: RuleRunner) -> None:
     process = Process(
-        argv=("/bin/bash", "-c", "/bin/sleep 0.2; /bin/echo -n 'European Burmese'"),
+        argv=("/bin/bash", "-c", "/bin/sleep 0.5; /bin/echo -n 'European Burmese'"),
         timeout_seconds=0.1,
         description="sleepy-cat",
     )
     result = rule_runner.request(FallibleProcessResult, [process])
     assert result.exit_code != 0
-    assert b"Exceeded timeout" in result.stdout
-    assert b"sleepy-cat" in result.stdout
+    assert b"Exceeded timeout" in result.stderr
+    assert b"sleepy-cat" in result.stderr
 
 
 def test_failing_process(rule_runner: RuleRunner) -> None:

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -20,8 +20,8 @@ use fs::{
   self, safe_create_dir_all_ioerror, DirectoryDigest, GlobExpansionConjunction, GlobMatching,
   PathGlobs, Permissions, RelativePath, StrictGlobMatching, EMPTY_DIRECTORY_DIGEST,
 };
-use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
+use futures::{try_join, FutureExt, TryFutureExt};
 use log::{debug, info};
 use nails::execution::ExitCode;
 use shell_quote::bash;
@@ -32,7 +32,6 @@ use tokio::process::{Child, Command};
 use tokio::sync::RwLock;
 use tokio::time::{timeout, Duration};
 use tokio_util::codec::{BytesCodec, FramedRead};
-use tryfuture::try_future;
 use workunit_store::{in_workunit, Level, Metric, RunningWorkunit};
 
 use crate::{
@@ -86,13 +85,13 @@ impl CommandRunner {
     self.platform
   }
 
-  fn construct_output_snapshot(
+  async fn construct_output_snapshot(
     store: Store,
     posix_fs: Arc<fs::PosixFS>,
     output_file_paths: BTreeSet<RelativePath>,
     output_dir_paths: BTreeSet<RelativePath>,
-  ) -> BoxFuture<'static, Result<Snapshot, String>> {
-    let output_paths: Result<Vec<String>, String> = output_dir_paths
+  ) -> Result<Snapshot, String> {
+    let output_paths = output_dir_paths
       .into_iter()
       .flat_map(|p| {
         let mut dir_glob = {
@@ -115,28 +114,25 @@ impl CommandRunner {
         s.into_string()
           .map_err(|e| format!("Error stringifying output paths: {:?}", e))
       })
-      .collect();
+      .collect::<Result<Vec<_>, _>>()?;
 
     // TODO: should we error when globs fail?
-    let output_globs = try_future!(PathGlobs::new(
-      try_future!(output_paths),
+    let output_globs = PathGlobs::new(
+      output_paths,
       StrictGlobMatching::Ignore,
       GlobExpansionConjunction::AllMatch,
     )
-    .parse());
+    .parse()?;
 
-    Box::pin(async move {
-      let path_stats = posix_fs
-        .expand_globs(output_globs, None)
-        .map_err(|err| format!("Error expanding output globs: {}", err))
-        .await?;
-      Snapshot::from_path_stats(
-        OneOffStoreFileByDigest::new(store, posix_fs, true),
-        path_stats,
-      )
-      .await
-    })
-    .boxed()
+    let path_stats = posix_fs
+      .expand_globs(output_globs, None)
+      .map_err(|err| format!("Error expanding output globs: {}", err))
+      .await?;
+    Snapshot::from_path_stats(
+      OneOffStoreFileByDigest::new(store, posix_fs, true),
+      path_stats,
+    )
+    .await
   }
 
   pub fn named_caches(&self) -> &NamedCaches {
@@ -226,38 +222,24 @@ pub enum ChildOutput {
 }
 
 ///
-/// The fully collected outputs of a completed child process.
+/// Collect the outputs of a child process.
 ///
-pub struct ChildResults {
-  pub stdout: Bytes,
-  pub stderr: Bytes,
-  pub exit_code: i32,
-}
+async fn collect_child_outputs<'a>(
+  stdout: &'a mut BytesMut,
+  stderr: &'a mut BytesMut,
+  mut stream: BoxStream<'static, Result<ChildOutput, String>>,
+) -> Result<i32, String> {
+  let mut exit_code = 1;
 
-impl ChildResults {
-  pub fn collect_from(
-    mut stream: BoxStream<'static, Result<ChildOutput, String>>,
-  ) -> BoxFuture<'static, Result<ChildResults, String>> {
-    let mut stdout = BytesMut::with_capacity(8192);
-    let mut stderr = BytesMut::with_capacity(8192);
-    let mut exit_code = 1;
-
-    async move {
-      while let Some(child_output_res) = stream.next().await {
-        match child_output_res? {
-          ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
-          ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
-          ChildOutput::Exit(code) => exit_code = code.0,
-        };
-      }
-      Ok(ChildResults {
-        stdout: stdout.into(),
-        stderr: stderr.into(),
-        exit_code,
-      })
-    }
-    .boxed()
+  while let Some(child_output_res) = stream.next().await {
+    match child_output_res? {
+      ChildOutput::Stdout(bytes) => stdout.extend_from_slice(&bytes),
+      ChildOutput::Stderr(bytes) => stderr.extend_from_slice(&bytes),
+      ChildOutput::Exit(code) => exit_code = code.0,
+    };
   }
+
+  Ok(exit_code)
 }
 
 #[async_trait]
@@ -472,26 +454,28 @@ pub trait CapturedWorkdir {
     platform: Platform,
   ) -> Result<FallibleProcessResultWithPlatform, String> {
     let start_time = Instant::now();
+    let mut stdout = BytesMut::with_capacity(8192);
+    let mut stderr = BytesMut::with_capacity(8192);
 
     // Spawn the process.
-    // NB: We fully buffer up the `Stream` above into final `ChildResults` below and so could
-    // instead be using `CommandExt::output_async` above to avoid the `ChildResults::collect_from`
-    // code. The idea going forward though is we eventually want to pass incremental results on
-    // down the line for streaming process results to console logs, etc. as tracked by:
-    //   https://github.com/pantsbuild/pants/issues/6089
-    let child_results_result = {
-      let child_results_future = ChildResults::collect_from(
+    // NB: We fully buffer the `Stream` into the stdout/stderr buffers, but the idea going forward
+    // is that we eventually want to pass incremental results on down the line for streaming
+    // process results to console logs, etc.
+    let exit_code_result = {
+      let exit_code_future = collect_child_outputs(
+        &mut stdout,
+        &mut stderr,
         self
           .run_in_workdir(&workdir_path, workdir_token, req.clone(), exclusive_spawn)
           .await?,
       );
       if let Some(req_timeout) = req.timeout {
-        timeout(req_timeout, child_results_future)
+        timeout(req_timeout, exit_code_future)
           .await
           .map_err(|e| e.to_string())
           .and_then(|r| r)
       } else {
-        child_results_future.await
+        exit_code_future.await
       }
     };
 
@@ -531,34 +515,39 @@ pub trait CapturedWorkdir {
       context.run_id,
     );
 
-    match child_results_result {
-      Ok(child_results) => {
-        let stdout = child_results.stdout;
-        let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
-
-        let stderr = child_results.stderr;
-        let stderr_digest = store.store_file_bytes(stderr.clone(), true).await?;
-
+    match exit_code_result {
+      Ok(exit_code) => {
+        let (stdout_digest, stderr_digest) = try_join!(
+          store.store_file_bytes(stdout.into(), true),
+          store.store_file_bytes(stderr.into(), true),
+        )?;
         Ok(FallibleProcessResultWithPlatform {
           stdout_digest,
           stderr_digest,
-          exit_code: child_results.exit_code,
+          exit_code,
           output_directory: output_snapshot.into(),
           platform,
           metadata: result_metadata,
         })
       }
       Err(msg) if msg == "deadline has elapsed" => {
-        let stdout = Bytes::from(format!(
-          "Exceeded timeout of {:.1} seconds when executing local process: {}",
-          req.timeout.map(|dur| dur.as_secs_f32()).unwrap_or(-1.0),
-          req.description
-        ));
-        let stdout_digest = store.store_file_bytes(stdout.clone(), true).await?;
+        stderr.extend_from_slice(
+          format!(
+            "\n\nExceeded timeout of {:.1} seconds when executing local process: {}",
+            req.timeout.map(|dur| dur.as_secs_f32()).unwrap_or(-1.0),
+            req.description
+          )
+          .as_bytes(),
+        );
+
+        let (stdout_digest, stderr_digest) = try_join!(
+          store.store_file_bytes(stdout.into(), true),
+          store.store_file_bytes(stderr.into(), true),
+        )?;
 
         Ok(FallibleProcessResultWithPlatform {
           stdout_digest,
-          stderr_digest: hashing::EMPTY_DIGEST,
+          stderr_digest,
           exit_code: -libc::SIGTERM,
           output_directory: EMPTY_DIRECTORY_DIGEST.clone(),
           platform,

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -565,7 +565,7 @@ async fn timeout() {
   let argv = vec![
     find_bash(),
     "-c".to_owned(),
-    "/bin/sleep 0.2; /bin/echo -n 'European Burmese'".to_string(),
+    "/bin/echo -n 'Calculating...'; /bin/sleep 0.5; /bin/echo -n 'European Burmese'".to_string(),
   ];
 
   let mut process = Process::new(argv);
@@ -575,9 +575,11 @@ async fn timeout() {
   let result = run_command_locally(process).await.unwrap();
 
   assert_eq!(result.original.exit_code, -15);
-  let error_msg = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
-  assert_that(&error_msg).contains("Exceeded timeout");
-  assert_that(&error_msg).contains("sleepy-cat");
+  let stdout = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
+  let stderr = String::from_utf8(result.stderr_bytes.to_vec()).unwrap();
+  assert_that(&stdout).contains("Calculating...");
+  assert_that(&stderr).contains("Exceeded timeout");
+  assert_that(&stderr).contains("sleepy-cat");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Currently the `stdout`/`stderr` of a timed out process are discarded. But because we were already streaming them, we can easily render them when a process exits due to a timeout.

[ci skip-build-wheels]