### PR TITLE
Exit normally from K8S parser with unsupported manifests (Cherry-pick of #17037)

### DIFF
--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -135,7 +135,7 @@ async def parse_kube_manifest(
             tool.pex,
             argv=[request.file.path],
             input_digest=file_digest,
-            description=f"Parsing Kubernetes manifest {request.file.path}",
+            description=f"Analyzing Kubernetes manifest {request.file.path}",
             level=LogLevel.DEBUG,
         ),
     )
@@ -158,9 +158,6 @@ async def parse_kube_manifest(
             image_refs.append((int(parts[0]), YamlPath.parse(parts[1]), parts[2]))
 
         return ParsedKubeManifest(filename=request.file.path, found_image_refs=tuple(image_refs))
-    elif result.exit_code == 2:
-        # Unrecognised YAML manifests, we complete with an empty list of image references
-        return ParsedKubeManifest(filename=request.file.path, found_image_refs=())
     else:
         parser_error = result.stderr.decode("utf-8")
         raise Exception(

--- a/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
@@ -20,8 +20,8 @@ def main(args: list[str]):
             # Hikaru fails with a `RuntimeError` when it finds a K8S manifest for an
             # API version and kind that doesn't understand.
             #
-            # We use this exit code to notify the Pants rule that this file needs to be ignored.
-            sys.exit(2)
+            # We exit the process early without giving any ouput.
+            sys.exit(0)
 
     for idx, doc in enumerate(parsed_docs):
         entries = doc.find_by_name("image")


### PR DESCRIPTION
It was observed that when having a complex Helm deployment that may contain manifests for CRDs, the Helm backend would render and parse them every time even if the contents of the original template (or the rendered manifest) haven't changed in-between runs.

This is due to the fact that the Helm K8S parser will exit with an `exit_code=2` to signal Pants when it has attempted to parse a manifest that it can not understand. This also causes the process cache to not be saved.

This changes the parser to exit normally (`exit_code=0`) and without returning any output for those cases, so the end result is the same (no container image references found in that given file) but without the re-rendering of those manifest all the time as a side effect.

[ci skip-rust]
[ci skip-build-wheels]

