### PR TITLE
Refactors `PythonBootstrap` to pre-calculate expanded interpreter paths

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -171,7 +171,7 @@ async def find_pex_python(
 ) -> PexEnvironment:
     return PexEnvironment(
         path=pex_environment_aware.path,
-        interpreter_search_paths=tuple(python_bootstrap.interpreter_search_paths()),
+        interpreter_search_paths=python_bootstrap.interpreter_search_paths,
         subprocess_environment_dict=subprocess_env_vars.vars,
         named_caches_dir=named_caches_dir.val,
         bootstrap_python=PythonExecutable.from_python_binary(python_binary),

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -13,14 +13,13 @@ from pants.core.util_rules import subprocess_environment, system_binaries
 from pants.core.util_rules.subprocess_environment import SubprocessEnvironmentVars
 from pants.core.util_rules.system_binaries import BinaryPath, PythonBinary
 from pants.engine.engine_aware import EngineAwareReturnType
-from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import collect_rules, rule
 from pants.option.global_options import NamedCachesDirOption
 from pants.option.option_types import BoolOption, IntOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized_method
+from pants.util.memo import memoized_property
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import create_path_env_var, softwrap
 
@@ -29,9 +28,12 @@ class PexSubsystem(Subsystem):
     options_scope = "pex"
     help = "How Pants uses Pex to run Python subprocesses."
 
-    class EnvironmentAware:
+    class EnvironmentAware(Subsystem.EnvironmentAware):
         # TODO(#9760): We'll want to deprecate this in favor of a global option which allows for a
         #  per-process override.
+
+        depends_on_env_vars = ("PATH",)
+
         _executable_search_paths = StrListOption(
             default=["<PATH>"],
             help=softwrap(
@@ -46,12 +48,12 @@ class PexSubsystem(Subsystem):
             metavar="<binary-paths>",
         )
 
-        @memoized_method
-        def path(self, env: EnvironmentVars) -> tuple[str, ...]:
+        @memoized_property
+        def path(self) -> tuple[str, ...]:
             def iter_path_entries():
                 for entry in self._executable_search_paths:
                     if entry == "<PATH>":
-                        path = env.get("PATH")
+                        path = self.env_vars.get("PATH")
                         if path:
                             yield from path.split(os.pathsep)
                     else:
@@ -168,7 +170,7 @@ async def find_pex_python(
     named_caches_dir: NamedCachesDirOption,
 ) -> PexEnvironment:
     return PexEnvironment(
-        path=pex_environment_aware.path(python_bootstrap.environment),
+        path=pex_environment_aware.path,
         interpreter_search_paths=tuple(python_bootstrap.interpreter_search_paths()),
         subprocess_environment_dict=subprocess_env_vars.vars,
         named_caches_dir=named_caches_dir.val,

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -18,7 +18,6 @@ from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
-from pants.util.memo import memoized_property
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -86,21 +85,7 @@ class PythonBootstrap:
     EXTRA_ENV_VAR_NAMES = ("PATH", "PYENV_ROOT")
 
     interpreter_names: tuple[str, ...]
-    raw_interpreter_search_paths: tuple[str, ...]
-    environment: EnvironmentVars
-    asdf_standard_tool_paths: tuple[str, ...]
-    asdf_local_tool_paths: tuple[str, ...]
-
-    @memoized_property
-    def interpreter_search_paths(self) -> tuple[str, ...]:
-        return tuple(
-            _expand_interpreter_search_paths(
-                self.raw_interpreter_search_paths,
-                self.environment,
-                self.asdf_standard_tool_paths,
-                self.asdf_local_tool_paths,
-            )
-        )
+    interpreter_search_paths: tuple[str, ...]
 
 
 def _expand_interpreter_search_paths(
@@ -252,12 +237,16 @@ async def python_bootstrap(
         ),
     )
 
+    expanded_paths = _expand_interpreter_search_paths(
+        interpreter_search_paths,
+        result.env,
+        result.standard_tool_paths,
+        result.local_tool_paths,
+    )
+
     return PythonBootstrap(
         interpreter_names=interpreter_names,
-        raw_interpreter_search_paths=interpreter_search_paths,
-        environment=result.env,
-        asdf_standard_tool_paths=result.standard_tool_paths,
-        asdf_local_tool_paths=result.local_tool_paths,
+        interpreter_search_paths=expanded_paths,
     )
 
 

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -92,12 +92,14 @@ class PythonBootstrap:
     asdf_local_tool_paths: tuple[str, ...]
 
     @memoized_method
-    def interpreter_search_paths(self):
-        return _expand_interpreter_search_paths(
-            self.raw_interpreter_search_paths,
-            self.environment,
-            self.asdf_standard_tool_paths,
-            self.asdf_local_tool_paths,
+    def interpreter_search_paths(self) -> tuple[str, ...]:
+        return tuple(
+            _expand_interpreter_search_paths(
+                self.raw_interpreter_search_paths,
+                self.environment,
+                self.asdf_standard_tool_paths,
+                self.asdf_local_tool_paths,
+            )
         )
 
 
@@ -106,7 +108,8 @@ def _expand_interpreter_search_paths(
     env: EnvironmentVars,
     asdf_standard_tool_paths: tuple[str, ...],
     asdf_local_tool_paths: tuple[str, ...],
-):
+) -> tuple[str, ...]:
+
     special_strings = {
         "<PEXRC>": _get_pex_python_paths,
         "<PATH>": lambda: _get_environment_paths(env),
@@ -115,7 +118,7 @@ def _expand_interpreter_search_paths(
         "<PYENV>": lambda: _get_pyenv_paths(env),
         "<PYENV_LOCAL>": lambda: _get_pyenv_paths(env, pyenv_local=True),
     }
-    expanded = []
+    expanded: list[str] = []
     from_pexrc = None
     for s in interpreter_search_paths:
         if s in special_strings:
@@ -137,7 +140,7 @@ def _expand_interpreter_search_paths(
                 """
             )
         )
-    return expanded
+    return tuple(expanded)
 
 
 def _get_environment_paths(env: EnvironmentVars):

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -18,7 +18,7 @@ from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
-from pants.util.memo import memoized_method
+from pants.util.memo import memoized_property
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -91,7 +91,7 @@ class PythonBootstrap:
     asdf_standard_tool_paths: tuple[str, ...]
     asdf_local_tool_paths: tuple[str, ...]
 
-    @memoized_method
+    @memoized_property
     def interpreter_search_paths(self) -> tuple[str, ...]:
         return tuple(
             _expand_interpreter_search_paths(

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -93,52 +93,51 @@ class PythonBootstrap:
 
     @memoized_method
     def interpreter_search_paths(self):
-        return self._expand_interpreter_search_paths(
+        return _expand_interpreter_search_paths(
             self.raw_interpreter_search_paths,
             self.environment,
             self.asdf_standard_tool_paths,
             self.asdf_local_tool_paths,
         )
 
-    @classmethod
-    def _expand_interpreter_search_paths(
-        cls,
-        interpreter_search_paths: Sequence[str],
-        env: EnvironmentVars,
-        asdf_standard_tool_paths: tuple[str, ...],
-        asdf_local_tool_paths: tuple[str, ...],
-    ):
-        special_strings = {
-            "<PEXRC>": _get_pex_python_paths,
-            "<PATH>": lambda: _get_environment_paths(env),
-            "<ASDF>": lambda: asdf_standard_tool_paths,
-            "<ASDF_LOCAL>": lambda: asdf_local_tool_paths,
-            "<PYENV>": lambda: _get_pyenv_paths(env),
-            "<PYENV_LOCAL>": lambda: _get_pyenv_paths(env, pyenv_local=True),
-        }
-        expanded = []
-        from_pexrc = None
-        for s in interpreter_search_paths:
-            if s in special_strings:
-                special_paths = special_strings[s]()
-                if s == "<PEXRC>":
-                    from_pexrc = special_paths
-                expanded.extend(special_paths)
-            else:
-                expanded.append(s)
-        # Some special-case logging to avoid misunderstandings.
-        if from_pexrc and len(expanded) > len(from_pexrc):
-            logger.info(
-                softwrap(
-                    f"""
-                    pexrc interpreters requested and found, but other paths were also specified,
-                    so interpreters may not be restricted to the pexrc ones. Full search path is:
 
-                    {":".join(expanded)}
-                    """
-                )
+def _expand_interpreter_search_paths(
+    interpreter_search_paths: Sequence[str],
+    env: EnvironmentVars,
+    asdf_standard_tool_paths: tuple[str, ...],
+    asdf_local_tool_paths: tuple[str, ...],
+):
+    special_strings = {
+        "<PEXRC>": _get_pex_python_paths,
+        "<PATH>": lambda: _get_environment_paths(env),
+        "<ASDF>": lambda: asdf_standard_tool_paths,
+        "<ASDF_LOCAL>": lambda: asdf_local_tool_paths,
+        "<PYENV>": lambda: _get_pyenv_paths(env),
+        "<PYENV_LOCAL>": lambda: _get_pyenv_paths(env, pyenv_local=True),
+    }
+    expanded = []
+    from_pexrc = None
+    for s in interpreter_search_paths:
+        if s in special_strings:
+            special_paths = special_strings[s]()
+            if s == "<PEXRC>":
+                from_pexrc = special_paths
+            expanded.extend(special_paths)
+        else:
+            expanded.append(s)
+    # Some special-case logging to avoid misunderstandings.
+    if from_pexrc and len(expanded) > len(from_pexrc):
+        logger.info(
+            softwrap(
+                f"""
+                pexrc interpreters requested and found, but other paths were also specified,
+                so interpreters may not be restricted to the pexrc ones. Full search path is:
+
+                {":".join(expanded)}
+                """
             )
-        return expanded
+        )
+    return expanded
 
 
 def _get_environment_paths(env: EnvironmentVars):

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -177,7 +177,7 @@ def test_expand_interpreter_search_paths() -> None:
                 asdf_local_tool_paths=asdf_paths_result.local_tool_paths,
             )
 
-    expected = [
+    expected = (
         "/foo",
         "/env/path1",
         "/env/path2",
@@ -190,5 +190,5 @@ def test_expand_interpreter_search_paths() -> None:
         *expected_pyenv_paths,
         *expected_pyenv_local_paths,
         "/qux",
-    ]
+    )
     assert expected == expanded_paths

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -6,7 +6,13 @@ from contextlib import contextmanager
 from typing import Iterable, List, Sequence, TypeVar
 
 from pants.base.build_environment import get_pants_cachedir
-from pants.core.subsystems.python_bootstrap import PythonBootstrap, get_pyenv_root
+from pants.core.subsystems.python_bootstrap import (
+    PythonBootstrap,
+    _get_environment_paths,
+    _get_pex_python_paths,
+    _get_pyenv_paths,
+    get_pyenv_root,
+)
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.asdf_test import fake_asdf_root, get_asdf_paths
@@ -59,15 +65,13 @@ def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> List[
 
 
 def test_get_environment_paths() -> None:
-    paths = PythonBootstrap.get_environment_paths(
-        EnvironmentVars({"PATH": "foo/bar:baz:/qux/quux"})
-    )
+    paths = _get_environment_paths(EnvironmentVars({"PATH": "foo/bar:baz:/qux/quux"}))
     assert ["foo/bar", "baz", "/qux/quux"] == paths
 
 
 def test_get_pex_python_paths() -> None:
     with setup_pexrc_with_pex_python_path(["foo/bar", "baz", "/qux/quux"]):
-        paths = PythonBootstrap.get_pex_python_paths()
+        paths = _get_pex_python_paths()
     assert ["foo/bar", "baz", "/qux/quux"] == paths
 
 
@@ -90,8 +94,8 @@ def test_get_pyenv_paths() -> None:
         expected_paths,
         expected_local_paths,
     ):
-        paths = PythonBootstrap.get_pyenv_paths(EnvironmentVars({"PYENV_ROOT": pyenv_root}))
-        local_paths = PythonBootstrap.get_pyenv_paths(
+        paths = _get_pyenv_paths(EnvironmentVars({"PYENV_ROOT": pyenv_root}))
+        local_paths = _get_pyenv_paths(
             EnvironmentVars({"PYENV_ROOT": pyenv_root}), pyenv_local=True
         )
     assert expected_paths == paths

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -8,6 +8,7 @@ from typing import Iterable, List, Sequence, TypeVar
 from pants.base.build_environment import get_pants_cachedir
 from pants.core.subsystems.python_bootstrap import (
     PythonBootstrap,
+    _expand_interpreter_search_paths,
     _get_environment_paths,
     _get_pex_python_paths,
     _get_pyenv_paths,
@@ -169,7 +170,7 @@ def test_expand_interpreter_search_paths() -> None:
                 local=True,
                 extra_env_var_names=PythonBootstrap.EXTRA_ENV_VAR_NAMES,
             )
-            expanded_paths = PythonBootstrap._expand_interpreter_search_paths(
+            expanded_paths = _expand_interpreter_search_paths(
                 paths,
                 env=asdf_paths_result.env,
                 asdf_standard_tool_paths=asdf_paths_result.standard_tool_paths,

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -592,7 +592,7 @@ async def find_binary(request: BinaryPathRequest) -> BinaryPaths:
 async def find_python(python_bootstrap: PythonBootstrap) -> PythonBinary:
     # PEX files are compatible with bootstrapping via Python 2.7 or Python 3.5+, but we select 3.6+
     # for maximum compatibility with internal scripts.
-    interpreter_search_paths = python_bootstrap.interpreter_search_paths()
+    interpreter_search_paths = python_bootstrap.interpreter_search_paths
     all_python_binary_paths = await MultiGet(
         Get(
             BinaryPaths,


### PR DESCRIPTION
Previously, `PythonBootstrap` had a method that would calculate the expanded interpreter paths when they are first consumed. This change moves the calculation of those expanded interpreter paths to the initial creation of `PythonBootstrap`.

Relatedly, a bunch of static methods defined on `PythonBootstrap` are now private functions at module scope. This is prework that will significantly improve the clarity of my next piece of work on `PythonBootstrap`, namely converting all of the various filesystem-dependent functions to `@rule`s.

**None of the helper methods have been changed**

Addresses #16800.