### PR TITLE
java resources jar file is non determinstic

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -328,6 +328,10 @@ class MkdirBinary(BinaryPath):
     pass
 
 
+class TouchBinary(BinaryPath):
+    pass
+
+
 class CpBinary(BinaryPath):
     pass
 
@@ -711,6 +715,14 @@ async def find_mkdir() -> MkdirBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path_or_raise(request, rationale="create directories")
     return MkdirBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `touch` binary", level=LogLevel.DEBUG)
+async def find_touch() -> TouchBinary:
+    request = BinaryPathRequest(binary_name="touch", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="touch file")
+    return TouchBinary(first_path.path, first_path.fingerprint)
 
 
 @rule(desc="Finding the `cp` binary", level=LogLevel.DEBUG)

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -3,6 +3,7 @@
 
 import itertools
 import logging
+import shlex
 from itertools import chain
 from pathlib import Path
 
@@ -87,6 +88,9 @@ async def assemble_resources_jar(
     input_files = {str(path) for path in chain(paths, directories)}
 
     resources_jar_input_digest = source_files.snapshot.digest
+
+    input_filenames = shlex.join(sorted(input_files))
+
     resources_jar_result = await Get(
         ProcessResult,
         Process(
@@ -97,13 +101,13 @@ async def assemble_resources_jar(
                     [
                         touch.path,
                         "-d 1980-01-01T00:00:00Z",
-                        *sorted(input_files),
-                        ";",
+                        input_filenames,
+                        "&&",
                         "TZ=UTC",
                         zip.path,
                         "-oX",
                         output_filename,
-                        *sorted(input_files),
+                        input_filenames,
                     ]
                 ),
             ],

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -89,7 +89,7 @@ async def assemble_resources_jar(
 
     resources_jar_input_digest = source_files.snapshot.digest
 
-    input_filenames = shlex.join(sorted(input_files))
+    input_filenames = " ".join(shlex.quote(file) for file in sorted(input_files))
 
     resources_jar_result = await Get(
         ProcessResult,

--- a/src/python/pants/jvm/resources_test.py
+++ b/src/python/pants/jvm/resources_test.py
@@ -104,3 +104,28 @@ def test_resources(rule_runner: RuleRunner) -> None:
     contents = rule_runner.request(DigestContents, list(classpath.digests()))
     assert contents[0].path == ".one.txt.root.resources.jar"
     assert filenames_from_zip(contents[0]) == ["one.txt"]
+
+
+@maybe_skip_jdk_test
+def test_resources_jar_is_determinstic(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "resources(name='root', sources=['**/*.txt'])",
+            "one.txt": "",
+            "two.txt": "",
+            "three/four.txt": "",
+            "three/five.txt": "",
+            "three/six/seven/eight.txt": "",
+            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
+        }
+    )
+
+    classpath = rule_runner.request(
+        Classpath, [Addresses([Address(spec_path="", target_name="root")])]
+    )
+
+    contents = rule_runner.request(DigestContents, list(classpath.digests()))
+
+    z = ZipFile(BytesIO(contents[0].content))
+    for info in z.infolist():
+        assert info.date_time == (1980, 1, 1, 0, 0, 0)


### PR DESCRIPTION
At the moment, java or scala projects won't benefit much from the remote cache because the resources jar local process file will usually win the remote cache read. As zip is non-deterministic, which means that the resources jar file would invalidate any dependents in the graph.

Using reproducible_jars would solve that, but the price would be running the strip jar for all jars.

This PR solves this by changing the dates of all the files in the zip file before archiving.