### PR TITLE
Prefactor `Scalafmt` to be friendlier to upcoming changes

### DIFF
--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -243,7 +243,9 @@ def test_gather_scalafmt_config_files(rule_runner: RuleRunner) -> None:
     )
 
     snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/*.scala"])])
-    request = rule_runner.request(ScalafmtConfigFiles, [GatherScalafmtConfigFilesRequest(snapshot)])
+    request = rule_runner.request(
+        ScalafmtConfigFiles, [GatherScalafmtConfigFilesRequest(snapshot.files)]
+    )
     assert sorted(request.source_dir_to_config_file.items()) == [
         ("foo/bar", "foo/bar/.scalafmt.conf"),
         ("foo/bar/xyyzzy", "foo/bar/.scalafmt.conf"),


### PR DESCRIPTION
Just like it's neighbor prefactor https://github.com/pantsbuild/pants/pull/16966, this PR changes the shape of `scalafmt` to match the upcoming schema change to `fmt`.


[ci skip-rust]
[ci skip-build-wheels]