### PR TITLE
Fix test break cause by importlib-metadata 5.0.0 release. (Cherry-pick of #17088)

### DIFF
--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -194,6 +194,9 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
         [tgt],
         extra_args=[
             "--flake8-extra-requirements=flake8-pantsbuild>=2.0,<3",
+            # N.B.: Needed to workaround break cause by the 5.0.0 release as documented here:
+            # https://github.com/python/importlib_metadata/issues/406
+            "--flake8-extra-requirements=importlib-metadata==4.13.0",
             "--flake8-lockfile=<none>",
         ],
     )


### PR DESCRIPTION
[ci skip-rust]
[ci skip-build-wheels]

(cherry picked from commit 98fab67dc4bff78155ffb34a60d98a127a74b0cf)