### PR TITLE
Stop treading on `env_vars` as an option name

### DIFF
--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -75,8 +75,7 @@ class GoGenerateGoalSubsystem(GoalSubsystem):
     )
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
-        # TODO(#17077): Rename this back to just `env_vars`.
-        generate_env_vars = StrListOption(
+        env_vars = StrListOption(
             default=["LANG", "LC_CTYPE", "LC_ALL", "PATH"],
             help=softwrap(
                 """

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -290,7 +290,7 @@ async def run_go_package_generators(
             FallibleFirstPartyPkgAnalysis,
             FirstPartyPkgAnalysisRequest(request.address, extra_build_tags=("generate",)),
         ),
-        Get(EnvironmentVars, EnvironmentVarsRequest(subsystem.generate_env_vars)),
+        Get(EnvironmentVars, EnvironmentVarsRequest(subsystem.env_vars)),
     )
     if not fallible_analysis.analysis:
         raise ValueError(f"Analysis failure for {request.address}: {fallible_analysis.stderr}")

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -24,7 +24,7 @@ class GolangSubsystem(Subsystem):
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
 
-        depends_on_env_vars = ("PATH",)
+        env_vars_used_by_options = ("PATH",)
 
         _go_search_paths = StrListOption(
             default=["<PATH>"],
@@ -147,7 +147,7 @@ class GolangSubsystem(Subsystem):
             def iter_path_entries():
                 for entry in self._cgo_tool_search_paths:
                     if entry == "<PATH>":
-                        path = self.env_vars.get("PATH")
+                        path = self._options_env.get("PATH")
                         if path:
                             yield from path.split(os.pathsep)
                     else:

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -16,7 +16,7 @@ class PythonNativeCodeSubsystem(Subsystem):
     help = "Options for building native code using Python, e.g. when resolving distributions."
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
-        depends_on_env_vars = ("CPPFLAGS", "LDFLAGS")
+        env_vars_used_by_options = ("CPPFLAGS", "LDFLAGS")
 
         # TODO(#7735): move the --cpp-flags and --ld-flags to a general subprocess support subsystem.
         _cpp_flags = StrListOption(
@@ -48,6 +48,6 @@ class PythonNativeCodeSubsystem(Subsystem):
         def _iter_values(self, env_var: str, values: Sequence[str]):
             for value in values:
                 if value == f"<{env_var}>":
-                    yield from safe_shlex_split(self.env_vars.get(env_var, ""))
+                    yield from safe_shlex_split(self._options_env.get(env_var, ""))
                 else:
                     yield value

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -32,7 +32,7 @@ class PexSubsystem(Subsystem):
         # TODO(#9760): We'll want to deprecate this in favor of a global option which allows for a
         #  per-process override.
 
-        depends_on_env_vars = ("PATH",)
+        env_vars_used_by_options = ("PATH",)
 
         _executable_search_paths = StrListOption(
             default=["<PATH>"],
@@ -53,7 +53,7 @@ class PexSubsystem(Subsystem):
             def iter_path_entries():
                 for entry in self._executable_search_paths:
                     if entry == "<PATH>":
-                        path = self.env_vars.get("PATH")
+                        path = self._options_env.get("PATH")
                         if path:
                             yield from path.split(os.pathsep)
                     else:

--- a/src/python/pants/backend/shell/shell_setup.py
+++ b/src/python/pants/backend/shell/shell_setup.py
@@ -32,7 +32,7 @@ class ShellSetup(Subsystem):
     )
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
-        depends_on_env_vars = ("PATH",)
+        env_vars_used_by_options = ("PATH",)
 
         _executable_search_path = StrListOption(
             default=["<PATH>"],
@@ -53,7 +53,7 @@ class ShellSetup(Subsystem):
             def iter_path_entries():
                 for entry in self._executable_search_path:
                     if entry == "<PATH>":
-                        path = self.env_vars.get("PATH")
+                        path = self._options_env.get("PATH")
                         if path:
                             yield from path.split(os.pathsep)
                     else:


### PR DESCRIPTION
Renames `depends_on_env_vars` to `env_vars_used_by_options` and `env_vars` to `_options_env`, this has two benefits:

1. Makes it easier to use `--env-vars` as an option name in subsystems (closes #17077)
2. Which better highlights the intended purpose of requesting env vars at construction time, and better highlights the fact that these env vars are only meant to be used when post-processing values. The docstring on `EnvironmentAware` also explains this intention now.

Bonus: renamed `GoGenerateGoalSubsystem.generate_env_vars` to `env_vars`, as was @tdyas' intention.