### PR TITLE
go: work around issue with options called --env-vars

### DIFF
--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -44,6 +44,7 @@ from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, goal_rule, rule, rule_helper
 from pants.engine.target import Targets
 from pants.option.option_types import StrListOption
+from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
 # Adapted from Go toolchain.
@@ -73,8 +74,9 @@ class GoGenerateGoalSubsystem(GoalSubsystem):
         """
     )
 
-    class EnvironmentAware:
-        env_vars = StrListOption(
+    class EnvironmentAware(Subsystem.EnvironmentAware):
+        # TODO(#17077): Rename this back to just `env_vars`.
+        generate_env_vars = StrListOption(
             default=["LANG", "LC_CTYPE", "LC_ALL", "PATH"],
             help=softwrap(
                 """
@@ -289,7 +291,7 @@ async def run_go_package_generators(
             FallibleFirstPartyPkgAnalysis,
             FirstPartyPkgAnalysisRequest(request.address, extra_build_tags=("generate",)),
         ),
-        Get(EnvironmentVars, EnvironmentVarsRequest(subsystem.env_vars)),
+        Get(EnvironmentVars, EnvironmentVarsRequest(subsystem.generate_env_vars)),
     )
     if not fallible_analysis.analysis:
         raise ValueError(f"Analysis failure for {request.address}: {fallible_analysis.stderr}")


### PR DESCRIPTION
As explained in https://github.com/pantsbuild/pants/issues/17077, `Subsystem.EnvironmentAware` defines a field called env_vars which prevents defining an option called `--env-vars`. Work around the issue for now by renaming the option.

[ci skip-build-wheels]