### PR TITLE
go/cgo: support compiling C, C++, ObjC, and Fortran sources

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -148,7 +148,23 @@ class GoModTarget(TargetGenerator):
 
 class GoPackageSourcesField(MultipleSourcesField):
     default = ("*.go", "*.s")
-    expected_file_extensions = (".go", ".s")
+    expected_file_extensions = (
+        ".go",
+        ".s",
+        ".c",
+        ".h",
+        ".hh",
+        ".hpp",
+        ".hxx",
+        ".cc",
+        ".cpp",
+        ".cxx",
+        ".m",
+        ".f",
+        ".F",
+        ".for",
+        ".f90",
+    )
     ban_subdirectories = True
     help = generate_multiple_sources_field_help_message(
         "Example: `sources=['example.go', '*_test.go', '!test_ignore.go']`"

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -53,6 +53,10 @@ class BuildGoPackageRequest(EngineAwareParameter):
         coverage_config: GoCoverageConfig | None = None,
         cgo_file_names: tuple[str, ...] = (),
         cgo_flags: CGoCompilerFlags | None = None,
+        c_files: tuple[str, ...] = (),
+        cxx_files: tuple[str, ...] = (),
+        objc_files: tuple[str, ...] = (),
+        fortran_files: tuple[str, ...] = (),
     ) -> None:
         """Build a package and its dependencies as `__pkg__.a` files.
 
@@ -73,6 +77,10 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self.coverage_config = coverage_config
         self.cgo_file_names = cgo_file_names
         self.cgo_flags = cgo_flags
+        self.c_files = c_files
+        self.cxx_files = cxx_files
+        self.objc_files = objc_files
+        self.fortran_files = fortran_files
         self._hashcode = hash(
             (
                 self.import_path,
@@ -88,6 +96,10 @@ class BuildGoPackageRequest(EngineAwareParameter):
                 self.coverage_config,
                 self.cgo_file_names,
                 self.cgo_flags,
+                self.c_files,
+                self.cxx_files,
+                self.objc_files,
+                self.fortran_files,
             )
         )
 
@@ -108,7 +120,11 @@ class BuildGoPackageRequest(EngineAwareParameter):
             f"embed_config={self.embed_config}, "
             f"coverage_config={self.coverage_config}, "
             f"cgo_file_names={self.cgo_file_names}, "
-            f"cgo_flags={self.cgo_flags}"
+            f"cgo_flags={self.cgo_flags}, "
+            f"c_files={self.c_files}, "
+            f"cxx_files={self.cxx_files}, "
+            f"objc_files={self.objc_files}, "
+            f"fortran_files={self.fortran_files}"
             ")"
         )
 
@@ -132,6 +148,10 @@ class BuildGoPackageRequest(EngineAwareParameter):
             and self.coverage_config == other.coverage_config
             and self.cgo_file_names == other.cgo_file_names
             and self.cgo_flags == other.cgo_flags
+            and self.c_files == other.c_files
+            and self.cxx_files == other.cxx_files
+            and self.objc_files == other.objc_files
+            and self.fortran_files == other.fortran_files
             # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
             and self.direct_dependencies == other.direct_dependencies
         )
@@ -340,6 +360,10 @@ async def build_go_package(
                 dir_path=request.dir_path,
                 cgo_files=cgo_files,
                 cgo_flags=request.cgo_flags,
+                c_files=request.c_files,
+                cxx_files=request.cxx_files,
+                objc_files=request.objc_files,
+                fortran_files=request.fortran_files,
             ),
         )
         assert cgo_compile_result is not None

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -174,6 +174,10 @@ async def setup_build_go_package_target_request(
         s_file_names = _first_party_pkg_analysis.s_files
         cgo_file_names = _first_party_pkg_analysis.cgo_files
         cgo_flags = _first_party_pkg_analysis.cgo_flags
+        c_files = _first_party_pkg_analysis.c_files
+        cxx_files = _first_party_pkg_analysis.cxx_files
+        objc_files = _first_party_pkg_analysis.m_files
+        fortran_files = _first_party_pkg_analysis.f_files
 
     elif target.has_field(GoThirdPartyPackageDependenciesField):
         import_path = target[GoImportPathField].value
@@ -199,7 +203,10 @@ async def setup_build_go_package_target_request(
         embed_config = _third_party_pkg_info.embed_config
         cgo_file_names = _third_party_pkg_info.cgo_files
         cgo_flags = _third_party_pkg_info.cgo_flags
-
+        c_files = _third_party_pkg_info.c_files
+        cxx_files = _third_party_pkg_info.cxx_files
+        objc_files = _third_party_pkg_info.m_files
+        fortran_files = _third_party_pkg_info.f_files
     else:
         raise AssertionError(
             f"Unknown how to build `{target.alias}` target at address {request.address} with Go. "
@@ -236,6 +243,10 @@ async def setup_build_go_package_target_request(
         s_file_names=s_file_names,
         cgo_file_names=cgo_file_names,
         cgo_flags=cgo_flags,
+        c_files=c_files,
+        cxx_files=cxx_files,
+        objc_files=objc_files,
+        fortran_files=fortran_files,
         minimum_go_version=minimum_go_version,
         direct_dependencies=tuple(direct_dependencies),
         for_tests=request.for_tests,

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -150,8 +150,6 @@ def test_cgo_compile(rule_runner: RuleRunner) -> None:
         pkg_name=analysis.name,
         digest=pkg_digest.digest,
         dir_path=analysis.dir_path,
-        m_files=(),
-        f_files=(),
         cgo_files=analysis.cgo_files,
         cgo_flags=analysis.cgo_flags,
     )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -91,6 +91,11 @@ class FirstPartyPkgAnalysis:
 
     cgo_flags: CGoCompilerFlags
 
+    c_files: tuple[str, ...]
+    cxx_files: tuple[str, ...]
+    m_files: tuple[str, ...]
+    h_files: tuple[str, ...]
+    f_files: tuple[str, ...]
     s_files: tuple[str, ...]
 
     minimum_go_version: str | None
@@ -173,6 +178,11 @@ class FallibleFirstPartyPkgAnalysis:
                 ldflags=tuple(metadata.get("CgoLDFLAGS", [])),
                 pkg_config=tuple(metadata.get("CgoPkgConfig", [])),
             ),
+            c_files=tuple(metadata.get("CFiles", [])),
+            cxx_files=tuple(metadata.get("CXXFiles", [])),
+            m_files=tuple(metadata.get("MFiles", [])),
+            h_files=tuple(metadata.get("HFiles", [])),
+            f_files=tuple(metadata.get("FFiles", [])),
             s_files=tuple(metadata.get("SFiles", [])),
             minimum_go_version=minimum_go_version,
             embed_patterns=tuple(metadata.get("EmbedPatterns", [])),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -63,9 +63,15 @@ class ThirdPartyPkgAnalysis:
     # tests directly on a third-party package.
     imports: tuple[str, ...]
     go_files: tuple[str, ...]
-    s_files: tuple[str, ...]
     cgo_files: tuple[str, ...]
     cgo_flags: CGoCompilerFlags
+
+    c_files: tuple[str, ...]
+    cxx_files: tuple[str, ...]
+    m_files: tuple[str, ...]
+    h_files: tuple[str, ...]
+    f_files: tuple[str, ...]
+    s_files: tuple[str, ...]
 
     minimum_go_version: str | None
 
@@ -408,11 +414,6 @@ async def analyze_go_third_party_package(
 
     for key in (
         "CompiledGoFiles",
-        "CFiles",
-        "CXXFiles",
-        "MFiles",
-        "HFiles",
-        "FFiles",
         "SwigFiles",
         "SwigCXXFiles",
         "SysoFiles",
@@ -445,6 +446,11 @@ async def analyze_go_third_party_package(
         dir_path=request.package_path,
         imports=tuple(request.pkg_json.get("Imports", ())),
         go_files=tuple(request.pkg_json.get("GoFiles", ())),
+        c_files=tuple(request.pkg_json.get("CFiles", ())),
+        cxx_files=tuple(request.pkg_json.get("CXXFiles", ())),
+        m_files=tuple(request.pkg_json.get("MFiles", ())),
+        h_files=tuple(request.pkg_json.get("HFiles", ())),
+        f_files=tuple(request.pkg_json.get("FFiles", ())),
         s_files=tuple(request.pkg_json.get("SFiles", ())),
         cgo_files=tuple(request.pkg_json.get("CgoFiles", ())),
         minimum_go_version=request.minimum_go_version,
@@ -606,6 +612,11 @@ def maybe_raise_or_create_error_or_create_failed_pkg_info(
             digest=EMPTY_DIGEST,
             imports=(),
             go_files=(),
+            c_files=(),
+            cxx_files=(),
+            h_files=(),
+            m_files=(),
+            f_files=(),
             s_files=(),
             minimum_go_version=None,
             embed_patterns=(),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -52,7 +52,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[GoModTarget],
     )
-    rule_runner.set_options([], env_inherit={"PATH"})
+    rule_runner.set_options(["--golang-cgo-enabled"], env_inherit={"PATH"})
     return rule_runner
 
 
@@ -347,79 +347,6 @@ def test_module_with_no_packages(rule_runner) -> None:
         AllThirdPartyPackages, [AllThirdPartyPackagesRequest(digest, "go.mod")]
     )
     assert not all_packages.import_paths_to_pkg_info
-
-
-def test_unsupported_sources(rule_runner: RuleRunner) -> None:
-    # `golang.org/x/mobile/bind/objc` uses `.h` files on both Linux and macOS.
-    digest = set_up_go_mod(
-        rule_runner,
-        dedent(
-            """\
-            module example.com/unsupported
-            go 1.16
-            require golang.org/x/mobile v0.0.0-20210924032853-1c027f395ef7
-            """
-        ),
-        dedent(
-            """\
-            github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOCMdNH+CiXJVYJh5UQNCOBG7jbELc=
-            github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-            github.com/yuin/goldmark v1.3.5 h1:dPmz1Snjq0kmkz159iL7S6WzdahUTHnHB5M56WFVifs=
-            github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-            golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-            golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-            golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
-            golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-            golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56 h1:estk1glOnSVeJ9tdEZZc5mAMDZk5lNJNyJ6DvrBkTEU=
-            golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
-            golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
-            golang.org/x/image v0.0.0-20190802002840-cff245a6509b h1:+qEpEAPhDZ1o0x3tHzZTQDArnOixOzGD9HUJfcg0mb4=
-            golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
-            golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
-            golang.org/x/mobile v0.0.0-20210924032853-1c027f395ef7 h1:CyFUjc175y/mbMjxe+WdqI72jguLyjQChKCDe9mfTvg=
-            golang.org/x/mobile v0.0.0-20210924032853-1c027f395ef7/go.mod h1:c4YKU3ZylDmvbw+H/PSvm42vhdWbuxCzbonauEAP9B8=
-            golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
-            golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
-            golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-            golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-            golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-            golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-            golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
-            golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-            golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-            golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
-            golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-            golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-            golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-            golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-            golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-            golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
-            golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-            golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
-            golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-            golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-            golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
-            golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-            golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-            golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
-            golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
-            golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-            golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-            golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-            golang.org/x/tools v0.1.2 h1:kRBLX7v7Af8W7Gdbbc908OJcdgtK8bOz9Uaj8/F1ACA=
-            golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
-            golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-            golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-            golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-            golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-            """
-        ),
-    )
-    pkg_info = rule_runner.request(
-        ThirdPartyPkgAnalysis,
-        [ThirdPartyPkgAnalysisRequest("golang.org/x/mobile/bind/objc", digest, "go.mod")],
-    )
-    assert pkg_info.error is not None
 
 
 def test_determine_pkg_info_module_with_replace_directive(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Thread through the analysis of C, C++, Obj-C, and Fortran sources from the analysis rules through to the compilation rules. This allows building a cgo package with `.c` files in my testing.