### PR TITLE
remove moot comment from requirements

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -5,7 +5,7 @@
 # Consider pinging us on Slack if you're thinking a new dependency might be needed.
 
 ansicolors==1.1.8
-chevron==0.14.0  # Should only be used by build-support.
+chevron==0.14.0
 fasteners==0.16.3
 freezegun==1.2.1
 


### PR DESCRIPTION
Remove moot comment from `requirements.txt` now that `chevron` is used in production rule code.

[ci skip-rust]

[ci skip-build-wheels]