### PR TITLE
Upgrade to Rust v1.64.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -53,7 +53,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 
@@ -196,7 +196,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 
@@ -201,7 +201,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 
@@ -416,7 +416,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 
@@ -520,7 +520,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 
@@ -659,7 +659,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
-        path: '~/.rustup/toolchains/1.63.0-*
+        path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "parking_lot 0.11.2",
- "pin-project 1.0.8",
+ "pin-project 1.0.12",
  "prost",
  "prost-build",
  "prost-types",
@@ -1410,7 +1410,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hyper",
- "pin-project 1.0.8",
+ "pin-project 1.0.12",
  "tokio",
 ]
 
@@ -2157,11 +2157,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal 1.0.8",
+ "pin-project-internal 1.0.12",
 ]
 
 [[package]]
@@ -2177,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3479,7 +3479,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
- "pin-project 1.0.8",
+ "pin-project 1.0.12",
  "rand 0.8.5",
  "tokio",
 ]
@@ -3572,7 +3572,7 @@ dependencies = [
  "hyper",
  "hyper-timeout",
  "percent-encoding",
- "pin-project 1.0.8",
+ "pin-project 1.0.12",
  "prost",
  "prost-derive",
  "rustls-native-certs",
@@ -3608,7 +3608,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.8",
+ "pin-project 1.0.12",
  "rand 0.8.5",
  "slab",
  "tokio",

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -380,11 +380,11 @@ impl<N: Node> InnerGraph<N> {
     self.live_internal(self.pg.node_indices().collect(), context.clone())
   }
 
-  fn live_internal<'g>(
-    &'g self,
+  fn live_internal(
+    &self,
     entryids: Vec<EntryId>,
     context: N::Context,
-  ) -> impl Iterator<Item = (&N, N::Item)> + 'g {
+  ) -> impl Iterator<Item = (&N, N::Item)> + '_ {
     entryids
       .into_iter()
       .filter_map(move |eid| self.entry_for_id(eid))

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -808,7 +808,7 @@ async fn workunit_to_py_value(
           .map_err(PyException::new_err)?
       }
       ArtifactOutput::Snapshot(digest_handle) => {
-        let digest = (&**digest_handle)
+        let digest = (**digest_handle)
           .as_any()
           .downcast_ref::<DirectoryDigest>()
           .ok_or_else(|| {
@@ -840,7 +840,7 @@ async fn workunit_to_py_value(
     let value = match user_metadata_item {
       UserMetadataItem::ImmediateString(v) => v.into_py(py),
       UserMetadataItem::ImmediateInt(n) => n.into_py(py),
-      UserMetadataItem::PyValue(py_val_handle) => (&**py_val_handle)
+      UserMetadataItem::PyValue(py_val_handle) => (**py_val_handle)
         .as_any()
         .downcast_ref::<Value>()
         .ok_or_else(|| {


### PR DESCRIPTION
Upgrade to Rust v1.64.0. [Blog](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html)

Note: Upgraded `pin-project` crate due to https://github.com/rust-lang/rust/issues/102217#issuecomment-1256852764.