### PR TITLE
Migrates several `Goal` classes to `LOCAL_ONLY` 

### DIFF
--- a/src/python/pants/backend/project_info/count_loc.py
+++ b/src/python/pants/backend/project_info/count_loc.py
@@ -56,6 +56,7 @@ class CountLinesOfCodeSubsystem(GoalSubsystem):
 
 class CountLinesOfCode(Goal):
     subsystem_cls = CountLinesOfCodeSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -34,7 +34,7 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
 
 class Dependencies(Goal):
     subsystem_cls = DependenciesSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/filedeps.py
+++ b/src/python/pants/backend/project_info/filedeps.py
@@ -59,6 +59,7 @@ class FiledepsSubsystem(LineOriented, GoalSubsystem):
 
 class Filedeps(Goal):
     subsystem_cls = FiledepsSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -144,7 +144,7 @@ def warn_deprecated_target_type(tgt_type: type[Target]) -> None:
 
 class FilterGoal(Goal):
     subsystem_cls = FilterSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_roots.py
+++ b/src/python/pants/backend/project_info/list_roots.py
@@ -14,7 +14,7 @@ class RootsSubsystem(LineOriented, GoalSubsystem):
 
 class Roots(Goal):
     subsystem_cls = RootsSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/list_targets.py
+++ b/src/python/pants/backend/project_info/list_targets.py
@@ -26,7 +26,7 @@ class ListSubsystem(LineOriented, GoalSubsystem):
 
 class List(Goal):
     subsystem_cls = ListSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -40,7 +40,7 @@ class PathsSubsystem(Outputting, GoalSubsystem):
 
 class PathsGoal(Goal):
     subsystem_cls = PathsSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 def find_paths_breadth_first(

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -39,6 +39,7 @@ class PeekSubsystem(Outputting, GoalSubsystem):
 
 class Peek(Goal):
     subsystem_cls = PeekSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 def _normalize_value(val: Any) -> Any:

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Tuple
+from typing import Iterable, List, Tuple
+
+import pytest
 
 from pants.base.build_root import BuildRoot
 from pants.core.goals.export import (
@@ -18,7 +20,13 @@ from pants.core.goals.export import (
     export,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
+from pants.core.util_rules.environments import (
+    EnvironmentField,
+    EnvironmentNameRequest,
+    EnvironmentTarget,
+    LocalEnvironmentTarget,
+    RemoteEnvironmentTarget,
+)
 from pants.engine.addresses import Address
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
@@ -38,11 +46,13 @@ from pants.testutil.rule_runner import (
 
 class MockTarget(Target):
     alias = "target"
-    core_fields = ()
+    core_fields = (EnvironmentField,)
 
 
-def make_target(path: str, target_name: str) -> Target:
-    return MockTarget({}, Address(path, target_name=target_name))
+def make_target(path: str, target_name: str, environment_name: str | None = None) -> Target:
+    return MockTarget(
+        {EnvironmentField.alias: environment_name}, Address(path, target_name=target_name)
+    )
 
 
 class MockExportRequest(ExportRequest):
@@ -111,8 +121,12 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                         )
                     ),
                 ),
+                MockGet(
+                    output_type=EnvironmentTarget,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda req: EnvironmentTarget(None),
+                ),
                 rule_runner.do_not_use_mock(Digest, (MergeDigests,)),
-                rule_runner.do_not_use_mock(EnvironmentTarget, (EnvironmentNameRequest,)),
                 rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
                 rule_runner.do_not_use_mock(EnvironmentVars, (EnvironmentVarsRequest,)),
                 MockEffect(
@@ -148,7 +162,50 @@ def test_run_export_rule() -> None:
             assert fp.read() == b"BAR"
 
 
-def test_bloop() -> None:
+_e = lambda path, env: make_target(path, path, env)
+
+
+@pytest.mark.parametrize(
+    ["targets", "err_present", "err_absent"],
+    [
+        # Only a local environment
+        [[_e("a", "l")], [], ["`a:a`"]],
+        # The remote environment should warn, the local environment should not
+        [[_e("a", "l"), _e("b", "r")], ["target `b:b`"], ["`a:a`"]],
+        # Only a remote environment, which should warn
+        [[_e("b", "r")], ["target `b:b`, which specifies", "environment `r`"], []],
+        # Two targets with the same remote environment (should trigger short plural message)
+        [
+            [_e("b", "r"), _e("c", "r")],
+            ["targets `b:b`, `c:c`, which specify", "environment `r`"],
+            [],
+        ],
+        # Two targets, each with their own remote environment, each should warn separately
+        [
+            [_e("b", "r"), _e("c", "r2")],
+            [
+                "target `b:b`, which specifies",
+                "target `c:c`, which specifies",
+                "environment `r`",
+                "environment `r2`",
+            ],
+            ["`b:b`, `c:c`"],
+        ],
+        # Four targets with the same remote environment (should trigger long plural message, omitting the later targets by lex order)
+        [
+            [_e("b", "r"), _e("c", "r"), _e("d", "r"), _e("e", "r")],
+            [
+                "targets including `b:b`, `c:c`, `d:d` (and others), which specify",
+                "environment `r`",
+            ],
+            ["`e:e`"],
+        ],
+    ],
+)
+def test_warnings_for_non_local_target_environments(
+    targets: Iterable[Target], err_present: Iterable[str], err_absent: Iterable[str]
+) -> None:
+
     rule_runner = RuleRunner(
         rules=[
             UnionRule(ExportRequest, MockExportRequest),
@@ -156,15 +213,69 @@ def test_bloop() -> None:
             QueryRule(EnvironmentVars, [EnvironmentVarsRequest]),
             QueryRule(InteractiveProcessResult, [InteractiveProcess]),
         ],
-        target_types=[MockTarget],
+        target_types=[MockTarget, LocalEnvironmentTarget, RemoteEnvironmentTarget],
     )
-    exit_code, stdout = run_export_rule(rule_runner, [make_target("foo/bar", "baz")])
-    assert exit_code == 0
-    assert "Wrote mock export for foo/bar:baz to dist/export/mock" in stdout
-    for filename in ["bar", "bar1", "bar2"]:
-        expected_dist_path = os.path.join(
-            rule_runner.build_root, "dist", "export", "mock", "foo", filename
+
+    union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
+    with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
+        fp.write(b"SOMEFILE")
+    with mock_console(create_options_bootstrapper()) as (console, stdio_reader):
+        digest = rule_runner.request(Digest, [CreateDigest([FileContent("foo/bar", b"BAR")])])
+        run_rule_with_mocks(
+            export,
+            rule_args=[
+                console,
+                Targets(targets),
+                Workspace(rule_runner.scheduler, _enforce_effects=False),
+                union_membership,
+                BuildRoot(),
+                DistDir(relpath=Path("dist")),
+            ],
+            mock_gets=[
+                MockGet(
+                    output_type=ExportResults,
+                    input_types=(ExportRequest,),
+                    mock=lambda req: ExportResults(
+                        (
+                            mock_export(
+                                req,
+                                digest,
+                                (),
+                            ),
+                        )
+                    ),
+                ),
+                rule_runner.do_not_use_mock(Digest, (MergeDigests,)),
+                MockGet(
+                    output_type=EnvironmentTarget,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=_give_an_environment,
+                ),
+                rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
+                rule_runner.do_not_use_mock(EnvironmentVars, (EnvironmentVarsRequest,)),
+                MockEffect(
+                    output_type=InteractiveProcessResult,
+                    input_types=(InteractiveProcess,),
+                    mock=lambda ip: _mock_run(rule_runner, ip),
+                ),
+            ],
+            union_membership=union_membership,
         )
-        assert os.path.isfile(expected_dist_path)
-        with open(expected_dist_path, "rb") as fp:
-            assert fp.read() == b"BAR"
+
+        # Messages
+        stderr = stdio_reader.get_stderr()
+        for present in err_present:
+            assert present in stderr
+        for absent in err_absent:
+            assert absent not in stderr
+
+
+def _give_an_environment(enr: EnvironmentNameRequest) -> EnvironmentTarget:
+    if enr.raw_value.startswith("l"):
+        return EnvironmentTarget(LocalEnvironmentTarget({}, Address("local", target_name="local")))
+    elif enr.raw_value.startswith("r"):
+        return EnvironmentTarget(
+            RemoteEnvironmentTarget({}, Address("remote", target_name="remote"))
+        )
+    else:
+        raise Exception()

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -18,6 +18,7 @@ from pants.core.goals.export import (
     export,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
 from pants.engine.addresses import Address
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
@@ -114,6 +115,11 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                     output_type=Digest,
                     input_types=(MergeDigests,),
                     mock=lambda md: rule_runner.request(Digest, [md]),
+                ),
+                MockGet(
+                    output_type=EnvironmentTarget,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda enr: rule_runner.request(EnvironmentTarget, [enr]),
                 ),
                 MockGet(
                     output_type=Digest,

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -102,7 +102,7 @@ class PackageSubsystem(GoalSubsystem):
 
 class Package(Goal):
     subsystem_cls = PackageSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
+    environment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
 
 class AllPackageableTargets(Targets):

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -64,6 +64,7 @@ class ReplSubsystem(GoalSubsystem):
 
 class Repl(Goal):
     subsystem_cls = ReplSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @frozen_after_init
@@ -102,6 +103,9 @@ async def run_repl(
     union_membership: UnionMembership,
     complete_env: CompleteEnvironmentVars,
 ) -> Repl:
+
+    # TODO: Warn if request is for non-local environment file
+
     # TODO: When we support multiple languages, detect the default repl to use based
     #  on the targets.  For now we default to the python repl.
     repl_shell_name = repl_subsystem.shell or "python"

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -7,6 +7,7 @@ from abc import ABC
 from dataclasses import dataclass
 from typing import ClassVar, Iterable, Mapping, Optional, Sequence, Tuple
 
+from pants.core.util_rules.environments import _warn_on_non_local_environments
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.env_vars import CompleteEnvironmentVars
@@ -104,7 +105,7 @@ async def run_repl(
     complete_env: CompleteEnvironmentVars,
 ) -> Repl:
 
-    # TODO: Warn if request is for non-local environment file
+    await _warn_on_non_local_environments(specified_targets, "the `repl` goal")
 
     # TODO: When we support multiple languages, detect the default repl to use based
     #  on the targets.  For now we default to the python repl.

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -12,6 +12,7 @@ from typing import Callable, Iterable, Mapping, NamedTuple, Optional, Tuple, Typ
 
 from pants.base.build_root import BuildRoot
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
+from pants.core.util_rules.environments import _warn_on_non_local_environments
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, Workspace
@@ -230,7 +231,7 @@ async def run(
 ) -> Run:
     field_set, target = await _find_what_to_run("the `run` goal")
 
-    # TODO: Warn if request is for non-local environment file
+    await _warn_on_non_local_environments((target,), "the `run` goal")
 
     request = await (
         Get(RunRequest, RunFieldSet, field_set)

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -150,6 +150,7 @@ class RunSubsystem(GoalSubsystem):
 
 class Run(Goal):
     subsystem_cls = RunSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 class RankedFieldSets(NamedTuple):
@@ -228,6 +229,8 @@ async def run(
     complete_env: CompleteEnvironmentVars,
 ) -> Run:
     field_set, target = await _find_what_to_run("the `run` goal")
+
+    # TODO: Warn if request is for non-local environment file
 
     request = await (
         Get(RunRequest, RunFieldSet, field_set)

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -122,11 +122,7 @@ def single_target_run(
                     input_types=(TargetRootsToFieldSetsRequest,),
                     mock=lambda _: TargetRootsToFieldSets(targets_to_field_sets),
                 ),
-                MockGet(
-                    output_type=EnvironmentTarget,
-                    input_types=(EnvironmentNameRequest,),
-                    mock=lambda enr: rule_runner.request(EnvironmentTarget, [enr]),
-                ),
+                rule_runner.do_not_use_mock(EnvironmentTarget, (EnvironmentNameRequest,)),
                 MockGet(
                     output_type=RunRequest,
                     input_types=(RunFieldSet,),

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -20,6 +20,7 @@ from pants.core.goals.run import (
     run,
 )
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
+from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent, Workspace
 from pants.engine.internals.specs_rules import (
@@ -120,6 +121,11 @@ def single_target_run(
                     output_type=TargetRootsToFieldSets,
                     input_types=(TargetRootsToFieldSetsRequest,),
                     mock=lambda _: TargetRootsToFieldSets(targets_to_field_sets),
+                ),
+                MockGet(
+                    output_type=EnvironmentTarget,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda enr: rule_runner.request(EnvironmentTarget, [enr]),
                 ),
                 MockGet(
                     output_type=RunRequest,

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -392,6 +392,7 @@ class TailorSubsystem(GoalSubsystem):
 
 class TailorGoal(Goal):
     subsystem_cls = TailorSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 def group_by_dir(paths: Iterable[str]) -> dict[str, set[str]]:

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -433,7 +433,7 @@ class TestSubsystem(GoalSubsystem):
 
 class Test(Goal):
     subsystem_cls = TestSubsystem
-    enviroment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
+    environment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
     __test__ = False
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -165,6 +165,7 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
 
 class UpdateBuildFilesGoal(Goal):
     subsystem_cls = UpdateBuildFilesSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule(desc="Update all BUILD files", level=LogLevel.DEBUG)

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -391,7 +391,8 @@ async def _warn_on_non_local_environments(specified_targets: Iterable[Target], s
     sorted_env_names = sorted(env_names, key=lambda en: (en[0], en[1].address.spec))
 
     env_names_and_targets = [
-        (i[0], tuple(j[1] for j in i[1])) for i in groupby(sorted_env_names, lambda x: x[0])
+        (env_name, tuple(target for _, target in group))
+        for env_name, group in groupby(sorted_env_names, lambda x: x[0])
     ]
 
     env_tgts = await MultiGet(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -614,8 +614,8 @@ def run_rule_with_mocks(
         if len(mock_gets) != len(task_rule.input_gets):
             raise ValueError(
                 f"Rule expected to receive Get providers for:\n"
-                f"{pformat(task_rule.input_gets)}\ngot:\n"
-                f"{pformat(mock_gets)}"
+                f"{pformat(mock_gets)}\ngot:\n"
+                f"{pformat(task_rule.input_gets)}"
             )
 
     res = rule(*(rule_args or ()))

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -23,6 +23,7 @@ from typing import (
     Iterator,
     Mapping,
     Sequence,
+    Type,
     TypeVar,
     cast,
 )
@@ -530,6 +531,14 @@ class RuleRunner:
                 remote_execution=False,
                 remote_execution_extra_platform_properties=[],
             ),
+        )
+
+    def do_not_use_mock(self, output_type: Type, input_types: Iterable[type]) -> MockGet:
+        """Returns a `MockGet` whose behavior is to run the actual rule using this `RuleRunner`"""
+        return MockGet(
+            output_type=output_type,
+            input_types=tuple(input_types),
+            mock=lambda *input_values: self.request(output_type, input_values),
         )
 
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -614,8 +614,8 @@ def run_rule_with_mocks(
         if len(mock_gets) != len(task_rule.input_gets):
             raise ValueError(
                 f"Rule expected to receive Get providers for:\n"
-                f"{pformat(mock_gets)}\ngot:\n"
-                f"{pformat(task_rule.input_gets)}"
+                f"{pformat(task_rule.input_gets)}\ngot:\n"
+                f"{pformat(mock_gets)}"
             )
 
     res = rule(*(rule_args or ()))


### PR DESCRIPTION
For `count_loc`, `filedeps`, `peek`, `tailor`, `update-build-files`, the migration is trivial: no environment-specific processes need to be run.

For `repl`, `run`, and `export`, a `rule_helper` is added that raises a warning if the user is asking to run against a target that specifies a non-local environment. This alerts the user to possibly unpredictable behavior, but for now, does _not_ inherently cause an explicit error. If we get to the point where we can run an `InteractiveProcess` in a foreign environment, we may wish to update this behaviour.

Finally, this resolves a regression from a copy-pasta introduced in a previous PR. Oops.

See #17129.