### PR TITLE
Streaming remote uploads read a chunk at a time

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1711,16 +1711,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "memoffset"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,7 +3141,6 @@ dependencies = [
  "lmdb-rkv",
  "log",
  "madvise",
- "memmap",
  "mock",
  "num_cpus",
  "parking_lot 0.12.1",

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -25,7 +25,6 @@ itertools = "0.10"
 lmdb-rkv = { git = "https://github.com/pantsbuild/lmdb-rs.git", rev = "6ae7a552aa2c932c3ddf652a68cdde2fed547cbc" }
 log = "0.4"
 madvise = "0.1"
-memmap = "0.7"
 parking_lot = "0.12"
 prost = "0.9"
 prost-types = "0.9"


### PR DESCRIPTION
To reduce memory usage, #12087 moved to streaming the entire content of a large `Digest` out into a `mmap`'d temporary file, and then executing a streaming upload from there.

To remove that extra copy (and drop the dependency on `memmap`, which has been replaced: see #14341), this change switches to producing a `Stream` of chunks from the LMDB store, which can be uploaded without further copying.

Fixes #14341.

[ci skip-build-wheels]