### PR TITLE
Generate help info about target_field_name to the docsite.

### DIFF
--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -16,6 +16,10 @@
     The blank line here appears to ensure it. }}
 
 {{{help}}}
+{{#target_field_name}}
+
+Can be overriden by field `{{target_field_name}}` on `local_environment`, `docker_environment`, or `remote_environment` targets.
+{{/target_field_name}}
 </div>
 <br>
 

--- a/src/python/pants/help/help_formatter.py
+++ b/src/python/pants/help/help_formatter.py
@@ -102,13 +102,6 @@ class HelpFormatter(MaybeColor):
         arg_lines = [f"  {self.maybe_magenta(args)}" for args in ohi.display_args]
         arg_lines.append(self.maybe_magenta(f"  {ohi.env_var}"))
         arg_lines.append(self.maybe_magenta(f"  {ohi.config_key}"))
-        if ohi.target_field_name:
-            arg_lines.append(
-                self.maybe_orange(
-                    f"  Can be overriden by field `{ohi.target_field_name}` on "
-                    "`local_environment`, `docker_environment`, or `remote_environment` targets."
-                )
-            )
 
         choices = "" if ohi.choices is None else f"one of: [{', '.join(ohi.choices)}]"
         choices_lines = [
@@ -142,6 +135,13 @@ class HelpFormatter(MaybeColor):
             for line in format_value(rv, "overrode: ", f"{indent}    ")
         ]
         description_lines = wrap(ohi.help)
+        if ohi.target_field_name:
+            description_lines.extend(
+                wrap(
+                    f"\nCan be overriden by field `{ohi.target_field_name}` on "
+                    "`local_environment`, `docker_environment`, or `remote_environment` targets."
+                )
+            )
         lines = [
             *arg_lines,
             *choices_lines,

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -232,8 +232,8 @@ def softwrap(text: str) -> str:
         - Replaces all occurrences of multiple spaces in a sentence with a single space
         - Replaces all occurrences of multiple newlines with exactly 2 newlines
         - Replaces singular newlines with a space (to turn a paragraph into one long line)
-            - Unless the following line is indented, in which case the newline and indentation
-              are preserved.
+            - Unless the following line is indented, or begins with a `* ` (to indicate an item in a list),
+              in which case the newline and indentation are preserved.
         - Double-newlines are preserved
         - Extra indentation is preserved, and also preserves the indented line's ending
             (If your indented line needs to be continued due to it being longer than the suggested
@@ -257,7 +257,12 @@ def softwrap(text: str) -> str:
     for i, line in enumerate(lines):
         line = _super_space_re.sub(r"\1 \2", line)
         next_line = lines[i + 1] if i + 1 < len(lines) else ""
-        if "\n" in (line, next_line) or line.startswith(" ") or next_line.startswith(" "):
+        if (
+            "\n" in (line, next_line)
+            or line.startswith(" ")
+            or next_line.startswith(" ")
+            or line.lstrip().startswith("* ")
+        ):
             result_strs.append(line)
         else:
             result_strs.append(line.rstrip())


### PR DESCRIPTION
Tweaks where this info is displayed in cli help, to match.

[ci skip-rust]

[ci skip-build-wheels]