### PR TITLE
go/gofmt: filter out non-go files from file list

### DIFF
--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -42,10 +42,12 @@ class GofmtRequest(FmtTargetsRequest):
 
 @rule(desc="Format with gofmt")
 async def gofmt_fmt(request: GofmtRequest.SubPartition, goroot: GoRoot) -> FmtResult:
+    # Filter out non-.go files, e.g. assembly sources, from the file list.
+    files = [f for f in request.files if f.endswith(".go")]
     argv = (
         os.path.join(goroot.path, "bin/gofmt"),
         "-w",
-        *request.files,
+        *files,
     )
     result = await Get(
         ProcessResult,


### PR DESCRIPTION
Filter out non-Go files, e.g. assembly files or C files, from the list of files to be formatted.

[ci skip-rust]

[ci skip-build-wheels]