### PR TITLE
Add Snowflake connector to module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -130,6 +130,7 @@ DEFAULT_MODULE_MAPPING = {
     "scikit-image": ("skimage",),
     "scikit-learn": ("sklearn",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
+    "snowflake-connector-python": ("snowflake.connector",),
     "streamlit-aggrid": ("st_aggrid",),
     "opensearch-py": ("opensearchpy",),
 }


### PR DESCRIPTION
Looks like there is no mapping for SF connector, this PR adds it.

SF repo: https://github.com/snowflakedb/snowflake-connector-python/tree/main/src/snowflake.

[ci skip-rust]
[ci skip-build-wheels]