### PR TITLE
Fix for hang with redirected stdio. (Cherry-pick of #16970)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "os_pipe",
  "task_executor",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -14,6 +14,7 @@ nails = "0.13"
 os_pipe = "1.0"
 task_executor = { path = "../task_executor" }
 tokio = { version = "1.16", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }
+tokio-stream = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1.16", features = ["io-std", "macros", "net", "rt-multi-thread"] }


### PR DESCRIPTION
As described in #16969, our use of blocking IO for logging/stdio can cause a deadlock by preventing the task which consumes the other end of the stdio pipes from running.

This change introduces dedicated threads to consume each of `stdout` and `stderr`, which prevents them from ever being subject to the state of the tokio runtime.

As mentioned in #16969, this is really more of a "workaround" than a fix for the deeper issue. But it reliably fixes #16121, and will prevent any other such issues.

[ci skip-build-wheels]
