### PR TITLE
add basic counters to docker command runner

### DIFF
--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -17,7 +17,7 @@ use nails::execution::ExitCode;
 use parking_lot::Mutex;
 use store::Store;
 use task_executor::Executor;
-use workunit_store::{in_workunit, RunningWorkunit};
+use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{
   apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, CapturedWorkdir, ChildOutput,
@@ -326,7 +326,7 @@ impl super::CommandRunner for CommandRunner {
       // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
       // renders at the Process's level.
       desc = Some(req.description.clone()),
-      |_workunit| async move {
+      |workunit| async move {
         let mut workdir = create_sandbox(
           self.executor.clone(),
           &self.work_dir_base,
@@ -376,8 +376,7 @@ impl super::CommandRunner for CommandRunner {
         )
         .await?;
 
-        // DOCKER-TODO: Add a metric for local docker execution?
-        // workunit.increment_counter(Metric::LocalExecutionRequests, 1);
+        workunit.increment_counter(Metric::DockerExecutionRequests, 1);
 
         let res = self
           .run_and_capture_workdir(
@@ -402,6 +401,11 @@ impl super::CommandRunner for CommandRunner {
             ProcessError::Unclassified(format!("Failed to execute: {}\n\n{}", req_debug_repr, msg))
           })
           .await;
+
+        match &res {
+          Ok(_) => workunit.increment_counter(Metric::DockerExecutionSuccess, 1),
+          Err(_) => workunit.increment_counter(Metric::DockerExecutionErrors, 1),
+        }
 
         if self.keep_sandboxes == KeepSandboxes::Always
           || self.keep_sandboxes == KeepSandboxes::OnFailure

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -403,7 +403,7 @@ impl super::CommandRunner for CommandRunner {
           .await;
 
         match &res {
-          Ok(_) => workunit.increment_counter(Metric::DockerExecutionSuccess, 1),
+          Ok(_) => workunit.increment_counter(Metric::DockerExecutionSuccesses, 1),
           Err(_) => workunit.increment_counter(Metric::DockerExecutionErrors, 1),
         }
 

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -52,7 +52,7 @@ pub enum Metric {
   /// Number of times that we backtracked due to missing digests.
   BacktrackAttempts,
   DockerExecutionRequests,
-  DockerExecutionSuccess,
+  DockerExecutionSuccesses,
   DockerExecutionErrors,
 }
 

--- a/src/rust/engine/workunit_store/src/metrics.rs
+++ b/src/rust/engine/workunit_store/src/metrics.rs
@@ -51,6 +51,9 @@ pub enum Metric {
   RemoteStoreMissingDigest,
   /// Number of times that we backtracked due to missing digests.
   BacktrackAttempts,
+  DockerExecutionRequests,
+  DockerExecutionSuccess,
+  DockerExecutionErrors,
 }
 
 impl Metric {


### PR DESCRIPTION
Add counters to the Docker command runner to count the number of requests with break-down of successes and failures.

[ci skip-build-wheels]
