### PR TITLE
Add `extra_platform_properties` field to remote execution environment

### DIFF
--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -115,9 +115,9 @@ def test_extract_process_config_from_environment() -> None:
             enable_remote_execution=re,
             expected_remote_execution=True,
             expected_docker_image=None,
-            expected_remote_execution_extra_platform_properties=[("global_k", "v")],
+            # The global option is ignored.
+            expected_remote_execution_extra_platform_properties=[],
         )
-    # `extra_platforms_field` should override the global default.
     assert_config(
         env_tgt=RemoteEnvironmentTarget(
             {RemoteExtraPlatformPropertiesField.alias: ["field_k=v"]}, Address("dir")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1698,8 +1698,11 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         help=softwrap(
             """
             Platform properties to set on remote execution requests.
+
             Format: property=value. Multiple values should be specified as multiple
-            occurrences of this flag. Pants itself may add additional platform properties.
+            occurrences of this flag.
+
+            Pants itself may add additional platform properties.
             """
         ),
         default=[],

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1703,6 +1703,9 @@ class GlobalOptions(BootstrapOptions, Subsystem):
             occurrences of this flag.
 
             Pants itself may add additional platform properties.
+
+            If you are using the remote_environment target mechanism, set this value as a field
+            on the target instead. This option will be ignored.
             """
         ),
         default=[],

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -546,9 +546,7 @@ pub struct Process {
 
   pub execution_strategy: ProcessExecutionStrategy,
 
-  /// Properties used for remote execution configuration. Regardless of remote execution, these
-  /// should impact the cache key.
-  pub platform_properties: Vec<(String, String)>,
+  pub remote_execution_platform_properties: Vec<(String, String)>,
 }
 
 impl Process {
@@ -580,7 +578,7 @@ impl Process {
       concurrency_available: 0,
       cache_scope: ProcessCacheScope::Successful,
       execution_strategy: ProcessExecutionStrategy::Local,
-      platform_properties: vec![],
+      remote_execution_platform_properties: vec![],
     }
   }
 
@@ -636,10 +634,13 @@ impl Process {
   }
 
   ///
-  /// Replaces the platform_properties used for this process.
+  /// Replaces the remote_execution_platform_properties used for this process.
   ///
-  pub fn platform_properties(mut self, properties: Vec<(String, String)>) -> Process {
-    self.platform_properties = properties;
+  pub fn remote_execution_platform_properties(
+    mut self,
+    properties: Vec<(String, String)>,
+  ) -> Process {
+    self.remote_execution_platform_properties = properties;
     self
   }
 }

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -446,7 +446,9 @@ impl Default for InputDigests {
 #[derive(DeepSizeOf, Debug, Clone, Hash, PartialEq, Eq, Serialize)]
 pub enum ProcessExecutionStrategy {
   Local,
-  RemoteExecution,
+  /// Stores the platform_properties.
+  RemoteExecution(Vec<(String, String)>),
+  /// Stores the image name.
   Docker(String),
 }
 
@@ -545,8 +547,6 @@ pub struct Process {
   pub cache_scope: ProcessCacheScope,
 
   pub execution_strategy: ProcessExecutionStrategy,
-
-  pub remote_execution_platform_properties: Vec<(String, String)>,
 }
 
 impl Process {
@@ -578,7 +578,6 @@ impl Process {
       concurrency_available: 0,
       cache_scope: ProcessCacheScope::Successful,
       execution_strategy: ProcessExecutionStrategy::Local,
-      remote_execution_platform_properties: vec![],
     }
   }
 
@@ -634,13 +633,13 @@ impl Process {
   }
 
   ///
-  /// Replaces the remote_execution_platform_properties used for this process.
+  /// Set the execution strategy to remote execution with the provided platform properties.
   ///
   pub fn remote_execution_platform_properties(
     mut self,
     properties: Vec<(String, String)>,
   ) -> Process {
-    self.remote_execution_platform_properties = properties;
+    self.execution_strategy = ProcessExecutionStrategy::RemoteExecution(properties);
     self
   }
 }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -43,7 +43,7 @@ use workunit_store::{
 
 use crate::{
   Context, FallibleProcessResultWithPlatform, Platform, Process, ProcessCacheScope, ProcessError,
-  ProcessResultMetadata, ProcessResultSource,
+  ProcessExecutionStrategy, ProcessResultMetadata, ProcessResultSource,
 };
 
 // Environment variable which is exclusively used for cache key invalidation.
@@ -868,7 +868,10 @@ pub fn make_execute_request(
       });
   }
 
-  let mut platform_properties = req.remote_execution_platform_properties.clone();
+  let mut platform_properties = match req.execution_strategy.clone() {
+    ProcessExecutionStrategy::RemoteExecution(properties) => properties,
+    _ => vec![],
+  };
 
   // TODO: Disabling append-only caches in remoting until server support exists due to
   //       interaction with how servers match platform properties.

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -868,7 +868,7 @@ pub fn make_execute_request(
       });
   }
 
-  let mut platform_properties = req.platform_properties.clone();
+  let mut platform_properties = req.remote_execution_platform_properties.clone();
 
   // TODO: Disabling append-only caches in remoting until server support exists due to
   //       interaction with how servers match platform properties.

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -89,8 +89,7 @@ async fn make_execute_request() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    remote_execution_platform_properties: vec![],
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![]),
   };
 
   let want_command = remexec::Command {
@@ -168,11 +167,10 @@ async fn make_execute_request_with_instance_name() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    remote_execution_platform_properties: vec![(
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![(
       "target_platform".to_owned(),
       "apple-2e".to_owned(),
-    )],
+    )]),
   };
 
   let want_command = remexec::Command {
@@ -256,8 +254,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    remote_execution_platform_properties: vec![],
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![]),
   };
 
   let mut want_command = remexec::Command {
@@ -484,8 +481,7 @@ async fn make_execute_request_with_timeout() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    remote_execution_platform_properties: vec![],
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![]),
   };
 
   let want_command = remexec::Command {
@@ -591,8 +587,7 @@ async fn make_execute_request_using_immutable_inputs() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
-    execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    remote_execution_platform_properties: vec![],
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![]),
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -90,7 +90,7 @@ async fn make_execute_request() {
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    platform_properties: vec![],
+    remote_execution_platform_properties: vec![],
   };
 
   let want_command = remexec::Command {
@@ -169,7 +169,10 @@ async fn make_execute_request_with_instance_name() {
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    platform_properties: vec![("target_platform".to_owned(), "apple-2e".to_owned())],
+    remote_execution_platform_properties: vec![(
+      "target_platform".to_owned(),
+      "apple-2e".to_owned(),
+    )],
   };
 
   let want_command = remexec::Command {
@@ -254,7 +257,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    platform_properties: vec![],
+    remote_execution_platform_properties: vec![],
   };
 
   let mut want_command = remexec::Command {
@@ -379,12 +382,13 @@ async fn make_execute_request_with_jdk() {
 #[tokio::test]
 async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   let input_directory = TestDirectory::containing_roland();
-  let mut req = Process::new(owned_string_vec(&["/bin/echo", "yo"])).platform_properties(vec![
-    ("FIRST".to_owned(), "foo".to_owned()),
-    ("Multi".to_owned(), "uno".to_owned()),
-    ("last".to_owned(), "bar".to_owned()),
-    ("Multi".to_owned(), "dos".to_owned()),
-  ]);
+  let mut req = Process::new(owned_string_vec(&["/bin/echo", "yo"]))
+    .remote_execution_platform_properties(vec![
+      ("FIRST".to_owned(), "foo".to_owned()),
+      ("Multi".to_owned(), "uno".to_owned()),
+      ("last".to_owned(), "bar".to_owned()),
+      ("Multi".to_owned(), "dos".to_owned()),
+    ]);
   req.platform = Platform::Linux_x86_64;
   req.input_digests = InputDigests::with_input_files(input_directory.directory_digest());
   req.description = "some description".to_owned();
@@ -481,7 +485,7 @@ async fn make_execute_request_with_timeout() {
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    platform_properties: vec![],
+    remote_execution_platform_properties: vec![],
   };
 
   let want_command = remexec::Command {
@@ -588,7 +592,7 @@ async fn make_execute_request_using_immutable_inputs() {
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
-    platform_properties: vec![],
+    remote_execution_platform_properties: vec![],
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -66,10 +66,6 @@ struct CommandSpec {
   #[structopt(long)]
   input_digest_length: Option<usize>,
 
-  /// Extra platform properties to set on the execution request.
-  #[structopt(long)]
-  extra_platform_property: Vec<String>,
-
   /// Environment variables with which the process should be run.
   #[structopt(long)]
   env: Vec<String>,
@@ -462,9 +458,6 @@ async fn make_request_from_flat_args(
     concurrency_available: args.command.concurrency_available.unwrap_or(0),
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::Local,
-    remote_execution_platform_properties: collection_from_keyvalues(
-      args.command.extra_platform_property.iter(),
-    ),
   };
 
   let metadata = ProcessMetadata {
@@ -558,16 +551,6 @@ async fn extract_request_from_action_digest(
     platform: Platform::current().unwrap(),
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::Local,
-    remote_execution_platform_properties: command
-      .platform
-      .iter()
-      .flat_map(|platform| {
-        platform
-          .properties
-          .iter()
-          .map(|property| (property.name.clone(), property.value.clone()))
-      })
-      .collect(),
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -462,7 +462,9 @@ async fn make_request_from_flat_args(
     concurrency_available: args.command.concurrency_available.unwrap_or(0),
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::Local,
-    platform_properties: collection_from_keyvalues(args.command.extra_platform_property.iter()),
+    remote_execution_platform_properties: collection_from_keyvalues(
+      args.command.extra_platform_property.iter(),
+    ),
   };
 
   let metadata = ProcessMetadata {
@@ -556,7 +558,7 @@ async fn extract_request_from_action_digest(
     platform: Platform::current().unwrap(),
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::Local,
-    platform_properties: command
+    remote_execution_platform_properties: command
       .platform
       .iter()
       .flat_map(|platform| {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -282,7 +282,7 @@ impl Core {
         |req| {
           matches!(
             req.execution_strategy,
-            ProcessExecutionStrategy::RemoteExecution
+            ProcessExecutionStrategy::RemoteExecution(_)
           )
         },
       ));

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -517,9 +517,9 @@ fn interactive_process(
       (py_interactive_process.extract().unwrap(), py_process, process_config)
     });
     match process_config.execution_strategy {
-      ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => panic!("InteractiveProcess should not set docker_image or remote_execution"),
-      _ => ()
-    };
+      ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => Err("InteractiveProcess should not set docker_image or remote_execution".to_owned()),
+      _ => Ok(())
+    }?;
     let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;
     let (run_in_workspace, restartable, keep_sandboxes) = Python::with_gil(|py| {
       let py_interactive_process_obj = py_interactive_process.to_object(py);

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -517,7 +517,7 @@ fn interactive_process(
       (py_interactive_process.extract().unwrap(), py_process, process_config)
     });
     match process_config.execution_strategy {
-      ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution => panic!("InteractiveProcess should not set docker_image or remote_execution"),
+      ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => panic!("InteractiveProcess should not set docker_image or remote_execution"),
       _ => ()
     };
     let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -403,8 +403,6 @@ impl ExecuteProcess {
       concurrency_available,
       cache_scope,
       execution_strategy: process_config.execution_strategy,
-      remote_execution_platform_properties: process_config
-        .remote_execution_extra_platform_properties,
     })
   }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -403,7 +403,8 @@ impl ExecuteProcess {
       concurrency_available,
       cache_scope,
       execution_strategy: process_config.execution_strategy,
-      platform_properties: process_config.remote_execution_extra_platform_properties,
+      remote_execution_platform_properties: process_config
+        .remote_execution_extra_platform_properties,
     })
   }
 


### PR DESCRIPTION
Follow up to https://github.com/pantsbuild/pants/pull/16906.

This follows the design principle from https://docs.google.com/document/d/14xYllPF_FjFMtJybTi2l_bZKfZsHvzGta7CIggdm_ms/edit that subsystems provide the default value for environment targets, and the fields allow overriding. That makes backward compatibility simple for existing RE users who are not yet using environment targets, as we will continue to respect `[GLOBAL].remote_execution_extra_platform_properties`.

This also tweaks our code so we no longer set `remote_execution_extra_platform_properties` on the `Process` when RE is not used, as it should be irrelevant. The Rust code is renamed to clarify this.