### PR TITLE
Auto-apply reviewers to cherrypicks.

### DIFF
--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -37,8 +37,16 @@ fi
 COMMIT=$(gh pr view "$PR_NUM" --json mergeCommit --jq '.mergeCommit.oid')
 TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
 CATEGORY_LABEL=$(gh pr view "$PR_NUM" --json labels --jq '.labels.[] | select(.name|test("category:.")).name')
+if [[ -z $CATEGORY_LABEL ]]; then
+  # This happens occasionally, e.g., when cherrypicking the same PR to different branches.
+  # Unclear why, but this may help ferret it out.
+  echo "Couldn't detect category label on PR. What's the label? (E.g., category:bugfix)"
+  read -r CATEGORY_LABEL
+fi
+REVIEWERS=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews.[].author.login' | sort | uniq)
 BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.$MILESTONE.XXXXXX")
 PR_CREATE_CMD=(gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --body-file "$BODY_FILE")
+while IFS= read -r REVIEWER; do PR_CREATE_CMD+=(--reviewer "$REVIEWER"); done <<< "$REVIEWERS"
 BRANCH_NAME="cherry-pick-$PR_NUM-to-$MILESTONE"
 
 if [[ -z $COMMIT ]]; then


### PR DESCRIPTION
Finds the reviewers of the source PR and applies them to the cherrypick. Means one less manual step when cherrypicking.

Also checks that a category label was successfully detected. I've noticed that occasionally one is not, which then causes CI to fail. This check will allow us to get to the bottom of that.