### PR TITLE
Change `fmt` plugin schema to allow for targetless formatters

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/black/integration_test.py
@@ -27,7 +27,7 @@ def rule_runner() -> RuleRunner:
             *black_fmt_rules(),
             *black_subsystem_rules(),
             *config_files.rules(),
-            QueryRule(FmtResult, (BlackRequest,)),
+            QueryRule(FmtResult, (BlackRequest.SubPartition,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -58,7 +58,12 @@ def run_black(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -
         env_inherit={"PATH", "PYENV_ROOT", "HOME", "LANG", "LC_ALL"},
     )
     snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/BUILD"])])
-    fmt_result = rule_runner.request(FmtResult, [BlackRequest(snapshot)])
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            BlackRequest.SubPartition(snapshot.files, key=None, _snapshot=snapshot),
+        ],
+    )
     return fmt_result
 
 

--- a/src/python/pants/backend/build_files/fmt/black/register.py
+++ b/src/python/pants/backend/build_files/fmt/black/register.py
@@ -1,21 +1,41 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from pants.backend.python.lint.black import subsystem as black_subsystem
 from pants.backend.python.lint.black.rules import _run_black
 from pants.backend.python.lint.black.subsystem import Black
-from pants.core.goals.fmt import FmtResult, _FmtBuildFilesRequest
+from pants.core.goals.fmt import FmtFilesRequest, FmtResult, Partitions
+from pants.engine.internals.build_files import BuildFileOptions
 from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 
 
-class BlackRequest(_FmtBuildFilesRequest):
+class BlackRequest(FmtFilesRequest):
     name = "black"
 
 
+@rule
+async def partition_build_files(
+    request: BlackRequest.PartitionRequest,
+    black: Black,
+    build_file_options: BuildFileOptions,
+) -> Partitions:
+    if black.skip:
+        return Partitions()
+
+    specified_build_files = FilespecMatcher(
+        includes=[os.path.join("**", p) for p in build_file_options.patterns],
+        excludes=build_file_options.ignores,
+    ).matches(request.files)
+
+    return Partitions.single_partition(specified_build_files)
+
+
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
-async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
+async def black_fmt(request: BlackRequest.SubPartition, black: Black) -> FmtResult:
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
     return await _run_black(request, black, black_ics)
 
@@ -23,6 +43,6 @@ async def black_fmt(request: BlackRequest, black: Black) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        UnionRule(_FmtBuildFilesRequest, BlackRequest),
+        *BlackRequest.registration_rules(),
         *black_subsystem.rules(),
     ]

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -1,50 +1,73 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
+
 from pants.backend.build_files.fmt.buildifier.subsystem import Buildifier
-from pants.core.goals.fmt import FmtResult, _FmtBuildFilesRequest
+from pants.core.goals.fmt import FmtFilesRequest, FmtResult, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.engine.internals.build_files import BuildFileOptions
 from pants.engine.internals.native_engine import Digest, MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.source.filespec import FilespecMatcher
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
 
-class BuildifierRequest(_FmtBuildFilesRequest):
+class BuildifierRequest(FmtFilesRequest):
     name = "buildifier"
+
+
+@rule
+async def partition_build_files(
+    request: BuildifierRequest.PartitionRequest,
+    buildifier: Buildifier,
+    build_file_options: BuildFileOptions,
+) -> Partitions:
+    if buildifier.skip:
+        return Partitions()
+
+    specified_build_files = FilespecMatcher(
+        includes=[os.path.join("**", p) for p in build_file_options.patterns],
+        excludes=build_file_options.ignores,
+    ).matches(request.files)
+
+    return Partitions.single_partition(specified_build_files)
 
 
 @rule(desc="Format with Buildifier", level=LogLevel.DEBUG)
 async def buildfier_fmt(
-    request: BuildifierRequest, buildifier: Buildifier, platform: Platform
+    request: BuildifierRequest.SubPartition, buildifier: Buildifier, platform: Platform
 ) -> FmtResult:
+    snapshot = await BuildifierRequest.SubPartition.get_snapshot(request)
     buildifier_tool = await Get(
         DownloadedExternalTool, ExternalToolRequest, buildifier.get_request(platform)
     )
     input_digest = await Get(
         Digest,
-        MergeDigests((request.snapshot.digest, buildifier_tool.digest)),
+        MergeDigests((snapshot.digest, buildifier_tool.digest)),
     )
     result = await Get(
         ProcessResult,
         Process(
-            argv=[buildifier_tool.exe, "-type=build", *request.snapshot.files],
+            argv=[buildifier_tool.exe, "-type=build", *snapshot.files],
             input_digest=input_digest,
-            output_files=request.snapshot.files,
-            description=f"Run buildifier on {pluralize(len(request.snapshot.files), 'file')}.",
+            output_files=snapshot.files,
+            description=f"Run buildifier on {pluralize(len(snapshot.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot)
+    return FmtResult.create(
+        result, snapshot, output_snapshot, formatter_name=BuildifierRequest.name
+    )
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(_FmtBuildFilesRequest, BuildifierRequest),
+        *BuildifierRequest.registration_rules(),
     ]

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
@@ -29,7 +29,7 @@ def rule_runner() -> RuleRunner:
             *buildifier_rules(),
             *external_tool.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [BuildifierRequest]),
+            QueryRule(FmtResult, [BuildifierRequest.SubPartition]),
         ],
         # NB: Objects are easier to test with
         objects={"materials": Materials},
@@ -59,7 +59,12 @@ def run_buildifier(rule_runner: RuleRunner) -> FmtResult:
         env_inherit={"PATH", "PYENV_ROOT"},
     )
     snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/BUILD"])])
-    fmt_result = rule_runner.request(FmtResult, [BuildifierRequest(snapshot)])
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            BuildifierRequest.SubPartition(snapshot.files, key=None, _snapshot=snapshot),
+        ],
+    )
     return fmt_result
 
 

--- a/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
@@ -27,7 +27,7 @@ def rule_runner() -> RuleRunner:
             *yapf_fmt_rules(),
             *yapf_subsystem_rules(),
             *config_files.rules(),
-            QueryRule(FmtResult, (YapfRequest,)),
+            QueryRule(FmtResult, (YapfRequest.SubPartition,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -39,7 +39,12 @@ def run_yapf(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) ->
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},
     )
     snapshot = rule_runner.request(Snapshot, [PathGlobs(["**/BUILD"])])
-    fmt_result = rule_runner.request(FmtResult, [YapfRequest(snapshot)])
+    fmt_result = rule_runner.request(
+        FmtResult,
+        [
+            YapfRequest.SubPartition(snapshot.files, key=None, _snapshot=snapshot),
+        ],
+    )
     return fmt_result
 
 

