### PR TITLE
remove override of register_plugin_field

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1056,14 +1056,6 @@ class TargetGenerator(Target):
                 "`TargetGenerator.moved_field`s, to avoid redundant graph edges."
             )
 
-    @classmethod
-    def register_plugin_field(cls, field: Type[Field], *, copy_field: bool = False) -> UnionRule:
-        if copy_field:
-            cls.copied_fields = cls.copied_fields + (field,)
-        else:
-            cls.moved_fields = cls.moved_fields + (field,)
-        return super().register_plugin_field(field)
-
 
 class TargetFilesGenerator(TargetGenerator):
     """A TargetGenerator which generates a Target per file matched by the generator.


### PR DESCRIPTION
As reported on Slack, after https://github.com/pantsbuild/pants/pull/16799, help for targets with plugin fields was listing those plugin fields multiple times. Remove the override of `register_plugin_field` on `TargetGenerator` since tests seems to pass without that code and the need to set the plugin field as a moved or copied field may be unnecessary if the field is registered on the generator and the generated target types.

[ci skip-rust]

[ci skip-build-wheels]