### PR TITLE
Document how CA certs path works with `docker_environment` and `remote_environment`

### DIFF
--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -139,7 +139,6 @@ def twine_env(env: EnvironmentVars, repo: str) -> EnvironmentVars:
 async def twine_upload(
     request: PublishPythonPackageRequest,
     twine_subsystem: TwineSubsystem,
-    twine_environment_aware: TwineSubsystem.EnvironmentAware,
     global_options: GlobalOptions,
 ) -> PublishProcesses:
     dists = tuple(
@@ -177,7 +176,7 @@ async def twine_upload(
         Get(ConfigFiles, ConfigFilesRequest, twine_subsystem.config_request()),
     )
 
-    ca_cert_request = twine_environment_aware.ca_certs_digest_request(global_options.ca_certs_path)
+    ca_cert_request = twine_subsystem.ca_certs_digest_request(global_options.ca_certs_path)
     ca_cert = await Get(Snapshot, CreateDigest, ca_cert_request) if ca_cert_request else None
     ca_cert_digest = (ca_cert.digest,) if ca_cert else ()
 

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -3,9 +3,6 @@
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import (
     GeneratePythonLockfile,
@@ -15,11 +12,12 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.fs import CreateDigest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.global_options import ca_certs_path_to_file_content
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
-from pants.util.docutil import git_url
+from pants.util.docutil import doc_url, git_url
 from pants.util.strutil import softwrap
 
 
@@ -72,6 +70,27 @@ class TwineSubsystem(PythonToolBase):
         ),
     )
 
+    ca_certs_path = StrOption(
+        advanced=True,
+        default="<inherit>",
+        help=softwrap(
+            f"""
+            Path to a file containing PEM-format CA certificates used for verifying secure
+            connections when publishing python distributions.
+
+            Uses the value from `[GLOBAL].ca_certs_path` by default. Set to `"<none>"` to
+            not use any certificates.
+
+            Even when using the `docker_environment` and `remote_environment` targets, this path
+            will be read from the local host, and those certs will be used in the environment.
+
+            This option cannot be overridden via environment targets, so if you need a different
+            value than what the rest of your organization is using, override the value via an
+            environment variable, CLI argument, or `.pants.rc` file. See {doc_url('options')}.
+            """
+        ),
+    )
+
     def config_request(self) -> ConfigFilesRequest:
         # Refer to https://twine.readthedocs.io/en/latest/#configuration for how config files are
         # discovered.
@@ -82,33 +101,11 @@ class TwineSubsystem(PythonToolBase):
             check_existence=[".pypirc"],
         )
 
-    class EnvironmentAware:
-        ca_certs_path = StrOption(
-            advanced=True,
-            default="<inherit>",
-            help=softwrap(
-                """
-                Path to a file containing PEM-format CA certificates used for verifying secure
-                connections when publishing python distributions.
-
-                Uses the value from `[GLOBAL].ca_certs_path` by default. Set to `"<none>"` to
-                not use the default CA certificate.
-                """
-            ),
-        )
-
-        def ca_certs_digest_request(self, default_ca_certs_path: str | None) -> CreateDigest | None:
-            ca_certs_path: str | None = self.ca_certs_path
-            if ca_certs_path == "<inherit>":
-                ca_certs_path = default_ca_certs_path
-            if not ca_certs_path or ca_certs_path == "<none>":
-                return None
-
-            # The certs file will typically not be in the repo, so we can't digest it via a PathGlobs.
-            # Instead we manually create a FileContent for it.
-            ca_certs_content = Path(ca_certs_path).read_bytes()
-            chrooted_ca_certs_path = os.path.basename(ca_certs_path)
-            return CreateDigest((FileContent(chrooted_ca_certs_path, ca_certs_content),))
+    def ca_certs_digest_request(self, default_ca_certs_path: str | None) -> CreateDigest | None:
+        if not self.ca_certs_path or self.ca_certs_path == "<none>":
+            return None
+        path = default_ca_certs_path if self.ca_certs_path == "<inherit>" else self.ca_certs_path
+        return CreateDigest((ca_certs_path_to_file_content(path),))
 
 
 class TwineLockfileSentinel(GeneratePythonToolLockfileSentinel):

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -102,9 +102,9 @@ class TwineSubsystem(PythonToolBase):
         )
 
     def ca_certs_digest_request(self, default_ca_certs_path: str | None) -> CreateDigest | None:
