### PR TITLE
Introduce and use `GoalToolMixin`

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -9,6 +9,13 @@ updatedAt: "2022-07-25T20:02:17.695Z"
 2.15
 ----
 
+### Subsystems used in `fmt`/`lint`/`check`/etc... should inherit from `GoalToolSubsystem`
+
+The new subsystem base is declared in `pants.options.subsystem`, and provides the `skip` option.
+
+If your subsystem participates in a goal like `fmt` or `check`, declare it as a base class, and remove
+your `skip` option.
+
 ### `platform` kwarg for `Process` deprecated
 
 Previously, we assumed processes were platform-agnostic, i.e. they had identical output on all
@@ -126,7 +133,7 @@ on `FieldSet`'s mechanisms for matching targets and getting field values.
 Rather than directly subclassing `GenerateToolLockfileSentinel`, we encourage you to subclass
 `GeneratePythonToolLockfileSentinel` and `GenerateJvmToolLockfileSentinel`. This is so that we can
 distinguish what language a tool belongs to, which is used for options like
-`[python].resolves_to_constraints_file` to validate which resolve names are recognized. 
+`[python].resolves_to_constraints_file` to validate which resolve names are recognized.
 
 Things will still work if you do not make this change, other than the new options not recognizing
 your tool.

--- a/src/python/pants/backend/build_files/fmt/buildifier/subsystem.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/subsystem.py
@@ -2,13 +2,15 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.core.util_rules.external_tool import TemplatedExternalTool
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.strutil import softwrap
 
 
-class Buildifier(TemplatedExternalTool):
+class Buildifier(GoalToolMixin, TemplatedExternalTool):
     options_scope = "buildifier"
     name = "Buildifier"
