### PR TITLE
Begin migration to explicitly scoped environments

### DIFF
--- a/pants-plugins/internal_plugins/rules_for_testing/register.py
+++ b/pants-plugins/internal_plugins/rules_for_testing/register.py
@@ -16,6 +16,7 @@ class ListAndDieForTestingSubsystem(GoalSubsystem):
 
 class ListAndDieForTesting(Goal):
     subsystem_cls = ListAndDieForTestingSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -98,6 +98,7 @@ class DependeesSubsystem(LineOriented, GoalSubsystem):
 
 class DependeesGoal(Goal):
     subsystem_cls = DependeesSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -34,6 +34,7 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
 
 class Dependencies(Goal):
     subsystem_cls = DependenciesSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -144,6 +144,7 @@ def warn_deprecated_target_type(tgt_type: type[Target]) -> None:
 
 class FilterGoal(Goal):
     subsystem_cls = FilterSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -14,6 +14,7 @@ class RootsSubsystem(LineOriented, GoalSubsystem):
 
 class Roots(Goal):
     subsystem_cls = RootsSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -26,6 +26,7 @@ class ListSubsystem(LineOriented, GoalSubsystem):
 
 class List(Goal):
     subsystem_cls = ListSubsystem
+    environment_migrated = True
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -40,6 +40,7 @@ class PathsSubsystem(Outputting, GoalSubsystem):
 
 class PathsGoal(Goal):
     subsystem_cls = PathsSubsystem
+    environment_migrated = True
 
 
 def find_paths_breadth_first(

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -8,10 +8,12 @@ from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, Type, cast
 
 from typing_extensions import final
 
+from pants.base.deprecated import deprecated_conditional
 from pants.engine.unions import UnionMembership
 from pants.option.option_types import StrOption
 from pants.option.scope import ScopeInfo
 from pants.option.subsystem import Subsystem
+from pants.util.docutil import doc_url
 from pants.util.meta import classproperty
 
 if TYPE_CHECKING:
@@ -81,6 +83,26 @@ class Goal:
 
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]
+
+    """Indicates that a Goal has been migrated to compute EnvironmentNames to build targets in.
+
+    All goals in `pantsbuild/pants` should be migrated before the 2.15.x branch is cut, so that
+    goals in plugins never need to experience this migration.
+      see https://github.com/pantsbuild/pants/issues/17129
+
+    TODO: Expand this, fill out the plugin migration guide, and deprecate setting `False` before landing.
+    """
+    environment_migrated: ClassVar[bool] = False
+
+    @classmethod
+    def _get_environment_migrated(cls) -> bool:
+        deprecated_conditional(
+            lambda: not cls.environment_migrated,
+            "2.17.0.dev0",
+            f"Not setting `Goal.environment_migrated=True` for `Goal` `{cls.name}`",
+            hint=f"See {doc_url('plugin-upgrade-guide')}\n",
+        )
+        return cls.environment_migrated
 
     @final
     @classproperty

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -84,13 +84,12 @@ class Goal:
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]
 
-    """Indicates that a Goal has been migrated to compute EnvironmentNames to build targets in.
+    f"""Indicates that a Goal has been migrated to compute EnvironmentNames to build targets in.
 
-    All goals in `pantsbuild/pants` should be migrated before the 2.15.x branch is cut, so that
-    goals in plugins never need to experience this migration.
-      see https://github.com/pantsbuild/pants/issues/17129
+    All goals in `pantsbuild/pants` should be migrated before the 2.15.x branch is cut, but end
+    user goals have until `2.17.0.dev0` to migrate.
 
-    TODO: Expand this, fill out the plugin migration guide, and deprecate setting `False` before landing.
+    See {doc_url('plugin-upgrade-guide')}.
     """
     environment_migrated: ClassVar[bool] = False
 


### PR DESCRIPTION
As described in #17129: we would like `@goal_rule`s to eventually make their own decisions about which environments to use, generally by consuming targets to do so, but possibly also by pinning themselves to other environments via configuration.

This change builds on #17179, and introduces a migration from `Goal.environment_migrated = {False => True}`. All graph-introspection goals consume only the APIs which are pinned to the local environment by #17179, and so are trivially migrated here. Other goals trigger a deprecation warning like the following:
```
DEPRECATED: Not setting `Goal.environment_migrated=True` for `Goal` `generate-lockfiles` is scheduled to be removed in version 2.17.0.dev0.

See https://www.pantsbuild.org/v2.15/docs/plugin-upgrade-guide
```

Before calling #17129 done, we will migrate all internal goals to `Goal.environment_migrated=True`.

[ci skip-rust]
[ci skip-build-wheels]