### PR TITLE
Set PEX_ROOT for export post-processing command.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -372,7 +372,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 65
+    timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -473,7 +473,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 80
+    timeout-minutes: 120
   build_wheels_macos11_arm64:
     env:
       ARCHFLAGS: -arch arm64
@@ -613,7 +613,7 @@ jobs:
       matrix:
         python-version:
         - '3.9'
-    timeout-minutes: 60
+    timeout-minutes: 120
   build_wheels_macos11_x86_64:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -716,7 +716,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 80
+    timeout-minutes: 120
   check_labels:
     if: github.repository_owner == 'pantsbuild'
     name: Ensure PR has a category label

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -587,7 +587,7 @@ def linux_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     "name": f"Build wheels and fs_util ({helper.platform_name()})",
                     "runs-on": helper.runs_on(),
                     "container": "quay.io/pypa/manylinux2014_x86_64:latest",
-                    "timeout-minutes": 65,
+                    "timeout-minutes": 90,
                     **helper.build_wheels_common,
                     "steps": [
                         *checkout(containerized=True),
@@ -669,7 +669,7 @@ def macos11_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 "build_wheels_macos11_x86_64": {
                     "name": f"Build wheels and fs_util ({helper.platform_name()})",
                     "runs-on": helper.runs_on(),
-                    "timeout-minutes": 80,
+                    "timeout-minutes": 120,
                     **helper.build_wheels_common,
                     "steps": [
                         *checkout(),
@@ -696,7 +696,7 @@ def macos_10_15_x86_64_jobs(python_versions: list[str]) -> Jobs:
         "build_wheels_macos10_15_x86_64": {
             "name": f"Build wheels and fs_util ({helper.platform_name()})",
             "runs-on": helper.runs_on(),
-            "timeout-minutes": 80,
+            "timeout-minutes": 120,
             **helper.build_wheels_common,
             "steps": [
                 *checkout(),
@@ -743,7 +743,7 @@ def macos11_arm64_jobs() -> Jobs:
             "name": f"Bootstrap Pants, build wheels and fs_util ({Platform.MACOS11_ARM64.value})",
             "runs-on": helper.runs_on(),
             "strategy": {"matrix": {"python-version": [PYTHON39_VERSION]}},
-            "timeout-minutes": 60,
+            "timeout-minutes": 120,
             "if": IS_PANTS_OWNER,
             "steps": steps,
             "env": {**helper.platform_env(), **DISABLE_REMOTE_CACHE_ENV},

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -188,7 +188,7 @@ async def do_export(
                             "venv",
                             "--pip",
                             "--collisions-ok",
-                            "--remove=all",
+                            "--remove=pex",
                             output_path,
                         ],
                         python=requirements_pex.python,

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -181,16 +181,18 @@ async def do_export(
             digest=merged_digest,
             post_processing_cmds=[
                 PostProcessingCommand(
-                    [
-                        requirements_pex.python.path,
+                    complete_pex_env.create_argv(
                         os.path.join(pex_pex_dest, pex_pex.exe),
-                        os.path.join("{digest_root}", requirements_pex.name),
-                        "venv",
-                        "--pip",
-                        "--collisions-ok",
-                        "--remove=all",
-                        output_path,
-                    ],
+                        *[
+                            os.path.join("{digest_root}", requirements_pex.name),
+                            "venv",
+                            "--pip",
+                            "--collisions-ok",
+                            "--remove=all",
+                            output_path,
+                        ],
+                        python=requirements_pex.python,
+                    ),
                     {
                         **complete_pex_env.environment_dict(python_configured=True),
                         "PEX_MODULE": "pex.tools",

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -134,6 +134,7 @@ async def do_export(
         else req.dest_prefix
     )
 
+    complete_pex_env = pex_env.in_workspace()
     if export_subsys.options.symlink_python_virtualenv:
         requirements_venv_pex = await Get(VenvPex, PexRequest, req.pex_request)
         py_version = await _get_full_python_version(requirements_venv_pex)
@@ -141,10 +142,9 @@ async def do_export(
         # we need some name for the symlink anyway.
         output_path = f"{{digest_root}}/{py_version}"
         description = (
-            f"Symlink to immutable virtualenv for {req.resolve_name or 'requirements'} "
+            f"symlink to immutable virtualenv for {req.resolve_name or 'requirements'} "
             f"(using Python {py_version})"
         )
-        complete_pex_env = pex_env.in_workspace()
         venv_abspath = os.path.join(complete_pex_env.pex_root, requirements_venv_pex.venv_rel_dir)
         return ExportResult(
             description,
@@ -161,7 +161,7 @@ async def do_export(
             f"{{digest_root}}/{py_version if req.qualify_path_with_python_version else ''}"
         )
         description = (
-            f"Mutable virtualenv for {req.resolve_name or 'requirements'} "
+            f"mutable virtualenv for {req.resolve_name or 'requirements'} "
             f"(using Python {py_version})"
         )
 
@@ -191,7 +191,10 @@ async def do_export(
                         "--remove=all",
                         output_path,
                     ],
-                    {"PEX_MODULE": "pex.tools"},
+                    {
+                        **complete_pex_env.environment_dict(python_configured=True),
+                        "PEX_MODULE": "pex.tools",
+                    },
                 ),
                 # Remove the PEX pex, to avoid confusion.
                 PostProcessingCommand(["rm", "-rf", pex_pex_dest]),

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -96,10 +96,11 @@ def test_export_venv_pipified(
                 "venv",
                 "--pip",
                 "--collisions-ok",
-                "--remove=all",
+                "--remove=pex",
                 f"{{digest_root}}/{current_interpreter}",
             )
-            assert ppc0.extra_env == FrozenDict({"PEX_MODULE": "pex.tools"})
+            assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"
+            assert ppc0.extra_env.get("PEX_ROOT") is not None
 
             ppc1 = result.post_processing_cmds[1]
             assert ppc1.argv == (


### PR DESCRIPTION
This is both a leak that foils our recommendations to users for maintenance of Pants caches and results in unneeded extra work when an export finds an empty ~/.pex but would have had hits in ~/.cache/pants/named_caches/pex_root if it had been pointed there.

[ci skip-rust]

[ci skip-build-wheels]