### PR TITLE
[internal] Preprocesses python bootstrap search paths to check for invalid settings

### DIFF
--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -1,9 +1,13 @@
 # Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import os
 from contextlib import contextmanager
 from typing import Iterable, List, Sequence, TypeVar
+
+import pytest
 
 from pants.base.build_environment import get_pants_cachedir
 from pants.core.subsystems.python_bootstrap import (
@@ -12,11 +16,20 @@ from pants.core.subsystems.python_bootstrap import (
     _get_environment_paths,
     _get_pex_python_paths,
     _get_pyenv_paths,
+    _preprocessed_interpreter_search_paths,
     get_pyenv_root,
 )
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.asdf_test import fake_asdf_root, get_asdf_paths
+from pants.core.util_rules.environments import (
+    DockerEnvironmentTarget,
+    DockerImageField,
+    EnvironmentTarget,
+    LocalEnvironmentTarget,
+    RemoteEnvironmentTarget,
+)
+from pants.engine.addresses import Address
 from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -192,3 +205,77 @@ def test_expand_interpreter_search_paths() -> None:
         "/qux",
     )
     assert expected == expanded_paths
+
+
+@pytest.mark.parametrize(
+    ("env_tgt_type", "search_paths", "is_default", "expected"),
+    (
+        (LocalEnvironmentTarget, ("<PYENV>",), False, ("<PYENV>",)),
+        (LocalEnvironmentTarget, ("<ASDF>",), False, ("<ASDF>",)),
+        (
+            LocalEnvironmentTarget,
+            ("<ASDF_LOCAL>", "/home/derryn/pythons"),
+            False,
+            ("<ASDF_LOCAL>", "/home/derryn/pythons"),
+        ),
+        (DockerEnvironmentTarget, ("<PYENV>", "<PATH>"), True, ("<PATH>",)),
+        (DockerEnvironmentTarget, ("<PYENV>", "<PATH>"), False, ValueError),
+        (DockerEnvironmentTarget, ("<PYENV>", "<PATH>"), False, ValueError),
+        (
+            DockerEnvironmentTarget,
+            ("<ASDF>", "/home/derryn/pythons"),
+            False,
+            ValueError,
+        ),  # Contains a banned special-string
+        (DockerEnvironmentTarget, ("<ASDF_LOCAL>",), False, ValueError),
+        (DockerEnvironmentTarget, ("<PYENV_LOCAL>",), False, ValueError),
+        (DockerEnvironmentTarget, ("<PEXRC>",), False, ValueError),
+        (DockerEnvironmentTarget, ("<PATH>",), False, ("<PATH>",)),
+        (
+            DockerEnvironmentTarget,
+            ("<PATH>", "/home/derryn/pythons"),
+            False,
+            ("<PATH>", "/home/derryn/pythons"),
+        ),
+        (RemoteEnvironmentTarget, ("<PYENV>", "<PATH>"), True, ("<PATH>",)),
+        (RemoteEnvironmentTarget, ("<PYENV>", "<PATH>"), False, ValueError),
+        (RemoteEnvironmentTarget, ("<PYENV>", "<PATH>"), False, ValueError),
+        (
+            RemoteEnvironmentTarget,
+            ("<ASDF>", "/home/derryn/pythons"),
+            False,
+            ValueError,
+        ),  # Contains a banned special-string
+        (RemoteEnvironmentTarget, ("<ASDF_LOCAL>",), False, ValueError),
+        (RemoteEnvironmentTarget, ("<PYENV_LOCAL>",), False, ValueError),
+        (RemoteEnvironmentTarget, ("<PEXRC>",), False, ValueError),
+        (RemoteEnvironmentTarget, ("<PATH>",), False, ("<PATH>",)),
+        (
+            RemoteEnvironmentTarget,
+            ("<PATH>", "/home/derryn/pythons"),
+            False,
+            ("<PATH>", "/home/derryn/pythons"),
+        ),
+    ),
+)
+def test_preprocessed_interpreter_search_paths(
+    env_tgt_type: type[LocalEnvironmentTarget]
+    | type[DockerEnvironmentTarget]
+    | type[RemoteEnvironmentTarget],
+    search_paths: Iterable[str],
+    is_default: bool,
+    expected: tuple[str] | type[ValueError],
+):
+
+    extra_kwargs: dict = {}
+    if env_tgt_type is DockerEnvironmentTarget:
+        extra_kwargs = {
+            DockerImageField.alias: "my_img",
+        }
+
+    env_tgt = EnvironmentTarget(env_tgt_type(extra_kwargs, address=Address("flem")))
+    if expected is not ValueError:
+        assert expected == _preprocessed_interpreter_search_paths(env_tgt, search_paths, is_default)
+    else:
+        with pytest.raises(ValueError):
+            _preprocessed_interpreter_search_paths(env_tgt, search_paths, is_default)

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -125,6 +125,7 @@ class Subsystem(metaclass=_SubsystemMeta):
             return default
 
         def _is_default(self, __name: str) -> bool:
+            """Returns true if the value of the named option is unchanged from the default."""
             from pants.core.util_rules.environments import resolve_environment_sensitive_option
 
             v = getattr(type(self), __name)

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -124,6 +124,17 @@ class Subsystem(metaclass=_SubsystemMeta):
             # We should just return the default at this point.
             return default
 
+        def _is_default(self, __name: str) -> bool:
+            from pants.core.util_rules.environments import resolve_environment_sensitive_option
+
+            v = getattr(type(self), __name)
+            assert isinstance(v, OptionsInfo)
+
+            return (
+                self.options.is_default(__name)
+                and resolve_environment_sensitive_option(v.flag_names[0], self) is None
+            )
+
     @memoized_classmethod
     def rules(cls: Any) -> Iterable[Rule]:
         from pants.core.util_rules.environments import add_option_fields_for


### PR DESCRIPTION
Per discussion in #16800, we're OK with using direct filesystem access to support pyenv support (and separately, asdf support) for local runtime environments only. This adds a preprocessing function that supports:

* no-opping for local/undefined environments
* handling the case where the search paths are unaltered from the default, by stripping out unsupported search paths
* raising an exception with fixing instructions if unsupported search paths are requested for remote/docker environments

n.b. `PythonBootstrap` is still incorrectly cached for pyenv users, and that will be addressed in one (hopefully) final PR.