### PR TITLE
go: add cgo support for tailor

### DIFF
--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -45,7 +45,7 @@ def has_package_main(content: bytes) -> bool:
     return _package_main_re.search(content) is not None
 
 
-def has_go_mod_ancestor(dirname: str, all_go_mod_dirs: set[str]) -> bool:
+def has_go_mod_ancestor(dirname: str, all_go_mod_dirs: frozenset[str]) -> bool:
     """We shouldn't add package targets if there is no `go.mod`, as it will cause an error."""
     return any(dirname.startswith(go_mod_dir) for go_mod_dir in all_go_mod_dirs)
 
@@ -100,44 +100,77 @@ async def _find_cgo_sources(
     return [*wildcard_globs, *sorted(files_to_add)], sorted(triggering_files)
 
 
+@dataclass(frozen=True)
+class FindPutativeGoPackageTargetRequest:
+    dir_path: str
+    files: tuple[str, ...]
+    all_go_mod_dirs: frozenset[str]
+
+
+@dataclass(frozen=True)
+class FindPutativeGoPackageTargetResult:
+    putative_target: PutativeTarget | None
+
+
+@rule
+async def find_putative_go_package_target(
+    request: FindPutativeGoPackageTargetRequest,
+    all_owned_sources: AllOwnedSources,
+) -> FindPutativeGoPackageTargetResult:
+    # Ignore paths that have `testdata` or `vendor` in them.
+    # From `go help packages`: Note, however, that a directory named vendor that itself
+    # contains code is not a vendored package: cmd/vendor would be a command named vendor.
+    dirname_parts = PurePath(request.dir_path).parts
+    if "testdata" in dirname_parts or "vendor" in dirname_parts[0:-1]:
+        return FindPutativeGoPackageTargetResult(None)
+    if not has_go_mod_ancestor(request.dir_path, request.all_go_mod_dirs):
+        return FindPutativeGoPackageTargetResult(None)
+
+    cgo_sources, triggering_cgo_files = await _find_cgo_sources(request.dir_path, all_owned_sources)
+    kwargs = {}
+    if cgo_sources:
+        kwargs = {"sources": ("*.go", *cgo_sources)}
+
+    return FindPutativeGoPackageTargetResult(
+        PutativeTarget.for_target_type(
+            GoPackageTarget,
+            path=request.dir_path,
+            name=None,
+            kwargs=kwargs,
+            triggering_sources=[*request.files, *triggering_cgo_files],
+        )
+    )
+
+
 @rule_helper
 async def _find_go_package_targets(
-    request: PutativeGoTargetsRequest, all_go_mod_dirs: set[str], all_owned_sources: AllOwnedSources
+    request: PutativeGoTargetsRequest,
+    all_go_mod_dirs: frozenset[str],
+    all_owned_sources: AllOwnedSources,
 ) -> list[PutativeTarget]:
-    putative_targets = []
     all_go_files = await Get(Paths, PathGlobs, request.path_globs("*.go"))
     unowned_go_files = set(all_go_files.files) - set(all_owned_sources)
-    for dirname, filenames in group_by_dir(unowned_go_files).items():
-        # Ignore paths that have `testdata` or `vendor` in them.
-        # From `go help packages`: Note, however, that a directory named vendor that itself
-        # contains code is not a vendored package: cmd/vendor would be a command named vendor.
-        dirname_parts = PurePath(dirname).parts
-        if "testdata" in dirname_parts or "vendor" in dirname_parts[0:-1]:
-            continue
-        if not has_go_mod_ancestor(dirname, all_go_mod_dirs):
-            continue
-
-        cgo_sources, triggering_cgo_files = await _find_cgo_sources(dirname, all_owned_sources)
-        kwargs = {}
-        if cgo_sources:
-            kwargs = {"sources": ("*.go", *cgo_sources)}
-
-        putative_targets.append(
-            PutativeTarget.for_target_type(
-                GoPackageTarget,
-                path=dirname,
-                name=None,
-                kwargs=kwargs,
-                triggering_sources=[*filenames, *triggering_cgo_files],
-            )
+    candidate_putative_targets = await MultiGet(
+        Get(
+            FindPutativeGoPackageTargetResult,
+            FindPutativeGoPackageTargetRequest(
+                dir_path=dirname,
+                files=tuple(filenames),
+                all_go_mod_dirs=all_go_mod_dirs,
+            ),
         )
-
-    return putative_targets
+        for dirname, filenames in group_by_dir(unowned_go_files).items()
+    )
+    return [
+        ptgt.putative_target
+        for ptgt in candidate_putative_targets
+        if ptgt.putative_target is not None
+    ]
 
 
 @rule_helper
 async def _find_go_binary_targets(
-    request: PutativeGoTargetsRequest, all_go_mod_dirs: set[str]
+    request: PutativeGoTargetsRequest, all_go_mod_dirs: frozenset[str]
 ) -> list[PutativeTarget]:
     all_go_files_digest_contents = await Get(DigestContents, PathGlobs, request.path_globs("*.go"))
 
@@ -185,7 +218,7 @@ async def find_putative_go_targets(
     putative_targets = []
     _all_go_mod_paths = await Get(Paths, PathGlobs, request.path_globs("go.mod"))
     all_go_mod_files = set(_all_go_mod_paths.files)
-    all_go_mod_dirs = {os.path.dirname(fp) for fp in all_go_mod_files}
+    all_go_mod_dirs = frozenset(os.path.dirname(fp) for fp in all_go_mod_files)
 
     if golang_subsystem.tailor_go_mod_targets:
         putative_targets.extend(await _find_go_mod_targets(all_go_mod_files, all_owned_sources))

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -137,7 +137,7 @@ async def find_putative_go_package_target(
             path=request.dir_path,
             name=None,
             kwargs=kwargs,
-            triggering_sources=[*request.files, *triggering_cgo_files],
+            triggering_sources=[*sorted(request.files), *triggering_cgo_files],
         )
     )
 

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -24,6 +24,7 @@ from pants.backend.go.util_rules import (
     third_party_pkg,
 )
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.core.goals.tailor import rules as core_tailor_rules
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -33,6 +34,7 @@ def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
             *go_tailor_rules(),
+            *core_tailor_rules(),
             *go_mod.rules(),
             *first_party_pkg.rules(),
             *third_party_pkg.rules(),
@@ -226,8 +228,8 @@ def test_has_package_main() -> None:
 
 
 def test_has_go_mod_ancestor() -> None:
-    assert has_go_mod_ancestor("dir/subdir", {"dir/subdir"}) is True
-    assert has_go_mod_ancestor("dir/subdir", {"dir/subdir/child"}) is False
-    assert has_go_mod_ancestor("dir/subdir", {"dir/another"}) is False
-    assert has_go_mod_ancestor("dir/subdir", {""}) is True
-    assert has_go_mod_ancestor("dir/subdir", {"another", "dir/another", "dir"}) is True
+    assert has_go_mod_ancestor("dir/subdir", frozenset({"dir/subdir"})) is True
+    assert has_go_mod_ancestor("dir/subdir", frozenset({"dir/subdir/child"})) is False
+    assert has_go_mod_ancestor("dir/subdir", frozenset({"dir/another"})) is False
+    assert has_go_mod_ancestor("dir/subdir", frozenset({""})) is True
+    assert has_go_mod_ancestor("dir/subdir", frozenset({"another", "dir/another", "dir"})) is True

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -136,6 +136,9 @@ def test_cgo_sources(rule_runner: RuleRunner) -> None:
             "foo/another.c": "",
             "foo/native.h": "",
             "foo/assembly.s": "",
+            "c_only/native.c": "",
+            "c_only/assembly.s": "",
+            "c_only/header.h": "",
         }
     )
     putative_targets = rule_runner.request(

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -117,6 +117,37 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_cgo_sources(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/go.mod": "",
+            "foo/main.go": "",
+            "foo/native.c": "",
+            "foo/another.c": "",
+            "foo/native.h": "",
+            "foo/assembly.s": "",
+        }
+    )
+    putative_targets = rule_runner.request(
+        PutativeTargets,
+        [
+            PutativeGoTargetsRequest(("foo",)),
+            AllOwnedSources(["foo/go.mod"]),
+        ],
+    )
+    assert putative_targets == PutativeTargets(
+        [
+            PutativeTarget.for_target_type(
+                GoPackageTarget,
+                path="foo",
+                name=None,
+                kwargs={"sources": ("*.go", "*.c", "*.s", "*.h")},
+                triggering_sources=["main.go", "another.c", "assembly.s", "native.c", "native.h"],
+            ),
+        ]
+    )
+
+
 def test_find_go_binary_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -105,7 +105,7 @@ def test_find_go_package_targets(rule_runner: RuleRunner) -> None:
                 GoPackageTarget,
                 path="unowned",
                 name=None,
-                triggering_sources=["f.go", "f1.go"],
+                triggering_sources=["f1.go", "f.go"],
             ),
             PutativeTarget.for_target_type(
                 GoPackageTarget,


### PR DESCRIPTION
Support detecting cgo-related files and adding them to `go_package` targets when running `./pants tailor`.