### PR TITLE
Improve usability of the `--engine-visualize-to` option

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -439,6 +439,7 @@ class SchedulerSession:
             # TODO: This increment-and-get is racey.
             name = f"graph.{self._scheduler._visualize_run_count:03d}.dot"
             self._scheduler._visualize_run_count += 1
+            logger.info(f"Visualizing graph as {name}")
             self.visualize_graph_to_file(os.path.join(self._scheduler.visualize_to_dir, name))
 
     def teardown_dynamic_ui(self) -> None:

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -838,7 +838,14 @@ impl<N: Node> Entry<N> {
 
   pub(crate) fn format(&self, context: &N::Context) -> String {
     let state = match self.peek(context) {
-      Some(ref nr) => format!("{:?}", nr),
+      Some(ref nr) => {
+        let item = format!("{:?}", nr);
+        if item.len() <= 1024 {
+          item
+        } else {
+          item.chars().take(1024).collect()
+        }
+      }
       None => "<None>".to_string(),
     };
     format!("{} == {}", self.node, state).replace('"', "\\\"")

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -46,13 +46,14 @@ use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use futures::future;
 use log::info;
 use parking_lot::Mutex;
+use petgraph::dot;
 use petgraph::graph::DiGraph;
 use petgraph::visit::{EdgeRef, VisitMap, Visitable};
 use petgraph::Direction;
 use task_executor::Executor;
 use tokio::time::sleep;
 
-pub use crate::node::{EntryId, Node, NodeContext, NodeError, NodeVisualizer, Stats};
+pub use crate::node::{EntryId, Node, NodeContext, NodeError, Stats};
 
 type PGraph<N> = DiGraph<Entry<N>, (), u32>;
 
@@ -306,53 +307,38 @@ impl<N: Node> InnerGraph<N> {
     invalidation_result
   }
 
-  fn visualize<V: NodeVisualizer<N>>(
-    &self,
-    mut visualizer: V,
-    roots: &[N],
-    path: &Path,
-    context: &N::Context,
-  ) -> io::Result<()> {
+  fn visualize(&self, roots: &[N], path: &Path, context: &N::Context) -> io::Result<()> {
     let file = File::create(path)?;
     let mut f = BufWriter::new(file);
 
-    f.write_all(b"digraph plans {\n")?;
-    f.write_fmt(format_args!(
-      "  node[colorscheme={}];\n",
-      visualizer.color_scheme()
-    ))?;
-    f.write_all(b"  concentrate=true;\n")?;
-    f.write_all(b"  rankdir=TB;\n")?;
-
-    let mut format_color = |entry: &Entry<N>| visualizer.color(entry, context);
-
-    let root_entries = roots
+    let root_ids = roots
       .iter()
-      .filter_map(|n| self.entry_id(n))
+      .filter_map(|node| self.entry_id(node))
       .cloned()
       .collect();
+    let included = self
+      .walk(root_ids, Direction::Outgoing, |_| false)
+      .collect::<HashSet<_>>();
 
-    for eid in self.walk(root_entries, Direction::Outgoing, |_| false) {
-      let entry = self.unsafe_entry_for_id(eid);
-      let node_str = entry.format(context);
+    let graph = self.pg.filter_map(
+      |node_id, node| {
+        if included.contains(&node_id) {
+          Some(node.format(context))
+        } else {
+          None
+        }
+      },
+      |_, _| Some("".to_owned()),
+    );
 
-      // Write the node header.
-      f.write_fmt(format_args!(
-        "  \"{}\" [style=filled, fillcolor={}];\n",
-        node_str,
-        format_color(entry)
-      ))?;
+    f.write_all(
+      format!(
+        "{}",
+        dot::Dot::with_config(&graph, &[dot::Config::EdgeNoLabel],)
+      )
+      .as_bytes(),
+    )?;
 
-      for dep_id in self.pg.neighbors(eid) {
-        let dep_entry = self.unsafe_entry_for_id(dep_id);
-
-        // Write an entry per edge.
-        let dep_str = dep_entry.format(context);
-        f.write_fmt(format_args!("    \"{}\" -> \"{}\"\n", node_str, dep_str))?;
-      }
-    }
-
-    f.write_all(b"}\n")?;
     Ok(())
   }
 
@@ -752,15 +738,9 @@ impl<N: Node> Graph<N> {
     inner.invalidate_from_roots(log_dirtied, predicate)
   }
 
-  pub fn visualize<V: NodeVisualizer<N>>(
-    &self,
-    visualizer: V,
-    roots: &[N],
-    path: &Path,
-    context: &N::Context,
-  ) -> io::Result<()> {
+  pub fn visualize(&self, roots: &[N], path: &Path, context: &N::Context) -> io::Result<()> {
     let inner = self.inner.lock();
-    inner.visualize(visualizer, roots, path, context)
+    inner.visualize(roots, path, context)
   }
 
   pub fn visit_live_reachable(

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 
 use petgraph::stable_graph;
 
-use crate::entry::Entry;
 use crate::Graph;
 
 // 2^32 Nodes ought to be more than enough for anyone!
@@ -67,21 +66,6 @@ pub trait NodeError: Clone + Debug + Eq + Send + Sync {
   /// Graph (generally while running).
   ///
   fn invalidated() -> Self;
-}
-
-///
-/// A trait used to visualize Nodes in either DOT/GraphViz format.
-///
-pub trait NodeVisualizer<N: Node> {
-  ///
-  /// Returns a GraphViz color scheme name for this visualizer.
-  ///
-  fn color_scheme(&self) -> &str;
-
-  ///
-  /// Returns a GraphViz color name/id within Self::color_scheme for the given Entry.
-  ///
-  fn color(&mut self, entry: &Entry<N>, context: &N::Context) -> String;
 }
 
 ///

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1,7 +1,7 @@
 // Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::fmt::Display;
@@ -37,7 +37,7 @@ use process_execution::{
 
 use crate::externs::engine_aware::{EngineAwareParameter, EngineAwareReturnType};
 use crate::externs::fs::PyFileDigest;
-use graph::{Entry, Node, NodeError, NodeVisualizer};
+use graph::{Node, NodeError};
 use hashing::Digest;
 use rule_graph::{DependencyKey, Query};
 use store::{self, Store, StoreError, StoreFileByDigest};
@@ -1221,32 +1221,6 @@ impl From<Task> for NodeKey {
   }
 }
 
-#[derive(Default)]
-pub struct Visualizer {
-  viz_colors: HashMap<String, String>,
-}
-
-impl NodeVisualizer<NodeKey> for Visualizer {
-  fn color_scheme(&self) -> &str {
-    "set312"
-  }
-
-  fn color(&mut self, entry: &Entry<NodeKey>, context: &<NodeKey as Node>::Context) -> String {
-    let max_colors = 12;
-    match entry.peek(context) {
-      None => "white".to_string(),
-      Some(_) => {
-        let viz_colors_len = self.viz_colors.len();
-        self
-          .viz_colors
-          .entry(entry.node().product_str())
-          .or_insert_with(|| format!("{}", viz_colors_len % max_colors + 1))
-          .clone()
-      }
-    }
-  }
-}
-
 ///
 /// There is large variance in the sizes of the members of this enum, so a few of them are boxed.
 ///
@@ -1266,22 +1240,6 @@ pub enum NodeKey {
 }
 
 impl NodeKey {
-  fn product_str(&self) -> String {
-    match self {
-      &NodeKey::ExecuteProcess(..) => "ProcessResult".to_string(),
-      &NodeKey::DownloadedFile(..) => "DownloadedFile".to_string(),
-      &NodeKey::Select(ref s) => format!("{}", s.product),
-      &NodeKey::SessionValues(_) => "SessionValues".to_string(),
-      &NodeKey::RunId(_) => "RunId".to_string(),
-      &NodeKey::Task(ref t) => format!("{}", t.task.product),
-      &NodeKey::Snapshot(..) => "Snapshot".to_string(),
-      &NodeKey::Paths(..) => "Paths".to_string(),
-      &NodeKey::DigestFile(..) => "DigestFile".to_string(),
-      &NodeKey::ReadLink(..) => "LinkDest".to_string(),
-      &NodeKey::Scandir(..) => "DirectoryListing".to_string(),
-    }
-  }
-
   pub fn fs_subject(&self) -> Option<&Path> {
     match self {
       &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -14,7 +14,7 @@ use log::debug;
 use tokio::time;
 
 use crate::context::{Context, Core};
-use crate::nodes::{NodeKey, Select, Visualizer};
+use crate::nodes::{NodeKey, Select};
 use crate::python::{Failure, Params, TypeId, Value};
 use crate::session::{ObservedValueResult, Root, Session};
 
@@ -71,12 +71,10 @@ impl Scheduler {
 
   pub fn visualize(&self, session: &Session, path: &Path) -> io::Result<()> {
     let context = Context::new(self.core.clone(), session.clone());
-    self.core.graph.visualize(
-      Visualizer::default(),
-      &session.roots_nodes(),
-      path,
-      &context,
-    )
+    self
+      .core
+      .graph
+      .visualize(&session.roots_nodes(), path, &context)
   }
 
   pub fn add_root_select(


### PR DESCRIPTION
`--engine-visualize-to` would frequently render very (very) long node ids, which would break graphviz rendering (which has line and/or label length limits). This change truncates very long names for readability, and switches to using `petgraph`'s native support for rendering `dot`, which uses node indexes as node ids and instead applies node labels. It also simplifies the implementation by removing node coloring for now.

Additionally, it wasn't always obvious when each of the dot graphs which are rendered during a run had been created. An `INFO` level message is now logged each time a graph is rendered, which helps correlate which graphs are relevant at points in time.

[ci skip-build-wheels]