### PR TITLE
Optionally export venvs via symlink into the pex_root.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -7,19 +7,22 @@ import logging
 import os
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import DefaultDict, Iterable, cast
+from typing import Any, DefaultDict, Iterable, cast
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
+from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_cli import PexPEX
+from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.export import (
+    Export,
     ExportError,
     ExportRequest,
     ExportResult,
     ExportResults,
+    ExportSubsystem,
     PostProcessingCommand,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -31,6 +34,7 @@ from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule, rule_helper
 from pants.engine.target import Target
 from pants.engine.unions import UnionMembership, UnionRule, union
+from pants.option.option_types import BoolOption
 from pants.util.docutil import bin_name
 from pants.util.strutil import path_safe, softwrap
 
@@ -77,74 +81,128 @@ class ExportPythonTool(EngineAwareParameter):
         return self.resolve_name
 
 
+class ExportPluginOptions:
+    symlink_python_virtualenv = BoolOption(
+        default=False,
+        help="Export a symlink into a cached Python virtualenv.  This virtualenv will have no pip binary, "
+        "and will be immutable. Any attempt to modify it will corrupt the cache!  It may, however, "
+        "take significantly less time to export than a standalone, mutable virtualenv will.",
+    )
+
+
 @rule_helper
-async def _do_export(
-    requirements_pex: Pex,
-    pex_pex: PexPEX,
-    dest: str,
-    resolve_name: str,
-    qualify_path_with_python_version: bool,
-) -> ExportResult:
-    if requirements_pex.python is None:
-        # An internal-only pex will always have the `python` field set.
-        # See the build_pex() rule and _determine_pex_python_and_platforms() helper in pex.py.
-        raise ExportError(f"The PEX to be exported for {resolve_name} must be internal_only.")
-
+async def _get_full_python_version(pex_or_venv_pex: Pex | VenvPex) -> str:
     # Get the full python version (including patch #).
-    res = await Get(
-        ProcessResult,
-        PexProcess(
-            pex=requirements_pex,
-            description="Get interpreter version",
-            argv=[
-                "-c",
-                "import sys; print('.'.join(str(x) for x in sys.version_info[0:3]))",
-            ],
-            extra_env={"PEX_INTERPRETER": "1"},
-        ),
-    )
-    py_version = res.stdout.strip().decode()
-
-    # NOTE: We add a unique prefix to the pex_pex path to avoid conflicts when multiple
-    # venvs are concurrently exporting. Without this prefix all the invocations write
-    # the pex_pex to `python/virtualenvs/tools/pex`, and the `rm -f` of the pex_pex
-    # path in one export will delete the binary out from under the others.
-    pex_pex_dir = f".{resolve_name}.tmp"
-    pex_pex_digest = await Get(Digest, AddPrefix(pex_pex.digest, pex_pex_dir))
-    pex_pex_dest = os.path.join("{digest_root}", pex_pex_dir)
-
-    merged_digest = await Get(Digest, MergeDigests([pex_pex_digest, requirements_pex.digest]))
-
-    description = f"for {resolve_name} " if resolve_name else ""
-    return ExportResult(
-        f"virtualenv {description}(using Python {py_version})",
-        dest,
-        digest=merged_digest,
-        post_processing_cmds=[
-            PostProcessingCommand(
-                [
-                    requirements_pex.python.path,
-                    os.path.join(pex_pex_dest, pex_pex.exe),
-                    os.path.join("{digest_root}", requirements_pex.name),
-                    "venv",
-                    "--pip",
-                    "--collisions-ok",
-                    "--remove=all",
-                    f"{{digest_root}}/{py_version if qualify_path_with_python_version else ''}",
-                ],
-                {"PEX_MODULE": "pex.tools"},
-            ),
-            # Remove the PEX pex, to avoid confusion.
-            PostProcessingCommand(["rm", "-rf", pex_pex_dest]),
+    is_venv_pex = isinstance(pex_or_venv_pex, VenvPex)
+    kwargs: dict[str, Any] = dict(
+        description="Get interpreter version",
+        argv=[
+            "-c",
+            "import sys; print('.'.join(str(x) for x in sys.version_info[0:3]))",
         ],
+        extra_env={"PEX_INTERPRETER": "1"},
     )
+    if is_venv_pex:
+        kwargs["venv_pex"] = pex_or_venv_pex
+        res = await Get(ProcessResult, VenvPexProcess(**kwargs))
+    else:
+        kwargs["pex"] = pex_or_venv_pex
+        res = await Get(ProcessResult, PexProcess(**kwargs))
+    return res.stdout.strip().decode()
+
+
+@dataclass(frozen=True)
+class VenvExportRequest:
+    pex_request: PexRequest
+    dest_prefix: str
+    resolve_name: str
+    qualify_path_with_python_version: bool
+
+
+@rule
+async def do_export(
+    req: VenvExportRequest,
+    pex_pex: PexPEX,
+    pex_env: PexEnvironment,
+    export_subsys: ExportSubsystem,
+) -> ExportResult:
+    if not req.pex_request.internal_only:
+        raise ExportError(f"The PEX to be exported for {req.resolve_name} must be internal_only.")
+    dest = (
+        os.path.join(req.dest_prefix, path_safe(req.resolve_name))
+        if req.resolve_name
+        else req.dest_prefix
+    )
+
+    if export_subsys.options.symlink_python_virtualenv:
+        requirements_venv_pex = await Get(VenvPex, PexRequest, req.pex_request)
+        py_version = await _get_full_python_version(requirements_venv_pex)
+        # Note that for symlinking we ignore qualify_path_with_python_version and always qualify, since
+        # we need some name for the symlink anyway.
+        output_path = f"{{digest_root}}/{py_version}"
+        description = (
+            f"Symlink to immutable virtualenv for {req.resolve_name or 'requirements'} "
+            f"(using Python {py_version})"
+        )
+        complete_pex_env = pex_env.in_workspace()
+        venv_abspath = os.path.join(complete_pex_env.pex_root, requirements_venv_pex.venv_rel_dir)
+        return ExportResult(
+            description,
+            dest,
+            post_processing_cmds=[PostProcessingCommand(["ln", "-s", venv_abspath, output_path])],
+        )
+    else:
+        # Note that an internal-only pex will always have the `python` field set.
+        # See the build_pex() rule and _determine_pex_python_and_platforms() helper in pex.py.
+        requirements_pex = await Get(Pex, PexRequest, req.pex_request)
+        assert requirements_pex.python is not None
+        py_version = await _get_full_python_version(requirements_pex)
+        output_path = (
+            f"{{digest_root}}/{py_version if req.qualify_path_with_python_version else ''}"
+        )
+        description = (
+            f"Mutable virtualenv for {req.resolve_name or 'requirements'} "
+            f"(using Python {py_version})"
+        )
+
+        # NOTE: We add a unique prefix to the pex_pex path to avoid conflicts when multiple
+        # venvs are concurrently exporting. Without this prefix all the invocations write
+        # the pex_pex to `python/virtualenvs/tools/pex`, and the `rm -f` of the pex_pex
+        # path in one export will delete the binary out from under the others.
+        pex_pex_dir = f".{req.resolve_name}.tmp"
+        pex_pex_digest = await Get(Digest, AddPrefix(pex_pex.digest, pex_pex_dir))
+        pex_pex_dest = os.path.join("{digest_root}", pex_pex_dir)
+
+        merged_digest = await Get(Digest, MergeDigests([pex_pex_digest, requirements_pex.digest]))
+
+        return ExportResult(
+            description,
+            dest,
+            digest=merged_digest,
+            post_processing_cmds=[
+                PostProcessingCommand(
+                    [
+                        requirements_pex.python.path,
+                        os.path.join(pex_pex_dest, pex_pex.exe),
+                        os.path.join("{digest_root}", requirements_pex.name),
+                        "venv",
+                        "--pip",
+                        "--collisions-ok",
+                        "--remove=all",
+                        output_path,
+                    ],
+                    {"PEX_MODULE": "pex.tools"},
+                ),
+                # Remove the PEX pex, to avoid confusion.
+                PostProcessingCommand(["rm", "-rf", pex_pex_dest]),
+            ],
+        )
 
 
 @rule
 async def export_virtualenv_for_targets(
     request: _ExportVenvRequest,
     python_setup: PythonSetup,
-    pex_pex: PexPEX,
 ) -> ExportResult:
     if request.resolve:
         interpreter_constraints = InterpreterConstraints(
@@ -157,48 +215,50 @@ async def export_virtualenv_for_targets(
             request.root_python_targets, python_setup
         ) or InterpreterConstraints(python_setup.interpreter_constraints)
 
-    # Note that a pex created from a RequirementsPexRequest has packed layout, which should lead
-    # to the best performance in this use case.
-    requirements_pex = await Get(
-        Pex,
+    # Note that a pex created from a RequirementsPexRequest has packed layout,
+    # which should lead to the best performance in this use case.
+    requirements_pex_request = await Get(
+        PexRequest,
         RequirementsPexRequest(
             (tgt.address for tgt in request.root_python_targets),
             hardcoded_interpreter_constraints=interpreter_constraints,
         ),
     )
 
-    dest = (
-        os.path.join("python", "virtualenvs", path_safe(request.resolve))
+    dest_prefix = (
+        os.path.join("python", "virtualenvs")
         if request.resolve
         else os.path.join("python", "virtualenv")
     )
 
-    export_result = await _do_export(
-        requirements_pex,
-        pex_pex,
-        dest,
-        request.resolve or "",
-        qualify_path_with_python_version=True,
+    export_result = await Get(
+        ExportResult,
+        VenvExportRequest(
+            requirements_pex_request,
+            dest_prefix,
+            request.resolve or "",
+            qualify_path_with_python_version=True,
+        ),
     )
     return export_result
 
 
 @rule
-async def export_tool(request: ExportPythonTool, pex_pex: PexPEX) -> ExportResult:
+async def export_tool(request: ExportPythonTool) -> ExportResult:
     assert request.pex_request is not None
 
-    # TODO: It seems unnecessary to qualify with "tools", since the tool resolve names don't collide
-    #  with user resolve names.  We should get rid of this via a deprecation cycle.
-    dest = os.path.join("python", "virtualenvs", "tools", request.resolve_name)
-    pex = await Get(Pex, PexRequest, request.pex_request)
-    export_result = await _do_export(
-        pex,
-        pex_pex,
-        dest,
-        request.resolve_name,
-        # TODO: It is pretty ad-hoc that we do add the interpreter version for resolves but not for tools.
-        #  We should pick one and deprecate the other.
-        qualify_path_with_python_version=False,
+    export_result = await Get(
+        ExportResult,
+        VenvExportRequest(
+            request.pex_request,
+            # TODO: It seems unnecessary to qualify with "tools", since the tool resolve names don't collide
+            #  with user resolve names.  We should get rid of this via a deprecation cycle.
+            os.path.join("python", "virtualenvs", "tools"),
+            request.resolve_name,
+            # TODO: It is pretty ad-hoc that we do add the interpreter version for resolves but not for tools.
+            #  We should pick one and deprecate the other.
+            qualify_path_with_python_version=False,
+        ),
     )
     return export_result
 
@@ -261,5 +321,6 @@ async def export_virtualenvs(
 def rules():
     return [
         *collect_rules(),
+        Export.subsystem_cls.register_plugin_options(ExportPluginOptions),
         UnionRule(ExportRequest, ExportVenvsRequest),
     ]

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -35,7 +35,13 @@ def rule_runner() -> RuleRunner:
     )
 
 
-def test_export_venvs(rule_runner: RuleRunner) -> None:
+@pytest.mark.parametrize("enable_resolves", [False, True])
+@pytest.mark.parametrize("symlink", [False, True])
+def test_export_venv_pipified(
+    rule_runner: RuleRunner,
+    enable_resolves: bool,
+    symlink: bool,
+) -> None:
     # We know that the current interpreter exists on the system.
     vinfo = sys.version_info
     current_interpreter = f"{vinfo.major}.{vinfo.minor}.{vinfo.micro}"
@@ -51,28 +57,34 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
         }
     )
 
-    def run(enable_resolves: bool) -> ExportResults:
-        rule_runner.set_options(
-            [
-                f"--python-interpreter-constraints=['=={current_interpreter}']",
-                "--python-resolves={'a': 'lock.txt', 'b': 'lock.txt'}",
-                f"--python-enable-resolves={enable_resolves}",
-                # Turn off lockfile validation to make the test simpler.
-                "--python-invalid-lockfile-behavior=ignore",
-            ],
-            env_inherit={"PATH", "PYENV_ROOT"},
-        )
-        targets = rule_runner.request(
-            Targets,
-            [
-                RawSpecs(
-                    recursive_globs=(RecursiveGlobSpec("src/foo"),), description_of_origin="tests"
-                )
-            ],
-        )
-        all_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets)])
+    symlink_flag = f"--{'' if symlink else 'no-'}export-symlink-python-virtualenv"
+    rule_runner.set_options(
+        [
+            f"--python-interpreter-constraints=['=={current_interpreter}']",
+            "--python-resolves={'a': 'lock.txt', 'b': 'lock.txt'}",
+            f"--python-enable-resolves={enable_resolves}",
+            # Turn off lockfile validation to make the test simpler.
+            "--python-invalid-lockfile-behavior=ignore",
+            symlink_flag,
+        ],
+        env_inherit={"PATH", "PYENV_ROOT"},
+    )
+    targets = rule_runner.request(
+        Targets,
+        [RawSpecs(recursive_globs=(RecursiveGlobSpec("src/foo"),), description_of_origin="tests")],
+    )
+    all_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets)])
 
