### PR TITLE
Replaces `environment_migrated` bool with `environment_behavior` enum

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -19,11 +19,11 @@ is now required in order to:
 
 Some deprecations are in place to reduce the burden on `@rule` authors:
 
-#### `Goal.environment_migrated`
+#### `Goal.environment_behavior`
 
-The `Goal` class has an `environment_migrated` property, which controls whether an `EnvironmentName` is automatically injected when a `@goal_rule` runs. When `environment_migrated=False` (the default), the `QueryRule` that is installed for a `@goal_rule` will include an `EnvironmentName`.
+The `Goal` class has an `environment_behavior` property, which controls whether an `EnvironmentName` is automatically injected when a `@goal_rule` runs. When `environment_behavior=UNMIGRATED` (the default), the `QueryRule` that is installed for a `@goal_rule` will include an `EnvironmentName` and will raise a deprecation error.
 
-To migrate a `Goal`, set `environment_migrated=True`, select an `EnvironmentName` to use for (different portions of) your `Goal`, and then provide the `EnvironmentName` to the relevant callsites. In general, `Goal`s should use `EnvironmentNameRequest` to get `EnvironmentName`s for the targets that they will be operating on.
+To migrate a `Goal`, select an `EnvironmentName` to use for (different portions of) your `Goal`, and then provide the `EnvironmentName` to the relevant callsites. In general, `Goal`s should use `EnvironmentNameRequest` to get `EnvironmentName`s for the targets that they will be operating on.
 ```python
 Get(
     EnvironmentName,
@@ -32,6 +32,8 @@ Get(
 )
 ```
 If rather than using the environment configured by a target your `Goal` should always be pinned to run in the local environment, you can instead request the `ChosenLocalEnvironmentName` and use its content as the `EnvironmentName`.
+
+To silence the deprecation warning, set `environment_behavior` to either `LOCAL_ONLY` or `USES_ENVIRONMENTS` depending on whether you use `ChosenLocalEnvironmentName` or `EnvironmentNameRequest` to request your `EnvironmentName`.
 
 Then, the `EnvironmentName` should be used at `Get` callsites which require an environment:
 ```python

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -30,13 +30,13 @@ In cases where the environment needs to be factored into to rule execution, you'
 
 2.15 adds the `environment_behavior` property to the `Goal` class, which controls whether an `EnvironmentName` is automatically injected when a `@goal_rule` runs. 
 
-When `environment_behavior=UNMIGRATED` (the default), the `QueryRule` that is installed for a `@goal_rule` will include an `EnvironmentName` and will raise a deprecation warning.
+When `environment_behavior=Goal.EnvironmentBehavior.UNMIGRATED` (the default), the `QueryRule` that is installed for a `@goal_rule` will include an `EnvironmentName` and will raise a deprecation warning.
 
-If your Goal only ever needs to use the local target environment, use `environment_behavior=LOCAL_ONLY`. The `QueryRule` installed for the `@goal_rule` will include an `EnvironmentName` that refers to a local environment, and will silence the deprecation warning. No further migration work needs to be done for your Goal.
+If your Goal only ever needs to use the local target environment, use `environment_behavior=Goal.EnvironmentBehavior.LOCAL_ONLY`. The `QueryRule` installed for the `@goal_rule` will include an `EnvironmentName` that refers to a local environment, and will silence the deprecation warning. No further migration work needs to be done for your Goal.
 
 ##### For goals that need to respect `EnvironmentField`s
 
-If your goal needs to select the target's specified environment when running underlying rules, set `environment_behavior=USES_ENVIRONMENTS`, which will silence the deprecation. Unlike for the `LOCAL_ONLY` behavior, any rules that require an `EnvironmentName` will need to specify that name directly.
+If your goal needs to select the target's specified environment when running underlying rules, set `environment_behavior=Goal.EnvironmentBehavior.USES_ENVIRONMENTS`, which will silence the deprecation. Unlike for the `LOCAL_ONLY` behavior, any rules that require an `EnvironmentName` will need to specify that name directly.
 
  In general, `Goal`s should use `EnvironmentNameRequest` to get `EnvironmentName`s for the targets that they will be operating on.
 ```python

--- a/pants-plugins/internal_plugins/rules_for_testing/register.py
+++ b/pants-plugins/internal_plugins/rules_for_testing/register.py
@@ -16,7 +16,7 @@ class ListAndDieForTestingSubsystem(GoalSubsystem):
 
 class ListAndDieForTesting(Goal):
     subsystem_cls = ListAndDieForTestingSubsystem
-    environment_migrated = True
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/dependees.py
+++ b/src/python/pants/backend/project_info/dependees.py
@@ -98,7 +98,7 @@ class DependeesSubsystem(LineOriented, GoalSubsystem):
 
 class DependeesGoal(Goal):
     subsystem_cls = DependeesSubsystem
