### PR TITLE
Fix partitioning in add-trailing-comma

### DIFF
--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -42,7 +42,7 @@ async def partition(
         Partitions()
         if add_trailing_comma.skip
         else Partitions.single_partition(
-            field_set.sources.file_path for field_set in request.field_sets
+            field_set.source.file_path for field_set in request.field_sets
         )
     )
 


### PR DESCRIPTION
Seems like #16980 broke `add-trailing-comma`, but not sure why it wasn't detected by the tests. This MR should fix it, and I'd _love_ to prove it with a test, but can't figure out why it isn't breaking the existing tests in the first place :)

# Rust tests and lints will be skipped. Delete if not intended. [ci skip-rust]