### PR TITLE
Speed up print_engine_hash by not creating the venv.

### DIFF
--- a/build-support/bin/rust/calculate_engine_hash.sh
+++ b/build-support/bin/rust/calculate_engine_hash.sh
@@ -26,7 +26,9 @@ function calculate_current_hash() {
   # NB: We fork a subshell because one or both of `ls-files`/`hash-object` are
   # sensitive to the CWD, and the `--work-tree` option doesn't seem to resolve that.
   #
-  # Assumes we're in the venv that will be used to build the native engine.
+  # Assumes that PY is set to the path to the interpreter that will be used to build the
+  # native engine. We only use this to extract the full Python version, so this can point
+  # to a raw interpreter, not necessarily one in a venv with Pants requirements installed.
   #
   # NB: Ensure that this stays in sync with `githooks/prepare-commit-msg`.
   (
@@ -35,7 +37,7 @@ function calculate_current_hash() {
       echo "${MODE_FLAG}"
       echo "${RUST_TOOLCHAIN_CONTENTS}"
       uname -mps
-      python --version 2>&1
+      "${PY}" --version 2>&1
       git ls-files --cached --others --exclude-standard \
         "${NATIVE_ROOT}" \
         "${REPO_ROOT}/rust-toolchain" \

--- a/build-support/bin/rust/print_engine_hash.sh
+++ b/build-support/bin/rust/print_engine_hash.sh
@@ -13,9 +13,4 @@ export PY
 # shellcheck source=build-support/bin/rust/calculate_engine_hash.sh
 source "${REPO_ROOT}/build-support/bin/rust/calculate_engine_hash.sh"
 
-# shellcheck source=build-support/pants_venv
-source "${REPO_ROOT}/build-support/pants_venv"
-
-activate_pants_venv 1>&2 # Redirect to ensure that we don't interfere with stdout.
-
 calculate_current_hash


### PR DESCRIPTION
We only need the venv so that `python` can be called to emit the full python version. But we don't need all the requirements installed for that.

[ci skip-build-wheels]