### PR TITLE
`--remote-execution` no longer implicitly enables `--remote-cache`

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -313,13 +313,6 @@ impl Core {
     local_cache_read: bool,
     local_cache_write: bool,
   ) -> Result<Arc<dyn CommandRunner>, String> {
-    // TODO: Until we can deprecate letting the flag default, we implicitly default
-    // cache_content_behavior when remote execution is in use. See the TODO in `global_options.py`.
-    let cache_content_behavior = if remoting_opts.execution_enable {
-      CacheContentBehavior::Defer
-    } else {
-      remoting_opts.cache_content_behavior
-    };
     if remote_cache_read || remote_cache_write {
       runner = Arc::new(remote_cache::CommandRunner::new(
         runner,
@@ -333,7 +326,7 @@ impl Core {
         remote_cache_read,
         remote_cache_write,
         remoting_opts.cache_warnings_behavior,
-        cache_content_behavior,
+        remoting_opts.cache_content_behavior,
         remoting_opts.cache_rpc_concurrency,
         remoting_opts.cache_read_timeout,
       )?);
@@ -345,7 +338,7 @@ impl Core {
         local_cache.clone(),
         full_store.clone(),
         local_cache_read,
-        cache_content_behavior,
+        remoting_opts.cache_content_behavior,
         process_cache_namespace,
       ));
     }
@@ -386,11 +379,8 @@ impl Core {
       capabilities_cell_opt,
     )?;
 
-    // TODO: Until we can deprecate letting remote-cache-{read,write} default, we implicitly
-    // enable them when remote execution is in use. See the TODO in `global_options.py`.
-    let remote_cache_read = exec_strategy_opts.remote_cache_read || remoting_opts.execution_enable;
-    let remote_cache_write =
-      exec_strategy_opts.remote_cache_write || remoting_opts.execution_enable;
+    let remote_cache_read = exec_strategy_opts.remote_cache_read;
+    let remote_cache_write = exec_strategy_opts.remote_cache_write;
     let local_cache_read_write = exec_strategy_opts.local_cache;
 
     let make_cached_runner = |should_cache_read: bool| -> Result<Arc<dyn CommandRunner>, String> {


### PR DESCRIPTION
Finished the TODO from https://github.com/pantsbuild/pants/pull/15854 and https://github.com/pantsbuild/pants/pull/15900.

Partially addresses https://github.com/pantsbuild/pants/issues/17142.