### PR TITLE
Fix JVM resources jar file to be deterministic by default (Cherry-pick of #16950)

### DIFF
--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -326,6 +326,10 @@ class MkdirBinary(BinaryPath):
     pass
 
 
+class TouchBinary(BinaryPath):
+    pass
+
+
 class ChmodBinary(BinaryPath):
     pass
 
@@ -685,6 +689,14 @@ async def find_mkdir() -> MkdirBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path_or_raise(request, rationale="create directories")
     return MkdirBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `touch` binary", level=LogLevel.DEBUG)
+async def find_touch() -> TouchBinary:
+    request = BinaryPathRequest(binary_name="touch", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="touch file")
+    return TouchBinary(first_path.path, first_path.fingerprint)
 
 
 @rule(desc="Finding the `chmod` binary", level=LogLevel.DEBUG)

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -3,6 +3,7 @@
 
 import itertools
 import logging
+import shlex
 from itertools import chain
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from pants.core.target_types import ResourcesFieldSet, ResourcesGeneratorFieldSe
 from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
-from pants.core.util_rules.system_binaries import ZipBinary
+from pants.core.util_rules.system_binaries import BashBinary, TouchBinary, ZipBinary
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessResult
@@ -42,6 +43,8 @@ class JvmResourcesRequest(ClasspathEntryRequest):
 @rule(desc="Assemble resources")
 async def assemble_resources_jar(
     zip: ZipBinary,
+    bash: BashBinary,
+    touch: TouchBinary,
     request: JvmResourcesRequest,
 ) -> FallibleClasspathEntry:
     # Request the component's direct dependency classpath, and additionally any prerequisite.
@@ -82,13 +85,28 @@ async def assemble_resources_jar(
     input_files = {str(path) for path in chain(paths, directories)}
 
     resources_jar_input_digest = source_files.snapshot.digest
+
+    input_filenames = " ".join(shlex.quote(file) for file in sorted(input_files))
+
     resources_jar_result = await Get(
         ProcessResult,
         Process(
             argv=[
-                zip.path,
-                output_filename,
-                *sorted(input_files),
+                bash.path,
+                "-c",
+                " ".join(
+                    [
+                        touch.path,
+                        "-d 1980-01-01T00:00:00Z",
+                        input_filenames,
+                        "&&",
+                        "TZ=UTC",
+                        zip.path,
+                        "-oX",
+                        output_filename,
+                        input_filenames,
+                    ]
+                ),
             ],
             description="Build resources JAR for {request.component}",
             input_digest=resources_jar_input_digest,

--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -108,7 +108,7 @@ async def assemble_resources_jar(
                     ]
                 ),
             ],
-            description="Build resources JAR for {request.component}",
+            description=f"Build resources JAR for {request.component}",
             input_digest=resources_jar_input_digest,
             output_files=output_files,
             level=LogLevel.DEBUG,

--- a/src/python/pants/jvm/resources_test.py
+++ b/src/python/pants/jvm/resources_test.py
@@ -114,7 +114,7 @@ def test_resources_jar_is_determinstic(rule_runner: RuleRunner) -> None:
             "three/four.txt": "",
             "three/five.txt": "",
             "three/six/seven/eight.txt": "",
-            "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
+            "3rdparty/jvm/default.lock": EMPTY_LOCKFILE,
         }
     )
 


### PR DESCRIPTION
At the moment, java or scala projects won't benefit much from the remote cache because the resources jar local process file will usually win the remote cache read. As zip is non-deterministic, which means that the resources jar file would invalidate any dependents in the graph.

Using reproducible_jars would solve that, but the price would be running the strip jar for all jars.

This PR solves this by changing the dates of all the files in the zip file before archiving.

[ci skip-rust]