--- a/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (ClangFormatRequest,)),
+            QueryRule(FmtResult, (ClangFormatRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[CCSourcesGeneratorTarget],
@@ -98,7 +98,9 @@ def run_clangformat(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ClangFormatRequest(field_sets, snapshot=input_sources.snapshot),
+            ClangFormatRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -128,7 +130,6 @@ def test_success_on_unformatted_file(rule_runner: RuleRunner) -> None:
         rule_runner,
         [tgt],
     )
-    assert fmt_result.skipped is False
     assert fmt_result.output == get_snapshot(rule_runner, {"main.cpp": DEFAULT_FORMATTED_FILE})
     assert fmt_result.did_change is True
 
@@ -165,14 +166,5 @@ def test_config(rule_runner: RuleRunner) -> None:
         rule_runner,
         [tgt],
     )
-    assert fmt_result.skipped is False
     assert fmt_result.output == get_snapshot(rule_runner, {"main.cpp": MOZILLA_FORMATTED_FILE})
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"main.cpp": UNFORMATTED_FILE, "BUILD": "cc_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="main.cpp"))
-    fmt_result = run_clangformat(rule_runner, [tgt], extra_args=["--clang-format-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -8,7 +8,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufDependenciesField,
     ProtobufSourceField,
 )
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.system_binaries import (
     BinaryShims,
@@ -22,7 +22,6 @@ from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -44,10 +43,24 @@ class BufFormatRequest(FmtTargetsRequest):
     name = "buf-format"
 
 
-@rule(level=LogLevel.DEBUG)
-async def setup_buf_format(
-    request: BufFormatRequest, buf: BufSubsystem, platform: Platform
-) -> Process:
+@rule
+async def partition_buf(
+    request: BufFormatRequest.PartitionRequest, buf: BufSubsystem
+) -> Partitions:
+    return (
+        Partitions()
+        if buf.format_skip
+        else Partitions.single_partition(
+            field_set.sources.file_path for field_set in request.field_sets
+        )
+    )
+
+
+@rule(desc="Format with buf format", level=LogLevel.DEBUG)
+async def run_buf_format(
+    request: BufFormatRequest.SubPartition, buf: BufSubsystem, platform: Platform
+) -> FmtResult:
+    snapshot = await BufFormatRequest.SubPartition.get_snapshot(request)
     diff_binary = await Get(DiffBinary, DiffBinaryRequest())
     download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
     binary_shims_get = Get(
@@ -63,7 +76,7 @@ async def setup_buf_format(
 
     input_digest = await Get(
         Digest,
-        MergeDigests((request.snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
+        MergeDigests((snapshot.digest, downloaded_buf.digest, binary_shims.digest)),
     )
 
     argv = [
@@ -72,30 +85,25 @@ async def setup_buf_format(
         "-w",
         *buf.format_args,
         "--path",
-        ",".join(request.snapshot.files),
+        ",".join(snapshot.files),
     ]
-    process = Process(
-        argv=argv,
-        input_digest=input_digest,
-        output_files=request.snapshot.files,
-        description=f"Run buf format on {pluralize(len(request.field_sets), 'file')}.",
-        level=LogLevel.DEBUG,
-        env={"PATH": binary_shims.bin_directory},
+    result = await Get(
+        ProcessResult,
+        Process(
+            argv=argv,
+            input_digest=input_digest,
+            output_files=snapshot.files,
+            description=f"Run buf format on {pluralize(len(request.files), 'file')}.",
+            level=LogLevel.DEBUG,
+            env={"PATH": binary_shims.bin_directory},
+        ),
     )
-    return process
-
-
-@rule(desc="Format with buf format", level=LogLevel.DEBUG)
-async def run_buf_format(request: BufFormatRequest, buf: BufSubsystem) -> FmtResult:
-    if buf.format_skip:
-        return FmtResult.skip(formatter_name=request.name)
-    result = await Get(ProcessResult, BufFormatRequest, request)
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot)
+    return FmtResult.create(result, snapshot, output_snapshot, formatter_name=BufFormatRequest.name)
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtTargetsRequest, BufFormatRequest),
+        *BufFormatRequest.registration_rules(),
     ]

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -28,7 +28,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [BufFormatRequest]),
+            QueryRule(FmtResult, [BufFormatRequest.SubPartition]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
         ],
         target_types=[ProtobufSourcesGeneratorTarget],
@@ -62,7 +62,9 @@ def run_buf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BufFormatRequest(field_sets, snapshot=input_sources.snapshot),
+            BufFormatRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
 
@@ -113,12 +115,4 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     fmt_result = run_buf(rule_runner, [tgt], extra_args=["--buf-format-args=--debug"])
     assert fmt_result.stdout == ""
     assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
-    assert fmt_result.did_change is False
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.proto": BAD_FILE, "BUILD": "protobuf_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
-    fmt_result = run_buf(rule_runner, [tgt], extra_args=["--buf-format-skip"])
-    assert fmt_result.skipped is True
     assert fmt_result.did_change is False

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *link.rules(),
             *assembly.rules(),
-            QueryRule(FmtResult, (GofmtRequest,)),
+            QueryRule(FmtResult, (GofmtRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
@@ -120,7 +120,9 @@ def run_gofmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GofmtRequest(field_sets, snapshot=input_sources.snapshot),
+            GofmtRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -188,13 +190,3 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner, {"good/f.go": GOOD_FILE, "bad/f.go": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files(
-        {"f.go": BAD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')"}
-    )
-    tgt = rule_runner.get_target(Address("", target_name="pkg"))
-    fmt_result = run_gofmt(rule_runner, [tgt], extra_args=["--gofmt-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.java.lint.google_java_format.skip_field import SkipGoogleJavaFormatField
 from pants.backend.java.lint.google_java_format.subsystem import GoogleJavaFormatSubsystem
 from pants.backend.java.target_types import JavaSourceField
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
@@ -45,14 +45,27 @@ class GoogleJavaFormatToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
     resolve_name = GoogleJavaFormatSubsystem.options_scope
 
 
+@rule
+async def partition_google_java_fmt(
+    request: GoogleJavaFormatRequest.PartitionRequest,
+    tool: GoogleJavaFormatSubsystem,
+) -> Partitions:
+    return (
+        Partitions()
+        if tool.skip
+        else Partitions.single_partition(
+            field_set.source.file_path for field_set in request.field_sets
+        )
+    )
+
+
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
 async def google_java_format_fmt(
-    request: GoogleJavaFormatRequest,
+    request: GoogleJavaFormatRequest.SubPartition,
     tool: GoogleJavaFormatSubsystem,
     jdk: InternalJdk,
 ) -> FmtResult:
-    if tool.skip:
-        return FmtResult.skip(formatter_name=request.name)
+    snapshot = await GoogleJavaFormatRequest.SubPartition.get_snapshot(request)
     lockfile_request = await Get(
         GenerateJvmLockfileFromTool, GoogleJavaFormatToolLockfileSentinel()
     )
@@ -78,7 +91,7 @@ async def google_java_format_fmt(
         "com.google.googlejavaformat.java.Main",
         *(["--aosp"] if tool.aosp else []),
         "--replace",
-        *request.snapshot.files,
+        *snapshot.files,
     ]
 
     result = await Get(
@@ -87,17 +100,23 @@ async def google_java_format_fmt(
             jdk=jdk,
             argv=args,
             classpath_entries=tool_classpath.classpath_entries(toolcp_relpath),
-            input_digest=request.snapshot.digest,
+            input_digest=snapshot.digest,
             extra_jvm_options=tool.jvm_options,
             extra_immutable_input_digests=extra_immutable_input_digests,
             extra_nailgun_keys=extra_immutable_input_digests,
-            output_files=request.snapshot.files,
-            description=f"Run Google Java Format on {pluralize(len(request.field_sets), 'file')}.",
+            output_files=snapshot.files,
+            description=f"Run Google Java Format on {pluralize(len(request.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+    return FmtResult.create(
+        result,
+        snapshot,
+        output_snapshot,
+        strip_chroot_path=True,
+        formatter_name=GoogleJavaFormatRequest.name,
+    )
 
 
 @rule
@@ -111,6 +130,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        UnionRule(FmtTargetsRequest, GoogleJavaFormatRequest),
+        *GoogleJavaFormatRequest.registration_rules(),
         UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -46,7 +46,7 @@ def rule_runner() -> RuleRunner:
             *target_types_rules(),
             *gjf_fmt_rules.rules(),
             *skip_field.rules(),
-            QueryRule(FmtResult, (GoogleJavaFormatRequest,)),
+            QueryRule(FmtResult, (GoogleJavaFormatRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[JavaSourceTarget, JavaSourcesGeneratorTarget],
@@ -94,7 +94,9 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GoogleJavaFormatRequest(field_sets, snapshot=input_sources.snapshot),
+            GoogleJavaFormatRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
@@ -32,7 +32,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (PrettierFmtRequest,)),
+            QueryRule(FmtResult, (PrettierFmtRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[JSSourcesGeneratorTarget],
@@ -102,7 +102,9 @@ def run_prettier(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            PrettierFmtRequest(field_sets, snapshot=input_sources.snapshot),
+            PrettierFmtRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -134,7 +136,6 @@ def test_success_on_unformatted_file(rule_runner: RuleRunner) -> None:
         rule_runner,
         [tgt],
     )
-    assert fmt_result.skipped is False
     assert fmt_result.output == get_snapshot(rule_runner, {"main.js": DEFAULT_FORMATTED_FILE})
     assert fmt_result.did_change is True
 
@@ -171,14 +172,5 @@ def test_config(rule_runner: RuleRunner) -> None:
         rule_runner,
         [tgt],
     )
-    assert fmt_result.skipped is False
     assert fmt_result.output == get_snapshot(rule_runner, {"main.js": CONFIG_FORMATTED_FILE})
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"main.js": UNFORMATTED_FILE, "BUILD": "javascript_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="main.js"))
-    fmt_result = run_prettier(rule_runner, [tgt], extra_args=["--prettier-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *skip_field.rules(),
             *system_binaries.rules(),
             *source_files.rules(),
-            QueryRule(FmtResult, (KtlintRequest,)),
+            QueryRule(FmtResult, (KtlintRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[KotlinSourceTarget, KotlinSourcesGeneratorTarget],
@@ -93,7 +93,9 @@ def run_ktlint(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            KtlintRequest(field_sets, snapshot=input_sources.snapshot),
+            KtlintRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -266,7 +266,7 @@ async def partition_inputs(
         return Partitions()
 
     applicable_file_paths = []
-    for fp in request.file_paths:
+    for fp in request.files:
         content_pattern_names, encoding = multi_matcher.get_applicable_content_pattern_names(fp)
         if content_pattern_names and encoding:
             applicable_file_paths.append(fp)

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -35,7 +35,7 @@ class AddTrailingCommaRequest(FmtTargetsRequest):
 
 
 @rule
-async def partition_clangformat(
+async def partition(
     request: AddTrailingCommaRequest.PartitionRequest, add_trailing_comma: AddTrailingComma
 ) -> Partitions:
     return (

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -8,13 +8,12 @@ from pants.backend.python.lint.add_trailing_comma.subsystem import AddTrailingCo
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -35,12 +34,24 @@ class AddTrailingCommaRequest(FmtTargetsRequest):
     name = AddTrailingComma.options_scope
 
 
+@rule
+async def partition_clangformat(
+    request: AddTrailingCommaRequest.PartitionRequest, add_trailing_comma: AddTrailingComma
+) -> Partitions:
+    return (
+        Partitions()
+        if add_trailing_comma.skip
+        else Partitions.single_partition(
+            field_set.sources.file_path for field_set in request.field_sets
+        )
+    )
+
+
 @rule(desc="Format with add-trailing-comma", level=LogLevel.DEBUG)
 async def add_trailing_comma_fmt(
-    request: AddTrailingCommaRequest, add_trailing_comma: AddTrailingComma
+    request: AddTrailingCommaRequest.SubPartition, add_trailing_comma: AddTrailingComma
 ) -> FmtResult:
-    if add_trailing_comma.skip:
-        return FmtResult.skip(formatter_name=request.name)
+    snapshot = await AddTrailingCommaRequest.SubPartition.get_snapshot(request)
     add_trailing_comma_pex = await Get(VenvPex, PexRequest, add_trailing_comma.to_pex_request())
 
     result = await Get(
@@ -50,21 +61,27 @@ async def add_trailing_comma_fmt(
             argv=(
                 "--exit-zero-even-if-changed",
                 *add_trailing_comma.args,
-                *request.snapshot.files,
+                *snapshot.files,
             ),
-            input_digest=request.snapshot.digest,
-            output_files=request.snapshot.files,
-            description=f"Run add-trailing-comma on {pluralize(len(request.field_sets), 'file')}.",
+            input_digest=snapshot.digest,
+            output_files=snapshot.files,
+            description=f"Run add-trailing-comma on {pluralize(len(request.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+    return FmtResult.create(
+        result,
+        snapshot,
+        output_snapshot,
+        strip_chroot_path=True,
+        formatter_name=AddTrailingCommaRequest.name,
+    )
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtTargetsRequest, AddTrailingCommaRequest),
+        *AddTrailingCommaRequest.registration_rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -35,9 +35,7 @@ class AutoflakeRequest(FmtTargetsRequest):
 
 
 @rule
-async def partition_clangformat(
-    request: AutoflakeRequest.PartitionRequest, autoflake: Autoflake
-) -> Partitions:
+async def partition(request: AutoflakeRequest.PartitionRequest, autoflake: Autoflake) -> Partitions:
     return (
         Partitions()
         if autoflake.skip

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -8,13 +8,12 @@ from pants.backend.python.lint.autoflake.subsystem import Autoflake
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -35,10 +34,22 @@ class AutoflakeRequest(FmtTargetsRequest):
     name = Autoflake.options_scope
 
 
+@rule
+async def partition_clangformat(
+    request: AutoflakeRequest.PartitionRequest, autoflake: Autoflake
+) -> Partitions:
+    return (
+        Partitions()
+        if autoflake.skip
+        else Partitions.single_partition(
+            field_set.source.file_path for field_set in request.field_sets
+        )
+    )
+
+
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
-async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtResult:
-    if autoflake.skip:
-        return FmtResult.skip(formatter_name=request.name)
+async def autoflake_fmt(request: AutoflakeRequest.SubPartition, autoflake: Autoflake) -> FmtResult:
+    snapshot = await AutoflakeRequest.SubPartition.get_snapshot(request)
     autoflake_pex = await Get(VenvPex, PexRequest, autoflake.to_pex_request())
 
     result = await Get(
@@ -48,21 +59,27 @@ async def autoflake_fmt(request: AutoflakeRequest, autoflake: Autoflake) -> FmtR
             argv=(
                 "--in-place",
                 *autoflake.args,
-                *request.snapshot.files,
+                *snapshot.files,
             ),
-            input_digest=request.snapshot.digest,
-            output_files=request.snapshot.files,
-            description=f"Run Autoflake on {pluralize(len(request.field_sets), 'file')}.",
+            input_digest=snapshot.digest,
+            output_files=snapshot.files,
+            description=f"Run Autoflake on {pluralize(len(request.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot, strip_chroot_path=True)
+    return FmtResult.create(
+        result,
+        snapshot,
+        output_snapshot,
+        strip_chroot_path=True,
+        formatter_name=AutoflakeRequest.name,
+    )
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtTargetsRequest, AutoflakeRequest),
+        *AutoflakeRequest.registration_rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (AutoflakeRequest,)),
+            QueryRule(FmtResult, (AutoflakeRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -63,7 +63,9 @@ def run_autoflake(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            AutoflakeRequest(field_sets, snapshot=input_sources.snapshot),
+            AutoflakeRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -114,14 +116,6 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner, {"good.py": GOOD_FILE, "bad.py": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_autoflake(rule_runner, [tgt], extra_args=["--autoflake-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False
 
 
 def test_stub_files(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -80,8 +80,6 @@ async def partition_black(
     # like `>=3.6` to result in requiring Python 3.8, which would error if 3.8 is not installed on
     # the machine.
     tool_interpreter_constraints = black.interpreter_constraints
-    print(tool_interpreter_constraints)
-    print(black.options.is_default("interpreter_constraints"))
     if black.options.is_default("interpreter_constraints"):
         try:
             # Don't compute this unless we have to, since it might fail.

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -13,7 +13,8 @@ from pants.backend.python.lint.black.rules import rules as black_rules
 from pants.backend.python.lint.black.subsystem import Black, BlackFieldSet
 from pants.backend.python.lint.black.subsystem import rules as black_subsystem_rules
 from pants.backend.python.target_types import PythonSourcesGeneratorTarget
-from pants.core.goals.fmt import FmtResult
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.core.goals.fmt import FmtResult, Partitions
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
@@ -37,7 +38,8 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (BlackRequest,)),
+            QueryRule(Partitions, (BlackRequest.PartitionRequest,)),
+            QueryRule(FmtResult, (BlackRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -51,7 +53,11 @@ NEEDS_CONFIG_FILE = "animal = 'Koala'\n"  # Note the single quotes.
 
 
 def run_black(
-    rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    *,
+    expected_ics: str = Black.default_interpreter_constraints[0],
+    extra_args: list[str] | None = None,
 ) -> FmtResult:
     rule_runner.set_options(
         ["--backend-packages=pants.backend.python.lint.black", *(extra_args or ())],
@@ -77,10 +83,19 @@ def run_black(
             SourceFilesRequest(field_set.source for field_set in field_sets),
         ],
     )
+    partitions = rule_runner.request(
+        Partitions,
+        [
+            BlackRequest.PartitionRequest(tuple(field_sets)),
+        ],
+    )
+    assert len(partitions) == 1
+    key, partition = next(iter(partitions.items()))
+    assert key == InterpreterConstraints([expected_ics])
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest(field_sets, snapshot=input_sources.snapshot),
+            BlackRequest.SubPartition(partition, key=key, _snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result
@@ -106,6 +121,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     fmt_result = run_black(
         rule_runner,
         [tgt],
+        expected_ics=interpreter_constraint,
         extra_args=[f"--black-interpreter-constraints=['{interpreter_constraint}']"],
     )
     assert "1 file left unchanged" in fmt_result.stderr
@@ -168,14 +184,6 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert fmt_result.did_change is False
 
 
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_black(rule_runner, [tgt], extra_args=["--black-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False
-
-
 @skip_unless_python38_present
 def test_works_with_python38(rule_runner: RuleRunner) -> None:
     """Black's typed-ast dependency does not understand Python 3.8, so we must instead run Black
@@ -197,7 +205,7 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
         {"f.py": content, "BUILD": "python_sources(name='t', interpreter_constraints=['>=3.8'])"}
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_black(rule_runner, [tgt])
+    fmt_result = run_black(rule_runner, [tgt], expected_ics=">=3.8")
     assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_snapshot(rule_runner, {"f.py": content})
     assert fmt_result.did_change is False
@@ -218,7 +226,7 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
         {"f.py": content, "BUILD": "python_sources(name='t', interpreter_constraints=['>=3.9'])"}
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_black(rule_runner, [tgt])
+    fmt_result = run_black(rule_runner, [tgt], expected_ics=">=3.9")
     assert "1 file left unchanged" in fmt_result.stderr
     assert fmt_result.output == get_snapshot(rule_runner, {"f.py": content})
     assert fmt_result.did_change is False

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -8,13 +8,12 @@ from pants.backend.python.lint.docformatter.subsystem import Docformatter
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -35,10 +34,24 @@ class DocformatterRequest(FmtTargetsRequest):
     name = Docformatter.options_scope
 
 
+@rule
+async def partition_docformatter(
+    request: DocformatterRequest.PartitionRequest, docformatter: Docformatter
+) -> Partitions:
+    return (
+        Partitions()
+        if docformatter.skip
+        else Partitions.single_partition(
+            field_set.source.file_path for field_set in request.field_sets
+        )
+    )
+
+
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
-async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformatter) -> FmtResult:
-    if docformatter.skip:
-        return FmtResult.skip(formatter_name=request.name)
+async def docformatter_fmt(
+    request: DocformatterRequest.SubPartition, docformatter: Docformatter
+) -> FmtResult:
+    snapshot = await DocformatterRequest.SubPartition.get_snapshot(request)
     docformatter_pex = await Get(VenvPex, PexRequest, docformatter.to_pex_request())
     result = await Get(
         ProcessResult,
@@ -47,21 +60,23 @@ async def docformatter_fmt(request: DocformatterRequest, docformatter: Docformat
             argv=(
                 "--in-place",
                 *docformatter.args,
-                *request.snapshot.files,
+                *snapshot.files,
             ),
-            input_digest=request.snapshot.digest,
-            output_files=request.snapshot.files,
-            description=(f"Run Docformatter on {pluralize(len(request.field_sets), 'file')}."),
+            input_digest=snapshot.digest,
+            output_files=snapshot.files,
+            description=(f"Run Docformatter on {pluralize(len(request.files), 'file')}."),
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot)
+    return FmtResult.create(
+        result, snapshot, output_snapshot, formatter_name=DocformatterRequest.name
+    )
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtTargetsRequest, DocformatterRequest),
+        *DocformatterRequest.registration_rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *docformatter_subsystem_rules(),
             *source_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (DocformatterRequest,)),
+            QueryRule(FmtResult, (DocformatterRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -59,7 +59,9 @@ def run_docformatter(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            DocformatterRequest(field_sets, snapshot=input_sources.snapshot),
+            DocformatterRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -121,14 +123,6 @@ def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
         extra_args=["--docformatter-args='--make-summary-multi-line'"],
     )
     assert fmt_result.output == get_snapshot(rule_runner, {"f.py": content})
-    assert fmt_result.did_change is False
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_docformatter(rule_runner, [tgt], extra_args=["--docformatter-skip"])
-    assert fmt_result.skipped is True
     assert fmt_result.did_change is False
 
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (IsortRequest,)),
+            QueryRule(FmtResult, (IsortRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -67,7 +67,9 @@ def run_isort(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            IsortRequest(field_sets, snapshot=input_sources.snapshot),
+            IsortRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -147,14 +149,6 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert fmt_result.stdout == "Fixing f.py\n"
     assert fmt_result.output == get_snapshot(rule_runner, {"f.py": FIXED_NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
-    fmt_result = run_isort(rule_runner, [tgt], extra_args=["--isort-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False
 
 
 def test_stub_files(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -11,14 +11,13 @@ from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, _FmtBuildFilesRequest
+from pants.core.goals.fmt import FmtRequest, FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import FieldSet, Target
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -41,21 +40,18 @@ class YapfRequest(FmtTargetsRequest):
 
 @rule_helper
 async def _run_yapf(
-    request: FmtTargetsRequest | _FmtBuildFilesRequest,
+    request: FmtRequest.SubPartition,
     yapf: Yapf,
     interpreter_constraints: InterpreterConstraints | None = None,
 ) -> FmtResult:
+    snapshot = await FmtRequest.SubPartition.get_snapshot(request)
     yapf_pex_get = Get(
         VenvPex, PexRequest, yapf.to_pex_request(interpreter_constraints=interpreter_constraints)
     )
-    config_files_get = Get(
-        ConfigFiles, ConfigFilesRequest, yapf.config_request(request.snapshot.dirs)
-    )
+    config_files_get = Get(ConfigFiles, ConfigFilesRequest, yapf.config_request(snapshot.dirs))
     yapf_pex, config_files = await MultiGet(yapf_pex_get, config_files_get)
 
-    input_digest = await Get(
-        Digest, MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
-    )
+    input_digest = await Get(Digest, MergeDigests((snapshot.digest, config_files.snapshot.digest)))
 
     result = await Get(
         ProcessResult,
@@ -65,28 +61,37 @@ async def _run_yapf(
                 *yapf.args,
                 "--in-place",
                 *(("--style", yapf.config) if yapf.config else ()),
-                *request.snapshot.files,
+                *snapshot.files,
             ),
             input_digest=input_digest,
-            output_files=request.snapshot.files,
-            description=f"Run yapf on {pluralize(len(request.snapshot.files), 'file')}.",
+            output_files=snapshot.files,
+            description=f"Run yapf on {pluralize(len(request.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(request, result, output_snapshot)
+    return FmtResult.create(result, snapshot, output_snapshot, formatter_name=YapfRequest.name)
+
+
+@rule
+async def partition_yapf(request: YapfRequest.PartitionRequest, yapf: Yapf) -> Partitions:
+    return (
+        Partitions()
+        if yapf.skip
+        else Partitions.single_partition(
+            field_set.source.file_path for field_set in request.field_sets
+        )
+    )
 
 
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
-async def yapf_fmt(request: YapfRequest, yapf: Yapf) -> FmtResult:
-    if yapf.skip:
-        return FmtResult.skip(formatter_name=request.name)
+async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
     return await _run_yapf(request, yapf)
 
 
 def rules():
     return [
         *collect_rules(),
-        UnionRule(FmtTargetsRequest, YapfRequest),
+        *YapfRequest.registration_rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -202,9 +202,6 @@ async def scalafmt_fmt(
     )
 
     output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-
-    print(original_snapshot)
-    print(output_snapshot)
     return FmtResult.create(
         result,
         original_snapshot,

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from typing import overload
 
 import pytest
 
@@ -19,10 +20,9 @@ from pants.backend.scala.lint.scalafmt.rules import (
 from pants.backend.scala.lint.scalafmt.rules import rules as scalafmt_rules
 from pants.backend.scala.target_types import ScalaSourcesGeneratorTarget, ScalaSourceTarget
 from pants.build_graph.address import Address
-from pants.core.goals.fmt import FmtResult
+from pants.core.goals.fmt import FmtResult, Partitions
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import CreateDigest, Digest, FileContent, PathGlobs, Snapshot
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
@@ -52,8 +52,8 @@ def rule_runner() -> RuleRunner:
             *target_types.rules(),
             *scalafmt_rules(),
             *skip_field.rules(),
-            QueryRule(FmtResult, (ScalafmtRequest,)),
-            QueryRule(SourceFiles, (SourceFilesRequest,)),
+            QueryRule(Partitions, (ScalafmtRequest.PartitionRequest,)),
+            QueryRule(FmtResult, (ScalafmtRequest.SubPartition,)),
             QueryRule(Snapshot, (PathGlobs,)),
             QueryRule(ScalafmtConfigFiles, (GatherScalafmtConfigFilesRequest,)),
         ],
@@ -103,21 +103,52 @@ runner.dialect = scala213
 """
 
 
-def run_scalafmt(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
+@overload
+def run_scalafmt(
+    rule_runner: RuleRunner, targets: list[Target], expected_partitions: None = None
+) -> FmtResult:
+    ...
+
+
+@overload
+def run_scalafmt(
+    rule_runner: RuleRunner, targets: list[Target], expected_partitions: dict[str, tuple[str, ...]]
+) -> list[FmtResult]:
+    ...
+
+
+def run_scalafmt(
+    rule_runner: RuleRunner,
+    targets: list[Target],
+    expected_partitions: dict[str, tuple[str, ...]] | None = None,
+) -> FmtResult | list[FmtResult]:
     field_sets = [ScalafmtFieldSet.create(tgt) for tgt in targets]
-    input_sources = rule_runner.request(
-        SourceFiles,
+    partitions = rule_runner.request(
+        Partitions,
         [
-            SourceFilesRequest(field_set.source for field_set in field_sets),
+            ScalafmtRequest.PartitionRequest(tuple(field_sets)),
         ],
     )
-    fmt_result = rule_runner.request(
-        FmtResult,
-        [
-            ScalafmtRequest(field_sets, snapshot=input_sources.snapshot),
-        ],
-    )
-    return fmt_result
+    if expected_partitions:
+        assert {
+            key.config_snapshot.files[0]: files for key, files in partitions.items()
+        } == expected_partitions
+    else:
+        assert len(partitions.items()) == 1
+    fmt_results = [
+        rule_runner.request(
+            FmtResult,
+            [
+                ScalafmtRequest.SubPartition(
+                    partition,
+                    key=key,
+                    _snapshot=rule_runner.request(Snapshot, [PathGlobs(partition)]),
+                )
+            ],
+        )
+        for key, partition in partitions.items()
+    ]
+    return fmt_results if expected_partitions else fmt_results[0]
 
 
 def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
@@ -196,11 +227,20 @@ def test_multiple_config_files(rule_runner: RuleRunner) -> None:
             Address("foo/bar", target_name="bar", relative_file_path="Bar.scala")
         ),
     ]
-    fmt_result = run_scalafmt(rule_runner, tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"foo/Foo.scala": GOOD_FILE, "foo/bar/Bar.scala": FIXED_BAD_FILE_INDENT_4}
+    fmt_results = run_scalafmt(
+        rule_runner,
+        tgts,
+        expected_partitions={
+            SCALAFMT_CONF_FILENAME: ("foo/Foo.scala",),
+            "foo/bar/" + SCALAFMT_CONF_FILENAME: ("foo/bar/Bar.scala",),
+        },
     )
-    assert fmt_result.did_change is True
+    assert not fmt_results[0].did_change
+    assert fmt_results[0].output == get_snapshot(rule_runner, {"foo/Foo.scala": GOOD_FILE})
+    assert fmt_results[1].did_change
+    assert fmt_results[1].output == get_snapshot(
+        rule_runner, {"foo/bar/Bar.scala": FIXED_BAD_FILE_INDENT_4}
+    )
 
 
 def test_find_nearest_ancestor_file() -> None:

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [ShfmtRequest]),
+            QueryRule(FmtResult, [ShfmtRequest.SubPartition]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
         ],
         target_types=[ShellSourcesGeneratorTarget],
@@ -87,7 +87,9 @@ def run_shfmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ShfmtRequest(field_sets, snapshot=input_sources.snapshot),
+            ShfmtRequest.SubPartition(
+                input_sources.snapshot.files, key=None, _snapshot=input_sources.snapshot
+            ),
         ],
     )
     return fmt_result
@@ -162,11 +164,3 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert fmt_result.stdout == "f.sh\n"
     assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": FIXED_NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is True
-
-
-def test_skip(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"f.sh": BAD_FILE, "BUILD": "shell_sources(name='t')"})
-    tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.sh"))
-    fmt_result = run_shfmt(rule_runner, [tgt], extra_args=["--shfmt-skip"])
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -1,5 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 import textwrap
 from typing import List, NewType
 
@@ -10,7 +12,7 @@ from pants.backend.terraform.lint.tffmt import tffmt
 from pants.backend.terraform.lint.tffmt.tffmt import TffmtRequest
 from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModuleTarget
 from pants.backend.terraform.tool import TerraformTool
-from pants.core.goals.fmt import FmtResult
+from pants.core.goals.fmt import FmtResult, Partitions
 from pants.core.util_rules import external_tool, source_files
 from pants.core.util_rules.external_tool import ExternalToolVersion
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -53,7 +55,8 @@ def rule_runner() -> RuleRunner:
             *tffmt.rules(),
             *tool.rules(),
             *source_files.rules(),
-            QueryRule(FmtResult, (TffmtRequest,)),
+            QueryRule(Partitions, (TffmtRequest.PartitionRequest,)),
+            QueryRule(FmtResult, (TffmtRequest.SubPartition,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
@@ -117,7 +120,7 @@ def run_tffmt(
     rule_runner: RuleRunner,
     targets: List[Target],
     options: RuleRunnerOptions,
-) -> FmtResult:
+) -> FmtResult | None:
     rule_runner.set_options(options)
     field_sets = [TerraformFieldSet.create(tgt) for tgt in targets]
     input_sources = rule_runner.request(
@@ -126,10 +129,26 @@ def run_tffmt(
             SourceFilesRequest(field_set.sources for field_set in field_sets),
         ],
     )
+    partitions = rule_runner.request(
+        Partitions,
+        [
+            TffmtRequest.PartitionRequest(tuple(field_sets)),
+        ],
+    )
+    if not partitions:
+        return None
+
+    assert len(partitions) == 1
+    key, files = next(iter(partitions.items()))
+    assert set(files) == set(input_sources.snapshot.files)
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            TffmtRequest(field_sets, snapshot=input_sources.snapshot),
+            TffmtRequest.SubPartition(
+                files,
+                key=key,
+                _snapshot=input_sources.snapshot,
+            ),
         ],
     )
     return fmt_result
@@ -147,6 +166,7 @@ def get_snapshot(rule_runner: RuleRunner, source_files: List[FileContent]) -> Sn
 def test_passing_source(rule_runner: RuleRunner, rule_runner_options: RuleRunnerOptions) -> None:
     target = make_target(rule_runner, [GOOD_SOURCE])
     fmt_result = run_tffmt(rule_runner, [target], rule_runner_options)
+    assert fmt_result
     assert fmt_result.stdout == ""
     assert fmt_result.output == get_snapshot(rule_runner, [GOOD_SOURCE])
     assert fmt_result.did_change is False
@@ -155,6 +175,7 @@ def test_passing_source(rule_runner: RuleRunner, rule_runner_options: RuleRunner
 def test_failing_source(rule_runner: RuleRunner, rule_runner_options: RuleRunnerOptions) -> None:
     target = make_target(rule_runner, [BAD_SOURCE])
     fmt_result = run_tffmt(rule_runner, [target], rule_runner_options)
+    assert fmt_result
     contents = get_content(rule_runner, fmt_result.output.digest)
     print(f">>>{contents[0].content.decode()}<<<")
     assert fmt_result.stderr == ""
@@ -165,6 +186,7 @@ def test_failing_source(rule_runner: RuleRunner, rule_runner_options: RuleRunner
 def test_mixed_sources(rule_runner: RuleRunner, rule_runner_options: RuleRunnerOptions) -> None:
     target = make_target(rule_runner, [GOOD_SOURCE, BAD_SOURCE])
     fmt_result = run_tffmt(rule_runner, [target], rule_runner_options)
+    assert fmt_result
     assert fmt_result.output == get_snapshot(rule_runner, [GOOD_SOURCE, FIXED_BAD_SOURCE])
     assert fmt_result.did_change is True
 
@@ -175,6 +197,7 @@ def test_multiple_targets(rule_runner: RuleRunner, rule_runner_options: RuleRunn
         make_target(rule_runner, [BAD_SOURCE], target_name="tgt_bad"),
     ]
     fmt_result = run_tffmt(rule_runner, targets, rule_runner_options)
+    assert fmt_result
     assert fmt_result.output == get_snapshot(rule_runner, [GOOD_SOURCE, FIXED_BAD_SOURCE])
     assert fmt_result.did_change is True
 
@@ -185,5 +208,4 @@ def test_skip(rule_runner: RuleRunner, rule_runner_options: RuleRunnerOptions) -
     rule_runner_options.append("--terraform-fmt-skip")  # skips running terraform
 
     fmt_result = run_tffmt(rule_runner, [target], rule_runner_options)
-    assert fmt_result.skipped is True
-    assert fmt_result.did_change is False
+    assert fmt_result is None

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -3,50 +3,35 @@
 
 from __future__ import annotations
 
+import dataclasses
 import itertools
 import logging
-import os
-from abc import ABCMeta
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Callable, ClassVar, Iterable, Iterator, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Iterable, Iterator, Sequence, Tuple, Type, TypeVar
 
 from pants.base.specs import Specs
-from pants.core.goals.style_request import (
-    StyleRequest,
-    determine_specified_tool_names,
-    only_option_help,
-    style_batch_size_help,
-)
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.goals.lint import LintFilesRequest, LintRequest, LintResult, LintTargetsRequest
+from pants.core.goals.lint import Partitions as LintPartitions
+from pants.core.goals.lint import _get_partitions_by_request_type
+from pants.core.goals.style_request import only_option_help, style_batch_size_help
+from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
+from pants.engine.engine_aware import EngineAwareReturnType
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import (
-    Digest,
-    MergeDigests,
-    PathGlobs,
-    Snapshot,
-    SnapshotDiff,
-    SpecsPaths,
-    Workspace,
-)
+from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot, SnapshotDiff, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.internals.build_files import BuildFileOptions
-from pants.engine.internals.native_engine import EMPTY_SNAPSHOT
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule, rule_helper
-from pants.engine.target import FieldSet, FilteredTargets, SourcesField, Target, Targets
-from pants.engine.unions import UnionMembership, union
+from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.option_types import IntOption, StrListOption
-from pants.source.filespec import FilespecMatcher
 from pants.util.collections import partition_sequentially
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
+from pants.util.memo import memoized_classproperty
+from pants.util.meta import frozen_after_init, runtime_ignore_subscripts
 from pants.util.strutil import strip_v2_chroot_path
 
 _F = TypeVar("_F", bound="FmtResult")
-_FS = TypeVar("_FS", bound=FieldSet)
 _T = TypeVar("_T")
 
 logger = logging.getLogger(__name__)
@@ -63,21 +48,22 @@ class FmtResult(EngineAwareReturnType):
     @classmethod
     def create(
         cls,
-        request: FmtTargetsRequest | _FmtBuildFilesRequest,
         process_result: ProcessResult | FallibleProcessResult,
+        input_snapshot: Snapshot,
         output: Snapshot,
         *,
+        formatter_name: str,
         strip_chroot_path: bool = False,
     ) -> FmtResult:
         def prep_output(s: bytes) -> str:
             return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
 
         return cls(
-            input=request.snapshot,
+            input=input_snapshot,
             output=output,
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
-            formatter_name=request.name,
+            formatter_name=formatter_name,
         )
 
     def __post_init__(self):
@@ -89,37 +75,14 @@ class FmtResult(EngineAwareReturnType):
             log += f"\n{self.stderr}"
         logger.debug(log)
 
-    @classmethod
-    def skip(cls: type[_F], *, formatter_name: str) -> _F:
-        return cls(
-            input=EMPTY_SNAPSHOT,
-            output=EMPTY_SNAPSHOT,
-            stdout="",
-            stderr="",
-            formatter_name=formatter_name,
-        )
-
-    @property
-    def skipped(self) -> bool:
-        return (
-            self.input == EMPTY_SNAPSHOT
-            and self.output == EMPTY_SNAPSHOT
-            and not self.stdout
-            and not self.stderr
-        )
-
     @property
     def did_change(self) -> bool:
         return self.output != self.input
 
     def level(self) -> LogLevel | None:
-        if self.skipped:
-            return LogLevel.DEBUG
         return LogLevel.WARN if self.did_change else LogLevel.INFO
 
     def message(self) -> str | None:
-        if self.skipped:
-            return f"{self.formatter_name} skipped."
         message = "made changes." if self.did_change else "made no changes."
 
         # NB: Instead of printing out `stdout` and `stderr`, we just print a list of files which
@@ -151,56 +114,74 @@ class FmtResult(EngineAwareReturnType):
         return False
 
 
-@union(in_scope_types=[EnvironmentName])
-@frozen_after_init
-@dataclass(unsafe_hash=True)
-class FmtTargetsRequest(StyleRequest[_FS]):
-    snapshot: Snapshot
-
-    def __init__(self, field_sets: Iterable[_FS], snapshot: Snapshot) -> None:
-        self.snapshot = snapshot
-        super().__init__(field_sets)
+Partitions = LintPartitions[str]
 
 
-@union(in_scope_types=[EnvironmentName])
-@dataclass(frozen=True)
-# Prefixed with `_` because we aren't sure if this union will stick long-term, or be subsumed when
-# we implement https://github.com/pantsbuild/pants/issues/16480.
-class _FmtBuildFilesRequest(EngineAwareParameter, metaclass=ABCMeta):
-    name: ClassVar[str]
+@union
+class FmtRequest(LintRequest):
+    is_formatter = True
 
-    snapshot: Snapshot
+    @runtime_ignore_subscripts
+    @frozen_after_init
+    @dataclass(unsafe_hash=True)
+    class SubPartition(LintRequest.SubPartition):
+        _snapshot: Snapshot | None = None
+
+        @property
+        def files(self) -> tuple[str, ...]:
+            return self.elements
+
+        @rule_helper(_public=True)
+        async def get_snapshot(self) -> Snapshot:
+            if self._snapshot is None:
+                return await Get(Snapshot, PathGlobs(self.files))
+
+            return self._snapshot
+
+    _SubPartitionBase = SubPartition
+
+    if not TYPE_CHECKING:
+
+        @memoized_classproperty
+        def SubPartition(cls):
+            @union(in_scope_types=[EnvironmentName])
+            class SubPartition(cls._SubPartitionBase):
+                pass
+
+            return SubPartition
+
+    @classmethod
+    def _get_registration_rules(cls) -> Iterable[UnionRule]:
+        yield from super()._get_registration_rules()
+        yield UnionRule(FmtRequest, cls)
+        yield UnionRule(FmtRequest.SubPartition, cls.SubPartition)
 
 
-@dataclass(frozen=True)
-class _FmtTargetBatchRequest:
-    """Format all the targets in the given batch.
-
-    NOTE: Several requests can be made in parallel (via `MultiGet`) iff the target batches are
-        non-overlapping. Within the request, the FmtTargetsRequests will be issued sequentially
-        with the result of each run fed into the next run. To maximize parallel performance, the
-        targets in a batch should share a FieldSet.
-    """
-
-    request_types: tuple[type[FmtTargetsRequest], ...]
-    targets: Targets
+class FmtTargetsRequest(FmtRequest, LintTargetsRequest):
+    @classmethod
+    def _get_registration_rules(cls) -> Iterable[UnionRule]:
+        yield from super()._get_registration_rules()
+        yield UnionRule(FmtTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
-@dataclass(frozen=True)
-class _FmtBuildFilesBatchRequest:
-    request_types: tuple[type[_FmtBuildFilesRequest], ...]
-    paths: tuple[str, ...]
+class FmtFilesRequest(FmtRequest, LintFilesRequest):
+    @classmethod
+    def _get_registration_rules(cls) -> Iterable[UnionRule]:
+        yield from super()._get_registration_rules()
+        yield UnionRule(FmtFilesRequest.PartitionRequest, cls.PartitionRequest)
+
+
+class _FmtSubpartitionBatchRequest(Collection[FmtRequest.SubPartition]):
+    """Request to serially format all the subpartitions in the given batch."""
 
 
 @dataclass(frozen=True)
 class _FmtBatchResult:
     results: tuple[FmtResult, ...]
-    input: Digest
-    output: Digest
 
     @property
     def did_change(self) -> bool:
-        return self.input != self.output
+        return any(result.did_change for result in self.results)
 
 
 class FmtSubsystem(GoalSubsystem):
@@ -209,7 +190,7 @@ class FmtSubsystem(GoalSubsystem):
 
     @classmethod
     def activated(cls, union_membership: UnionMembership) -> bool:
-        return FmtTargetsRequest in union_membership
+        return FmtRequest in union_membership
 
     only = StrListOption(
         help=only_option_help("fmt", "formatter", "isort", "shfmt"),
@@ -225,89 +206,18 @@ class Fmt(Goal):
     subsystem_cls = FmtSubsystem
 
 
-def _get_request_types(
-    fmt_subsystem: FmtSubsystem,
-    union_membership: UnionMembership,
-) -> tuple[tuple[type[FmtTargetsRequest], ...], tuple[type[_FmtBuildFilesRequest], ...]]:
-    fmt_target_request_types = union_membership.get(FmtTargetsRequest)
-    fmt_build_files_request_types = union_membership.get(_FmtBuildFilesRequest)
-
-    # NOTE: Unlike lint.py, we don't check for ambiguous names between target formatters and BUILD
-    # formatters, since BUILD files are Python and we re-use Python formatters for BUILD files
-    # (like `black`).
-
-    formatters_to_run = determine_specified_tool_names(
-        "fmt",
-        fmt_subsystem.only,
-        [*fmt_target_request_types, *fmt_build_files_request_types],
-    )
-
-    filtered_fmt_target_request_types = tuple(
-        request_type
-        for request_type in fmt_target_request_types
-        if request_type.name in formatters_to_run
-    )
-    filtered_fmt_build_files_request_types = tuple(
-        request_type
-        for request_type in fmt_build_files_request_types
-        if request_type.name in formatters_to_run
-    )
-
-    return filtered_fmt_target_request_types, filtered_fmt_build_files_request_types
-
-
-def _batch(
-    iterable: Iterable[_T], batch_size: int, key: Callable[[_T], str] = lambda x: str(x)
-) -> Iterator[list[_T]]:
-    partitions = partition_sequentially(
-        iterable,
-        key=key,
-        size_target=batch_size,
-        size_max=4 * batch_size,
-    )
-    for partition in partitions:
-        yield partition
-
-
-def _batch_targets(
-    request_types: Iterable[type[FmtTargetsRequest]],
-    targets: Iterable[Target],
-    batch_size: int,
-) -> dict[Targets, tuple[type[FmtTargetsRequest], ...]]:
-    """Groups targets by the relevant Request types, then batches them.
-
-    Returns a mapping from batch -> Request types.
-    """
-
-    targets_by_request_order = defaultdict(list)
-
-    for target in targets:
-        applicable_request_types = []
-        for request_type in request_types:
-            if request_type.field_set_type.is_applicable(target):
-                applicable_request_types.append(request_type)
-        if applicable_request_types:
-            targets_by_request_order[tuple(applicable_request_types)].append(target)
-
-    target_batches_by_fmt_request_order = {
-        Targets(target_batch): applicable_request_types
-        for applicable_request_types, targets in targets_by_request_order.items()
-        for target_batch in _batch(targets, batch_size, key=lambda t: t.address.spec)
-    }
-
-    return target_batches_by_fmt_request_order
-
-
 @rule_helper
 async def _write_files(workspace: Workspace, batched_results: Iterable[_FmtBatchResult]):
-    changed_digests = tuple(
-        batched_result.output for batched_result in batched_results if batched_result.did_change
-    )
-    if changed_digests:
+    if any(batched_result.did_change for batched_result in batched_results):
         # NB: this will fail if there are any conflicting changes, which we want to happen rather
         # than silently having one result override the other. In practice, this should never
         # happen due to us grouping each language's formatters into a single digest.
-        merged_formatted_digest = await Get(Digest, MergeDigests(changed_digests))
+        merged_formatted_digest = await Get(
+            Digest,
+            MergeDigests(
+                batched_result.results[-1].output.digest for batched_result in batched_results
+            ),
+        )
         workspace.write_digest(merged_formatted_digest)
 
 
@@ -329,8 +239,6 @@ def _print_results(
         if any(result.did_change for result in results):
             sigil = console.sigil_succeeded_with_edits()
             status = "made changes"
-        elif all(result.skipped for result in results):
-            continue
         else:
             sigil = console.sigil_succeeded()
             status = "made no changes"
@@ -342,64 +250,68 @@ async def fmt(
     console: Console,
     specs: Specs,
     fmt_subsystem: FmtSubsystem,
-    build_file_options: BuildFileOptions,
     workspace: Workspace,
     union_membership: UnionMembership,
 ) -> Fmt:
-    fmt_target_request_types, fmt_build_files_request_types = _get_request_types(
-        fmt_subsystem, union_membership
+    fmt_request_types = list(union_membership.get(FmtRequest))
+    target_partitioners = list(union_membership.get(FmtTargetsRequest.PartitionRequest))
+    file_partitioners = list(union_membership.get(FmtFilesRequest.PartitionRequest))
+
+    partitions_by_request_type = await _get_partitions_by_request_type(
+        fmt_request_types,
+        target_partitioners,
+        file_partitioners,
+        fmt_subsystem,
+        specs,
+        lambda request_type: Get(Partitions, FmtTargetsRequest.PartitionRequest, request_type),
+        lambda request_type: Get(Partitions, FmtFilesRequest.PartitionRequest, request_type),
     )
 
-    _get_targets = Get(
-        FilteredTargets,
-        Specs,
-        specs if fmt_target_request_types else Specs.empty(),
-    )
-    _get_specs_paths = Get(
-        SpecsPaths, Specs, specs if fmt_build_files_request_types else Specs.empty()
-    )
-
-    targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
-    specified_build_files = FilespecMatcher(
-        includes=[os.path.join("**", p) for p in build_file_options.patterns],
-        excludes=build_file_options.ignores,
-    ).matches(specs_paths.files)
-
-    targets_to_request_types = _batch_targets(
-        fmt_target_request_types,
-        targets,
-        fmt_subsystem.batch_size,
-    )
-
-    all_requests = [
-        *(
-            Get(
-                _FmtBatchResult,
-                _FmtTargetBatchRequest(fmt_request_types, target_batch),
-            )
-            for target_batch, fmt_request_types in targets_to_request_types.items()
-        ),
-        *(
-            Get(
-                _FmtBatchResult,
-                _FmtBuildFilesBatchRequest(fmt_build_files_request_types, tuple(paths_batch)),
-            )
-            for paths_batch in _batch(
-                specified_build_files,
-                fmt_subsystem.batch_size,
-            )
-        ),
-    ]
-    target_batch_results = cast("tuple[_FmtBatchResult, ...]", await MultiGet(all_requests))
-
-    individual_results = list(
-        itertools.chain.from_iterable(result.results for result in target_batch_results)
-    )
-
-    if not individual_results:
+    if not partitions_by_request_type:
         return Fmt(exit_code=0)
 
-    await _write_files(workspace, target_batch_results)
+    def batch(files: Iterable[str]) -> Iterator[tuple[str, ...]]:
+        batches = partition_sequentially(
+            files,
+            key=lambda x: str(x),
+            size_target=fmt_subsystem.batch_size,
+            size_max=4 * fmt_subsystem.batch_size,
+        )
+        for batch in batches:
+            yield tuple(batch)
+
+    def _make_disjoint_subpartition_batch_requests() -> Iterable[_FmtSubpartitionBatchRequest]:
+        partition_infos: Sequence[Tuple[Type[FmtRequest], Any]]
+        files: Sequence[str]
+
+        partition_infos_by_files = defaultdict(list)
+        for request_type, partitions_list in partitions_by_request_type.items():
+            for partitions in partitions_list:
+                for key, files in partitions.items():
+                    for file in files:
+                        partition_infos_by_files[file].append((request_type, key))
+
+        files_by_partition_info = defaultdict(list)
+        for file, partition_infos in partition_infos_by_files.items():
+            files_by_partition_info[tuple(partition_infos)].append(file)
+
+        for partition_infos, files in files_by_partition_info.items():
+            for subpartition in batch(files):
+                yield _FmtSubpartitionBatchRequest(
+                    request_type.SubPartition(subpartition, partition_key)
+                    for request_type, partition_key in partition_infos
+                )
+
+    all_results = await MultiGet(
+        Get(_FmtBatchResult, _FmtSubpartitionBatchRequest, request)
+        for request in _make_disjoint_subpartition_batch_requests()
+    )
+
+    individual_results = list(
+        itertools.chain.from_iterable(result.results for result in all_results)
+    )
+
+    await _write_files(workspace, all_results)
     _print_results(console, individual_results)
 
     # Since the rules to produce FmtResult should use ExecuteRequest, rather than
@@ -408,57 +320,36 @@ async def fmt(
 
 
 @rule
-async def fmt_build_files(
-    request: _FmtBuildFilesBatchRequest,
+async def fmt_batch(
+    request: _FmtSubpartitionBatchRequest,
 ) -> _FmtBatchResult:
-    original_snapshot = await Get(Snapshot, PathGlobs(request.paths))
-    prior_snapshot = original_snapshot
+    current_snapshot = None
 
     results = []
-    for fmt_build_files_request_type in request.request_types:
-        fmt_build_files_request = fmt_build_files_request_type(
-            snapshot=prior_snapshot,
-        )
-        result = await Get(FmtResult, _FmtBuildFilesRequest, fmt_build_files_request)
+    for subpartition in request:
+        subpartition = dataclasses.replace(subpartition, _snapshot=current_snapshot)
+        result = await Get(FmtResult, FmtRequest.SubPartition, subpartition)
         results.append(result)
-        prior_snapshot = result.output
-    return _FmtBatchResult(
-        tuple(results),
-        input=original_snapshot.digest,
-        output=prior_snapshot.digest,
-    )
+
+        assert set(result.output.files) == set(
+            subpartition.files
+        ), f"Expected {result.output.files} to match {subpartition.files}"
+        # NB: We don't unconditionally assign to `current_snapshot`, so that the case in which the
+        # formatter (and all prior formatters) do not change the source we'll use a `None` snapshot.
+        # This speeds up runs of `./pants fmt lint` since `lint.py` will always use a `None` snapshot
+        # and so the result will be memoized.
+        if result.did_change:
+            current_snapshot = result.output
+    return _FmtBatchResult(tuple(results))
 
 
-@rule
-async def fmt_target_batch(
-    request: _FmtTargetBatchRequest,
-) -> _FmtBatchResult:
-    original_sources = await Get(
-        SourceFiles,
-        SourceFilesRequest(target[SourcesField] for target in request.targets),
-    )
-    prior_snapshot = original_sources.snapshot
-
-    results = []
-    for fmt_targets_request_type in request.request_types:
-        fmt_targets_request = fmt_targets_request_type(
-            (
-                fmt_targets_request_type.field_set_type.create(target)
-                for target in request.targets
-                if fmt_targets_request_type.field_set_type.is_applicable(target)
-            ),
-            snapshot=prior_snapshot,
-        )
-        if not fmt_targets_request.field_sets:
-            continue
-        result = await Get(FmtResult, FmtTargetsRequest, fmt_targets_request)
-        results.append(result)
-        if not result.skipped:
-            prior_snapshot = result.output
-    return _FmtBatchResult(
-        tuple(results),
-        input=original_sources.snapshot.digest,
-        output=prior_snapshot.digest,
+@rule(level=LogLevel.DEBUG)
+async def convert_fmt_result_to_lint_result(fmt_result: FmtResult) -> LintResult:
+    return LintResult(
+        1 if fmt_result.did_change else 0,
+        fmt_result.stdout,
+        fmt_result.stderr,
+        linter_name=fmt_result.formatter_name,
     )
 
 

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -211,7 +211,7 @@ async def _write_files(workspace: Workspace, batched_results: Iterable[_FmtBatch
     if any(batched_result.did_change for batched_result in batched_results):
         # NB: this will fail if there are any conflicting changes, which we want to happen rather
         # than silently having one result override the other. In practice, this should never
-        # happen due to us grouping each language's formatters into a single digest.
+        # happen due to us grouping each file's formatters into a single digest.
         merged_formatted_digest = await Get(
             Digest,
             MergeDigests(

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -168,7 +168,7 @@ class LintRequest:
                         return Partitions()
 
                     # One possible implementation
-                    return Partitions.single_partition(request.field_sets)LintRequest
+                    return Partitions.single_partition(request.field_sets)
 
         2. A rule which takes an instance of your request type's `SubPartition` class property, and
             returns a `LintResult instance.

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import logging
-import os
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import (
@@ -24,26 +23,21 @@ from typing import (
 from typing_extensions import final
 
 from pants.base.specs import Specs
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, _FmtBuildFilesRequest
 from pants.core.goals.style_request import (
-    StyleRequest,
     determine_specified_tool_names,
     only_option_help,
     style_batch_size_help,
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import EMPTY_DIGEST, Digest, PathGlobs, Snapshot, SpecsPaths, Workspace
+from pants.engine.fs import EMPTY_DIGEST, Digest, SpecsPaths, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
-from pants.engine.internals.build_files import BuildFileOptions
-from pants.engine.internals.native_engine import FilespecMatcher
 from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule, rule_helper
-from pants.engine.target import FieldSet, FilteredTargets, SourcesField
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule_helper
+from pants.engine.target import FieldSet, FilteredTargets
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.util.collections import partition_sequentially
@@ -56,11 +50,9 @@ from pants.util.strutil import softwrap, strip_v2_chroot_path
 
 logger = logging.getLogger(__name__)
 
-_SR = TypeVar("_SR", bound=StyleRequest)
 _T = TypeVar("_T")
 _FieldSetT = TypeVar("_FieldSetT", bound=FieldSet)
 _PartitionElementT = TypeVar("_PartitionElementT")
-_GoalSubsystemT = TypeVar("_GoalSubsystemT", bound=GoalSubsystem)
 
 
 @dataclass(frozen=True)
@@ -176,7 +168,7 @@ class LintRequest:
                         return Partitions()
 
                     # One possible implementation
-                    return Partitions.single_partition(request.field_sets)
+                    return Partitions.single_partition(request.field_sets)LintRequest
 
         2. A rule which takes an instance of your request type's `SubPartition` class property, and
             returns a `LintResult instance.
@@ -280,7 +272,7 @@ class LintFilesRequest(LintRequest, EngineAwareParameter):
             2. `<Plugin Defined Subclass>.PartitionRequest` is the unique type used as the union member.
         """
 
-        file_paths: tuple[str, ...]
+        files: tuple[str, ...]
 
     _PartitionRequestBase = PartitionRequest
 
@@ -312,13 +304,7 @@ class LintSubsystem(GoalSubsystem):
 
     @classmethod
     def activated(cls, union_membership: UnionMembership) -> bool:
-        return bool(
-            {
-                LintRequest,
-                FmtTargetsRequest,
-                _FmtBuildFilesRequest,
-            }.intersection(union_membership.union_rules.keys())
-        )
+        return LintRequest in union_membership
 
     only = StrListOption(
         help=only_option_help("lint", "linter", "flake8", "shellcheck"),
@@ -376,23 +362,29 @@ def _get_error_code(results: Sequence[LintResult]) -> int:
     return 0
 
 
+_CoreRequestType = TypeVar("_CoreRequestType", bound=LintRequest)
+_TargetPartitioner = TypeVar("_TargetPartitioner", bound=LintTargetsRequest.PartitionRequest)
+_FilePartitioner = TypeVar("_FilePartitioner", bound=LintFilesRequest.PartitionRequest)
+
+
 @rule_helper
 async def _get_partitions_by_request_type(
-    core_request_types: Iterable[type[LintRequest]],
-    target_partitioners: Iterable[type[LintTargetsRequest.PartitionRequest]],
-    file_partitioners: Iterable[type[LintFilesRequest.PartitionRequest]],
-    subsystem: _GoalSubsystemT,
+    core_request_types: Iterable[type[_CoreRequestType]],
+    target_partitioners: Iterable[type[_TargetPartitioner]],
+    file_partitioners: Iterable[type[_FilePartitioner]],
+    subsystem: GoalSubsystem,
     specs: Specs,
-    specified_names: Iterable[str],
     # NB: Because the rule parser code will collect `Get`s from caller's scope, these allows the
     # caller to customize the specific `Get`.
-    make_targets_partition_request_get: Callable[
-        [LintTargetsRequest.PartitionRequest], Get[Partitions]
-    ],
-    make_files_partition_request_get: Callable[
-        [LintFilesRequest.PartitionRequest], Get[Partitions]
-    ],
-) -> dict[type[LintRequest], list[Partitions]]:
+    make_targets_partition_request_get: Callable[[_TargetPartitioner], Get[Partitions]],
+    make_files_partition_request_get: Callable[[_FilePartitioner], Get[Partitions]],
+) -> dict[type[_CoreRequestType], list[Partitions]]:
+    specified_names = determine_specified_tool_names(
+        subsystem.name,
+        subsystem.only,  # type: ignore[attr-defined]
+        core_request_types,
+    )
+
     filtered_core_request_types = [
         request_type for request_type in core_request_types if request_type.name in specified_names
     ]
@@ -433,13 +425,13 @@ async def _get_partitions_by_request_type(
                 if field_set_type.is_applicable(target)
             )
             return make_targets_partition_request_get(
-                partition_targets_type.PartitionRequest(field_sets)
+                partition_targets_type.PartitionRequest(field_sets)  # type: ignore[arg-type]
             )
         else:
             assert partition_request_type in file_partitioners
             partition_files_type = cast(LintFilesRequest, request_type)
             return make_files_partition_request_get(
-                partition_files_type.PartitionRequest(specs_paths.files)
+                partition_files_type.PartitionRequest(specs_paths.files)  # type: ignore[arg-type]
             )
 
     all_partitions = await MultiGet(
@@ -457,7 +449,6 @@ async def lint(
     console: Console,
     workspace: Workspace,
     specs: Specs,
-    build_file_options: BuildFileOptions,
     lint_subsystem: LintSubsystem,
     union_membership: UnionMembership,
     dist_dir: DistDir,
@@ -465,28 +456,23 @@ async def lint(
     lint_request_types = union_membership.get(LintRequest)
     target_partitioners = union_membership.get(LintTargetsRequest.PartitionRequest)
     file_partitioners = union_membership.get(LintFilesRequest.PartitionRequest)
-    fmt_target_request_types = cast(
-        "Iterable[type[FmtTargetsRequest]]", union_membership.get(FmtTargetsRequest)
-    )
-    fmt_build_request_types = cast(
-        "Iterable[type[_FmtBuildFilesRequest]]", union_membership.get(_FmtBuildFilesRequest)
-    )
-    specified_names = determine_specified_tool_names(
-        lint_subsystem.name,
-        lint_subsystem.only,
-        [*lint_request_types, *fmt_target_request_types, *fmt_build_request_types],
-    )
 
     partitions_by_request_type = await _get_partitions_by_request_type(
-        lint_request_types,
+        [
+            request_type
+            for request_type in lint_request_types
+            if not (request_type.is_formatter and lint_subsystem.skip_formatters)
+        ],
         target_partitioners,
         file_partitioners,
         lint_subsystem,
         specs,
-        specified_names,
         lambda request_type: Get(Partitions, LintTargetsRequest.PartitionRequest, request_type),
         lambda request_type: Get(Partitions, LintFilesRequest.PartitionRequest, request_type),
     )
+
+    if not partitions_by_request_type:
+        return Lint(exit_code=0)
 
     def batch(
         iterable: Iterable[_T], key: Callable[[_T], str] = lambda x: str(x)
@@ -510,111 +496,24 @@ async def lint(
         for request_type, partitions_list in partitions_by_request_type.items()
     }
 
-    lint_subpartitions = [
+    subpartitions = [
         request_type.SubPartition(elements, key)
         for request_type, batch in lint_batches_by_request_type.items()
         for elements, key in batch
     ]
 
-    # NOTE: Fmt support has been prefactored to be isolated from core "lint" support as a follow-up
-    # change will remove this in entirety. Therefore, this has some duplication/suboptimal code.
-    fmt_target_request_types = [
-        request_type
-        for request_type in fmt_target_request_types
-        if request_type.name in specified_names
-    ]
-    fmt_build_request_types = [
-        request_type
-        for request_type in fmt_build_request_types
-        if request_type.name in specified_names
-    ]
+    all_batch_results = await MultiGet(
+        Get(LintResult, LintRequest.SubPartition, request) for request in subpartitions
+    )
 
-    def batch_by_type(
-        request_types: Iterable[type[_SR]],
-    ) -> tuple[tuple[type[_SR], tuple[FieldSet, ...]], ...]:
-        def key(fs: FieldSet) -> str:
-            return fs.address.spec
-
-        return tuple(
-            (request_type, tuple(field_set_batch))
-            for request_type in request_types
-            for field_set_batch in partition_sequentially(
-                (
-                    request_type.field_set_type.create(target)
-                    for target in targets
-                    if request_type.field_set_type.is_applicable(target)
-                ),
-                key=key,
-                size_target=lint_subsystem.batch_size,
-                size_max=4 * lint_subsystem.batch_size,
-            )
-        )
-
-    fmt_target_requests: Iterable[FmtTargetsRequest] = ()
-    fmt_build_requests: Iterable[_FmtBuildFilesRequest] = ()
-    if not lint_subsystem.skip_formatters:
-        _get_targets = Get(
-            FilteredTargets,
-            Specs,
-            specs if fmt_target_request_types else Specs.empty(),
-        )
-        _get_specs_paths = Get(
-            SpecsPaths, Specs, specs if fmt_build_request_types else Specs.empty()
-        )
-
-        targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
-        specified_build_files = FilespecMatcher(
-            includes=[os.path.join("**", p) for p in build_file_options.patterns],
-            excludes=build_file_options.ignores,
-        ).matches(specs_paths.files)
-        batched_fmt_target_request_pairs = batch_by_type(fmt_target_request_types)
-        all_fmt_source_batches = await MultiGet(
-            Get(
-                SourceFiles,
-                SourceFilesRequest(
-                    cast(
-                        SourcesField,
-                        getattr(field_set, "sources", getattr(field_set, "source", None)),
-                    )
-                    for field_set in batch
-                ),
-            )
-            for _, batch in batched_fmt_target_request_pairs
-        )
-        fmt_target_requests = (
-            request_type(
-                batch,
-                snapshot=source_files_snapshot.snapshot,
-            )
-            for (request_type, batch), source_files_snapshot in zip(
-                batched_fmt_target_request_pairs, all_fmt_source_batches
-            )
-        )
-
-        build_file_batch_snapshots = await MultiGet(
-            Get(Snapshot, PathGlobs(paths_batch))
-            for paths_batch in partition_sequentially(
-                specified_build_files,
-                key=lambda x: str(x),
-                size_target=lint_subsystem.batch_size,
-                size_max=4 * lint_subsystem.batch_size,
-            )
-        )
-        fmt_build_requests = (
-            fmt_build_request_type(snapshot)
-            for fmt_build_request_type in fmt_build_request_types
-            for snapshot in build_file_batch_snapshots
-        )
-
-    all_requests = [
-        *(Get(LintResult, LintRequest.SubPartition, request) for request in lint_subpartitions),
-        *(Get(LintResult, FmtTargetsRequest, request) for request in fmt_target_requests),
-        *(Get(LintResult, _FmtBuildFilesRequest, request) for request in fmt_build_requests),
-    ]
-    all_batch_results = await MultiGet(all_requests)
+    core_request_types_by_subpartition_type = {
+        request_type.SubPartition: request_type for request_type in lint_request_types
+    }
 
     formatter_failed = any(
-        result.exit_code for result in all_batch_results[len(lint_subpartitions) :]
+        result.exit_code
+        for subpartition, result in zip(subpartitions, all_batch_results)
+        if core_request_types_by_subpartition_type[type(subpartition)].is_formatter
     )
 
     results_by_tool = defaultdict(list)
@@ -634,16 +533,6 @@ async def lint(
         formatter_failed,
     )
     return Lint(_get_error_code(all_batch_results))
-
-
-@rule
-async def convert_fmt_result_to_lint_result(fmt_result: FmtResult) -> LintResult:
-    return LintResult(
-        1 if fmt_result.did_change else 0,
-        fmt_result.stdout,
-        fmt_result.stderr,
-        linter_name=fmt_result.formatter_name,
-    )
 
 
 def rules():

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -311,7 +311,11 @@ async def format_build_file_with_yapf(
 ) -> RewrittenBuildFile:
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     yapf_ics = await Yapf._find_python_interpreter_constraints_from_lockfile(yapf)
-    result = await _run_yapf(YapfRequest(input_snapshot), yapf, yapf_ics)
+    result = await _run_yapf(
+        YapfRequest.SubPartition(input_snapshot.files, key=None, _snapshot=input_snapshot),
+        yapf,
+        yapf_ics,
+    )
     output_content = await Get(DigestContents, Digest, result.output.digest)
 
     formatted_build_file_content = next(fc for fc in output_content if fc.path == request.path)
@@ -336,7 +340,11 @@ async def format_build_file_with_black(
 ) -> RewrittenBuildFile:
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
-    result = await _run_black(BlackRequest(input_snapshot), black, black_ics)
+    result = await _run_black(
+        BlackRequest.SubPartition(input_snapshot.files, key=None, _snapshot=input_snapshot),
+        black,
+        black_ics,
+    )
     output_content = await Get(DigestContents, Digest, result.output.digest)
 
     formatted_build_file_content = next(fc for fc in output_content if fc.path == request.path)


### PR DESCRIPTION
(Commits are useful to review in order)

This PR follow up the `lint` schema change to extend it to `fmt`.
Same idea stands, with the big differences being:
- Formatters Partitions are always of files
- `fmt` has to make "lanes" of disjoint subpartitions to ensure that no parallel execution of formatters formats the same file

Note, there's a subtle contract violation I'll file an issue for where we _might_  split a terraform directory into multiple subpartitions if a subset of files is either larger than the batch size (unlikely) or a file formatter tries to format a strict subset of them. I'll file a ticket where we can discuss. @tdyas has confirmed this isn't actually an issue today (the files will still be formatted the same way), but we should track it nonetheless.

Some future changes:
- partitioner rule maker for the "default" partitioners
- "coersion" rules to handle the plumbed-through params of `LintResult` and `FmtResult`

[ci skip-rust]
[ci skip-build-wheels]