### PR TITLE
Fix invalid field error message for parametrized fields.

### DIFF
--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -8,6 +8,6 @@ python_tests(
     overrides={
         "local_dists_test.py": {"timeout": 120},
         "pex_from_targets_test.py": {"timeout": 200},
-        "pex_test.py": {"timeout": 720},
+        "pex_test.py": {"timeout": 600},
     },
 )

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -8,6 +8,6 @@ python_tests(
     overrides={
         "local_dists_test.py": {"timeout": 120},
         "pex_from_targets_test.py": {"timeout": 200},
-        "pex_test.py": {"timeout": 600},
+        "pex_test.py": {"timeout": 720},
     },
 )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -227,15 +227,23 @@ async def resolve_target_parametrizations(
                 if field_value is not None:
                     template_fields[field_type.alias] = field_value
 
+        field_type_aliases = target_type._get_field_aliases_to_field_types(
+            target_type.class_field_types(union_membership)
+        ).keys()
         generator_fields_parametrized = {
-            name for name, field in generator_fields.items() if isinstance(field, Parametrize)
+            name
+            for name, field in generator_fields.items()
+            if isinstance(field, Parametrize) and name in field_type_aliases
         }
         if generator_fields_parametrized:
             noun = pluralize(len(generator_fields_parametrized), "field", include_count=False)
+            generator_fields_parametrized_text = ", ".join(
+                repr(f) for f in generator_fields_parametrized
+            )
             raise InvalidFieldException(
                 f"Only fields which will be moved to generated targets may be parametrized, "
                 f"so target generator {address} (with type {target_type.alias}) cannot "
-                f"parametrize the {generator_fields_parametrized} {noun}."
+                f"parametrize the {generator_fields_parametrized_text} {noun}."
             )
 
         base_generator = target_type(

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -49,6 +49,7 @@ from pants.engine.target import (
     HydrateSourcesRequest,
     InferDependenciesRequest,
     InferredDependencies,
+    InvalidFieldException,
     MultipleSourcesField,
     OverridesField,
     SecondaryOwnerMixin,
@@ -1345,6 +1346,23 @@ def test_parametrize_16190(generated_targets_rule_runner: RuleRunner) -> None:
             "demo:parent@parent=b": {"demo:child@child=b"},
         },
     )
+
+
+@pytest.mark.parametrize(
+    "field_content",
+    [
+        "tagz=['tag']",
+        "tagz=parametrize(['tag1'], ['tag2'])",
+    ],
+)
+def test_parametrize_16910(generated_targets_rule_runner: RuleRunner, field_content: str) -> None:
+    with engine_error(InvalidFieldException, contains=f"Unrecognized field `{field_content}`"):
+        assert_generated(
+            generated_targets_rule_runner,
+            Address("demo"),
+            f"generator({field_content}, sources=['*.ext'])",
+            ["f1.ext", "f2.ext"],
+        )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -115,7 +115,7 @@ class Parametrize:
     def __repr__(self) -> str:
         strs = [str(s) for s in self.args]
         strs.extend(f"{alias}={value}" for alias, value in self.kwargs.items())
-        return f"parametrize({', '.join(strs)}"
+        return f"parametrize({', '.join(strs)})"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
In case the field is invalid for the target type (unknown field) avoid failing early for parametrized fields as that is secondary.

Fixes #16910 
