### PR TITLE
Switch `LintRequest.name` to `.tool_subsystem`

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/register.py
+++ b/src/python/pants/backend/build_files/fmt/black/register.py
@@ -14,7 +14,7 @@ from pants.util.logging import LogLevel
 
 
 class BlackRequest(FmtFilesRequest):
-    tool_name = "black"
+    tool_subsystem = Black
 
 
 @rule

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -18,7 +18,7 @@ from pants.util.strutil import pluralize
 
 
 class BuildifierRequest(FmtFilesRequest):
-    tool_name = "buildifier"
+    tool_subsystem = Buildifier
 
 
 @rule

--- a/src/python/pants/backend/build_files/fmt/yapf/register.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/register.py
@@ -14,7 +14,7 @@ from pants.util.logging import LogLevel
 
 
 class YapfRequest(FmtFilesRequest):
-    tool_name = "yapf"
+    tool_subsystem = Yapf
 
 
 @rule

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -32,7 +32,7 @@ class ClangFormatFmtFieldSet(FieldSet):
 
 class ClangFormatRequest(FmtTargetsRequest):
     field_set_type = ClangFormatFmtFieldSet
-    tool_name = ClangFormat.options_scope
+    tool_subsystem = ClangFormat
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -23,6 +23,7 @@ from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 from pants.util.strutil import pluralize
 
 
@@ -40,7 +41,11 @@ class BufFieldSet(FieldSet):
 
 class BufFormatRequest(FmtTargetsRequest):
     field_set_type = BufFieldSet
-    tool_name = "buf-format"
+    tool_subsystem = BufSubsystem  # type: ignore[assignment]
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "buf-format"
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -18,6 +18,7 @@ from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 from pants.util.strutil import pluralize
 
 
@@ -35,7 +36,11 @@ class BufFieldSet(FieldSet):
 
 class BufLintRequest(LintTargetsRequest):
     field_set_type = BufFieldSet
-    tool_name = "buf-lint"
+    tool_subsystem = BufSubsystem  # type: ignore[assignment]
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "buf-lint"
 
 
 @rule

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -33,7 +33,7 @@ class HadolintFieldSet(FieldSet):
 
 class HadolintRequest(LintTargetsRequest):
     field_set_type = HadolintFieldSet
-    tool_name = Hadolint.options_scope
+    tool_subsystem = Hadolint
 
 
 def generate_argv(

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -35,7 +35,7 @@ class GofmtFieldSet(FieldSet):
 
 class GofmtRequest(FmtTargetsRequest):
     field_set_type = GofmtFieldSet
-    tool_name = GofmtSubsystem.options_scope
+    tool_subsystem = GofmtSubsystem
 
 
 @rule

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -48,7 +48,7 @@ class GolangciLintFieldSet(FieldSet):
 
 class GolangciLintRequest(LintTargetsRequest):
     field_set_type = GolangciLintFieldSet
-    tool_name = GolangciLint.options_scope
+    tool_subsystem = GolangciLint
 
 
 @rule

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -40,7 +40,7 @@ class GoVetFieldSet(FieldSet):
 
 class GoVetRequest(LintTargetsRequest):
     field_set_type = GoVetFieldSet
-    tool_name = GoVetSubsystem.options_scope
+    tool_subsystem = GoVetSubsystem
 
 
 @rule

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -32,7 +32,7 @@ class HelmLintFieldSet(HelmChartFieldSet):
 
 class HelmLintRequest(LintTargetsRequest):
     field_set_type = HelmLintFieldSet
-    tool_name = HelmSubsystem.options_scope
+    tool_subsystem = HelmSubsystem  # type: ignore[assignment]
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -38,7 +38,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
 
 class GoogleJavaFormatRequest(FmtTargetsRequest):
     field_set_type = GoogleJavaFormatFieldSet
-    tool_name = GoogleJavaFormatSubsystem.options_scope
+    tool_subsystem = GoogleJavaFormatSubsystem
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateJvmToolLockfileSentinel):

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -32,7 +32,7 @@ class PrettierFmtFieldSet(FieldSet):
 
 class PrettierFmtRequest(FmtTargetsRequest):
     field_set_type = PrettierFmtFieldSet
