### PR TITLE
Fix constructing an Action from its action digest in `process_executor`

### DIFF
--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -551,6 +551,11 @@ async fn extract_request_from_action_digest(
     env: command
       .environment_variables
       .iter()
+      .filter(|env| {
+        // Filter out environment variables which will be (re-)set by ExecutionRequest
+        // construction.
+        env.name != process_execution::remote::CACHE_KEY_TARGET_PLATFORM_ENV_VAR_NAME
+      })
       .map(|env| (env.name.clone(), env.value.clone()))
       .collect(),
     working_directory,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -411,10 +411,17 @@ async fn make_request(
         execution_strategy,
         platform,
         args.remote_instance_name.clone(),
+        args.command.cache_key_gen_version.clone(),
       ).await
     }
     (None, None, None, None, Some(buildbarn_url)) => {
-      extract_request_from_buildbarn_url(store, buildbarn_url, execution_strategy, platform).await
+      extract_request_from_buildbarn_url(
+        store,
+        buildbarn_url,
+        execution_strategy,
+        platform,
+        args.command.cache_key_gen_version.clone()
+      ).await
     }
     (None, None, None, None, None) => {
       Err("Must specify either action input digest or action digest or buildbarn URL".to_owned())
@@ -498,6 +505,7 @@ async fn extract_request_from_action_digest(
   execution_strategy: ProcessExecutionStrategy,
   platform: Platform,
   instance_name: Option<String>,
+  cache_key_gen_version: Option<String>,
 ) -> Result<(process_execution::Process, ProcessMetadata), String> {
   let action = store
     .load_file_bytes_with(action_digest, |bytes| Action::decode(bytes))
@@ -587,7 +595,7 @@ async fn extract_request_from_action_digest(
 
   let metadata = ProcessMetadata {
     instance_name,
-    cache_key_gen_version: None,
+    cache_key_gen_version,
   };
 
   Ok((process, metadata))
@@ -598,6 +606,7 @@ async fn extract_request_from_buildbarn_url(
   buildbarn_url: &str,
   execution_strategy: ProcessExecutionStrategy,
   platform: Platform,
+  cache_key_gen_version: Option<String>,
 ) -> Result<(process_execution::Process, ProcessMetadata), String> {
   let url_parts: Vec<&str> = buildbarn_url.trim_end_matches('/').split('/').collect();
   if url_parts.len() < 4 {
@@ -650,6 +659,7 @@ async fn extract_request_from_buildbarn_url(
     execution_strategy,
     platform,
     Some(instance.to_owned()),
+    cache_key_gen_version,
   )
   .await
 }


### PR DESCRIPTION
Fix constructing an Action from an action digest, by filtering out environment variables which are (re-)set by execution request construction (which otherwise cause a failure to set a reserved environment variable name).

Fixes `process_executor` when used with an Action digest produced for the sample server added in #17209. Afterwards, can use:
```
RUST_LOG=debug ./cargo run -p process_executor -- \
  --action-digest=abcd01234.. \
  --action-digest-length=42 \
  --remote-instance-name="" \
  --cache-key-gen-version=7 \
  --server=http://127.0.0.1:50051 \
  --cas-server=http://127.0.0.1:50051
```
...to reproduce a failed process execution. The `--cache-key-gen-version` can be incremented to force cache misses.

[ci skip-build-wheels]