### PR TITLE
Streamline CI

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -12,24 +12,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Cargo audit (for security vulnerabilities)
       run: './cargo install --version 0.16.0 cargo-audit
 

--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,24 +11,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -16,6 +16,20 @@ jobs:
     runs-on:
     - ubuntu-20.04
     steps:
+    - name: Debug inputs
+      run: 'echo "rust: ${{ needs.classify_changes.outputs.rust }}"
+
+        echo "ci_config: ${{ needs.classify_changes.outputs.ci_config }}"
+
+        echo "release: ${{ needs.classify_changes.outputs.release }}"
+
+        echo "docs: ${{ needs.classify_changes.outputs.docs }}"
+
+        echo "docs_only: ${{ needs.classify_changes.outputs.docs_only }}"
+
+        echo "other: ${{ needs.classify_changes.outputs.other }}"
+
+        '
     - name: Check out code
       uses: actions/checkout@v3
       with:
@@ -106,7 +120,7 @@ jobs:
       run: './pants run build-support/bin/generate_github_workflows.py -- --check
 
         '
-    - if: needs.classify_changes.outputs.rust == true
+    - if: needs.classify_changes.outputs.rust == 'true'
       name: Test and lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
@@ -220,7 +234,7 @@ jobs:
           src/python/pants/engine/internals/native_engine.so.metadata'
     - env:
         TMPDIR: ${{ runner.temp }}
-      if: needs.classify_changes.outputs.rust == true
+      if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
       run: ./cargo test --tests -- --nocapture
     strategy:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -20,24 +20,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -124,7 +106,7 @@ jobs:
       run: './pants run build-support/bin/generate_github_workflows.py -- --check
 
         '
-    - if: '!contains(env.COMMIT_MESSAGE, ''[ci skip-rust]'')'
+    - if: needs.classify_changes.outputs.rust == true
       name: Test and lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
@@ -154,24 +136,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -256,7 +220,7 @@ jobs:
           src/python/pants/engine/internals/native_engine.so.metadata'
     - env:
         TMPDIR: ${{ runner.temp }}
-      if: '!contains(env.COMMIT_MESSAGE, ''[ci skip-rust]'')'
+      if: needs.classify_changes.outputs.rust == true
       name: Test Rust
       run: ./cargo test --tests -- --nocapture
     strategy:
@@ -292,24 +256,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -358,24 +304,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -447,24 +375,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -536,24 +446,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -627,24 +519,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -16,20 +16,6 @@ jobs:
     runs-on:
     - ubuntu-20.04
     steps:
-    - name: Debug inputs
-      run: 'echo "rust: ${{ needs.classify_changes.outputs.rust }}"
-
-        echo "ci_config: ${{ needs.classify_changes.outputs.ci_config }}"
-
-        echo "release: ${{ needs.classify_changes.outputs.release }}"
-
-        echo "docs: ${{ needs.classify_changes.outputs.docs }}"
-
-        echo "docs_only: ${{ needs.classify_changes.outputs.docs_only }}"
-
-        echo "other: ${{ needs.classify_changes.outputs.other }}"
-
-        '
     - name: Check out code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -590,33 +590,16 @@ jobs:
     if: always()
     name: Merge OK
     needs:
-    - set_merge_ok_docs_only
-    - set_merge_ok_not_docs_only
+    - set_merge_ok
     runs-on:
     - ubuntu-20.04
     steps:
-    - run: "merge_ok_docs_only=\"${{ needs.set_merge_ok_docs_only.outputs.merge_ok\
-        \ }}\"\nmerge_ok_not_docs_only=\"${{ needs.set_merge_ok_not_docs_only.outputs.merge_ok\
-        \ }}\"\nif [[ \"${merge_ok_docs_only}\" == \"true\" || \"${merge_ok_not_docs_only}\"\
+    - run: "merge_ok=\"${{ needs.set_merge_ok.outputs.merge_ok }}\"\nif [[ \"${merge_ok}\"\
         \ == \"true\" ]]; then\n    echo \"Merge OK\"\n    exit 0\nelse\n    echo\
         \ \"Merge NOT OK\"\n    exit 1\nfi\n"
-  set_merge_ok_docs_only:
-    if: always() && needs.classify_changes.outputs.docs_only == true && !contains(needs.*.result,
-      'failure') && !contains(needs.*.result, 'cancelled')
-    name: Set Merge OK
-    needs:
-    - classify_changes
-    - check_labels
-    outputs:
-      merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
-    runs-on:
-    - ubuntu-20.04
-    steps:
-    - id: set_merge_ok
-      run: echo '::set-output name=merge_ok::true'
-  set_merge_ok_not_docs_only:
-    if: always() && needs.classify_changes.outputs.docs_only != true && !contains(needs.*.result,
-      'failure') && !contains(needs.*.result, 'cancelled')
+  set_merge_ok:
+    if: always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result,
+      'cancelled')
     name: Set Merge OK
     needs:
     - classify_changes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,27 +12,13 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     needs:
     - classify_changes
     runs-on:
     - ubuntu-20.04
     steps:
