### PR TITLE
Simplify Pants's internal use of local environments

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -9,17 +9,6 @@ files(name="files", sources=["BUILD_ROOT", "pants.toml"])
 
 python_test_utils(name="test_utils")
 
-_local_environment(
-    name="default_env",
-)
-
-_local_environment(
-    name="macos_local_env",
-    compatible_platforms=["macos_arm64", "macos_x86_64"],
-    # Avoid system Python interpreters, which tend to be broken on macOS.
-    python_bootstrap_search_path=["<PYENV>"],
-)
-
 # Used for experimenting with the new Docker support.
 _docker_environment(
     name="docker_env",

--- a/pants.toml
+++ b/pants.toml
@@ -97,10 +97,7 @@ root_patterns = [
 ]
 
 [environments-preview.names]
-default_env = "//:default_env"
-# TODO(#7735): Define `//:macos_local_env` after figuring out why our Build Wheels Mac job is
-#  failing when this is set:
-#  https://github.com/pantsbuild/pants/runs/8082954359?check_suite_focus=true#step:9:657
+# We don't define any local environments because the options system covers our cases adequately.
 docker = "//:docker_env"
 
 [tailor]


### PR DESCRIPTION
There's no need for us to set up local environments, now that local environments are only to _override_ values from the subsystems. (Before, we were going to deprecate the subsystems.)

We may in the future want to add a macos_arm64 environment. That is safe for us to do without adding other local environments thanks to https://github.com/pantsbuild/pants/pull/16983.

See https://github.com/pantsbuild/pants/pull/17043 for an alternative way we could be leveraging environments locally.

[ci skip-rust]