### PR TITLE
Only use remote cache when cache scope is Always or Successful

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -444,7 +444,10 @@ impl crate::CommandRunner for CommandRunner {
     let (command_digest, action_digest) =
       crate::remote::ensure_action_stored_locally(&self.store, &command, &action).await?;
 
-    let (result, hit_cache) = if self.cache_read {
+    let use_remote_cache = request.cache_scope == ProcessCacheScope::Always
+      || request.cache_scope == ProcessCacheScope::Successful;
+
+    let (result, hit_cache) = if self.cache_read && use_remote_cache {
       self
         .speculate_read_action_cache(
           context.clone(),
@@ -461,7 +464,11 @@ impl crate::CommandRunner for CommandRunner {
       )
     };
 
-    if !hit_cache && (result.exit_code == 0 || write_failures_to_cache) && self.cache_write {
+    if !hit_cache
+      && (result.exit_code == 0 || write_failures_to_cache)
+      && self.cache_write
+      && use_remote_cache
+    {
       let command_runner = self.clone();
       let result = result.clone();
       let _write_join = self.executor.spawn(in_workunit!(

--- a/testprojects/src/jvm/BUILD
+++ b/testprojects/src/jvm/BUILD
@@ -1,5 +1,4 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(name="lib")
-pex_binary(name="main", entry_point="main.py")
+files(name="lib_directory", sources=["org/pantsbuild/example/lib/**/*"])

--- a/testprojects/src/python/hello/main/BUILD
+++ b/testprojects/src/python/hello/main/BUILD
@@ -3,3 +3,8 @@
 
 python_sources(name="lib")
 pex_binary(name="main", entry_point="main.py")
+
+file(name="main_file", source="main.py")
+archive(name="archive_zip", format="zip", files=[":main_file"])
+archive(name="archive_tar", format="tar", files=[":main_file"])
+archive(name="archive_targz", format="tar.gz", files=[":main_file"])

--- a/tests/python/pants_test/integration/BUILD
+++ b/tests/python/pants_test/integration/BUILD
@@ -43,7 +43,7 @@ python_tests(name="prelude_integration", sources=["prelude_integration_test.py"]
 python_tests(
     name="remote_cache_integration",
     sources=["remote_cache_integration_test.py"],
-    dependencies=["testprojects/src/python:hello_directory"],
+    dependencies=["testprojects/src/jvm:lib_directory"],
     timeout=180,
 )
 

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -44,9 +44,10 @@ def test_warns_on_remote_cache_errors() -> None:
             [
                 "--backend-packages=['pants.backend.python']",
                 "--no-dynamic-ui",
+                "--no-local-cache",
                 *remote_cache_args(cas.address, behavior),
                 "package",
-                "testprojects/src/python/hello/main:main",
+                "testprojects/src/python/hello/main::",
             ],
             use_pantsd=False,
         )

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -42,12 +42,12 @@ def test_warns_on_remote_cache_errors() -> None:
     def run(behavior: RemoteCacheWarningsBehavior) -> str:
         pants_run = run_pants(
             [
-                "--backend-packages=['pants.backend.python']",
+                "--backend-packages=['pants.backend.experimental.java']",
                 "--no-dynamic-ui",
                 "--no-local-cache",
                 *remote_cache_args(cas.address, behavior),
-                "package",
-                "testprojects/src/python/hello/main::",
+                "check",
+                "testprojects/src/jvm/org/pantsbuild/example/lib/ExampleLib.java",
             ],
             use_pantsd=False,
         )
@@ -70,6 +70,18 @@ def test_warns_on_remote_cache_errors() -> None:
     fourth_read_err = read_err(4)
     fourth_write_err = write_err(4)
 
+    # Generate lock files first, as the test is java test.
+    pants_run = run_pants(
+        [
+            "--backend-packages=['pants.backend.experimental.java']",
+            "--no-dynamic-ui",
+            "--no-local-cache",
+            "generate-lockfiles",
+        ],
+        use_pantsd=False,
+    )
+    pants_run.assert_success()
+
     ignore_result = run(RemoteCacheWarningsBehavior.ignore)
     for err in [
         first_read_err,
@@ -89,7 +101,7 @@ def test_warns_on_remote_cache_errors() -> None:
 
     backoff_result = run(RemoteCacheWarningsBehavior.backoff)
     for err in [first_read_err, first_write_err, fourth_read_err, fourth_write_err]:
-        assert err in backoff_result
+        assert err in backoff_result, f"Not found in:\n{backoff_result}"
     for err in [third_read_err, third_write_err]:
         assert err not in backoff_result
 


### PR DESCRIPTION
Processes with `ProcessCacheScope`s that prevent caching [already have unique `Digest`s](https://github.com/pantsbuild/pants/blob/1d007fb2a971d8518ab5311eadb0f8444c1f1fe8/src/rust/engine/process_execution/src/remote.rs#L894-L906). But in cases where we know that we should miss a remote cache, we can skip the lookup entirely.

[ci skip-build-wheels]