### PR TITLE
go: render coverage reports as HTML

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -410,6 +410,8 @@ async def run_go_tests(
         coverage_data = GoCoverageData(
             coverage_digest=result.output_digest,
             import_path=import_path,
+            sources_digest=pkg_digest.digest,
+            sources_dir_path=pkg_analysis.dir_path,
         )
 
     return TestResult.from_fallible_process_result(

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.core.util_rules.distdir import DistDir
-from pants.option.option_types import ArgsListOption, EnumOption, StrOption
+from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -52,6 +52,16 @@ class GoTestSubsystem(Subsystem):
             `{distdir}` is replaced with the Pants `distdir`, and `{import_path_escaped}` is
             replaced with the applicable package's import path but with slashes converted to
             underscores.
+            """
+        ),
+    )
+
+    coverage_html = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            If true, then convert coverage reports to HTML format and write a `coverage.html` file next to the
+            raw coverage data.
             """
         ),
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -477,6 +477,8 @@ async def build_go_package(
         BuiltGoPackageCodeCoverageMetadata(
             import_path=request.import_path,
             cover_file_metadatas=cover_file_metadatas,
+            sources_digest=request.digest,
+            sources_dir_path=request.dir_path,
         )
         if cover_file_metadatas
         else None

--- a/src/python/pants/backend/go/util_rules/coverage.py
+++ b/src/python/pants/backend/go/util_rules/coverage.py
@@ -23,6 +23,8 @@ from pants.util.ordered_set import FrozenOrderedSet
 class GoCoverageData(CoverageData):
     coverage_digest: Digest
     import_path: str
+    sources_digest: Digest
+    sources_dir_path: str
 
 
 class GoCoverMode(enum.Enum):
@@ -62,6 +64,8 @@ class FileCodeCoverageMetadata:
 class BuiltGoPackageCodeCoverageMetadata:
     import_path: str
     cover_file_metadatas: tuple[FileCodeCoverageMetadata, ...]
+    sources_digest: Digest
+    sources_dir_path: str
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/util_rules/coverage_html.py
+++ b/src/python/pants/backend/go/util_rules/coverage_html.py
@@ -1,0 +1,286 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import io
+import math
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import Sequence
+
+import chevron
+
+from pants.backend.go.util_rules.coverage import GoCoverMode
+from pants.backend.go.util_rules.coverage_profile import (
+    GoCoverageBoundary,
+    GoCoverageProfile,
+    parse_go_coverage_profiles,
+)
+from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Digest
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+
+
+@dataclass(frozen=True)
+class RenderGoCoverageProfileToHtmlRequest:
+    raw_coverage_profile: bytes
+    description_of_origin: str
+    sources_digest: Digest
+    sources_dir_path: str
+
+
+@dataclass(frozen=True)
+class RenderGoCoverageProfileToHtmlResult:
+    html_output: bytes
+
+
+@dataclass(frozen=True)
+class RenderedFile:
+    name: str
+    body: str
+    coverage: float
+
+
+def _get_pkg_name(filename: str) -> str | None:
+    elems = filename.split("/")
+    i = len(elems) - 2
+    while i >= 0:
+        if elems[i] != "":
+            return elems[i]
+        i -= 1
+    return None
+
+
+def _percent_covered(profile: GoCoverageProfile) -> float:
+    covered = 0
+    total = 0
+    for block in profile.blocks:
+        total += block.num_stmt
+        if block.count > 0:
+            covered += block.num_stmt
+    if total == 0:
+        return 0.0
+    return float(covered) / float(total) * 100.0
+
+
+def _render_source_file(content: bytes, boundaries: Sequence[GoCoverageBoundary]) -> str:
+    rendered = io.StringIO()
+    for i in range(len(content)):
+        while boundaries and boundaries[0].offset == i:
+            b = boundaries[0]
+            if b.start:
+                n = 0
+                if b.count > 0:
+                    n = int(math.floor(b.norm * 9)) + 1
+                rendered.write('<span class="cov{}" title="{}">'.format(n, b.count))
+            else:
+                rendered.write("</span>")
+            boundaries = boundaries[1:]
+        c = content[i]
+        if c == ord(">"):
+            rendered.write("&gt;")
+        elif c == ord("<"):
+            rendered.write("&lt;")
+        elif c == ord("&"):
+            rendered.write("&amp;")
+        elif c == ord("\t"):
+            rendered.write("        ")
+        else:
+            rendered.write(chr(c))
+    return rendered.getvalue()
+
+
+@rule
+async def render_go_coverage_profile_to_html(
+    request: RenderGoCoverageProfileToHtmlRequest,
+) -> RenderGoCoverageProfileToHtmlResult:
+    digest_contents = await Get(DigestContents, Digest, request.sources_digest)
+    profiles = parse_go_coverage_profiles(
+        request.raw_coverage_profile, description_of_origin=request.description_of_origin
+    )
+
+    files: list[RenderedFile] = []
+    pkg_name: str | None = None
+    cover_mode_set = False
+    for profile in profiles:
+        if pkg_name is None:
+            pkg_name = _get_pkg_name(profile.filename)
+        if profile.cover_mode == GoCoverMode.SET:
+            cover_mode_set = True
+
+        name = PurePath(profile.filename).name
+
+        file_contents: bytes | None = None
+        full_file_path = str(PurePath(request.sources_dir_path, name))
+        for entry in digest_contents:
+            if entry.path == full_file_path:
+                file_contents = entry.content
+                break
+
+        if file_contents is None:
+            continue
+
+        files.append(
+            RenderedFile(
+                name=name,
+                body=_render_source_file(file_contents, profile.boundaries(file_contents)),
+                coverage=_percent_covered(profile),
+            )
+        )
+
+    rendered = chevron.render(
+        template=_HTML_TEMPLATE,
+        data={
+            "pkg_name": pkg_name or "",
+            "set": cover_mode_set,
+            "files": [
+                {
+                    "i": i,
+                    "name": file.name,
+                    "coverage": "{:.1f}".format(file.coverage),
+                    "body": file.body,
+                }
+                for i, file in enumerate(files)
+            ],
+        },
+    )
+
+    return RenderGoCoverageProfileToHtmlResult(rendered.encode())
+
+
+_HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <title>{{#pkg_name}}{{pkg_name}}: {{/pkg_name}}Go Coverage Report</title>
+        <style>
+            body {
+                background: black;
+                color: rgb(80, 80, 80);
+            }
+            body, pre, #legend span {
+                font-family: Menlo, monospace;
+                font-weight: bold;
+            }
+            #topbar {
+                background: black;
+                position: fixed;
+                top: 0; left: 0; right: 0;
+                height: 42px;
+                border-bottom: 1px solid rgb(80, 80, 80);
+            }
+            #content {
+                margin-top: 50px;
+            }
+            #nav, #legend {
+                float: left;
+                margin-left: 10px;
+            }
+            #legend {
+                margin-top: 12px;
+            }
+            #nav {
+                margin-top: 10px;
+            }
+            #legend span {
+                margin: 0 5px;
+            }
+            <!--
+            Colors generated by:
+            def rgb(n):
+                if n == 0:
+                    return "rgb(192, 0, 0)" # Red
+                # Gradient from gray to green.
+                r = 128 - 12*(n-1)
+                g = 128 + 12*(n-1)
+                b = 128 + 3*(n-1)
+                return f"rgb({r}, {g}, {b})"
+
+            def colors():
+                for i in range(11):
+                    print(f".cov{i} {{ color: {rgb(i)} }}")
+            -->
+            .cov0 { color: rgb(192, 0, 0) }
+            .cov1 { color: rgb(128, 128, 128) }
+            .cov2 { color: rgb(116, 140, 131) }
+            .cov3 { color: rgb(104, 152, 134) }
+            .cov4 { color: rgb(92, 164, 137) }
+            .cov5 { color: rgb(80, 176, 140) }
+            .cov6 { color: rgb(68, 188, 143) }
+            .cov7 { color: rgb(56, 200, 146) }
+            .cov8 { color: rgb(44, 212, 149) }
+            .cov9 { color: rgb(32, 224, 152) }
+            .cov10 { color: rgb(20, 236, 155) }
+        </style>
+    </head>
+    <body>
+        <div id="topbar">
+            <div id="nav">
+                <select id="files">
+                    {{#files}}
+                    <option value="file{{i}}">{{name}} ({{coverage}}%)</option>
+                    {{/files}}
+                </select>
+            </div>
+            <div id="legend">
+                <span>not tracked</span>
+                {{#set}}
+                <span class="cov0">not covered</span>
+                <span class="cov8">covered</span>
+                {{/set}}
+                {{^set}}
+                <span class="cov0">no coverage</span>
+                <span class="cov1">low coverage</span>
+                <span class="cov2">*</span>
+                <span class="cov3">*</span>
+                <span class="cov4">*</span>
+                <span class="cov5">*</span>
+                <span class="cov6">*</span>
+                <span class="cov7">*</span>
+                <span class="cov8">*</span>
+                <span class="cov9">*</span>
+                <span class="cov10">high coverage</span>
+                {{/set}}
+            </div>
+        </div>
+        <div id="content">
+            {{#files}}
+            <pre class="file" id="file{{i}}" style="display: none">{{{body}}}</pre>
+            {{/files}}
+        </div>
+    </body>
+    <script>
+        (function() {
+            var files = document.getElementById('files');
+            var visible;
+            files.addEventListener('change', onChange, false);
+            function select(part) {
+                if (visible)
+                    visible.style.display = 'none';
+                visible = document.getElementById(part);
+                if (!visible)
+                    return;
+                files.value = part;
+                visible.style.display = 'block';
+                location.hash = part;
+            }
+            function onChange() {
+                select(files.value);
+                window.scrollTo(0, 0);
+            }
+            if (location.hash != "") {
+                select(location.hash.substr(1));
+            }
+            if (!visible) {
+                select("file0");
+            }
+        })();
+    </script>
+</html>
+"""
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/go/util_rules/coverage_html.py
+++ b/src/python/pants/backend/go/util_rules/coverage_html.py
@@ -21,6 +21,14 @@ from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 
+# Adapted from Go toolchain.
+# See https://github.com/golang/go/blob/a0441c7ae3dea57a0553c9ea77e184c34b7da40f/src/cmd/cover/html.go
+#
+# Original copyright:
+#  // Copyright 2013 The Go Authors. All rights reserved.
+#  // Use of this source code is governed by a BSD-style
+#  // license that can be found in the LICENSE file.
+
 
 @dataclass(frozen=True)
 class RenderGoCoverageProfileToHtmlRequest:

--- a/src/python/pants/backend/go/util_rules/coverage_html.py
+++ b/src/python/pants/backend/go/util_rules/coverage_html.py
@@ -24,6 +24,14 @@ from pants.engine.rules import collect_rules, rule
 # Adapted from Go toolchain.
 # See https://github.com/golang/go/blob/a0441c7ae3dea57a0553c9ea77e184c34b7da40f/src/cmd/cover/html.go
 #
+# Note: `go tool cover` could not be used for the HTML support because it attempts to find the source files
+# on its own using go list.
+# See https://github.com/golang/go/blob/a0441c7ae3dea57a0553c9ea77e184c34b7da40f/src/cmd/cover/func.go#L200-L222.
+#
+# The Go rules have been engineered to avoid `go list` due to it needing, among other things, all transitive
+# third-party dependencies available to it when analyzing first-party sources. Thus, the use of `go list` by
+# `go tool cover` in this case means we cannot use `go tool cover` to generate the HTML.
+#
 # Original copyright:
 #  // Copyright 2013 The Go Authors. All rights reserved.
 #  // Use of this source code is governed by a BSD-style

--- a/src/python/pants/backend/go/util_rules/coverage_output.py
+++ b/src/python/pants/backend/go/util_rules/coverage_output.py
@@ -5,11 +5,17 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
+from pants.backend.go.util_rules import coverage_html
 from pants.backend.go.util_rules.coverage import GoCoverageData
+from pants.backend.go.util_rules.coverage_html import (
+    RenderGoCoverageProfileToHtmlRequest,
+    RenderGoCoverageProfileToHtmlResult,
+)
 from pants.core.goals.test import CoverageDataCollection, CoverageReports, FilesystemCoverageReport
 from pants.core.util_rules import distdir
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.fs import CreateDigest, DigestContents, FileContent
 from pants.engine.internals.native_engine import Digest, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
@@ -32,6 +38,7 @@ class RenderGoCoverageReportRequest(EngineAwareParameter):
 @dataclass(frozen=True)
 class RenderGoCoverageReportResult:
     coverage_report: FilesystemCoverageReport
+    html_report: FilesystemCoverageReport | None = None
 
 
 @rule
@@ -43,7 +50,42 @@ async def go_render_coverage_report(
     output_dir = go_test_subsystem.coverage_output_dir(
         distdir=distdir_value, import_path=request.raw_report.import_path
     )
-    snapshot = await Get(Snapshot, Digest, request.raw_report.coverage_digest)
+    snapshot, digest_contents = await MultiGet(
+        Get(Snapshot, Digest, request.raw_report.coverage_digest),
+        Get(DigestContents, Digest, request.raw_report.coverage_digest),
+    )
+
+    html_coverage_report: FilesystemCoverageReport | None = None
+    if go_test_subsystem.coverage_html:
+        html_result = await Get(
+            RenderGoCoverageProfileToHtmlResult,
+            RenderGoCoverageProfileToHtmlRequest(
+                raw_coverage_profile=digest_contents[0].content,
+                description_of_origin=f"Go package with import path `{request.raw_report.import_path}`",
+                sources_digest=request.raw_report.sources_digest,
+                sources_dir_path=request.raw_report.sources_dir_path,
+            ),
+        )
+        html_report_snapshot = await Get(
+            Snapshot,
+            CreateDigest(
+                [
+                    FileContent(
+                        path="coverage.html",
+                        content=html_result.html_output,
+                    )
+                ]
+            ),
+        )
+
+        html_coverage_report = FilesystemCoverageReport(
+            coverage_insufficient=False,
+            result_snapshot=html_report_snapshot,
+            directory_to_materialize_to=output_dir,
+            report_file=output_dir / "coverage.html",
+            report_type="go_cover_html",
+        )
+
     coverage_report = FilesystemCoverageReport(
         coverage_insufficient=False,
         result_snapshot=snapshot,
@@ -53,6 +95,7 @@ async def go_render_coverage_report(
     )
     return RenderGoCoverageReportResult(
         coverage_report=coverage_report,
+        html_report=html_coverage_report,
     )
 
 
@@ -70,12 +113,19 @@ async def go_gather_coverage_reports(
         for raw_coverage_report in raw_coverage_reports
     )
 
-    return CoverageReports(reports=tuple(r.coverage_report for r in coverage_report_results))
+    coverage_reports = []
+    for result in coverage_report_results:
+        coverage_reports.append(result.coverage_report)
+        if result.html_report:
+            coverage_reports.append(result.html_report)
+
+    return CoverageReports(reports=tuple(coverage_reports))
 
 
 def rules():
     return (
         *collect_rules(),
+        *coverage_html.rules(),
         *distdir.rules(),
         UnionRule(CoverageDataCollection, GoCoverageDataCollection),
     )

--- a/src/python/pants/backend/go/util_rules/coverage_profile.py
+++ b/src/python/pants/backend/go/util_rules/coverage_profile.py
@@ -1,0 +1,189 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import dataclasses
+import math
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+
+from pants.backend.go.util_rules.coverage import GoCoverMode
+from pants.util.strutil import strip_prefix
+
+#
+# This is a transcription of the Go coverage support library at
+# https://cs.opensource.google/go/x/tools/+/master:cover/profile.go.
+#
+# Original copyright:
+#   // Copyright 2013 The Go Authors. All rights reserved.
+#   // Use of this source code is governed by a BSD-style
+#   // license that can be found in the LICENSE file.
+#
+
+
+@dataclass(frozen=True)
+class GoCoverageProfileBlock:
+    start_line: int
+    start_col: int
+    end_line: int
+    end_col: int
+    num_stmt: int
+    count: int
+
+
+@dataclass(frozen=True)
+class GoCoverageBoundary:
+    offset: int
+    start: bool
+    count: int
+    norm: float
+    index: int
+
+
+@dataclass(frozen=True)
+class GoCoverageProfile:
+    """Parsed representation of a raw Go coverage profile for a single file.
+
+    A coverage outpyt file may report on multiple files which will be split into different instances
+    of this dataclass.
+    """
+
+    filename: str
+    cover_mode: GoCoverMode
+    blocks: tuple[GoCoverageProfileBlock, ...]
+
+    def boundaries(self, src: bytes) -> tuple[GoCoverageBoundary, ...]:
+        max_count = 0
+        for block in self.blocks:
+            if block.count > max_count:
+                max_count = block.count
+        divisor = math.log(max_count)
+
+        index = 0
+
+        def boundary(offset: int, start: bool, count: int) -> GoCoverageBoundary:
+            nonlocal index, max_count
+            b = GoCoverageBoundary(offset=offset, start=start, count=count, norm=0.0, index=index)
+            index = index + 1
+            if not start or count == 0:
+                return b
+            new_norm = None
+            if max_count <= 1:
+                new_norm = 0.8  # Profile is in "set" mode; we want a heat map. Use cov8 in the CSS.
+            elif count > 0:
+                new_norm = math.log(count) / divisor
+            if new_norm is not None:
+                b = dataclasses.replace(b, norm=new_norm)
+            return b
+
+        line, col = 1, 2  # TODO: Why is this 2?
+        si, bi = 0, 0
+        boundaries = []
+        while si < len(src) and bi < len(self.blocks):
+            b = self.blocks[bi]
+            if b.start_line == line and b.start_col == col:
+                boundaries.append(boundary(si, True, b.count))
+            if b.end_line == line and b.end_col == col or line > b.end_line:
+                boundaries.append(boundary(si, False, 0))
+                bi += 1
+                continue  # Don't advance through src; maybe the next block starts here.
+            if src[si] == ord("\n"):
+                line += 1
+                col = 0
+            col += 1
+            si += 1
+
+        boundaries.sort(key=lambda b: (b.offset, b.index))
+        return tuple(boundaries)
+
+
+_BLOCK_REGEX = re.compile(r"^(.+):([0-9]+)\.([0-9]+),([0-9]+)\.([0-9]+) ([0-9]+) ([0-9]+)$")
+
+
+def parse_go_coverage_profiles(
+    contents: bytes, *, description_of_origin: str
+) -> tuple[GoCoverageProfile, ...]:
+    lines = iter(contents.decode().splitlines())
+
+    # Extract the mode line from the first line.
+    mode_line = next(lines)
+    if not mode_line.startswith("mode: "):
+        raise ValueError(
+            f"Malformed Go coverage file `{description_of_origin}`: invalid cover mode specifier"
+        )
+
+    raw_mode = strip_prefix(mode_line, "mode: ")
+    cover_mode = GoCoverMode(raw_mode)
+
+    # Parse the coverage blocks from the remainder of the file.
+    blocks_by_file: dict[str, list[GoCoverageProfileBlock]] = defaultdict(list)
+    for line in lines:
+        parsed_profile_line = _BLOCK_REGEX.fullmatch(line)
+        if not parsed_profile_line:
+            raise ValueError(
+                f"Malformed Go coverage file `{description_of_origin}`: invalid profile block line"
+            )
+
+        filename = parsed_profile_line.group(1)
+        start_line = int(parsed_profile_line.group(2))
+        start_col = int(parsed_profile_line.group(3))
+        end_line = int(parsed_profile_line.group(4))
+        end_col = int(parsed_profile_line.group(5))
+        num_stmt = int(parsed_profile_line.group(6))
+        count = int(parsed_profile_line.group(7))
+
+        blocks_by_file[filename].append(
+            GoCoverageProfileBlock(
+                start_line=start_line,
+                start_col=start_col,
+                end_line=end_line,
+                end_col=end_col,
+                num_stmt=num_stmt,
+                count=count,
+            )
+        )
+
+    profiles = [
+        GoCoverageProfile(
+            filename=filename,
+            cover_mode=cover_mode,
+            blocks=tuple(blocks),
+        )
+        for filename, blocks in blocks_by_file.items()
+    ]
+
+    # Merge blocks from the same location.
+    for profile_index, profile in enumerate(profiles):
+        blocks = list(profile.blocks)
+        blocks.sort(key=lambda b: (b.start_line, b.start_col))
+        j = 1
+        for i in range(1, len(blocks)):
+            b = blocks[i]
+            last = blocks[j - 1]
+            if (
+                b.start_line == last.start_line
+                and b.start_col == last.start_col
+                and b.end_line == last.end_line
+                and b.end_col == last.end_col
+            ):
+                if b.num_stmt != last.num_stmt:
+                    raise ValueError(
+                        f"inconsistent NumStmt: changed from {last.num_stmt} to {b.num_stmt}"
+                    )
+                if cover_mode == GoCoverMode.SET:
+                    blocks[j - 1] = dataclasses.replace(
+                        blocks[j - 1], count=blocks[j - 1].count | b.count
+                    )
+                else:
+                    blocks[j - 1] = dataclasses.replace(
+                        blocks[j - 1], count=blocks[j - 1].count + b.count
+                    )
+                continue
+            blocks[j] = b
+            j = j + 1
+
+        profiles[profile_index] = dataclasses.replace(profile, blocks=tuple(blocks[:j]))
+
+    profiles.sort(key=lambda p: p.filename)
+    return tuple(profiles)

--- a/src/python/pants/backend/go/util_rules/coverage_profile_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_profile_test.py
@@ -1,0 +1,308 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go.util_rules.coverage import GoCoverMode
+from pants.backend.go.util_rules.coverage_profile import (
+    GoCoverageProfile,
+    GoCoverageProfileBlock,
+    parse_go_coverage_profiles,
+)
+
+#
+# This is a transcription of the Go coverage support library at
+# https://cs.opensource.google/go/x/tools/+/master:cover/profile_test.go.
+#
+# Original copyright:
+#   // Copyright 2019 The Go Authors. All rights reserved.
+#   // Use of this source code is governed by a BSD-style
+#   // license that can be found in the LICENSE file.
+#
+
+
+@dataclass(frozen=True)
+class ProfileTestCase:
+    name: str
+    input: str
+    profiles: tuple[GoCoverageProfile, ...] = ()
+    expect_exception: bool = False
+
+
+_TEST_CASES = [
+    ProfileTestCase(
+        name="parsing an empty file produces empty output",
+        input="mode: set",
+        profiles=(),
+    ),
+    ProfileTestCase(
+        name="simple valid file produces expected output",
+        input=dedent(
+            """\
+            mode: set
+            some/fancy/path:42.69,44.16 2 1
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="some/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=1,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="file with syntax characters in path produces expected output",
+        input=dedent(
+            """\
+            mode: set
+            some fancy:path/some,file.go:42.69,44.16 2 1
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="some fancy:path/some,file.go",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=1,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="file with multiple blocks in one file produces expected output",
+        input=dedent(
+            """\
+            mode: set
+            some/fancy/path:42.69,44.16 2 1
+            some/fancy/path:44.16,46.3 1 0
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="some/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=1,
+                    ),
+                    GoCoverageProfileBlock(
+                        start_line=44,
+                        start_col=16,
+                        end_line=46,
+                        end_col=3,
+                        num_stmt=1,
+                        count=0,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="file with multiple files produces expected output",
+        input=dedent(
+            """\
+            mode: set
+            another/fancy/path:44.16,46.3 1 0
+            some/fancy/path:42.69,44.16 2 1
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="another/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=44,
+                        start_col=16,
+                        end_line=46,
+                        end_col=3,
+                        num_stmt=1,
+                        count=0,
+                    ),
+                ),
+            ),
+            GoCoverageProfile(
+                filename="some/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=1,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="intertwined files are merged correctly",
+        input=dedent(
+            """\
+            mode: set
+            some/fancy/path:42.69,44.16 2 1
+            another/fancy/path:47.2,47.13 1 1
+            some/fancy/path:44.16,46.3 1 0
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="another/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=47,
+                        start_col=2,
+                        end_line=47,
+                        end_col=13,
+                        num_stmt=1,
+                        count=1,
+                    ),
+                ),
+            ),
+            GoCoverageProfile(
+                filename="some/fancy/path",
+                cover_mode=GoCoverMode.SET,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=1,
+                    ),
+                    GoCoverageProfileBlock(
+                        start_line=44,
+                        start_col=16,
+                        end_line=46,
+                        end_col=3,
+                        num_stmt=1,
+                        count=0,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="duplicate blocks are merged correctly",
+        input=dedent(
+            """\
+            mode: count
+            some/fancy/path:42.69,44.16 2 4
+            some/fancy/path:42.69,44.16 2 3
+            """
+        ),
+        profiles=(
+            GoCoverageProfile(
+                filename="some/fancy/path",
+                cover_mode=GoCoverMode.COUNT,
+                blocks=(
+                    GoCoverageProfileBlock(
+                        start_line=42,
+                        start_col=69,
+                        end_line=44,
+                        end_col=16,
+                        num_stmt=2,
+                        count=7,
+                    ),
+                ),
+            ),
+        ),
+    ),
+    ProfileTestCase(
+        name="an invalid mode line is an error",
+        input="mode:count",
+        expect_exception=True,
+    ),
+    ProfileTestCase(
+        name="a missing field is an error",
+        input=dedent(
+            """\
+            mode: count
+            some/fancy/path:42.69,44.16 2
+            """
+        ),
+        expect_exception=True,
+    ),
+    ProfileTestCase(
+        name="a missing path field is an error",
+        input=dedent(
+            """\
+            mode: count
+            42.69,44.16 2 3
+            """
+        ),
+        expect_exception=True,
+    ),
+    ProfileTestCase(
+        name="a non-numeric count is an error",
+        input=dedent(
+            """\
+            mode: count
+            42.69,44.16 2 nope
+            """
+        ),
+        expect_exception=True,
+    ),
+    ProfileTestCase(
+        name="an empty path is an error",
+        input=dedent(
+            """\
+            mode: count
+            :42.69,44.16 2 3
+            """
+        ),
+        expect_exception=True,
+    ),
+    ProfileTestCase(
+        name="a negative count is an error",
+        input=dedent(
+            """\
+            mode: count
+            some/fancy/path:42.69,44.16 2 -1
+            """
+        ),
+        expect_exception=True,
+    ),
+]
+
+
+@pytest.mark.parametrize("case", _TEST_CASES, ids=lambda c: c.name)  # type: ignore[no-any-return]
+def test_parse_go_coverage_profiles(case) -> None:
+    try:
+        profiles = parse_go_coverage_profiles(case.input.encode(), description_of_origin="test")
+        if case.expect_exception:
+            raise ValueError(f"Expected exception but did not see it for test case `{case.name}`")
+        assert profiles == case.profiles
+    except Exception:
+        if not case.expect_exception:
+            raise

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import textwrap
-from typing import cast
 
 import pytest
 
@@ -28,6 +27,7 @@ from pants.backend.go.util_rules.coverage import GoCoverageData
 from pants.backend.go.util_rules.coverage_output import GoCoverageDataCollection
 from pants.build_graph.address import Address
 from pants.core.goals.test import (
+    CoverageReport,
     CoverageReports,
     FilesystemCoverageReport,
     TestResult,
@@ -110,8 +110,7 @@ def test_basic_coverage(rule_runner: RuleRunner) -> None:
         CoverageReports, [GoCoverageDataCollection([coverage_data])]
     )
     assert len(coverage_reports.reports) == 2
-    reports = cast(list[FilesystemCoverageReport], list(coverage_reports.reports))
-    reports.sort(key=lambda x: x.report_type)
+    reports: list[CoverageReport] = list(coverage_reports.reports)
 
     go_report = reports[0]
     assert isinstance(go_report, FilesystemCoverageReport)

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import textwrap
+from typing import cast
 
 import pytest
 
@@ -108,9 +109,18 @@ def test_basic_coverage(rule_runner: RuleRunner) -> None:
     coverage_reports = rule_runner.request(
         CoverageReports, [GoCoverageDataCollection([coverage_data])]
     )
-    assert len(coverage_reports.reports) == 1
-    coverage_report = coverage_reports.reports[0]
-    assert isinstance(coverage_report, FilesystemCoverageReport)
-    digest_contents = rule_runner.request(DigestContents, (coverage_report.result_snapshot.digest,))
+    assert len(coverage_reports.reports) == 2
+    reports = cast(list[FilesystemCoverageReport], list(coverage_reports.reports))
+    reports.sort(key=lambda x: x.report_type)
+
+    go_report = reports[0]
+    assert isinstance(go_report, FilesystemCoverageReport)
+    digest_contents = rule_runner.request(DigestContents, (go_report.result_snapshot.digest,))
     assert len(digest_contents) == 1
     assert digest_contents[0].path == "cover.out"
+
+    html_report = reports[1]
+    assert isinstance(html_report, FilesystemCoverageReport)
+    digest_contents = rule_runner.request(DigestContents, (html_report.result_snapshot.digest,))
+    assert len(digest_contents) == 1
+    assert digest_contents[0].path == "coverage.html"


### PR DESCRIPTION
Add support for rendering Go coverage reports in HTML format [just like `go tool cover` does](https://github.com/golang/go/blob/a0441c7ae3dea57a0553c9ea77e184c34b7da40f/src/cmd/cover/html.go).