### PR TITLE
Make interpreter path expansion cache-correct

### DIFF
--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -10,10 +10,11 @@ from typing import Iterable
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.core.util_rules.environments import EnvironmentTarget
+from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule, rule_helper
+from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -77,10 +78,47 @@ async def _environment_paths() -> list[str]:
     return []
 
 
+def _error_if_not_compatible_with_asdf(
+    env_tgt: EnvironmentTarget,
+    _search_paths: Iterable[str],
+) -> None:
+    """Raises an exception if any special search path strings any are invalid for the environment.
+
+    If the environment is non-local and there are invalid tokens for those environments, raise
+    `ValueError`.
+    """
+
+    env = env_tgt.val
+
+    if env is None or isinstance(env, LocalEnvironmentTarget):
+        return
+
+    not_allowed = {"<ASDF>", "<ASDF_LOCAL>"}
+
+    any_not_allowed = set(_search_paths) & not_allowed
+    if any_not_allowed:
+        env_type = type(env)
+        raise ValueError(
+            softwrap(
+                f"`[python-bootstrap].search_paths` is configured to use local Go discovery "
+                f"tools, which do not work in {env_type.__name__} runtime environments. To fix "
+                f"this, set the value of `golang_go_search_paths` in the `{env.alias}` "
+                f"defined at `{env.address}` to contain only hardcoded paths or the `<PATH>` "
+                "special string."
+            )
+        )
+
+    return
+
+
 @rule
 async def resolve_go_bootstrap(
     golang_subsystem: GolangSubsystem, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> GoBootstrap:
+
+    _error_if_not_compatible_with_asdf(
+        golang_env_aware.env_tgt, golang_env_aware.raw_go_search_paths
+    )
     paths = await _go_search_paths(
         golang_env_aware.env_tgt, golang_subsystem, golang_env_aware.raw_go_search_paths
     )

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -197,9 +197,10 @@ def _contains_asdf_path_tokens(interpreter_search_paths: Iterable[str]) -> tuple
 
 @_uncacheable_rule
 async def _get_pyenv_paths(request: _PyEnvPathsRequest) -> _SearchPaths:
-    """Returns a list of paths to Python interpreters managed by pyenv.
+    """Returns a tuple of paths to Python interpreters managed by pyenv.
 
-    :param env: The environment to use to look up pyenv.
+    :param `request.env_tgt`: The environment target -- if not referring to a local/no environment,
+                                this will return an empty path.
     :param bool pyenv_local: If True, only use the interpreter specified by
                                 '.python-version' file under `build_root`.
     """
@@ -210,7 +211,7 @@ async def _get_pyenv_paths(request: _PyEnvPathsRequest) -> _SearchPaths:
     pyenv_local = request.pyenv_local
     env = await Get(EnvironmentVars, EnvironmentVarsRequest(("PYENV_ROOT", "HOME")))
 
-    pyenv_root = get_pyenv_root(env)
+    pyenv_root = _get_pyenv_root(env)
     if not pyenv_root:
         return _SearchPaths(())
 
@@ -245,7 +246,7 @@ async def _get_pyenv_paths(request: _PyEnvPathsRequest) -> _SearchPaths:
     return _SearchPaths(tuple(paths))
 
 
-def get_pyenv_root(env: EnvironmentVars) -> str | None:
+def _get_pyenv_root(env: EnvironmentVars) -> str | None:
     """See https://github.com/pyenv/pyenv#environment-variables."""
     from_env = env.get("PYENV_ROOT")
     if from_env:

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -127,6 +127,7 @@ async def _expand_interpreter_search_paths(
         asdf_paths = await Get(
             AsdfToolPathsResult,
             AsdfToolPathsRequest(
+                env_tgt=env_tgt,
                 tool_name="python",
                 tool_description="Python interpreters",
                 resolve_standard=has_asdf_standard_path_token,

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -12,13 +12,15 @@ import pytest
 from pants.base.build_environment import get_pants_cachedir
 from pants.core.subsystems.python_bootstrap import (
     PythonBootstrap,
-    _expand_interpreter_search_paths,
+    _ExpandInterpreterSearchPathsRequest,
     _get_environment_paths,
     _get_pex_python_paths,
-    _get_pyenv_paths,
     _preprocessed_interpreter_search_paths,
+    _PyEnvPathsRequest,
+    _SearchPaths,
     get_pyenv_root,
 )
+from pants.core.subsystems.python_bootstrap import rules as python_bootstrap_rules
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.core.util_rules.asdf_test import fake_asdf_root, get_asdf_paths
@@ -37,6 +39,20 @@ from pants.util.contextutil import environment_as, temporary_dir
 from pants.util.dirutil import safe_mkdir_for
 
 _T = TypeVar("_T")
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *python_bootstrap_rules(),
+            *asdf.rules(),
+            QueryRule(AsdfToolPathsResult, (AsdfToolPathsRequest,)),
+            QueryRule(_SearchPaths, [_PyEnvPathsRequest]),
+            QueryRule(_SearchPaths, [_ExpandInterpreterSearchPathsRequest]),
+        ],
+        target_types=[],
+    )
 
 
 @contextmanager
@@ -67,10 +83,12 @@ def setup_pexrc_with_pex_python_path(interpreter_paths):
 @contextmanager
 def fake_pyenv_root(fake_versions, fake_local_version):
     with temporary_dir() as pyenv_root:
-        fake_version_dirs = [os.path.join(pyenv_root, "versions", v, "bin") for v in fake_versions]
+        fake_version_dirs = tuple(
+            os.path.join(pyenv_root, "versions", v, "bin") for v in fake_versions
+        )
         for d in fake_version_dirs:
             os.makedirs(d)
-        fake_local_version_dirs = [os.path.join(pyenv_root, "versions", fake_local_version, "bin")]
+        fake_local_version_dirs = (os.path.join(pyenv_root, "versions", fake_local_version, "bin"),)
         yield pyenv_root, fake_version_dirs, fake_local_version_dirs
 
 
@@ -99,36 +117,35 @@ def test_get_pyenv_root() -> None:
     assert get_pyenv_root(EnvironmentVars({})) is None
 
 
-def test_get_pyenv_paths() -> None:
+def test_get_pyenv_paths(rule_runner: RuleRunner) -> None:
     local_pyenv_version = "3.5.5"
     all_pyenv_versions = ["2.7.14", local_pyenv_version]
-    RuleRunner().write_files({".python-version": f"{local_pyenv_version}\n"})
+    rule_runner.write_files({".python-version": f"{local_pyenv_version}\n"})
     with fake_pyenv_root(all_pyenv_versions, local_pyenv_version) as (
         pyenv_root,
         expected_paths,
         expected_local_paths,
     ):
-        paths = _get_pyenv_paths(EnvironmentVars({"PYENV_ROOT": pyenv_root}))
-        local_paths = _get_pyenv_paths(
-            EnvironmentVars({"PYENV_ROOT": pyenv_root}), pyenv_local=True
+        tgt = LocalEnvironmentTarget({}, Address("flem"))
+        paths = rule_runner.request(
+            _SearchPaths,
+            [_PyEnvPathsRequest(tgt, EnvironmentVars({"PYENV_ROOT": pyenv_root}), False)],
         )
-    assert expected_paths == paths
-    assert expected_local_paths == local_paths
+        local_paths = rule_runner.request(
+            _SearchPaths,
+            [_PyEnvPathsRequest(tgt, EnvironmentVars({"PYENV_ROOT": pyenv_root}), True)],
+        )
+    assert expected_paths == paths.paths
+    assert expected_local_paths == local_paths.paths
 
 
-def test_expand_interpreter_search_paths() -> None:
+def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
     local_pyenv_version = "3.5.5"
     all_python_versions = ["2.7.14", local_pyenv_version, "3.7.10", "3.9.4", "3.9.5"]
     asdf_home_versions = [0, 1, 2]
     asdf_local_versions = [2, 1, 4]
     asdf_local_versions_str = " ".join(
         materialize_indices(all_python_versions, asdf_local_versions)
-    )
-    rule_runner = RuleRunner(
-        rules=[
-            *asdf.rules(),
-            QueryRule(AsdfToolPathsResult, (AsdfToolPathsRequest,)),
-        ]
     )
     rule_runner.write_files(
         {
@@ -159,7 +176,7 @@ def test_expand_interpreter_search_paths() -> None:
             expected_pyenv_paths,
             expected_pyenv_local_paths,
         ):
-            paths = [
+            paths = (
                 "/foo",
                 "<PATH>",
                 "/bar",
@@ -170,7 +187,7 @@ def test_expand_interpreter_search_paths() -> None:
                 "<PYENV>",
                 "<PYENV_LOCAL>",
                 "/qux",
-            ]
+            )
             asdf_paths_result = get_asdf_paths(
                 rule_runner,
                 {
@@ -183,11 +200,17 @@ def test_expand_interpreter_search_paths() -> None:
                 local=True,
                 extra_env_var_names=PythonBootstrap.EXTRA_ENV_VAR_NAMES,
             )
-            expanded_paths = _expand_interpreter_search_paths(
-                paths,
-                env=asdf_paths_result.env,
-                asdf_standard_tool_paths=asdf_paths_result.standard_tool_paths,
-                asdf_local_tool_paths=asdf_paths_result.local_tool_paths,
+            expanded_paths = rule_runner.request(
+                _SearchPaths,
+                [
+                    _ExpandInterpreterSearchPathsRequest(
+                        paths,
+                        EnvironmentTarget(LocalEnvironmentTarget({}, Address("flem"))),
+                        env=asdf_paths_result.env,
+                        asdf_standard_tool_paths=asdf_paths_result.standard_tool_paths,
+                        asdf_local_tool_paths=asdf_paths_result.local_tool_paths,
+                    )
+                ],
             )
 
     expected = (
@@ -204,7 +227,7 @@ def test_expand_interpreter_search_paths() -> None:
         *expected_pyenv_local_paths,
         "/qux",
     )
-    assert expected == expanded_paths
+    assert expected == expanded_paths.paths
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -15,10 +15,10 @@ from pants.core.subsystems.python_bootstrap import (
     _ExpandInterpreterSearchPathsRequest,
     _get_environment_paths,
     _get_pex_python_paths,
+    _get_pyenv_root,
     _preprocessed_interpreter_search_paths,
     _PyEnvPathsRequest,
     _SearchPaths,
-    get_pyenv_root,
 )
 from pants.core.subsystems.python_bootstrap import rules as python_bootstrap_rules
 from pants.core.util_rules import asdf
@@ -112,9 +112,9 @@ def test_get_pyenv_root() -> None:
     default_root = f"{home}/.pyenv"
     explicit_root = f"{home}/explicit"
 
-    assert explicit_root == get_pyenv_root(EnvironmentVars({"PYENV_ROOT": explicit_root}))
-    assert default_root == get_pyenv_root(EnvironmentVars({"HOME": home}))
-    assert get_pyenv_root(EnvironmentVars({})) is None
+    assert explicit_root == _get_pyenv_root(EnvironmentVars({"PYENV_ROOT": explicit_root}))
+    assert default_root == _get_pyenv_root(EnvironmentVars({"HOME": home}))
+    assert _get_pyenv_root(EnvironmentVars({})) is None
 
 
 def test_get_pyenv_paths(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -24,7 +24,6 @@ class AsdfToolPathsRequest:
     tool_description: str
     resolve_standard: bool
     resolve_local: bool
-    extra_env_var_names: tuple[str, ...]
     paths_option_name: str
     bin_relpath: str = "bin"
 
@@ -32,7 +31,6 @@ class AsdfToolPathsRequest:
 @dataclass(frozen=True)
 class AsdfToolPathsResult:
     tool_name: str
-    env: EnvironmentVars
     standard_tool_paths: tuple[str, ...] = ()
     local_tool_paths: tuple[str, ...] = ()
 
@@ -193,7 +191,6 @@ async def resolve_asdf_tool_paths(
         "ASDF_DATA_DIR",
         tool_env_name,
         "HOME",
-        *request.extra_env_var_names,
     ]
     env = await Get(EnvironmentVars, EnvironmentVarsRequest(env_vars_to_request))
 
@@ -223,7 +220,6 @@ async def resolve_asdf_tool_paths(
 
     return AsdfToolPathsResult(
         tool_name=request.tool_name,
-        env=env,
         standard_tool_paths=standard_tool_paths,
         local_tool_paths=local_tool_paths,
     )

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -83,7 +83,6 @@ def get_asdf_paths(
     *,
     standard: bool,
     local: bool,
-    extra_env_var_names: Iterable[str] = (),
 ) -> AsdfToolPathsResult:
     rule_runner.set_session_values(
         {
@@ -98,7 +97,6 @@ def get_asdf_paths(
                 tool_description="<test>",
                 resolve_standard=standard,
                 resolve_local=local,
-                extra_env_var_names=tuple(extra_env_var_names),
                 paths_option_name="<test>",
             )
         ],

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -6,8 +6,18 @@ from contextlib import contextmanager
 from pathlib import Path, PurePath
 from typing import Iterable, Mapping, Sequence, TypeVar
 
+import pytest
+
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult, get_asdf_data_dir
+from pants.core.util_rules.environments import (
+    DockerEnvironmentTarget,
+    DockerImageField,
+    EnvironmentTarget,
+    LocalEnvironmentTarget,
+    RemoteEnvironmentTarget,
+)
+from pants.engine.addresses import Address
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
@@ -79,6 +89,7 @@ def test_get_asdf_dir() -> None:
 
 def get_asdf_paths(
     rule_runner: RuleRunner,
+    env_tgt: EnvironmentTarget,
     env: Mapping[str, str],
     *,
     standard: bool,
@@ -93,6 +104,7 @@ def get_asdf_paths(
         AsdfToolPathsResult,
         [
             AsdfToolPathsRequest(
+                env_tgt=env_tgt,
                 tool_name="python",
                 tool_description="<test>",
                 resolve_standard=standard,
@@ -103,7 +115,22 @@ def get_asdf_paths(
     )
 
 
-def test_get_asdf_paths() -> None:
+@pytest.mark.parametrize(
+    ("env_tgt_type", "should_have_values"),
+    (
+        (LocalEnvironmentTarget, True),
+        (None, True),
+        (DockerEnvironmentTarget, False),
+        (RemoteEnvironmentTarget, False),
+    ),
+)
+def test_get_asdf_paths(
+    env_tgt_type: type[LocalEnvironmentTarget]
+    | type[DockerEnvironmentTarget]
+    | type[RemoteEnvironmentTarget]
+    | None,
+    should_have_values: bool,
+) -> None:
     # 3.9.4 is intentionally "left out" so that it's only found if the "all installs" fallback is
     # used
     all_python_versions = ["2.7.14", "3.5.5", "3.7.10", "3.9.4", "3.9.5"]
@@ -140,21 +167,41 @@ def test_get_asdf_paths() -> None:
         expected_asdf_home_paths,
         expected_asdf_local_paths,
     ):
+
+        extra_kwargs: dict = {}
+        if env_tgt_type is DockerEnvironmentTarget:
+            extra_kwargs = {
+                DockerImageField.alias: "my_img",
+            }
+        env_tgt = EnvironmentTarget(
+            env_tgt_type(extra_kwargs, Address("flem")) if env_tgt_type is not None else None
+        )
+
         # Check the "all installed" fallback
         result = get_asdf_paths(
-            rule_runner, {"ASDF_DATA_DIR": asdf_dir}, standard=True, local=False
+            rule_runner, env_tgt, {"ASDF_DATA_DIR": asdf_dir}, standard=True, local=False
         )
         all_paths = result.standard_tool_paths
 
         result = get_asdf_paths(
-            rule_runner, {"HOME": home_dir, "ASDF_DATA_DIR": asdf_dir}, standard=True, local=True
+            rule_runner,
+            env_tgt,
+            {"HOME": home_dir, "ASDF_DATA_DIR": asdf_dir},
+            standard=True,
+            local=True,
         )
         home_paths = result.standard_tool_paths
         local_paths = result.local_tool_paths
 
-        # The order the filesystem returns the "installed" folders is arbitrary
-        assert set(expected_asdf_paths) == set(all_paths)
+        if should_have_values:
+            # The order the filesystem returns the "installed" folders is arbitrary
+            assert set(expected_asdf_paths) == set(all_paths)
 
-        # These have a fixed order defined by the `.tool-versions` file
-        assert expected_asdf_home_paths == home_paths
-        assert expected_asdf_local_paths == local_paths
+            # These have a fixed order defined by the `.tool-versions` file
+            assert expected_asdf_home_paths == home_paths
+            assert expected_asdf_local_paths == local_paths
+        else:
+            # asdf bails quickly on non-local environments
+            assert () == all_paths
+            assert () == home_paths
+            assert () == local_paths


### PR DESCRIPTION
Following discussion with @stuhood, it emerged that none of the filesystem-sensitive code in `python_bootstrap` is cache-correct, in that the functions that hit the filesystem were not marked `uncacheable`.

This PR refactors `_expand_interpreter_search_paths` and `_get_pyenv_paths` into rules, marking `_get_pyenv_paths` as uncacheable. This reduces the footprint of the sandbox-unsafe code to just `_get_pyenv_paths`.

It also reduces the scope of `AsdfToolPathsRequest`, and moves the point where it is requested to inside the path expansion rule, and only if `asdf` is actually requested.

Closes #16800.