### PR TITLE
skip shutting down container cache if Docker was never used

### DIFF
--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -56,6 +56,10 @@ impl DockerOnceCell {
     }
   }
 
+  pub fn initialized(&self) -> bool {
+    self.cell.initialized()
+  }
+
   pub async fn get(&self) -> Result<&Docker, String> {
     self
       .cell
@@ -726,6 +730,11 @@ impl ContainerCache {
   }
 
   pub async fn shutdown(&self) -> Result<(), String> {
+    // Skip shutting down if Docker was never initialized in the first place.
+    if !self.docker.initialized() {
+      return Ok(());
+    }
+
     let docker = match self.docker.get().await {
       Ok(d) => d,
       Err(err) => {


### PR DESCRIPTION
Skip shutting down the Docker container cache if Docker was never initialized in the first place.

[ci skip-build-wheels]