### PR TITLE
Upgrade Tokio to v1.21.1

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.4",
  "url",
  "winapi",
 ]
@@ -831,7 +831,7 @@ dependencies = [
  "time 0.3.14",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.4",
  "tryfuture",
  "ui",
  "url",
@@ -1732,36 +1732,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.13"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713d550d9b44d89174e066b7a6217ae06234c10cb47819a88290d2b353c31799"
+checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1856,7 +1834,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio 0.8.3",
+ "mio",
  "walkdir",
  "winapi",
 ]
@@ -2328,7 +2306,7 @@ dependencies = [
  "testutil",
  "tokio",
  "tokio-rustls 0.23.4",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.4",
  "tonic",
  "tryfuture",
  "uname",
@@ -2448,7 +2426,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
- "parking_lot 0.12.1",
+ "parking_lot 0.11.2",
  "pyo3-build-config 0.16.6",
  "pyo3-ffi",
  "pyo3-macros",
@@ -2719,7 +2697,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls 0.23.4",
- "tokio-util 0.7.2",
+ "tokio-util 0.7.4",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -3096,9 +3074,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.1"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -3435,28 +3413,30 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.16.1"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
+checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.13",
+ "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -3508,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
+checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3533,9 +3513,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f988a1a1adc2fb21f9c12aa96441da33a1728193ae0b95d2be22dbd17fcb4e5c"
+checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
 dependencies = [
  "bytes",
  "futures-core",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -149,7 +149,7 @@ task_executor = { path = "task_executor" }
 tempfile = "3"
 testutil_mock = { package = "mock", path = "testutil/mock" }
 time = "0.3"
-tokio = { version = "1.16", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.21", features = ["macros", "rt-multi-thread"] }
 tokio-retry = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
 tryfuture = { path = "tryfuture" }

--- a/src/rust/engine/async_latch/Cargo.toml
+++ b/src/rust/engine/async_latch/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 parking_lot = "0.12"
-tokio = { version = "1.16", features = ["sync"] }
+tokio = { version = "1.21", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.16", features = ["rt", "macros", "time"] }
+tokio = { version = "1.21", features = ["rt", "macros", "time"] }

--- a/src/rust/engine/async_value/Cargo.toml
+++ b/src/rust/engine/async_value/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "1.16", features = ["macros", "sync"] }
+tokio = { version = "1.21", features = ["macros", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.16", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1.21", features = ["macros", "rt", "sync", "time"] }

--- a/src/rust/engine/client/Cargo.toml
+++ b/src/rust/engine/client/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.20.0"
-tokio = { version = "1.16", features = ["rt-multi-thread", "macros", "net", "io-std", "io-util"] }
+tokio = { version = "1.21", features = ["rt-multi-thread", "macros", "net", "io-std", "io-util"] }
 uname = "0.1"
 
 [dev-dependencies]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -30,4 +30,4 @@ workunit_store = { path = "../workunit_store" }
 [dev-dependencies]
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "1.16", features = ["rt", "macros"] }
+tokio = { version = "1.21", features = ["rt", "macros"] }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -21,7 +21,7 @@ parking_lot = "0.12"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.3"
-tokio = { version = "1.16", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.21", features = ["rt-multi-thread", "macros", "signal"] }
 tokio-stream = { version = "0.1", features = ["signal"] }
 workunit_store = { path = "../../workunit_store" }
 

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -22,5 +22,5 @@ serde_json = "1.0"
 serde_derive = "1.0"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
-tokio = { version = "1.16", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
 workunit_store = { path = "../../workunit_store" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -35,7 +35,7 @@ sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3"
 tokio-rustls = "0.23"
-tokio = { version = "1.16", features = ["fs"] }
+tokio = { version = "1.21", features = ["fs"] }
 tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower-service = "0.3"
 tryfuture = { path = "../../tryfuture" }
@@ -47,7 +47,7 @@ criterion = "0.3"
 mock = { path = "../../testutil/mock" }
 num_cpus = "1"
 testutil = { path = "../../testutil" }
-tokio = { version = "1.16", features = ["rt", "macros"] }
+tokio = { version = "1.21", features = ["rt", "macros"] }
 walkdir = "2"
 
 [[bench]]

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -15,9 +15,9 @@ log = "0.4"
 parking_lot = "0.12"
 petgraph = "0.6"
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.16", features = ["time", "parking_lot"] }
+tokio = { version = "1.21", features = ["time", "parking_lot"] }
 
 [dev-dependencies]
 rand = "0.8"
 env_logger = "0.9.0"
-tokio = { version = "1.16", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.21", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -19,7 +19,7 @@ prost = "0.9"
 rand = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
 rustls-pemfile = "0.2"
-tokio = { version = "1.4", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -15,7 +15,7 @@ num_enum = "0.5"
 parking_lot = "0.12"
 regex = "1"
 stdio = { path = "../stdio" }
-tokio = { version = "1.16" }
+tokio = { version = "1.21" }
 uuid = { version = "1.1", features = ["v4"] }
 
 [build-dependencies]

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -13,8 +13,8 @@ log = "0.4"
 nails = "0.13"
 os_pipe = "1.0"
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.16", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }
+tokio = { version = "1.21", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }
 tokio-stream = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.16", features = ["io-std", "macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.21", features = ["io-std", "macros", "net", "rt-multi-thread"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -32,7 +32,7 @@ store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3"
 concrete_time = { path = "../concrete_time" }
-tokio = { version = "1.16", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
 tokio-util = { version = "0.7", features = ["codec"] }
 uname = "0.1.1"
@@ -61,4 +61,4 @@ sharded_lmdb = { path = "../sharded_lmdb" }
 spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "1.16", features = ["macros"] }
+tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -21,5 +21,5 @@ shlex = "1.1.0"
 store = { path = "../fs/store" }
 structopt = "0.3.26"
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.16", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
 workunit_store = { path = "../workunit_store"}

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -16,4 +16,4 @@ tempfile = "3"
 
 [dev-dependencies]
 parking_lot = "0.12"
-tokio = { version = "1.16", features = ["macros"] }
+tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/stdio/Cargo.toml
+++ b/src/rust/engine/stdio/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 log = "0.4"
 parking_lot = "0.12"
-tokio = { version = "1.16", features = ["rt"] }
+tokio = { version = "1.21", features = ["rt"] }

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -10,5 +10,5 @@ arc-swap = "1.5"
 futures = "0.3"
 lazy_static = "1"
 stdio = { path = "../stdio" }
-tokio = { version = "1.16", features = ["rt-multi-thread"] }
+tokio = { version = "1.21", features = ["rt-multi-thread"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -18,5 +18,5 @@ prost = "0.9"
 prost-types = "0.9"
 protos = { path = "../../protos" }
 testutil = { path = ".." }
-tokio = { version = "1.16", features = ["time"] }
+tokio = { version = "1.21", features = ["time"] }
 tonic = { version = "0.6" }

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -19,4 +19,4 @@ task_executor = { path = "../task_executor" }
 [dev-dependencies]
 tempfile = "3"
 testutil = { path = "../testutil" }
-tokio = { version = "1.16", features = ["rt", "macros"] }
+tokio = { version = "1.21", features = ["rt", "macros"] }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -19,9 +19,9 @@ rand = "0.8"
 smallvec = { version = "1", features=["union"] }
 strum = "0.24"
 strum_macros = "0.24"
-tokio = { version = "1.16", features = ["rt", "sync"] }
+tokio = { version = "1.21", features = ["rt", "sync"] }
 
 [dev-dependencies]
 futures = "0.3"
 internment = "0.6"
-tokio = { version = "1.16", features = ["macros"] }
+tokio = { version = "1.21", features = ["macros"] }


### PR DESCRIPTION
Upgrade Tokio to v1.21.1 plus upgrade related Tokio ecosystem crates.

Besides bug fixes, the main motivation to upgrade is to gain access to `tokio::task::JoinSet` for use in https://github.com/pantsbuild/pants/pull/16952.
