### PR TITLE
resources jar is reproducible by default, no need to strip (Cherry-pick of #17036)

### DIFF
--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -28,7 +28,6 @@ from pants.jvm.compile import (
     FallibleClasspathEntries,
     FallibleClasspathEntry,
 )
-from pants.jvm.strip_jar.strip_jar import StripJarRequest
 from pants.jvm.subsystems import JvmSubsystem
 from pants.util.logging import LogLevel
 
@@ -119,8 +118,6 @@ async def assemble_resources_jar(
     )
 
     output_digest = resources_jar_result.output_digest
-    if jvm.reproducible_jars:
-        output_digest = await Get(Digest, StripJarRequest(output_digest, tuple(output_files)))
     cpe = ClasspathEntry(output_digest, output_files, [])
 
     merged_cpe_digest = await Get(


### PR DESCRIPTION
I tested this both in the CI and locally and it seems the zip operation now yields consistent result and doesn't need the strip jar anymore.