-    - name: Debug inputs
-      run: 'echo "rust: ${{ needs.classify_changes.outputs.rust }}"
-
-        echo "ci_config: ${{ needs.classify_changes.outputs.ci_config }}"
-
-        echo "release: ${{ needs.classify_changes.outputs.release }}"
-
-        echo "docs: ${{ needs.classify_changes.outputs.docs }}"
-
-        echo "docs_only: ${{ needs.classify_changes.outputs.docs_only }}"
-
-        echo "other: ${{ needs.classify_changes.outputs.other }}"
-
-        '
     - name: Check out code
       uses: actions/checkout@v3
       with:
@@ -144,7 +130,7 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Bootstrap Pants, test Rust (macOS11-x86_64)
     needs:
     - classify_changes
@@ -253,8 +239,8 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
-      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
-      != true)
+      || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
+      != 'true')
     name: Build wheels (Linux-x86_64)
     needs:
     - classify_changes
@@ -313,8 +299,8 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
-      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
-      != true)
+      || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
+      != 'true')
     name: Build wheels (macOS10-15-x86_64)
     needs:
     - classify_changes
@@ -379,8 +365,8 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
-      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
-      != true)
+      || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
+      != 'true')
     name: Build wheels (macOS11-ARM64)
     needs:
     - classify_changes
@@ -441,8 +427,8 @@ jobs:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
-      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
-      != true)
+      || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
+      != 'true')
     name: Build wheels (macOS11-x86_64)
     needs:
     - classify_changes
@@ -551,7 +537,7 @@ jobs:
         \ \"${i}\"\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Lint Python and Shell
     needs:
     - bootstrap_pants_linux_x86_64
@@ -639,7 +625,7 @@ jobs:
       run: echo '::set-output name=merge_ok::true'
   test_python_linux_x86_64_0:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Test Python (Linux-x86_64) Shard 0/3
     needs:
     - bootstrap_pants_linux_x86_64
@@ -712,7 +698,7 @@ jobs:
     timeout-minutes: 90
   test_python_linux_x86_64_1:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Test Python (Linux-x86_64) Shard 1/3
     needs:
     - bootstrap_pants_linux_x86_64
@@ -785,7 +771,7 @@ jobs:
     timeout-minutes: 90
   test_python_linux_x86_64_2:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Test Python (Linux-x86_64) Shard 2/3
     needs:
     - bootstrap_pants_linux_x86_64
@@ -860,7 +846,7 @@ jobs:
     env:
       ARCHFLAGS: -arch x86_64
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
-      != true)
+      != 'true')
     name: Test Python (macOS11-x86_64)
     needs:
     - bootstrap_pants_macos11_x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,24 +23,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -127,7 +109,7 @@ jobs:
       run: './pants run build-support/bin/generate_github_workflows.py -- --check
 
         '
-    - if: '!contains(env.COMMIT_MESSAGE, ''[ci skip-rust]'')'
+    - if: needs.classify_changes.outputs.rust == true
       name: Test and lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
@@ -159,24 +141,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -261,7 +225,7 @@ jobs:
           src/python/pants/engine/internals/native_engine.so.metadata'
     - env:
         TMPDIR: ${{ runner.temp }}
-      if: '!contains(env.COMMIT_MESSAGE, ''[ci skip-rust]'')'
+      if: needs.classify_changes.outputs.rust == true
       name: Test Rust
       run: ./cargo test --tests -- --nocapture
     strategy:
@@ -274,9 +238,10 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+    if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
+      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
       != true)
-    name: Build wheels and fs_util (Linux-x86_64)
+    name: Build wheels (Linux-x86_64)
     needs:
     - classify_changes
     runs-on:
@@ -288,24 +253,6 @@ jobs:
         fetch-depth: 10
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install rustup
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
@@ -322,25 +269,17 @@ jobs:
 
         '
     - env: {}
-      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
-        ./build-support/bin/release.sh build-local-pex
+        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+
 
         ./build-support/bin/release.sh build-wheels
 
         USE_PY38=true ./build-support/bin/release.sh build-wheels
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-fs-util
-
-        '
-    - env: {}
-      if: github.event_name == 'push'
-      name: Build fs_util
-      run: ./build-support/bin/release.sh build-fs-util
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -359,9 +298,10 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+    if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
+      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
       != true)
-    name: Build wheels and fs_util (macOS10-15-x86_64)
+    name: Build wheels (macOS10-15-x86_64)
     needs:
     - classify_changes
     runs-on:
@@ -371,29 +311,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name != 'pull_request'
-      name: Setup toolchain auth
-      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
-
-        '
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
@@ -411,28 +328,24 @@ jobs:
         cache-bin: 'false'
         shared-key: engine
         workspaces: src/rust/engine
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
     - env:
         ARCHFLAGS: -arch x86_64