+    example_goal_name = "fmt"
     help = softwrap(
         """
         Buildifier is a tool for formatting BUILD files with a standard convention.
@@ -40,7 +42,6 @@ class Buildifier(TemplatedExternalTool):
         "linux_x86_64": "linux-amd64",
     }
 
-    skip = SkipOption("fmt")
     args = ArgsListOption(example="-lint=fix")
 
     # NB: buildifier doesn't (yet) support config files https://github.com/bazelbuild/buildtools/issues/479

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -18,14 +18,16 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
-class ClangFormat(PythonToolBase):
+class ClangFormat(GoalToolMixin, PythonToolBase):
     options_scope = "clang-format"
     name = "ClangFormat"
+    example_goal_name = "fmt"
     help = softwrap(
         """
         The clang-format utility for formatting C/C++ (and others) code
@@ -40,7 +42,6 @@ class ClangFormat(PythonToolBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--version")
 
     register_lockfile = True

--- a/src/python/pants/backend/docker/lint/hadolint/subsystem.py
+++ b/src/python/pants/backend/docker/lint/hadolint/subsystem.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
-from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.strutil import softwrap
 
 
-class Hadolint(TemplatedExternalTool):
+class Hadolint(GoalToolMixin, TemplatedExternalTool):
     options_scope = "hadolint"
     name = "Hadolint"
+    example_goal_name = "lint"
     help = "A linter for Dockerfiles."
 
     default_version = "v2.10.0"
@@ -31,7 +33,6 @@ class Hadolint(TemplatedExternalTool):
         "linux_x86_64": "Linux-x86_64",
     }
 
-    skip = SkipOption("lint")
     args = ArgsListOption(example="--format json")
     config = FileOption(
         default=None,

--- a/src/python/pants/backend/go/lint/gofmt/subsystem.py
+++ b/src/python/pants/backend/go/lint/gofmt/subsystem.py
@@ -1,13 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.option_types import SkipOption
-from pants.option.subsystem import Subsystem
+
+from pants.option.subsystem import GoalToolMixin, Subsystem
 
 
-class GofmtSubsystem(Subsystem):
+class GofmtSubsystem(GoalToolMixin, Subsystem):
     options_scope = "gofmt"
     name = "gofmt"
+    example_goal_name = "fmt"
     help = "Gofmt-specific options."
-
-    skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/go/lint/vet/subsystem.py
+++ b/src/python/pants/backend/go/lint/vet/subsystem.py
@@ -2,13 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.option.option_types import SkipOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 
 
-class GoVetSubsystem(Subsystem):
+class GoVetSubsystem(GoalToolMixin, Subsystem):
     options_scope = "go-vet"
     name = "`go vet`"
+    example_goal_name = "lint"
     help = "`go vet`-specific options."
-
-    skip = SkipOption("lint")

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -31,8 +31,12 @@ class JavacCheckRequest(CheckRequest):
 @rule(desc="Check javac compilation", level=LogLevel.DEBUG)
 async def javac_check(
     request: JavacCheckRequest,
+    javac: JavacSubsystem,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
+    if javac.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/java/lint/google_java_format/subsystem.py
+++ b/src/python/pants/backend/java/lint/google_java_format/subsystem.py
@@ -2,14 +2,16 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import BoolOption, SkipOption
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
-class GoogleJavaFormatSubsystem(JvmToolBase):
+class GoogleJavaFormatSubsystem(GoalToolMixin, JvmToolBase):
     options_scope = "google-java-format"
     name = "Google Java Format"
+    example_goal_name = "fmt"
     help = "Google Java Format (https://github.com/google/google-java-format)"
 
     default_version = "1.13.0"
@@ -21,7 +23,6 @@ class GoogleJavaFormatSubsystem(JvmToolBase):
     default_lockfile_path = "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     aosp = BoolOption(
         default=False,
         help=softwrap(

--- a/src/python/pants/backend/java/subsystems/javac.py
+++ b/src/python/pants/backend/java/subsystems/javac.py
@@ -6,14 +6,15 @@ from __future__ import annotations
 import logging
 
 from pants.option.option_types import ArgsListOption, BoolOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 
 logger = logging.getLogger(__name__)
 
 
-class JavacSubsystem(Subsystem):
+class JavacSubsystem(GoalToolMixin, Subsystem):
     options_scope = "javac"
     name = "javac"
+    example_goal_name = "check"
     help = "The javac Java source compiler."
 
     args = ArgsListOption(example="-g -deprecation")

--- a/src/python/pants/backend/javascript/lint/prettier/subsystem.py
+++ b/src/python/pants/backend/javascript/lint/prettier/subsystem.py
@@ -7,14 +7,15 @@ import os
 from typing import Iterable
 
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.option.option_types import ArgsListOption, SkipOption
-from pants.option.subsystem import Subsystem
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.strutil import softwrap
 
 
-class Prettier(Subsystem):
+class Prettier(GoalToolMixin, Subsystem):
     options_scope = "prettier"
     name = "Prettier"
+    example_goal_name = "fmt"
     help = softwrap(
         """
         The Prettier utility for formatting JS/TS (and others) code
@@ -24,7 +25,6 @@ class Prettier(Subsystem):
 
     default_version = "prettier@2.6.2"
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--version")
 
     def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:

--- a/src/python/pants/backend/kotlin/goals/check.py
+++ b/src/python/pants/backend/kotlin/goals/check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 
+from pants.backend.kotlin.subsystems.kotlinc import KotlincSubsystem
 from pants.backend.kotlin.target_types import KotlinFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
@@ -30,8 +31,12 @@ class KotlincCheckRequest(CheckRequest):
 @rule(desc="Check compilation for Kotlin", level=LogLevel.DEBUG)
 async def kotlinc_check(
     request: KotlincCheckRequest,
+    kotlinc: KotlincSubsystem,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
+    if kotlinc.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/kotlin/lint/ktlint/subsystem.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/subsystem.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import SkipOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class KtlintSubsystem(JvmToolBase):
+class KtlintSubsystem(GoalToolMixin, JvmToolBase):
     options_scope = "ktlint"
     name = "Ktlint"
+    example_goal_name = "fmt"
     help = "Ktlint, the anti-bikeshedding Kotlin linter with built-in formatter (https://ktlint.github.io/)"
 
     default_version = "0.45.2"
@@ -19,5 +20,3 @@ class KtlintSubsystem(JvmToolBase):
     )
     default_lockfile_path = "src/python/pants/backend/kotlin/lint/ktlint/ktlint.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-    skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/kotlin/subsystems/kotlinc.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlinc.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 from pants.option.option_types import ArgsListOption, DictOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.strutil import softwrap
 
 
-class KotlincSubsystem(Subsystem):
+class KotlincSubsystem(GoalToolMixin, Subsystem):
     options_scope = "kotlinc"
     name = "kotlinc"
+    example_goal_name = "check"
     help = "The Kotlin programming language (https://kotlinlang.org/)."
 
     args = ArgsListOption(

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -14,7 +14,7 @@ from pants.core.goals.lint import LintFilesRequest, LintResult, Partitions
 from pants.engine.fs import DigestContents, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import DictOption, EnumOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
@@ -70,8 +70,9 @@ class ValidationConfig:
         )
 
 
-class RegexLintSubsystem(Subsystem):
+class RegexLintSubsystem(GoalToolMixin, Subsystem):
     options_scope = "regex-lint"
+    example_goal_name = "lint"
     help = softwrap(
         """
         Lint your code using regex patterns, e.g. to check for copyright headers.

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -14,13 +14,15 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class AddTrailingComma(PythonToolBase):
+class AddTrailingComma(GoalToolMixin, PythonToolBase):
     options_scope = "add-trailing-comma"
     name = "add-trailing-comma"
+    example_goal_name = "fmt"
     help = "The add-trailing-comma Python code formatter (https://github.com/asottile/add-trailing-comma)."
 
     default_version = "add-trailing-comma==2.2.3"
@@ -39,7 +41,6 @@ class AddTrailingComma(PythonToolBase):
     )
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py36-plus")
     export = ExportToolOption()
 

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -14,13 +14,15 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class Autoflake(PythonToolBase):
+class Autoflake(GoalToolMixin, PythonToolBase):
     options_scope = "autoflake"
     name = "Autoflake"
+    example_goal_name = "fmt"
     help = "The Autoflake Python code formatter (https://github.com/myint/autoflake)."
 
     default_version = "autoflake==1.4"
@@ -34,7 +36,6 @@ class Autoflake(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/autoflake/autoflake.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(
         example="--remove-all-unused-imports --target-version=py37 --quiet",
         # This argument was previously hardcoded. Moved it a default argument

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -25,7 +25,8 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, FileOption, SkipOption
+from pants.option.option_types import ArgsListOption, FileOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
@@ -43,9 +44,10 @@ class BanditFieldSet(FieldSet):
         return tgt.get(SkipBanditField).value
 
 
-class Bandit(PythonToolBase):
+class Bandit(GoalToolMixin, PythonToolBase):
     options_scope = "bandit"
     name = "Bandit"
+    example_goal_name = "lint"
     help = "A tool for finding security issues in Python code (https://bandit.readthedocs.io)."
 
     # When upgrading, check if Bandit has started using PEP 517 (a `pyproject.toml` file). If so,
@@ -65,7 +67,6 @@ class Bandit(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/bandit/bandit.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("lint")
     args = ArgsListOption(example="--skip B101,B308 --confidence")
     export = ExportToolOption()
     config = FileOption(

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -28,7 +28,8 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule, rule_helper
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
@@ -46,9 +47,10 @@ class BlackFieldSet(FieldSet):
         return tgt.get(SkipBlackField).value
 
 
-class Black(PythonToolBase):
+class Black(GoalToolMixin, PythonToolBase):
     options_scope = "black"
     name = "Black"
+    example_goal_name = "fmt"
     help = "The Black Python code formatter (https://black.readthedocs.io/)."
 
     default_version = "black==22.6.0"
@@ -63,7 +65,6 @@ class Black(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
     default_extra_requirements = ['typing-extensions>=3.10.0.0; python_version < "3.10"']
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--target-version=py37 --quiet")
     export = ExportToolOption()
     config = FileOption(

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -13,13 +13,15 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class Docformatter(PythonToolBase):
+class Docformatter(GoalToolMixin, PythonToolBase):
     options_scope = "docformatter"
     name = "docformatter"
+    example_goal_name = "fmt"
     help = "The Python docformatter tool (https://github.com/myint/docformatter)."
 
     default_version = "docformatter>=1.4,<1.5"
@@ -33,7 +35,6 @@ class Docformatter(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/docformatter/docformatter.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--wrap-summaries=100 --pre-summary-newline")
     export = ExportToolOption()
 

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -40,9 +40,9 @@ from pants.option.option_types import (
     BoolOption,
     FileListOption,
     FileOption,
-    SkipOption,
     TargetListOption,
 )
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import doc_url, git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
@@ -61,9 +61,10 @@ class Flake8FieldSet(FieldSet):
         return tgt.get(SkipFlake8Field).value
 
 
-class Flake8(PythonToolBase):
+class Flake8(GoalToolMixin, PythonToolBase):
     options_scope = "flake8"
     name = "Flake8"
+    example_goal_name = "lint"
     help = "The Flake8 Python linter (https://flake8.pycqa.org/)."
 
     default_version = "flake8>=3.9.2,<4.0"
@@ -74,7 +75,6 @@ class Flake8(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/flake8/flake8.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("lint")
     args = ArgsListOption(example="--ignore E123,W456 --enable-extensions H111")
     export = ExportToolOption()
     config = FileOption(

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -18,14 +18,16 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, BoolOption, FileListOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
-class Isort(PythonToolBase):
+class Isort(GoalToolMixin, PythonToolBase):
     options_scope = "isort"
     name = "isort"
+    example_goal_name = "fmt"
     help = "The Python import sorter tool (https://pycqa.github.io/isort/)."
 
     default_version = "isort[pyproject,colors]>=5.9.3,<6.0"
@@ -39,7 +41,6 @@ class Isort(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/isort/isort.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--case-sensitive --trailing-comma")
     export = ExportToolOption()
     config = FileListOption(

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -36,13 +36,8 @@ from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.engine.unions import UnionRule
-from pants.option.option_types import (
-    ArgsListOption,
-    BoolOption,
-    FileOption,
-    SkipOption,
-    TargetListOption,
-)
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption, TargetListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import doc_url, git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
@@ -67,9 +62,10 @@ class PylintFieldSet(FieldSet):
 # --------------------------------------------------------------------------------------
 
 
-class Pylint(PythonToolBase):
+class Pylint(GoalToolMixin, PythonToolBase):
     options_scope = "pylint"
     name = "Pylint"
+    example_goal_name = "lint"
     help = "The Pylint linter for Python code (https://www.pylint.org/)."
 
     default_version = "pylint>=2.13.0,<2.15"
@@ -81,7 +77,6 @@ class Pylint(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
     uses_requirements_from_source_plugins = True
 
-    skip = SkipOption("lint")
     args = ArgsListOption(example="--ignore=foo.py,bar.py --disable=C0330,W0311")
     export = ExportToolOption()
     config = FileOption(

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -14,13 +14,15 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.option.option_types import ArgsListOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class PyUpgrade(PythonToolBase):
+class PyUpgrade(GoalToolMixin, PythonToolBase):
     options_scope = "pyupgrade"
     name = "pyupgrade"
+    example_goal_name = "fmt"
     help = (
         "Upgrade syntax for newer versions of the language (https://github.com/asottile/pyupgrade)."
     )
@@ -36,7 +38,6 @@ class PyUpgrade(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py39-plus --keep-runtime-typing")
     export = ExportToolOption()
 

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -18,14 +18,16 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
-class Yapf(PythonToolBase):
+class Yapf(GoalToolMixin, PythonToolBase):
     options_scope = "yapf"
     name = "yapf"
+    example_goal_name = "fmt"
     help = "A formatter for Python files (https://github.com/google/yapf)."
 
     default_version = "yapf==0.32.0"
@@ -40,7 +42,6 @@ class Yapf(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/lint/yapf/yapf.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(
         example="--no-local-style",
         extra_help=softwrap(

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -18,14 +18,16 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption, StrOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
-class TwineSubsystem(PythonToolBase):
+class TwineSubsystem(GoalToolMixin, PythonToolBase):
     options_scope = "twine"
     name = "Twine"
+    example_goal_name = "publish"
     help = "The utility for publishing Python distributions to PyPI and other Python repositories."
 
     default_version = "twine>=3.7.1,<3.8"
@@ -45,7 +47,6 @@ class TwineSubsystem(PythonToolBase):
     default_lockfile_path = "src/python/pants/backend/python/subsystems/twine.lock"
     default_lockfile_url = git_url(default_lockfile_path)
 
-    skip = SkipOption("publish")
     args = ArgsListOption(example="--skip-existing")
     config = FileOption(
         default=None,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -58,11 +58,11 @@ from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
     FileOption,
-    SkipOption,
     StrListOption,
     StrOption,
     TargetListOption,
 )
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import bin_name, doc_url, git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
@@ -89,9 +89,10 @@ class MyPyFieldSet(FieldSet):
 # --------------------------------------------------------------------------------------
 
 
-class MyPy(PythonToolBase):
+class MyPy(GoalToolMixin, PythonToolBase):
     options_scope = "mypy"
     name = "MyPy"
+    example_goal_name = "check"
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
     default_version = "mypy==0.961"
@@ -107,7 +108,6 @@ class MyPy(PythonToolBase):
     default_lockfile_url = git_url(default_lockfile_path)
     uses_requirements_from_source_plugins = True
 
-    skip = SkipOption("check")
     args = ArgsListOption(example="--python-version 3.7 --disallow-any-expr")
     export = ExportToolOption()
     config = FileOption(

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -31,8 +31,12 @@ class ScalacCheckRequest(CheckRequest):
 @rule(desc="Check compilation for Scala", level=LogLevel.DEBUG)
 async def scalac_check(
     request: ScalacCheckRequest,
+    scalac: Scalac,
     classpath_entry_request: ClasspathEntryRequestFactory,
 ) -> CheckResults:
+    if scalac.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import SkipOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.docutil import git_url
 
 
-class ScalafmtSubsystem(JvmToolBase):
+class ScalafmtSubsystem(GoalToolMixin, JvmToolBase):
     options_scope = "scalafmt"
     name = "scalafmt"
+    example_goal_name = "fmt"
     help = "scalafmt (https://scalameta.org/scalafmt/)"
 
     default_version = "3.2.1"
@@ -21,5 +22,3 @@ class ScalafmtSubsystem(JvmToolBase):
         "src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-
-    skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 from pants.option.option_types import ArgsListOption, DictOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.strutil import softwrap
 
 
-class Scalac(Subsystem):
+class Scalac(GoalToolMixin, Subsystem):
     options_scope = "scalac"
     name = "scalac"
+    example_goal_name = "check"
     help = "The Scala compiler."
 
     default_plugins_lockfile_path = (

--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -9,13 +9,15 @@ from typing import Iterable
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
-from pants.option.option_types import ArgsListOption, BoolOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.strutil import softwrap
 
 
-class Shellcheck(TemplatedExternalTool):
+class Shellcheck(GoalToolMixin, TemplatedExternalTool):
     options_scope = "shellcheck"
     name = "Shellcheck"
+    example_goal_name = "lint"
     help = "A linter for shell scripts."
 
     default_version = "v0.8.0"
@@ -37,7 +39,6 @@ class Shellcheck(TemplatedExternalTool):
         "linux_x86_64": "linux.x86_64",
     }
 
-    skip = SkipOption("lint")
     args = ArgsListOption(example="-e SC20529")
     config_discovery = BoolOption(
         default=True,

--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -9,13 +9,15 @@ from typing import Iterable
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
-from pants.option.option_types import ArgsListOption, BoolOption, SkipOption
+from pants.option.option_types import ArgsListOption, BoolOption
+from pants.option.subsystem import GoalToolMixin
 from pants.util.strutil import softwrap
 
 
-class Shfmt(TemplatedExternalTool):
+class Shfmt(GoalToolMixin, TemplatedExternalTool):
     options_scope = "shfmt"
     name = "shfmt"
+    example_goal_name = "fmt"
     help = "An autoformatter for shell scripts (https://github.com/mvdan/sh)."
 
     default_version = "v3.2.4"
@@ -36,7 +38,6 @@ class Shfmt(TemplatedExternalTool):
         "linux_x86_64": "linux_amd64",
     }
 
-    skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="-i 2")
     config_discovery = BoolOption(
         default=True,

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -11,17 +11,15 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import SkipOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.strutil import pluralize
 
 
-class TerraformValidateSubsystem(Subsystem):
+class TerraformValidateSubsystem(GoalToolMixin, Subsystem):
     options_scope = "terraform-validate"
     name = "`terraform validate`"
+    example_goal_name = "check"
     help = """Terraform validate options."""
-
-    skip = SkipOption("check")
 
 
 class TerraformCheckRequest(CheckRequest):

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -20,20 +20,18 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import SkipOption
-from pants.option.subsystem import Subsystem
+from pants.option.subsystem import GoalToolMixin, Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 
 
-class TfFmtSubsystem(Subsystem):
+class TfFmtSubsystem(GoalToolMixin, Subsystem):
     options_scope = "terraform-fmt"
     name = "`terraform fmt`"
+    example_goal_name = "fmt"
     help = "Terraform fmt options."
-
-    skip = SkipOption("fmt", "lint")
 
 
 class TffmtRequest(FmtTargetsRequest):


### PR DESCRIPTION
Introducing and using `GoalToolMixin` for two reasons:
- Reduces boilerplate for `skip`, and ups the consistency of these disparate subsystems.
- In a future change I need to take in these subclasses in a function, and having them be of a common type makes everyone happy

Note the places that `skip` didn't exist before. Those `skips` are useful, as even in `check`:
- There could be plugin-introduced additional checkers
- The user might want to use a wide spec, and skip certain checkers (`./pants --mypy-skip check ::`)

Commits useful to review in-order.

[ci skip-rust]
[ci skip-build-wheels]