### PR TITLE
Provide a "default" partitioner for `lint`/`fmt`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -8,7 +8,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufDependenciesField,
     ProtobufSourceField,
 )
-from pants.core.goals.lint import LintResult, LintTargetsRequest, Partitions
+from pants.core.goals.lint import LintResult, LintTargetsRequest, PartitionerType, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -114,4 +114,9 @@ async def run_buf(
 
 
 def rules():
-    return [*collect_rules(), *BufLintRequest.registration_rules()]
+    return [
+        *collect_rules(),
+        *BufLintRequest.registration_rules(
+            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
+        ),
+    ]

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -8,7 +8,7 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufDependenciesField,
     ProtobufSourceField,
 )
-from pants.core.goals.lint import LintResult, LintTargetsRequest, PartitionerType, Partitions
+from pants.core.goals.lint import LintResult, LintTargetsRequest, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -116,7 +116,5 @@ async def run_buf(
 def rules():
     return [
         *collect_rules(),
-        *BufLintRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *BufLintRequest.registration_rules(),
     ]

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -11,7 +11,8 @@ from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.lint import PartitionerType
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
@@ -36,19 +37,6 @@ class GofmtFieldSet(FieldSet):
 class GofmtRequest(FmtTargetsRequest):
     field_set_type = GofmtFieldSet
     tool_subsystem = GofmtSubsystem
-
-
-@rule
-async def partition_gofmt(
-    request: GofmtRequest.PartitionRequest, gofmt: GofmtSubsystem
-) -> Partitions:
-    return (
-        Partitions()
-        if gofmt.skip
-        else Partitions.single_partition(
-            field_set.sources.file_path for field_set in request.field_sets
-        )
-    )
 
 
 @rule(desc="Format with gofmt")
@@ -78,5 +66,5 @@ def rules():
     return [
         *collect_rules(),
         *goroot.rules(),
-        *GofmtRequest.registration_rules(),
+        *GofmtRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -16,7 +16,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoModRequest,
 )
 from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.core.goals.lint import LintResult, LintTargetsRequest, Partitions
+from pants.core.goals.lint import LintResult, LintTargetsRequest, PartitionerType
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
@@ -41,15 +41,6 @@ class GoVetFieldSet(FieldSet):
 class GoVetRequest(LintTargetsRequest):
     field_set_type = GoVetFieldSet
     tool_subsystem = GoVetSubsystem
-
-
-@rule
-async def partition_go_vet(
-    request: GoVetRequest.PartitionRequest[GoVetFieldSet], go_vet_subsystem: GoVetSubsystem
-) -> Partitions[GoVetFieldSet]:
-    return (
-        Partitions() if go_vet_subsystem.skip else Partitions.single_partition(request.field_sets)
-    )
 
 
 @rule(level=LogLevel.DEBUG)
@@ -93,5 +84,5 @@ async def run_go_vet(request: GoVetRequest.SubPartition[GoVetFieldSet]) -> LintR
 def rules():
     return [
         *collect_rules(),
-        *GoVetRequest.registration_rules(),
+        *GoVetRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -8,7 +8,8 @@ from pants.backend.python.lint.add_trailing_comma.subsystem import AddTrailingCo
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.lint import PartitionerType
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
@@ -32,19 +33,6 @@ class AddTrailingCommaFieldSet(FieldSet):
 class AddTrailingCommaRequest(FmtTargetsRequest):
     field_set_type = AddTrailingCommaFieldSet
     tool_subsystem = AddTrailingComma
-
-
-@rule
-async def partition(
-    request: AddTrailingCommaRequest.PartitionRequest, add_trailing_comma: AddTrailingComma
-) -> Partitions:
-    return (
-        Partitions()
-        if add_trailing_comma.skip
-        else Partitions.single_partition(
-            field_set.sources.file_path for field_set in request.field_sets
-        )
-    )
 
 
 @rule(desc="Format with add-trailing-comma", level=LogLevel.DEBUG)
@@ -81,6 +69,8 @@ async def add_trailing_comma_fmt(
 def rules():
     return [
         *collect_rules(),
-        *AddTrailingCommaRequest.registration_rules(),
+        *AddTrailingCommaRequest.registration_rules(
+            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
+        ),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -8,7 +8,8 @@ from pants.backend.python.lint.autoflake.subsystem import Autoflake
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.lint import PartitionerType
 from pants.engine.fs import Digest
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
@@ -32,17 +33,6 @@ class AutoflakeFieldSet(FieldSet):
 class AutoflakeRequest(FmtTargetsRequest):
     field_set_type = AutoflakeFieldSet
     tool_subsystem = Autoflake
-
-
-@rule
-async def partition(request: AutoflakeRequest.PartitionRequest, autoflake: Autoflake) -> Partitions:
-    return (
-        Partitions()
-        if autoflake.skip
-        else Partitions.single_partition(
-            field_set.source.file_path for field_set in request.field_sets
-        )
-    )
 
 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
@@ -77,6 +67,8 @@ async def autoflake_fmt(request: AutoflakeRequest.SubPartition, autoflake: Autof
 def rules():
     return [
         *collect_rules(),
-        *AutoflakeRequest.registration_rules(),
+        *AutoflakeRequest.registration_rules(
+            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
+        ),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pants.backend.shell.lint.shellcheck.skip_field import SkipShellcheckField
 from pants.backend.shell.lint.shellcheck.subsystem import Shellcheck
 from pants.backend.shell.target_types import ShellDependenciesField, ShellSourceField
-from pants.core.goals.lint import LintResult, LintTargetsRequest, Partitions
+from pants.core.goals.lint import LintResult, LintTargetsRequest, PartitionerType
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -34,13 +34,6 @@ class ShellcheckFieldSet(FieldSet):
 class ShellcheckRequest(LintTargetsRequest):
     field_set_type = ShellcheckFieldSet
     tool_subsystem = Shellcheck
-
-
-@rule
-async def partition_shellcheck(
-    request: ShellcheckRequest.PartitionRequest[ShellcheckFieldSet], shellcheck: Shellcheck
-) -> Partitions[ShellcheckFieldSet]:
-    return Partitions() if shellcheck.skip else Partitions.single_partition(request.field_sets)
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
@@ -110,4 +103,9 @@ async def run_shellcheck(
 
 
 def rules():
-    return [*collect_rules(), *ShellcheckRequest.registration_rules()]
+    return [
+        *collect_rules(),
+        *ShellcheckRequest.registration_rules(
+            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
+        ),
+    ]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from pants.backend.shell.lint.shfmt.skip_field import SkipShfmtField
 from pants.backend.shell.lint.shfmt.subsystem import Shfmt
 from pants.backend.shell.target_types import ShellSourceField
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
+from pants.core.goals.lint import PartitionerType
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.fs import Digest, MergeDigests
@@ -33,17 +34,6 @@ class ShfmtFieldSet(FieldSet):
 class ShfmtRequest(FmtTargetsRequest):
     field_set_type = ShfmtFieldSet
     tool_subsystem = Shfmt
-
-
-@rule
-async def partition_shfmt(request: ShfmtRequest.PartitionRequest, shfmt: Shfmt) -> Partitions:
-    return (
-        Partitions()
-        if shfmt.skip
-        else Partitions.single_partition(
-            field_set.sources.file_path for field_set in request.field_sets
-        )
-    )
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
@@ -92,5 +82,5 @@ async def shfmt_fmt(
 def rules():
     return [
         *collect_rules(),
-        *ShfmtRequest.registration_rules(),
+        *ShfmtRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -195,7 +195,7 @@ class FmtTargetsRequest(FmtRequest, LintTargetsRequest):
                 )
             )
 
-        yield from collect_rules(locals())
+        return collect_rules(locals())
 
     @classmethod
     def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -10,10 +10,16 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Iterator, NamedTuple, Sequence, Tuple, Type, TypeVar
 
 from pants.base.specs import Specs
-from pants.core.goals.lint import LintFilesRequest, LintRequest, LintResult, LintTargetsRequest
+from pants.core.goals.lint import (
+    LintFilesRequest,
+    LintRequest,
+    LintResult,
+    LintTargetsRequest,
+    PartitionerType,
+)
 from pants.core.goals.lint import Partitions as LintPartitions
 from pants.core.goals.lint import _get_partitions_by_request_type
-from pants.core.goals.multi_tool_goal_helper import BatchSizeOption, OnlyOption
+from pants.core.goals.multi_tool_goal_helper import BatchSizeOption, OnlyOption, SkippableSubsystem
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareReturnType
@@ -22,9 +28,16 @@ from pants.engine.fs import Digest, MergeDigests, PathGlobs, Snapshot, SnapshotD
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import FallibleProcessResult, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule, rule_helper
+from pants.engine.target import (
+    SourcesField,
+    SourcesPaths,
+    SourcesPathsRequest,
+    _get_field_set_fields,
+)
 from pants.engine.unions import UnionMembership, UnionRule, distinct_union_type_per_subclass, union
 from pants.util.collections import partition_sequentially
 from pants.util.logging import LogLevel
+from pants.util.memo import memoized_classproperty
 from pants.util.meta import frozen_after_init, runtime_ignore_subscripts
 from pants.util.strutil import strip_v2_chroot_path
 
@@ -130,23 +143,80 @@ class FmtRequest(LintRequest):
             return self.elements
 
     @classmethod
-    def _get_registration_rules(cls) -> Iterable[UnionRule]:
-        yield from super()._get_registration_rules()
+    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable[UnionRule]:
+        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtRequest, cls)
         yield UnionRule(FmtRequest.SubPartition, cls.SubPartition)
 
 
 class FmtTargetsRequest(FmtRequest, LintTargetsRequest):
+    @memoized_classproperty
+    def _default_single_partition_partitioner_rules(cls) -> Iterable:
+        # NB: This only works if the FieldSet has a single `SourcesField` field. We check here for
+        # a better user experience.
+        sources_field_name = None
+        for fieldname, fieldtype in _get_field_set_fields(cls.field_set_type).items():
+            if issubclass(fieldtype, SourcesField):
+                if sources_field_name is None:
+                    sources_field_name = fieldname
+                    break
+                raise TypeError(
+                    f"Type {cls.field_set_type} has multiple `SourcesField` fields."
+                    + " Pants can't provide a default partitioner."
+                )
+        else:
+            raise TypeError(
+                f"Type {cls.field_set_type} has does not have a `SourcesField` field."
+                + " Pants can't provide a default partitioner."
+            )
+
+        @rule(
+            _param_type_overrides={
+                "request": cls.PartitionRequest,
+                "subsystem": cls.tool_subsystem,
+            }
+        )
+        async def default_single_partition_partitioner(
+            request: FmtTargetsRequest.PartitionRequest, subsystem: SkippableSubsystem
+        ) -> Partitions:
+            assert sources_field_name is not None
+            all_sources_paths = await MultiGet(
+                Get(SourcesPaths, SourcesPathsRequest(getattr(field_set, sources_field_name)))
+                for field_set in request.field_sets
+            )
+
+            return (
+                Partitions()
+                if subsystem.skip
+                else Partitions.single_partition(
+                    itertools.chain.from_iterable(
+                        sources_paths.files for sources_paths in all_sources_paths
+                    )
+                )
+            )
+
+        yield from collect_rules(locals())
+
     @classmethod
-    def _get_registration_rules(cls) -> Iterable[UnionRule]:
-        yield from super()._get_registration_rules()
+    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+        if partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
+            yield from cls._default_single_partition_partitioner_rules
+            partitioner_type = PartitionerType.CUSTOM
+
+        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
 class FmtFilesRequest(FmtRequest, LintFilesRequest):
     @classmethod
-    def _get_registration_rules(cls) -> Iterable[UnionRule]:
-        yield from super()._get_registration_rules()
+    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+        if partitioner_type is not PartitionerType.CUSTOM:
+            raise ValueError(
+                "Pants does not provide default partitioners for `FmtFilesRequest`."
+                + " You will need to provide your own partitioner rule."
+            )
+
+        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -265,7 +265,7 @@ class LintTargetsRequest(LintRequest):
                 Partitions() if subsystem.skip else Partitions.single_partition(request.field_sets)
             )
 
-        yield from collect_rules(locals())
+        return collect_rules(locals())
 
     @classmethod
     def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1300,16 +1300,18 @@ def _generate_file_level_targets(
 # -----------------------------------------------------------------------------------------------
 # FieldSet
 # -----------------------------------------------------------------------------------------------
+def _get_field_set_fields(field_set: Type[FieldSet]) -> Dict[str, Type[Field]]:
+    return {
+        name: field_type
+        for name, field_type in get_type_hints(field_set).items()
+        if isinstance(field_type, type) and issubclass(field_type, Field)
+    }
 
 
 def _get_field_set_fields_from_target(
     field_set: Type[FieldSet], target: Target
 ) -> Dict[str, Field]:
-    all_expected_fields: Dict[str, Type[Field]] = {
-        name: field_type
-        for name, field_type in get_type_hints(field_set).items()
-        if isinstance(field_type, type) and issubclass(field_type, Field)
-    }
+    all_expected_fields = _get_field_set_fields(field_set)
     return {
         dataclass_field_name: (
             target[field_cls] if field_cls in field_set.required_fields else target.get(field_cls)


### PR DESCRIPTION
It's been several changes getting here, but here we are!

This PR gives plugin authors the ability to opt into a "default" partitioner rule, returning (optionally, if not skipped) a single Partitions object with one big partition. Refactors have been made to all the plugins which can take advantage of this rule.

The design is made with additional default partitioners in mind as well.

[ci skip-rust]
[ci skip-build-wheels]