### PR TITLE
Don't require a `local_environment` target for each platform

### DIFF
--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -26,7 +26,6 @@ from pants.core.util_rules.environments import (
     EnvironmentTarget,
     FallbackEnvironmentField,
     LocalEnvironmentTarget,
-    NoCompatibleEnvironmentError,
     NoFallbackEnvironmentError,
     RemoteEnvironmentTarget,
     RemoteExtraPlatformPropertiesField,
@@ -189,10 +188,9 @@ def test_choose_local_environment(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--environments-preview-names={'e': '//:e1'}"])
     assert get_env().val.address == Address("", target_name="e1")  # type: ignore[union-attr]
 
-    # Error if `--names` set, but no compatible platforms
+    # If `--names` is set, but no compatible platforms, do not choose an environment.
     rule_runner.set_options(["--environments-preview-names={'e': '//:not-compatible'}"])
-    with engine_error(NoCompatibleEnvironmentError):
-        get_env()
+    assert get_env().val is None
 
     # Error if >1 compatible targets.
     rule_runner.set_options(["--environments-preview-names={'e1': '//:e1', 'e2': '//:e2'}"])


### PR DESCRIPTION
We now are using subsystems as the default value of env vars & executable search paths. That is, `local_environment` targets are solely needed if you want to _override_ those option values.

We want it to be ergonomic to add a `local_environment` target to handle one specific platform, e.g. macOS ARM often being problematic, without you needing to also add boilerplate for the other platforms. There was no good reason we were erroring for other platforms, given the new subsystem approach.

[ci skip-rust]
[ci skip-build-wheels]