### PR TITLE
Support custom post renderers in Helm deployments

### DIFF
--- a/docs/markdown/Helm/helm-deployments.md
+++ b/docs/markdown/Helm/helm-deployments.md
@@ -253,7 +253,7 @@ In this example, the deployment at `src/deploy:main` declares a dependency on a 
 Post-renderers
 --------------
 
-User-defined [Helm post-renderers](https://helm.sh/docs/topics/advanced/#post-rendering) are supported by the Helm backend by means of the `post_renderers` field in the `helm_deployment` target. This field takes addresses to other runnable targets (any target that can be run using `./pants run [address]`) and will compile and run those targets as part of `experimental-deploy` goal. The referenced targets can be either shell commands or custom-made in any of the other languages supported by Pants.
+User-defined [Helm post-renderers](https://helm.sh/docs/topics/advanced/#post-rendering) are supported by the Helm backend by means of the `post_renderers` field in the `helm_deployment` target. This field takes addresses to other runnable targets (any target that can be run using `./pants run [address]`) and will build and run those targets as part of `experimental-deploy` goal. The referenced targets can be either shell commands or custom-made in any of the other languages supported by Pants.
 
 As an example, let's show how we can use the tool [`vals`](https://github.com/variantdev/vals) as a post-renderer and replace all references to secret values stored in HashiCorp Vault by their actual values. The following example is composed of a Helm chart that creates a secret resource in Kubernetes and a Helm deployment that is configured to use `vals` as a post-renderer:
 

--- a/docs/markdown/Helm/helm-deployments.md
+++ b/docs/markdown/Helm/helm-deployments.md
@@ -279,16 +279,9 @@ data:
 type: Opaque
 ```
 ```python src/deploy/BUILD
-experimental_shell_command(
+experimental_run_shell_command(
   name="vals",
   command="vals eval -f -",
-  extra_env_vars=[
-    "VAULT_ADDR",
-    "VAULT_NAMESPACE",
-    "VAULT_TOKEN",
-    ...
-  ],
-  tools=["vals"],
 )
 
 helm_deployment(

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -219,6 +219,11 @@ async def setup_post_renderer_launcher(
     )
 
     def shell_escape(arg: str) -> str:
+        """Escape the shell argument by wrapping it around single quotes.
+
+        Found at:
+        https://stackoverflow.com/questions/15783701/which-characters-need-to-be-escaped-when-using-bash
+        """
         return re.sub(r"/'\\\\''", r"1s/^/'/; \$s/\$/'/", arg)
 
     def shell_cmd(args: Iterable[str]) -> str:

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -9,7 +9,7 @@ import pkgutil
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 import yaml
 
@@ -22,16 +22,20 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import CatBinary
+from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.process import Process
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
+from pants.engine.target import FieldSetsPerTarget, FieldSetsPerTargetRequest, Targets
 from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
+from pants.util.meta import frozen_after_init
 
 logger = logging.getLogger(__name__)
 
@@ -114,12 +118,14 @@ class SetupHelmPostRenderer(EngineAwareParameter):
 
     replacements: FrozenYamlIndex[str]
     description_of_origin: str
+    extra_post_renderers: UnparsedAddressInputs | None = None
 
     def debug_hint(self) -> str | None:
         return self.description_of_origin
 
 
-@dataclass(frozen=True)
+@frozen_after_init
+@dataclass(unsafe_hash=True)
 class HelmPostRenderer(EngineAwareReturnType):
     exe: str
     digest: Digest
@@ -127,6 +133,23 @@ class HelmPostRenderer(EngineAwareReturnType):
     env: FrozenDict[str, str]
     append_only_caches: FrozenDict[str, str]
     description_of_origin: str
+
+    def __init__(
+        self,
+        *,
+        exe: str,
+        digest: Digest,
+        description_of_origin: str,
+        env: Mapping[str, str] | None = None,
+        immutable_input_digests: Mapping[str, Digest] | None = None,
+        append_only_caches: Mapping[str, str] | None = None,
+    ) -> None:
+        self.exe = exe
+        self.digest = digest
+        self.description_of_origin = description_of_origin
+        self.env = FrozenDict(env or {})
+        self.append_only_caches = FrozenDict(append_only_caches or {})
+        self.immutable_input_digests = FrozenDict(immutable_input_digests or {})
 
     def level(self) -> LogLevel | None:
         return LogLevel.DEBUG
@@ -136,6 +159,19 @@ class HelmPostRenderer(EngineAwareReturnType):
 
     def metadata(self) -> dict[str, Any] | None:
         return {"exe": self.exe, "env": self.env, "append_only_caches": self.append_only_caches}
+
+
+@rule_helper
+async def _resolve_post_renderers(
+    address_inputs: UnparsedAddressInputs,
+) -> Iterable[RunRequest]:
+    targets = await Get(Targets, UnparsedAddressInputs, address_inputs)
+    field_sets_per_target = await Get(
+        FieldSetsPerTarget, FieldSetsPerTargetRequest(RunFieldSet, targets)
+    )
+    return await MultiGet(
+        Get(RunRequest, RunFieldSet, field_set) for field_set in field_sets_per_target.field_sets
+    )
 
 
 @rule(desc="Configure Helm post-renderer", level=LogLevel.DEBUG)
@@ -171,7 +207,19 @@ async def setup_post_renderer_launcher(
     )
 
     # Build a shell wrapper script which will be the actual entry-point sent to Helm as the post-renderer.
-    post_renderer_process_cli = " ".join(post_renderer_process.argv)
+    # Extra post-renderers are plugged by piping the output of one into the next one in the order they
+    # have been defined.
+    extra_post_renderers = (
+        await _resolve_post_renderers(request.extra_post_renderers)
+        if request.extra_post_renderers
+        else []
+    )
+    post_renderer_process_cli = " | ".join(
+        [
+            " ".join(post_renderer_process.argv),
+            *[" ".join(post_renderer.args) for post_renderer in extra_post_renderers],
+        ]
+    )
     logger.debug(f"Built post-renderer process CLI: {post_renderer_process_cli}")
 
     postrenderer_wrapper_script = dedent(
@@ -197,16 +245,48 @@ async def setup_post_renderer_launcher(
         ),
     )
 
-    # Extract all info needed to invoke the post-renderer from the PEX process
+    # Combine all required settings from the internal and extra post-postrenders
     launcher_digest = await Get(
-        Digest, MergeDigests([wrapper_digest, post_renderer_process.input_digest])
+        Digest,
+        MergeDigests(
+            [
+                wrapper_digest,
+                post_renderer_process.input_digest,
+                *[post_renderer.digest for post_renderer in extra_post_renderers],
+            ]
+        ),
     )
+    launcher_env = {
+        **post_renderer_process.env,
+        **{
+            k: v
+            for post_renderer in extra_post_renderers
+            for k, v in post_renderer.extra_env.items()
+        },
+    }
+    launcher_append_only_caches = {
+        **post_renderer_process.append_only_caches,
+        **{
+            k: v
+            for post_renderer in extra_post_renderers
+            for k, v in (post_renderer.append_only_caches or {}).items()
+        },
+    }
+    launcher_immutable_input_digests = {
+        **post_renderer_process.immutable_input_digests,
+        **{
+            k: v
+            for post_renderer in extra_post_renderers
+            for k, v in (post_renderer.immutable_input_digests or {}).items()
+        },
+    }
+
     return HelmPostRenderer(
         exe=_HELM_POST_RENDERER_WRAPPER_SCRIPT,
         digest=launcher_digest,
-        env=post_renderer_process.env,
-        append_only_caches=post_renderer_process.append_only_caches,
-        immutable_input_digests=post_renderer_process.immutable_input_digests,
+        env=launcher_env,
+        append_only_caches=launcher_append_only_caches,
+        immutable_input_digests=launcher_immutable_input_digests,
         description_of_origin=request.description_of_origin,
     )
 

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -245,7 +245,7 @@ async def setup_post_renderer_launcher(
         ),
     )
 
-    # Combine all required settings from the internal and extra post-postrenders
+    # Combine all required settings for the internal and extra post-renderers
     launcher_digest = await Get(
         Digest,
         MergeDigests(

--- a/src/python/pants/backend/helm/subsystems/post_renderer_test.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer_test.py
@@ -11,6 +11,7 @@ import pytest
 from pants.backend.helm.subsystems import post_renderer
 from pants.backend.helm.subsystems.post_renderer import HelmPostRenderer, SetupHelmPostRenderer
 from pants.backend.helm.utils.yaml import MutableYamlIndex, YamlPath
+from pants.core.goals.run import rules as run_rules
 from pants.engine.fs import DigestContents, Snapshot
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import QueryRule
@@ -22,6 +23,7 @@ def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
             *post_renderer.rules(),
+            *run_rules(),
             QueryRule(HelmPostRenderer, (SetupHelmPostRenderer,)),
             QueryRule(ProcessResult, (Process,)),
         ]

--- a/src/python/pants/backend/helm/subsystems/post_renderer_test.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer_test.py
@@ -73,6 +73,6 @@ def test_post_renderer_is_runnable(rule_runner: RuleRunner) -> None:
         elif file.path == "post_renderer_wrapper.sh":
             script_lines = file.content.decode().splitlines()
             assert (
-                "./helm_post_renderer.pex_pex_shim.sh ./post_renderer.cfg.yaml ./__stdin.yaml"
+                "./helm_post_renderer.pex_pex_shim.sh ./post_renderer.cfg.yaml ./__helm_stdout.yaml"
                 in script_lines
             )

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -22,6 +22,7 @@ from pants.engine.target import (
     MultipleSourcesField,
     OverridesField,
     SingleSourceField,
+    SpecialCasedDependencies,
     StringField,
     StringSequenceField,
     Target,
@@ -463,6 +464,21 @@ class HelmDeploymentTimeoutField(IntField):
     valid_numbers = ValidNumbers.positive_only
 
 
+class HelmDeploymentPostRenderersField(SpecialCasedDependencies):
+    alias = "post_renderers"
+    help = softwrap(
+        """
+        List of runnable targets to be used to post-process the helm chart after being renderer by Helm.
+
+        This is equivalent to the same post-renderer feature already available in Helm with the difference
+        that this supports a list of executables instead of a single one.
+
+        When more than one post-renderer is given, they will be combined into a single one in which the
+        input of each of them would be output of the previous one.
+        """
+    )
+
+
 class HelmDeploymentTarget(Target):
     alias = "helm_deployment"
     core_fields = (
@@ -476,6 +492,7 @@ class HelmDeploymentTarget(Target):
         HelmDeploymentCreateNamespaceField,
         HelmDeploymentNoHooksField,
         HelmDeploymentTimeoutField,
+        HelmDeploymentPostRenderersField,
     )
     help = "A Helm chart deployment."
 
@@ -496,6 +513,7 @@ class HelmDeploymentFieldSet(FieldSet):
     no_hooks: HelmDeploymentNoHooksField
     dependencies: HelmDeploymentDependenciesField
     values: HelmDeploymentValuesField
+    post_renderers: HelmDeploymentPostRenderersField
 
     def format_values(
         self, interpolation_context: InterpolationContext, *, ignore_missing: bool = False

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -468,7 +468,7 @@ class HelmDeploymentPostRenderersField(SpecialCasedDependencies):
     alias = "post_renderers"
     help = softwrap(
         """
-        List of runnable targets to be used to post-process the helm chart after being renderer by Helm.
+        List of runnable targets to be used to post-process the helm chart after being rendered by Helm.
 
         This is equivalent to the same post-renderer feature already available in Helm with the difference
         that this supports a list of executables instead of a single one.

--- a/src/python/pants/backend/helm/util_rules/post_renderer.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer.py
@@ -147,7 +147,11 @@ async def prepare_post_renderer_for_helm_deployment(
 
     return await Get(
         HelmPostRenderer,
-        SetupHelmPostRenderer(replacements, description_of_origin=request.field_set.address.spec),
+        SetupHelmPostRenderer(
+            replacements,
+            extra_post_renderers=request.field_set.post_renderers.to_unparsed_address_inputs(),
+            description_of_origin=request.field_set.address.spec,
+        ),
     )
 
 

--- a/src/python/pants/backend/helm/util_rules/post_renderer.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer.py
@@ -149,8 +149,8 @@ async def prepare_post_renderer_for_helm_deployment(
         HelmPostRenderer,
         SetupHelmPostRenderer(
             replacements,
-            extra_post_renderers=request.field_set.post_renderers.to_unparsed_address_inputs(),
             description_of_origin=request.field_set.address.spec,
+            extra_post_renderers=request.field_set.post_renderers.to_unparsed_address_inputs(),
         ),
     )
 

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -32,6 +32,9 @@ from pants.backend.helm.util_rules.renderer import (
 )
 from pants.backend.helm.util_rules.renderer_test import _read_file_from_digest
 from pants.backend.helm.util_rules.tool import HelmProcess
+from pants.backend.shell import shell_command
+from pants.backend.shell.target_types import ShellCommandTarget, ShellSourcesGeneratorTarget
+from pants.core.goals.run import rules as run_rules
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
 from pants.engine.process import ProcessResult
@@ -54,12 +57,20 @@ async def custom_test_image_tags(_: CustomTestImageTagRequest) -> DockerImageTag
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
-        target_types=[HelmChartTarget, HelmDeploymentTarget, DockerImageTarget],
+    rule_runner = RuleRunner(
+        target_types=[
+            HelmChartTarget,
+            HelmDeploymentTarget,
+            DockerImageTarget,
+            ShellSourcesGeneratorTarget,
+            ShellCommandTarget,
+        ],
         rules=[
             *infer_deployment.rules(),
             *source_files.rules(),
             *post_renderer.rules(),
+            *run_rules(),
+            *shell_command.rules(),
             custom_test_image_tags,
             UnionRule(DockerImageTagsRequest, CustomTestImageTagRequest),
             QueryRule(HelmPostRenderer, (HelmDeploymentPostRendererRequest,)),
@@ -67,6 +78,34 @@ def rule_runner() -> RuleRunner:
             QueryRule(ProcessResult, (HelmProcess,)),
         ],
     )
+    source_root_patterns = ("src/*",)
+    rule_runner.set_options(
+        [f"--source-root-patterns={repr(source_root_patterns)}"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+    return rule_runner
+
+
+_TEST_GIVEN_CONFIGMAP_FILE = dedent(
+    """\
+    apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: foo-config
+    data:
+      foo_key: foo_value
+    """
+)
+
+_TEST_EXPECTED_CONFIGMAP_FILE = (
+    dedent(
+        """\
+      ---
+      # Source: mychart/templates/configmap.yaml
+      """
+    )
+    + _TEST_GIVEN_CONFIGMAP_FILE
+)
 
 
 def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
@@ -80,16 +119,7 @@ def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
                 """
             ),
             "src/mychart/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
-            "src/mychart/templates/configmap.yaml": dedent(
-                """\
-              apiVersion: v1
-              kind: ConfigMap
-              metadata:
-                name: foo-config
-              data:
-                foo_key: foo_value
-              """
-            ),
+            "src/mychart/templates/configmap.yaml": _TEST_GIVEN_CONFIGMAP_FILE,
             "src/mychart/templates/pod.yaml": dedent(
                 """\
                 {{- $root := . -}}
@@ -137,12 +167,6 @@ def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
             "src/image/Dockerfile.init": "FROM busybox:1.28",
             "src/image/Dockerfile.app": "FROM busybox:1.28",
         }
-    )
-
-    source_root_patterns = ("src/*",)
-    rule_runner.set_options(
-        [f"--source-root-patterns={repr(source_root_patterns)}"],
-        env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
 
     expected_config_file = dedent(
@@ -225,7 +249,81 @@ def test_can_prepare_post_renderer(rule_runner: RuleRunner) -> None:
     assert "mychart/templates/pod.yaml" in rendered_output.snapshot.files
     assert "mychart/templates/configmap.yaml" in rendered_output.snapshot.files
 
+    rendered_configmap_file = _read_file_from_digest(
+        rule_runner,
+        digest=rendered_output.snapshot.digest,
+        filename="mychart/templates/configmap.yaml",
+    )
+    assert rendered_configmap_file == _TEST_EXPECTED_CONFIGMAP_FILE
+
     rendered_pod_file = _read_file_from_digest(
         rule_runner, digest=rendered_output.snapshot.digest, filename="mychart/templates/pod.yaml"
     )
     assert rendered_pod_file == expected_rendered_pod
+
+
+def test_use_simple_extra_post_renderer(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/mychart/BUILD": "helm_chart()",
+            "src/mychart/Chart.yaml": HELM_CHART_FILE,
+            "src/mychart/templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            "src/mychart/templates/configmap.yaml": _TEST_GIVEN_CONFIGMAP_FILE,
+            "src/shell/BUILD": dedent(
+                """\
+              shell_sources(name="scripts")
+
+              experimental_shell_command(
+                name="custom_post_renderer",
+                tools=["cat"],
+                command="./my-script.sh",
+                dependencies=[":scripts"]
+              )
+              """
+            ),
+            "src/shell/script.sh": dedent(
+                """\
+              #!/bin/bash
+              cat <&0
+              """
+            ),
+            "src/deployment/BUILD": dedent(
+                """\
+              helm_deployment(
+                name="test",
+                dependencies=["//src/mychart"],
+                post_renderers=["//src/shell:custom_post_renderer"]
+              )
+              """
+            ),
+        }
+    )
+
+    deployment_addr = Address("src/deployment", target_name="test")
+    tgt = rule_runner.get_target(deployment_addr)
+    field_set = HelmDeploymentFieldSet.create(tgt)
+
+    post_renderer = rule_runner.request(
+        HelmPostRenderer,
+        [HelmDeploymentPostRendererRequest(field_set)],
+    )
+
+    rendered_output = rule_runner.request(
+        RenderedHelmFiles,
+        [
+            HelmDeploymentRequest(
+                field_set=field_set,
+                cmd=HelmDeploymentCmd.RENDER,
+                description="Test post-renderer output",
+                post_renderer=post_renderer,
+            )
+        ],
+    )
+    assert "mychart/templates/configmap.yaml" in rendered_output.snapshot.files
+
+    rendered_configmap_file = _read_file_from_digest(
+        rule_runner,
+        digest=rendered_output.snapshot.digest,
+        filename="mychart/templates/configmap.yaml",
+    )
+    assert rendered_configmap_file == _TEST_EXPECTED_CONFIGMAP_FILE

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -290,9 +290,9 @@ async def setup_render_helm_deployment_process(
     if request.post_renderer:
         logger.debug(f"Using post-renderer stage in deployment {request.field_set.address}")
         input_digests.append(request.post_renderer.digest)
-        env = request.post_renderer.env
+        env.update(request.post_renderer.env)
         immutable_input_digests.update(request.post_renderer.immutable_input_digests)
-        append_only_caches = request.post_renderer.append_only_caches
+        append_only_caches.update(request.post_renderer.append_only_caches)
 
     merged_digests = await Get(Digest, MergeDigests(input_digests))
 

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -173,6 +173,8 @@ class RenderedHelmFiles(EngineAwareReturnType):
         return {"address": self.address, "chart": self.chart, "post_processed": self.post_processed}
 
     def cacheable(self) -> bool:
+        # When using post-renderers it may not be safe to cache the generated files as the final result
+        # may contain secrets or other kind of sensitive information.
         return not self.post_processed
 
 
@@ -314,6 +316,9 @@ async def setup_render_helm_deployment_process(
             return f'"{value}"'
         return value
 
+    # If using a post-renderer we are only going to keep the process result cached in
+    # memory to prevent storing in disk, either locally or remotely, secrets or other
+    # sensitive values that may been added in by the post-renderer.
     process_cache = (
         ProcessCacheScope.PER_RESTART_SUCCESSFUL
         if request.post_renderer

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -172,6 +172,9 @@ class RenderedHelmFiles(EngineAwareReturnType):
     def metadata(self) -> dict[str, Any] | None:
         return {"address": self.address, "chart": self.chart, "post_processed": self.post_processed}
 
+    def cacheable(self) -> bool:
+        return not self.post_processed
+
 
 @rule_helper
 async def _build_interpolation_context(helm_subsystem: HelmSubsystem) -> InterpolationContext:

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable
 
 from pants.backend.helm.subsystems import post_renderer
 from pants.backend.helm.subsystems.helm import HelmSubsystem
@@ -284,12 +284,12 @@ async def setup_render_helm_deployment_process(
     input_digests = [output_digest]
 
     # Additional process values in case a post_renderer has been requested.
-    env: Mapping[str, str] = {}
+    env: dict[str, str] = {}
     immutable_input_digests: dict[str, Digest] = {
         **chart.immutable_input_digests,
         value_files_prefix: value_files.snapshot.digest,
     }
-    append_only_caches: Mapping[str, str] = {}
+    append_only_caches: dict[str, str] = {}
     if request.post_renderer:
         logger.debug(f"Using post-renderer stage in deployment {request.field_set.address}")
         input_digests.append(request.post_renderer.digest)


### PR DESCRIPTION
This Pull Request proposes relates to #16430 proposing an alternative to the addition of support for the Helm Secrets plugin by adding support to user-defined post-renderers in `helm_deployment` targets.

The proposed solution comes from the realization that helping end-users define secrets for their deployments in a safe way could be achieved in a simple way by helping end users to choose their preferred tools to post-process their Helm templates and perform any modifications to the final Kubernetes manifests on the fly while still preserving the files safe. The requirement to not have the final secrets value in Pants' cache is achieved by marking as _non-cacheable_ the returned rendered files whenever they have been going through the post-renderer.

This additionally has the benefit of opening the door to end users to define their own post-renderers.

[ci skip-rust]
[ci skip-build-wheels]