### PR TITLE
Add sample REAPI server to use when manually testing remote execution.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,8 @@ docker_environment(
     image="python:3.9",
 )
 
+# See `build-support/reapi-sample-server/README.md` for information on how to use this environment
+# for internal testing.
 remote_environment(
     name="buildgrid_remote",
     python_bootstrap_search_path=["<PATH>"],

--- a/BUILD
+++ b/BUILD
@@ -17,8 +17,5 @@ docker_environment(
 
 remote_environment(
     name="buildgrid_remote",
-    extra_platform_properties=[
-        "OSFamily=linux",
-    ],
     python_bootstrap_search_path=["<PATH>"],
 )

--- a/BUILD
+++ b/BUILD
@@ -14,3 +14,11 @@ docker_environment(
     name="docker_env",
     image="python:3.9",
 )
+
+remote_environment(
+    name="buildgrid_remote",
+    extra_platform_properties=[
+        "OSFamily=linux",
+    ],
+    python_bootstrap_search_path=["<PATH>"],
+)

--- a/build-support/reapi-sample-server/Dockerfile
+++ b/build-support/reapi-sample-server/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.9.12-slim-buster@sha256:62ed2b347a385102d33f5e82530862359f8dc60464674d78cef844b02d150a50
+
+RUN apt-get update && apt-get install -y git libcurl4-openssl-dev build-essential libssl-dev
+
+RUN git clone https://gitlab.com/BuildGrid/buildgrid.git && \
+    git -C buildgrid reset --hard 82341d090db55e11257d92ea38f9afd61fa15486
+
+RUN pip install ./buildgrid
+
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod 555 /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/build-support/reapi-sample-server/README.md
+++ b/build-support/reapi-sample-server/README.md
@@ -1,0 +1,11 @@
+The `run.sh` script in this directory launches a very basic / insecure instance of the https://buildgrid.build/ remote execution service inside a single Docker container.
+
+To use it to experiment with Pants' remote execution implementation, you'd start the server in one shell with `run.sh`, and then use Pants config similar to the following to enable it:
+```toml pants.toml
+remote_execution = true
+remote_store_address = "grpc://127.0.0.1:50051"
+remote_execution_address = "grpc://127.0.0.1:50051"
+remote_instance_name = ""
+# TODO: See https://gitlab.com/BuildGrid/buildgrid/-/blob/master/buildgrid/server/server.py#L212-222
+process_execution_remote_parallelism = 8
+```

--- a/build-support/reapi-sample-server/README.md
+++ b/build-support/reapi-sample-server/README.md
@@ -1,11 +1,3 @@
 The `run.sh` script in this directory launches a very basic / insecure instance of the https://buildgrid.build/ remote execution service inside a single Docker container.
 
-To use it to experiment with Pants' remote execution implementation, you'd start the server in one shell with `run.sh`, and then use Pants config similar to the following to enable it:
-```toml pants.toml
-remote_execution = true
-remote_store_address = "grpc://127.0.0.1:50051"
-remote_execution_address = "grpc://127.0.0.1:50051"
-remote_instance_name = ""
-# TODO: See https://gitlab.com/BuildGrid/buildgrid/-/blob/master/buildgrid/server/server.py#L212-222
-process_execution_remote_parallelism = 8
-```
+To use it to experiment with Pants' remote execution implementation, you'd start the server in one shell with `run.sh`. Then, set a target like `python_test` to use `environment='remote'`, and run Pants with `--pants-config-files=pants.remote-execution.toml`.

--- a/build-support/reapi-sample-server/entrypoint.sh
+++ b/build-support/reapi-sample-server/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+bgd server start --verbose buildgrid/data/config/default.yml &
+
+bgd bot --verbose --remote http://localhost:50051 --remote-cas http://localhost:50051 host-tools

--- a/build-support/reapi-sample-server/run.sh
+++ b/build-support/reapi-sample-server/run.sh
@@ -8,7 +8,8 @@ if [[ -z "${NO_BUILD:-}" ]]; then
   docker build -t buildgrid_local build-support/reapi-sample-server
 fi
 
-docker run \
+exec docker run \
+  --platform=linux/amd64 \
   -v "$HOME/.docker-run/buildgrid_local":/root \
   -p 127.0.0.1:50051:50051/tcp \
   -ti \

--- a/build-support/reapi-sample-server/run.sh
+++ b/build-support/reapi-sample-server/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ -z "${NO_BUILD:-}" ]]; then
+  docker build -t buildgrid_local build-support/reapi-sample-server
+fi
+
+docker run \
+  -v "$HOME/.docker-run/buildgrid_local":/root \
+  -p 127.0.0.1:50051:50051/tcp \
+  -ti \
+  --rm \
+  buildgrid_local

--- a/pants.remote-execution.toml
+++ b/pants.remote-execution.toml
@@ -1,3 +1,6 @@
+# See `build-support/reapi-sample-server/README.md` for information on how to use this config
+# for internal testing.
+
 [GLOBAL]
 
 # NB: We disable the `toolchain` plugin to avoid it overriding remote execution settings,

--- a/pants.remote-execution.toml
+++ b/pants.remote-execution.toml
@@ -6,7 +6,7 @@
 # NB: We disable the `toolchain` plugin to avoid it overriding remote execution settings,
 # and disable config verification to ignore `toolchain` related settings.
 plugins = []
-no_verify_config = true
+verify_config = false
 
 remote_execution = true
 remote_cache_read = true

--- a/pants.remote-execution.toml
+++ b/pants.remote-execution.toml
@@ -1,0 +1,11 @@
+[GLOBAL]
+remote_execution = true
+remote_cache_read = true
+remote_cache_write = true
+
+remote_store_address = "grpc://127.0.0.1:50051"
+remote_execution_address = "grpc://127.0.0.1:50051"
+remote_instance_name = ""
+
+# TODO: See https://gitlab.com/BuildGrid/buildgrid/-/blob/master/buildgrid/server/server.py#L212-222
+process_execution_remote_parallelism = 8

--- a/pants.remote-execution.toml
+++ b/pants.remote-execution.toml
@@ -1,4 +1,10 @@
 [GLOBAL]
+
+# NB: We disable the `toolchain` plugin to avoid it overriding remote execution settings,
+# and disable config verification to ignore `toolchain` related settings.
+plugins = []
+no_verify_config = true
+
 remote_execution = true
 remote_cache_read = true
 remote_cache_write = true

--- a/pants.toml
+++ b/pants.toml
@@ -99,6 +99,8 @@ root_patterns = [
 [environments-preview.names]
 # We don't define any local environments because the options system covers our cases adequately.
 docker = "//:docker_env"
+# Used for iterating on remote-execution.
+remote = "//:buildgrid_remote"
 
 [tailor]
 build_file_header = """\


### PR DESCRIPTION
To assist with manual testing of remote execution, this change adds a sample server using `buildgrid`'s example setup, and its basic `hosttools` worker.

[ci skip-rust]
[ci skip-build-wheels]