### PR TITLE
go: refactor tailor rule into rule helpers

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -147,10 +147,12 @@ class GoModTarget(TargetGenerator):
 
 
 class GoPackageSourcesField(MultipleSourcesField):
-    default = ("*.go", "*.s")
+    default = ("*.go",)
     expected_file_extensions = (
         ".go",
         ".s",
+        ".S",
+        ".sx"
         ".c",
         ".h",
         ".hh",

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -152,7 +152,7 @@ class GoPackageSourcesField(MultipleSourcesField):
         ".go",
         ".s",
         ".S",
-        ".sx"
+        ".sx",
         ".c",
         ".h",
         ".hh",

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -113,7 +113,7 @@ def test_build_package_with_assembly(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 go_mod(name="mod")
-                go_package(name="pkg")
+                go_package(name="pkg", sources=["*.go", "*.s"])
                 go_binary(name="bin")
                 """
             ),


### PR DESCRIPTION
Refactor the tailor rule for Go into several rule helpers.

[ci skip-build-wheels]

[ci skip-rust]