### PR TITLE
Remote execution can be toggled per Environment / `Process`

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -410,6 +410,7 @@ def extract_process_config_from_environment(
     return ProcessConfigFromEnvironment(
         platform=platform.value,
         docker_image=docker_image,
+        remote_execution=global_options.remote_execution and not docker_image,
         remote_execution_extra_platform_properties=[
             tuple(pair.split("=", maxsplit=1))  # type: ignore[misc]
             for pair in global_options.remote_execution_extra_platform_properties

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -177,6 +177,7 @@ class ProcessConfigFromEnvironment:
         *,
         platform: str,
         docker_image: str | None,
+        remote_execution: bool,
         remote_execution_extra_platform_properties: Sequence[tuple[str, str]],
     ) -> None: ...
     def __eq__(self, other: ProcessConfigFromEnvironment | Any) -> bool: ...

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -523,6 +523,7 @@ class RuleRunner:
             ProcessConfigFromEnvironment(
                 platform=Platform.create_for_localhost().value,
                 docker_image=None,
+                remote_execution=False,
                 remote_execution_extra_platform_properties=[],
             ),
         )

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -76,7 +76,7 @@ async fn runner_errors_if_docker_image_not_set() {
   // Because `docker_image` is set but it does not exist, this process should fail.
   let err = run_command_via_docker(
     Process::new(owned_string_vec(&["/bin/echo", "-n", "foo"]))
-      .docker_image("does-not-exist:latest".to_owned()),
+      .docker("does-not-exist:latest".to_owned()),
   )
   .await
   .unwrap_err();
@@ -104,7 +104,7 @@ async fn runner_errors_if_docker_image_not_set() {
 async fn stdout() {
   skip_if_no_docker_available_in_macos_ci!();
   let result = run_command_via_docker(
-    Process::new(owned_string_vec(&["/bin/echo", "-n", "foo"])).docker_image(IMAGE.to_owned()),
+    Process::new(owned_string_vec(&["/bin/echo", "-n", "foo"])).docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -125,7 +125,7 @@ async fn stdout_and_stderr_and_exit_code() {
       "-c",
       "echo -n foo ; echo >&2 -n bar ; exit 1",
     ]))
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -143,7 +143,7 @@ async fn capture_exit_code_signal() {
 
   // Launch a process that kills itself with a signal.
   let result = run_command_via_docker(
-    Process::new(owned_string_vec(&[SH_PATH, "-c", "kill $$"])).docker_image(IMAGE.to_owned()),
+    Process::new(owned_string_vec(&[SH_PATH, "-c", "kill $$"])).docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -191,7 +191,7 @@ async fn env() {
   let result = run_command_via_docker(
     Process::new(owned_string_vec(&["/bin/env"]))
       .env(env.clone())
-      .docker_image(IMAGE.to_owned()),
+      .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -212,7 +212,7 @@ async fn env_is_deterministic() {
     env.insert("BAR".to_string(), "not foo".to_string());
     Process::new(owned_string_vec(&["/bin/env"]))
       .env(env)
-      .docker_image(IMAGE.to_owned())
+      .docker(IMAGE.to_owned())
   }
 
   let result1 = run_command_via_docker(make_request()).await.unwrap();
@@ -230,7 +230,7 @@ async fn binary_not_found() {
 
   // Use `xyzzy` as a command that should not exist.
   let result = run_command_via_docker(
-    Process::new(owned_string_vec(&["xyzzy", "-n", "foo"])).docker_image(IMAGE.to_owned()),
+    Process::new(owned_string_vec(&["xyzzy", "-n", "foo"])).docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -243,7 +243,7 @@ async fn output_files_none() {
   skip_if_no_docker_available_in_macos_ci!();
 
   let result = run_command_via_docker(
-    Process::new(owned_string_vec(&[SH_PATH, "-c", "exit 0"])).docker_image(IMAGE.to_owned()),
+    Process::new(owned_string_vec(&[SH_PATH, "-c", "exit 0"])).docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -265,7 +265,7 @@ async fn output_files_one() {
       format!("echo -n {} > roland.ext", TestData::roland().string()),
     ])
     .output_files(relative_paths(&["roland.ext"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -296,7 +296,7 @@ async fn output_dirs() {
     ])
     .output_files(relative_paths(&["treats.ext"]).collect())
     .output_directories(relative_paths(&["cats"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -326,7 +326,7 @@ async fn output_files_many() {
       ),
     ])
     .output_files(relative_paths(&["cats/roland.ext", "treats.ext"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -355,7 +355,7 @@ async fn output_files_execution_failure() {
       ),
     ])
     .output_files(relative_paths(&["roland.ext"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -385,7 +385,7 @@ async fn output_files_partial_output() {
         .into_iter()
         .collect(),
     )
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -412,7 +412,7 @@ async fn output_overlapping_file_and_dir() {
     ])
     .output_files(relative_paths(&["cats/roland.ext"]).collect())
     .output_directories(relative_paths(&["cats"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -438,7 +438,7 @@ async fn append_only_cache_created() {
   let result = run_command_via_docker(
     Process::new(owned_string_vec(&["/bin/ls", dest_base]))
       .append_only_caches(vec![(cache_name, cache_dest)].into_iter().collect())
-      .docker_image(IMAGE.to_owned()),
+      .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -459,7 +459,7 @@ async fn test_apply_chroot() {
   let work_dir = TempDir::new().unwrap();
   let mut req = Process::new(owned_string_vec(&["/usr/bin/env"]))
     .env(env.clone())
-    .docker_image(IMAGE.to_owned());
+    .docker(IMAGE.to_owned());
   local::apply_chroot(work_dir.path().to_str().unwrap(), &mut req);
 
   let path = format!("/usr/bin:{}/bin", work_dir.path().to_str().unwrap());
@@ -481,7 +481,7 @@ async fn test_chroot_placeholder() {
   let result = run_command_via_docker_in_dir(
     Process::new(vec!["/bin/env".to_owned()])
       .env(env.clone())
-      .docker_image(IMAGE.to_owned()),
+      .docker(IMAGE.to_owned()),
     work_root.clone(),
     KeepSandboxes::Always,
     &mut workunit,
@@ -515,7 +515,7 @@ async fn all_containing_directories_for_outputs_are_created() {
     ])
     .output_files(relative_paths(&["cats/roland.ext"]).collect())
     .output_directories(relative_paths(&["birds/falcons"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -541,7 +541,7 @@ async fn output_empty_dir() {
       "/bin/mkdir falcons".to_string(),
     ])
     .output_directories(relative_paths(&["falcons"]).collect())
-    .docker_image(IMAGE.to_owned()),
+    .docker(IMAGE.to_owned()),
   )
   .await
   .unwrap();
@@ -566,10 +566,9 @@ async fn timeout() {
     "/bin/echo -n 'Calculating...'; /bin/sleep 5; /bin/echo -n 'European Burmese'".to_string(),
   ];
 
-  let mut process = Process::new(argv);
+  let mut process = Process::new(argv).docker(IMAGE.to_owned());
   process.timeout = Some(Duration::from_millis(500));
   process.description = "sleepy-cat".to_string();
-  process.docker_image = Some(IMAGE.to_owned());
 
   let result = run_command_via_docker(process).await.unwrap();
 
@@ -611,14 +610,14 @@ async fn working_directory() {
     SH_PATH.to_string(),
     "-c".to_owned(),
     "/bin/ls".to_string(),
-  ]);
+  ])
+  .docker(IMAGE.to_owned());
   process.working_directory = Some(RelativePath::new("cats").unwrap());
   process.output_directories = relative_paths(&["roland.ext"]).collect::<BTreeSet<_>>();
   process.input_digests =
     InputDigests::with_input_files(TestDirectory::nested().directory_digest());
   process.timeout = Some(Duration::from_secs(1));
   process.description = "confused-cat".to_string();
-  process.docker_image = Some(IMAGE.to_owned());
 
   let result = run_command_via_docker_in_dir(
     process,
@@ -669,7 +668,8 @@ async fn immutable_inputs() {
     SH_PATH.to_string(),
     "-c".to_owned(),
     "/bin/ls".to_string(),
-  ]);
+  ])
+  .docker(IMAGE.to_owned());
   process.input_digests = InputDigests::new(
     &store,
     TestDirectory::containing_falcons_dir().directory_digest(),
@@ -687,7 +687,6 @@ async fn immutable_inputs() {
   .unwrap();
   process.timeout = Some(Duration::from_secs(1));
   process.description = "confused-cat".to_string();
-  process.docker_image = Some(IMAGE.to_string());
 
   let result = run_command_via_docker_in_dir(
     process,

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -92,7 +92,7 @@ async fn runner_errors_if_docker_image_not_set() {
     .unwrap_err();
   if let ProcessError::Unclassified(msg) = &err {
     assert!(
-      msg.contains("docker_image not set on the Process, but the Docker CommandRunner was used")
+      msg.contains("The Docker execution strategy was not set on the Process, but the Docker CommandRunner was used")
     );
   } else {
     panic!("unexpected value: {:?}", err)

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -443,6 +443,13 @@ impl Default for InputDigests {
   }
 }
 
+#[derive(DeepSizeOf, Debug, Clone, Hash, PartialEq, Eq, Serialize)]
+pub enum ProcessExecutionStrategy {
+  Local,
+  RemoteExecution,
+  Docker(String),
+}
+
 ///
 /// A process to be executed.
 ///
@@ -537,8 +544,7 @@ pub struct Process {
 
   pub cache_scope: ProcessCacheScope,
 
-  /// The docker image to run the process with.
-  pub docker_image: Option<String>,
+  pub execution_strategy: ProcessExecutionStrategy,
 
   /// Properties used for remote execution configuration. Regardless of remote execution, these
   /// should impact the cache key.
@@ -573,7 +579,7 @@ impl Process {
       execution_slot_variable: None,
       concurrency_available: 0,
       cache_scope: ProcessCacheScope::Successful,
-      docker_image: None,
+      execution_strategy: ProcessExecutionStrategy::Local,
       platform_properties: vec![],
     }
   }
@@ -622,10 +628,10 @@ impl Process {
   }
 
   ///
-  /// Replaces the docker_image used for this process.
+  /// Set the execution strategy to Docker, with the specified image.
   ///
-  pub fn docker_image(mut self, docker_image: String) -> Process {
-    self.docker_image = Some(docker_image);
+  pub fn docker(mut self, image: String) -> Process {
+    self.execution_strategy = ProcessExecutionStrategy::Docker(image);
     self
   }
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -24,7 +24,7 @@ use workunit_store::{RunId, WorkunitStore};
 use crate::remote::{CommandRunner, ExecutionError, OperationOrStatus};
 use crate::{
   CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, InputDigests,
-  Platform, Process, ProcessCacheScope, ProcessError,
+  Platform, Process, ProcessCacheScope, ProcessError, ProcessExecutionStrategy,
 };
 use fs::{RelativePath, EMPTY_DIRECTORY_DIGEST};
 use std::any::type_name;
@@ -89,7 +89,7 @@ async fn make_execute_request() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
   };
 
@@ -168,7 +168,7 @@ async fn make_execute_request_with_instance_name() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![("target_platform".to_owned(), "apple-2e".to_owned())],
   };
 
@@ -253,7 +253,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
   };
 
@@ -478,7 +478,7 @@ async fn make_execute_request_with_timeout() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
   };
 
@@ -585,7 +585,7 @@ async fn make_execute_request_using_immutable_inputs() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
   };
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -37,7 +37,7 @@ use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
   local::KeepSandboxes, CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches,
-  Platform, ProcessCacheScope,
+  Platform, ProcessCacheScope, ProcessExecutionStrategy,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
@@ -463,7 +463,7 @@ async fn make_request_from_flat_args(
     execution_slot_variable: None,
     concurrency_available: args.command.concurrency_available.unwrap_or(0),
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::Local,
     platform_properties: collection_from_keyvalues(args.command.extra_platform_property.iter()),
   };
 
@@ -557,7 +557,7 @@ async fn extract_request_from_action_digest(
     jdk_home: None,
     platform_constraint: None,
     cache_scope: ProcessCacheScope::Always,
-    docker_image: None,
+    execution_strategy: ProcessExecutionStrategy::Local,
     platform_properties: command
       .platform
       .iter()

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -29,7 +29,7 @@ use tokio::process;
 use fs::{DigestTrie, DirectoryDigest, PathStat, RelativePath};
 use hashing::{Digest, EMPTY_DIGEST};
 use process_execution::local::{apply_chroot, create_sandbox, prepare_workdir, KeepSandboxes};
-use process_execution::ManagedChild;
+use process_execution::{ManagedChild, ProcessExecutionStrategy};
 use rule_graph::DependencyKey;
 use stdio::TryCloneAsFile;
 use store::{SnapshotOps, SubsetParams};
@@ -516,9 +516,10 @@ fn interactive_process(
         .unwrap();
       (py_interactive_process.extract().unwrap(), py_process, process_config)
     });
-    if let Some(docker_image) = process_config.docker_image {
-      panic!("InteractiveProcess should not run with a docker environment, but set to {docker_image}")
-    }
+    match process_config.execution_strategy {
+      ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution => panic!("InteractiveProcess should not set docker_image or remote_execution"),
+      _ => ()
+    };
     let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;
     let (run_in_workspace, restartable, keep_sandboxes) = Python::with_gil(|py| {
       let py_interactive_process_obj = py_interactive_process.to_object(py);

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -386,7 +386,7 @@ impl ExecuteProcess {
         .try_into()?
     };
 
-    Ok(process_execution::Process {
+    Ok(Process {
       argv: externs::getattr(value, "argv").unwrap(),
       env,
       working_directory,
@@ -402,7 +402,7 @@ impl ExecuteProcess {
       execution_slot_variable,
       concurrency_available,
       cache_scope,
-      docker_image: process_config.docker_image,
+      execution_strategy: process_config.execution_strategy,
       platform_properties: process_config.remote_execution_extra_platform_properties,
     })
   }


### PR DESCRIPTION
We want to allow using remote execution (RE) alongside other strategies like local Docker, so enabling RE cannot be solely a global toggle.

Same as our Docker strategy from https://github.com/pantsbuild/pants/pull/16791, we set remote execution for the entire Environment subgraph. This means that all Processes necessary for something like `test` will run in the same RE environment.

This requires changing our command runner setup. Now, we create the RE command runner if RE is enabled globally, even if some processes may not use it. The SwitchedCommandRunner determines whether we use Docker, Local, or RE. 

In the future, we could add speculation between Local and RE with something Python side like `await FirstOf(Get(.., {env1: ..}), Get(.., {env2: ..}))`.

--

This PR has no impact for existing RE users: if RE is enabled, we will always use RE.

Instead, this improves the situation so that RE users can also use Docker environments, whereas before we would still try to use RE.