### PR TITLE
Allow public `rule_helpers`

### DIFF
--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -112,14 +112,20 @@ def test_rule_helpers_class_methods() -> None:
     assert_awaitables(rule1, [])
 
     async def rule2():
-        container_instance._static_helper(1)
+        HelperContainer._static_helper(1)
 
+    # Rule helpers must be called via module-scoped attributes
     assert_awaitables(rule2, [(int, str), (str, int)])
 
     async def rule3():
+        container_instance._static_helper(1)
+
+    assert_awaitables(rule3, [(int, str), (str, int)])
+
+    async def rule4():
         container_instance._method_helper(1)
 
-    assert_awaitables(rule3, [(int, str)])
+    assert_awaitables(rule4, [(int, str)])
 
 
 def test_valid_get_unresolvable_product_type() -> None:

--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -112,20 +112,14 @@ def test_rule_helpers_class_methods() -> None:
     assert_awaitables(rule1, [])
 
     async def rule2():
-        HelperContainer._static_helper(1)
+        container_instance._static_helper(1)
 
-    # Rule helpers must be called via module-scoped attributes
     assert_awaitables(rule2, [(int, str), (str, int)])
 
     async def rule3():
-        container_instance._static_helper(1)
-
-    assert_awaitables(rule3, [(int, str), (str, int)])
-
-    async def rule4():
         container_instance._method_helper(1)
 
-    assert_awaitables(rule4, [(int, str)])
+    assert_awaitables(rule3, [(int, str)])
 
 
 def test_valid_get_unresolvable_product_type() -> None:

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -319,8 +319,8 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def _rule_helper_decorator(func: Callable[P, R], public: bool = False) -> Callable[P, R]:
-    if not public and not func.__name__.startswith("_"):
+def _rule_helper_decorator(func: Callable[P, R], _public: bool = False) -> Callable[P, R]:
+    if not _public and not func.__name__.startswith("_"):
         raise ValueError("@rule_helpers must be private. I.e. start with an underscore.")
 
     if hasattr(func, "rule"):
@@ -353,7 +353,7 @@ def rule_helper(
     awaitables.
 
     There are a few restrictions:
-        1. Rule helpers must be "private". I.e. start with an underscore (unless marked "public").
+        1. Rule helpers must be "private". I.e. start with an underscore.
         2. Rule hlpers must be `async`
         3. Rule helpers can't be rules
         4. Rule helpers must be accessed by attributes chained from a module variable (see below)

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -20,6 +20,7 @@ from typing import (
     TypeVar,
     Union,
     get_type_hints,
+    overload,
 )
 
 from typing_extensions import ParamSpec
@@ -318,7 +319,33 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+def _rule_helper_decorator(func: Callable[P, R], public: bool = False) -> Callable[P, R]:
+    if not public and not func.__name__.startswith("_"):
+        raise ValueError("@rule_helpers must be private. I.e. start with an underscore.")
+
+    if hasattr(func, "rule"):
+        raise ValueError("Cannot use both @rule and @rule_helper.")
+
+    if not inspect.iscoroutinefunction(func):
+        raise ValueError("@rule_helpers must be async.")
+
+    setattr(func, "rule_helper", func)
+    return func
+
+
+@overload
 def rule_helper(func: Callable[P, R]) -> Callable[P, R]:
+    ...
+
+
+@overload
+def rule_helper(func: None = None, **kwargs: Any) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    ...
+
+
+def rule_helper(
+    func: Callable[P, R] | None = None, **kwargs: Any
+) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator which marks a function as a "rule helper".
 
     Functions marked as rule helpers are allowed to be called by rules and other rule helpers
@@ -326,7 +353,7 @@ def rule_helper(func: Callable[P, R]) -> Callable[P, R]:
     awaitables.
 
     There are a few restrictions:
-        1. Rule helpers must be "private". I.e. start with an underscore
+        1. Rule helpers must be "private". I.e. start with an underscore (unless marked "public").
         2. Rule hlpers must be `async`
         3. Rule helpers can't be rules
         4. Rule helpers must be accessed by attributes chained from a module variable (see below)
@@ -353,17 +380,14 @@ def rule_helper(func: Callable[P, R]) -> Callable[P, R]:
             await arg.helper()  # Not OK, won't collect awaitables from `helper`
     ```
     """
-    if not func.__name__.startswith("_"):
-        raise ValueError("@rule_helpers must be private. I.e. start with an underscore.")
+    if func is None:
 
-    if hasattr(func, "rule"):
-        raise ValueError("Cannot use both @rule and @rule_helper.")
+        def wrapper(func: Callable[P, R]) -> Callable[P, R]:
+            return _rule_helper_decorator(func, **kwargs)
 
-    if not inspect.iscoroutinefunction(func):
-        raise ValueError("@rule_helpers must be async.")
+        return wrapper
 
-    setattr(func, "rule_helper", func)
-    return func
+    return _rule_helper_decorator(func, **kwargs)
 
 
 class Rule(ABC):

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -1020,7 +1020,7 @@ def test_invalid_rule_helper_name() -> None:
         async def foo() -> A:
             pass
 
-    @rule_helper(public=True)
+    @rule_helper(_public=True)
     async def bar() -> A:
         pass
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -1020,6 +1020,10 @@ def test_invalid_rule_helper_name() -> None:
         async def foo() -> A:
             pass
 
+    @rule_helper(public=True)
+    async def bar() -> A:
+        pass
+
 
 def test_cant_be_both_rule_and_rule_helper() -> None:
     with pytest.raises(ValueError, match="Cannot use both @rule and @rule_helper"):


### PR DESCRIPTION
In the upcoming `fmt` change to wire into the new `lint` schema, the `SubPartition` will have an optional `snapshot` (`None` in `lint`, the snapshot in `fmt`). In order to bridge this gap, my plan is to have a public `get_snapshot` helper `staticmethod` `rule_helper`:

```python
class SubPartition:
    ...

    @staticmethod
    @rule_helper(public=True)
    async def get_snapshot(instance: SubPartition) -> Snapshot:
        return instance._snapshot if instance._snapshot is not None else await Get(Snapshot, PathGlobs(instance.filepaths))

# Usage
snapshot = await SubPartition.get_snapshot(request)
```

[ci skip-rust]
[ci skip-build-wheels]