### PR TITLE
Make GolangSubsystem environment-aware

### DIFF
--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -313,7 +313,7 @@ async def _cc(
     flags: Iterable[str],
     obj_file: str,
     description: str,
-    golang_subsystem: GolangSubsystem,
+    golang_env_aware: GolangSubsystem.EnvironmentAware,
 ) -> Process:
     compiler_path = await Get(
         BinaryPath,
@@ -328,7 +328,7 @@ async def _cc(
         Get(SetupCompilerCmdResult, SetupCompilerCmdRequest((compiler_path.path,), work_dir)),
         Get(
             EnvironmentVars,
-            EnvironmentVarsRequest(golang_subsystem.env_vars_to_pass_to_subprocesses),
+            EnvironmentVarsRequest(golang_env_aware.env_vars_to_pass_to_subprocesses),
         ),
         Get(Digest, MergeDigests([input_digest, wrapper_script.digest])),
     )
@@ -361,7 +361,6 @@ async def _gccld(
     flags: Iterable[str],
     objs: Iterable[str],
     description: str,
-    golang_subsystem: GolangSubsystem,
 ) -> FallibleProcessResult:
     compiler_path = await Get(
         BinaryPath,
@@ -420,18 +419,18 @@ async def _dynimport(
     pkg_name: str,
     goroot: GoRoot,
     import_go_path: str,
-    golang_subsystem: GolangSubsystem,
+    golang_env_aware: GolangSubsystem.EnvironmentAware,
     use_cxx_linker: bool,
 ) -> _DynImportResult:
     cgo_main_compile_process = await _cc(
-        binary_name=golang_subsystem.cgo_gcc_binary_name,
+        binary_name=golang_env_aware.cgo_gcc_binary_name,
         input_digest=input_digest,
         work_dir=obj_dir_path,
         src_file=os.path.join(obj_dir_path, "_cgo_main.c"),
         flags=cflags,
         obj_file=os.path.join(obj_dir_path, "_cgo_main.o"),
         description="Compile _cgo_main.c",
-        golang_subsystem=golang_subsystem,
+        golang_env_aware=golang_env_aware,
     )
     cgo_main_compile_result = await Get(ProcessResult, Process, cgo_main_compile_process)
     obj_digest = await Get(
@@ -454,9 +453,9 @@ async def _dynimport(
             ldflags = [arg for arg in ldflags if arg != "-static"]
 
     linker_binary_name = (
-        golang_subsystem.cgo_gxx_binary_name
+        golang_env_aware.cgo_gxx_binary_name
         if use_cxx_linker
-        else golang_subsystem.cgo_gcc_binary_name
+        else golang_env_aware.cgo_gcc_binary_name
     )
 
     cgo_binary_link_result = await _gccld(
@@ -467,7 +466,6 @@ async def _dynimport(
         flags=ldflags,
         objs=[*obj_files, os.path.join(obj_dir_path, "_cgo_main.o")],
         description="Link _cgo_.o",
-        golang_subsystem=golang_subsystem,
     )
     if cgo_binary_link_result.exit_code != 0:
         # From `go` source:
@@ -509,7 +507,6 @@ async def _dynimport(
             flags=[*ldflags, allow_unresolved_symbols_ldflag],
             objs=obj_files,
             description="Link _cgo_.o",
-            golang_subsystem=golang_subsystem,
         )
         if cgo_binary_link_result.exit_code != 0:
             raise ValueError(
@@ -623,7 +620,7 @@ def _replace_srcdir_in_flags(flags: Iterable[str], dir_path: str) -> tuple[str, 
 
 @rule
 async def cgo_compile_request(
-    request: CGoCompileRequest, goroot: GoRoot, golang_subsystem: GolangSubsystem
+    request: CGoCompileRequest, goroot: GoRoot, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> CGoCompileResult:
     dir_path = request.dir_path if request.dir_path else "."
     obj_dir_path = f"{dir_path}/__obj__" if dir_path else "__obj__"
@@ -636,10 +633,10 @@ async def cgo_compile_request(
     # directives.
     flags = dataclasses.replace(
         flags,
-        cflags=golang_subsystem.cgo_c_flags + flags.cflags,
-        cxxflags=golang_subsystem.cgo_cxx_flags + flags.cxxflags,
-        fflags=golang_subsystem.cgo_fortran_flags + flags.fflags,
-        ldflags=golang_subsystem.cgo_linker_flags + flags.ldflags,
+        cflags=golang_env_aware.cgo_c_flags + flags.cflags,
+        cxxflags=golang_env_aware.cgo_cxx_flags + flags.cxxflags,
+        fflags=golang_env_aware.cgo_fortran_flags + flags.fflags,
+        ldflags=golang_env_aware.cgo_linker_flags + flags.ldflags,
     )
 
     # Resolve pkg-config flags into compiler and linker flags.
@@ -667,7 +664,7 @@ async def cgo_compile_request(
     # Likewise for Fortran, except there are many Fortran compilers.
     # Support gfortran out of the box and let others pass the correct link options
     # via CGO_LDFLAGS
-    if request.fortran_files and "gfortran" in golang_subsystem.cgo_fortran_binary_name:
+    if request.fortran_files and "gfortran" in golang_env_aware.cgo_fortran_binary_name:
         flags = dataclasses.replace(flags, ldflags=flags.ldflags + ("-lgfortran",))
 
     # TODO(#16838): Add MSan (memory sanitizer) option.
@@ -761,14 +758,14 @@ async def cgo_compile_request(
         out_obj_files.append(ofile)
 
         compile_process = await _cc(
-            binary_name=golang_subsystem.cgo_gcc_binary_name,
+            binary_name=golang_env_aware.cgo_gcc_binary_name,
             input_digest=cgo_result.output_digest,
             work_dir=obj_dir_path,
             src_file=gcc_file,
             flags=cflags,
             obj_file=ofile,
             description=f"Compile cgo source: {gcc_file}",
-            golang_subsystem=golang_subsystem,
+            golang_env_aware=golang_env_aware,
         )
         compile_process_gets.append(Get(ProcessResult, Process, compile_process))
 
@@ -780,14 +777,14 @@ async def cgo_compile_request(
         out_obj_files.append(ofile)
 
         compile_process = await _cc(
-            binary_name=golang_subsystem.cgo_gxx_binary_name,
+            binary_name=golang_env_aware.cgo_gxx_binary_name,
             input_digest=cgo_result.output_digest,
             work_dir=obj_dir_path,
             src_file=cxx_file,
             flags=cxxflags,
             obj_file=ofile,
             description=f"Compile cgo C++ source: {cxx_file}",
-            golang_subsystem=golang_subsystem,
+            golang_env_aware=golang_env_aware,
         )
         compile_process_gets.append(Get(ProcessResult, Process, compile_process))
 
@@ -798,14 +795,14 @@ async def cgo_compile_request(
         out_obj_files.append(ofile)
 
         compile_process = await _cc(
-            binary_name=golang_subsystem.cgo_gcc_binary_name,
+            binary_name=golang_env_aware.cgo_gcc_binary_name,
             input_digest=cgo_result.output_digest,
             work_dir=obj_dir_path,
             src_file=objc_file,
             flags=cflags,
             obj_file=ofile,
             description=f"Compile cgo Objective-C source: {objc_file}",
-            golang_subsystem=golang_subsystem,
+            golang_env_aware=golang_env_aware,
         )
         compile_process_gets.append(Get(ProcessResult, Process, compile_process))
 
@@ -818,14 +815,14 @@ async def cgo_compile_request(
         out_obj_files.append(ofile)
 
         compile_process = await _cc(
-            binary_name=golang_subsystem.cgo_fortran_binary_name,
+            binary_name=golang_env_aware.cgo_fortran_binary_name,
             input_digest=cgo_result.output_digest,
             work_dir=obj_dir_path,
             src_file=fortran_file,
             flags=fflags,
             obj_file=ofile,
             description=f"Compile cgo Fortran source: {fortran_file}",
-            golang_subsystem=golang_subsystem,
+            golang_env_aware=golang_env_aware,
         )
         compile_process_gets.append(Get(ProcessResult, Process, compile_process))
 
@@ -856,7 +853,7 @@ async def cgo_compile_request(
         pkg_name=request.pkg_name,
         goroot=goroot,
         import_go_path=os.path.join(obj_dir_path, "_cgo_import.go"),
-        golang_subsystem=golang_subsystem,
+        golang_env_aware=golang_env_aware,
         use_cxx_linker=bool(request.cxx_files),
     )
     if dynimport_result.dyn_out_go:

--- a/src/python/pants/backend/go/util_rules/cgo_binaries.py
+++ b/src/python/pants/backend/go/util_rules/cgo_binaries.py
@@ -12,7 +12,6 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathTest,
 )
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 
@@ -28,12 +27,11 @@ class CGoBinaryPathRequest(EngineAwareParameter):
 
 @rule
 async def find_cgo_binary_path(
-    request: CGoBinaryPathRequest, golang_subsystem: GolangSubsystem
+    request: CGoBinaryPathRequest, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> BinaryPath:
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
     path_request = BinaryPathRequest(
         binary_name=request.binary_name,
-        search_path=golang_subsystem.cgo_tool_search_paths(env),
+        search_path=golang_env_aware.cgo_tool_search_paths,
         test=request.binary_path_test,
     )
     paths = await Get(BinaryPaths, BinaryPathRequest, path_request)

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -5,74 +5,84 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from typing import Iterable
 
 from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import collect_rules, rule, rule_helper
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class GoBootstrap:
-    raw_go_search_paths: tuple[str, ...]
-    asdf_standard_tool_paths: tuple[str, ...]
-    asdf_local_tool_paths: tuple[str, ...]
-    _path: str | None
+    go_search_paths: tuple[str, ...]
 
-    @property
-    def go_search_paths(self) -> tuple[str, ...]:
-        special_strings = {
-            "<PATH>": lambda: self.environment_paths,
-            "<ASDF>": lambda: self.asdf_standard_tool_paths,
-            "<ASDF_LOCAL>": lambda: self.asdf_local_tool_paths,
-        }
-        expanded: list[str] = []
-        for s in self.raw_go_search_paths:
-            if s in special_strings:
-                special_paths = special_strings[s]()
-                expanded.extend(special_paths)
-            else:
-                expanded.append(s)
-        return tuple(expanded)
 
-    @property
-    def environment_paths(self) -> list[str]:
-        """Returns a list of paths specified by the PATH env var."""
-        if self._path:
-            return self._path.split(os.pathsep)
-        return []
+@rule_helper
+async def _go_search_paths(
+    golang_subsystem: GolangSubsystem, paths: Iterable[str]
+) -> tuple[str, ...]:
+
+    resolve_standard, resolve_local = "<ASDF>" in paths, "<ASDF_LOCAL>" in paths
+
+    if resolve_standard or resolve_local:
+        # AsdfToolPathsResult is uncacheable, so only request it if absolutely necessary.
+        asdf_result = await Get(
+            AsdfToolPathsResult,
+            AsdfToolPathsRequest(
+                tool_name=golang_subsystem.asdf_tool_name,
+                tool_description="Go distribution",
+                resolve_standard=resolve_standard,
+                resolve_local=resolve_local,
+                paths_option_name="[golang].go_search_paths",
+                extra_env_var_names=(),
+                bin_relpath=golang_subsystem.asdf_bin_relpath,
+            ),
+        )
+        asdf_standard_tool_paths = asdf_result.standard_tool_paths
+        asdf_local_tool_paths = asdf_result.local_tool_paths
+    else:
+        asdf_standard_tool_paths = ()
+        asdf_local_tool_paths = ()
+
+    special_strings = {
+        "<ASDF>": lambda: asdf_standard_tool_paths,
+        "<ASDF_LOCAL>": lambda: asdf_local_tool_paths,
+    }
+
+    expanded: list[str] = []
+    for s in paths:
+        if s == "<PATH>":
+            expanded.extend(await _environment_paths())
+        elif s in special_strings:
+            special_paths = special_strings[s]()
+            expanded.extend(special_paths)
+        else:
+            expanded.append(s)
+    return tuple(expanded)
+
+
+@rule_helper
+async def _environment_paths() -> list[str]:
+    """Returns a list of paths specified by the PATH env var."""
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(("PATH",)))
+    path = env.get("PATH")
+    if path:
+        return path.split(os.pathsep)
+    return []
 
 
 @rule
 async def resolve_go_bootstrap(
     golang_subsystem: GolangSubsystem, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> GoBootstrap:
-    raw_go_search_paths = golang_env_aware.raw_go_search_paths
-    result = await Get(
-        AsdfToolPathsResult,
-        AsdfToolPathsRequest(
-            tool_name=golang_subsystem.asdf_tool_name,
-            tool_description="Go distribution",
-            resolve_standard="<ASDF>" in raw_go_search_paths,
-            resolve_local="<ASDF_LOCAL>" in raw_go_search_paths,
-            paths_option_name="[golang].go_search_paths",
-            extra_env_var_names=(),
-            bin_relpath=golang_subsystem.asdf_bin_relpath,
-        ),
-    )
+    paths = await _go_search_paths(golang_subsystem, golang_env_aware.raw_go_search_paths)
 
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(("PATH",)))
-
-    return GoBootstrap(
-        raw_go_search_paths=raw_go_search_paths,
-        asdf_standard_tool_paths=result.standard_tool_paths,
-        asdf_local_tool_paths=result.local_tool_paths,
-        _path=env.get("PATH", None),
-    )
+    return GoBootstrap(go_search_paths=paths)
 
 
 def compatible_go_version(*, compiler_version: str, target_version: str) -> bool:

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -104,14 +104,14 @@ async def setup_go_sdk_process(
     request: GoSdkProcess,
     go_sdk_run: GoSdkRunSetup,
     bash: BashBinary,
-    golang_subsystem: GolangSubsystem,
+    golang_env_aware: GolangSubsystem.EnvironmentAware,
     goroot: GoRoot,
 ) -> Process:
     input_digest, env_vars = await MultiGet(
         Get(Digest, MergeDigests([go_sdk_run.digest, request.input_digest])),
         Get(
             EnvironmentVars,
-            EnvironmentVarsRequest(golang_subsystem.env_vars_to_pass_to_subprocesses),
+            EnvironmentVarsRequest(golang_env_aware.env_vars_to_pass_to_subprocesses),
         ),
     )
     maybe_replace_sandbox_root_env = (


### PR DESCRIPTION
This moves the path-specific options for `GolangSubsystem` into an `EnvironmentAware` block, and factors `cgo_tool_search_paths` into a property based on the new `depends_on_env_vars` functionality.

Further, the `GoBootstrap` code is refactored to pre-compute the go search paths, saving a request to the uncacheable `asdf` rules if they are not necessary.

Still todo -- erroring if `asdf` is used in a non-local environment.

Unblocks work on #16800 