### PR TITLE
Support declaring atom file targets in BUILD files.

### DIFF
--- a/src/python/pants/build_graph/address.py
+++ b/src/python/pants/build_graph/address.py
@@ -473,7 +473,9 @@ class Address(EngineAwareParameter):
 
     @property
     def atom_file_target_name(self) -> str | None:
-        return f"{self._relative_file_path}:{self.target_name}"
+        if self.is_file_target:
+            return f"{self._relative_file_path}:{self.target_name}"
+        return None
 
     @property
     def parameters_repr(self) -> str:

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -201,6 +201,7 @@ async def resolve_target_parametrizations(
     unmatched_build_file_globs: UnmatchedBuildFileGlobs,
 ) -> _TargetParametrizations:
     address = request.address
+
     target_adaptor, target_type = await _determine_target_adaptor_and_type(
         address, registered_target_types, description_of_origin=request.description_of_origin
     )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -201,7 +201,6 @@ async def resolve_target_parametrizations(
     unmatched_build_file_globs: UnmatchedBuildFileGlobs,
 ) -> _TargetParametrizations:
     address = request.address
-
     target_adaptor, target_type = await _determine_target_adaptor_and_type(
         address, registered_target_types, description_of_origin=request.description_of_origin
     )

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -145,6 +145,26 @@ def test_address_family_create_multiple() -> None:
     } == dict(address_family.addresses_to_target_adaptors.items())
 
 
+def test_address_family_create_file_target() -> None:
+    address_family = AddressFamily.create(
+        "name/space",
+        [
+            AddressMap(
+                "name/space/0",
+                {
+                    "demo.py:lib": TargetAdaptor(type_alias="thing", name="demo.py:lib"),
+                },
+            )
+        ],
+    )
+    assert "name/space" == address_family.namespace
+    assert {
+        Address("name/space", target_name="lib", relative_file_path="demo.py"): TargetAdaptor(
+            type_alias="thing", name="demo.py:lib"
+        ),
+    } == dict(address_family.addresses_to_target_adaptors.items())
+
+
 def test_address_family_create_empty() -> None:
     # Case where directory exists but is empty.
     address_family = AddressFamily.create("name/space", [])


### PR DESCRIPTION
Fixes #14419

The use case for declaring file targets at the atomic level becomes increasingly valuable with the introduction of synthetic targets (#16998) in order to preserve the current way of addressing file level targets.

I get a feeling that this PR opens a can of worms however, so I'm not sure if this is the best approach to tackle this, but from my limited explorations it seems to do what I want it to. That is, I can declare a single `python_source()` target and have it show up the same as if it was generated from a `python_sources()` target.

This implementation proposes to support using a `:` in the name of a target to indicate a file level target, which mimics the syntax presented for these addresses.

```python
# src/example/BUILD
python_source(name="demo1.py:example", source="demo1.py")
python_source(name="demo2.py:example", source="demo2.py")
```
