### PR TITLE
Update maintainer job description

### DIFF
--- a/docs/markdown/Getting Help/the-pants-community/maintainers.md
+++ b/docs/markdown/Getting Help/the-pants-community/maintainers.md
@@ -14,7 +14,6 @@ What is a maintainer?
 [Maintainers are the core group of trusted people with a long-term interest in Pants, who have made regular contributions for some time, and plan to continue to do so](doc:the-pants-community#maintainers). Maintainers are entrusted to make decisions on the future and direction of Pants. In doing so, it is their responsibility to uphold the health, culture, and quality of the project.
 
 We do not expect a minimum commitment of time from Maintainers, nor do we expect maintainers to contribute in specific ways, rather, we expect them to act in a way that makes Pants better whenever they interact with the project and our community.
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 What do maintainers do?
 -----------------------

--- a/docs/markdown/Getting Help/the-pants-community/maintainers.md
+++ b/docs/markdown/Getting Help/the-pants-community/maintainers.md
@@ -6,38 +6,81 @@ hidden: false
 createdAt: "2020-05-16T22:36:48.659Z"
 updatedAt: "2022-05-26T22:13:54.279Z"
 ---
-The Pants community has several Maintainers: people with a proven track record of contributions to the community and an ongoing commitment to the project, who guide the contributions of the wider community.
+Pants community Maintainers are contributors who have been recognized by the project as stewards of Pants. They have a proven record of contributions, are committed to ensuring the continued success of our project, and through their actions help to grow our Community.
 
-Maintainer responsibilities
----------------------------
-
-It is the responsibility of a maintainer to uphold the health and quality of the project.
-
-- Maintainers are responsible for the quality of the contributions they approve.
-- Maintainers should raise objections to changes that may impact the performance, security, or maintainability of the project.
-- Maintainers should help shepherd changes through our contribution process.
-- Maintainers should maintain a courteous and professional demeanor when participating in the community.
-- Maintainers should be regular participants on our public communications channels.
-
-> 📘 Releases
-> 
-> Pants publishes at least one new dev or stable release a week. A subset of the Maintainers takes responsibility for publishing these releases.
-> 
-> We use a [Google Calendar](https://calendar.google.com/calendar/b/0/embed?src=hvd8qnf6fnp5klnk7u46q1noeo@group.calendar.google.com&ctz=America/Los_Angeles) to coordinate who is on release duty in a given week. When it is time for a release, the Maintainer who has release duty that week is responsible for updating the release documentation, creating release builds, and shepherding them through the review and [release process](doc:release-process).
-
-Becoming a maintainer
+What is a maintainer?
 ---------------------
 
-Maintainer candidates are nominated by existing maintainers from among the wider contributor base. Criteria for nomination include:
+[Maintainers are the core group of trusted people with a long-term interest in Pants, who have made regular contributions for some time, and plan to continue to do so](doc:the-pants-community#maintainers). Maintainers are entrusted to make decisions on the future and direction of Pants. In doing so, it is their responsibility to uphold the health, culture, and quality of the project.
 
-- The candidate's desire to become a maintainer.
-- A track record of good contributions.
-- A friendly, helpful, positive attitude.
+We do not expect a minimum commitment of time from Maintainers, nor do we expect maintainers to contribute in specific ways, rather, we expect them to act in a way that makes Pants better whenever they interact with the project and our community.
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-If a contributor has been nominated, and is willing to become a maintainer, then their candidacy will be discussed and voted on by the existing maintainers.
+What do maintainers do?
+-----------------------
 
-Maintainer onboarding
+Every Maintainer contributes to the health of Pants in ways that are valuable. We don't need each Maintainer to do all of the things needed to sustain the project, as long as we collectively have those skills. If your track record as a [Contributor](doc:the-pants-community#contributors) includes any of the following, you will be valuable as a Maintainer, and you do not need to change how you contribute to the project unless you enthusiastically choose to do so.
+
+Maintainers shape the features and capabilities of Pants, and how we present and explain them to our users:
+
+-   They approve code and documentation changes from other maintainers and contributors, especially in their area of expertise
+-   They ensure the contributions they approve meet our project's quality standards
+
+Maintainers set the direction for the future of Pants:
+
+-   They participate in Pants' design process, offering their expertise and opinions when appropriate, or if they are called upon
+-   They understand the current and future needs and goals of the project, and provide informed context that justifies accepting or rejecting a proposal
+-   They contribute expertise in an important area of concern for the project; for example, performance, security, maintainability, product management, user experience, documentation, or open source governance
+
+Maintainers set the tone and establish the culture of the Pants Community, and foster its growth:
+
+-   They are welcoming when they interact with current and prospective members of the  community
+-   They maintain a courteous and professional demeanor when participating in the community, upholding the standards set in our Code of Conduct
+-   They help steward changes through our contribution process, especially by helping new contributors identify where changes fit into Pants, or by giving context for why certain features do not, or should not exist
+-   They are active participants in one or more of our communication channels as they are able, or as they are called on
+-   They help sustain the project's long-term growth and sustainability by seeking ways to make contributing to the project more enjoyable, engaging, and educational for others
+
+
+### Time commitment
+
+Most Maintainers perform the role as a volunteer commitment, without direct support from their employer. We understand everyone's availability can vary from day to day, and that we can't really make demands on your time. We appreciate the generosity you are able to show to the project, and value what you bring to it.
+
+We expect Maintainers to be able to answer questions about their areas of expertise as they are called upon. If you are unable to respond to a question in a timely manner, we'd appreciate it if you could make that clear, so someone else can offer help, or a decision can be made in your absence.
+
+If there are demands on your time that prevent you from participating in the Pants community, that's OK! We can usually cope with this, especially if you can let other maintainers know in advance. That way, we can prioritize work that you might have otherwise taken on, and ensure there isn't a daunting pile of issues and pull requests awaiting you when you return.
+
+If you no longer feel that you are able to contribute effectively as a maintainer, you may request to be converted to a [Maintainer Emeritus](doc:the-pants-community#former-team-members).
+
+
+### Release duty is optional
+
+Some maintainers also accept responsibility for publishing both development and stable releases of Pants. Releases are usually published once per week.
+
+We use a [Google Calendar](https://calendar.google.com/calendar/b/0/embed?src=hvd8qnf6fnp5klnk7u46q1noeo@group.calendar.google.com&ctz=America/Los_Angeles) to coordinate who is on release duty in a given week. When it is time for a release, the Maintainer who has release duty that week is responsible for updating the release documentation, creating release builds, and stewarding them through the review and [release process](doc:release-process).
+
+Release duty is a commitment beyond that of a Maintainer, and we do not expect Maintainers to take on this additional responsibility without enthusiastically opting in.
+
+
+Becoming a Maintainer
 ---------------------
+
+Maintainer candidates are nominated by existing Maintainers from among the wider contributor base. Criteria for nomination include:
+
+-   Candidate has a record of good contributions to Pants
+-   Candidate has a record of collaboration with Pants community members
+-   Candidate understands the principles described on this page
+-   Candidate is committed to upholding Pants community standards, including the Code of Conduct
+
+Candidates will only be publicly nominated after one Maintainer has determined they are willing to become a Maintainer. 
+
+If a contributor has been nominated, and is willing to become a Maintainer, then their candidacy will be discussed and voted on by the existing Maintainers.
+
+
+
+Onboarding tasks
+----------------
+
+### Maintainer onboarding
 
 New maintainers should be:
 
@@ -52,8 +95,8 @@ New maintainers should be:
   - in the [Slack #announce room](doc:getting-help#slack)
   - by [@pantsbuild on Twitter](https://twitter.com/pantsbuild)
 
-Contributor onboarding
-----------------------
+
+### Contributor onboarding
 
 New Contributors should be:
 

--- a/docs/markdown/Getting Help/the-pants-community/maintainers.md
+++ b/docs/markdown/Getting Help/the-pants-community/maintainers.md
@@ -4,7 +4,7 @@ slug: "maintainers"
 excerpt: "What Pants maintainers do and how to become one."
 hidden: false
 createdAt: "2020-05-16T22:36:48.659Z"
-updatedAt: "2022-05-26T22:13:54.279Z"
+updatedAt: "2022-09-28T00:00:00.000Z"
 ---
 Pants community Maintainers are contributors who have been recognized by the project as stewards of Pants. They have a proven record of contributions, are committed to ensuring the continued success of our project, and through their actions help to grow our Community.
 


### PR DESCRIPTION
This updates the maintainers page to better describe the role and time commitment of maintainers. This was raised to the maintainers group on Slack a week ago.