### PR TITLE
Don't mention a specific version in the manual install instructions. (Cherry-pick of #16888)

### DIFF
--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -194,10 +194,6 @@ Go to the [documentation dashboard](https://dash.readme.com/). In the top left d
 
 Also, update the [Changelog](doc:changelog) page with the new release series at the top of the table. It's okay if there are no "highlights" yet.
 
-### Update the version in Installing Pants
-
-Update [Installing Pants](doc:installation) to use the version you're releasing in the `pants.toml` snippet.
-
 ### Regenerate the references
 
 On the relevant release branch, run `./pants run build-support/bin/generate_docs.py -- --sync --api-key <key>` with your key from <https://dash.readme.com/project/pants/v2.8/api-key>.

--- a/docs/markdown/Getting Started/getting-started/manual-installation.md
+++ b/docs/markdown/Getting Started/getting-started/manual-installation.md
@@ -13,10 +13,14 @@ Manual installation
 
 Pants is invoked via a launch script named `./pants` , saved at the root of the repository. This script will install Pants and handle upgrades.
 
-First, set up a minimal `pants.toml` config file to instruct the script to download the latest 2.13 release:
+First, pick a release version. You can see the available releases [on PyPI](https://pypi.org/project/pantsbuild.pants/).
+We recommend picking the current stable release, unless you have reason to need a more recent one,
+such as a release candidate or a development release.
+
+Then, set up a minimal `pants.toml` config file, filling in the version you selected:
 
 ```bash
-printf '[GLOBAL]\npants_version = "2.13.0.dev5"\n' > pants.toml
+printf '[GLOBAL]\npants_version = "X.Y.Z"\n' > pants.toml
 ```
 
 Then, download the script:


### PR DESCRIPTION
It's a hassle to keep updated, and this isn't the recommended install method any more anyway.
