### PR TITLE
Add python 3.10 to acceptable GCF runtimes (Cherry-pick of #17028)

### DIFF
--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -196,6 +196,7 @@ class PythonGoogleCloudFunctionRuntimes(Enum):
     PYTHON_37 = "python37"
     PYTHON_38 = "python38"
     PYTHON_39 = "python39"
+    PYTHON_310 = "python310"
 
 
 class PythonGoogleCloudFunctionRuntime(StringField):


### PR DESCRIPTION
Based on https://cloud.google.com/functions/docs/concepts/python-runtime, currently `pants` does not allow you to pick python 3.10. This PR adds that runtime as one of the enums so it doesn't fail anymore.

I have tested this change against another repository that creates a GCF and `pants` was able to successfully generate the .zip file. I also pushed that file to Google Cloud and it worked as expected - tested it by using a `match case` statement. 
