### PR TITLE
improve remote cache logging for hit or miss

### DIFF
--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -270,11 +270,24 @@ impl CommandRunner {
       .await;
       match response {
         Ok(cached_response_opt) => {
-          log::debug!(
-            "remote cache response: digest={:?}: {:?}",
-            action_digest,
-            cached_response_opt
-          );
+          match &cached_response_opt {
+            Some(cached_response) => {
+              log::debug!(
+                "remote cache hit for: {:?} digest={:?} response={:?}",
+                request.description,
+                action_digest,
+                cached_response
+              );
+            }
+            None => {
+              log::debug!(
+                "remote cache miss for: {:?} digest={:?}",
+                request.description,
+                action_digest
+              );
+            }
+          }
+
           cached_response_opt
         }
         Err(err) => {


### PR DESCRIPTION
when debugging the remote cache with current log messages it is hard to figure out hits vs misses. 
This PR makes it easy to find hits vs misses in the log.
