### PR TITLE
Add plugin subsystem option support

### DIFF
--- a/src/python/pants/backend/explorer/graphql/query/conftest.py
+++ b/src/python/pants/backend/explorer/graphql/query/conftest.py
@@ -14,6 +14,7 @@ from pants.backend.explorer.rules import validate_explorer_dependencies
 from pants.backend.project_info import peek
 from pants.engine.explorer import RequestState
 from pants.engine.target import RegisteredTargetTypes
+from pants.engine.unions import UnionMembership
 from pants.help.help_info_extracter import AllHelpInfo, HelpInfoExtracter
 from pants.testutil.rule_runner import RuleRunner
 
@@ -38,7 +39,9 @@ def all_help_info(rule_runner: RuleRunner) -> AllHelpInfo:
         return ("somescope", f"used_by_{scope or 'GLOBAL_SCOPE'}")
 
     return HelpInfoExtracter.get_all_help_info(
-        options=rule_runner.options_bootstrapper.full_options(rule_runner.build_config),
+        options=rule_runner.options_bootstrapper.full_options(
+            rule_runner.build_config, union_membership=UnionMembership({})
+        ),
         union_membership=rule_runner.union_membership,
         consumed_scopes_mapper=fake_consumed_scopes_mapper,
         registered_target_types=RegisteredTargetTypes.create(rule_runner.build_config.target_types),

--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -123,13 +123,14 @@ class LocalPantsRunner:
         :param scheduler: If being called from the daemon, a warmed scheduler to use.
         """
         options_initializer = options_initializer or OptionsInitializer(options_bootstrapper)
-        build_config, options = options_initializer.build_config_and_options(
-            options_bootstrapper, env, raise_=True
+        build_config = options_initializer.build_config(options_bootstrapper, env)
+        union_membership = UnionMembership.from_rules(build_config.union_rules)
+        options = options_initializer.options(
+            options_bootstrapper, env, build_config, union_membership, raise_=True
         )
         stdio_destination_use_color(options.for_global_scope().colors)
 
         run_tracker = RunTracker(options_bootstrapper.args, options)
-        union_membership = UnionMembership.from_rules(build_config.union_rules)
 
         # Option values are usually computed lazily on demand, but command line options are
         # eagerly computed for validation.

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -269,9 +269,9 @@ def test_get_all_help_info():
         args=["./pants"],
         bootstrap_option_values=None,
     )
-    Global.register_options_on_scope(options)
-    Foo.register_options_on_scope(options)
-    Bar.register_options_on_scope(options)
+    Global.register_options_on_scope(options, UnionMembership({}))
+    Foo.register_options_on_scope(options, UnionMembership({}))
+    Bar.register_options_on_scope(options, UnionMembership({}))
 
     @rule
     def rule_info_test(foo: Foo) -> Target:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -14,6 +14,7 @@ import pkg_resources
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
+from pants.engine.unions import UnionMembership
 from pants.help.flag_error_help_printer import FlagErrorHelpPrinter
 from pants.init.bootstrap_scheduler import BootstrapScheduler
 from pants.init.engine_initializer import EngineInitializer
@@ -102,19 +103,24 @@ class OptionsInitializer:
         self._bootstrap_scheduler = create_bootstrap_scheduler(options_bootstrapper, executor)
         self._plugin_resolver = PluginResolver(self._bootstrap_scheduler)
 
-    def build_config_and_options(
+    def build_config(
         self,
         options_bootstrapper: OptionsBootstrapper,
         env: CompleteEnvironmentVars,
+    ) -> BuildConfiguration:
+        return _initialize_build_configuration(self._plugin_resolver, options_bootstrapper, env)
+
+    def options(
+        self,
+        options_bootstrapper: OptionsBootstrapper,
+        env: CompleteEnvironmentVars,
+        build_config: BuildConfiguration,
+        union_membership: UnionMembership,
         *,
         raise_: bool,
-    ) -> tuple[BuildConfiguration, Options]:
-        build_config = _initialize_build_configuration(
-            self._plugin_resolver, options_bootstrapper, env
-        )
+    ) -> Options:
         with self.handle_unknown_flags(options_bootstrapper, env, raise_=raise_):
-            options = options_bootstrapper.full_options(build_config)
-        return build_config, options
+            return options_bootstrapper.full_options(build_config, union_membership)
 
     @contextmanager
     def handle_unknown_flags(
@@ -136,7 +142,10 @@ class OptionsInitializer:
             no_arg_bootstrapper = dataclasses.replace(
                 options_bootstrapper, args=("dummy_first_arg",)
             )
-            options = no_arg_bootstrapper.full_options(build_config)
+            options = no_arg_bootstrapper.full_options(
+                build_config,
+                union_membership=UnionMembership({}),
+            )
             FlagErrorHelpPrinter(options).handle_unknown_flags(err)
             if raise_:
                 raise err

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -12,6 +12,7 @@ import pytest
 from pants.base.build_environment import get_buildroot
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.unions import UnionMembership
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import DynamicRemoteOptions, GlobalOptions
 from pants.option.options_bootstrapper import OptionsBootstrapper
@@ -41,7 +42,9 @@ def create_dynamic_remote_options(
         args.append(f"--remote-auth-plugin={plugin}")
     ob = create_options_bootstrapper(args)
     env = CompleteEnvironmentVars({})
-    _build_config, options = OptionsInitializer(ob).build_config_and_options(ob, env, raise_=False)
+    oi = OptionsInitializer(ob)
+    _build_config = oi.build_config(ob, env)
+    options = oi.options(ob, env, _build_config, union_membership=UnionMembership({}), raise_=False)
     return DynamicRemoteOptions.from_options(
         options, env, remote_auth_plugin_func=_build_config.remote_auth_plugin_func
     )[0]

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from textwrap import dedent
 
 from pants.base.build_environment import get_buildroot
+from pants.engine.unions import UnionMembership
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.option.scope import ScopeInfo
@@ -133,7 +134,8 @@ class TestOptionsBootstrapper:
                     ScopeInfo(""),
                     ScopeInfo("foo"),
                     ScopeInfo("fruit"),
-                ]
+                ],
+                union_membership=UnionMembership({}),
             )
             # So we don't choke on these on the cmd line.
             opts.register("", "--pants-workdir")
@@ -175,6 +177,7 @@ class TestOptionsBootstrapper:
                     ScopeInfo("compile_apt"),
                     ScopeInfo("fruit"),
                 ],
+                union_membership=UnionMembership({}),
             )
             # So we don't choke on these on the cmd line.
             options.register("", "--pants-config-files", type=list)
@@ -244,7 +247,8 @@ class TestOptionsBootstrapper:
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("resolver"),
-                ]
+                ],
+                union_membership=UnionMembership({}),
             )
             opts_single_config.register("", "--pantsrc-files", type=list)
             opts_single_config.register("resolver", "--resolver")
@@ -259,13 +263,15 @@ class TestOptionsBootstrapper:
                 known_scope_infos=[
                     ScopeInfo(""),
                     ScopeInfo("foo"),
-                ]
+                ],
+                union_membership=UnionMembership({}),
             )
             opts2 = bootstrapper.full_options_for_scopes(
                 known_scope_infos=[
                     ScopeInfo("foo"),
                     ScopeInfo(""),
-                ]
+                ],
+                union_membership=UnionMembership({}),
             )
             assert opts1 is opts2
 
@@ -274,14 +280,21 @@ class TestOptionsBootstrapper:
                     ScopeInfo(""),
                     ScopeInfo("foo"),
                     ScopeInfo(""),
-                ]
+                ],
+                union_membership=UnionMembership({}),
             )
             assert opts1 is opts3
 
-            opts4 = bootstrapper.full_options_for_scopes(known_scope_infos=[ScopeInfo("")])
+            opts4 = bootstrapper.full_options_for_scopes(
+                known_scope_infos=[ScopeInfo("")],
+                union_membership=UnionMembership({}),
+            )
             assert opts1 is not opts4
 
-            opts5 = bootstrapper.full_options_for_scopes(known_scope_infos=[ScopeInfo("")])
+            opts5 = bootstrapper.full_options_for_scopes(
+                known_scope_infos=[ScopeInfo("")],
+                union_membership=UnionMembership({}),
+            )
             assert opts4 is opts5
             assert opts1 is not opts5
 

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -10,14 +10,17 @@ from abc import ABCMeta
 from itertools import chain
 from typing import TYPE_CHECKING, Any, ClassVar, Iterable, TypeVar, cast
 
+from typing_extensions import final
+
 from pants import ox
 from pants.engine.internals.selectors import AwaitableConstraints, Get
+from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.errors import OptionsError
 from pants.option.option_types import OptionsInfo, collect_options_info
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.scope import Scope, ScopedOptions, ScopeInfo, normalize_scope
-from pants.util.memo import memoized_classmethod
+from pants.util.memo import memoized_classmethod, memoized_classproperty
 
 if TYPE_CHECKING:
     # Needed to avoid an import cycle.
@@ -133,6 +136,28 @@ class Subsystem(metaclass=_SubsystemMeta):
 
         return list(inner())
 
+    @final
+    @memoized_classproperty
+    def _plugin_option_cls(cls) -> type:
+        @union
+        class PluginOption:
+            pass
+
+        return PluginOption
+
+    @classmethod
+    def register_plugin_options(cls, options_container: type) -> UnionRule:
+        """Register additional options on the subsystem.
+
+        In the `rules()` register.py entry-point, include `OtherSubsystem.register_plugin_options(<OptionsContainer>)`.
+        `<OptionsContainer>` should be a type with option class attributes, similar to how they are
+        defined for subsystems.
+
+        This will register the option as a first-class citizen.
+        Plugins can use this new option like any other.
+        """
+        return UnionRule(cls._plugin_option_cls, options_container)
+
     @classmethod
     def _construct_subsystem_rule(cls) -> Rule:
         """Returns a `TaskRule` that will construct the target Subsystem."""
@@ -223,14 +248,17 @@ class Subsystem(metaclass=_SubsystemMeta):
         return cls.create_scope_info(scope=cls.options_scope, subsystem_cls=cls)
 
     @classmethod
-    def register_options_on_scope(cls, options: Options):
+    def register_options_on_scope(cls, options: Options, union_membership: UnionMembership):
         """Trigger registration of this Subsystem's options.
 
         Subclasses should not generally need to override this method.
         """
         register = options.registration_function_for_subsystem(cls)
+        plugin_option_containers = union_membership.get(cls._plugin_option_cls)
         for options_info in chain(
-            collect_options_info(cls), collect_options_info(cls.EnvironmentAware)
+            collect_options_info(cls),
+            collect_options_info(cls.EnvironmentAware),
+            *(collect_options_info(container) for container in plugin_option_containers),
         ):
             register(*options_info.flag_names, **options_info.flag_options)
 

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -3,8 +3,10 @@
 
 import pytest
 
+from pants.engine.unions import UnionMembership
 from pants.option.config import Config
 from pants.option.errors import OptionsError
+from pants.option.option_types import BoolOption, StrListOption
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options import Options
 from pants.option.subsystem import Subsystem
@@ -70,6 +72,33 @@ def test_register_options_blessed(caplog) -> None:
         args=["./pants"],
         bootstrap_option_values=None,
     )
-    GoodToGo.register_options_on_scope(options)
+    GoodToGo.register_options_on_scope(options, UnionMembership({}))
 
     assert not caplog.records, "The current blessed means of registering options should never warn."
+
+
+def test_register_plugin_options() -> None:
+    class Electrical(Subsystem):
+        options_scope = "electrical"
+
+    class LampPlugin:
+        is_on = BoolOption(default=False, help="Luxo Jr.")
+
+    class Blender:
+        contents = StrListOption(help="brrrrr")
+
+    options = Options.create(
+        env={},
+        config=Config.load([]),
+        known_scope_infos=[Electrical.get_scope_info()],
+        args=["./pants"],
+        bootstrap_option_values=None,
+    )
+    Electrical.register_options_on_scope(
+        options,
+        UnionMembership({Electrical._plugin_option_cls: [LampPlugin, Blender]}),
+    )
+
+    electrical_subsystem = Electrical(options.for_scope(Electrical.options_scope))
+    assert not electrical_subsystem.options.is_on
+    assert electrical_subsystem.options.contents == []

--- a/src/python/pants/pantsd/pants_daemon_core.py
+++ b/src/python/pants/pantsd/pants_daemon_core.py
@@ -13,6 +13,7 @@ from typing_extensions import Protocol
 from pants.build_graph.build_configuration import BuildConfiguration
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.native_engine import PyExecutor
+from pants.engine.unions import UnionMembership
 from pants.init.engine_initializer import EngineInitializer, GraphScheduler
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.global_options import AuthPluginResult, DynamicRemoteOptions
@@ -126,8 +127,10 @@ class PantsDaemonCore:
         """
 
         with self._handle_exceptions():
-            build_config, options = self._options_initializer.build_config_and_options(
-                options_bootstrapper, env, raise_=True
+            build_config = self._options_initializer.build_config(options_bootstrapper, env)
+            union_membership = UnionMembership.from_rules(build_config.union_rules)
+            options = self._options_initializer.options(
+                options_bootstrapper, env, build_config, union_membership, raise_=True
             )
 
         scheduler_restart_explanation: str | None = None

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -261,7 +261,9 @@ class RuleRunner:
         self.options_bootstrapper = create_options_bootstrapper(args=bootstrap_args)
         self.extra_session_values = extra_session_values or {}
         self.max_workunit_verbosity = max_workunit_verbosity
-        options = self.options_bootstrapper.full_options(self.build_config)
+        options = self.options_bootstrapper.full_options(
+            self.build_config, union_membership=self.union_membership
+        )
         global_options = self.options_bootstrapper.bootstrap_options.for_global_scope()
 
         dynamic_remote_options, _ = DynamicRemoteOptions.from_options(options, self.environment)
@@ -356,7 +358,8 @@ class RuleRunner:
         self.set_options(merged_args, env=env, env_inherit=env_inherit)
 
         raw_specs = self.options_bootstrapper.full_options_for_scopes(
-            [GlobalOptions.get_scope_info(), goal.subsystem_cls.get_scope_info()]
+            [GlobalOptions.get_scope_info(), goal.subsystem_cls.get_scope_info()],
+            self.union_membership,
         ).specs
         specs = SpecsParser(self.build_root).parse_specs(
             raw_specs, description_of_origin="RuleRunner.run_goal_rule()"
@@ -683,7 +686,7 @@ def mock_console(
     global_bootstrap_options = options_bootstrapper.bootstrap_options.for_global_scope()
     colors = (
         options_bootstrapper.full_options_for_scopes(
-            [GlobalOptions.get_scope_info()], allow_unknown_options=True
+            [GlobalOptions.get_scope_info()], UnionMembership({}), allow_unknown_options=True
         )
         .for_global_scope()
         .colors

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -47,7 +47,7 @@ from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule as QueryRule
 from pants.engine.rules import rule
 from pants.engine.target import AllTargets, Target, WrappedTarget, WrappedTargetRequest
-from pants.engine.unions import UnionMembership
+from pants.engine.unions import UnionMembership, UnionRule
 from pants.init.engine_initializer import EngineInitializer
 from pants.init.logging import initialize_stdio, initialize_stdio_raw, stdio_destination
 from pants.option.global_options import (
@@ -262,7 +262,10 @@ class RuleRunner:
         self.extra_session_values = extra_session_values or {}
         self.max_workunit_verbosity = max_workunit_verbosity
         options = self.options_bootstrapper.full_options(
-            self.build_config, union_membership=self.union_membership
+            self.build_config,
+            union_membership=UnionMembership.from_rules(
+                rule for rule in self.rules if isinstance(rule, UnionRule)
+            ),
         )
         global_options = self.options_bootstrapper.bootstrap_options.for_global_scope()
 

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -5,6 +5,7 @@ import unittest
 
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
+from pants.engine.unions import UnionMembership
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -18,9 +19,15 @@ class OptionsInitializerTest(unittest.TestCase):
         )
 
         env = CompleteEnvironmentVars({})
+        initializer = OptionsInitializer(options_bootstrapper)
+        build_config = initializer.build_config(options_bootstrapper, env)
         with self.assertRaises(ExecutionError):
-            OptionsInitializer(options_bootstrapper).build_config_and_options(
-                options_bootstrapper, env, raise_=True
+            initializer.options(
+                options_bootstrapper,
+                env,
+                build_config,
+                union_membership=UnionMembership({}),
+                raise_=True,
             )
 
     def test_global_options_validation(self) -> None:
@@ -31,8 +38,12 @@ class OptionsInitializerTest(unittest.TestCase):
             allow_pantsrc=False,
         )
         env = CompleteEnvironmentVars({})
+        initializer = OptionsInitializer(ob)
+        build_config = initializer.build_config(ob, env)
         with self.assertRaises(ExecutionError) as exc:
-            OptionsInitializer(ob).build_config_and_options(ob, env, raise_=True)
+            initializer.options(
+                ob, env, build_config, union_membership=UnionMembership({}), raise_=True
+            )
         self.assertIn(
             "The `--no-watch-filesystem` option may not be set if `--pantsd` or `--loop` is set.",
             str(exc.exception),

--- a/tests/python/pants_test/init/test_options_initializer.py
+++ b/tests/python/pants_test/init/test_options_initializer.py
@@ -5,7 +5,6 @@ import unittest
 
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.unions import UnionMembership
 from pants.init.options_initializer import OptionsInitializer
 from pants.option.options_bootstrapper import OptionsBootstrapper
 
@@ -20,15 +19,8 @@ class OptionsInitializerTest(unittest.TestCase):
 
         env = CompleteEnvironmentVars({})
         initializer = OptionsInitializer(options_bootstrapper)
-        build_config = initializer.build_config(options_bootstrapper, env)
         with self.assertRaises(ExecutionError):
-            initializer.options(
-                options_bootstrapper,
-                env,
-                build_config,
-                union_membership=UnionMembership({}),
-                raise_=True,
-            )
+            initializer.build_config(options_bootstrapper, env)
 
     def test_global_options_validation(self) -> None:
         # Specify an invalid combination of options.
@@ -39,11 +31,8 @@ class OptionsInitializerTest(unittest.TestCase):
         )
         env = CompleteEnvironmentVars({})
         initializer = OptionsInitializer(ob)
-        build_config = initializer.build_config(ob, env)
         with self.assertRaises(ExecutionError) as exc:
-            initializer.options(
-                ob, env, build_config, union_membership=UnionMembership({}), raise_=True
-            )
+            initializer.build_config(ob, env)
         self.assertIn(
             "The `--no-watch-filesystem` option may not be set if `--pantsd` or `--loop` is set.",
             str(exc.exception),


### PR DESCRIPTION
We've all talked about it, and now it's here!

Some use-cases we have today, that could see themselves be ported over to plugin-options:
- tool "skipping" -> `--black-skip` becomes `--fmt-skip-black` (which also nicely mirrors the `skip_black` plugin field)
- `tailor` -> `python.tailor_source_targets` becomes `tailor.python_source_targets` or `tailor.python.source_targets`
- probably a lot more, but it's late and I'm not feeling creative :stuck_out_tongue: 

Note that the most common use case I'd imagine would be goal subsystems, but this doesn't limit ourselves to that,

Also, no thoughts here on how to migrate :smile: 

[ci skip-rust]
[ci skip-build-wheels]