### PR TITLE
Remote execution is only enabled globally if environments aren't used at all

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -695,7 +695,7 @@ async def extract_process_config_from_environment(
 ) -> ProcessConfigFromEnvironment:
     docker_image = None
     remote_execution = False
-    raw_remote_execution_extra_platform_properties = ()
+    raw_remote_execution_extra_platform_properties: tuple[str, ...] = ()
 
     # If the environments mechanism is not used, fall back to legacy behavior of
     # `--remote-execution` being a global toggle.

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -73,6 +73,11 @@ class EnvironmentsSubsystem(Subsystem):
         )
     )
 
+    def remote_execution_used_globally(self, global_options: GlobalOptions) -> bool:
+        """If the environments mechanism is not used, `--remote-execution` toggles remote execution
+        globally."""
+        return not self.names and global_options.remote_execution
+
 
 # -------------------------------------------------------------------------------------------
 # Environment targets
@@ -697,9 +702,7 @@ async def extract_process_config_from_environment(
     remote_execution = False
     raw_remote_execution_extra_platform_properties: tuple[str, ...] = ()
 
-    # If the environments mechanism is not used, fall back to legacy behavior of
-    # `--remote-execution` being a global toggle.
-    if not environments_subsystem.names and global_options.remote_execution:
+    if environments_subsystem.remote_execution_used_globally(global_options):
         remote_execution = True
         raw_remote_execution_extra_platform_properties = (
             global_options.remote_execution_extra_platform_properties

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from pants.core.util_rules.environments import (
     DockerImageField,
     DockerPlatformField,
+    EnvironmentsSubsystem,
     EnvironmentTarget,
     RemotePlatformField,
 )
@@ -19,7 +20,11 @@ from pants.util.logging import LogLevel
 
 
 @rule
-def current_platform(env_tgt: EnvironmentTarget, global_options: GlobalOptions) -> Platform:
+def current_platform(
+    env_tgt: EnvironmentTarget,
+    global_options: GlobalOptions,
+    environments_subsystem: EnvironmentsSubsystem,
+) -> Platform:
     if env_tgt.val:
         if env_tgt.val.has_field(DockerPlatformField):
             return Platform(env_tgt.val[DockerPlatformField].normalized_value)
@@ -28,18 +33,20 @@ def current_platform(env_tgt: EnvironmentTarget, global_options: GlobalOptions) 
         # Else, it's a local environment.
         return Platform.create_for_localhost()
 
-    # Else, the environments mechanism is not used. For now, at least, we continue to support
-    # enabling remote execution globally for every build via the `--remote-execution` option.
-    return (
-        Platform.linux_x86_64
-        if global_options.remote_execution
-        else Platform.create_for_localhost()
-    )
+    # If the environments mechanism is not used, fall back to legacy behavior of
+    # `--remote-execution` being a global toggle.
+    if not environments_subsystem.names and global_options.remote_execution:
+        return Platform.linux_x86_64
+
+    return Platform.create_for_localhost()
 
 
 @rule
 async def complete_environment_vars(
-    session_values: SessionValues, env_tgt: EnvironmentTarget, global_options: GlobalOptions
+    session_values: SessionValues,
+    env_tgt: EnvironmentTarget,
+    global_options: GlobalOptions,
+    environments_subsystem: EnvironmentsSubsystem,
 ) -> CompleteEnvironmentVars:
     # If a local environment is used, we simply use SessionValues. Otherwise, we need to run `env`
     # and parse the output.
@@ -57,7 +64,9 @@ async def complete_environment_vars(
             # Else, it's a local environment.
             return session_values[CompleteEnvironmentVars]
     else:
-        if global_options.remote_execution:
+        # If the environments mechanism is not used, fall back to legacy behavior of
+        # `--remote-execution` being a global toggle.
+        if not environments_subsystem.names and global_options.remote_execution:
             description_of_env_source = "the remote execution environment"
         else:
             return session_values[CompleteEnvironmentVars]

--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -13,7 +13,7 @@ from pants.core.util_rules.environments import (
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.internals.session import SessionValues
 from pants.engine.platform import Platform
-from pants.engine.process import Process, ProcessResult, ProcessCacheScope
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel

--- a/src/python/pants/engine/internals/platform_rules_test.py
+++ b/src/python/pants/engine/internals/platform_rules_test.py
@@ -13,6 +13,7 @@ from pants.core.util_rules.environments import (
     DockerEnvironmentTarget,
     DockerImageField,
     DockerPlatformField,
+    EnvironmentsSubsystem,
     EnvironmentTarget,
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
@@ -33,18 +34,31 @@ from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_
 def test_current_platform() -> None:
     def assert_platform(
         *,
+        envs_enabled: bool = True,
         env_tgt: LocalEnvironmentTarget | RemoteEnvironmentTarget | DockerEnvironmentTarget | None,
         remote_execution: bool,
         expected: Platform,
     ) -> None:
         global_options = create_subsystem(GlobalOptions, remote_execution=remote_execution)
+        env_subsystem = create_subsystem(
+            EnvironmentsSubsystem,
+            names={"name": "addr"} if envs_enabled else {},
+        )
         result = run_rule_with_mocks(
-            current_platform, rule_args=[EnvironmentTarget(env_tgt), global_options]
+            current_platform, rule_args=[EnvironmentTarget(env_tgt), global_options, env_subsystem]
         )
         assert result == expected
 
     assert_platform(env_tgt=None, remote_execution=False, expected=Platform.create_for_localhost())
-    assert_platform(env_tgt=None, remote_execution=True, expected=Platform.linux_x86_64)
+    assert_platform(
+        env_tgt=None, envs_enabled=False, remote_execution=True, expected=Platform.linux_x86_64
+    )
+    assert_platform(
+        env_tgt=None,
+        envs_enabled=True,
+        remote_execution=True,
+        expected=Platform.create_for_localhost(),
+    )
 
     for re in (False, True):
         assert_platform(
@@ -80,11 +94,16 @@ def test_current_platform() -> None:
 def test_complete_env_vars() -> None:
     def assert_env_vars(
         *,
+        envs_enabled: bool = True,
         env_tgt: LocalEnvironmentTarget | RemoteEnvironmentTarget | DockerEnvironmentTarget | None,
         remote_execution: bool,
         expected_env: str,
     ) -> None:
         global_options = create_subsystem(GlobalOptions, remote_execution=remote_execution)
+        env_subsystem = create_subsystem(
+            EnvironmentsSubsystem,
+            names={"name": "addr"} if envs_enabled else {},
+        )
 
         def mock_env_process(process: Process) -> ProcessResult:
             return Mock(
@@ -99,6 +118,7 @@ def test_complete_env_vars() -> None:
                 ),
                 EnvironmentTarget(env_tgt),
                 global_options,
+                env_subsystem,
             ],
             mock_gets=[
                 MockGet(output_type=ProcessResult, input_types=(Process,), mock=mock_env_process)
@@ -107,7 +127,8 @@ def test_complete_env_vars() -> None:
         assert dict(result) == {expected_env: "true"}
 
     assert_env_vars(env_tgt=None, remote_execution=False, expected_env="LOCAL")
-    assert_env_vars(env_tgt=None, remote_execution=True, expected_env="REMOTE")
+    assert_env_vars(env_tgt=None, envs_enabled=False, remote_execution=True, expected_env="REMOTE")
+    assert_env_vars(env_tgt=None, envs_enabled=True, remote_execution=True, expected_env="LOCAL")
 
     for re in (False, True):
         assert_env_vars(


### PR DESCRIPTION
It's now possible to use environments generally, but for the current env target to be set to None, thanks to https://github.com/pantsbuild/pants/pull/16983.

This was resulting in faulty logic that we were treating the `--remote-execution` flag as a global switch for remoting, when really if environment targets are used at all, then we should only use remoting when a `remote_environment` target is active.

[ci skip-rust]

[ci skip-build-wheels]