-    tool_name = Prettier.options_scope
+    tool_subsystem = Prettier
 
 
 @rule

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -38,7 +38,7 @@ class KtlintFieldSet(FieldSet):
 
 class KtlintRequest(FmtTargetsRequest):
     field_set_type = KtlintFieldSet
-    tool_name = KtlintSubsystem.options_scope
+    tool_subsystem = KtlintSubsystem
 
 
 class KtlintToolLockfileSentinel(GenerateJvmToolLockfileSentinel):

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -13,7 +13,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE
 from pants.core.goals.lint import LintFilesRequest, LintResult, Partitions
 from pants.engine.fs import DigestContents, PathGlobs
 from pants.engine.rules import Get, collect_rules, rule
-from pants.option.option_types import DictOption, EnumOption
+from pants.option.option_types import DictOption, EnumOption, SkipOption
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -72,6 +72,7 @@ class ValidationConfig:
 
 class RegexLintSubsystem(Subsystem):
     options_scope = "regex-lint"
+    name = "regex-lint"
     help = softwrap(
         """
         Lint your code using regex patterns, e.g. to check for copyright headers.
@@ -82,6 +83,7 @@ class RegexLintSubsystem(Subsystem):
         """
     )
 
+    skip = SkipOption("lint")
     _config = DictOption[Any](
         help=softwrap(
             """
@@ -254,7 +256,7 @@ class MultiMatcher:
 
 
 class RegexLintRequest(LintFilesRequest):
-    tool_name = RegexLintSubsystem.options_scope
+    tool_subsystem = RegexLintSubsystem
 
 
 @rule

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -31,7 +31,7 @@ class AddTrailingCommaFieldSet(FieldSet):
 
 class AddTrailingCommaRequest(FmtTargetsRequest):
     field_set_type = AddTrailingCommaFieldSet
-    tool_name = AddTrailingComma.options_scope
+    tool_subsystem = AddTrailingComma
 
 
 @rule

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -31,7 +31,7 @@ class AutoflakeFieldSet(FieldSet):
 
 class AutoflakeRequest(FmtTargetsRequest):
     field_set_type = AutoflakeFieldSet
-    tool_name = Autoflake.options_scope
+    tool_subsystem = Autoflake
 
 
 @rule

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -22,7 +22,7 @@ from pants.util.strutil import pluralize
 
 class BanditRequest(LintTargetsRequest):
     field_set_type = BanditFieldSet
-    tool_name = Bandit.options_scope
+    tool_subsystem = Bandit
 
 
 def generate_argv(source_files: SourceFiles, bandit: Bandit) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -22,7 +22,7 @@ from pants.util.strutil import pluralize, softwrap
 
 class BlackRequest(FmtTargetsRequest):
     field_set_type = BlackFieldSet
-    tool_name = Black.options_scope
+    tool_subsystem = Black
 
 
 @rule_helper

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -31,7 +31,7 @@ class DocformatterFieldSet(FieldSet):
 
 class DocformatterRequest(FmtTargetsRequest):
     field_set_type = DocformatterFieldSet
-    tool_name = Docformatter.options_scope
+    tool_subsystem = Docformatter
 
 
 @rule

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -28,7 +28,7 @@ from pants.util.strutil import pluralize
 
 class Flake8Request(LintTargetsRequest):
     field_set_type = Flake8FieldSet
-    tool_name = Flake8.options_scope
+    tool_subsystem = Flake8
 
 
 def generate_argv(source_files: SourceFiles, flake8: Flake8) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -34,7 +34,7 @@ class IsortFieldSet(FieldSet):
 
 class IsortRequest(FmtTargetsRequest):
     field_set_type = IsortFieldSet
-    tool_name = Isort.options_scope
+    tool_subsystem = Isort
 
 
 def generate_argv(

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -53,7 +53,7 @@ class PartitionKey:
 
 class PylintRequest(LintTargetsRequest):
     field_set_type = PylintFieldSet
-    tool_name = Pylint.options_scope
+    tool_subsystem = Pylint
 
 
 def generate_argv(field_sets: tuple[PylintFieldSet, ...], pylint: Pylint) -> Tuple[str, ...]:

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -32,7 +32,7 @@ class PyUpgradeFieldSet(FieldSet):
 
 class PyUpgradeRequest(FmtTargetsRequest):
     field_set_type = PyUpgradeFieldSet
-    tool_name = PyUpgrade.options_scope
+    tool_subsystem = PyUpgrade
 
 
 @rule

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -35,7 +35,7 @@ class YapfFieldSet(FieldSet):
 
 class YapfRequest(FmtTargetsRequest):
     field_set_type = YapfFieldSet
-    tool_name = Yapf.options_scope
+    tool_subsystem = Yapf
 
 
 @rule_helper

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -43,7 +43,7 @@ class ScalafmtFieldSet(FieldSet):
 
 class ScalafmtRequest(FmtTargetsRequest):
     field_set_type = ScalafmtFieldSet
-    tool_name = ScalafmtSubsystem.options_scope
+    tool_subsystem = ScalafmtSubsystem
 
 
 class ScalafmtToolLockfileSentinel(GenerateJvmToolLockfileSentinel):

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -33,7 +33,7 @@ class ShellcheckFieldSet(FieldSet):
 
 class ShellcheckRequest(LintTargetsRequest):
     field_set_type = ShellcheckFieldSet
-    tool_name = Shellcheck.options_scope
+    tool_subsystem = Shellcheck
 
 
 @rule

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -32,7 +32,7 @@ class ShfmtFieldSet(FieldSet):
 
 class ShfmtRequest(FmtTargetsRequest):
     field_set_type = ShfmtFieldSet
-    tool_name = Shfmt.options_scope
+    tool_subsystem = Shfmt
 
 
 @rule

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -34,7 +34,7 @@ class TfFmtSubsystem(Subsystem):
 
 class TffmtRequest(FmtTargetsRequest):
     field_set_type = TerraformFieldSet
-    tool_name = TfFmtSubsystem.options_scope
+    tool_subsystem = TfFmtSubsystem
 
 
 @rule

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -35,6 +35,7 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, SingleSourceField, Target
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 
 FORTRAN_FILE = FileContent("formatted.f98", b"READ INPUT TAPE 5\n")
 SMALLTALK_FILE = FileContent("formatted.st", b"y := self size + super size.')\n")
@@ -58,7 +59,10 @@ class FortranFieldSet(FieldSet):
 
 class FortranFmtRequest(FmtTargetsRequest):
     field_set_type = FortranFieldSet
-    tool_name = "FortranConditionallyDidChange"
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "FortranConditionallyDidChange"
 
 
 @rule
@@ -97,7 +101,10 @@ class SmalltalkFieldSet(FieldSet):
 
 class SmalltalkNoopRequest(FmtTargetsRequest):
     field_set_type = SmalltalkFieldSet
-    tool_name = "SmalltalkDidNotChange"
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "SmalltalkDidNotChange"
 
 
 @rule
@@ -119,7 +126,10 @@ async def smalltalk_noop(request: SmalltalkNoopRequest.SubPartition) -> FmtResul
 
 class SmalltalkSkipRequest(FmtTargetsRequest):
     field_set_type = SmalltalkFieldSet
-    tool_name = "SmalltalkSkipped"
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "SmalltalkSkipped"
 
 
 @rule
@@ -135,7 +145,9 @@ async def smalltalk_skip(request: SmalltalkSkipRequest.SubPartition) -> FmtResul
 class BrickyBuildFileFormatter(FmtFilesRequest):
     """Ensures all non-comment lines only consist of the word 'brick'."""
 
-    tool_name = "BrickyBobby"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "BrickyBobby"
 
 
 @rule

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -25,6 +25,7 @@ from pants.base.specs import Specs
 from pants.core.goals.multi_tool_goal_helper import (
     BatchSizeOption,
     OnlyOption,
+    SkippableSubsystem,
     determine_specified_tool_names,
     write_reports,
 )
@@ -44,7 +45,7 @@ from pants.util.collections import partition_sequentially
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init, runtime_ignore_subscripts
+from pants.util.meta import classproperty, frozen_after_init, runtime_ignore_subscripts
 from pants.util.strutil import softwrap, strip_v2_chroot_path
 
 logger = logging.getLogger(__name__)
@@ -190,8 +191,12 @@ class LintRequest:
         `LintTargetsRequest.PartitionRequest`/`LintFilesRequest.PartitionRequest`.
     """
 
-    tool_name: ClassVar[str]
+    tool_subsystem: ClassVar[type[SkippableSubsystem]]
     is_formatter: ClassVar[bool] = False
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return cls.tool_subsystem.options_scope
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
     # NB: Not frozen so `fmt` can subclass

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -32,6 +32,7 @@ from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 
 _LintRequestT = TypeVar("_LintRequestT", bound=LintRequest)
 
@@ -73,7 +74,9 @@ class MockLintTargetsRequest(MockLintRequest, LintTargetsRequest):
 
 
 class SuccessfulRequest(MockLintTargetsRequest):
-    tool_name = "SuccessfulLinter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "SuccessfulLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -81,7 +84,9 @@ class SuccessfulRequest(MockLintTargetsRequest):
 
 
 class FailingRequest(MockLintTargetsRequest):
-    tool_name = "FailingLinter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "FailingLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -89,7 +94,9 @@ class FailingRequest(MockLintTargetsRequest):
 
 
 class ConditionallySucceedsRequest(MockLintTargetsRequest):
-    tool_name = "ConditionallySucceedsLinter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "ConditionallySucceedsLinter"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -99,7 +106,9 @@ class ConditionallySucceedsRequest(MockLintTargetsRequest):
 
 
 class SkippedRequest(MockLintTargetsRequest):
-    tool_name = "SkippedLinter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "SkippedLinter"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -116,7 +125,10 @@ class InvalidFieldSet(MockLinterFieldSet):
 
 class InvalidRequest(MockLintTargetsRequest):
     field_set_type = InvalidFieldSet
-    tool_name = "InvalidLinter"
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "InvalidLinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -136,7 +148,9 @@ def mock_target_partitioner(
 
 
 class MockFilesRequest(MockLintRequest, LintFilesRequest):
-    tool_name = "FilesLinter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "FilesLinter"
 
     @classmethod
     def get_lint_result(cls, files: Iterable[str]) -> LintResult:
@@ -166,7 +180,9 @@ class MockFmtRequest(MockLintRequest, FmtTargetsRequest):
 
 
 class SuccessfulFormatter(MockFmtRequest):
-    tool_name = "SuccessfulFormatter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "SuccessfulFormatter"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -174,7 +190,9 @@ class SuccessfulFormatter(MockFmtRequest):
 
 
 class FailingFormatter(MockFmtRequest):
-    tool_name = "FailingFormatter"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "FailingFormatter"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -182,7 +200,9 @@ class FailingFormatter(MockFmtRequest):
 
 
 class BuildFileFormatter(MockLintRequest, FmtFilesRequest):
-    tool_name = "BobTheBUILDer"
+    @classproperty
+    def tool_name(cls) -> str:
+        return "BobTheBUILDer"
 
     @classmethod
     def get_lint_result(cls, files: Iterable[str]) -> LintResult:

--- a/src/python/pants/core/goals/multi_tool_goal_helper.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper.py
@@ -11,10 +11,15 @@ from typing_extensions import Protocol
 
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Digest, Workspace
-from pants.option.option_types import IntOption, StrListOption
+from pants.option.option_types import IntOption, SkipOption, StrListOption
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
+
+
+class SkippableSubsystem(Protocol):
+    options_scope: str
+    skip: SkipOption
 
 
 class OnlyOption(StrListOption):

--- a/src/python/pants/core/goals/multi_tool_goal_helper_test.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper_test.py
@@ -13,12 +13,15 @@ from pants.core.goals.multi_tool_goal_helper import determine_specified_tool_nam
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Workspace
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.meta import classproperty
 from pants.util.strutil import softwrap
 
 
 def test_determine_specified_tool_names() -> None:
     class StyleReq:
-        tool_name = "my-tool"
+        @classproperty
+        def tool_name(cls) -> str:
+            return "my-tool"
 
     with pytest.raises(ValueError) as exc:
         determine_specified_tool_names(


### PR DESCRIPTION
Last prefactor before the "provide a default partitioner" PR :tada: 

In addition to being the required plumbing for the "default partitioner", I like the `Protocol` that we expect every `fmt`/`lint` plugin to be skippable (see that `regex-lint` wasn't skippable before :fearful: )

[ci skip-rust]
[ci skip-build-wheels]