### PR TITLE
Add missing skip options to subsystems/rules

### DIFF
--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -38,7 +38,11 @@ class HelmLintRequest(LintTargetsRequest):
 @rule
 async def partition_helm_lint(
     request: HelmLintRequest.PartitionRequest[HelmLintFieldSet],
+    helm: HelmSubsystem,
 ) -> Partitions[HelmLintFieldSet]:
+    if helm.skip:
+        return Partitions()
+
     field_sets = tuple(
         field_set for field_set in request.field_sets if not field_set.skip_lint.value
     )

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -14,6 +14,7 @@ from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
     DictOption,
+    SkipOption,
     StrListOption,
     StrOption,
 )
@@ -132,6 +133,7 @@ class HelmSubsystem(TemplatedExternalTool):
         advanced=True,
     )
 
+    skip = SkipOption("lint")
     args = ArgsListOption(
         example="--dry-run",
         passthrough=True,

--- a/src/python/pants/backend/java/goals/check.py
+++ b/src/python/pants/backend/java/goals/check.py
@@ -32,7 +32,11 @@ class JavacCheckRequest(CheckRequest):
 async def javac_check(
     request: JavacCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
+    javac_subsystem: JavacSubsystem,
 ) -> CheckResults:
+    if javac_subsystem.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/java/subsystems/javac.py
+++ b/src/python/pants/backend/java/subsystems/javac.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 
-from pants.option.option_types import ArgsListOption, BoolOption
+from pants.option.option_types import ArgsListOption, BoolOption, SkipOption
 from pants.option.subsystem import Subsystem
 
 logger = logging.getLogger(__name__)
@@ -16,6 +16,7 @@ class JavacSubsystem(Subsystem):
     name = "javac"
     help = "The javac Java source compiler."
 
+    skip = SkipOption("check")
     args = ArgsListOption(example="-g -deprecation")
 
     tailor_source_targets = BoolOption(

--- a/src/python/pants/backend/kotlin/goals/check.py
+++ b/src/python/pants/backend/kotlin/goals/check.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 
+from pants.backend.kotlin.subsystems.kotlinc import KotlincSubsystem
 from pants.backend.kotlin.target_types import KotlinFieldSet
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.addresses import Addresses
@@ -31,7 +32,11 @@ class KotlincCheckRequest(CheckRequest):
 async def kotlinc_check(
     request: KotlincCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
+    kotlinc: KotlincSubsystem,
 ) -> CheckResults:
+    if kotlinc.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/kotlin/subsystems/kotlinc.py
+++ b/src/python/pants/backend/kotlin/subsystems/kotlinc.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from pants.option.option_types import ArgsListOption, DictOption
+from pants.option.option_types import ArgsListOption, DictOption, SkipOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -12,6 +12,7 @@ class KotlincSubsystem(Subsystem):
     name = "kotlinc"
     help = "The Kotlin programming language (https://kotlinlang.org/)."
 
+    skip = SkipOption("check")
     args = ArgsListOption(
         example="-Werror",
         extra_help="See https://kotlinlang.org/docs/compiler-reference.html for supported arguments.",

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -13,7 +13,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.core.goals.lint import LintFilesRequest, LintResult, Partitions
 from pants.engine.fs import DigestContents, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
-from pants.option.option_types import DictOption, EnumOption
+from pants.option.option_types import DictOption, EnumOption, SkipOption
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -72,6 +72,7 @@ class ValidationConfig:
 
 class RegexLintSubsystem(Subsystem):
     options_scope = "regex-lint"
+    name = "regex-lint"
     help = softwrap(
         """
         Lint your code using regex patterns, e.g. to check for copyright headers.
@@ -82,6 +83,7 @@ class RegexLintSubsystem(Subsystem):
         """
     )
 
+    skip = SkipOption("lint")
     _config = DictOption[Any](
         help=softwrap(
             """
@@ -261,6 +263,9 @@ class RegexLintRequest(LintFilesRequest):
 async def partition_inputs(
     request: RegexLintRequest.PartitionRequest, regex_lint_subsystem: RegexLintSubsystem
 ) -> Partitions[str]:
+    if regex_lint_subsystem.skip:
+        return Partitions()
+
     multi_matcher = regex_lint_subsystem.get_multi_matcher()
     if multi_matcher is None:
         return Partitions()

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -375,7 +375,6 @@ async def mypy_determine_partitions(
     )
 
 
-# TODO(#10864): Improve performance, e.g. by leveraging the MyPy cache.
 @rule(desc="Typecheck using MyPy", level=LogLevel.DEBUG)
 async def mypy_typecheck(request: MyPyRequest, mypy: MyPy) -> CheckResults:
     if mypy.skip:

--- a/src/python/pants/backend/scala/goals/check.py
+++ b/src/python/pants/backend/scala/goals/check.py
@@ -32,7 +32,11 @@ class ScalacCheckRequest(CheckRequest):
 async def scalac_check(
     request: ScalacCheckRequest,
     classpath_entry_request: ClasspathEntryRequestFactory,
+    scalac: Scalac,
 ) -> CheckResults:
+    if scalac.skip:
+        return CheckResults([], checker_name=request.name)
+
     coarsened_targets = await Get(
         CoarsenedTargets, Addresses(field_set.address for field_set in request.field_sets)
     )

--- a/src/python/pants/backend/scala/subsystems/scalac.py
+++ b/src/python/pants/backend/scala/subsystems/scalac.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pants.option.option_types import ArgsListOption, DictOption
+from pants.option.option_types import ArgsListOption, DictOption, SkipOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -21,6 +21,7 @@ class Scalac(Subsystem):
         "scalac_plugins.default.lockfile.txt",
     )
 
+    skip = SkipOption("check")
     args = ArgsListOption(example="-encoding UTF-8")
 
     # TODO: see if we can use an actual list mechanism? If not, this seems like an OK option


### PR DESCRIPTION
I believe the `test` goal should also follow suit, but for now only modifying `fmt`/`lint`/`check` subsystems/rules.

[ci skip-rust]
[ci skip-build-wheels]