-        if not self.ca_certs_path or self.ca_certs_path == "<none>":
-            return None
         path = default_ca_certs_path if self.ca_certs_path == "<inherit>" else self.ca_certs_path
+        if not path or path == "<none>":
+            return None
         return CreateDigest((ca_certs_path_to_file_content(path),))
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
-import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Iterable, List, Mapping, Optional, Tuple
 
 from pants.backend.python.subsystems.python_native_code import PythonNativeCodeSubsystem
@@ -22,12 +20,12 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
-from pants.engine.fs import CreateDigest, Digest, Directory, FileContent, MergeDigests
+from pants.engine.fs import CreateDigest, Digest, Directory, MergeDigests
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
-from pants.option.global_options import GlobalOptions
+from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_content
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty, frozen_after_init
@@ -131,20 +129,11 @@ async def setup_pex_cli_process(
     tmpdir = ".tmp"
     gets: List[Get] = [Get(Digest, CreateDigest([Directory(tmpdir)]))]
 
-    # The certs file will typically not be in the repo, so we can't digest it via a PathGlobs.
-    # Instead, we manually create a FileContent for it.
     cert_args = []
     if global_options.ca_certs_path:
-        ca_certs_content = Path(global_options.ca_certs_path).read_bytes()
-        chrooted_ca_certs_path = os.path.basename(global_options.ca_certs_path)
-
-        gets.append(
-            Get(
-                Digest,
-                CreateDigest((FileContent(chrooted_ca_certs_path, ca_certs_content),)),
-            )
-        )
-        cert_args = ["--cert", chrooted_ca_certs_path]
+        ca_certs_fc = ca_certs_path_to_file_content(global_options.ca_certs_path)
+        gets.append(Get(Digest, CreateDigest((ca_certs_fc,))))
+        cert_args = ["--cert", ca_certs_fc.path]
 
     digests_to_merge = [pex_pex.digest]
     digests_to_merge.extend(await MultiGet(gets))

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1952,8 +1952,9 @@ def ca_certs_path_to_file_content(path: str) -> FileContent:
 
     Note that the certs are always read on the localhost, even when using Docker and remote
     execution. Then, those certs can be copied into the process.
+
+    Warning: this will not detect when the contents of cert files changes, because we use
+    `pathlib.Path.read_bytes()`. Better would be
+    # https://github.com/pantsbuild/pants/issues/10842
     """
-    # Because the certs path may not exist in the repo, we use `Path`. Better would be
-    # https://github.com/pantsbuild/pants/issues/10842 so that we invalidate when the contents
-    # change.
     return FileContent(os.path.basename(path), Path(path).read_bytes())


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/16987.

We have three uses for certs path:

1. Connecting to remote execution server
2. The `DownloadFile` intrinsic, which always happens on local host regardless of Docker and remote execution
3. Subprocesses like Pex and Twine

Those first two uses would be difficult to load via environment targets, as they are used when bootstrapping Pants itself. I think I could possibly get it to work: we'd only let you set the values via `local_environment` targets. Every where that calls the helper `determine_bootstrap_environment`, we'd set = the certs path set to `None` at first, then determine the certs path to use, and finally start a new session:

https://github.com/pantsbuild/pants/blob/9769d88d2b914a51ffe7210495fdc5995ca64418/src/python/pants/core/util_rules/environments.py#L302-L307

That would work as long as we don't make network calls to determine the environment target, which we don't. But this all would be difficult to pull off. 

Meanwhile, for subprocesses, it's not hard for us to use an "environment aware" option that env targets can set, so long as we added a dedicated option like `[GLOBAL].ca_certs_path_subprocesses`. But @illicitonion wisely pointed out that should generally not be necessary: we can simply copy the _contents_ of the certs from local host into those environments, which we already do!

So, there's little value to setting certs paths for `docker_environment` and `remote_environment`. While it is valuable to set it for `local_environment`, so that e.g. macOS can have different config than Linux, it is too hard to achieve this given the bootstrapping chicken-and-egg problem. 

Therefore, this PR keeps the status quo, but documents these nuances.

[ci skip-rust]
[ci skip-build-wheels]