### PR TITLE
Always include relevant params in workunit descriptions, and include descriptions in traces by default

### DIFF
--- a/src/python/pants/base/specs_integration_test.py
+++ b/src/python/pants/base/specs_integration_test.py
@@ -80,8 +80,8 @@ def test_address_literal() -> None:
         assert run(["list", *list_specs]).stdout.splitlines() == list_specs
 
         test_result = run(["test", f"{tmpdir}/py:tests"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded." in test_result
-        assert f"{tmpdir}/py/base/common_test.py:../tests succeeded." in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
+        assert f"{tmpdir}/py/base/common_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
 
@@ -109,14 +109,14 @@ def test_sibling_addresses() -> None:
         # Even though no `python_test` targets are explicitly defined in `util/`, a generated
         # target is resident there.
         test_result = run(["test", f"{tmpdir}/py/utils:"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded." in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" not in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
         # Even though no `_test.py` files live in this dir, we match the `python_tests` target
         # and replace it with its generated targets.
         test_result = run(["test", f"{tmpdir}/py:"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded." in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
@@ -137,7 +137,7 @@ def test_descendent_addresses() -> None:
         ]
 
         test_result = run(["test", f"{tmpdir}/py::"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded." in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 

--- a/src/python/pants/bin/local_pants_runner_integration_test.py
+++ b/src/python/pants/bin/local_pants_runner_integration_test.py
@@ -13,9 +13,10 @@ def test_print_stacktrace() -> None:
     list_rule_name = "pants.backend.project_info.list_targets"
     no_print_stacktrace = run(["--no-print-stacktrace"])
     assert "Traceback" not in no_print_stacktrace.stderr
-    assert list_rule_name not in no_print_stacktrace.stderr
     assert "Engine traceback:" in no_print_stacktrace.stderr
+    assert list_rule_name not in no_print_stacktrace.stderr
 
     print_stacktrace = run(["--print-stacktrace"])
-    assert "Engine traceback" in print_stacktrace.stderr
+    assert "Traceback" in print_stacktrace.stderr
+    assert "Engine traceback:" in print_stacktrace.stderr
     assert list_rule_name in print_stacktrace.stderr

--- a/src/python/pants/bin/local_pants_runner_integration_test.py
+++ b/src/python/pants/bin/local_pants_runner_integration_test.py
@@ -10,9 +10,12 @@ def test_print_stacktrace() -> None:
     def run(args: Sequence[str]) -> PantsResult:
         return run_pants(command=[*args, "list", "definitely-does-not-exist::"])
 
+    list_rule_name = "pants.backend.project_info.list_targets"
     no_print_stacktrace = run(["--no-print-stacktrace"])
     assert "Traceback" not in no_print_stacktrace.stderr
-    assert "traceback" not in no_print_stacktrace.stderr
+    assert list_rule_name not in no_print_stacktrace.stderr
+    assert "Engine traceback:" in no_print_stacktrace.stderr
 
     print_stacktrace = run(["--print-stacktrace"])
-    assert "Traceback" in print_stacktrace.stderr
+    assert "Engine traceback" in print_stacktrace.stderr
+    assert list_rule_name in print_stacktrace.stderr

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -147,9 +147,9 @@ class TestResult(EngineAwareReturnType):
 
     def message(self) -> str:
         if self.skipped:
-            return f"{self.address} skipped."
+            return "skipped."
         status = "succeeded" if self.exit_code == 0 else f"failed (exit code {self.exit_code})"
-        message = f"{self.address} {status}."
+        message = f"{status}."
         if self.output_setting == ShowOutput.NONE or (
             self.output_setting == ShowOutput.FAILED and self.exit_code == 0
         ):

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -471,7 +471,7 @@ def test_streaming_output_skip() -> None:
         stdout="",
         stderr="",
         expected_level=LogLevel.DEBUG,
-        expected_message="demo_test:demo_test skipped.",
+        expected_message="skipped.",
     )
 
 
@@ -482,19 +482,15 @@ def test_streaming_output_success() -> None:
     assert_success_streamed(
         expected_message=dedent(
             """\
-            demo_test:demo_test succeeded.
+            succeeded.
             stdout
             stderr
 
             """
         ),
     )
-    assert_success_streamed(
-        output_setting=ShowOutput.FAILED, expected_message="demo_test:demo_test succeeded."
-    )
-    assert_success_streamed(
-        output_setting=ShowOutput.NONE, expected_message="demo_test:demo_test succeeded."
-    )
+    assert_success_streamed(output_setting=ShowOutput.FAILED, expected_message="succeeded.")
+    assert_success_streamed(output_setting=ShowOutput.NONE, expected_message="succeeded.")
 
 
 def test_streaming_output_failure() -> None:
@@ -503,7 +499,7 @@ def test_streaming_output_failure() -> None:
     )
     message = dedent(
         """\
-        demo_test:demo_test failed (exit code 1).
+        failed (exit code 1).
         stdout
         stderr
 
@@ -512,7 +508,7 @@ def test_streaming_output_failure() -> None:
     assert_failure_streamed(expected_message=message)
     assert_failure_streamed(output_setting=ShowOutput.FAILED, expected_message=message)
     assert_failure_streamed(
-        output_setting=ShowOutput.NONE, expected_message="demo_test:demo_test failed (exit code 1)."
+        output_setting=ShowOutput.NONE, expected_message="failed (exit code 1)."
     )
 
 

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -21,8 +21,8 @@ class EnvironmentName(EngineAwareParameter):
 
     val: str | None
 
-    def debug_hint(self) -> str:
-        return self.val or "<none>"
+    def debug_hint(self) -> str | None:
+        return f"environment:{self.val}" if self.val else None
 
 
 def __getattr__(name):

--- a/src/python/pants/engine/internals/engine_test.py
+++ b/src/python/pants/engine/internals/engine_test.py
@@ -194,7 +194,7 @@ class TestEngine(SchedulerTestBase):
         with pytest.raises(ExecutionError) as cm:
             list(scheduler.product_request(A, subjects=[(B())]))
         assert_equal_with_printing(
-            "1 Exception encountered:\n\n  Exception: An exception for B\n", str(cm.value)
+            "1 Exception encountered:\n\nException: An exception for B\n", str(cm.value)
         )
 
     def test_no_include_trace_error_multiple_paths_raises_executionerror(
@@ -209,8 +209,9 @@ class TestEngine(SchedulerTestBase):
                 """
                 2 Exceptions encountered:
 
-                  Exception: An exception for B
-                  Exception: An exception for B
+                Exception: An exception for B
+
+                (and 1 more)
                 """
             ).lstrip(),
             str(cm.value),
@@ -228,13 +229,17 @@ class TestEngine(SchedulerTestBase):
 
                 Engine traceback:
                   in select
+                    ..
                   in pants.engine.internals.engine_test.nested_raise
+                    ..
+
                 Traceback (most recent call last):
                   File LOCATION-INFO, in nested_raise
                     fn_raises(x)
                   File LOCATION-INFO, in fn_raises
                     raise Exception(f"An exception for {type(x).__name__}")
                 Exception: An exception for B
+
                 """
             ).lstrip(),
             remove_locations_from_traceback(str(cm.value)),

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1141,7 +1141,7 @@ async def _fill_parameters(
     )
 
 
-@rule(desc="Resolve direct dependencies")
+@rule(desc="Resolve direct dependencies of target")
 async def resolve_dependencies(
     request: DependenciesRequest,
     target_types_to_generate_requests: TargetTypesToGenerateTargetsRequests,

--- a/src/python/pants/engine/internals/nodes.py
+++ b/src/python/pants/engine/internals/nodes.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Optional, Tuple
 
@@ -12,10 +14,40 @@ class Return:
     value: Any
 
 
+_Frame = Tuple[str, Optional[str]]
+
+
 @dataclass(frozen=True)
 class Throw:
     """Indicates that a Node should have been able to return a value, but failed."""
 
     exc: Exception
-    python_traceback: Optional[str] = None
-    engine_traceback: Tuple[str, ...] = ()
+    python_traceback: str | None = None
+    engine_traceback: tuple[_Frame, ...] = ()
+
+    def _render_frame(self, frame: _Frame, include_trace_on_error: bool) -> str | None:
+        """Renders either only the description (if set), or both the name and description."""
+        name, desc = frame
+
+        if include_trace_on_error:
+            return f"{name}\n    {desc or '..'}"
+        elif desc:
+            return f"{desc}"
+        else:
+            return None
+
+    def render(self, include_trace_on_error: bool) -> str:
+        all_rendered_frames = [
+            self._render_frame(frame, include_trace_on_error)
+            for frame in reversed(self.engine_traceback)
+        ]
+        rendered_frames = [f for f in all_rendered_frames if f]
+        engine_traceback_str = ""
+        if rendered_frames:
+            sep = "\n  in "
+            engine_traceback_str = "Engine traceback:" + sep + sep.join(rendered_frames) + "\n\n"
+        if include_trace_on_error:
+            python_traceback_str = f"{self.python_traceback}" if self.python_traceback else ""
+        else:
+            python_traceback_str = f"{type(self.exc).__name__}: {str(self.exc)}"
+        return f"{engine_traceback_str}{python_traceback_str}"

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -485,29 +485,13 @@ class SchedulerSession:
 
     def _raise_on_error(self, throws: list[Throw]) -> NoReturn:
         exception_noun = pluralize(len(throws), "Exception")
-
-        if self._scheduler.include_trace_on_error:
-            throw = throws[0]
-            etb = throw.engine_traceback
-            python_traceback_str = throw.python_traceback or ""
-            engine_traceback_str = ""
-            others_msg = f"\n(and {len(throws) - 1} more)" if len(throws) > 1 else ""
-            if etb:
-                sep = "\n  in "
-                engine_traceback_str = "Engine traceback:" + sep + sep.join(reversed(etb)) + "\n"
-            raise ExecutionError(
-                f"{exception_noun} encountered:\n\n"
-                f"{engine_traceback_str}"
-                f"{python_traceback_str}"
-                f"{others_msg}",
-                wrapped_exceptions=tuple(t.exc for t in throws),
-            )
-        else:
-            exception_strs = "\n  ".join(f"{type(t.exc).__name__}: {str(t.exc)}" for t in throws)
-            raise ExecutionError(
-                f"{exception_noun} encountered:\n\n  {exception_strs}\n",
-                wrapped_exceptions=tuple(t.exc for t in throws),
-            )
+        others_msg = f"\n(and {len(throws) - 1} more)\n" if len(throws) > 1 else ""
+        raise ExecutionError(
+            f"{exception_noun} encountered:\n\n"
+            f"{throws[0].render(self._scheduler.include_trace_on_error)}\n"
+            f"{others_msg}",
+            wrapped_exceptions=tuple(t.exc for t in throws),
+        )
 
     def execute(self, execution_request: ExecutionRequest) -> list[Any]:
         """Invoke the engine for the given ExecutionRequest, returning successful values or raising.

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -269,13 +269,17 @@ def test_trace_includes_rule_exception_traceback() -> None:
 
          Engine traceback:
            in select
+             ..
            in {__name__}.{nested_raise.__name__}
+             Nested raise
+
          Traceback (most recent call last):
            File LOCATION-INFO, in nested_raise
              fn_raises()
            File LOCATION-INFO, in fn_raises
              raise Exception("An exception!")
          Exception: An exception!
+
          """
     )
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -473,7 +473,7 @@ struct PyResult {
   #[pyo3(get)]
   python_traceback: Option<String>,
   #[pyo3(get)]
-  engine_traceback: Vec<String>,
+  engine_traceback: Vec<(String, Option<String>)>,
 }
 
 fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> PyResult {
@@ -505,7 +505,10 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> PyResult {
         is_throw: true,
         result: val.into(),
         python_traceback: Some(python_traceback),
-        engine_traceback,
+        engine_traceback: engine_traceback
+          .into_iter()
+          .map(|ff| (ff.name, ff.desc))
+          .collect(),
       }
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1302,9 +1302,31 @@ impl NodeKey {
   /// `Node`s need a user-facing name. For `Node`s derived from Python `@rule`s, the
   /// user-facing name should be the same as the `desc` annotation on the rule decorator.
   ///
-  fn user_facing_name(&self) -> Option<String> {
+  fn workunit_desc(&self, context: &Context) -> Option<String> {
     match self {
-      NodeKey::Task(ref task) => task.task.display_info.desc.as_ref().map(|s| s.to_owned()),
+      NodeKey::Task(ref task) => {
+        let task_desc = task.task.display_info.desc.as_ref().map(|s| s.to_owned())?;
+
+        let displayable_param_names: Vec<_> = {
+          let gil = Python::acquire_gil();
+          let py = gil.python();
+          Self::engine_aware_params(context, py, &task.params)
+            .filter_map(|k| EngineAwareParameter::debug_hint((*k.value).as_ref(py)))
+            .collect()
+        };
+
+        let desc = if displayable_param_names.is_empty() {
+          task_desc
+        } else {
+          format!(
+            "{} - {}",
+            task_desc,
+            display_sorted_in_parens(displayable_param_names.iter())
+          )
+        };
+
+        Some(desc)
+      }
       NodeKey::Snapshot(ref s) => Some(format!("Snapshotting: {}", s.path_globs)),
       NodeKey::Paths(ref s) => Some(format!("Finding files: {}", s.path_globs)),
       NodeKey::ExecuteProcess(epr) => {
@@ -1341,22 +1363,17 @@ impl NodeKey {
   /// Filters the given Params to those which are subtypes of EngineAwareParameter.
   ///
   fn engine_aware_params<'a>(
-    context: Context,
+    context: &Context,
     py: Python<'a>,
     params: &'a Params,
-  ) -> impl Iterator<Item = Value> + 'a {
+  ) -> impl Iterator<Item = &'a Key> + 'a {
     let engine_aware_param_ty = context.core.types.engine_aware_parameter.as_py_type(py);
-    params.keys().filter_map(move |key| {
-      if key
+    params.keys().filter(move |key| {
+      key
         .type_id()
         .as_py_type(py)
         .is_subclass(engine_aware_param_ty)
         .unwrap_or(false)
-      {
-        Some(key.to_value())
-      } else {
-        None
-      }
     })
   }
 }
@@ -1370,22 +1387,27 @@ impl Node for NodeKey {
 
   async fn run(self, context: Context) -> Result<NodeOutput, Failure> {
     let workunit_name = self.workunit_name();
-    let params = match &self {
-      NodeKey::Task(ref task) => task.params.clone(),
-      _ => Params::default(),
+    let workunit_desc = self.workunit_desc(&context);
+    let maybe_params = match &self {
+      NodeKey::Task(ref task) => Some(&task.params),
+      _ => None,
     };
     let context2 = context.clone();
 
     in_workunit!(
       workunit_name,
       self.workunit_level(),
-      desc = self.user_facing_name(),
+      desc = workunit_desc.clone(),
       user_metadata = {
-        let gil = Python::acquire_gil();
-        let py = gil.python();
-        Self::engine_aware_params(context.clone(), py, &params)
-          .flat_map(|val| EngineAwareParameter::metadata((*val).as_ref(py)))
-          .collect()
+        if let Some(params) = maybe_params {
+          let gil = Python::acquire_gil();
+          let py = gil.python();
+          Self::engine_aware_params(&context, py, params)
+            .flat_map(|k| EngineAwareParameter::metadata((*k.value).as_ref(py)))
+            .collect()
+        } else {
+          vec![]
+        }
       },
       |workunit| async move {
         // Ensure that we have installed filesystem watches before Nodes which inspect the
@@ -1425,33 +1447,7 @@ impl Node for NodeKey {
         }
 
         // If the node failed, expand the Failure with a new frame.
-        result = result.map_err(|failure| {
-          let name = workunit_name;
-          let displayable_param_names: Vec<_> = {
-            let gil = Python::acquire_gil();
-            let py = gil.python();
-            Self::engine_aware_params(context2, py, &params)
-              .filter_map(|val| EngineAwareParameter::debug_hint((*val).as_ref(py)))
-              .collect()
-          };
-          let failure_name = if displayable_param_names.is_empty() {
-            name.to_owned()
-          } else if displayable_param_names.len() == 1 {
-            format!(
-              "{} ({})",
-              name,
-              display_sorted_in_parens(displayable_param_names.iter())
-            )
-          } else {
-            format!(
-              "{} {}",
-              name,
-              display_sorted_in_parens(displayable_param_names.iter())
-            )
-          };
-
-          failure.with_pushed_frame(&failure_name)
-        });
+        result = result.map_err(|failure| failure.with_pushed_frame(workunit_name, workunit_desc));
 
         result
       }


### PR DESCRIPTION
In order to:
1. begin to render an environment in more places (when one is in use)
2. add more human readable, useful context to errors when they occur

... this change appends all `EngineAwareParams` to the workunit descriptions of tasks, and renders workunit descriptions in engine backtraces by default.

----

The impact on common use is fairly subtle, because this does not impact `Process` (which represents the majority of labeled `debug` level workunits), but you can see it in test output rendering:
```
09:56:14.93 [INFO] Completed: Run Pytest - (environment:docker, src/python/pants/util/strutil_test.py:tests) - succeeded.
```

You can see the impact on backtraces in the changes to the tests. As one example (note: this is with `--no-print-stacktrace`):
```
$ ./pants --no-print-stacktrace dependencies src/python/pants/base/::
10:01:35.84 [ERROR] 1 Exception encountered:

Engine traceback:
  in `dependencies` goal
  in Resolve direct dependencies of target - src/python/pants/base/exception_sink_integration_test.py:exception_sink_integration_test

InvalidSpecPathError: Invalid address /testprojects:pants_plugins_directory from the `dependencies` field from the target src/python/pants/base/exception_sink_integration_test.py:exception_sink_integration_test. Cannot use absolute paths.
```

While this information is lightly redundant with the use cases which were improved in #14468, there are likely to be other errors which currently do not have enough context added. And almost no explicit inclusion of the environment in error messages currently happens, but would need to if context were to be added manually.

[ci skip-build-wheels]