### PR TITLE
Minor cleanups to fmt/lint

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/register.py
+++ b/src/python/pants/backend/build_files/fmt/black/register.py
@@ -43,6 +43,6 @@ async def black_fmt(request: BlackRequest.SubPartition, black: Black) -> FmtResu
 def rules():
     return [
         *collect_rules(),
-        *BlackRequest.registration_rules(),
+        *BlackRequest.rules(),
         *black_subsystem.rules(),
     ]

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -68,5 +68,5 @@ async def buildfier_fmt(
 def rules():
     return [
         *collect_rules(),
-        *BuildifierRequest.registration_rules(),
+        *BuildifierRequest.rules(),
     ]

--- a/src/python/pants/backend/build_files/fmt/yapf/register.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/register.py
@@ -43,6 +43,6 @@ async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        *YapfRequest.registration_rules(),
+        *YapfRequest.rules(),
         *yapf_subsystem.rules(),
     ]

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -34,6 +34,7 @@ class ClangFormatFmtFieldSet(FieldSet):
 class ClangFormatRequest(FmtTargetsRequest):
     field_set_type = ClangFormatFmtFieldSet
     tool_subsystem = ClangFormat
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(level=LogLevel.DEBUG)
@@ -95,5 +96,5 @@ async def clangformat_fmt(
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *ClangFormatRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *ClangFormatRequest.rules(),
     )

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -95,7 +95,5 @@ async def clangformat_fmt(
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *ClangFormatRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *ClangFormatRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     )

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -111,5 +111,5 @@ async def run_buf_format(
 def rules():
     return [
         *collect_rules(),
-        *BufFormatRequest.registration_rules(),
+        *BufFormatRequest.rules(),
     ]

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -116,5 +116,5 @@ async def run_buf(
 def rules():
     return [
         *collect_rules(),
-        *BufLintRequest.registration_rules(),
+        *BufLintRequest.rules(),
     ]

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -34,6 +34,7 @@ class HadolintFieldSet(FieldSet):
 class HadolintRequest(LintTargetsRequest):
     field_set_type = HadolintFieldSet
     tool_subsystem = Hadolint
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 def generate_argv(
@@ -102,5 +103,5 @@ async def run_hadolint(
 def rules():
     return [
         *collect_rules(),
-        *HadolintRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *HadolintRequest.rules(),
     ]

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -102,7 +102,5 @@ async def run_hadolint(
 def rules():
     return [
         *collect_rules(),
-        *HadolintRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *HadolintRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -66,5 +66,5 @@ def rules():
     return [
         *collect_rules(),
         *goroot.rules(),
-        *GofmtRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *GofmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -37,6 +37,7 @@ class GofmtFieldSet(FieldSet):
 class GofmtRequest(FmtTargetsRequest):
     field_set_type = GofmtFieldSet
     tool_subsystem = GofmtSubsystem
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with gofmt")
@@ -66,5 +67,5 @@ def rules():
     return [
         *collect_rules(),
         *goroot.rules(),
-        *GofmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *GofmtRequest.rules(),
     ]

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -183,5 +183,5 @@ async def run_golangci_lint(
 def rules():
     return [
         *collect_rules(),
-        *GolangciLintRequest.registration_rules(),
+        *GolangciLintRequest.rules(),
     ]

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -41,6 +41,7 @@ class GoVetFieldSet(FieldSet):
 class GoVetRequest(LintTargetsRequest):
     field_set_type = GoVetFieldSet
     tool_subsystem = GoVetSubsystem
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(level=LogLevel.DEBUG)
@@ -84,5 +85,5 @@ async def run_go_vet(request: GoVetRequest.SubPartition[GoVetFieldSet]) -> LintR
 def rules():
     return [
         *collect_rules(),
-        *GoVetRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *GoVetRequest.rules(),
     ]

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -84,5 +84,5 @@ async def run_go_vet(request: GoVetRequest.SubPartition[GoVetFieldSet]) -> LintR
 def rules():
     return [
         *collect_rules(),
-        *GoVetRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *GoVetRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -76,4 +76,4 @@ async def run_helm_lint(
 
 
 def rules():
-    return [*collect_rules(), *tool.rules(), *HelmLintRequest.registration_rules()]
+    return [*collect_rules(), *tool.rules(), *HelmLintRequest.rules()]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -40,6 +40,7 @@ class GoogleJavaFormatFieldSet(FieldSet):
 class GoogleJavaFormatRequest(FmtTargetsRequest):
     field_set_type = GoogleJavaFormatFieldSet
     tool_subsystem = GoogleJavaFormatSubsystem
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 class GoogleJavaFormatToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
@@ -116,6 +117,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        *GoogleJavaFormatRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *GoogleJavaFormatRequest.rules(),
         UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -116,8 +116,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        *GoogleJavaFormatRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *GoogleJavaFormatRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         UnionRule(GenerateToolLockfileSentinel, GoogleJavaFormatToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -34,6 +34,7 @@ class PrettierFmtFieldSet(FieldSet):
 class PrettierFmtRequest(FmtTargetsRequest):
     field_set_type = PrettierFmtFieldSet
     tool_subsystem = Prettier
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(level=LogLevel.DEBUG)
@@ -84,5 +85,5 @@ async def prettier_fmt(request: PrettierFmtRequest.SubPartition, prettier: Prett
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *PrettierFmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *PrettierFmtRequest.rules(),
     )

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -84,7 +84,5 @@ async def prettier_fmt(request: PrettierFmtRequest.SubPartition, prettier: Prett
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *PrettierFmtRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *PrettierFmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     )

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -101,8 +101,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        *KtlintRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *KtlintRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         UnionRule(GenerateToolLockfileSentinel, KtlintToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -40,6 +40,7 @@ class KtlintFieldSet(FieldSet):
 class KtlintRequest(FmtTargetsRequest):
     field_set_type = KtlintFieldSet
     tool_subsystem = KtlintSubsystem
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 class KtlintToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
@@ -101,6 +102,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_tool.rules(),
-        *KtlintRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *KtlintRequest.rules(),
         UnionRule(GenerateToolLockfileSentinel, KtlintToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -339,4 +339,4 @@ async def lint_with_regex_patterns(
 
 
 def rules():
-    return (*collect_rules(), *RegexLintRequest.registration_rules())
+    return (*collect_rules(), *RegexLintRequest.rules())

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -69,8 +69,6 @@ async def add_trailing_comma_fmt(
 def rules():
     return [
         *collect_rules(),
-        *AddTrailingCommaRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *AddTrailingCommaRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -33,6 +33,7 @@ class AddTrailingCommaFieldSet(FieldSet):
 class AddTrailingCommaRequest(FmtTargetsRequest):
     field_set_type = AddTrailingCommaFieldSet
     tool_subsystem = AddTrailingComma
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with add-trailing-comma", level=LogLevel.DEBUG)
@@ -69,6 +70,6 @@ async def add_trailing_comma_fmt(
 def rules():
     return [
         *collect_rules(),
-        *AddTrailingCommaRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *AddTrailingCommaRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -67,8 +67,6 @@ async def autoflake_fmt(request: AutoflakeRequest.SubPartition, autoflake: Autof
 def rules():
     return [
         *collect_rules(),
-        *AutoflakeRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *AutoflakeRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -33,6 +33,7 @@ class AutoflakeFieldSet(FieldSet):
 class AutoflakeRequest(FmtTargetsRequest):
     field_set_type = AutoflakeFieldSet
     tool_subsystem = Autoflake
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with Autoflake", level=LogLevel.DEBUG)
@@ -67,6 +68,6 @@ async def autoflake_fmt(request: AutoflakeRequest.SubPartition, autoflake: Autof
 def rules():
     return [
         *collect_rules(),
-        *AutoflakeRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *AutoflakeRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -104,4 +104,4 @@ async def bandit_lint(
 
 
 def rules():
-    return [*collect_rules(), *BanditRequest.registration_rules(), *pex.rules()]
+    return [*collect_rules(), *BanditRequest.rules(), *pex.rules()]

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -125,6 +125,6 @@ async def black_fmt(request: BlackRequest.SubPartition, black: Black) -> FmtResu
 def rules():
     return [
         *collect_rules(),
-        *BlackRequest.registration_rules(),
+        *BlackRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -33,6 +33,7 @@ class DocformatterFieldSet(FieldSet):
 class DocformatterRequest(FmtTargetsRequest):
     field_set_type = DocformatterFieldSet
     tool_subsystem = Docformatter
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
@@ -64,6 +65,6 @@ async def docformatter_fmt(
 def rules():
     return [
         *collect_rules(),
-        *DocformatterRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *DocformatterRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -64,8 +64,6 @@ async def docformatter_fmt(
 def rules():
     return [
         *collect_rules(),
-        *DocformatterRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *DocformatterRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -140,6 +140,6 @@ async def run_flake8(
 def rules():
     return [
         *collect_rules(),
-        *Flake8Request.registration_rules(),
+        *Flake8Request.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -104,6 +104,6 @@ async def isort_fmt(request: IsortRequest.SubPartition, isort: Isort) -> FmtResu
 def rules():
     return [
         *collect_rules(),
-        *IsortRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *IsortRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -36,6 +36,7 @@ class IsortFieldSet(FieldSet):
 class IsortRequest(FmtTargetsRequest):
     field_set_type = IsortFieldSet
     tool_subsystem = Isort
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 def generate_argv(
@@ -104,6 +105,6 @@ async def isort_fmt(request: IsortRequest.SubPartition, isort: Isort) -> FmtResu
 def rules():
     return [
         *collect_rules(),
-        *IsortRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *IsortRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -213,6 +213,6 @@ async def run_pylint(
 def rules():
     return [
         *collect_rules(),
-        *PylintRequest.registration_rules(),
+        *PylintRequest.rules(),
         *pex_from_targets.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -34,6 +34,7 @@ class PyUpgradeFieldSet(FieldSet):
 class PyUpgradeRequest(FmtTargetsRequest):
     field_set_type = PyUpgradeFieldSet
     tool_subsystem = PyUpgrade
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with pyupgrade", level=LogLevel.DEBUG)
@@ -60,6 +61,6 @@ async def pyupgrade_fmt(request: PyUpgradeRequest.SubPartition, pyupgrade: PyUpg
 def rules():
     return [
         *collect_rules(),
-        *PyUpgradeRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *PyUpgradeRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -60,8 +60,6 @@ async def pyupgrade_fmt(request: PyUpgradeRequest.SubPartition, pyupgrade: PyUpg
 def rules():
     return [
         *collect_rules(),
-        *PyUpgradeRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *PyUpgradeRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -37,6 +37,7 @@ class YapfFieldSet(FieldSet):
 class YapfRequest(FmtTargetsRequest):
     field_set_type = YapfFieldSet
     tool_subsystem = Yapf
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule_helper
@@ -87,6 +88,6 @@ async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        *YapfRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *YapfRequest.rules(),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -87,6 +87,6 @@ async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
 def rules():
     return [
         *collect_rules(),
-        *YapfRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *YapfRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         *pex.rules(),
     ]

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -219,6 +219,6 @@ def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        *ScalafmtRequest.registration_rules(),
+        *ScalafmtRequest.rules(),
         UnionRule(GenerateToolLockfileSentinel, ScalafmtToolLockfileSentinel),
     ]

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -34,6 +34,7 @@ class ShellcheckFieldSet(FieldSet):
 class ShellcheckRequest(LintTargetsRequest):
     field_set_type = ShellcheckFieldSet
     tool_subsystem = Shellcheck
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
@@ -105,5 +106,5 @@ async def run_shellcheck(
 def rules():
     return [
         *collect_rules(),
-        *ShellcheckRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *ShellcheckRequest.rules(),
     ]

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -105,7 +105,5 @@ async def run_shellcheck(
 def rules():
     return [
         *collect_rules(),
-        *ShellcheckRequest.registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *ShellcheckRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -82,5 +82,5 @@ async def shfmt_fmt(
 def rules():
     return [
         *collect_rules(),
-        *ShfmtRequest.registration_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *ShfmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
     ]

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -34,6 +34,7 @@ class ShfmtFieldSet(FieldSet):
 class ShfmtRequest(FmtTargetsRequest):
     field_set_type = ShfmtFieldSet
     tool_subsystem = Shfmt
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
@@ -82,5 +83,5 @@ async def shfmt_fmt(
 def rules():
     return [
         *collect_rules(),
-        *ShfmtRequest.rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *ShfmtRequest.rules(),
     ]

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -77,5 +77,5 @@ def rules():
         *collect_rules(),
         *external_tool.rules(),
         *tool_rules(),
-        *TffmtRequest.registration_rules(),
+        *TffmtRequest.rules(),
     ]

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -143,8 +143,8 @@ class FmtRequest(LintRequest):
             return self.elements
 
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable[UnionRule]:
-        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable[UnionRule]:
+        yield from super()._get_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtRequest, cls)
         yield UnionRule(FmtRequest.SubPartition, cls.SubPartition)
 
@@ -198,25 +198,25 @@ class FmtTargetsRequest(FmtRequest, LintTargetsRequest):
         return collect_rules(locals())
 
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
         if partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
             yield from cls._default_single_partition_partitioner_rules
             partitioner_type = PartitionerType.CUSTOM
 
-        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
 class FmtFilesRequest(FmtRequest, LintFilesRequest):
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
         if partitioner_type is not PartitionerType.CUSTOM:
             raise ValueError(
                 "Pants does not provide default partitioners for `FmtFilesRequest`."
                 + " You will need to provide your own partitioner rule."
             )
 
-        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules(partitioner_type=partitioner_type)
         yield UnionRule(FmtFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -143,8 +143,8 @@ class FmtRequest(LintRequest):
             return self.elements
 
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable[UnionRule]:
-        yield from super()._get_rules(partitioner_type=partitioner_type)
+    def _get_rules(cls) -> Iterable[UnionRule]:
+        yield from super()._get_rules()
         yield UnionRule(FmtRequest, cls)
         yield UnionRule(FmtRequest.SubPartition, cls.SubPartition)
 
@@ -198,25 +198,29 @@ class FmtTargetsRequest(FmtRequest, LintTargetsRequest):
         return collect_rules(locals())
 
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
-        if partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
+    def _get_rules(cls) -> Iterable:
+        if cls.partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
             yield from cls._default_single_partition_partitioner_rules
-            partitioner_type = PartitionerType.CUSTOM
 
-        yield from super()._get_rules(partitioner_type=partitioner_type)
+        yield from (
+            rule
+            for rule in super()._get_rules()
+            # NB: We don't want to yield `lint.py`'s default partitioner
+            if isinstance(rule, UnionRule)
+        )
         yield UnionRule(FmtTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
 class FmtFilesRequest(FmtRequest, LintFilesRequest):
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
-        if partitioner_type is not PartitionerType.CUSTOM:
+    def _get_rules(cls) -> Iterable:
+        if cls.partitioner_type is not PartitionerType.CUSTOM:
             raise ValueError(
                 "Pants does not provide default partitioners for `FmtFilesRequest`."
                 + " You will need to provide your own partitioner rule."
             )
 
-        yield from super()._get_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules()
         yield UnionRule(FmtFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -200,9 +200,7 @@ def fmt_rule_runner(
             *collect_rules(),
             *source_files.rules(),
             *fmt_rules(),
-            *itertools.chain.from_iterable(
-                request_type.registration_rules() for request_type in request_types
-            ),
+            *itertools.chain.from_iterable(request_type.rules() for request_type in request_types),
         ],
         target_types=target_types,
     )
@@ -476,9 +474,7 @@ def test_default_single_partition_partitioner(kitchen_field_set_type, field_sets
         tool_subsystem = KitchenSubsystem
 
     rules = [
-        *FmtKitchenRequest._get_registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *FmtKitchenRequest._get_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         QueryRule(Partitions, [FmtKitchenRequest.PartitionRequest]),
     ]
     rule_runner = RuleRunner(rules=rules)

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -472,9 +472,10 @@ def test_default_single_partition_partitioner(kitchen_field_set_type, field_sets
     class FmtKitchenRequest(FmtTargetsRequest):
         field_set_type = kitchen_field_set_type
         tool_subsystem = KitchenSubsystem
+        partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
     rules = [
-        *FmtKitchenRequest._get_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *FmtKitchenRequest._get_rules(),
         QueryRule(Partitions, [FmtKitchenRequest.PartitionRequest]),
     ]
     rule_runner = RuleRunner(rules=rules)

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -196,7 +196,7 @@ class LintRequest:
         def rules():
             return [
                 *collect_rules(),
-                *DryCleaningRequest.registration_rules()
+                *DryCleaningRequest.rules()
             ]
 
     NOTE: For more information about the `PartitionRequest` types, see
@@ -221,13 +221,11 @@ class LintRequest:
 
     @final
     @classmethod
-    def registration_rules(
-        cls, *, partitioner_type: PartitionerType = PartitionerType.CUSTOM
-    ) -> Iterable:
-        yield from cls._get_registration_rules(partitioner_type=partitioner_type)
+    def rules(cls, *, partitioner_type: PartitionerType = PartitionerType.CUSTOM) -> Iterable:
+        yield from cls._get_rules(partitioner_type=partitioner_type)
 
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
         yield UnionRule(LintRequest, cls)
         yield UnionRule(LintRequest.SubPartition, cls.SubPartition)
 
@@ -268,11 +266,11 @@ class LintTargetsRequest(LintRequest):
         return collect_rules(locals())
 
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
         if partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
             yield from cls._default_single_partition_partitioner_rules
 
-        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules(partitioner_type=partitioner_type)
         yield UnionRule(LintTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
@@ -292,14 +290,14 @@ class LintFilesRequest(LintRequest, EngineAwareParameter):
         files: tuple[str, ...]
 
     @classmethod
-    def _get_registration_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
         if partitioner_type is not PartitionerType.CUSTOM:
             raise ValueError(
                 "Pants does not provide default partitioners for `LintFilesRequest`."
                 + " You will need to provide your own partitioner rule."
             )
 
-        yield from super()._get_registration_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules(partitioner_type=partitioner_type)
         yield UnionRule(LintFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -204,6 +204,8 @@ class LintRequest:
     """
 
     tool_subsystem: ClassVar[type[SkippableSubsystem]]
+    partitioner_type: ClassVar[PartitionerType] = PartitionerType.CUSTOM
+
     is_formatter: ClassVar[bool] = False
 
     @classproperty
@@ -221,11 +223,11 @@ class LintRequest:
 
     @final
     @classmethod
-    def rules(cls, *, partitioner_type: PartitionerType = PartitionerType.CUSTOM) -> Iterable:
-        yield from cls._get_rules(partitioner_type=partitioner_type)
+    def rules(cls) -> Iterable:
+        yield from cls._get_rules()
 
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
+    def _get_rules(cls) -> Iterable:
         yield UnionRule(LintRequest, cls)
         yield UnionRule(LintRequest.SubPartition, cls.SubPartition)
 
@@ -266,11 +268,11 @@ class LintTargetsRequest(LintRequest):
         return collect_rules(locals())
 
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
-        if partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
+    def _get_rules(cls) -> Iterable:
+        if cls.partitioner_type is PartitionerType.DEFAULT_SINGLE_PARTITION:
             yield from cls._default_single_partition_partitioner_rules
 
-        yield from super()._get_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules()
         yield UnionRule(LintTargetsRequest.PartitionRequest, cls.PartitionRequest)
 
 
@@ -290,14 +292,14 @@ class LintFilesRequest(LintRequest, EngineAwareParameter):
         files: tuple[str, ...]
 
     @classmethod
-    def _get_rules(cls, *, partitioner_type: PartitionerType) -> Iterable:
-        if partitioner_type is not PartitionerType.CUSTOM:
+    def _get_rules(cls) -> Iterable:
+        if cls.partitioner_type is not PartitionerType.CUSTOM:
             raise ValueError(
                 "Pants does not provide default partitioners for `LintFilesRequest`."
                 + " You will need to provide your own partitioner rule."
             )
 
-        yield from super()._get_rules(partitioner_type=partitioner_type)
+        yield from super()._get_rules()
         yield UnionRule(LintFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -401,9 +401,10 @@ def test_default_single_partition_partitioner() -> None:
     class LintKitchenRequest(LintTargetsRequest):
         field_set_type = MockLinterFieldSet
         tool_subsystem = KitchenSubsystem
+        partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
     rules = [
-        *LintKitchenRequest._get_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
+        *LintKitchenRequest._get_rules(),
         QueryRule(Partitions, [LintKitchenRequest.PartitionRequest]),
     ]
     rule_runner = RuleRunner(rules=rules)

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -403,9 +403,7 @@ def test_default_single_partition_partitioner() -> None:
         tool_subsystem = KitchenSubsystem
 
     rules = [
-        *LintKitchenRequest._get_registration_rules(
-            partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION
-        ),
+        *LintKitchenRequest._get_rules(partitioner_type=PartitionerType.DEFAULT_SINGLE_PARTITION),
         QueryRule(Partitions, [LintKitchenRequest.PartitionRequest]),
     ]
     rule_runner = RuleRunner(rules=rules)


### PR DESCRIPTION
`registration_rules` -> `rules`
`partitioner_type` is now a classvar (thanks Stu!)

[ci skip-rust]
[ci skip-build-wheels]