-      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
-        ./build-support/bin/release.sh build-local-pex
+        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+
 
         ./build-support/bin/release.sh build-wheels
 
         USE_PY38=true ./build-support/bin/release.sh build-wheels
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-fs-util
-
-        '
-    - env:
-        ARCHFLAGS: -arch x86_64
-      if: github.event_name == 'push'
-      name: Build fs_util
-      run: ./build-support/bin/release.sh build-fs-util
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -446,15 +359,15 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 120
+    timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
-      ARCHFLAGS: -arch arm64
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+    if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
+      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
       != true)
-    name: Bootstrap Pants, build wheels and fs_util (macOS11-ARM64)
+    name: Build wheels (macOS11-ARM64)
     needs:
     - classify_changes
     runs-on:
@@ -464,31 +377,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - name: Tell Pants to use Python ${{ matrix.python-version }}
-      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
-
-        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
-        }}.*'']" >> $GITHUB_ENV
-
-        '
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
@@ -506,85 +394,42 @@ jobs:
         cache-bin: 'false'
         shared-key: engine
         workspaces: src/rust/engine
-    - id: get-engine-hash
-      name: Get native engine hash
-      run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
-
-        '
-      shell: bash
-    - name: Cache native engine
-      uses: actions/cache@v3
-      with:
-        key: 'macOS11-ARM64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-
-          '
-        path: '.pants
-
-          src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
-    - name: Bootstrap Pants
-      run: 'arch -arm64 ./pants --version
+    - env:
+        ARCHFLAGS: -arch arm64
+      name: Build wheels
+      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
-        '
-    - name: Run smoke tests
-      run: 'arch -arm64 ./pants list ::
+        USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
-        arch -arm64 ./pants roots
 
-        arch -arm64 ./pants help goals
-
-        arch -arm64 ./pants help targets
-
-        arch -arm64 ./pants help subsystems
-
-        '
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-macOS11-ARM64
+        name: pants-log-wheels-macOS11-ARM64
         path: .pants.d/pants.log
-    - name: Upload native binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: native_binaries.${{ matrix.python-version }}.macOS11-ARM64
-        path: '.pants
-
-          src/python/pants/engine/internals/native_engine.so
-
-          src/python/pants/engine/internals/native_engine.so.metadata'
-    - if: (github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]'))
-        && (github.repository_owner == 'pantsbuild')
-      name: Build wheels
-      run: USE_PY39=true arch -arm64 ./build-support/bin/release.sh build-wheels
-    - if: github.event_name == 'push'
-      name: Build fs_util
-      run: USE_PY39=true arch -arm64 ./build-support/bin/release.sh build-fs-util
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    strategy:
-      matrix:
-        python-version:
-        - '3.9'
-    timeout-minutes: 120
+    timeout-minutes: 90
   build_wheels_macos11_x86_64:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
-    if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
+    if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
+      || needs.classify_changes.outputs.release == true)) && (needs.classify_changes.outputs.docs_only
       != true)
-    name: Build wheels and fs_util (macOS11-x86_64)
+    name: Build wheels (macOS11-x86_64)
     needs:
     - classify_changes
     runs-on:
@@ -594,29 +439,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name != 'pull_request'
-      name: Setup toolchain auth
-      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
-
-        '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Cache Rust toolchain
@@ -636,28 +458,24 @@ jobs:
         cache-bin: 'false'
         shared-key: engine
         workspaces: src/rust/engine
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
     - env:
         ARCHFLAGS: -arch x86_64
-      if: github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
 
-        ./build-support/bin/release.sh build-local-pex
+        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+
 
         ./build-support/bin/release.sh build-wheels
 
         USE_PY38=true ./build-support/bin/release.sh build-wheels
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-fs-util
-
-        '
-    - env:
-        ARCHFLAGS: -arch x86_64
-      if: github.event_name == 'push'
-      name: Build fs_util
-      run: ./build-support/bin/release.sh build-fs-util
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -671,7 +489,7 @@ jobs:
       if: github.event_name == 'push'
       name: Deploy to S3
       run: ./build-support/bin/deploy_to_s3.py
-    timeout-minutes: 120
+    timeout-minutes: 90
   check_labels:
     if: github.repository_owner == 'pantsbuild'
     name: Ensure PR has a category label
@@ -732,24 +550,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:
@@ -801,7 +601,8 @@ jobs:
         \ == \"true\" ]]; then\n    echo \"Merge OK\"\n    exit 0\nelse\n    echo\
         \ \"Merge NOT OK\"\n    exit 1\nfi\n"
   set_merge_ok_docs_only:
-    if: needs.classify_changes.outputs.docs_only == true
+    if: always() && needs.classify_changes.outputs.docs_only == true && !contains(needs.*.result,
+      'failure') && !contains(needs.*.result, 'cancelled')
     name: Set Merge OK
     needs:
     - classify_changes
@@ -814,7 +615,8 @@ jobs:
     - id: set_merge_ok
       run: echo '::set-output name=merge_ok::true'
   set_merge_ok_not_docs_only:
