### PR TITLE
Show environment-awareness options in help

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -7,7 +7,7 @@ import dataclasses
 import logging
 import shlex
 from dataclasses import dataclass
-from typing import Any, Callable, ClassVar, Iterable, Optional, Tuple, Type, Union, cast
+from typing import Any, Callable, ClassVar, Iterable, Optional, Sequence, Tuple, Type, Union, cast
 
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
@@ -718,6 +718,10 @@ def add_option_fields_for(env_aware: type[Subsystem.EnvironmentAware]) -> Iterab
     return field_rules
 
 
+def option_field_name_for(flag_names: Sequence[str]) -> str:
+    return flag_names[0][2:].replace("-", "_")
+
+
 def _add_option_field_for(
     env_aware_t: type[Subsystem.EnvironmentAware],
     option: OptionsInfo,
@@ -725,7 +729,7 @@ def _add_option_field_for(
     option_type: type = option.flag_options["type"]
     scope = env_aware_t.subsystem.options_scope
 
-    snake_name = option.flag_names[0][2:].replace("-", "_")
+    snake_name = option_field_name_for(option.flag_names)
 
     # Note that there is not presently good support for enum options. `str`-backed enums should
     # be easy enough to add though...

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -104,7 +104,8 @@ class HelpFormatter(MaybeColor):
         arg_lines.append(self.maybe_magenta(f"  {ohi.config_key}"))
         arg_lines.append(
             self.maybe_orange(
-                "  Can be overriden by `local_environment`, `docker_environment`, or `remote_environment` targets."
+                f"  Can be overriden by field `{ohi.target_field_name}` on `local_environment`, "
+                "`docker_environment`, or `remote_environment` targets."
             )
         )
 

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -102,6 +102,11 @@ class HelpFormatter(MaybeColor):
         arg_lines = [f"  {self.maybe_magenta(args)}" for args in ohi.display_args]
         arg_lines.append(self.maybe_magenta(f"  {ohi.env_var}"))
         arg_lines.append(self.maybe_magenta(f"  {ohi.config_key}"))
+        arg_lines.append(
+            self.maybe_orange(
+                "  Can be overriden by `local_environment`, `docker_environment`, or `remote_environment` targets."
+            )
+        )
 
         choices = "" if ohi.choices is None else f"one of: [{', '.join(ohi.choices)}]"
         choices_lines = [

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -27,6 +27,7 @@ from typing import (
 
 from pants.base import deprecated
 from pants.build_graph.build_configuration import BuildConfiguration
+from pants.core.util_rules.environments import option_field_name_for
 from pants.engine.goal import GoalSubsystem
 from pants.engine.rules import Rule, TaskRule
 from pants.engine.target import Field, RegisteredTargetTypes, StringField, Target, TargetGenerator
@@ -79,7 +80,8 @@ class OptionHelpInfo:
                             scope context (e.g., [--baz, --no-baz, --qux])
     env_var: The environment variable that set's the option.
     config_key: The config key for this option (in the section named for its scope).
-
+    target_field_name: The name for the field that overrides this option in `local_environment`,
+                       `remote_environment`, or `docker_environment`.
     typ: The type of the option.
     default: The value of this option if no flags are specified (derived from config and env vars).
     help: The help message registered for this option.
@@ -96,6 +98,7 @@ class OptionHelpInfo:
     unscoped_cmd_line_args: tuple[str, ...]
     env_var: str
     config_key: str
+    target_field_name: str
     typ: type
     default: Any
     help: str
@@ -872,6 +875,8 @@ class HelpInfoExtracter:
         # Global options have three env var variants. The last one is the most human-friendly.
         env_var = Parser.get_env_var_names(self._scope, dest)[-1]
 
+        target_field_name = f"{self._scope_prefix}_{option_field_name_for(args)}".replace("-", "_")
+
         ret = OptionHelpInfo(
             display_args=tuple(display_args),
             comma_separated_display_args=", ".join(display_args),
@@ -879,6 +884,7 @@ class HelpInfoExtracter:
             unscoped_cmd_line_args=tuple(unscoped_cmd_line_args),
             env_var=env_var,
             config_key=dest,
+            target_field_name=target_field_name,
             typ=typ,
             default=default,
             help=help_msg,

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -3,7 +3,11 @@
 
 from typing import List
 
-from colors import cyan, green, magenta, red, yellow
+from colors import color, cyan, green, magenta, red, yellow
+
+
+def _orange(s: str):
+    return color(s, "orange")
 
 
 class MaybeColor:
@@ -14,6 +18,7 @@ class MaybeColor:
         noop = lambda x: x
         self.maybe_cyan = cyan if color else noop
         self.maybe_green = green if color else noop
+        self.maybe_orange = _orange if color else noop
         self.maybe_red = red if color else noop
         self.maybe_magenta = magenta if color else noop
         self.maybe_yellow = yellow if color else noop

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -366,6 +366,7 @@ class Parser:
         "mutually_exclusive_group",
         "daemon",
         "passthrough",
+        "environment_aware",
     }
 
     _allowed_member_types = {

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -7,7 +7,6 @@ import functools
 import inspect
 import re
 from abc import ABCMeta
-from itertools import chain
 from typing import TYPE_CHECKING, Any, ClassVar, Iterable, TypeVar, cast
 
 from pants import ox
@@ -275,10 +274,14 @@ class Subsystem(metaclass=_SubsystemMeta):
         """
         register = options.registration_function_for_subsystem(cls)
         plugin_option_containers = union_membership.get(cls.PluginOption)
-        for options_info in chain(
-            collect_options_info(cls),
-            collect_options_info(cls.EnvironmentAware),
-            *(collect_options_info(container) for container in plugin_option_containers),
+        for options_info in collect_options_info(cls):
+            register(*options_info.flag_names, **options_info.flag_options)
+        for options_info in collect_options_info(cls.EnvironmentAware):
+            register(*options_info.flag_names, environment_aware=True, **options_info.flag_options)
+        for options_info in (
+            option
+            for container in plugin_option_containers
+            for option in collect_options_info(container)
         ):
             register(*options_info.flag_names, **options_info.flag_options)
 

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -80,11 +80,11 @@ class Subsystem(metaclass=_SubsystemMeta):
     class EnvironmentAware(metaclass=ABCMeta):
         """A separate container for options that may be redefined by the runtime environment.
 
-        To define environment-sensitive options, create an inner class in the `Subsystem` called
+        To define environment-aware options, create an inner class in the `Subsystem` called
         `EnvironmentAware`. Option fields share their scope with their enclosing `Subsystem`,
         and the values of fields will default to the values set through Pants' configuration.
 
-        To consume environment-sensitive options, inject the `EnvironmentAware` inner class into
+        To consume environment-aware options, inject the `EnvironmentAware` inner class into
         your rule.
 
         Optionally, it is possible to specify environment variables that are required when


### PR DESCRIPTION
Updates docstrings to say "environment-aware" instead of "environment-sensitive".

Adds a help message for all environment-aware options, showing the field name that can be set to override a given option's value in an environment.

Closes #17108.