### PR TITLE
A few refactors of  `lint.py`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
@@ -59,10 +59,10 @@ def run_buf(
         [BufLintRequest.PartitionRequest(tuple(BufFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BufLintRequest.SubPartition(subpartition)],
+            [BufLintRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -51,7 +51,7 @@ def generate_argv(
 async def partition_hadolint(
     request: HadolintRequest.PartitionRequest[HadolintFieldSet], hadolint: Hadolint
 ) -> Partitions[HadolintFieldSet]:
-    return Partitions() if hadolint.skip else Partitions([request.field_sets])
+    return Partitions() if hadolint.skip else Partitions.single_partition(request.field_sets)
 
 
 @rule(desc="Lint with Hadolint", level=LogLevel.DEBUG)
@@ -64,7 +64,8 @@ async def run_hadolint(
     )
 
     dockerfile_infos = await MultiGet(
-        Get(DockerfileInfo, DockerfileInfoRequest(field_set.address)) for field_set in request
+        Get(DockerfileInfo, DockerfileInfoRequest(field_set.address))
+        for field_set in request.elements
     )
 
     input_digest = await Get(

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -52,10 +52,10 @@ def run_hadolint(
         [HadolintRequest.PartitionRequest(tuple(HadolintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HadolintRequest.SubPartition(subpartition)],
+            [HadolintRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -101,10 +101,10 @@ def run_go_vet(
         [GoVetRequest.PartitionRequest(tuple(GoVetFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [GoVetRequest.SubPartition(subpartition)],
+            [GoVetRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -61,10 +61,10 @@ def run_helm_lint(
         [HelmLintRequest.PartitionRequest(tuple(HelmLintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HelmLintRequest.SubPartition(subpartition)],
+            [HelmLintRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -271,7 +271,7 @@ async def partition_inputs(
         if content_pattern_names and encoding:
             applicable_file_paths.append(fp)
 
-    return Partitions([tuple(applicable_file_paths)])
+    return Partitions.single_partition(applicable_file_paths)
 
 
 @rule(desc="Lint with regex patterns", level=LogLevel.DEBUG)
@@ -281,7 +281,7 @@ async def lint_with_regex_patterns(
     multi_matcher = regex_lint_subsystem.get_multi_matcher()
     assert multi_matcher is not None
     file_to_content_pattern_names_and_encoding = {}
-    for fp in request:
+    for fp in request.elements:
         content_pattern_names, encoding = multi_matcher.get_applicable_content_pattern_names(fp)
         assert content_pattern_names and encoding
         file_to_content_pattern_names_and_encoding[fp] = (content_pattern_names, encoding)

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -9,7 +9,7 @@ from typing import Sequence
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.lint.bandit.rules import BanditRequest, PartitionElement
+from pants.backend.python.lint.bandit.rules import BanditRequest
 from pants.backend.python.lint.bandit.rules import rules as bandit_rules
 from pants.backend.python.lint.bandit.subsystem import BanditFieldSet
 from pants.backend.python.lint.bandit.subsystem import rules as bandit_subsystem_rules
@@ -59,14 +59,14 @@ def run_bandit(
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
     partition = rule_runner.request(
-        Partitions[PartitionElement],
+        Partitions[BanditFieldSet],
         [BanditRequest.PartitionRequest(tuple(BanditFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BanditRequest.SubPartition(subpartition)],
+            [BanditRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -8,7 +8,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.python import target_types_rules
-from pants.backend.python.lint.flake8.rules import Flake8Request, PartitionElement
+from pants.backend.python.lint.flake8.rules import Flake8Request
 from pants.backend.python.lint.flake8.rules import rules as flake8_rules
 from pants.backend.python.lint.flake8.subsystem import Flake8FieldSet
 from pants.backend.python.lint.flake8.subsystem import rules as flake8_subsystem_rules
@@ -55,14 +55,14 @@ def run_flake8(
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
     partition = rule_runner.request(
-        Partitions[PartitionElement],
+        Partitions[Flake8FieldSet],
         [Flake8Request.PartitionRequest(tuple(Flake8FieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [Flake8Request.SubPartition(subpartition)],
+            [Flake8Request.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Tuple, cast
 
 from pants.backend.python.lint.pylint.subsystem import (
     Pylint,
@@ -34,15 +34,14 @@ from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import CoarsenedTarget, CoarsenedTargets, CoarsenedTargetsRequest
+from pants.engine.target import CoarsenedTargets, CoarsenedTargetsRequest
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
 @dataclass(frozen=True)
-class PartitionElement:
-    source_path: str
-    coarsened_target: CoarsenedTarget
+class PartitionKey:
+    coarsened_targets: CoarsenedTargets
     # NB: These are the same across every element in a partition
     resolve_description: str | None
     interpreter_constraints: InterpreterConstraints
@@ -57,13 +56,13 @@ class PylintRequest(LintTargetsRequest):
     name = Pylint.options_scope
 
 
-def generate_argv(source_paths: tuple[str, ...], pylint: Pylint) -> Tuple[str, ...]:
+def generate_argv(field_sets: tuple[PylintFieldSet, ...], pylint: Pylint) -> Tuple[str, ...]:
     args = []
     if pylint.config is not None:
         args.append(f"--rcfile={pylint.config}")
     args.append("--jobs={pants_concurrency}")
     args.extend(pylint.args)
-    args.extend(source_paths)
+    args.extend(field_set.source.value for field_set in field_sets)
     return tuple(args)
 
 
@@ -73,7 +72,7 @@ async def partition_pylint(
     pylint: Pylint,
     python_setup: PythonSetup,
     first_party_plugins: PylintFirstPartyPlugins,
-) -> Partitions[PartitionElement]:
+) -> Partitions[PylintFieldSet]:
     if pylint.skip:
         return Partitions()
 
@@ -92,14 +91,15 @@ async def partition_pylint(
     coarsened_targets_by_address = coarsened_targets.by_address()
 
     return Partitions(
-        tuple(
-            PartitionElement(
-                field_set.source.file_path,
-                coarsened_targets_by_address[field_set.address],
+        (
+            PartitionKey(
+                CoarsenedTargets(
+                    coarsened_targets_by_address[field_set.address] for field_set in field_sets
+                ),
                 resolve if len(python_setup.resolves) > 1 else None,
                 InterpreterConstraints.merge((interpreter_constraints, first_party_ics)),
-            )
-            for field_set in field_sets
+            ),
+            tuple(field_sets),
         )
         for (
             resolve,
@@ -110,21 +110,19 @@ async def partition_pylint(
 
 @rule(desc="Lint using Pylint", level=LogLevel.DEBUG)
 async def run_pylint(
-    request: PylintRequest.SubPartition[PartitionElement],
+    request: PylintRequest.SubPartition[PylintFieldSet],
     pylint: Pylint,
     first_party_plugins: PylintFirstPartyPlugins,
 ) -> LintResult:
-    sources_paths = tuple(element.source_path for element in request)
-    coarsened_targets = CoarsenedTargets(element.coarsened_target for element in request)
-    interpreter_constraints = request[0].interpreter_constraints
+    partition_key = cast(PartitionKey, request.key)
     requirements_pex_get = Get(
         Pex,
         RequirementsPexRequest(
-            (target.address for target in coarsened_targets.closure()),
+            (target.address for target in partition_key.coarsened_targets.closure()),
             # NB: These constraints must be identical to the other PEXes. Otherwise, we risk using
             # a different version for the requirements than the other two PEXes, which can result
             # in a PEX runtime error about missing dependencies.
-            hardcoded_interpreter_constraints=interpreter_constraints,
+            hardcoded_interpreter_constraints=partition_key.interpreter_constraints,
         ),
     )
 
@@ -132,12 +130,14 @@ async def run_pylint(
         Pex,
         PexRequest,
         pylint.to_pex_request(
-            interpreter_constraints=interpreter_constraints,
+            interpreter_constraints=partition_key.interpreter_constraints,
             extra_requirements=first_party_plugins.requirement_strings,
         ),
     )
 
-    sources_get = Get(PythonSourceFiles, PythonSourceFilesRequest(coarsened_targets.closure()))
+    sources_get = Get(
+        PythonSourceFiles, PythonSourceFilesRequest(partition_key.coarsened_targets.closure())
+    )
     # Ensure that the empty report dir exists.
     report_directory_digest_get = Get(Digest, CreateDigest([Directory(REPORT_DIR)]))
 
@@ -154,7 +154,7 @@ async def run_pylint(
             VenvPexRequest(
                 PexRequest(
                     output_filename="pylint_runner.pex",
-                    interpreter_constraints=interpreter_constraints,
+                    interpreter_constraints=partition_key.interpreter_constraints,
                     main=pylint.main,
                     internal_only=True,
                     pex_path=[pylint_pex, requirements_pex],
@@ -192,19 +192,19 @@ async def run_pylint(
         FallibleProcessResult,
         VenvPexProcess(
             pylint_runner_pex,
-            argv=generate_argv(sources_paths, pylint),
+            argv=generate_argv(request.elements, pylint),
             input_digest=input_digest,
             output_directories=(REPORT_DIR,),
             extra_env={"PEX_EXTRA_SYS_PATH": ":".join(pythonpath)},
-            concurrency_available=len(request),
-            description=f"Run Pylint on {pluralize(len(request), 'target')}.",
+            concurrency_available=len(request.elements),
+            description=f"Run Pylint on {pluralize(len(request.elements), 'target')}.",
             level=LogLevel.DEBUG,
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
     return LintResult.from_fallible_process_result(
         result,
-        partition_description=request[0].description(),
+        partition_description=partition_key.description(),
         linter_name=Pylint.options_scope,
         report=report,
     )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -62,7 +62,7 @@ def generate_argv(field_sets: tuple[PylintFieldSet, ...], pylint: Pylint) -> Tup
         args.append(f"--rcfile={pylint.config}")
     args.append("--jobs={pants_concurrency}")
     args.extend(pylint.args)
-    args.extend(field_set.source.value for field_set in field_sets)
+    args.extend(field_set.source.file_path for field_set in field_sets)
     return tuple(args)
 
 

--- a/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
@@ -54,10 +54,10 @@ def run_shellcheck(
         ],
     )
     results = []
-    for subpartition in partition:
+    for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [ShellcheckRequest.SubPartition(subpartition)],
+            [ShellcheckRequest.SubPartition(subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -145,7 +145,7 @@ def mock_lint_partition(request: Any) -> LintResult:
     request_type = {cls.SubPartition: cls for cls in MockLintRequest.__subclasses__()}[
         type(request)
     ]
-    return request_type(request).lint_result  # type: ignore[abstract]
+    return request_type(request.elements).lint_result  # type: ignore[abstract]
 
 
 class MockFmtRequest(FmtTargetsRequest):

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -127,7 +127,7 @@ def mock_target_partitioner(
     if type(request) is SkippedRequest.PartitionRequest:
         return Partitions()
 
-    return Partitions([request.field_sets])
+    return Partitions.single_partition(request.field_sets)
 
 
 class MockFilesRequest(LintFilesRequest):
@@ -135,7 +135,7 @@ class MockFilesRequest(LintFilesRequest):
 
 
 def mock_file_partitioner(request: MockFilesRequest.PartitionRequest) -> Partitions[str]:
-    return Partitions([request.file_paths])
+    return Partitions.single_partition(request.file_paths)
 
 
 def mock_lint_partition(request: Any) -> LintResult:


### PR DESCRIPTION
The big changes are:
- Bumping the "metadata" of a partition to be a first-class-citizen and renaming it to "PartitionKey" to better encompass its intent.
- Making `Partitions` a mapping from key -> partition (with the key option for single partitions. Will be `None`)
- Refactored the memoized class property types to be unconditionally declared with most of the relevant type-checking-and-runtime info, and only conditionally declare the runtime version (which inherits from the both-type)

[ci skip-build-sheels]
[ci skip-rust]