### PR TITLE
Fix macros depending on macros from other files (Cherry-pick of #17183)

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -72,6 +72,9 @@ async def evaluate_preludes(build_file_options: BuildFileOptions) -> BuildFilePr
     # Fortunately, we don't care about it - preludes should not be able to override builtins, so we just pop it out.
     # TODO: Give a nice error message if a prelude tries to set a expose a non-hashable value.
     locals.pop("__builtins__", None)
+    # Ensure preludes can reference each other by populating the shared globals object with references
+    # to the other symbols
+    globals.update(locals)
     return BuildFilePreludeSymbols(FrozenDict(locals))
 
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -390,7 +390,7 @@ def test_build_files_share_globals() -> None:
         mock_gets=[
             MockGet(
                 output_type=DigestContents,
-                input_types=(PathGlobs,),
+                input_type=PathGlobs,
                 mock=lambda _: DigestContents(
                     [
                         FileContent(


### PR DESCRIPTION
Cross-prelude references were broken in https://github.com/pantsbuild/pants/pull/16174 because the shared global object no longer held references to all the other symbols.

Fixed and added test (fails before, passes after)


[ci skip-rust]
[ci skip-build-wheels]
