### PR TITLE
Cherrypicks of recent CI improvements to 2.14.x

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -293,7 +293,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'
       name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v2.1.0
       with:
         count: 1
         labels: category:new feature, category:user api change, category:plugin api

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -63,8 +63,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -72,7 +72,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -84,7 +84,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -123,7 +123,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -195,7 +195,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -206,8 +206,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -215,7 +215,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -227,7 +227,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -266,7 +266,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -342,7 +342,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -431,7 +431,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -520,7 +520,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -609,7 +609,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -684,7 +684,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -52,7 +52,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -61,20 +61,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -195,7 +186,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -204,20 +195,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -66,8 +66,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -75,7 +75,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'Linux-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -87,7 +87,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -126,7 +126,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -200,7 +200,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -211,8 +211,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -220,7 +220,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -232,7 +232,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -271,7 +271,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -415,7 +415,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-15-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -426,8 +426,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS10-15-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -435,7 +435,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS10-15-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - env:
@@ -519,7 +519,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-ARM64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -530,8 +530,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-ARM64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -539,7 +539,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-ARM64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - id: get-engine-hash
@@ -551,7 +551,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-ARM64-engine-${ steps.get-engine-hash.outputs.hash }-v1
+        key: 'macOS11-ARM64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
 
           '
         path: '.pants
@@ -590,7 +590,7 @@ jobs:
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-ARM64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-ARM64
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -658,7 +658,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${ hashFiles('rust-toolchain') }-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -669,8 +669,8 @@ jobs:
     - name: Cache Cargo
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-${ hashFiles(''src/rust/engine/Cargo.*'')
-          }-v1
+        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
+          }}-v1
 
           '
         path: '~/.cargo/registry
@@ -678,7 +678,7 @@ jobs:
           ~/.cargo/git
 
           '
-        restore-keys: 'macOS11-x86_64-cargo-${ hashFiles(''rust-toolchain'') }-
+        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
 
           '
     - env:
