### PR TITLE
Upgrade Pex to 2.1.108. (Cherry-pick of #17112)

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -15,7 +15,7 @@ humbug==0.2.7
 
 ijson==3.1.4
 packaging==21.3
-pex==2.1.107
+pex==2.1.108
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -19,7 +19,7 @@
 //     "ijson==3.1.4",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.107",
+//     "pex==2.1.108",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -782,13 +782,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f2b8a523bf62d27445691a569cbb99ae1c5196351a25fafcf01b9045f7c1f011",
-              "url": "https://files.pythonhosted.org/packages/30/89/6e2681b36e9f6aabc4a91cc43525e45a6dddded5793001fa52fa0d0fc39a/pex-2.1.107-py2.py3-none-any.whl"
+              "hash": "3f12edb36525daca66ac4e0e1a3bcaa76c119217bca1bac7c1b01e9a62641f25",
+              "url": "https://files.pythonhosted.org/packages/95/70/be0d481a60c87f16ca6cc29339ef79e88f5e4027b07c87660cbb9d873d56/pex-2.1.108-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d2a35b93daab737d172225eb35fd381761b3c6834865a597c18d56360e56ed66",
-              "url": "https://files.pythonhosted.org/packages/ae/53/aeb79df2d7b0fdec0627dff2657df78bd33815198f40890c9a6dc6865f8d/pex-2.1.107.tar.gz"
+              "hash": "ec1263f39d24d61881ca4232db9972b74f67899393a7bb316efa3933cf59574f",
+              "url": "https://files.pythonhosted.org/packages/ee/cb/f483c30024d6bac3f7f46791a9eb92cbf70c8ba46848edaf72a7bba7cedc/pex-2.1.108.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -796,7 +796,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.107"
+          "version": "2.1.108"
         },
         {
           "artifacts": [
@@ -2238,7 +2238,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.107",
+  "pex_version": "2.1.108",
   "pip_version": "20.3.4-patched",
   "prefer_older_binary": false,
   "requirements": [
@@ -2252,7 +2252,7 @@
     "ijson==3.1.4",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.107",
+    "pex==2.1.108",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -49,13 +49,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f2b8a523bf62d27445691a569cbb99ae1c5196351a25fafcf01b9045f7c1f011",
-              "url": "https://files.pythonhosted.org/packages/30/89/6e2681b36e9f6aabc4a91cc43525e45a6dddded5793001fa52fa0d0fc39a/pex-2.1.107-py2.py3-none-any.whl"
+              "hash": "3f12edb36525daca66ac4e0e1a3bcaa76c119217bca1bac7c1b01e9a62641f25",
+              "url": "https://files.pythonhosted.org/packages/95/70/be0d481a60c87f16ca6cc29339ef79e88f5e4027b07c87660cbb9d873d56/pex-2.1.108-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d2a35b93daab737d172225eb35fd381761b3c6834865a597c18d56360e56ed66",
-              "url": "https://files.pythonhosted.org/packages/ae/53/aeb79df2d7b0fdec0627dff2657df78bd33815198f40890c9a6dc6865f8d/pex-2.1.107.tar.gz"
+              "hash": "ec1263f39d24d61881ca4232db9972b74f67899393a7bb316efa3933cf59574f",
+              "url": "https://files.pythonhosted.org/packages/ee/cb/f483c30024d6bac3f7f46791a9eb92cbf70c8ba46848edaf72a7bba7cedc/pex-2.1.108.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -63,14 +63,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.107"
+          "version": "2.1.108"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.107",
+  "pex_version": "2.1.108",
   "pip_version": "20.3.4-patched",
   "prefer_older_binary": false,
   "requirements": [

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -39,9 +39,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.107"
+    default_version = "v2.1.108"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.103,<3.0"
+    version_constraints = ">=2.1.108,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -50,8 +50,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "bfc19b16e0f298742dd933289bd8057dd503f9ad0678310412d382800d48b3ae",
-                    "3840814",
+                    "21d7803ef39203a6b2ae9f9e2678636e3c38ba17226ea33d6305f0683ab72e84",
+                    "3848678",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This picks up a fix for extremely slow PEX boot times when the PEX contains requirements with large extras sets.

See the changelog here:
+ https://github.com/pantsbuild/pex/releases/tag/v2.1.108

(cherry picked from commit c172368152cfda938cf3ec6d211ec87f9d6ffe71)

[ci skip-rust]
[ci skip-build-wheels]