### PR TITLE
Add venv_site_packages_copies option to pex

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -24,6 +24,7 @@ from pants.backend.python.target_types import (
     PexScriptField,
     PexShebangField,
     PexStripEnvField,
+    PexVenvSitePackagesCopies,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
@@ -72,6 +73,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     include_requirements: PexIncludeRequirementsField
     include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
+    venv_site_packages_copies: PexVenvSitePackagesCopies
 
     @property
     def _execution_mode(self) -> PexExecutionMode:
@@ -95,6 +97,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.extend(("--venv", "prepend"))
         if self.include_tools.value is True:
             args.append("--include-tools")
+        if self.venv_site_packages_copies.value is True:
+            args.append("--venv-site-packages-copies")
         return tuple(args)
 
 

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -104,16 +104,13 @@ def test_entry_point(
 
 @pytest.mark.parametrize("execution_mode", [None, PexExecutionMode.VENV])
 @pytest.mark.parametrize("include_tools", [True, False])
-@pytest.mark.parametrize("venv_site_packages_copies", [True, False])
 def test_execution_mode_and_include_tools(
     execution_mode: Optional[PexExecutionMode],
     include_tools: bool,
-    venv_site_packages_copies: bool,
 ):
     run = run_generic_test(
         execution_mode=execution_mode,
         include_tools=include_tools,
-        venv_site_packages_copies=venv_site_packages_copies,
     )
 
     if include_tools:

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -18,6 +18,7 @@ def run_generic_test(
     execution_mode: Optional[PexExecutionMode] = None,
     include_tools: bool = False,
     layout: Optional[PexLayout] = None,
+    venv_site_packages_copies: bool = False,
 ) -> Callable[..., PantsResult]:
     sources = {
         "src_root1/project/app.py": dedent(
@@ -44,6 +45,7 @@ def run_generic_test(
               execution_mode={execution_mode.value if execution_mode is not None else None!r},
               include_tools={include_tools!r},
               layout={layout.value if layout is not None else None!r},
+              venv_site_packages_copies={venv_site_packages_copies!r},
             )
             """
         ),
@@ -102,13 +104,16 @@ def test_entry_point(
 
 @pytest.mark.parametrize("execution_mode", [None, PexExecutionMode.VENV])
 @pytest.mark.parametrize("include_tools", [True, False])
+@pytest.mark.parametrize("venv_site_packages_copies", [True, False])
 def test_execution_mode_and_include_tools(
     execution_mode: Optional[PexExecutionMode],
     include_tools: bool,
+    venv_site_packages_copies: bool,
 ):
     run = run_generic_test(
         execution_mode=execution_mode,
         include_tools=include_tools,
+        venv_site_packages_copies=venv_site_packages_copies,
     )
 
     if include_tools:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -612,6 +612,18 @@ class PexIncludeToolsField(BoolField):
     )
 
 
+class PexVenvSitePackagesCopies(BoolField):
+    alias = "venv_site_packages_copies"
+    default = False
+    help = softwrap(
+        """
+        If execution_mode is venv, populate the venv site packages using hard links or copies of resolved PEX dependencies instead of symlinks.
+
+        This can be used to work around problems with tools or libraries that are confused by symlinked source files.
+        """
+    )
+
+
 _PEX_BINARY_COMMON_FIELDS = (
     InterpreterConstraintsField,
     PythonResolveField,
@@ -629,6 +641,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexIncludeRequirementsField,
     PexIncludeSourcesField,
     PexIncludeToolsField,
+    PexVenvSitePackagesCopies,
     RestartableField,
 )
 


### PR DESCRIPTION
Turned out this option is necessary to run targets with packages depending on Qt, matplotlib etc.

Addresses https://github.com/pantsbuild/pants/issues/14559