### PR TITLE
Add `parametrize()` support for `__defaults__`. (Cherry-pick of #16977)

### DIFF
--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -20,6 +20,8 @@ from pants.engine.internals.build_files import (
     evaluate_preludes,
     parse_address_family,
 )
+from pants.engine.internals.defaults import ParametrizeDefault
+from pants.engine.internals.parametrize import Parametrize
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRequest
@@ -197,7 +199,9 @@ def test_resolve_address() -> None:
 @pytest.fixture
 def target_adaptor_rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[QueryRule(TargetAdaptor, (TargetAdaptorRequest,))], target_types=[MockTgt]
+        rules=[QueryRule(TargetAdaptor, (TargetAdaptorRequest,))],
+        target_types=[MockTgt],
+        objects={"parametrize": Parametrize},
     )
 
 
@@ -310,6 +314,28 @@ def test_inherit_defaults(target_adaptor_rule_runner: RuleRunner) -> None:
 
     # The defaults originates from a parent BUILD file, and as such has been frozen.
     assert target_adaptor.kwargs["tags"] == ("root",)
+
+
+def test_parametrize_defaults(target_adaptor_rule_runner: RuleRunner) -> None:
+    target_adaptor_rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                __defaults__(
+                  all=dict(
+                    tags=parametrize(a=["a", "root"], b=["non-root", "b"])
+                  )
+                )
+                """
+            ),
+            "helloworld/dir/BUILD": "mock_tgt()",
+        }
+    )
+    target_adaptor = target_adaptor_rule_runner.request(
+        TargetAdaptor,
+        [TargetAdaptorRequest(Address("helloworld/dir"), description_of_origin="tests")],
+    )
+    assert target_adaptor.kwargs["tags"] == ParametrizeDefault(a=("a", "root"), b=("non-root", "b"))
 
 
 def test_target_adaptor_not_found(target_adaptor_rule_runner: RuleRunner) -> None:

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -8,7 +8,12 @@ from collections import namedtuple
 import pytest
 
 from pants.core.target_types import GenericTarget, GenericTargetDependenciesField
-from pants.engine.internals.defaults import BuildFileDefaults, BuildFileDefaultsParserState
+from pants.engine.internals.defaults import (
+    BuildFileDefaults,
+    BuildFileDefaultsParserState,
+    ParametrizeDefault,
+)
+from pants.engine.internals.parametrize import Parametrize
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -223,6 +228,17 @@ Scenario = namedtuple(
                 expected_defaults={"test_gen_targets": {"dependencies": ("some/dep",)}},
             ),
             id="default value for moved field",
+        ),
+        pytest.param(
+            Scenario(
+                args=({Test1Target.alias: {"tags": Parametrize(["foo"], ["bar"], baz=["baz"])}},),
+                expected_defaults={
+                    "test_type_1": {
+                        "tags": ParametrizeDefault(("foo",), ("bar",), baz=("baz",)),  # type: ignore[arg-type]
+                    }
+                },
+            ),
+            id="parametrize default field value",
         ),
     ],
 )


### PR DESCRIPTION
This PR implements support for using parametrization for the BUILD file defaults feature. Closes #16937 

Example:

```python
# BUILD
__defaults__(
  all=dict(
    resolve=parametrize("resolve-a", "resolve-b")
  )
)
```

[ci skip-rust]
[ci skip-build-wheels]