### PR TITLE
Support overriding param types for rule code

### DIFF
--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -196,7 +196,10 @@ def rule_decorator(func, **kwargs) -> Callable:
     func_params = inspect.signature(func).parameters
     for parameter in param_type_overrides:
         if parameter not in func_params:
-            raise ValueError(f"Unknown parameter name in `param_type_overrides`: {parameter}")
+            raise ValueError(
+                f"Unknown parameter name in `param_type_overrides`: {parameter}."
+                + f" Parameter names: '{', '.join(func_params)}'"
+            )
 
     parameter_types = tuple(
         param_type_overrides[parameter]

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -202,10 +202,8 @@ def rule_decorator(func, **kwargs) -> Callable:
             )
 
     parameter_types = tuple(
-        param_type_overrides[parameter]
-        if parameter in param_type_overrides
-        else _ensure_type_annotation(
-            type_annotation=type_hints.get(parameter),
+        _ensure_type_annotation(
+            type_annotation=param_type_overrides.get(parameter, type_hints.get(parameter)),
             name=f"{func_id} parameter {parameter}",
             raise_type=MissingParameterTypeAnnotation,
         )

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -1028,6 +1028,12 @@ def test_param_type_overrides() -> None:
         async def obey_human_orders() -> A:
             return A()
 
+    with pytest.raises(MissingParameterTypeAnnotation, match="must be a type"):
+
+        @rule(param_type_overrides={"param1": "A string"})
+        async def protect_existence(param1) -> A:
+            return A()
+
 
 def test_invalid_rule_helper_name() -> None:
     with pytest.raises(ValueError, match="must be private"):

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -1013,6 +1013,22 @@ def test_duplicated_rules() -> None:
             return B()
 
 
+def test_param_type_overrides() -> None:
+    type1 = int  # use a runtime type
+
+    @rule(param_type_overrides={"param1": type1, "param2": dict})
+    async def dont_injure_humans(param1: str, param2, param3: list) -> A:
+        return A()
+
+    assert dont_injure_humans.rule.input_selectors == (int, dict, list)
+
+    with pytest.raises(ValueError, match="paramX"):
+
+        @rule(param_type_overrides={"paramX": int})
+        async def obey_human_orders() -> A:
+            return A()
+
+
 def test_invalid_rule_helper_name() -> None:
     with pytest.raises(ValueError, match="must be private"):
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -1016,7 +1016,7 @@ def test_duplicated_rules() -> None:
 def test_param_type_overrides() -> None:
     type1 = int  # use a runtime type
 
-    @rule(param_type_overrides={"param1": type1, "param2": dict})
+    @rule(_param_type_overrides={"param1": type1, "param2": dict})
     async def dont_injure_humans(param1: str, param2, param3: list) -> A:
         return A()
 
@@ -1024,13 +1024,13 @@ def test_param_type_overrides() -> None:
 
     with pytest.raises(ValueError, match="paramX"):
 
-        @rule(param_type_overrides={"paramX": int})
+        @rule(_param_type_overrides={"paramX": int})
         async def obey_human_orders() -> A:
             return A()
 
     with pytest.raises(MissingParameterTypeAnnotation, match="must be a type"):
 
-        @rule(param_type_overrides={"param1": "A string"})
+        @rule(_param_type_overrides={"param1": "A string"})
         async def protect_existence(param1) -> A:
             return A()
 


### PR DESCRIPTION
The main use-case is runtime-typed parameters (for use in "helper"/"inner" rules).

```python

def make_rule(sometype: type[BaseType]):
    @rule(param_type_overrides={"request": sometype.var_type})
    async def helper_rule(request: WhateverVarTypeShouldBe) -> str:
        ...

    return helper_rule
```

[ci skip-rust]
[ci skip-build-wheels]