### PR TITLE
Fix macros depending on macros from other files

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -59,19 +59,23 @@ async def evaluate_preludes(build_file_options: BuildFileOptions) -> BuildFilePr
     globals: dict[str, Any] = {
         **{name: getattr(builtins, name) for name in dir(builtins) if name.endswith("Error")},
     }
+    locals: dict[str, Any] = {}
     for file_content in prelude_digest_contents:
         try:
             file_content_str = file_content.content.decode()
             content = compile(file_content_str, file_content.path, "exec")
-            exec(content, globals)
+            exec(content, globals, locals)
         except Exception as e:
             raise Exception(f"Error parsing prelude file {file_content.path}: {e}")
         error_on_imports(file_content_str, file_content.path)
     # __builtins__ is a dict, so isn't hashable, and can't be put in a FrozenDict.
     # Fortunately, we don't care about it - preludes should not be able to override builtins, so we just pop it out.
     # TODO: Give a nice error message if a prelude tries to set a expose a non-hashable value.
-    globals.pop("__builtins__", None)
-    return BuildFilePreludeSymbols(FrozenDict(globals))
+    locals.pop("__builtins__", None)
+    # Ensure preludes can reference each other by populating the shared globals object with references
+    # to the other symbols
+    globals.update(locals)
+    return BuildFilePreludeSymbols(FrozenDict(locals))
 
 
 @rule

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -379,3 +379,48 @@ def test_build_file_address() -> None:
     # Generated targets should use their target generator's BUILD file.
     assert_bfa_resolved(Address("helloworld", generated_name="f.txt"))
     assert_bfa_resolved(Address("helloworld", relative_file_path="f.txt"))
+
+
+def test_build_files_share_globals() -> None:
+    """Test that a macro in a prelude can reference another macro in another prelude.
+
+    At some point a change was made to separate the globals/locals dict (uninentional) which has the
+    unintended side-effect of having the `__globals__` of a macro not contain references to every
+    other symbol in every other prelude.
+    """
+
+    symbols = run_rule_with_mocks(
+        evaluate_preludes,
+        rule_args=[BuildFileOptions((), prelude_globs=("prelude",))],
+        mock_gets=[
+            MockGet(
+                output_type=DigestContents,
+                input_types=(PathGlobs,),
+                mock=lambda _: DigestContents(
+                    [
+                        FileContent(
+                            path="/dev/null/prelude1",
+                            content=dedent(
+                                """\
+                                def hello():
+                                    pass
+                                """
+                            ).encode(),
+                        ),
+                        FileContent(
+                            path="/dev/null/prelude2",
+                            content=dedent(
+                                """\
+                                def world():
+                                    pass
+                                """
+                            ).encode(),
+                        ),
+                    ]
+                ),
+            ),
+        ],
+    )
+    assert symbols.symbols["hello"].__globals__ is symbols.symbols["world"].__globals__
+    assert "world" in symbols.symbols["hello"].__globals__
+    assert "hello" in symbols.symbols["world"].__globals__


### PR DESCRIPTION
Cross-prelude references were broken in https://github.com/pantsbuild/pants/pull/16174 because the shared global object no longer held references to all the other symbols.

Fixed and added test (fails before, passes after)


[ci skip-rust]
[ci skip-build-wheels]