-        for result, resolve in zip(all_results, ["a", "b"] if enable_resolves else [""]):
+    for result, resolve in zip(all_results, ["a", "b"] if enable_resolves else [""]):
+        if symlink:
+            assert len(result.post_processing_cmds) == 1
+            ppc0 = result.post_processing_cmds[0]
+            assert ppc0.argv[0:2] == ("ln", "-s")
+            # The third arg is the full path to the venv under the pex_root, which we
+            # don't easily know here, so we ignore it in this comparison.
+            assert ppc0.argv[3] == os.path.join("{digest_root}", current_interpreter)
+            assert ppc0.extra_env == FrozenDict()
+        else:
             assert len(result.post_processing_cmds) == 2
 
             ppc0 = result.post_processing_cmds[0]
@@ -97,15 +109,11 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
             )
             assert ppc1.extra_env == FrozenDict()
 
-        return all_results
-
-    resolve_results = run(enable_resolves=True)
-    assert len(resolve_results) == 2
-    assert {result.reldir for result in resolve_results} == {
-        "python/virtualenvs/a",
-        "python/virtualenvs/b",
-    }
-
-    no_resolve_results = run(enable_resolves=False)
-    assert len(no_resolve_results) == 1
-    assert no_resolve_results[0].reldir == "python/virtualenv"
+    reldirs = [result.reldir for result in all_results]
+    if enable_resolves:
+        assert reldirs == [
+            "python/virtualenvs/a",
+            "python/virtualenvs/b",
+        ]
+    else:
+        assert reldirs == ["python/virtualenv"]


### PR DESCRIPTION
Uses the new plugin subsystem options to make this an option on the `export` scope, which is neat!

The symlinked venv has no pip binary and so is immutable. This is dramatically faster than creating a pipified venv, but any attempt to modify such a venv will corrupt the pants cache, so caveat emptor.

Also refactors export_test.py to use parametrization.

[ci skip-rust]
[ci skip-build-wheels]