### PR TITLE
Add an optional speculation delay when using a remote cache (Cherry-pick of #16922)

### DIFF
--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -64,6 +64,7 @@ class Process:
     concurrency_available: int
     cache_scope: ProcessCacheScope
     platform: str | None
+    remote_cache_speculation_delay_millis: int
 
     def __init__(
         self,
@@ -85,6 +86,7 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         platform: Platform | None = None,
+        remote_cache_speculation_delay_millis: int = 0,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -132,6 +134,7 @@ class Process:
         self.concurrency_available = concurrency_available
         self.cache_scope = cache_scope
         self.platform = platform.value if platform is not None else None
+        self.remote_cache_speculation_delay_millis = remote_cache_speculation_delay_millis
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -325,6 +325,7 @@ class JvmProcess:
     extra_env: FrozenDict[str, str]
     cache_scope: ProcessCacheScope | None
     use_nailgun: bool
+    remote_cache_speculation_delay: int | None
 
     def __init__(
         self,
@@ -344,6 +345,7 @@ class JvmProcess:
         platform: Platform | None = None,
         cache_scope: ProcessCacheScope | None = None,
         use_nailgun: bool = True,
+        remote_cache_speculation_delay: int | None = None,
     ):
         self.jdk = jdk
         self.argv = tuple(argv)
@@ -361,6 +363,7 @@ class JvmProcess:
         self.extra_immutable_input_digests = FrozenDict(extra_immutable_input_digests or {})
         self.extra_env = FrozenDict(extra_env or {})
         self.use_nailgun = use_nailgun
+        self.remote_cache_speculation_delay = remote_cache_speculation_delay
 
         if not use_nailgun and extra_nailgun_keys:
             raise AssertionError(
@@ -374,7 +377,7 @@ _JVM_HEAP_SIZE_UNITS = ["", "k", "m", "g"]
 
 @rule
 async def jvm_process(
-    bash: BashBinary, request: JvmProcess, global_options: GlobalOptions
+    bash: BashBinary, request: JvmProcess, jvm: JvmSubsystem, global_options: GlobalOptions
 ) -> Process:
 
     jdk = request.jdk
@@ -418,6 +421,12 @@ async def jvm_process(
     if request.use_nailgun:
         use_nailgun = [*jdk.immutable_input_digests, *request.extra_nailgun_keys]
 
+    remote_cache_speculation_delay_millis = 0
+    if request.remote_cache_speculation_delay is not None:
+        remote_cache_speculation_delay_millis = request.remote_cache_speculation_delay
+    elif request.use_nailgun:
+        remote_cache_speculation_delay_millis = jvm.nailgun_remote_cache_speculation_delay
+
     return Process(
         [*jdk.args(bash, request.classpath_entries), *jvm_options, *request.argv],
         input_digest=request.input_digest,
@@ -432,6 +441,7 @@ async def jvm_process(
         append_only_caches=jdk.append_only_caches,
         output_files=request.output_files,
         cache_scope=request.cache_scope or ProcessCacheScope.SUCCESSFUL,
+        remote_cache_speculation_delay_millis=remote_cache_speculation_delay_millis,
     )
 
 

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pants.option.option_types import BoolOption, DictOption, StrListOption, StrOption
+from pants.option.option_types import BoolOption, DictOption, IntOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -94,6 +94,25 @@ class JvmSubsystem(Subsystem):
 
             Because some compilers do not support this step as a native operation, it can have a
             performance cost, and is not enabled by default.
+            """
+        ),
+        advanced=True,
+    )
+    # See https://github.com/pantsbuild/pants/issues/14937 for discussion of one way to improve
+    # our behavior around cancellation with nailgun.
+    nailgun_remote_cache_speculation_delay = IntOption(
+        default=1000,
+        help=softwrap(
+            """
+            The time in milliseconds to delay speculation of nailgun processes while reading
+            from the remote cache.
+
+            When speculating, a remote cache hit will cancel the local copy of a process. But
+            because nailgun does not natively support cancellation, that requires killing a
+            nailgun server, which will mean that future processes take longer to warm up.
+
+            This setting allows for trading off waiting for potentially slow cache entries
+            against potentially having to warm up a new nailgun server.
             """
         ),
         advanced=True,

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -530,6 +530,8 @@ pub struct Process {
   pub platform_constraint: Option<Platform>,
 
   pub cache_scope: ProcessCacheScope,
+
+  pub remote_cache_speculation_delay: std::time::Duration,
 }
 
 impl Process {
@@ -560,6 +562,7 @@ impl Process {
       execution_slot_variable: None,
       concurrency_available: 0,
       cache_scope: ProcessCacheScope::Successful,
+      remote_cache_speculation_delay: std::time::Duration::from_millis(0),
     }
   }
 
@@ -603,6 +606,11 @@ impl Process {
     append_only_caches: BTreeMap<CacheName, RelativePath>,
   ) -> Process {
     self.append_only_caches = append_only_caches;
+    self
+  }
+
+  pub fn remote_cache_speculation_delay(mut self, delay: std::time::Duration) -> Process {
+    self.remote_cache_speculation_delay = delay;
     self
   }
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -255,7 +255,7 @@ impl CommandRunner {
     >,
   ) -> Result<(FallibleProcessResultWithPlatform, bool), ProcessError> {
     // A future to read from the cache and log the results accordingly.
-    let cache_read_future = async {
+    let mut cache_read_future = async {
       let response = check_action_cache(
         action_digest,
         &request.description,
@@ -291,42 +291,63 @@ impl CommandRunner {
       Level::Trace,
       |workunit| async move {
         tokio::select! {
-          cache_result = cache_read_future => {
-            if let Some(cached_response) = cache_result {
-              let lookup_elapsed = cache_lookup_start.elapsed();
-              workunit.increment_counter(Metric::RemoteCacheSpeculationRemoteCompletedFirst, 1);
-              if let Some(time_saved) = cached_response.metadata.time_saved_from_cache(lookup_elapsed) {
-                let time_saved = time_saved.as_millis() as u64;
-                workunit.increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
-                workunit.record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
-              }
-              // When we successfully use the cache, we change the description and increase the level
-              // (but not so much that it will be logged by default).
-              workunit.update_metadata(|initial| {
-                initial.map(|(initial, _)|
-                (WorkunitMetadata {
-                  desc: initial
-                    .desc
-                    .as_ref()
-                    .map(|desc| format!("Hit: {}", desc)),
-                  ..initial
-                }, Level::Debug))
-              });
-              Ok((cached_response, true))
-            } else {
-              // Note that we don't increment a counter here, as there is nothing of note in this
-              // scenario: the remote cache did not save unnecessary local work, nor was the remote
-              // trip unusually slow such that local execution was faster.
-              local_execution_future.await.map(|res| (res, false))
-            }
+          cache_result = &mut cache_read_future => {
+            self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await
           }
-          local_result = &mut local_execution_future => {
-            workunit.increment_counter(Metric::RemoteCacheSpeculationLocalCompletedFirst, 1);
-            local_result.map(|res| (res, false))
+          _ = tokio::time::sleep(request.remote_cache_speculation_delay) => {
+            tokio::select! {
+              cache_result = cache_read_future => {
+                self.handle_cache_read_completed(workunit, cache_lookup_start, cache_result, local_execution_future).await
+              }
+              local_result = &mut local_execution_future => {
+                workunit.increment_counter(Metric::RemoteCacheSpeculationLocalCompletedFirst, 1);
+                local_result.map(|res| (res, false))
+              }
+            }
           }
         }
       }
     ).await
+  }
+
+  async fn handle_cache_read_completed(
+    &self,
+    workunit: &mut RunningWorkunit,
+    cache_lookup_start: Instant,
+    cache_result: Option<FallibleProcessResultWithPlatform>,
+    local_execution_future: BoxFuture<'_, Result<FallibleProcessResultWithPlatform, ProcessError>>,
+  ) -> Result<(FallibleProcessResultWithPlatform, bool), ProcessError> {
+    if let Some(cached_response) = cache_result {
+      let lookup_elapsed = cache_lookup_start.elapsed();
+      workunit.increment_counter(Metric::RemoteCacheSpeculationRemoteCompletedFirst, 1);
+      if let Some(time_saved) = cached_response
+        .metadata
+        .time_saved_from_cache(lookup_elapsed)
+      {
+        let time_saved = time_saved.as_millis() as u64;
+        workunit.increment_counter(Metric::RemoteCacheTotalTimeSavedMs, time_saved);
+        workunit.record_observation(ObservationMetric::RemoteCacheTimeSavedMs, time_saved);
+      }
+      // When we successfully use the cache, we change the description and increase the level
+      // (but not so much that it will be logged by default).
+      workunit.update_metadata(|initial| {
+        initial.map(|(initial, _)| {
+          (
+            WorkunitMetadata {
+              desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+              ..initial
+            },
+            Level::Debug,
+          )
+        })
+      });
+      Ok((cached_response, true))
+    } else {
+      // Note that we don't increment a counter here, as there is nothing of note in this
+      // scenario: the remote cache did not save unnecessary local work, nor was the remote
+      // trip unusually slow such that local execution was faster.
+      local_execution_future.await.map(|res| (res, false))
+    }
   }
 
   /// Stores an execution result into the remote Action Cache.

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -89,6 +89,7 @@ async fn make_execute_request() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -166,6 +167,7 @@ async fn make_execute_request_with_instance_name() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -256,6 +258,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let mut want_command = remexec::Command {
@@ -493,6 +496,7 @@ async fn make_execute_request_with_timeout() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {
@@ -598,6 +602,7 @@ async fn make_execute_request_using_immutable_inputs() {
     execution_slot_variable: None,
     concurrency_available: 0,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -455,6 +455,7 @@ async fn make_request_from_flat_args(
     execution_slot_variable: None,
     concurrency_available: args.command.concurrency_available.unwrap_or(0),
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: Duration::from_millis(0),
   };
 
   let metadata = ProcessMetadata {
@@ -548,6 +549,7 @@ async fn extract_request_from_action_digest(
     jdk_home: None,
     platform_constraint: None,
     cache_scope: ProcessCacheScope::Always,
+    remote_cache_speculation_delay: Duration::from_millis(0),
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -358,6 +358,10 @@ impl ExecuteProcess {
         None
       };
 
+    let remote_cache_speculation_delay = std::time::Duration::from_millis(
+      externs::getattr::<i32>(value, "remote_cache_speculation_delay_millis").unwrap() as u64,
+    );
+
     Ok(process_execution::Process {
       argv: externs::getattr(value, "argv").unwrap(),
       env,
@@ -374,6 +378,7 @@ impl ExecuteProcess {
       execution_slot_variable,
       concurrency_available,
       cache_scope,
+      remote_cache_speculation_delay,
     })
   }
 


### PR DESCRIPTION
When `nailgun` is combined with a remote cache, cancellation of `nailgun` processes due to cache hits results in `nailgun` servers getting killed (as expected: see #14937 for more on that topic).

But the cost of killing a `nailgun` server (which makes _future_ processes run more slowly) is not currently accounted for by our default setting of speculating for all requests. And figuring out the exact likelihood that we will hit the cache is a challenging problem.

This change adds an (optional, but enabled by default) delay before starting a `nailgun` process when a remote cache is in use.

Fixes #16921.

[ci skip-build-wheels]