-    if: needs.classify_changes.outputs.docs_only != true
+    if: always() && needs.classify_changes.outputs.docs_only != true && !contains(needs.*.result,
+      'failure') && !contains(needs.*.result, 'cancelled')
     name: Set Merge OK
     needs:
     - classify_changes
@@ -853,24 +655,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -944,24 +728,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1035,24 +801,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1128,24 +876,6 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - if: github.event_name == 'push'
-      name: Get commit message for branch builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
-    - if: github.event_name == 'pull_request'
-      name: Get commit message for PR builds
-      run: 'echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-
-        echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-
-        echo "EOF" >> $GITHUB_ENV
-
-        '
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -529,13 +529,11 @@ jobs:
         separator: '|'
     - id: classify
       name: Classify changed files
-      run: "                        affected=$(python build-support/bin/classify_changed_files.py\
-        \                           '${{ steps.files.outputs.all_modified_files }}')\n\
-        \                        echo \"Affected:\n${affected}\"\n               \
-        \         if [[ \"${affected}\" == \"docs\" ]]; then\n                   \
-        \       echo '::set-output name=docs_only::true'\n                       \
-        \ fi\n                        for i in ${affected}; do\n                 \
-        \         echo \"::set-output name=${i}::true\"\n                        done\n"
+      run: "affected=$(python build-support/bin/classify_changed_files.py \"${{ steps.files.outputs.all_modified_files\
+        \ }}\")\necho \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n\
+        \  echo \"::set-output name=docs_only::true\"\n  echo \"docs_only\"\nfi\n\
+        for i in ${affected}; do\n  echo \"::set-output name=${i}::true\"\n  echo\
+        \ \"XX ${i} XX\"\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != true)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,20 @@ jobs:
     runs-on:
     - ubuntu-20.04
     steps:
+    - name: Debug inputs
+      run: 'echo "rust: ${{ needs.classify_changes.outputs.rust }}"
+
+        echo "ci_config: ${{ needs.classify_changes.outputs.ci_config }}"
+
+        echo "release: ${{ needs.classify_changes.outputs.release }}"
+
+        echo "docs: ${{ needs.classify_changes.outputs.docs }}"
+
+        echo "docs_only: ${{ needs.classify_changes.outputs.docs_only }}"
+
+        echo "other: ${{ needs.classify_changes.outputs.other }}"
+
+        '
     - name: Check out code
       uses: actions/checkout@v3
       with:
@@ -109,7 +123,7 @@ jobs:
       run: './pants run build-support/bin/generate_github_workflows.py -- --check
 
         '
-    - if: needs.classify_changes.outputs.rust == true
+    - if: needs.classify_changes.outputs.rust == 'true'
       name: Test and lint Rust
       run: 'sudo apt-get install -y pkg-config fuse libfuse-dev
 
@@ -225,7 +239,7 @@ jobs:
           src/python/pants/engine/internals/native_engine.so.metadata'
     - env:
         TMPDIR: ${{ runner.temp }}
-      if: needs.classify_changes.outputs.rust == true
+      if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
       run: ./cargo test --tests -- --nocapture
     strategy:
@@ -513,6 +527,7 @@ jobs:
       ci_config: ${{ steps.classify.outputs.ci_config }}
       docs: ${{ steps.classify.outputs.docs }}
       docs_only: ${{ steps.classify.outputs.docs_only }}
+      other: ${{ steps.classify.outputs.other }}
       release: ${{ steps.classify.outputs.release }}
       rust: ${{ steps.classify.outputs.rust }}
     runs-on:
@@ -533,7 +548,7 @@ jobs:
         \ }}\")\necho \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n\
         \  echo \"::set-output name=docs_only::true\"\n  echo \"docs_only\"\nfi\n\
         for i in ${affected}; do\n  echo \"::set-output name=${i}::true\"\n  echo\
-        \ \"XX ${i} XX\"\ndone\n"
+        \ \"${i}\"\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != true)

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -77,7 +77,7 @@ PYTHON39_VERSION = "3.9"
 ALL_PYTHON_VERSIONS = [PYTHON37_VERSION, PYTHON38_VERSION, PYTHON39_VERSION]
 
 DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == 'true'"
-DONT_SKIP_WHEELS = "github.event_name == 'push' || needs.classify_changes.outputs.release == true"
+DONT_SKIP_WHEELS = "github.event_name == 'push' || needs.classify_changes.outputs.release == 'true'"
 IS_PANTS_OWNER = "github.repository_owner == 'pantsbuild'"
 
 # NB: This overrides `pants.ci.toml`.
