### PR TITLE
go: add `go-generate` goal to run `go generate` on a package

### DIFF
--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -3,7 +3,7 @@
 
 from pants.backend.go import target_type_rules
 from pants.backend.go.go_sources import load_go_binary
-from pants.backend.go.goals import check, package_binary, run_binary, tailor, test
+from pants.backend.go.goals import check, generate, package_binary, run_binary, tailor, test
 from pants.backend.go.lint.gofmt import skip_field as gofmt_skip_field
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
 from pants.backend.go.target_types import (
@@ -48,6 +48,7 @@ def rules():
         *coverage_output.rules(),
         *cgo.rules(),
         *third_party_pkg.rules(),
+        *generate.rules(),
         *go_bootstrap.rules(),
         *goroot.rules(),
         *import_analysis.rules(),

--- a/src/python/pants/backend/go/go_sources/analyze_package/main.go
+++ b/src/python/pants/backend/go/go_sources/analyze_package/main.go
@@ -427,6 +427,11 @@ func main() {
 	// TODO: Consider allowing caller to set build tags or platform? Setting platform GOOS/GOARCH will be
 	// necessary for multi-platform support.
 	buildContext := &build.Default
+	extraBuildTagsEnv := os.Getenv("EXTRA_BUILD_TAGS")
+	if extraBuildTagsEnv != "" {
+		extraBuildTags := strings.Split(extraBuildTagsEnv, ",")
+		buildContext.BuildTags = append(buildContext.BuildTags, extraBuildTags...)
+	}
 
 	for _, arg := range os.Args[1:] {
 		pkg, err := analyzePackage(arg, buildContext)

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -33,6 +33,17 @@ from pants.engine.target import Targets
 
 logger = logging.getLogger(__name__)
 
+
+# Adapted from Go toolchain.
+# See https://github.com/golang/go/blob/master/src/cmd/go/internal/generate/generate.go and
+# https://github.com/golang/go/blob/cc1b20e8adf83865a1dbffa259c7a04ef0699b43/src/os/env.go#L16-L96
+#
+# Original copyright:
+#   // Copyright 2011 The Go Authors. All rights reserved.
+#   // Use of this source code is governed by a BSD-style
+#   // license that can be found in the LICENSE file.
+
+
 _GENERATE_DIRECTIVE_RE = re.compile(rb"^//go:generate[ \t](.*)$")
 
 

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -26,7 +26,6 @@ from pants.backend.go.util_rules import (
 from pants.core.goals.test import get_filtered_environment
 from pants.core.util_rules import source_files
 from pants.engine.fs import DigestContents, FileContent
-from pants.engine.internals.native_engine import Digest
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -54,6 +54,14 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
+# Adapted from Go toolchain.
+# See https://github.com/golang/go/blob/cc1b20e8adf83865a1dbffa259c7a04ef0699b43/src/os/env_test.go#L14-L67
+#
+# Original copyright:
+#   // Copyright 2010 The Go Authors. All rights reserved.
+#   // Use of this source code is governed by a BSD-style
+#   // license that can be found in the LICENSE file.
+
 _EXPAND_TEST_CASES = [
     ("", ""),
     ("$*", "all the args"),

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -1,0 +1,114 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.goals import generate
+from pants.backend.go.goals.generate import GoGenerateGoal, _expand_env
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    link,
+    sdk,
+    tests_analysis,
+    third_party_pkg,
+)
+from pants.core.goals.test import get_filtered_environment
+from pants.core.util_rules import source_files
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner, logging
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *generate.rules(),
+            # to avoid rule graph errors?
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *first_party_pkg.rules(),
+            *go_mod.rules(),
+            *link.rules(),
+            *sdk.rules(),
+            *target_type_rules.rules(),
+            *tests_analysis.rules(),
+            *third_party_pkg.rules(),
+            *source_files.rules(),
+            get_filtered_environment,
+        ],
+        target_types=[GoModTarget, GoPackageTarget],
+        preserve_tmpdirs=True,
+    )
+    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+_EXPAND_TEST_CASES = [
+    ("", ""),
+    ("$*", "all the args"),
+    ("$$", "PID"),
+    ("${*}", "all the args"),
+    ("$1", "ARGUMENT1"),
+    ("${1}", "ARGUMENT1"),
+    ("now is the time", "now is the time"),
+    ("$HOME", "/usr/gopher"),
+    ("$home_1", "/usr/foo"),
+    ("${HOME}", "/usr/gopher"),
+    ("${H}OME", "(Value of H)OME"),
+    ("A$$$#$1$H$home_1*B", "APIDNARGSARGUMENT1(Value of H)/usr/foo*B"),
+    ("start$+middle$^end$", "start$+middle$^end$"),
+    ("mixed$|bag$$$", "mixed$|bagPID$"),
+    ("$", "$"),
+    ("$}", "$}"),
+    ("${", ""),  # invalid syntax; eat up the characters
+    ("${}", ""),  # invalid syntax; eat up the characters
+]
+
+
+@pytest.mark.parametrize("input,output", _EXPAND_TEST_CASES)
+def test_expand_env(input, output) -> None:
+    m = {
+        "*": "all the args",
+        "#": "NARGS",
+        "$": "PID",
+        "1": "ARGUMENT1",
+        "HOME": "/usr/gopher",
+        "H": "(Value of H)",
+        "home_1": "/usr/foo",
+        "_": "underscore",
+    }
+    assert _expand_env(input, m) == output
+
+
+@logging
+def test_generate_run_commands(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "grok/BUILD": "go_mod(name='mod')\ngo_package()",
+            "grok/go.mod": "module example.com/grok\n",
+            "grok/gen.go": textwrap.dedent(
+                """\
+            //go:build generate
+            package grok
+            //go:generate -command shell /bin/sh -c
+            //go:generate shell "echo grok-$GOLINE > generated.txt"
+            """
+            ),
+            "grok/empty.go": "package grok\n",
+        }
+    )
+    result = rule_runner.run_goal_rule(GoGenerateGoal, args=["grok::"], env_inherit={"PATH"})
+    assert result.exit_code == 0
+    generated_file = Path(rule_runner.build_root, "grok", "generated.txt")
+    assert generated_file.read_text() == "grok-4\n"


### PR DESCRIPTION
Support running `go generate` on Go packages via new `go-generate` goal.

Closes https://github.com/pantsbuild/pants/issues/13881.

[ci skip-build-wheels]
