### PR TITLE
Adjust `ensure_remote_has_recursive` to succeed if content only exists remotely (Cherry-pick of #17204)

### DIFF
--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -753,6 +753,25 @@ async fn upload_missing_files() {
 }
 
 #[tokio::test]
+async fn upload_succeeds_for_digests_which_only_exist_remotely() {
+  let dir = TempDir::new().unwrap();
+  let cas = new_empty_cas();
+
+  let testdata = TestData::roland();
+
+  cas
+    .blobs
+    .lock()
+    .insert(testdata.fingerprint(), testdata.bytes());
+
+  // The data does not exist locally, but already exists remotely: succeed.
+  new_store(dir.path(), &cas.address())
+    .ensure_remote_has_recursive(vec![testdata.digest()])
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
 async fn upload_missing_file_in_directory() {
   let dir = TempDir::new().unwrap();
   let cas = new_empty_cas();


### PR DESCRIPTION
As reported in #17181: remote cache writes currently fail when remote execution is used, because the cache content does not exist locally, but `ensure_remote_has_recursive` implicitly required that certain types existed locally in order to succeed.

This change adjusts `ensure_remote_has_recursive` to succeed even if content does not exist locally, by making the handling of missing digests reported by `expand_local_digests` more explicit.

This additionally fixes some issues related to using `cache_content_behavior={validate,defer}`, because callers using `ensure_remote_has_recursive` on `Digests` which they received from unknown sources would not have been able to determine when it was safe to call it.

Fixes #17181, fixes #16298.

[ci skip-build-wheels]