@@ -508,19 +508,6 @@ def linux_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
             "timeout-minutes": 40,
             "if": IS_PANTS_OWNER,
             "steps": [
-                {
-                    "name": "Debug inputs",
-                    "run": dedent(
-                        """\
-                        echo "rust: ${{ needs.classify_changes.outputs.rust }}"
-                        echo "ci_config: ${{ needs.classify_changes.outputs.ci_config }}"
-                        echo "release: ${{ needs.classify_changes.outputs.release }}"
-                        echo "docs: ${{ needs.classify_changes.outputs.docs }}"
-                        echo "docs_only: ${{ needs.classify_changes.outputs.docs_only }}"
-                        echo "other: ${{ needs.classify_changes.outputs.other }}"
-                        """
-                    ),
-                },
                 *helper.bootstrap_pants(install_python=True),
                 {
                     "name": "Validate CI config",
@@ -892,7 +879,7 @@ def generate() -> dict[Path, str]:
         needs.extend(["classify_changes"])
         val["needs"] = needs
         if_cond = val.get("if")
-        not_docs_only = "needs.classify_changes.outputs.docs_only != true"
+        not_docs_only = "needs.classify_changes.outputs.docs_only != 'true'"
         val["if"] = not_docs_only if if_cond is None else f"({if_cond}) && ({not_docs_only})"
     pr_jobs.update(merge_ok(sorted(pr_jobs.keys())))
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -115,15 +115,16 @@ def classify_changes() -> Jobs:
                     "id": "classify",
                     "name": "Classify changed files",
                     "run": dedent(
-                        """\
-                        affected=$(python build-support/bin/classify_changed_files.py \
-                          '${{ steps.files.outputs.all_modified_files }}')
-                        echo "Affected:\n${affected}"
-                        if [[ "${affected}" == "docs" ]]; then
-                          echo '::set-output name=docs_only::true'
+                        f"""\
+                        affected=$(python build-support/bin/classify_changed_files.py "{gha_expr("steps.files.outputs.all_modified_files")}")
+                        echo "Affected:"
+                        if [[ "${{affected}}" == "docs" ]]; then
+                          echo "::set-output name=docs_only::true"
+                          echo "docs_only"
                         fi
-                        for i in ${affected}; do
-                          echo "::set-output name=${i}::true"
+                        for i in ${{affected}}; do
+                          echo "::set-output name=${{i}}::true"
+                          echo "XX ${{i}} XX"
                         done
                         """
                     ),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -598,7 +598,6 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
         # For manylinux compatibility, we build wheels in a container rather than directly
         # on the Ubuntu runner. As a result, we have custom steps here to check out
         # the code, install rustup and expose Pythons.
-        # TODO: Run tests etc. using this container image, so we can reuse the rust engine build?
         # TODO: Apply rust caching here.
         container = "quay.io/pypa/manylinux2014_x86_64:latest"
         initial_steps = [
@@ -825,6 +824,8 @@ def merge_ok(pr_jobs: list[str]) -> Jobs:
         "set_merge_ok": {
             "name": "Set Merge OK",
             "runs-on": Helper(Platform.LINUX_X86_64).runs_on(),
+            # NB: This always() condition is critical, as it ensures that this job is run even if
+            #   jobs it depends on are skipped.
             "if": "always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')",
             "needs": ["classify_changes", "check_labels"] + sorted(pr_jobs),
             "outputs": {"merge_ok": f"{gha_expr('steps.set_merge_ok.outputs.merge_ok')}"},

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -38,6 +38,10 @@ class Platform(Enum):
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
+GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS11_X86_64}
+SELF_HOSTED = {Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
+
+
 def gha_expr(expr: str) -> str:
     """Properly quote GitHub Actions expressions.
 
@@ -70,18 +74,15 @@ NATIVE_FILES = [
 PYTHON37_VERSION = "3.7"
 PYTHON38_VERSION = "3.8"
 PYTHON39_VERSION = "3.9"
+ALL_PYTHON_VERSIONS = [PYTHON37_VERSION, PYTHON38_VERSION, PYTHON39_VERSION]
 
-DONT_SKIP_RUST = "!contains(env.COMMIT_MESSAGE, '[ci skip-rust]')"
-DONT_SKIP_WHEELS = (
-    "github.event_name == 'push' || !contains(env.COMMIT_MESSAGE, '[ci skip-build-wheels]')"
-)
-
+DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == true"
+DONT_SKIP_WHEELS = "github.event_name == 'push' || needs.classify_changes.outputs.release == true"
+IS_PANTS_OWNER = "github.repository_owner == 'pantsbuild'"
 
 # NB: This overrides `pants.ci.toml`.
 DISABLE_REMOTE_CACHE_ENV = {"PANTS_REMOTE_CACHE_READ": "false", "PANTS_REMOTE_CACHE_WRITE": "false"}
 
-
-IS_PANTS_OWNER = "github.repository_owner == 'pantsbuild'"
 
 # ----------------------------------------------------------------------
 # Actions
@@ -103,7 +104,7 @@ def classify_changes() -> Jobs:
                 "ci_config": gha_expr("steps.classify.outputs.ci_config"),
             },
             "steps": [
-                *checkout(get_commit_msg=False),
+                *checkout(),
                 {
                     "id": "files",
                     "name": "Get changed files",
@@ -160,7 +161,7 @@ def ensure_category_label() -> Sequence[Step]:
     ]
 
 
-def checkout(*, containerized: bool = False, get_commit_msg: bool = True) -> Sequence[Step]:
+def checkout(*, containerized: bool = False) -> Sequence[Step]:
     """Get prior commits and the commit message."""
     steps = [
         # See https://github.community/t/accessing-commit-message-in-pull-request-event/17158/8
@@ -182,37 +183,6 @@ def checkout(*, containerized: bool = False, get_commit_msg: bool = True) -> Seq
                 "name": "Configure Git",
                 "run": 'git config --global safe.directory "$GITHUB_WORKSPACE"',
             }
-        )
-    if get_commit_msg:
-        steps.extend(
-            [
-                # For a push event, the commit we care about is HEAD itself.
-                # This CI currently only runs on PRs, so this is future-proofing.
-                {
-                    "name": "Get commit message for branch builds",
-                    "if": "github.event_name == 'push'",
-                    "run": dedent(
-                        """\
-                    echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-                    echo "$(git log --format=%B -n 1 HEAD)" >> $GITHUB_ENV
-                    echo "EOF" >> $GITHUB_ENV
-                    """
-                    ),
-                },
-                # For a pull_request event, the commit we care about is the second parent of the
-                # merge commit. This CI currently only runs on PRs, so this is future-proofing.
-                {
-                    "name": "Get commit message for PR builds",
-                    "if": "github.event_name == 'pull_request'",
-                    "run": dedent(
-                        """\
-                    echo "COMMIT_MESSAGE<<EOF" >> $GITHUB_ENV
-                    echo "$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_ENV
-                    echo "EOF" >> $GITHUB_ENV
-                    """
-                    ),
-                },
-            ]
         )
     return steps
 
@@ -458,35 +428,35 @@ class Helper:
             self.native_binaries_upload(),
         ]
 
-    def build_steps(self) -> list[Step]:
+    def build_wheels(self, python_versions: list[str]) -> list[Step]:
+        cmd = dedent(
+            # We use MODE=debug on PR builds to speed things up, given that those are
+            # only smoke tests of our release process.
+            # Note that the build-local-pex run is just for smoke-testing that pex
+            # builds work, and it must come *before* the build-wheels runs, since
+            # it cleans out `dist/deploy`, which the build-wheels runs populate for
+            # later attention by deploy_to_s3.py.
+            """\
+            [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
+            USE_PY39=true ./build-support/bin/release.sh build-local-pex
+            """
+        )
+
+        def build_wheels_for(env_var: str) -> str:
+            env_setting = f"{env_var}=true " if env_var else ""
+            return f"\n{env_setting}./build-support/bin/release.sh build-wheels"
+
+        if PYTHON37_VERSION in python_versions:
+            cmd += build_wheels_for("")
+        if PYTHON38_VERSION in python_versions:
+            cmd += build_wheels_for("USE_PY38")
+        if PYTHON39_VERSION in python_versions:
+            cmd += build_wheels_for("USE_PY39")
+
         return [
             {
                 "name": "Build wheels",
-                "run": dedent(
-                    # We use MODE=debug on PR builds to speed things up, given that those are
-                    # only smoke tests of our release process.
-                    # Note that the build-local-pex run is just for smoke-testing that pex
-                    # builds work, and it must come *before* the build-wheels runs, since
-                    # it cleans out `dist/deploy`, which the build-wheels runs populate for
-                    # later attention by deploy_to_s3.py.
-                    """\
-                    [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-                    ./build-support/bin/release.sh build-local-pex
-                    ./build-support/bin/release.sh build-wheels
-                    USE_PY38=true ./build-support/bin/release.sh build-wheels
-                    USE_PY39=true ./build-support/bin/release.sh build-wheels
-                    ./build-support/bin/release.sh build-fs-util
-                    """
-                ),
-                "if": DONT_SKIP_WHEELS,
-                "env": self.platform_env(),
-            },
-            {
-                "name": "Build fs_util",
-                "run": "./build-support/bin/release.sh build-fs-util",
-                # We only build fs_util on branch builds, given that Pants compilation already
-                # checks the code compiles and the release process is simple and low-stakes.
-                "if": "github.event_name == 'push'",
+                "run": cmd,
                 "env": self.platform_env(),
             },
         ]
@@ -503,13 +473,8 @@ class Helper:
             },
         }
 