@@ -801,7 +801,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -945,7 +945,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1036,7 +1036,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1127,7 +1127,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.Linux-x86_64
+        name: native_binaries.${{ matrix.python-version }}.Linux-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -1204,7 +1204,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${ matrix.python-version }.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,11 +11,11 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -147,11 +147,11 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Bootstrap Pants, test Rust (macOS11-x86_64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - macos-11
     steps:
@@ -274,11 +274,11 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Build wheels and fs_util (Linux-x86_64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -359,11 +359,11 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Build wheels and fs_util (macOS10-15-x86_64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - macOS-10.15-X64
     steps:
@@ -452,11 +452,11 @@ jobs:
       ARCHFLAGS: -arch arm64
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Bootstrap Pants, build wheels and fs_util (macOS11-ARM64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - macOS-11-ARM64
     steps:
@@ -582,11 +582,11 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Build wheels and fs_util (macOS11-x86_64)
     needs:
-    - docs_only_check
+    - classify_changes
     runs-on:
     - macos-11
     steps:
@@ -688,11 +688,15 @@ jobs:
         labels: category:new feature, category:user api change, category:plugin api
           change, category:performance, category:bugfix, category:documentation, category:internal
         mode: exactly
-  docs_only_check:
+  classify_changes:
     if: github.repository_owner == 'pantsbuild'
-    name: Check for docs-only change
+    name: Classify changes
     outputs:
-      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+      ci_config: ${{ steps.classify.outputs.ci_config }}
+      docs: ${{ steps.classify.outputs.docs }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      release: ${{ steps.classify.outputs.release }}
+      rust: ${{ steps.classify.outputs.rust }}
     runs-on:
     - ubuntu-20.04
     steps:
@@ -702,21 +706,25 @@ jobs:
         fetch-depth: 10
     - id: files
       name: Get changed files
-      uses: tj-actions/changed-files@v32.0.0
+      uses: tj-actions/changed-files@v32
       with:
-        files_ignore: docs/**|build-support/bin/generate_user_list.py
-        files_ignore_separator: '|'
-    - id: docs_only_check
-      if: steps.files.outputs.any_changed != 'true'
-      name: Check for docs-only changes
-      run: echo '::set-output name=docs_only::DOCS_ONLY'
+        separator: '|'
+    - id: classify
+      name: Classify changed files
+      run: "                        affected=$(python build-support/bin/classify_changed_files.py\
+        \                           '${{ steps.files.outputs.all_modified_files }}')\n\
+        \                        echo \"Affected:\n${affected}\"\n               \
+        \         if [[ \"${affected}\" == \"docs\" ]]; then\n                   \
+        \       echo '::set-output name=docs_only::true'\n                       \
+        \ fi\n                        for i in ${affected}; do\n                 \
+        \         echo \"::set-output name=${i}::true\"\n                        done\n"
   lint_python:
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Lint Python and Shell
     needs:
     - bootstrap_pants_linux_x86_64
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -793,10 +801,10 @@ jobs:
         \ == \"true\" ]]; then\n    echo \"Merge OK\"\n    exit 0\nelse\n    echo\
         \ \"Merge NOT OK\"\n    exit 1\nfi\n"
   set_merge_ok_docs_only:
-    if: needs.docs_only_check.outputs.docs_only == 'DOCS_ONLY'
+    if: needs.classify_changes.outputs.docs_only == true
     name: Set Merge OK
     needs:
-    - docs_only_check
+    - classify_changes
     - check_labels
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
@@ -806,10 +814,10 @@ jobs:
     - id: set_merge_ok
       run: echo '::set-output name=merge_ok::true'
   set_merge_ok_not_docs_only:
-    if: needs.docs_only_check.outputs.docs_only != 'DOCS_ONLY'
+    if: needs.classify_changes.outputs.docs_only != true
     name: Set Merge OK
     needs:
-    - docs_only_check
+    - classify_changes
     - check_labels
     - bootstrap_pants_linux_x86_64
     - bootstrap_pants_macos11_x86_64
@@ -818,7 +826,7 @@ jobs:
     - build_wheels_macos11_arm64
     - build_wheels_macos11_x86_64
     - check_labels
-    - docs_only_check
+    - classify_changes
     - lint_python
     - test_python_linux_x86_64_0
     - test_python_linux_x86_64_1
@@ -832,12 +840,12 @@ jobs:
     - id: set_merge_ok
       run: echo '::set-output name=merge_ok::true'
   test_python_linux_x86_64_0:
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Test Python (Linux-x86_64) Shard 0/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -923,12 +931,12 @@ jobs:
         - '3.7'
     timeout-minutes: 90
   test_python_linux_x86_64_1:
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Test Python (Linux-x86_64) Shard 1/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -1014,12 +1022,12 @@ jobs:
         - '3.7'
     timeout-minutes: 90
   test_python_linux_x86_64_2:
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Test Python (Linux-x86_64) Shard 2/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - docs_only_check
+    - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
@@ -1107,12 +1115,12 @@ jobs:
   test_python_macos11_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
-    if: (github.repository_owner == 'pantsbuild') && (needs.docs_only_check.outputs.docs_only
-      != 'DOCS_ONLY')
+    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+      != true)
     name: Test Python (macOS11-x86_64)
     needs:
     - bootstrap_pants_macos11_x86_64
-    - docs_only_check
+    - classify_changes
     runs-on:
     - macos-11
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -161,7 +160,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Bootstrap Pants, test Rust (macOS11-x86_64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - macos-11
@@ -298,7 +296,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Build wheels and fs_util (Linux-x86_64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -384,7 +381,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Build wheels and fs_util (macOS10-15-x86_64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - macOS-10.15-X64
@@ -487,7 +483,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Bootstrap Pants, build wheels and fs_util (macOS11-ARM64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - macOS-11-ARM64
@@ -627,7 +622,6 @@ jobs:
       != 'DOCS_ONLY')
     name: Build wheels and fs_util (macOS11-x86_64)
     needs:
-    - check_labels
     - docs_only_check
     runs-on:
     - macos-11
@@ -767,7 +761,6 @@ jobs:
     name: Lint Python and Shell
     needs:
     - bootstrap_pants_linux_x86_64
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -849,6 +842,7 @@ jobs:
     name: Set Merge OK
     needs:
     - docs_only_check
+    - check_labels
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
@@ -861,6 +855,7 @@ jobs:
     name: Set Merge OK
     needs:
     - docs_only_check
+    - check_labels
     - bootstrap_pants_linux_x86_64
     - bootstrap_pants_macos11_x86_64
     - build_wheels_linux_x86_64
@@ -887,7 +882,6 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 0/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -979,7 +973,6 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 1/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -1071,7 +1064,6 @@ jobs:
     name: Test Python (Linux-x86_64) Shard 2/3
     needs:
     - bootstrap_pants_linux_x86_64
-    - check_labels
     - docs_only_check
     runs-on:
     - ubuntu-20.04
@@ -1165,7 +1157,6 @@ jobs:
     name: Test Python (macOS11-x86_64)
     needs:
     - bootstrap_pants_macos11_x86_64
-    - check_labels
     - docs_only_check
     runs-on:
     - macos-11

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -727,7 +727,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       if: github.event_name == 'pull_request'
       name: Ensure category label
-      uses: mheap/github-action-required-labels@v1
+      uses: mheap/github-action-required-labels@v2.1.0
       with:
         count: 1
         labels: category:new feature, category:user api change, category:plugin api
@@ -747,7 +747,7 @@ jobs:
         fetch-depth: 10
     - id: files
       name: Get changed files
-      uses: tj-actions/changed-files@v23.1
+      uses: tj-actions/changed-files@v32.0.0
       with:
         files_ignore: docs/**|build-support/bin/generate_user_list.py
         files_ignore_separator: '|'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -755,7 +755,7 @@ jobs:
       name: Get changed files
       uses: tj-actions/changed-files@v23.1
       with:
-        files_ignore: docs/**
+        files_ignore: docs/**|build-support/bin/generate_user_list.py
         files_ignore_separator: '|'
     - id: docs_only_check
       if: steps.files.outputs.any_changed != 'true'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -64,20 +64,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'Linux-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -200,7 +191,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -209,20 +200,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -415,7 +397,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -424,20 +406,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'macOS10-15-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - env:
         ARCHFLAGS: -arch x86_64
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
@@ -519,7 +492,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -528,20 +501,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'macOS11-ARM64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
       run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
@@ -658,7 +622,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v1
+        key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.63.0-*
 
           ~/.rustup/update-hashes
@@ -667,20 +631,11 @@ jobs:
 
           '
     - name: Cache Cargo
-      uses: actions/cache@v3
+      uses: benjyw/rust-cache@461b9f8eee66b575bce78977bf649b8b7a8d53f1
       with:
-        key: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-${{ hashFiles(''src/rust/engine/Cargo.*'')
-          }}-v1
-
-          '
-        path: '~/.cargo/registry
-
-          ~/.cargo/git
-
-          '
-        restore-keys: 'macOS11-x86_64-cargo-${{ hashFiles(''rust-toolchain'') }}-
-
-          '
+        cache-bin: 'false'
+        shared-key: engine
+        workspaces: src/rust/engine
     - env:
         ARCHFLAGS: -arch x86_64
       if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')

--- a/build-support/bin/classify_changed_files.py
+++ b/build-support/bin/classify_changed_files.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import enum
+import fnmatch
+import sys
+from collections import defaultdict
+
+# This script may be run in CI before Pants is bootstrapped, so it must be kept simple
+# and runnable without `./pants run`.
+
+
+class Affected(enum.Enum):
+    docs = "docs"
+    rust = "rust"
+    release = "release"
+    ci_config = "ci_config"
+    other = "other"
+
+
+_docs_globs = ["docs/*", "build-support/bin/generate_user_list.py"]
+_rust_globs = ["src/rust/engine/*", "rust-toolchain", "build-support/bin/rust/*"]
+_release_globs = [
+    "pants.toml",
+    "src/python/pants/VERSION",
+    "src/python/pants/notes/*",
+    "src/python/pants/init/BUILD",
+    "build-support/bin/release.sh",
+    "build-support/bin/release_helper.py",
+]
+_ci_config_globs = [
+    "build-support/bin/classify_changed_files.py",
+    "build-support/bin/generate_github_workflows.py",
+]
+
+
+_affected_to_globs = {
+    Affected.docs: _docs_globs,
+    Affected.rust: _rust_globs,
+    Affected.release: _release_globs,
+    Affected.ci_config: _ci_config_globs,
+}
+
+
+def classify(changed_files: list[str]) -> set[Affected]:
+    classified: dict[Affected, set[str]] = defaultdict(set)
+    for affected, globs in _affected_to_globs.items():
+        for pattern in globs:
+            classified[affected].update(fnmatch.filter(changed_files, pattern))
+    ret = {k for k, v in classified.items() if v}
+    if set(changed_files) - set().union(*classified.values()):
+        ret.add(Affected.other)
+    return ret
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        return
+    affecteds = classify(sys.argv[1].split("|"))
+    for affected in sorted([a.name for a in affecteds]):
+        print(affected)
+
+
+if __name__ == "__main__":
+    main()

--- a/build-support/bin/classify_changed_files_test.py
+++ b/build-support/bin/classify_changed_files_test.py
@@ -1,0 +1,24 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+from classify_changed_files import Affected, classify
+
+
+@pytest.mark.parametrize(
+    ["changed_files", "expected"],
+    (
+        [["docs/path/to/some/doc", "docs/path/to/some/other/doc"], {Affected.docs}],
+        [["src/rust/engine/path/to/file.rs"], {Affected.rust}],
+        [["src/python/pants/VERSION"], {Affected.release}],
+        [["build-support/bin/generate_github_workflows.py"], {Affected.ci_config}],
+        [["src/python/pants/whatever.py"], {Affected.other}],
+        [["docs/path/to/some/doc", "rust-toolchain"], {Affected.docs, Affected.rust}],
+        [
+            ["docs/path/to/some/doc", "rust-toolchain", "src/python/pants/whatever.py"],
+            {Affected.docs, Affected.rust, Affected.other},
+        ],
+    ),
+)
+def test_classification(changed_files, expected):
+    assert classify(changed_files) == expected

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -110,7 +110,7 @@ def is_docs_only() -> Jobs:
                 {
                     "id": "files",
                     "name": "Get changed files",
-                    "uses": "tj-actions/changed-files@v23.1",
+                    "uses": "tj-actions/changed-files@v32.0.0",
                     "with": {"files_ignore_separator": "|", "files_ignore": "|".join(docs_files)},
                 },
                 {
@@ -132,7 +132,7 @@ def ensure_category_label() -> Sequence[Step]:
         {
             "if": "github.event_name == 'pull_request'",
             "name": "Ensure category label",
-            "uses": "mheap/github-action-required-labels@v1",
+            "uses": "mheap/github-action-required-labels@v2.1.0",
             "env": {"GITHUB_TOKEN": gha_expr("secrets.GITHUB_TOKEN")},
             "with": {
                 "mode": "exactly",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -82,7 +82,7 @@ def _docs_only_cond(docs_only: bool) -> str:
 def is_docs_only() -> Jobs:
     """Check if this change only involves docs."""
     linux_x86_64_helper = Helper(Platform.LINUX_X86_64)
-    docs_files = ["docs/**"]
+    docs_files = ["docs/**", "build-support/bin/generate_user_list.py"]
     return {
         "docs_only_check": {
             "name": "Check for docs-only change",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -918,7 +918,7 @@ def set_merge_ok(needs: list[str], docs_only: bool) -> Jobs:
             # If in the future we have any docs-related checks, we can make both "Set Merge OK"
             # jobs depend on them here (it has to be both since some changes may modify docs
             # as well as code, and so are not "docs only").
-            "needs": ["docs_only_check"] + sorted(needs),
+            "needs": ["docs_only_check", "check_labels"] + sorted(needs),
             "outputs": {"merge_ok": "${{ steps.set_merge_ok.outputs.merge_ok }}"},
             "steps": [
                 {
@@ -978,7 +978,7 @@ def generate() -> dict[Path, str]:
         needs = val.get("needs", [])
         if isinstance(needs, str):
             needs = [needs]
-        needs.extend(["check_labels", "docs_only_check"])
+        needs.extend(["docs_only_check"])
         val["needs"] = needs
         if_cond = val.get("if")
         val["if"] = not_docs_only if if_cond is None else f"({if_cond}) && ({not_docs_only})"

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -38,6 +38,22 @@ class Platform(Enum):
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
+def gha_expr(expr: str) -> str:
+    """Properly quote GitHub Actions expressions.
+
+    Because we use f-strings often, but not always, in this script, it is very easy to get the
+    quoting of the double curly braces wrong, especially when changing a non-f-string to an f-string
+    or vice versa. So instead we universally delegate to this function.
+    """
+    # Here we use simple string concat instead of getting tangled up with escaping in f-strings.
+    return "${{ " + expr + " }}"
+
+
+def hashFiles(path: str) -> str:
+    """Generate a properly quoted hashFiles call for the given path."""
+    return gha_expr(f"hashFiles('{path}')")
+
+
 # ----------------------------------------------------------------------
 # Constants
 # ----------------------------------------------------------------------
@@ -88,7 +104,7 @@ def is_docs_only() -> Jobs:
             "name": "Check for docs-only change",
             "runs-on": linux_x86_64_helper.runs_on(),
             "if": IS_PANTS_OWNER,
-            "outputs": {"docs_only": "${{ steps.docs_only_check.outputs.docs_only }}"},
+            "outputs": {"docs_only": gha_expr("steps.docs_only_check.outputs.docs_only")},
             "steps": [
                 *checkout(get_commit_msg=False),
                 {
@@ -117,7 +133,7 @@ def ensure_category_label() -> Sequence[Step]:
             "if": "github.event_name == 'pull_request'",
             "name": "Ensure category label",
             "uses": "mheap/github-action-required-labels@v1",
-            "env": {"GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"},
+            "env": {"GITHUB_TOKEN": gha_expr("secrets.GITHUB_TOKEN")},
             "with": {
                 "mode": "exactly",
                 "count": 1,
@@ -195,8 +211,8 @@ def setup_toolchain_auth() -> Step:
         "name": "Setup toolchain auth",
         "if": "github.event_name != 'pull_request'",
         "run": dedent(
-            """\
-            echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+            f"""\
+            echo TOOLCHAIN_AUTH_TOKEN="{gha_expr('secrets.TOOLCHAIN_AUTH_TOKEN')}" >> $GITHUB_ENV
             """
         ),
     }
@@ -234,7 +250,7 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                "key": "${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
+                "key": f"{gha_expr('runner.os')}-rustup-{hashFiles('rust-toolchain')}-v1",
             },
         },
         {
@@ -242,8 +258,8 @@ def rust_caches() -> Sequence[Step]:
             "uses": "actions/cache@v3",
             "with": {
                 "path": "~/.cargo/registry\n~/.cargo/git\n",
-                "key": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
-                "restore-keys": "${{ runner.os }}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
+                "key": f"{gha_expr('runner.os')}-cargo-{hashFiles('rust-toolchain')}-{hashFiles('src/rust/engine/Cargo.*')}-v1\n",
+                "restore-keys": f"{gha_expr('runner.os')}-cargo-{hashFiles('rust-toolchain')}-\n",
             },
         },
     ]
@@ -274,8 +290,8 @@ def deploy_to_s3() -> Step:
         "run": "./build-support/bin/deploy_to_s3.py",
         "if": "github.event_name == 'push'",
         "env": {
-            "AWS_SECRET_ACCESS_KEY": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
-            "AWS_ACCESS_KEY_ID": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+            "AWS_SECRET_ACCESS_KEY": f"{gha_expr('secrets.AWS_SECRET_ACCESS_KEY')}",
+            "AWS_ACCESS_KEY_ID": f"{gha_expr('secrets.AWS_ACCESS_KEY_ID')}",
         },
     }
 
@@ -285,18 +301,18 @@ def setup_primary_python(install_python: bool = True) -> Sequence[Step]:
     if install_python:
         ret.append(
             {
-                "name": "Set up Python ${{ matrix.python-version }}",
+                "name": f"Set up Python {gha_expr('matrix.python-version')}",
                 "uses": "actions/setup-python@v3",
-                "with": {"python-version": "${{ matrix.python-version }}"},
+                "with": {"python-version": f"{gha_expr('matrix.python-version')}"},
             }
         )
     ret.append(
         {
-            "name": "Tell Pants to use Python ${{ matrix.python-version }}",
+            "name": f"Tell Pants to use Python {gha_expr('matrix.python-version')}",
             "run": dedent(
-                """\
-                echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
-                echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['==${{ matrix.python-version }}.*']" >> $GITHUB_ENV
+                f"""\
+                echo "PY=python{gha_expr('matrix.python-version')}" >> $GITHUB_ENV
+                echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['=={gha_expr('matrix.python-version')}.*']" >> $GITHUB_ENV
                 """
             ),
         }
@@ -366,7 +382,7 @@ class Helper:
             "name": "Upload native binaries",
             "uses": "actions/upload-artifact@v3",
             "with": {
-                "name": f"native_binaries.${{ matrix.python-version }}.{self.platform_name()}",
+                "name": f"native_binaries.{gha_expr('matrix.python-version')}.{self.platform_name()}",
                 "path": "\n".join(NATIVE_FILES),
             },
         }
@@ -376,7 +392,7 @@ class Helper:
             "name": "Download native binaries",
             "uses": "actions/download-artifact@v3",
             "with": {
-                "name": f"native_binaries.${{ matrix.python-version }}.{self.platform_name()}",
+                "name": f"native_binaries.{gha_expr('matrix.python-version')}.{self.platform_name()}",
             },
         }
 
@@ -387,7 +403,7 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": f"~/.rustup/toolchains/{rust_channel()}-*\n~/.rustup/update-hashes\n~/.rustup/settings.toml\n",
-                    "key": f"{self.platform_name()}-rustup-${{ hashFiles('rust-toolchain') }}-v1",
+                    "key": f"{self.platform_name()}-rustup-{hashFiles('rust-toolchain')}-v1",
                 },
             },
             {
@@ -395,8 +411,8 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": "~/.cargo/registry\n~/.cargo/git\n",
-                    "key": f"{self.platform_name()}-cargo-${{ hashFiles('rust-toolchain') }}-${{ hashFiles('src/rust/engine/Cargo.*') }}-v1\n",
-                    "restore-keys": f"{self.platform_name()}-cargo-${{ hashFiles('rust-toolchain') }}-\n",
+                    "key": f"{self.platform_name()}-cargo-{hashFiles('rust-toolchain')}-{hashFiles('src/rust/engine/Cargo.*')}-v1\n",
+                    "restore-keys": f"{self.platform_name()}-cargo-{hashFiles('rust-toolchain')}-\n",
                 },
             },
         ]
@@ -419,7 +435,7 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": "\n".join(NATIVE_FILES),
-                    "key": f"{self.platform_name()}-engine-${{ steps.get-engine-hash.outputs.hash }}-v1\n",
+                    "key": f"{self.platform_name()}-engine-{gha_expr('steps.get-engine-hash.outputs.hash')}-v1\n",
                 },
             },
         ]
@@ -614,7 +630,7 @@ def macos11_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                     # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
                     # pass on GHA MacOS containers.
                     "run": helper.wrap_cmd("./cargo test --tests -- --nocapture"),
-                    "env": {"TMPDIR": "${{ runner.temp }}"},
+                    "env": {"TMPDIR": f"{gha_expr('runner.temp')}"},
                     "if": DONT_SKIP_RUST,
                 },
             ],
@@ -795,9 +811,7 @@ def workflow_dispatch_inputs(
         }
         for wi in workflow_inputs
     }
-    env = {
-        wi.name: ("${{ github.event.inputs." + wi.name.lower() + " }}") for wi in workflow_inputs
-    }
+    env = {wi.name: gha_expr("github.event.inputs." + wi.name.lower()) for wi in workflow_inputs}
     return inputs, env
 
 
@@ -919,7 +933,7 @@ def set_merge_ok(needs: list[str], docs_only: bool) -> Jobs:
             # jobs depend on them here (it has to be both since some changes may modify docs
             # as well as code, and so are not "docs only").
             "needs": ["docs_only_check", "check_labels"] + sorted(needs),
-            "outputs": {"merge_ok": "${{ steps.set_merge_ok.outputs.merge_ok }}"},
+            "outputs": {"merge_ok": f"{gha_expr('steps.set_merge_ok.outputs.merge_ok')}"},
             "steps": [
                 {
                     "id": "set_merge_ok",
@@ -946,10 +960,10 @@ def merge_ok(non_docs_only_jobs: list[str]) -> Jobs:
                 "steps": [
                     {
                         "run": dedent(
-                            """\
-                    merge_ok_docs_only="${{ needs.set_merge_ok_docs_only.outputs.merge_ok }}"
-                    merge_ok_not_docs_only="${{ needs.set_merge_ok_not_docs_only.outputs.merge_ok }}"
-                    if [[ "${merge_ok_docs_only}" == "true" || "${merge_ok_not_docs_only}" == "true" ]]; then
+                            f"""\
+                    merge_ok_docs_only="{gha_expr('needs.set_merge_ok_docs_only.outputs.merge_ok')}"
+                    merge_ok_not_docs_only="{gha_expr('needs.set_merge_ok_not_docs_only.outputs.merge_ok')}"
+                    if [[ "${{merge_ok_docs_only}}" == "true" || "${{merge_ok_not_docs_only}}" == "true" ]]; then
                         echo "Merge OK"
                         exit 0
                     else
@@ -1027,8 +1041,8 @@ def generate() -> dict[Path, str]:
                         {
                             "uses": "styfle/cancel-workflow-action@0.9.1",
                             "with": {
-                                "workflow_id": "${{ github.event.workflow.id }}",
-                                "access_token": "${{ github.token }}",
+                                "workflow_id": f"{gha_expr('github.event.workflow.id')}",
+                                "access_token": f"{gha_expr('github.token')}",
                             },
                         }
                     ],

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -87,43 +87,54 @@ IS_PANTS_OWNER = "github.repository_owner == 'pantsbuild'"
 # Actions
 # ----------------------------------------------------------------------
 
-_DOCS_ONLY_TEXT = "DOCS_ONLY"
 
-
-def _docs_only_cond(docs_only: bool) -> str:
-    op = "==" if docs_only else "!="
-    return f"needs.docs_only_check.outputs.docs_only {op} '{_DOCS_ONLY_TEXT}'"
-
-
-def is_docs_only() -> Jobs:
-    """Check if this change only involves docs."""
+def classify_changes() -> Jobs:
     linux_x86_64_helper = Helper(Platform.LINUX_X86_64)
-    docs_files = ["docs/**", "build-support/bin/generate_user_list.py"]
     return {
-        "docs_only_check": {
-            "name": "Check for docs-only change",
+        "classify_changes": {
+            "name": "Classify changes",
             "runs-on": linux_x86_64_helper.runs_on(),
             "if": IS_PANTS_OWNER,
-            "outputs": {"docs_only": gha_expr("steps.docs_only_check.outputs.docs_only")},
+            "outputs": {
+                "docs_only": gha_expr("steps.classify.outputs.docs_only"),
+                "docs": gha_expr("steps.classify.outputs.docs"),
+                "rust": gha_expr("steps.classify.outputs.rust"),
+                "release": gha_expr("steps.classify.outputs.release"),
+                "ci_config": gha_expr("steps.classify.outputs.ci_config"),
+            },
             "steps": [
                 *checkout(get_commit_msg=False),
                 {
                     "id": "files",
                     "name": "Get changed files",
-                    "uses": "tj-actions/changed-files@v32.0.0",
-                    "with": {"files_ignore_separator": "|", "files_ignore": "|".join(docs_files)},
+                    "uses": "tj-actions/changed-files@v32",
+                    "with": {"separator": "|"},
                 },
                 {
-                    "id": "docs_only_check",
-                    "name": "Check for docs-only changes",
-                    # Note that if no changes were detected in the step above, the string
-                    # may be empty, not 'false', so we check for != 'true'.
-                    "if": "steps.files.outputs.any_changed != 'true'",
-                    "run": f"echo '::set-output name=docs_only::{_DOCS_ONLY_TEXT}'",
+                    "id": "classify",
+                    "name": "Classify changed files",
+                    "run": dedent(
+                        """\
+                        affected=$(python build-support/bin/classify_changed_files.py \
+                          '${{ steps.files.outputs.all_modified_files }}')
+                        echo "Affected:\n${affected}"
+                        if [[ "${affected}" == "docs" ]]; then
+                          echo '::set-output name=docs_only::true'
+                        fi
+                        for i in ${affected}; do
+                          echo "::set-output name=${i}::true"
+                        done
+                        """
+                    ),
                 },
             ],
         },
     }
+
+
+def _docs_only_cond(docs_only: bool) -> str:
+    op = "==" if docs_only else "!="
+    return f"needs.classify_changes.outputs.docs_only {op} true"
 
 
 def ensure_category_label() -> Sequence[Step]:
@@ -918,7 +929,7 @@ def set_merge_ok(needs: list[str], docs_only: bool) -> Jobs:
             # If in the future we have any docs-related checks, we can make both "Set Merge OK"
             # jobs depend on them here (it has to be both since some changes may modify docs
             # as well as code, and so are not "docs only").
-            "needs": ["docs_only_check", "check_labels"] + sorted(needs),
+            "needs": ["classify_changes", "check_labels"] + sorted(needs),
             "outputs": {"merge_ok": f"{gha_expr('steps.set_merge_ok.outputs.merge_ok')}"},
             "steps": [
                 {
@@ -971,14 +982,14 @@ def generate() -> dict[Path, str]:
 
     not_docs_only = _docs_only_cond(docs_only=False)
     pr_jobs = test_workflow_jobs([PYTHON37_VERSION], cron=False)
-    pr_jobs.update(**is_docs_only())
+    pr_jobs.update(**classify_changes())
     for key, val in pr_jobs.items():
-        if key in {"check_labels", "docs_only_check"}:
+        if key in {"check_labels", "classify_changes"}:
             continue
         needs = val.get("needs", [])
         if isinstance(needs, str):
             needs = [needs]
-        needs.extend(["docs_only_check"])
+        needs.extend(["classify_changes"])
         val["needs"] = needs
         if_cond = val.get("if")
         val["if"] = not_docs_only if if_cond is None else f"({if_cond}) && ({not_docs_only})"


### PR DESCRIPTION
Cherrypicks of #17218, #17169, #17194, #17172, #16806, #16796. 

Since this branch is still being released from, we want it to benefit from recent and upcoming CI improvements.

Cherry-picking them all in one PR saves on CI resources and time. And since no Pants source code is modified, only CI config, it seems fine to not cherry-pick separately.