### PR TITLE
`wait` for killed nailgun processes. (Cherry-pick of #16924)

### DIFF
--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -495,7 +495,10 @@ impl Drop for BorrowedNailgunProcess {
         "Killing nailgun process {:?} due to cancellation.",
         process.as_ref().unwrap().name
       );
-      let _ = process.as_mut().unwrap().handle.kill();
+      if process.as_mut().unwrap().handle.kill().is_ok() {
+        // NB: This is blocking, but should be a short wait in general.
+        let _ = process.as_mut().unwrap().handle.wait();
+      }
     }
   }
 }


### PR DESCRIPTION
When a nailgun process run is cancelled, the `BorrowedNailgunProcess` `Drop` guard is supposed to kill the process, so that the next request to the pool will start a new process.

But because we weren't `wait`ing for the process to have actually exited after receiving `SIGKILL`, there was a race condition where we would have sent the signal, but the process had not yet actually exited by the time the next request came along.

To fix that, we introduce a `wait`. Eventually, we would like this to use async-`Drop` instead.

Fixes #16895.