-    build_wheels_common = {
-        "env": DISABLE_REMOTE_CACHE_ENV,
-        "if": IS_PANTS_OWNER,
-    }
 
-
-def linux_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
+def linux_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
     helper = Helper(Platform.LINUX_X86_64)
 
     def test_python_linux(shard: str) -> dict[str, Any]:
@@ -575,41 +540,10 @@ def linux_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
         "test_python_linux_x86_64_1": test_python_linux("1/3"),
         "test_python_linux_x86_64_2": test_python_linux("2/3"),
     }
-    if not cron:
-        jobs.update(
-            {
-                "build_wheels_linux_x86_64": {
-                    "name": f"Build wheels and fs_util ({helper.platform_name()})",
-                    "runs-on": helper.runs_on(),
-                    "container": "quay.io/pypa/manylinux2014_x86_64:latest",
-                    "timeout-minutes": 90,
-                    **helper.build_wheels_common,
-                    "steps": [
-                        *checkout(containerized=True),
-                        # TODO: Why is this necessary? the hosted container is
-                        #  supposed to come with rustup preinstalled.
-                        install_rustup(),
-                        {
-                            "name": "Expose Pythons",
-                            "run": (
-                                'echo "PATH=${PATH}:'
-                                "/opt/python/cp37-cp37m/bin:"
-                                "/opt/python/cp38-cp38/bin:"
-                                '/opt/python/cp39-cp39/bin" >> $GITHUB_ENV'
-                            ),
-                        },
-                        setup_toolchain_auth(),
-                        *helper.build_steps(),
-                        helper.upload_log_artifacts(name="wheels"),
-                        deploy_to_s3(),
-                    ],
-                },
-            }
-        )
     return jobs
 
 
