### PR TITLE
Introduce `distinct_union_type_per_subclass` for those "special" inner class unions

### DIFF
--- a/src/python/pants/build_graph/build_configuration.py
+++ b/src/python/pants/build_graph/build_configuration.py
@@ -252,10 +252,10 @@ class BuildConfiguration:
                 )
             for target_type in target_types:
                 self._target_type_to_providers[target_type].append(plugin_or_backend)
-                # Access the Target._plugin_field_cls here to ensure the PluginField class is
+                # Access the Target.PluginField here to ensure the PluginField class is
                 # created before the UnionMembership is instantiated, as the class hierarchy is
                 # walked during union membership setup.
-                _ = target_type._plugin_field_cls
+                _ = target_type.PluginField
 
         def register_remote_auth_plugin(self, remote_auth_plugin: Callable) -> None:
             self._remote_auth_plugin = remote_auth_plugin

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -477,7 +477,7 @@ class HelpInfoExtracter:
                     ),
                     get_field_type_provider=lambda field_type: cls.get_provider(
                         build_configuration.union_rule_to_providers.get(
-                            UnionRule(target_type._plugin_field_cls, field_type)
+                            UnionRule(target_type.PluginField, field_type)
                         )
                         if build_configuration is not None
                         else None

--- a/src/python/pants/option/subsystem_test.py
+++ b/src/python/pants/option/subsystem_test.py
@@ -96,7 +96,7 @@ def test_register_plugin_options() -> None:
     )
     Electrical.register_options_on_scope(
         options,
-        UnionMembership({Electrical._plugin_option_cls: [LampPlugin, Blender]}),
+        UnionMembership({Electrical.PluginOption: [LampPlugin, Blender]}),
     )
 
     electrical_subsystem = Electrical(options.for_scope(Electrical.options_scope))


### PR DESCRIPTION
The diff should show the difference in syntax here. The new way not only appeases `mypy` through a one-and-only type definition, but continues to allow for the per-subclass distinct-but-equal semantics.

Note I had to combine the technique with `unions` directly because `@union` stores an attribute pointing to the type itself. When copied this strategy failed. That's OK though because this technique is only useful for unions :smile:  

[ci skip-rust]
[ci skip-build-wheels]