### PR TITLE
Set PEX_ROOT for export post-processing command. (cherry-pick of #17177)

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -14,7 +14,7 @@ from pants.backend.python.target_types import PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_cli import PexPEX
-from pants.backend.python.util_rules.pex_environment import PythonExecutable, PexEnvironment
+from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.export import (
     ExportError,
@@ -146,7 +146,7 @@ async def export_virtualenv(
                 ],
                 {
                     **complete_pex_env.environment_dict(python_configured=True),
-                    "PEX_MODULE": "pex.tools"
+                    "PEX_MODULE": "pex.tools",
                 },
             ),
             PostProcessingCommand(["rm", "-f", pex_pex_path]),
@@ -155,7 +155,9 @@ async def export_virtualenv(
 
 
 @rule
-async def export_tool(request: ExportPythonTool, pex_pex: PexPEX, pex_env: PexEnvironment) -> ExportResult:
+async def export_tool(
+    request: ExportPythonTool, pex_pex: PexPEX, pex_env: PexEnvironment
+) -> ExportResult:
     assert request.pex_request is not None
 
     # TODO: Unify export_virtualenv() and export_tool(), since their implementations mostly overlap.
@@ -195,7 +197,7 @@ async def export_tool(request: ExportPythonTool, pex_pex: PexPEX, pex_env: PexEn
                 ],
                 {
                     **complete_pex_env.environment_dict(python_configured=True),
-                    "PEX_MODULE": "pex.tools"
+                    "PEX_MODULE": "pex.tools",
                 },
             ),
             PostProcessingCommand(["rm", "-rf", pex_pex_dest]),

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -87,7 +87,8 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
                 "--remove=all",
                 f"{{digest_root}}/{current_interpreter}",
             )
-            assert ppc0.extra_env == FrozenDict({"PEX_MODULE": "pex.tools"})
+            assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"
+            assert "PEX_ROOT" in ppc0.extra_env
 
             ppc1 = result.post_processing_cmds[1]
             assert ppc1.argv == (


### PR DESCRIPTION
This is both a leak that foils our recommendations to users for maintenance of 
Pants caches and results in unneeded extra work when an export finds an 
empty ~/.pex but would have had hits in ~/.cache/pants/named_caches/pex_root 
if it had been pointed there.

A reapplication of part of #17177, but not really a straight cherry-pick, as it would not 
apply even remotely cleanly.

