### PR TITLE
Add `_render_message` to `LintResult` to workaround double-logging

### DIFF
--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -345,6 +345,7 @@ async def convert_fmt_result_to_lint_result(fmt_result: FmtResult) -> LintResult
         fmt_result.stdout,
         fmt_result.stderr,
         linter_name=fmt_result.formatter_name,
+        _render_message=False,  # Don't re-render the message
     )
 
 

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -58,7 +58,7 @@ class LintResult(EngineAwareReturnType):
     linter_name: str
     partition_description: str | None = None
     report: Digest = EMPTY_DIGEST
-    _render_message: bool = False
+    _render_message: bool = True
 
     @classmethod
     def create(
@@ -85,8 +85,8 @@ class LintResult(EngineAwareReturnType):
         return {"partition": self.partition_description}
 
     def level(self) -> LogLevel | None:
-        if self._render_message:
-            return LogLevel.DEBUG
+        if not self._render_message:
+            return LogLevel.TRACE
         if self.exit_code != 0:
             return LogLevel.ERROR
         return LogLevel.INFO

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -58,6 +58,7 @@ class LintResult(EngineAwareReturnType):
     linter_name: str
     partition_description: str | None = None
     report: Digest = EMPTY_DIGEST
+    _render_message: bool = False
 
     @classmethod
     def create(
@@ -84,7 +85,11 @@ class LintResult(EngineAwareReturnType):
         return {"partition": self.partition_description}
 
     def level(self) -> LogLevel | None:
-        return LogLevel.ERROR if self.exit_code != 0 else LogLevel.INFO
+        if self._render_message:
+            return LogLevel.DEBUG
+        if self.exit_code != 0:
+            return LogLevel.ERROR
+        return LogLevel.INFO
 
     def message(self) -> str | None:
         message = self.linter_name


### PR DESCRIPTION
Fixes #17201

[ci skip-rust]
[ci skip-build-wheels]