### PR TITLE
Add warning about dependency inference + `extra_type_stubs`.

### DIFF
--- a/docs/markdown/Python/python-goals/python-check-goal.md
+++ b/docs/markdown/Python/python-goals/python-check-goal.md
@@ -186,6 +186,30 @@ MY_SETTING = URLPattern(pattern="foo", callback=lambda: None)
 python_source(name="django_settings", source="django_settings.py")
 ```
 
+> 🚧 Importing from `extra_type_stubs`
+>
+> Requirements specified in `[mypy].extra_type_stubs` are not visible to the `python-infer` subsystem, and cannot be referenced as explicit `dependencies`. If you `import` from a stubs module in your code you may see a warning/error depending on the value you've configured for `[python-infer].unowned_dependency_behavior` - goals other than `check` will also raise `ImportError`s if the `import` isn't conditional on the value of `typing.TYPE_CHECKING`:
+>
+> ```toml pants.toml
+> [python-infer]
+> unowned_dependency_behavior = "warning"
+>
+> [mypy]
+> extra_type_stubs = ["mypy-boto3-ec2==1.20.49"]
+> ```
+> ```python src/example.py
+> from typing import TYPE_CHECKING
+>
+> # Unsafe! Will fail outside of `check`
+> from mypy_boto3_ec2 import EC2Client
+>
+> if TYPE_CHECKING:
+>     # Safe, but will be flagged as a warning
+>     from mypy_boto3_ec2 import EC2ServiceResource
+> ```
+>
+> For these reasons, it's recommended to load any type-stub libraries that require explicit imports as part of your normal [third-party dependencies](doc:python-third-party-dependencies).
+
 > 📘 MyPy Protobuf support
 >
 > Add `mypy_plugin = true` to the `[python-protobuf]` scope. See [Protobuf](doc:protobuf-python) for more information.


### PR DESCRIPTION
Closes #16882

[ci skip-rust]

[ci skip-build-wheels]