### PR TITLE
Fix quoting of GitHub Actions expressions.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -63,8 +63,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -84,7 +84,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -123,7 +123,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -195,7 +195,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -206,8 +206,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -215,7 +215,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -227,7 +227,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -266,7 +266,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -342,7 +342,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -431,7 +431,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -520,7 +520,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -609,7 +609,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -684,7 +684,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -66,8 +66,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -75,7 +75,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -87,7 +87,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -126,7 +126,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -200,7 +200,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -211,8 +211,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -220,7 +220,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -232,7 +232,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -271,7 +271,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -415,7 +415,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-15-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -426,8 +426,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS10-15-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -435,7 +435,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS10-15-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - env:
@@ -519,7 +519,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -530,8 +530,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-ARM64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -539,7 +539,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-ARM64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -551,7 +551,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-ARM64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-ARM64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -590,7 +590,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-ARM64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-ARM64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -658,7 +658,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.64.0-*
 
           ~/.rustup/update-hashes
@@ -669,8 +669,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -678,7 +678,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - env:
@@ -801,7 +801,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -945,7 +945,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1036,7 +1036,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1127,7 +1127,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1204,7 +1204,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -38,6 +38,22 @@ class Platform(Enum):
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
+def gha_expr(expr: str) -> str:
+    """Properly quote GitHub Actions expressions.
+
+    Because we use f-strings often, but not always, in this script, it is very easy to get the
+    quoting of the double curly braces wrong, especially when changing a non-f-string to an f-string
+    or vice versa. So instead we universally delegate to this function.
+    """
+    # Here we use simple string concat instead of getting tangled up with escaping in f-strings.
+    return "${{ " + expr + " }}"
+
+
+def hashFiles(path: str) -> str:
+    """Generate a properly quoted hashFiles call for the given path."""
+    return gha_expr(f"hashFiles('{path}')")
+
+
 # ----------------------------------------------------------------------
 # Constants
 # ----------------------------------------------------------------------
@@ -88,7 +104,7 @@ def is_docs_only() -> Jobs:
             "name": "Check for docs-only change",
             "runs-on": linux_x86_64_helper.runs_on(),
             "if": IS_PANTS_OWNER,
-            "outputs": {"docs_only": "${{ steps.docs_only_check.outputs.docs_only }}"},
+            "outputs": {"docs_only": gha_expr("steps.docs_only_check.outputs.docs_only")},
             "steps": [
                 *checkout(get_commit_msg=False),
                 {
@@ -117,7 +133,7 @@ def ensure_category_label() -> Sequence[Step]:
             "if": "github.event_name == 'pull_request'",
             "name": "Ensure category label",
             "uses": "mheap/github-action-required-labels@v1",
-            "env": {"GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"},
+            "env": {"GITHUB_TOKEN": gha_expr("secrets.GITHUB_TOKEN")},
             "with": {
                 "mode": "exactly",
                 "count": 1,
@@ -195,8 +211,8 @@ def setup_toolchain_auth() -> Step:
         "name": "Setup toolchain auth",
         "if": "github.event_name != 'pull_request'",
         "run": dedent(
-            """\
-            echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+            f"""\
+            echo TOOLCHAIN_AUTH_TOKEN="{gha_expr('secrets.TOOLCHAIN_AUTH_TOKEN')}" >> $GITHUB_ENV
             """
         ),
     }
@@ -234,7 +250,7 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
+                "key": f"{gha_expr('runner.os')}-rustup-{hashFiles('rust-toolchain')}-v1",
             },
         },
         {
@@ -242,8 +258,8 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": "~/.cargo/registry\n~/.cargo/git\n",
-                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
-                "restore-keys": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
+                "key": f"{gha_expr('runner.os')}-cargo-{hashFiles('rust-toolchain')}-{hashFiles('src/rust/engine/Cargo.*')}-v1\n",
+                "restore-keys": f"{gha_expr('runner.os')}-cargo-{hashFiles('rust-toolchain')}-\n",
             },
         },
     ]
@@ -274,8 +290,8 @@ def deploy_to_s3() -> Step:
         "run": "./build-support/bin/deploy_to_s3.py",
         "if": "github.event_name == 'push'",
         "env": {
-            "AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            "AWS_ACCESS_KEY_ID": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+            "AWS_SECRET_ACCESS_KEY": f"{gha_expr('secrets.AWS_SECRET_ACCESS_KEY')}",
+            "AWS_ACCESS_KEY_ID": f"{gha_expr('secrets.AWS_ACCESS_KEY_ID')}",
         },
     }
 
@@ -285,18 +301,18 @@ def setup_primary_python(install_python: bool = True) -> Sequence[Step]:
     if install_python:
         ret.append(
             {
-                "name": "Set up Python ${{ matrix.python-version }}",
+                "name": f"Set up Python {gha_expr('matrix.python-version')}",
                 "uses": "actions/setup-python@v3",
-                "with": {"python-version": "${{ matrix.python-version }}"},
+                "with": {"python-version": f"{gha_expr('matrix.python-version')}"},
             }
         )
     ret.append(
         {
-            "name": "Tell Pants to use Python ${{ matrix.python-version }}",
+            "name": f"Tell Pants to use Python {gha_expr('matrix.python-version')}",
             "run": dedent(
-                """\
-                echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
-                echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['==${{ matrix.python-version }}.*']" >> $GITHUB_ENV
+                f"""\
+                echo "PY=python{gha_expr('matrix.python-version')}" >> $GITHUB_ENV
+                echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['=={gha_expr('matrix.python-version')}.*']" >> $GITHUB_ENV
                 """
             ),
         }
@@ -366,7 +382,7 @@ class Helper:
             "name": "Upload native binaries",
             "uses": "actions/upload-artifact@v3",
             "with": {
-                "name": f"native_binaries.${{ matrix.python-version }}.{self.platform_name()}",
+                "name": f"native_binaries.{gha_expr('matrix.python-version')}.{self.platform_name()}",
                 "path": "\n".join(NATIVE_FILES),
             },
         }
@@ -376,7 +392,7 @@ class Helper:
             "name": "Download native binaries",
             "uses": "actions/download-artifact@v3",
             "with": {
-                "name": f"native_binaries.${{ matrix.python-version }}.{self.platform_name()}",
+                "name": f"native_binaries.{gha_expr('matrix.python-version')}.{self.platform_name()}",
             },
         }
 
