### PR TITLE
Fix venv re-population race.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -749,8 +749,7 @@ class VenvScriptWriter:
 
             # If the seeded venv has been removed from the PEX_ROOT, we re-seed from the original
             # `--venv` mode PEX file.
-            if [ ! -e "${{target_venv_executable}}" ]; then
-                rm -rf "${{venv_dir}}" || true
+            if [ ! -e "${{venv_dir}}" ]; then
                 PEX_INTERPRETER=1 ${{execute_pex_args}} -c ''
             fi
 


### PR DESCRIPTION
There was a race in venv re-population due to a non-atomic `rm`, create
sequence. There was no real need for the `rm` and the create is atomic 
on its own; so just remove the `rm` which was only attempting to guard
"corrupted" venvs in a slapdash way. Now the venv either exists or it
doesn't from the script point of view. If the venv exists but has been
tampered with, its execution will consistently fail until there is a
manual intervention removing the venv dir offline.

Fixes #14618
Fixes #16778