-    environment_migrated = True
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -34,7 +34,7 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
 
 class Dependencies(Goal):
     subsystem_cls = DependenciesSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -144,7 +144,7 @@ def warn_deprecated_target_type(tgt_type: type[Target]) -> None:
 
 class FilterGoal(Goal):
     subsystem_cls = FilterSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -14,7 +14,7 @@ class RootsSubsystem(LineOriented, GoalSubsystem):
 
 class Roots(Goal):
     subsystem_cls = RootsSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -26,7 +26,7 @@ class ListSubsystem(LineOriented, GoalSubsystem):
 
 class List(Goal):
     subsystem_cls = ListSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -40,7 +40,7 @@ class PathsSubsystem(Outputting, GoalSubsystem):
 
 class PathsGoal(Goal):
     subsystem_cls = PathsSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 def find_paths_breadth_first(

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -102,7 +102,7 @@ class PackageSubsystem(GoalSubsystem):
 
 class Package(Goal):
     subsystem_cls = PackageSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
 
 class AllPackageableTargets(Targets):

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -433,7 +433,7 @@ class TestSubsystem(GoalSubsystem):
 
 class Test(Goal):
     subsystem_cls = TestSubsystem
-    environment_migrated = True
+    enviroment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
     __test__ = False
 

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -4,6 +4,8 @@
 from abc import abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
+from enum import Enum
+import enum
 from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, Type, cast
 
 from typing_extensions import final
@@ -81,6 +83,28 @@ class Goal:
     value to indicate whether the rule exited cleanly.
     """
 
+    class EnvironmentBehavior(Enum):
+        """ Indicates that a goal's behavior with respect to environments has not been considered.
+        
+        If set, will trigger a deprecation warning. If the desired behavior is to stay pinned to
+        defaults, changing to `LOCAL_ONLY` will silence the warning for this goal."""
+        UNMIGRATED = 1
+
+        """ Indicates that the goal will always operate on the local environment target.
+        
+        This is largely the same behavior as Pants has had pre-2.15. Set to this value to silence
+        the deprecation warning that arises from using `UNMIGRATED`."""
+        LOCAL_ONLY = 2
+
+        f""" Indicates that the goal chooses the environments to use to execute rules within the goal.
+        
+        This requires migration work to be done by the goal author. See 
+        {doc_url('plugin-upgrade-guide')}.
+        """
+        USES_ENVIRONMENTS = 3
+
+
+
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]
 
@@ -91,17 +115,18 @@ class Goal:
 
     See {doc_url('plugin-upgrade-guide')}.
     """
-    environment_migrated: ClassVar[bool] = False
+    environment_behavior: ClassVar[EnvironmentBehavior] = EnvironmentBehavior.UNMIGRATED
 
     @classmethod
     def _get_environment_migrated(cls) -> bool:
         deprecated_conditional(
-            lambda: not cls.environment_migrated,
+            lambda: cls.environment_behavior == Goal.EnvironmentBehavior.UNMIGRATED,
             "2.17.0.dev0",
-            f"Not setting `Goal.environment_migrated=True` for `Goal` `{cls.name}`",
+            f"Setting `Goal.environment_behavior=EnvironmentBehavior.UNMIGRATED` for `Goal` "
+            f"`{cls.name}`",
             hint=f"See {doc_url('plugin-upgrade-guide')}\n",
         )
-        return cls.environment_migrated
+        return cls.environment_behavior != Goal.EnvironmentBehavior.UNMIGRATED
 
     @final
     @classproperty

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
-import enum
 from typing import TYPE_CHECKING, Callable, ClassVar, Iterator, Type, cast
 
 from typing_extensions import final
@@ -84,26 +83,26 @@ class Goal:
     """
 
     class EnvironmentBehavior(Enum):
-        """ Indicates that a goal's behavior with respect to environments has not been considered.
-        
+        """Indicates that a goal's behavior with respect to environments has not been considered.
+
         If set, will trigger a deprecation warning. If the desired behavior is to stay pinned to
-        defaults, changing to `LOCAL_ONLY` will silence the warning for this goal."""
+        defaults, changing to `LOCAL_ONLY` will silence the warning for this goal.
+        """
+
         UNMIGRATED = 1
 
         """ Indicates that the goal will always operate on the local environment target.
-        
+
         This is largely the same behavior as Pants has had pre-2.15. Set to this value to silence
         the deprecation warning that arises from using `UNMIGRATED`."""
         LOCAL_ONLY = 2
 
         f""" Indicates that the goal chooses the environments to use to execute rules within the goal.
-        
-        This requires migration work to be done by the goal author. See 
+
+        This requires migration work to be done by the goal author. See
         {doc_url('plugin-upgrade-guide')}.
         """
         USES_ENVIRONMENTS = 3
-
-
 
     exit_code: int
     subsystem_cls: ClassVar[Type[GoalSubsystem]]

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -118,7 +118,7 @@ class Goal:
     environment_behavior: ClassVar[EnvironmentBehavior] = EnvironmentBehavior.UNMIGRATED
 
     @classmethod
-    def _get_environment_migrated(cls) -> bool:
+    def _selects_environments(cls) -> bool:
         deprecated_conditional(
             lambda: cls.environment_behavior == Goal.EnvironmentBehavior.UNMIGRATED,
             "2.17.0.dev0",
@@ -126,7 +126,7 @@ class Goal:
             f"`{cls.name}`",
             hint=f"See {doc_url('plugin-upgrade-guide')}\n",
         )
-        return cls.environment_behavior != Goal.EnvironmentBehavior.UNMIGRATED
+        return cls.environment_behavior == Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
     @final
     @classproperty

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -286,7 +286,8 @@ class EngineInitializer:
             )
         )
 
-        environment_migrated_goal_param_types = [
+        # param types for goals with the `USES_ENVIRONMENT` behaviour (see `goal.py`)
+        environment_selecting_goal_param_types = [
             t for t in GraphSession.goal_param_types if t != EnvironmentName
         ]
         rules = FrozenOrderedSet(
@@ -296,8 +297,8 @@ class EngineInitializer:
                 *(
                     QueryRule(
                         goal_type,
-                        environment_migrated_goal_param_types
-                        if goal_type._get_environment_migrated()
+                        environment_selecting_goal_param_types
+                        if goal_type._selects_environments()
                         else GraphSession.goal_param_types,
                     )
                     for goal_type in goal_map.values()


### PR DESCRIPTION
Per discussion in #17129, this allows us to state whether a given `Goal` has had a thorough migration to environments, or has been left to work in a local-only context. This is useful for goals like `fmt`, which can probably run local-only for now.