### PR TITLE
Update to latest version of the github-action-required-labels and changed-files actions

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -293,7 +293,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'
       name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v2.1.0
       with:
         count: 1
         labels: category:new feature, category:user api change, category:plugin api

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -727,7 +727,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'
       name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v2.1.0
       with:
         count: 1
         labels: category:new feature, category:user api change, category:plugin api
@@ -747,7 +747,7 @@ jobs:
         fetch-depth: 10
     - id: files
       name: Get changed files
-      uses: tj-actions/changed-files@v23.1
+      uses: tj-actions/changed-files@v32.0.0
       with:
         files_ignore: docs/**|build-support/bin/generate_user_list.py
         files_ignore_separator: '|'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -110,7 +110,7 @@ def is_docs_only() -> Jobs:
                 {
                     "id": "files",
                     "name": "Get changed files",
-                    "uses": "tj-actions/changed-files@v23.1",
+                    "uses": "tj-actions/changed-files@v32.0.0",
                     "with": {"files_ignore_separator": "|", "files_ignore": "|".join(docs_files)},
                 },
                 {
@@ -132,7 +132,7 @@ def ensure_category_label() -> Sequence[Step]:
         {
             "if": "github.event_name == 'pull_request'",
             "name": "Ensure category label",
-            "uses": "mheap/github-action-required-labels@v1",
+            "uses": "mheap/github-action-required-labels@v2.1.0",
             "env": {"GITHUB_TOKEN": gha_expr("secrets.GITHUB_TOKEN")},
             "with": {
                 "mode": "exactly",


### PR DESCRIPTION

Since the older version use a deprecated NodeJS version.
https://github.com/pantsbuild/pants/actions/runs/3229916892
![Screen Shot 2022-10-11 at 5 27 54 PM](https://user-images.githubusercontent.com/1268088/195201770-2589d67a-16ca-4907-9d46-c1ca8ae57ee3.png)