@@ -387,7 +403,7 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                    "key": f"{self.platform_name()}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
+                    "key": f"{self.platform_name()}-rustup-{hashFiles('rust-toolchain')}-v1",
                 },
             },
             {
@@ -395,8 +411,8 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": "~/.cargo/registry\n~/.cargo/git\n",
-                    "key": f"{self.platform_name()}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
-                    "restore-keys": f"{self.platform_name()}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
+                    "key": f"{self.platform_name()}-cargo-{hashFiles('rust-toolchain')}-{hashFiles('src/rust/engine/Cargo.*')}-v1\n",
+                    "restore-keys": f"{self.platform_name()}-cargo-{hashFiles('rust-toolchain')}-\n",
                 },
             },
         ]
@@ -419,7 +435,7 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": "\n".join(NATIVE_FILES),
-                    "key": f"{self.platform_name()}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1\n",
+                    "key": f"{self.platform_name()}-engine-{gha_expr('steps.get-engine-hash.outputs.hash')}-v1\n",
                 },
             },
         ]
@@ -614,7 +630,7 @@ def macos11_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
                     # pass on GHA MacOS containers.
                     "run": helper.wrap_cmd("./cargo test --tests -- --nocapture"),
-                    "env": {"TMPDIR": "${{ runner.temp }}"},
+                    "env": {"TMPDIR": f"{gha_expr('runner.temp')}"},
                     "if": DONT_SKIP_RUST,
                 },
             ],
@@ -795,9 +811,7 @@ def workflow_dispatch_inputs(
         }
         for wi in workflow_inputs
     }
-    env = {
-        wi.name: ("${{ github.event.inputs." + wi.name.lower() + " }}") for wi in workflow_inputs
-    }
+    env = {wi.name: gha_expr("github.event.inputs." + wi.name.lower()) for wi in workflow_inputs}
     return inputs, env
 
 
@@ -919,7 +933,7 @@ def set_merge_ok(needs: list[str], docs_only: bool) -> Jobs:
             # jobs depend on them here (it has to be both since some changes may modify docs
             # as well as code, and so are not "docs only").
             "needs": ["docs_only_check", "check_labels"] + sorted(needs),
-            "outputs": {"merge_ok": "${{ steps.set_merge_ok.outputs.merge_ok }}"},
+            "outputs": {"merge_ok": f"{gha_expr('steps.set_merge_ok.outputs.merge_ok')}"},
             "steps": [
                 {
                     "id": "set_merge_ok",
@@ -946,10 +960,10 @@ def merge_ok(non_docs_only_jobs: list[str]) -> Jobs:
                 "steps": [
                     {
                         "run": dedent(
-                            """\
-                    merge_ok_docs_only="${{ needs.set_merge_ok_docs_only.outputs.merge_ok }}"
-                    merge_ok_not_docs_only="${{ needs.set_merge_ok_not_docs_only.outputs.merge_ok }}"
-                    if [[ "${merge_ok_docs_only}" == "true" || "${merge_ok_not_docs_only}" == "true" ]]; then
+                            f"""\
+                    merge_ok_docs_only="{gha_expr('needs.set_merge_ok_docs_only.outputs.merge_ok')}"
+                    merge_ok_not_docs_only="{gha_expr('needs.set_merge_ok_not_docs_only.outputs.merge_ok')}"
+                    if [[ "${{merge_ok_docs_only}}" == "true" || "${{merge_ok_not_docs_only}}" == "true" ]]; then
                         echo "Merge OK"
                         exit 0
                     else
@@ -1027,8 +1041,8 @@ def generate() -> dict[Path, str]:
                         {
                             "uses": "styfle/cancel-workflow-action@0.9.1",
                             "with": {
-                                "workflow_id": "${{ github.event.workflow.id }}",
-                                "access_token": "${{ github.token }}",
+                                "workflow_id": f"{gha_expr('github.event.workflow.id')}",
+                                "access_token": f"{gha_expr('github.token')}",
                             },
                         }
                     ],


### PR DESCRIPTION
We were previously using `${{ expr }}` in f-strings, which caused them to emit `${ expr }` into the YAML, which is incorrect.

See here for how expressions must be represented in the GitHub Actions YAML: https://docs.github.com/en/actions/learn-github-actions/expressions#about-expressions

Correctly quoting this in an f-string would require 4 braces, which is unwieldy. Plus, it's common while editing to turn a regular string into an f-string or vice versa, and it would be very easy to neglect to change the quoting as needed.

Instead, we introduce a helper function and use it exclusively.

Note that this bug caused us to generate useless, constant keys for the GHA cache - in fact I noticed something was awry when I saw CI builds re-building rust code after a successful cache restore. Good thing our rust bootstrapping script is defensive. I'd say we were pretty lucky if the only impact was performance; This could potentially have lead us to actively step on our own toes in bad ways.