### PR TITLE
Add an optional speculation delay when using a remote cache

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -67,6 +67,7 @@ class Process:
     execution_slot_variable: str | None
     concurrency_available: int
     cache_scope: ProcessCacheScope
+    remote_cache_speculation_delay_millis: int
 
     def __init__(
         self,
@@ -88,6 +89,7 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         platform: Platform | None = None,
+        remote_cache_speculation_delay_millis: int = 0,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -134,6 +136,7 @@ class Process:
         self.execution_slot_variable = execution_slot_variable
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
+        self.remote_cache_speculation_delay_millis = remote_cache_speculation_delay_millis
 
         if platform is not None:
             warn_or_error(

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -373,7 +373,7 @@ _JVM_HEAP_SIZE_UNITS = ["", "k", "m", "g"]
 
 @rule
 async def jvm_process(
-    bash: BashBinary, request: JvmProcess, global_options: GlobalOptions
+    bash: BashBinary, request: JvmProcess, jvm: JvmSubsystem, global_options: GlobalOptions
 ) -> Process:
 
     jdk = request.jdk
@@ -421,9 +421,7 @@ async def jvm_process(
     if request.remote_cache_speculation_delay is not None:
         remote_cache_speculation_delay_millis = request.remote_cache_speculation_delay
     elif request.use_nailgun:
-        remote_cache_speculation_delay_millis = (
-            global_options.nailgun_remote_cache_speculation_delay
-        )
+        remote_cache_speculation_delay_millis = jvm.nailgun_remote_cache_speculation_delay
 
     return Process(
         [*jdk.args(bash, request.classpath_entries), *jvm_options, *request.argv],

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -323,6 +323,7 @@ class JvmProcess:
     extra_env: FrozenDict[str, str]
     cache_scope: ProcessCacheScope | None
     use_nailgun: bool
+    remote_cache_speculation_delay: int | None
 
     def __init__(
         self,
@@ -341,6 +342,7 @@ class JvmProcess:
         timeout_seconds: int | float | None = None,
         cache_scope: ProcessCacheScope | None = None,
         use_nailgun: bool = True,
+        remote_cache_speculation_delay: int | None = None,
     ):
         self.jdk = jdk
         self.argv = tuple(argv)
@@ -357,6 +359,7 @@ class JvmProcess:
         self.extra_immutable_input_digests = FrozenDict(extra_immutable_input_digests or {})
         self.extra_env = FrozenDict(extra_env or {})
         self.use_nailgun = use_nailgun
+        self.remote_cache_speculation_delay = remote_cache_speculation_delay
 
         if not use_nailgun and extra_nailgun_keys:
             raise AssertionError(
@@ -414,6 +417,14 @@ async def jvm_process(
     if request.use_nailgun:
         use_nailgun = [*jdk.immutable_input_digests, *request.extra_nailgun_keys]
 
+    remote_cache_speculation_delay_millis = 0
+    if request.remote_cache_speculation_delay is not None:
+        remote_cache_speculation_delay_millis = request.remote_cache_speculation_delay
+    elif request.use_nailgun:
+        remote_cache_speculation_delay_millis = (
+            global_options.nailgun_remote_cache_speculation_delay
+        )
+
     return Process(
         [*jdk.args(bash, request.classpath_entries), *jvm_options, *request.argv],
         input_digest=request.input_digest,
@@ -427,6 +438,7 @@ async def jvm_process(
         append_only_caches=jdk.append_only_caches,
         output_files=request.output_files,
         cache_scope=request.cache_scope or ProcessCacheScope.SUCCESSFUL,
+        remote_cache_speculation_delay_millis=remote_cache_speculation_delay_millis,
     )
 
 

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pants.option.option_types import BoolOption, DictOption, StrListOption, StrOption
+from pants.option.option_types import BoolOption, DictOption, IntOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -94,6 +94,25 @@ class JvmSubsystem(Subsystem):
 
             Because some compilers do not support this step as a native operation, it can have a
             performance cost, and is not enabled by default.
+            """
+        ),
+        advanced=True,
+    )
+    # See https://github.com/pantsbuild/pants/issues/14937 for discussion of one way to improve
+    # our behavior around cancellation with nailgun.
+    nailgun_remote_cache_speculation_delay = IntOption(
+        default=1000,
+        help=softwrap(
+            """
+            The time in milliseconds to delay speculation of nailgun processes while reading
+            from the remote cache.
+
+            When speculating, a remote cache hit will cancel the local copy of a process. But
+            because nailgun does not natively support cancellation, that requires killing a
+            nailgun server, which will mean that future processes take longer to warm up.
+
+            This setting allows for trading off waiting for potentially slow cache entries
+            against potentially having to warm up a new nailgun server.
             """
         ),
         advanced=True,

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -487,6 +487,7 @@ class ExecutionOptions:
     local_cache: bool
     process_execution_local_parallelism: int
     process_execution_local_enable_nailgun: bool
+    nailgun_remote_cache_speculation_delay: int
     process_execution_remote_parallelism: int
     process_execution_cache_namespace: str | None
     process_execution_graceful_shutdown_timeout: int
@@ -534,6 +535,7 @@ class ExecutionOptions:
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             process_execution_graceful_shutdown_timeout=bootstrap_options.process_execution_graceful_shutdown_timeout,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
+            nailgun_remote_cache_speculation_delay=bootstrap_options.nailgun_remote_cache_speculation_delay,
             cache_content_behavior=bootstrap_options.cache_content_behavior,
             process_total_child_memory_usage=bootstrap_options.process_total_child_memory_usage,
             process_per_child_memory_usage=bootstrap_options.process_per_child_memory_usage,
@@ -619,6 +621,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     local_cache=True,
     cache_content_behavior=CacheContentBehavior.fetch,
     process_execution_local_enable_nailgun=True,
+    nailgun_remote_cache_speculation_delay=0,
     process_execution_graceful_shutdown_timeout=3,
     # Remote store setup.
     remote_store_address=None,
@@ -1286,6 +1289,15 @@ class BootstrapOptions:
     process_execution_local_enable_nailgun = BoolOption(
         default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_enable_nailgun,
         help="Whether or not to use nailgun to run JVM requests that are marked as supporting nailgun.",
+        advanced=True,
+    )
+    nailgun_remote_cache_speculation_delay = IntOption(
+        default=DEFAULT_EXECUTION_OPTIONS.nailgun_remote_cache_speculation_delay,
+        help=softwrap(
+            """
+            The time in milliseconds to delay remote cache read speculation of nailgun processes.
+            """
+        ),
         advanced=True,
     )
     process_execution_graceful_shutdown_timeout = IntOption(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -487,7 +487,6 @@ class ExecutionOptions:
     local_cache: bool
     process_execution_local_parallelism: int
     process_execution_local_enable_nailgun: bool
-    nailgun_remote_cache_speculation_delay: int
     process_execution_remote_parallelism: int
     process_execution_cache_namespace: str | None
     process_execution_graceful_shutdown_timeout: int
@@ -535,7 +534,6 @@ class ExecutionOptions:
             process_execution_cache_namespace=bootstrap_options.process_execution_cache_namespace,
             process_execution_graceful_shutdown_timeout=bootstrap_options.process_execution_graceful_shutdown_timeout,
             process_execution_local_enable_nailgun=bootstrap_options.process_execution_local_enable_nailgun,
-            nailgun_remote_cache_speculation_delay=bootstrap_options.nailgun_remote_cache_speculation_delay,
             cache_content_behavior=bootstrap_options.cache_content_behavior,
             process_total_child_memory_usage=bootstrap_options.process_total_child_memory_usage,
             process_per_child_memory_usage=bootstrap_options.process_per_child_memory_usage,
@@ -621,7 +619,6 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     local_cache=True,
     cache_content_behavior=CacheContentBehavior.fetch,
     process_execution_local_enable_nailgun=True,
-    nailgun_remote_cache_speculation_delay=0,
     process_execution_graceful_shutdown_timeout=3,
     # Remote store setup.
     remote_store_address=None,
@@ -1289,15 +1286,6 @@ class BootstrapOptions:
     process_execution_local_enable_nailgun = BoolOption(
         default=DEFAULT_EXECUTION_OPTIONS.process_execution_local_enable_nailgun,
         help="Whether or not to use nailgun to run JVM requests that are marked as supporting nailgun.",
-        advanced=True,
-    )
-    nailgun_remote_cache_speculation_delay = IntOption(
-        default=DEFAULT_EXECUTION_OPTIONS.nailgun_remote_cache_speculation_delay,
-        help=softwrap(
-            """
-            The time in milliseconds to delay remote cache read speculation of nailgun processes.
-            """
-        ),
         advanced=True,
     )
     process_execution_graceful_shutdown_timeout = IntOption(

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -549,6 +549,8 @@ pub struct Process {
   /// Properties used for remote execution configuration. Regardless of remote execution, these
   /// should impact the cache key.
   pub platform_properties: Vec<(String, String)>,
+
+  pub remote_cache_speculation_delay: std::time::Duration,
 }
 
 impl Process {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -583,6 +583,7 @@ impl Process {
       cache_scope: ProcessCacheScope::Successful,
       execution_strategy: ProcessExecutionStrategy::Local,
       platform_properties: vec![],
+      remote_cache_speculation_delay: std::time::Duration::from_millis(0),
     }
   }
 
@@ -642,6 +643,11 @@ impl Process {
   ///
   pub fn platform_properties(mut self, properties: Vec<(String, String)>) -> Process {
     self.platform_properties = properties;
+    self
+  }
+
+  pub fn remote_cache_speculation_delay(mut self, delay: std::time::Duration) -> Process {
+    self.remote_cache_speculation_delay = delay;
     self
   }
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -255,7 +255,7 @@ impl CommandRunner {
     >,
   ) -> Result<(FallibleProcessResultWithPlatform, bool), ProcessError> {
     // A future to read from the cache and log the results accordingly.
-    let cache_read_future = async {
+    let mut cache_read_future = async {
       let response = check_action_cache(
         action_digest,
         &request.description,
@@ -291,10 +291,10 @@ impl CommandRunner {
       Level::Trace,
       |workunit| async move {
         tokio::select! {
-          cache_result = &cache_read_future => {
+          cache_result = &mut cache_read_future => {
             self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await
           }
-          s = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+          _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
             tokio::select! {
               cache_result = cache_read_future => {
                 self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -294,7 +294,7 @@ impl CommandRunner {
           cache_result = &mut cache_read_future => {
             self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await
           }
-          _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+          _ = tokio::time::sleep(request.remote_cache_speculation_delay) => {
             tokio::select! {
               cache_result = cache_read_future => {
                 self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await
@@ -464,8 +464,6 @@ impl crate::CommandRunner for CommandRunner {
     // Ensure the action and command are stored locally.
     let (command_digest, action_digest) =
       crate::remote::ensure_action_stored_locally(&self.store, &command, &action).await?;
-
-    let use_nailgun = !request.input_digests.use_nailgun.is_empty();
 
     let (result, hit_cache) = if self.cache_read {
       self

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -313,6 +313,7 @@ async fn cache_read_speculation() {
   async fn run_process(
     local_delay_ms: u64,
     remote_delay_ms: u64,
+    remote_cache_speculation_delay_ms: u64,
     cache_hit: bool,
     workunit: &mut RunningWorkunit,
   ) -> (i32, usize) {
@@ -326,6 +327,9 @@ async fn cache_read_speculation() {
       create_cached_runner(local_runner, &store_setup, CacheContentBehavior::Defer);
 
     let (process, action_digest) = create_process(&store_setup).await;
+    let process = process.remote_cache_speculation_delay(std::time::Duration::from_millis(
+      remote_cache_speculation_delay_ms,
+    ));
     if cache_hit {
       store_setup
         .cas
@@ -344,17 +348,32 @@ async fn cache_read_speculation() {
   }
 
   // Case 1: remote is faster than local.
-  let (exit_code, local_call_count) = run_process(200, 0, true, &mut workunit).await;
+  let (exit_code, local_call_count) = run_process(200, 0, 0, true, &mut workunit).await;
   assert_eq!(exit_code, 0);
   assert_eq!(local_call_count, 0);
 
   // Case 2: local is faster than remote.
-  let (exit_code, local_call_count) = run_process(0, 200, true, &mut workunit).await;
+  let (exit_code, local_call_count) = run_process(0, 200, 0, true, &mut workunit).await;
   assert_eq!(exit_code, 1);
   assert_eq!(local_call_count, 1);
 
   // Case 3: the remote lookup wins, but there is no cache entry so we fallback to local execution.
-  let (exit_code, local_call_count) = run_process(200, 0, false, &mut workunit).await;
+  let (exit_code, local_call_count) = run_process(200, 0, 0, false, &mut workunit).await;
+  assert_eq!(exit_code, 1);
+  assert_eq!(local_call_count, 1);
+
+  // Case 4: remote is faster than speculation read delay.
+  let (exit_code, local_call_count) = run_process(0, 100, 200, true, &mut workunit).await;
+  assert_eq!(exit_code, 0);
+  assert_eq!(local_call_count, 0);
+
+  // Case 5: remote is faster than speculation read delay, but there is no cache entry so we fallback to local execution.
+  let (exit_code, local_call_count) = run_process(0, 100, 200, false, &mut workunit).await;
+  assert_eq!(exit_code, 1);
+  assert_eq!(local_call_count, 1);
+
+  // Case 6: local with speculation read delay is faster than remote.
+  let (exit_code, local_call_count) = run_process(0, 200, 100, true, &mut workunit).await;
   assert_eq!(exit_code, 1);
   assert_eq!(local_call_count, 1);
 }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -91,6 +91,7 @@ async fn make_execute_request() {
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -170,6 +171,7 @@ async fn make_execute_request_with_instance_name() {
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![("target_platform".to_owned(), "apple-2e".to_owned())],
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -255,6 +257,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let mut want_command = remexec::Command {
@@ -482,6 +485,7 @@ async fn make_execute_request_with_timeout() {
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -589,6 +593,7 @@ async fn make_execute_request_using_immutable_inputs() {
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::RemoteExecution,
     platform_properties: vec![],
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -463,6 +463,7 @@ async fn make_request_from_flat_args(
     cache_scope: ProcessCacheScope::Always,
     execution_strategy: ProcessExecutionStrategy::Local,
     platform_properties: collection_from_keyvalues(args.command.extra_platform_property.iter()),
+    remote_cache_speculation_delay: Duration::from_millis(0),
   };
 
   let metadata = ProcessMetadata {
@@ -566,6 +567,7 @@ async fn extract_request_from_action_digest(
           .map(|property| (property.name.clone(), property.value.clone()))
       })
       .collect(),
+    remote_cache_speculation_delay: Duration::from_millis(0),
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -386,6 +386,10 @@ impl ExecuteProcess {
         .try_into()?
     };
 
+    let remote_cache_speculation_delay = std::time::Duration::from_millis(
+      externs::getattr::<i32>(value, "remote_cache_speculation_delay_millis").unwrap() as u64,
+    );
+
     Ok(Process {
       argv: externs::getattr(value, "argv").unwrap(),
       env,
@@ -404,6 +408,7 @@ impl ExecuteProcess {
       cache_scope,
       execution_strategy: process_config.execution_strategy,
       platform_properties: process_config.remote_execution_extra_platform_properties,
+      remote_cache_speculation_delay,
     })
   }
 


### PR DESCRIPTION
When `nailgun` is combined with a remote cache, cancellation of `nailgun` processes due to cache hits results in `nailgun` servers getting killed (as expected: see #14937 for more on that topic).

But the cost of killing a `nailgun` server (which makes _future_ processes run more slowly) is not currently accounted for by our default setting of speculating for all requests. And figuring out the exact likelihood that we will hit the cache is a challenging problem.

This change adds an (optional, but enabled by default) delay before starting a `nailgun` process when a remote cache is in use.

Fixes #16921.

[ci skip-build-wheels]