### PR TITLE
Switch the sample server to using `buildbox-worker`

### DIFF
--- a/build-support/reapi-sample-server/Dockerfile
+++ b/build-support/reapi-sample-server/Dockerfile
@@ -1,7 +1,20 @@
 FROM python:3.9.12-slim-buster@sha256:62ed2b347a385102d33f5e82530862359f8dc60464674d78cef844b02d150a50
 
-RUN apt-get update && apt-get install -y git libcurl4-openssl-dev build-essential libssl-dev
+RUN apt-get update && apt-get install -y \
+    build-essential cmake git grpc++ libcurl4-openssl-dev libgmock-dev libgrpc++-dev \
+    libgrpc-dev libgtest-dev libprotobuf-dev libssl-dev pkg-config protobuf-compiler \
+    protobuf-compiler-grpc python3 python3-pip uuid-dev
 
+COPY download_install.sh /tmp/download_install.sh
+RUN chmod +x /tmp/download_install.sh && mkdir -p /out
+
+# Install buildbox components in order.
+RUN /tmp/download_install.sh buildbox-common c5a2ee2b448c636507489fd7b26a29394e3b0edb
+ENV BUILDBOX_COMMON_SOURCE_ROOT=/tmp/buildbox-common
+RUN /tmp/download_install.sh buildbox-worker 9565a93292b04e103d62817153553d62c6f9237e YES
+RUN /tmp/download_install.sh buildbox-run-hosttools 5fc4184de288f19d40a90c6498462f57de49539d YES
+
+# Install buildgrid.
 RUN git clone https://gitlab.com/BuildGrid/buildgrid.git && \
     git -C buildgrid reset --hard 82341d090db55e11257d92ea38f9afd61fa15486
 

--- a/build-support/reapi-sample-server/download_install.sh
+++ b/build-support/reapi-sample-server/download_install.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euox pipefail
+
+# Installs a `buildbox` component given its name and commit sha.
+COMPONENT=$1
+COMMIT_SHA=$2
+TEST_BINARY="${3:-}"
+
+git clone --filter=tree:0 "https://gitlab.com/BuildGrid/buildbox/${COMPONENT}.git" /tmp/${COMPONENT}
+cd /tmp/${COMPONENT}
+git checkout "${COMMIT_SHA}"
+cmake -B /tmp/${COMPONENT}/build /tmp/${COMPONENT} -DBUILD_TESTING=OFF && \
+make -C /tmp/${COMPONENT}/build install
+make -C /tmp/${COMPONENT}/build install DESTDIR=/out 
+ if [[ -n "${TEST_BINARY}" ]]; then
+     sh -c "${COMPONENT} --help &> /dev/null"
+ fi

--- a/build-support/reapi-sample-server/entrypoint.sh
+++ b/build-support/reapi-sample-server/entrypoint.sh
@@ -4,4 +4,12 @@ set -xeuo pipefail
 
 bgd server start -vvv buildgrid/data/config/default.yml &
 
-bgd bot -vvv --remote http://localhost:50051 --remote-cas http://localhost:50051 host-tools
+# Allow the server to start before starting a worker.
+sleep 2
+
+buildbox-worker \
+  --buildbox-run=buildbox-run-hosttools \
+  --bots-remote=http://localhost:50051 \
+  --cas-remote=http://localhost:50051 \
+  --request-timeout=30 \
+  --runner-arg=--disable-localcas my_bot


### PR DESCRIPTION
The "Example/proof-of-concept" buildgrid worker has [a bug](https://gitlab.com/BuildGrid/buildgrid/-/issues/396) which prevents it from building more complicated inputs. The `buildbox-worker` is better tested and more widely used.

Fixes #17230.