### PR TITLE
Add an `environment=` field to `pex_binary`, and support for environments to the `package` goal

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,4 +13,5 @@ python_test_utils(name="test_utils")
 _docker_environment(
     name="docker_env",
     image="python:3.9",
+    python_bootstrap_search_path=["<PATH>"],
 )

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -38,6 +38,7 @@ from pants.core.goals.package import (
 )
 from pants.core.goals.run import RunFieldSet
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     TransitiveTargets,
@@ -74,6 +75,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
     venv_site_packages_copies: PexVenvSitePackagesCopies
+    environment: EnvironmentField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -643,6 +643,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexIncludeToolsField,
     PexVenvSitePackagesCopies,
     RestartableField,
+    EnvironmentField,
 )
 
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 from pants.core.util_rules import distdir
 from pants.core.util_rules.distdir import DistDir
-from pants.engine.environment import EnvironmentName
+from pants.core.util_rules.environments import EnvironmentName, EnvironmentNameRequest
 from pants.engine.fs import Digest, MergeDigests, Workspace
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
@@ -132,9 +132,20 @@ async def package_asset(workspace: Workspace, dist_dir: DistDir) -> Package:
     if not target_roots_to_field_sets.field_sets:
         return Package(exit_code=0)
 
-    packages = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set)
+    environment_names_per_field_set = await MultiGet(
+        Get(
+            EnvironmentName,
+            EnvironmentNameRequest,
+            EnvironmentNameRequest.from_field_set(field_set),
+        )
         for field_set in target_roots_to_field_sets.field_sets
+    )
+    packages = await MultiGet(
+        Get(BuiltPackage, {field_set: PackageFieldSet, environment_name: EnvironmentName})
+        for field_set, environment_name in zip(
+            target_roots_to_field_sets.field_sets,
+            environment_names_per_field_set,
+        )
     )
     merged_digest = await Get(Digest, MergeDigests(pkg.digest for pkg in packages))
     workspace.write_digest(merged_digest, path_prefix=str(dist_dir.relpath))


### PR DESCRIPTION
`pex_binary` targets gain an `environment=` field, which drives the environment in which they are packaged. 

This was validated working using the instructions from #17096.

[ci skip-rust]
[ci skip-build-wheels]