### PR TITLE
Migrate `test` goal to explicitly scoped environments

### DIFF
--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -127,7 +127,7 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                 ),
                 MockEffect(
                     output_type=InteractiveProcessResult,
-                    input_type=InteractiveProcess,
+                    input_types=(InteractiveProcess,),
                     mock=lambda ip: _mock_run(rule_runner, ip),
                 ),
             ],

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -133,7 +133,7 @@ def single_target_run(
                 ),
                 MockEffect(
                     output_type=InteractiveProcessResult,
-                    input_type=InteractiveProcess,
+                    input_types=(InteractiveProcess,),
                     mock=rule_runner.run_interactive_process,
                 ),
             ],

--- a/src/python/pants/engine/desktop.py
+++ b/src/python/pants/engine/desktop.py
@@ -6,11 +6,12 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Iterable, Tuple
 
+from pants.core.util_rules.environments import ChosenLocalEnvironmentName, EnvironmentName
 from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.platform import Platform
 from pants.engine.process import InteractiveProcess
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
@@ -35,13 +36,21 @@ class OpenFiles:
 @rule
 async def find_open_program(
     request: OpenFilesRequest,
-    plat: Platform,
-    complete_env: CompleteEnvironmentVars,
+    local_environment_name: ChosenLocalEnvironmentName,
 ) -> OpenFiles:
+    plat, complete_env = await MultiGet(
+        Get(Platform, EnvironmentName, local_environment_name.val),
+        Get(CompleteEnvironmentVars, EnvironmentName, local_environment_name.val),
+    )
     open_program_name = "open" if plat.is_macos else "xdg-open"
     open_program_paths = await Get(
         BinaryPaths,
-        BinaryPathRequest(binary_name=open_program_name, search_path=("/bin", "/usr/bin")),
+        {
+            BinaryPathRequest(
+                binary_name=open_program_name, search_path=("/bin", "/usr/bin")
+            ): BinaryPathRequest,
+            local_environment_name.val: EnvironmentName,
+        },
     )
     if not open_program_paths.first_path:
         error = (

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -539,14 +539,10 @@ class RuleRunner:
 
 
 @dataclass(frozen=True)
-class MockEffect(Generic[_O, _I]):
+class MockEffect(Generic[_O]):
     output_type: type[_O]
-    input_type: type[_I]
-    mock: Callable[[_I], _O]
-
-    @property
-    def input_types(self) -> tuple[type, ...]:
-        return (self.input_type,)
+    input_types: tuple[type, ...]
+    mock: Callable[..., _O]
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
As part of #17155, migrates the `test` goal to explicitly scoped environments.

[ci skip-rust]
[ci skip-build-wheels]