### PR TITLE
Make fmt/lint result types less boilerplate-y

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/black/integration_test.py
@@ -61,7 +61,7 @@ def run_black(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.SubPartition(snapshot.files, key=None, snapshot=snapshot),
+            BlackRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -7,7 +7,7 @@ from pants.backend.build_files.fmt.buildifier.subsystem import Buildifier
 from pants.core.goals.fmt import FmtFilesRequest, FmtResult, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.engine.internals.build_files import BuildFileOptions
-from pants.engine.internals.native_engine import Digest, MergeDigests, Snapshot
+from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
@@ -59,10 +59,7 @@ async def buildfier_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=BuildifierRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
@@ -62,7 +62,7 @@ def run_buildifier(rule_runner: RuleRunner) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BuildifierRequest.SubPartition(snapshot.files, key=None, snapshot=snapshot),
+            BuildifierRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
@@ -42,7 +42,7 @@ def run_yapf(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) ->
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest.SubPartition(snapshot.files, key=None, snapshot=snapshot),
+            YapfRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -13,7 +13,7 @@ from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, Rule, collect_rules, rule
 from pants.engine.target import FieldSet
@@ -83,14 +83,7 @@ async def clangformat_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        formatter_name=ClangFormatRequest.tool_name,
-        strip_chroot_path=True,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
@@ -99,7 +99,7 @@ def run_clangformat(
         FmtResult,
         [
             ClangFormatRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -17,7 +17,6 @@ from pants.core.util_rules.system_binaries import (
     DiffBinaryRequest,
 )
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -102,10 +101,7 @@ async def run_buf_format(
             env={"PATH": binary_shims.bin_directory},
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=BufFormatRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -63,7 +63,7 @@ def run_buf(
         FmtResult,
         [
             BufFormatRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -109,9 +109,7 @@ async def run_buf(
             level=LogLevel.DEBUG,
         ),
     )
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=BufLintRequest.tool_name
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
@@ -63,7 +63,7 @@ def run_buf(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BufLintRequest.SubPartition(subpartition, key)],
+            [BufLintRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -99,9 +99,7 @@ async def run_hadolint(
         ),
     )
 
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=Hadolint.options_scope
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -56,7 +56,7 @@ def run_hadolint(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HadolintRequest.SubPartition(subpartition, key)],
+            [HadolintRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -13,8 +13,6 @@ from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -58,10 +56,7 @@ async def gofmt_fmt(request: GofmtRequest.SubPartition, goroot: GoRoot) -> FmtRe
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=GofmtRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -121,7 +121,7 @@ def run_gofmt(
         FmtResult,
         [
             GofmtRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -171,9 +171,7 @@ async def run_golangci_lint(
         ),
     )
 
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=GolangciLint.options_scope
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -110,7 +110,7 @@ def run_golangci_lint(
     results = []
     for key, subpartition in partition.items():
         result = rule_runner.request(
-            LintResult, [GolangciLintRequest.SubPartition(subpartition, key)]
+            LintResult, [GolangciLintRequest.SubPartition("", subpartition, key)]
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -79,9 +79,7 @@ async def run_go_vet(request: GoVetRequest.SubPartition[Any, GoVetFieldSet]) -> 
         ),
     )
 
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=GoVetSubsystem.options_scope
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -103,7 +103,7 @@ def run_go_vet(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [GoVetRequest.SubPartition(subpartition, key)],
+            [GoVetRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -68,11 +68,7 @@ async def run_helm_lint(
             description=f"Linting chart: {chart.info.name}",
         ),
     )
-    return LintResult.from_fallible_process_result(
-        process_result,
-        linter_name=HelmSubsystem.options_scope,
-        partition_description=chart.info.name,
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -64,7 +64,7 @@ def run_helm_lint(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HelmLintRequest.SubPartition(subpartition, key)],
+            [HelmLintRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -9,8 +9,6 @@ from pants.backend.java.target_types import JavaSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -96,14 +94,7 @@ async def google_java_format_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=GoogleJavaFormatRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -95,7 +95,7 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
         FmtResult,
         [
             GoogleJavaFormatRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -13,7 +13,7 @@ from pants.backend.javascript.target_types import JSSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.fs import Digest, MergeDigests
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, Rule, collect_rules, rule
 from pants.engine.target import FieldSet
@@ -72,14 +72,7 @@ async def prettier_fmt(request: PrettierFmtRequest.SubPartition, prettier: Prett
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=PrettierFmtRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
@@ -103,7 +103,7 @@ def run_prettier(
         FmtResult,
         [
             PrettierFmtRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -9,8 +9,6 @@ from pants.backend.kotlin.target_types import KotlinSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -81,14 +79,7 @@ async def ktlint_fmt(
         ),
     )
 
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=KtlintRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
@@ -94,7 +94,7 @@ def run_ktlint(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
         FmtResult,
         [
             KtlintRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/openapi/lint/spectral/rules.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules.py
@@ -110,9 +110,7 @@ async def run_spectral(
         ),
     )
 
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=SpectralRequest.tool_name
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
@@ -71,7 +71,7 @@ def run_spectral(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [SpectralRequest.SubPartition(subpartition, key)],
+            [SpectralRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -10,8 +10,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -57,14 +55,7 @@ async def add_trailing_comma_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=AddTrailingCommaRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
@@ -68,7 +68,7 @@ def run_add_trailing_comma(
         FmtResult,
         [
             AddTrailingCommaRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -10,8 +10,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -55,14 +53,7 @@ async def autoflake_fmt(request: AutoflakeRequest.SubPartition, autoflake: Autof
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=AutoflakeRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -64,7 +64,7 @@ def run_autoflake(
         FmtResult,
         [
             AutoflakeRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -95,12 +95,7 @@ async def bandit_lint(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.from_fallible_process_result(
-        result,
-        partition_description=request.key.description,
-        linter_name=Bandit.options_scope,
-        report=report,
-    )
+    return LintResult.create(request, result, report=report)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -67,7 +67,7 @@ def run_bandit(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BanditRequest.SubPartition(subpartition, key)],
+            [BanditRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -13,7 +13,6 @@ from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProc
 from pants.core.goals.fmt import FmtRequest, FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.util.logging import LogLevel
@@ -64,14 +63,7 @@ async def _run_black(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=BlackRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 @rule

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -95,7 +95,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.SubPartition(partition, key=key, snapshot=input_sources.snapshot),
+            BlackRequest.SubPartition("", partition, key=key, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -10,8 +10,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -56,10 +54,7 @@ async def docformatter_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=DocformatterRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -60,7 +60,7 @@ def run_docformatter(
         FmtResult,
         [
             DocformatterRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -129,12 +129,7 @@ async def run_flake8(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.from_fallible_process_result(
-        result,
-        partition_description=interpreter_constraints.description,
-        linter_name=Flake8.options_scope,
-        report=report,
-    )
+    return LintResult.create(request, result, report=report)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -63,7 +63,7 @@ def run_flake8(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [Flake8Request.SubPartition(subpartition, key)],
+            [Flake8Request.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -14,7 +14,6 @@ from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -92,14 +91,7 @@ async def isort_fmt(request: IsortRequest.SubPartition, isort: Isort) -> FmtResu
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        strip_chroot_path=True,
-        formatter_name=IsortRequest.tool_name,
-    )
+    return await FmtResult.create(request, result, strip_chroot_path=True)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -68,7 +68,7 @@ def run_isort(
         FmtResult,
         [
             IsortRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -202,12 +202,7 @@ async def run_pylint(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.from_fallible_process_result(
-        result,
-        partition_description=request.key.description,
-        linter_name=Pylint.options_scope,
-        report=report,
-    )
+    return LintResult.create(request, result, report=report)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -78,7 +78,7 @@ def run_pylint(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [PylintRequest.SubPartition(subpartition, key)],
+            [PylintRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -11,8 +11,6 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target
@@ -52,10 +50,7 @@ async def pyupgrade_fmt(request: PyUpgradeRequest.SubPartition, pyupgrade: PyUpg
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=PyUpgradeRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -74,7 +74,7 @@ def run_pyupgrade(
         FmtResult,
         [
             PyUpgradeRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -15,7 +15,6 @@ from pants.core.goals.fmt import FmtRequest, FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import FieldSet, Target
@@ -74,10 +73,7 @@ async def _run_yapf(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=YapfRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -70,7 +70,7 @@ def run_yapf(
         FmtResult,
         [
             YapfRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -203,13 +203,7 @@ async def scalafmt_fmt(
         ),
     )
 
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result,
-        request.snapshot,
-        output_snapshot,
-        formatter_name=ScalafmtRequest.tool_name,
-    )
+    return await FmtResult.create(request, result)
 
 
 @rule

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -141,6 +141,7 @@ def run_scalafmt(
             FmtResult,
             [
                 ScalafmtRequest.SubPartition(
+                    "",
                     partition,
                     key=key,
                     snapshot=rule_runner.request(Snapshot, [PathGlobs(partition)]),

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -100,9 +100,7 @@ async def run_shellcheck(
             level=LogLevel.DEBUG,
         ),
     )
-    return LintResult.from_fallible_process_result(
-        process_result, linter_name=Shellcheck.options_scope
-    )
+    return LintResult.create(request, process_result)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
@@ -58,7 +58,7 @@ def run_shellcheck(
     for key, subpartition in partition.items():
         result = rule_runner.request(
             LintResult,
-            [ShellcheckRequest.SubPartition(subpartition, key)],
+            [ShellcheckRequest.SubPartition("", subpartition, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -11,7 +11,6 @@ from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -74,10 +73,7 @@ async def shfmt_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    output_snapshot = await Get(Snapshot, Digest, result.output_digest)
-    return FmtResult.create(
-        result, request.snapshot, output_snapshot, formatter_name=ShfmtRequest.tool_name
-    )
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -88,7 +88,7 @@ def run_shfmt(
         FmtResult,
         [
             ShfmtRequest.SubPartition(
-                input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],
     )

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -13,8 +13,6 @@ from pants.backend.terraform.tool import rules as tool_rules
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -77,9 +75,7 @@ async def tffmt_fmt(request: TffmtRequest.SubPartition, tffmt: TfFmtSubsystem) -
         ),
     )
 
-    output = await Get(Snapshot, Digest, result.output_digest)
-
-    return FmtResult.create(result, request.snapshot, output, formatter_name=TffmtRequest.tool_name)
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -145,6 +145,7 @@ def run_tffmt(
         FmtResult,
         [
             TffmtRequest.SubPartition(
+                "",
                 files,
                 key=key,
                 snapshot=input_sources.snapshot,

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -60,12 +60,11 @@ class LintResult(EngineAwareReturnType):
     report: Digest = EMPTY_DIGEST
 
     @classmethod
-    def from_fallible_process_result(
+    def create(
         cls,
+        request: LintRequest.SubPartition,
         process_result: FallibleProcessResult,
         *,
-        linter_name: str,
-        partition_description: str | None = None,
         strip_chroot_path: bool = False,
         report: Digest = EMPTY_DIGEST,
     ) -> LintResult:
@@ -76,8 +75,8 @@ class LintResult(EngineAwareReturnType):
             exit_code=process_result.exit_code,
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
-            linter_name=linter_name,
-            partition_description=partition_description,
+            linter_name=request.tool_name,
+            partition_description=request.key.description,
             report=report,
         )
 
@@ -424,7 +423,10 @@ async def lint(
 
     subpartitions = [
         request_type.SubPartition(
-            elements, key, **{"snapshot": next(snapshots_iter)} if request_type.is_formatter else {}
+            request_type.tool_name,
+            elements,
+            key,
+            **{"snapshot": next(snapshots_iter)} if request_type.is_formatter else {},
         )
         for request_type, batch in lint_batches_by_request_type.items()
         for elements, key in batch

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -76,7 +76,7 @@ class LintResult(EngineAwareReturnType):
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
             linter_name=request.tool_name,
-            partition_description=request.key.description,
+            partition_description=request.key.description if request.key else None,
             report=report,
         )
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -312,7 +312,9 @@ async def format_build_file_with_yapf(
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     yapf_ics = await Yapf._find_python_interpreter_constraints_from_lockfile(yapf)
     result = await _run_yapf(
-        YapfRequest.SubPartition(input_snapshot.files, key=None, snapshot=input_snapshot),
+        YapfRequest.SubPartition(
+            Yapf.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
+        ),
         yapf,
         yapf_ics,
     )
@@ -341,7 +343,9 @@ async def format_build_file_with_black(
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
     result = await _run_black(
-        BlackRequest.SubPartition(input_snapshot.files, key=None, snapshot=input_snapshot),
+        BlackRequest.SubPartition(
+            Black.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
+        ),
         black,
         black_ics,
     )

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -84,6 +84,7 @@ class Partitions(FrozenDict["PartitionKeyT", "tuple[PartitionElementT, ...]"]):
 @dataclass(unsafe_hash=True)
 @runtime_ignore_subscripts
 class _SubPartitionBase(Generic[PartitionKeyT, PartitionElementT]):
+    tool_name: str
     elements: tuple[PartitionElementT, ...]
     key: PartitionKeyT
 


### PR DESCRIPTION
Now we're making the `.create` take the request type and pass any relevant information through it to the result creator. This eliminates a handful of boilerplate params.

Commit useful to review in order.

[ci skip-rust]
[ci skip-build-wheels]