### PR TITLE
Remote cache reads are resilient to remote execution writing to the cache

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -652,6 +652,11 @@ impl Process {
     self.remote_cache_speculation_delay = delay;
     self
   }
+
+  pub fn cache_scope(mut self, cache_scope: ProcessCacheScope) -> Process {
+    self.cache_scope = cache_scope;
+    self
+  }
 }
 
 ///

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -271,20 +271,16 @@ impl CommandRunner {
       .await;
       match response {
         Ok(cached_response_opt) => match &cached_response_opt {
-          Some(cached_response) => {
+          Some(cached_response) if cached_response.exit_code == 0 || failures_cached => {
             log::debug!(
               "remote cache hit for: {:?} digest={:?} response={:?}",
               request.description,
               action_digest,
               cached_response
             );
-            if cached_response.exit_code == 0 || failures_cached {
-              cached_response_opt
-            } else {
-              None
-            }
+            cached_response_opt
           }
-          None => {
+          _ => {
             log::debug!(
               "remote cache miss for: {:?} digest={:?}",
               request.description,

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -248,6 +248,7 @@ impl CommandRunner {
     context: Context,
     cache_lookup_start: Instant,
     action_digest: Digest,
+    failures_cached: bool,
     request: &Process,
     mut local_execution_future: BoxFuture<
       '_,
@@ -269,27 +270,29 @@ impl CommandRunner {
       )
       .await;
       match response {
-        Ok(cached_response_opt) => {
-          match &cached_response_opt {
-            Some(cached_response) => {
-              log::debug!(
-                "remote cache hit for: {:?} digest={:?} response={:?}",
-                request.description,
-                action_digest,
-                cached_response
-              );
-            }
-            None => {
-              log::debug!(
-                "remote cache miss for: {:?} digest={:?}",
-                request.description,
-                action_digest
-              );
+        Ok(cached_response_opt) => match &cached_response_opt {
+          Some(cached_response) => {
+            log::debug!(
+              "remote cache hit for: {:?} digest={:?} response={:?}",
+              request.description,
+              action_digest,
+              cached_response
+            );
+            if cached_response.exit_code == 0 || failures_cached {
+              cached_response_opt
+            } else {
+              None
             }
           }
-
-          cached_response_opt
-        }
+          None => {
+            log::debug!(
+              "remote cache miss for: {:?} digest={:?}",
+              request.description,
+              action_digest
+            );
+            None
+          }
+        },
         Err(err) => {
           self.log_cache_error(err.to_string(), CacheErrorType::ReadError);
           None
@@ -472,7 +475,7 @@ impl crate::CommandRunner for CommandRunner {
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
     )?;
-    let write_failures_to_cache = request.cache_scope == ProcessCacheScope::Always;
+    let failures_cached = request.cache_scope == ProcessCacheScope::Always;
 
     // Ensure the action and command are stored locally.
     let (command_digest, action_digest) =
@@ -487,6 +490,7 @@ impl crate::CommandRunner for CommandRunner {
           context.clone(),
           cache_lookup_start,
           action_digest,
+          failures_cached,
           &request.clone(),
           self.inner.run(context.clone(), workunit, request),
         )
@@ -499,7 +503,7 @@ impl crate::CommandRunner for CommandRunner {
     };
 
     if !hit_cache
-      && (result.exit_code == 0 || write_failures_to_cache)
+      && (result.exit_code == 0 || failures_cached)
       && self.cache_write
       && use_remote_cache
     {


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/17189

[ci skip-build-wheels]