### PR TITLE
docker: set platform when creating containers

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "bollard"
 version = "0.13.0"
-source = "git+https://github.com/fussybeaver/bollard.git?rev=2e10fe31076a6e298697fc6e31fa3676b7498b6c#2e10fe31076a6e298697fc6e31fa3676b7498b6c"
+source = "git+https://github.com/fussybeaver/bollard.git?rev=2d66d11b44aeff0373ece3d64a44b243e5152973#2d66d11b44aeff0373ece3d64a44b243e5152973"
 dependencies = [
  "base64",
  "bollard-stubs 1.42.0-rc.4",
@@ -215,7 +215,7 @@ dependencies = [
 [[package]]
 name = "bollard-stubs"
 version = "1.42.0-rc.4"
-source = "git+https://github.com/fussybeaver/bollard.git?rev=2e10fe31076a6e298697fc6e31fa3676b7498b6c#2e10fe31076a6e298697fc6e31fa3676b7498b6c"
+source = "git+https://github.com/fussybeaver/bollard.git?rev=2d66d11b44aeff0373ece3d64a44b243e5152973#2d66d11b44aeff0373ece3d64a44b243e5152973"
 dependencies = [
  "serde",
  "serde_with",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 async-stream = "0.3"
 async-trait = "0.1"
 async-lock = "2.5"
-bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2e10fe31076a6e298697fc6e31fa3676b7498b6c" }
+bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
 bollard-stubs = "1.42.0-rc.3"
 walkdir = "2"
 protos = { path = "../protos" }

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use async_oncecell::OnceCell;
 use async_trait::async_trait;
-use bollard::container::{LogOutput, RemoveContainerOptions};
+use bollard::container::{CreateContainerOptions, LogOutput, RemoveContainerOptions};
 use bollard::exec::StartExecResults;
 use bollard::image::CreateImageOptions;
 use bollard::service::CreateImageInfo;
@@ -641,10 +641,12 @@ impl ContainerCache {
       &config
     );
 
-    // TODO: Pass `platform` parameter via options argument once https://github.com/fussybeaver/bollard/pull/259
-    // is approved upstream.
+    let create_options = CreateContainerOptions::<&str> {
+      name: "",
+      platform: Some(docker_platform_identifier(&platform)),
+    };
     let container = docker
-      .create_container::<&str, String>(None, config)
+      .create_container::<&str, String>(Some(create_options), config)
       .await
       .map_err(|err| format!("Failed to create Docker container: {:?}", err))?;
 

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -78,7 +78,7 @@ impl DockerOnceCell {
               return Err(format!("Pants requires Docker to support API version 1.41 or higher. Local Docker only supports: {:?}", &version.api_version));
             }
           }
-          _ => return Err(format!("Unparesable API version `{}` returned by Docker.", &api_version)),
+          _ => return Err(format!("Unparseable API version `{}` returned by Docker.", &api_version)),
         }
 
         Ok(docker)


### PR DESCRIPTION
Update `bollard` and make use of new ability to set platform upon container creation.

For tests, the `busybox` image is only available for Linux and not macOS. Thus on macOS the tests fail since no macOS version of busybox image is available. Solve by pinning the platform used for tests to Linux. On Linux this is fine since same OS. On macOS, this works due to macOS Docker support for running Linux containers.