### PR TITLE
Move all non-generate related resolve types to `pants.engine.resolves`.

### DIFF
--- a/src/python/pants/backend/java/dependency_inference/java_parser.py
+++ b/src/python/pants/backend/java/dependency_inference/java_parser.py
@@ -11,11 +11,12 @@ from dataclasses import dataclass
 import pkg_resources
 
 from pants.backend.java.dependency_inference.types import JavaSourceDependencyAnalysis
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -7,12 +7,13 @@ import os
 from dataclasses import dataclass
 from typing import Any, Iterator
 
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import CreateDigest, DigestContents, Directory, FileContent
 from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, RemovePrefix
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -27,15 +27,17 @@ from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
     GenerateLockfileResult,
     GenerateLockfilesSubsystem,
-    KnownUserResolveNames,
-    KnownUserResolveNamesRequest,
-    RequestedUserResolveNames,
     UserGenerateLockfiles,
     WrappedGenerateLockfile,
 )
 from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, MergeDigests
 from pants.engine.process import ProcessCacheScope, ProcessResult
+from pants.engine.resolves import (
+    KnownUserResolveNames,
+    KnownUserResolveNamesRequest,
+    RequestedUserResolveNames,
+)
 from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import AllTargets
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -17,10 +17,10 @@ from pants.backend.python.util_rules.pex_requirements import (
     ToolCustomLockfile,
     ToolDefaultLockfile,
 )
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, NO_TOOL_LOCKFILE
 from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
 from pants.engine.fs import Digest, FileContent
 from pants.engine.internals.selectors import Get
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE, NO_TOOL_LOCKFILE
 from pants.engine.rules import rule_helper
 from pants.option.errors import OptionsError
 from pants.option.option_types import BoolOption, StrListOption, StrOption

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -9,7 +9,7 @@ import os
 from typing import Iterable, List, Optional, TypeVar, cast
 
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
+from pants.engine.resolves import UnrecognizedResolveNamesError
 from pants.option.option_types import (
     BoolOption,
     DictOption,

--- a/src/python/pants/backend/python/subsystems/setup_test.py
+++ b/src/python/pants/backend/python/subsystems/setup_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
+from pants.engine.resolves import UnrecognizedResolveNamesError
 from pants.testutil.option_util import create_subsystem
 
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -27,7 +27,6 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.pip_requirement import PipRequirement
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.core.goals.test import (
@@ -37,6 +36,7 @@ from pants.core.goals.test import (
 )
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address, Addresses
+from pants.engine.resolves import UnrecognizedResolveNamesError
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -38,10 +38,10 @@ from pants.backend.python.target_types_rules import (
     resolve_pex_entry_point,
 )
 from pants.backend.python.util_rules import python_sources
-from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.engine.addresses import Address
 from pants.engine.internals.graph import _TargetParametrizations, _TargetParametrizationsRequest
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.resolves import UnrecognizedResolveNamesError
 from pants.engine.target import (
     InferredDependencies,
     InvalidFieldException,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -39,11 +39,12 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.generate_lockfiles import NO_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
+from pants.engine.resolves import NO_TOOL_LOCKFILE
 from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import (
     AllTargets,

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -10,7 +10,7 @@ from typing import Any, Iterator, Mapping
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import (
     AddPrefix,
@@ -24,6 +24,7 @@ from pants.engine.fs import (
 )
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult, ProcessExecutionFailure, ProcessResult
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionRule

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -18,7 +18,6 @@ from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfileRequest,
     Lockfile,
 )
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, NO_TOOL_LOCKFILE
 from pants.core.goals.update_build_files import (
     FormatWithBlackRequest,
     FormatWithYapfRequest,
@@ -40,6 +39,7 @@ from pants.core.goals.update_build_files import (
 from pants.core.target_types import GenericTarget
 from pants.core.util_rules import config_files
 from pants.engine.fs import EMPTY_DIGEST
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE, NO_TOOL_LOCKFILE
 from pants.engine.rules import SubsystemRule, rule
 from pants.engine.target import RegisteredTargetTypes, StringField, Target, TargetGenerator
 from pants.engine.unions import UnionMembership, UnionRule

--- a/src/python/pants/engine/resolves.py
+++ b/src/python/pants/engine/resolves.py
@@ -1,0 +1,254 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Iterable, Sequence
+
+from pants.engine.collection import Collection
+from pants.engine.environment import EnvironmentName
+from pants.engine.rules import collect_rules
+from pants.engine.target import Target
+from pants.engine.unions import union
+from pants.util.docutil import doc_url
+from pants.util.strutil import bullet_list, softwrap
+
+logger = logging.getLogger(__name__)
+
+
+@union
+class KnownUserResolveNamesRequest:
+    """A hook for a language ecosystem to declare which resolves it has defined.
+
+    Each language ecosystem should set up a subclass and register it with a UnionRule. Implement a
+    rule that goes from the subclass -> KnownUserResolveNames, usually by simply reading the
+    `resolves` option from the relevant subsystem.
+    """
+
+
+@dataclass(frozen=True)
+class KnownUserResolveNames:
+    """All defined user resolves for a particular language ecosystem.
+
+    See KnownUserResolveNamesRequest for how to use this type. `option_name` should be formatted
+    like `[options-scope].resolves`
+    """
+
+    names: tuple[str, ...]
+    option_name: str
+    requested_resolve_names_cls: type[RequestedUserResolveNames]
+
+
+@union(in_scope_types=[EnvironmentName])
+class RequestedUserResolveNames(Collection[str]):
+    """The user resolves requested for a particular language ecosystem.
+
+    Each language ecosystem should set up a subclass and register it with a UnionRule. Implement a
+    rule that goes from the subclass -> UserGenerateLockfiles.
+    """
+
+
+DEFAULT_TOOL_LOCKFILE = "<default>"
+NO_TOOL_LOCKFILE = "<none>"
+
+
+class UnrecognizedResolveNamesError(Exception):
+    def __init__(
+        self,
+        unrecognized_resolve_names: list[str],
+        all_valid_names: Iterable[str],
+        *,
+        description_of_origin: str,
+    ) -> None:
+        # TODO(#12314): maybe implement "Did you mean?"
+        if len(unrecognized_resolve_names) == 1:
+            unrecognized_str = unrecognized_resolve_names[0]
+            name_description = "name"
+        else:
+            unrecognized_str = str(sorted(unrecognized_resolve_names))
+            name_description = "names"
+        super().__init__(
+            softwrap(
+                f"""
+            Unrecognized resolve {name_description} from {description_of_origin}:
+            {unrecognized_str}\n\nAll valid resolve names: {sorted(all_valid_names)}
+            """
+            )
+        )
+
+
+class _ResolveProviderType(Enum):
+    TOOL = 1
+    USER = 2
+
+
+@dataclass(frozen=True, order=True)
+class _ResolveProvider:
+    option_name: str
+    type_: _ResolveProviderType
+
+
+class AmbiguousResolveNamesError(Exception):
+    def __init__(self, ambiguous_name: str, providers: set[_ResolveProvider]) -> None:
+        tool_providers = []
+        user_providers = []
+        for provider in sorted(providers):
+            if provider.type_ == _ResolveProviderType.TOOL:
+                tool_providers.append(provider.option_name)
+            else:
+                user_providers.append(provider.option_name)
+
+        if tool_providers:
+            if not user_providers:
+                raise AssertionError(
+                    softwrap(
+                        f"""
+                        {len(tool_providers)} tools have the same options_scope: {ambiguous_name}.
+                        If you're writing a plugin, rename your `GenerateToolLockfileSentinel`s so
+                        that there is no ambiguity. Otherwise, please open a bug at
+                        https://github.com/pantsbuild/pants/issues/new.
+                        """
+                    )
+                )
+            if len(user_providers) == 1:
+                msg = softwrap(
+                    f"""
+                    A resolve name from the option `{user_providers[0]}` collides with the
+                    name of a tool resolve: {ambiguous_name}
+
+                    To fix, please update `{user_providers[0]}` to use a different resolve name.
+                    """
+                )
+            else:
+                msg = softwrap(
+                    f"""
+                    Multiple options define the resolve name `{ambiguous_name}`, but it is
+                    already claimed by a tool: {user_providers}
+
+                    To fix, please update these options so that none of them use
+                    `{ambiguous_name}`.
+                    """
+                )
+        else:
+            assert len(user_providers) > 1
+            msg = softwrap(
+                f"""
+                The same resolve name `{ambiguous_name}` is used by multiple options, which
+                causes ambiguity: {user_providers}
+
+                To fix, please update these options so that `{ambiguous_name}` is not used more
+                than once.
+                """
+            )
+        super().__init__(msg)
+
+
+# -----------------------------------------------------------------------------------------------
+# Helpers for determining the resolve
+# -----------------------------------------------------------------------------------------------
+
+
+class NoCompatibleResolveException(Exception):
+    """No compatible resolve could be found for a set of targets."""
+
+    @classmethod
+    def bad_input_roots(
+        cls,
+        targets: Iterable[Target],
+        *,
+        maybe_get_resolve: Callable[[Target], str | None],
+        doc_url_slug: str,
+        workaround: str | None,
+    ) -> NoCompatibleResolveException:
+        resolves_to_addresses = defaultdict(list)
+        for tgt in targets:
+            maybe_resolve = maybe_get_resolve(tgt)
+            if maybe_resolve is not None:
+                resolves_to_addresses[maybe_resolve].append(tgt.address.spec)
+
+        formatted_resolve_lists = "\n\n".join(
+            f"{resolve}:\n{bullet_list(sorted(addresses))}"
+            for resolve, addresses in sorted(resolves_to_addresses.items())
+        )
+        return NoCompatibleResolveException(
+            softwrap(
+                f"""
+            The input targets did not have a resolve in common.\n\n
+            {formatted_resolve_lists}\n\n
+            Targets used together must use the same resolve, set by the `resolve` field. For more
+            information on 'resolves' (lockfiles), see {doc_url(doc_url_slug)}.
+            """
+            )
+            + (f"\n\n{workaround}" if workaround else "")
+        )
+
+    @classmethod
+    def bad_dependencies(
+        cls,
+        *,
+        maybe_get_resolve: Callable[[Target], str | None],
+        doc_url_slug: str,
+        root_resolve: str,
+        root_targets: Sequence[Target],
+        dependencies: Iterable[Target],
+    ) -> NoCompatibleResolveException:
+        if len(root_targets) == 1:
+            addr = root_targets[0].address
+            prefix = softwrap(
+                f"""
+                The target {addr} uses the `resolve` `{root_resolve}`, but some of its
+                dependencies are not compatible with that resolve:
+
+
+
+                """
+            )
+            change_input_targets_instructions = f"of the target {addr}"
+        else:
+            assert root_targets
+            prefix = softwrap(
+                f"""
+                The input targets use the `resolve` `{root_resolve}`, but some of their
+                dependencies are not compatible with that resolve.
+
+                Input targets:
+
+                {bullet_list(sorted(t.address.spec for t in root_targets))}
+
+                Bad dependencies:
+                """
+            )
+            change_input_targets_instructions = "of the input targets"
+
+        deps_strings = []
+        for dep in dependencies:
+            maybe_resolve = maybe_get_resolve(dep)
+            if maybe_resolve is None or maybe_resolve == root_resolve:
+                continue
+            deps_strings.append(f"{dep.address} ({maybe_resolve})")
+
+        return NoCompatibleResolveException(
+            softwrap(
+                f"""
+                {prefix}
+
+                {bullet_list(deps_strings)}
+
+                All dependencies must work with the same `resolve`. To fix this, either change
+                the `resolve=` field on those dependencies to `{root_resolve}`, or change
+                the `resolve=` {change_input_targets_instructions}. If those dependencies should
+                work with multiple resolves, use the `parametrize` mechanism with the `resolve=`
+                field or manually create multiple targets for the same entity.
+
+                For more information, see {doc_url(doc_url_slug)}.
+                """
+            )
+        )
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/jvm/goals/lockfile.py
+++ b/src/python/pants/jvm/goals/lockfile.py
@@ -10,15 +10,17 @@ from typing import Mapping
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
     GenerateLockfileResult,
-    KnownUserResolveNames,
-    KnownUserResolveNamesRequest,
-    RequestedUserResolveNames,
     UserGenerateLockfiles,
     WrappedGenerateLockfile,
 )
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import MultiGet
+from pants.engine.resolves import (
+    KnownUserResolveNames,
+    KnownUserResolveNamesRequest,
+    RequestedUserResolveNames,
+)
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import AllTargets
 from pants.engine.unions import UnionMembership, UnionRule, union

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING, Any, FrozenSet, Iterable, Iterator, List, Tupl
 import toml
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateLockfilesSubsystem
+from pants.core.goals.generate_lockfiles import GenerateLockfilesSubsystem
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.collection import Collection
@@ -36,6 +36,7 @@ from pants.engine.fs import (
 )
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import ProcessResult
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import CoarsenedTargets, Target, Targets
 from pants.engine.unions import UnionRule

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 from typing import ClassVar
 
 from pants.build_graph.address import Address, AddressInput
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.addresses import Addresses
 from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Targets
 from pants.jvm.goals import lockfile

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 
 import textwrap
 
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import Digest, DigestContents
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import SubsystemRule, rule
 from pants.jvm.goals.lockfile import GenerateJvmLockfile
 from pants.jvm.goals.lockfile import rules as lockfile_rules

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -6,10 +6,11 @@ from typing import Tuple
 
 import pkg_resources
 
-from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, GenerateToolLockfileSentinel
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, Directory, FileContent
 from pants.engine.internals.native_engine import MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, ProcessResult
+from pants.engine.resolves import DEFAULT_TOOL_LOCKFILE
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 from abc import ABCMeta
 from typing import Optional
 
-from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.core.goals.test import TestExtraEnvVarsField, TestTimeoutField
 from pants.engine.addresses import Address
+from pants.engine.resolves import UnrecognizedResolveNamesError
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,


### PR DESCRIPTION
This is a generalization for the lockfile resolves data types and unions that are not specific for only generating lockfiles by moving them out of the `pants.core.goals.generate_lockfiles` module they become reusable for more use cases than merely lockfile creation.

=== There is NO code change in this PR only re-organizations. ;) ===

This is a prep PR for an upcoming feature to introspect and diff lock files. My goal is to make it easy to see what has been changed in a lock file after running `./pants generate-lockfiles`. Design proposal issue tbw after I've run some feasibility tests.


PS.
The main motivation for this refactor is that I want to add another union type to `KnownUserResolveNames` that is for loading a lock files data in a generic way, not generating it so felt wrong to add that to the `generate_lockfiles` goal module, and creating a new union type for it didn't feel right either as the current ones were kind of generically named already.