### PR TITLE
docker: ensure image names have an image ID appended

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -650,7 +650,7 @@ async def _maybe_add_docker_image_id(image_name: str, platform: Platform) -> str
         ),
     )
 
-    # TODO: Consider appending the correct image ID to the existing image name so error messages about the
+    # TODO(17104): Consider appending the correct image ID to the existing image name so error messages about the
     # image have context for the user. Note: The image ID used for a "repo digest" (tag and image ID) is not
     # the same as just the image's ID.
     return resolve_result.image_id

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -89,6 +89,7 @@ def test_extract_process_config_from_environment() -> None:
         assert result.platform == Platform.linux_arm64.value
         assert result.remote_execution is expected_remote_execution
         if expected_docker_image is not None:
+            # TODO(17104): Account for any prepended image name here once implemented.
             assert result.docker_image == "sha256:abc123"
         else:
             assert result.docker_image is None


### PR DESCRIPTION
Ensure that Docker image names have a Docker image ID appended. (The image ID is the SHA-256 hash of an image.) This will ensure that the engine properly caches build actions run via `docker::CommandRunner` only if the image ID still matches.

[ci skip-rust]