-def macos11_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
+def macos11_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
     helper = Helper(Platform.MACOS11_X86_64)
     jobs = {
         "bootstrap_pants_macos11_x86_64": {
@@ -660,50 +594,56 @@ def macos11_x86_64_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             ],
         },
     }
-    if not cron:
-        jobs.update(
-            {
-                "build_wheels_macos11_x86_64": {
-                    "name": f"Build wheels and fs_util ({helper.platform_name()})",
-                    "runs-on": helper.runs_on(),
-                    "timeout-minutes": 120,
-                    **helper.build_wheels_common,
-                    "steps": [
-                        *checkout(),
-                        setup_toolchain_auth(),
-                        expose_all_pythons(),
-                        # NB: We only cache Rust, but not `native_engine.so` and the Pants
-                        # virtualenv. This is because we must build both these things with
-                        # multiple Python versions, whereas that caching assumes only one primary
-                        # Python version (marked via matrix.strategy).
-                        *helper.rust_caches(),
-                        *helper.build_steps(),
-                        helper.upload_log_artifacts(name="wheels"),
-                        deploy_to_s3(),
-                    ],
-                },
-            }
-        )
     return jobs
 
 
-def macos_10_15_x86_64_jobs(python_versions: list[str]) -> Jobs:
-    helper = Helper(Platform.MACOS10_15_X86_64)
+def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
+    helper = Helper(platform)
+    if platform == Platform.LINUX_X86_64:
+        # For manylinux compatibility, we build wheels in a container rather than directly
+        # on the Ubuntu runner. As a result, we have custom steps here to check out
+        # the code, install rustup and expose Pythons.
+        # TODO: Run tests etc. using this container image, so we can reuse the rust engine build?
+        # TODO: Apply rust caching here.
+        container = "quay.io/pypa/manylinux2014_x86_64:latest"
+        initial_steps = [
+            *checkout(containerized=True),
+            install_rustup(),
+            {
+                "name": "Expose Pythons",
+                "run": (
+                    'echo "PATH=${PATH}:'
+                    "/opt/python/cp37-cp37m/bin:"
+                    "/opt/python/cp38-cp38/bin:"
+                    '/opt/python/cp39-cp39/bin" >> $GITHUB_ENV'
+                ),
+            },
+        ]
+    else:
+        container = None
+        initial_steps = [
+            *checkout(),
+            # Self-hosted runners already have all relevant pythons exposed on their PATH, so we
+            # only run expose_all_pythons() on the GitHub-hosted platforms.
+            *([expose_all_pythons()] if platform in GITHUB_HOSTED else []),
+            # NB: We only cache Rust, but not `native_engine.so` and the Pants
+            # virtualenv. This is because we must build both these things with
+            # multiple Python versions, whereas that caching assumes only one primary
+            # Python version (marked via matrix.strategy).
+            *helper.rust_caches(),
+        ]
     return {
-        "build_wheels_macos10_15_x86_64": {
-            "name": f"Build wheels and fs_util ({helper.platform_name()})",
+        f"build_wheels_{str(platform.value).lower().replace('-', '_')}": {
+            "if": f"({IS_PANTS_OWNER}) && ({DONT_SKIP_WHEELS})",
+            "name": f"Build wheels ({str(platform.value)})",
             "runs-on": helper.runs_on(),
-            "timeout-minutes": 120,
-            **helper.build_wheels_common,
-            "steps": [
-                *checkout(),
+            **({"container": container} if container else {}),
+            "timeout-minutes": 90,
+            "env": DISABLE_REMOTE_CACHE_ENV,
+            "steps": initial_steps
+            + [
                 setup_toolchain_auth(),
-                # NB: We only cache Rust, but not `native_engine.so` and the Pants
-                # virtualenv. This is because we must build both these things with
-                # multiple Python versions, whereas that caching assumes only one primary
-                # Python version (marked via matrix.strategy).
-                *helper.rust_caches(),
-                *helper.build_steps(),
+                *helper.build_wheels(python_versions),
                 helper.upload_log_artifacts(name="wheels"),
                 deploy_to_s3(),
             ],
@@ -711,40 +651,12 @@ def macos_10_15_x86_64_jobs(python_versions: list[str]) -> Jobs:
     }
 
 
-def macos11_arm64_jobs() -> Jobs:
-    helper = Helper(Platform.MACOS11_ARM64)
-    # The setup-python action doesn't yet support installing ARM64 Pythons.
-    # Instead we pre-install Python 3.9 on the self-hosted runner.
-    steps = list(helper.bootstrap_pants(install_python=False))
-    # TODO: Build local pex? Will require some changes to _release_helper.py to qualify
-    #  the .pex file name with the architecture, intead of just "darwin".
-    steps.append(
-        {
-            "name": "Build wheels",
-            "run": f"USE_PY39=true {helper.wrap_cmd('./build-support/bin/release.sh build-wheels')}",
-            "if": f"({DONT_SKIP_WHEELS}) && ({IS_PANTS_OWNER})",
-        }
-    )
-    steps.append(
-        {
-            "name": "Build fs_util",
-            "run": f"USE_PY39=true {helper.wrap_cmd('./build-support/bin/release.sh build-fs-util')}",
-            # We only build fs_util on branch builds, given that Pants compilation already
-            # checks the code compiles and the release process is simple and low-stakes.
-            "if": "github.event_name == 'push'",
-        }
-    )
-    steps.append(deploy_to_s3())
+def build_wheels_jobs() -> Jobs:
     return {
-        "build_wheels_macos11_arm64": {
-            "name": f"Bootstrap Pants, build wheels and fs_util ({Platform.MACOS11_ARM64.value})",
-            "runs-on": helper.runs_on(),
-            "strategy": {"matrix": {"python-version": [PYTHON39_VERSION]}},
-            "timeout-minutes": 120,
-            "if": IS_PANTS_OWNER,
-            "steps": steps,
-            "env": {**helper.platform_env(), **DISABLE_REMOTE_CACHE_ENV},
-        },
+        **build_wheels_job(Platform.LINUX_X86_64, ALL_PYTHON_VERSIONS),
+        **build_wheels_job(Platform.MACOS11_X86_64, ALL_PYTHON_VERSIONS),
+        **build_wheels_job(Platform.MACOS10_15_X86_64, ALL_PYTHON_VERSIONS),
+        **build_wheels_job(Platform.MACOS11_ARM64, [PYTHON39_VERSION]),
     }
 
 
@@ -758,11 +670,10 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
             "steps": ensure_category_label(),
         },
     }
-    jobs.update(**linux_x86_64_jobs(python_versions, cron=cron))
-    jobs.update(**macos11_x86_64_jobs(python_versions, cron=cron))
+    jobs.update(**linux_x86_64_test_jobs(python_versions))
+    jobs.update(**macos11_x86_64_test_jobs(python_versions))
     if not cron:
-        jobs.update(**macos_10_15_x86_64_jobs(python_versions))
-        jobs.update(**macos11_arm64_jobs())
+        jobs.update(**build_wheels_jobs())
     jobs.update(
         {
             "lint_python": {
@@ -925,7 +836,7 @@ def set_merge_ok(needs: list[str], docs_only: bool) -> Jobs:
         key: {
             "name": "Set Merge OK",
             "runs-on": Helper(Platform.LINUX_X86_64).runs_on(),
-            "if": _docs_only_cond(docs_only),
+            "if": f"always() && {_docs_only_cond(docs_only)} && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')",
             # If in the future we have any docs-related checks, we can make both "Set Merge OK"
             # jobs depend on them here (it has to be both since some changes may modify docs
             # as well as code, and so are not "docs only").

--- a/src/rust/engine/fs/src/glob_matching_tests.rs
+++ b/src/rust/engine/fs/src/glob_matching_tests.rs
@@ -1,8 +1,6 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-deliberately breaking rust tests to see what happens
-
 use crate::glob_matching::PathGlob;
 use crate::{GitignoreStyleExcludes, GlobExpansionConjunction, PathGlobs, StrictGlobMatching};
 

--- a/src/rust/engine/fs/src/glob_matching_tests.rs
+++ b/src/rust/engine/fs/src/glob_matching_tests.rs
@@ -1,6 +1,8 @@
 // Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+deliberately breaking rust tests to see what happens
+
 use crate::glob_matching::PathGlob;
 use crate::{GitignoreStyleExcludes, GlobExpansionConjunction, PathGlobs, StrictGlobMatching};
 


### PR DESCRIPTION
- Unifies the code that generates the "Build wheels" jobs, so they are now uniform (with allowances for the containerization on Linux). This means in particular that we no longer bootstrap Pants on macOS11 on ARM64, as there was no particular reason to, and we weren't doing so on macOS10.15 on x86 for example.
- Uses the new classifier to skip these jobs entirely if unneeded.
- Similarly, uses the new classifier to skip rust steps if unneeded.
- Removes the steps for getting the commit message, since we no longer need it.

Now, to force a rust or wheel build even if no files were affected, you can temporarily modify a relevant file. If this becomes a hassle we can think of another way to achieve this, that doesn't involve the commit message.