### PR TITLE
Add `--docker-execution` option

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -528,7 +528,7 @@ async def resolve_environment_name(
                     `{DockerPlatformField.alias}` to `{localhost_platform}`. Alternatively, consider
                     not explicitly setting the field `{DockerPlatformField.alias}` for the target
                     {env_tgt.val.address} because the default behavior is to use the CPU architecture
-                    of the current host for the platform (although this requires the docker image
+                    of the current host for the platform (although this requires that the docker image
                     supports that CPU architecture).
                     """
                 ),

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1701,6 +1701,22 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         advanced=True,
     )
 
+    docker_execution = BoolOption(
+        default=True,
+        advanced=True,
+        help=softwrap(
+            """
+            If true, `docker_environment` targets can be used to run builds inside a Docker
+            container.
+
+            If false, anytime a `docker_environment` target is used, Pants will instead fallback to
+            whatever the target's `fallback_environment` field is set to.
+
+            This can be useful, for example, if you want to always use Docker locally, but disable
+            it in CI, or vice versa.
+            """
+        ),
+    )
     remote_execution_extra_platform_properties = StrListOption(
         advanced=True,
         help=softwrap(


### PR DESCRIPTION
This gives more flexibility to likely user stories, such as wanting to use Docker in CI but not locally, or vice versa.

Before, the sole way to turn off Docker was on Linux that you used a different platform for the Docker image than the local host. That condition is not possible on macOS, so there was no way to disable Docker there.

[ci skip-rust]
[ci skip-build-wheels]