### PR TITLE
Drop requirement for partition key types to have a `description`

### DIFF
--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -68,7 +68,7 @@ async def run_helm_lint(
             description=f"Linting chart: {chart.info.name}",
         ),
     )
-    return LintResult.create(request, process_result)
+    return LintResult.create(request, process_result, description=chart.description)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -95,7 +95,9 @@ async def bandit_lint(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.create(request, result, report=report)
+    return LintResult.create(
+        request, result, report=report, description=interpreter_constraints.description
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -129,7 +129,9 @@ async def run_flake8(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.create(request, result, report=report)
+    return LintResult.create(
+        request, result, report=report, description=interpreter_constraints.description
+    )
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -202,7 +202,7 @@ async def run_pylint(
         ),
     )
     report = await Get(Digest, RemovePrefix(result.output_digest, REPORT_DIR))
-    return LintResult.create(request, result, report=report)
+    return LintResult.create(request, result, report=report, description=request.key.description)
 
 
 def rules():

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -66,6 +66,7 @@ class LintResult(EngineAwareReturnType):
         request: LintRequest.SubPartition,
         process_result: FallibleProcessResult,
         *,
+        description: str | None = None,
         strip_chroot_path: bool = False,
         report: Digest = EMPTY_DIGEST,
     ) -> LintResult:
@@ -77,7 +78,7 @@ class LintResult(EngineAwareReturnType):
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
             linter_name=request.tool_name,
-            partition_description=request.key.description if request.key else None,
+            partition_description=description,
             report=report,
         )
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -508,7 +508,7 @@ def test_default_single_partition_partitioner() -> None:
         MockLinterFieldSet(Address("bowl"), MultipleSourcesField(["bowl"], Address("bowl"))),
     )
     partitions = rule_runner.request(Partitions, [LintKitchenRequest.PartitionRequest(field_sets)])
-    assert partitions == Partitions([(None, field_sets)])  # type: ignore[type-var]
+    assert partitions == Partitions([(None, field_sets)])
 
     rule_runner.set_options(["--kitchen-skip"])
     partitions = rule_runner.request(Partitions, [LintKitchenRequest.PartitionRequest(field_sets)])

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -10,8 +10,6 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Generic, Iterable, TypeVar
 
-from typing_extensions import Protocol
-
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
@@ -39,13 +37,7 @@ class PartitionerType(Enum):
     """Registers a partitioner which returns the inputs as a single partition."""
 
 
-class PartitionKey(Protocol):
-    @property
-    def description(self) -> str:
-        ...
-
-
-PartitionKeyT = TypeVar("PartitionKeyT", bound=PartitionKey)
+PartitionKeyT = TypeVar("PartitionKeyT")
 PartitionElementT = TypeVar("PartitionElementT")
 
 


### PR DESCRIPTION
Requiring all implementations of partition keys to have a `description` property has proven to be a rough edge when implementing the one-partition-per-input strategy. By loosening the restriction we make it easier for plugin authors to use types like `Address` or `str` as their partition keys, and also enable the generation/lookup of partition descriptions within tool-execution rules (instead of forcing it to happen in partitioning rules). Plugins that _want_ to generate a description as part of their partitioning rule are still able to do so - this is demonstrated by a handful of updated plugins in this PR.

This will be convenient when implementing the framework for partitioned testing.