### PR TITLE
Fix `bsp-groups.toml` example in documentation

### DIFF
--- a/docs/markdown/Java and Scala/jvm-overview.md
+++ b/docs/markdown/Java and Scala/jvm-overview.md
@@ -294,8 +294,7 @@ After Setup (see below), and after IntelliJ has finished indexing your code, you
 # A "group" named `default`.
 # Multiple groups are supported: consider creating a group per project or team.
 [groups.default]
-addresses = 
-[  
+addresses = [  
   "src/jvm::",  
   "tests/jvm::",  
 ]


### PR DESCRIPTION
Related to: https://github.com/pantsbuild/pants/issues/17122

Example of `bsp-groups.toml` file in documentation could lead to the following problem on MacOs Monterey (python 3.8.6) when running BSP server

```
org.eclipse.lsp4j.jsonrpc.ResponseErrorException: pants.engine.internals.scheduler.ExecutionError: 1 Exception encountered:

  TomlDecodeError: Key name found without value. Reached end of line. (line 7 column 2 char 190)
```

Fixing `addresses` eliminates this problem. Fixes #17122.