### PR TITLE
Rename `SubPartition` to `Batch` in partitioning types.

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -34,7 +34,7 @@ In order to support targetless formatters, `fmt` needs to know which _files_ you
 Therefore the plugin API for `fmt` has forked into 2 rules:
 
 1. A rule taking `<RequestType>.PartitionRequest` and returning a `Partitions` object. This is sometimes referred to as the "partitioner" rule.
-2. A rule taking `<RequestType>.SubPartition` and returning a `FmtResult`. This is sometimes referred to as the "runner" rule.
+2. A rule taking `<RequestType>.Batch` and returning a `FmtResult`. This is sometimes referred to as the "runner" rule.
 
 This way `fmt` can serialize tool runs that operate on the same file(s) while parallelizing tool runs
 that don't overlap.
@@ -50,7 +50,7 @@ The partitioner rule gives you an opportunity to perform expensive `Get`s once f
 to partition the inputs based on metadata to simplify your runner, and to have a place for easily
 skipping your tool if requested.
 
-The runner rule will mostly remain unchanged, aside from the request type (`<RequestType>.SubPartition`),
+The runner rule will mostly remain unchanged, aside from the request type (`<RequestType>.Batch`),
 which now has a `.files` property.
 
 If you don't require any `Get`s or metadata for your tool in your partitioner rule,
@@ -65,7 +65,7 @@ Lint:
 Lint plugins are almost identical to format plugins, except in 2 ways:
 
 1. Your partitioner rule still returns a `Partitions` object, but the element type can be anything.
-2. `<RequestType>.SubPartition` has a `.elements` field instead of `.files`.
+2. `<RequestType>.Batch` has a `.elements` field instead of `.files`.
 
 -----
 

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-fmt-goal.md
@@ -101,11 +101,11 @@ class ShfmtRequest(FmtTargetsRequest):
 
 # 3. Create `fmt` rules
 
-You will need a rule for `fmt` which takes the `FmtTargetsRequest.SubPartition` from step 3  (e.g. `ShfmtRequest`) as a parameter and returns a `FmtResult`.
+You will need a rule for `fmt` which takes the `FmtTargetsRequest.Batch` from step 3  (e.g. `ShfmtRequest`) as a parameter and returns a `FmtResult`.
 
 ```python
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
-async def shfmt_fmt(request: ShfmtRequest.SubPartition, shfmt: Shfmt, platform: Platform) -> FmtResult:
+async def shfmt_fmt(request: ShfmtRequest.Batch, shfmt: Shfmt, platform: Platform) -> FmtResult:
     download_shfmt_get = Get(
         DownloadedExternalTool,
         ExternalToolRequest,
@@ -152,7 +152,7 @@ async def shfmt_fmt(request: ShfmtRequest.SubPartition, shfmt: Shfmt, platform: 
     return await FmtResult.create(request, result, output_snapshot)
 ```
 
-The `FmtRequest.SubPartition` has `.snapshot`, which stores the list of files and the `Digest` for each source file.
+The `FmtRequest.Batch` has `.snapshot`, which stores the list of files and the `Digest` for each source file.
 
 If you used `ExternalTool` in step 1, you will use `Get(DownloadedExternalTool, ExternalToolRequest)` to ensure that the tool is fetched.
 

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-lint-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-lint-goal.md
@@ -100,8 +100,8 @@ class ShellcheckRequest(LintTargetsRequest):
 
 # 3. Create a rule for your linter logic
 
-Your rule should take as a parameter `ShellcheckRequest.SubPartition` and the
-`Subsystem` (or `ExternalTool`) from step 1 (a `SubPartition` is an object containing a subset of all
+Your rule should take as a parameter `ShellcheckRequest.Batch` and the
+`Subsystem` (or `ExternalTool`) from step 1 (a `Batch` is an object containing a subset of all
 the matched field sets for your tool). It should return a `LintResult`:
 
 ```python
@@ -117,7 +117,7 @@ async def run_shellcheck(
     return LintResult.create(...)
 ```
 
-The `ShellcheckRequest.SubPartition` instance has a property called `.elements`, which in this case,
+The `ShellcheckRequest.Batch` instance has a property called `.elements`, which in this case,
 stores a collection of the `FieldSet`s defined in step 2. Each `FieldSet` corresponds to a single target.
 Pants will have already validated that there is at least one valid `FieldSet`.
 
@@ -158,7 +158,7 @@ from pants.util.strutil import pluralize
 
 @rule
 async def run_shellcheck(
-    request: ShellcheckRequest.SubPartition, shellcheck: Shellcheck, platform: Platform
+    request: ShellcheckRequest.Batch, shellcheck: Shellcheck, platform: Platform
 ) -> LintResult:
     download_shellcheck_request = Get(
         DownloadedExternalTool,

--- a/src/python/pants/backend/build_files/fmt/black/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/black/integration_test.py
@@ -61,7 +61,7 @@ def run_black(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
+            BlackRequest.Batch("", snapshot.files, partition_key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/black/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/black/integration_test.py
@@ -27,7 +27,7 @@ def rule_runner() -> RuleRunner:
             *black_fmt_rules(),
             *black_subsystem_rules(),
             *config_files.rules(),
-            QueryRule(FmtResult, (BlackRequest.SubPartition,)),
+            QueryRule(FmtResult, (BlackRequest.Batch,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -61,7 +61,7 @@ def run_black(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
+            BlackRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/black/register.py
+++ b/src/python/pants/backend/build_files/fmt/black/register.py
@@ -15,7 +15,7 @@ class BlackRequest(FmtBuildFilesRequest):
 
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
-async def black_fmt(request: BlackRequest.SubPartition, black: Black) -> FmtResult:
+async def black_fmt(request: BlackRequest.Batch, black: Black) -> FmtResult:
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
     return await _run_black(request, black, black_ics)
 

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules.py
@@ -20,7 +20,7 @@ class BuildifierRequest(FmtBuildFilesRequest):
 
 @rule(desc="Format with Buildifier", level=LogLevel.DEBUG)
 async def buildfier_fmt(
-    request: BuildifierRequest.SubPartition, buildifier: Buildifier, platform: Platform
+    request: BuildifierRequest.Batch, buildifier: Buildifier, platform: Platform
 ) -> FmtResult:
     buildifier_tool = await Get(
         DownloadedExternalTool, ExternalToolRequest, buildifier.get_request(platform)

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
@@ -29,7 +29,7 @@ def rule_runner() -> RuleRunner:
             *buildifier_rules(),
             *external_tool.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [BuildifierRequest.SubPartition]),
+            QueryRule(FmtResult, [BuildifierRequest.Batch]),
         ],
         # NB: Objects are easier to test with
         objects={"materials": Materials},
@@ -62,7 +62,7 @@ def run_buildifier(rule_runner: RuleRunner) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BuildifierRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
+            BuildifierRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/rules_integration_test.py
@@ -62,7 +62,7 @@ def run_buildifier(rule_runner: RuleRunner) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BuildifierRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
+            BuildifierRequest.Batch("", snapshot.files, partition_key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
@@ -42,7 +42,7 @@ def run_yapf(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) ->
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
+            YapfRequest.Batch("", snapshot.files, partition_key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/integration_test.py
@@ -27,7 +27,7 @@ def rule_runner() -> RuleRunner:
             *yapf_fmt_rules(),
             *yapf_subsystem_rules(),
             *config_files.rules(),
-            QueryRule(FmtResult, (YapfRequest.SubPartition,)),
+            QueryRule(FmtResult, (YapfRequest.Batch,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -42,7 +42,7 @@ def run_yapf(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) ->
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest.SubPartition("", snapshot.files, key=None, snapshot=snapshot),
+            YapfRequest.Batch("", snapshot.files, key=None, snapshot=snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/build_files/fmt/yapf/register.py
+++ b/src/python/pants/backend/build_files/fmt/yapf/register.py
@@ -15,7 +15,7 @@ class YapfRequest(FmtBuildFilesRequest):
 
 
 @rule(desc="Format with Yapf", level=LogLevel.DEBUG)
-async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
+async def yapf_fmt(request: YapfRequest.Batch, yapf: Yapf) -> FmtResult:
     yapf_ics = await Yapf._find_python_interpreter_constraints_from_lockfile(yapf)
     return await _run_yapf(request, yapf, yapf_ics)
 

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -38,9 +38,7 @@ class ClangFormatRequest(FmtTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG)
-async def clangformat_fmt(
-    request: ClangFormatRequest.SubPartition, clangformat: ClangFormat
-) -> FmtResult:
+async def clangformat_fmt(request: ClangFormatRequest.Batch, clangformat: ClangFormat) -> FmtResult:
 
     # Look for any/all of the clang-format configuration files (recurse sub-dirs)
     config_files_get = Get(

--- a/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
@@ -99,7 +99,10 @@ def run_clangformat(
         FmtResult,
         [
             ClangFormatRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (ClangFormatRequest.SubPartition,)),
+            QueryRule(FmtResult, (ClangFormatRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[CCSourcesGeneratorTarget],
@@ -98,7 +98,7 @@ def run_clangformat(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ClangFormatRequest.SubPartition(
+            ClangFormatRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -62,7 +62,7 @@ async def partition_buf(
 
 @rule(desc="Format with buf format", level=LogLevel.DEBUG)
 async def run_buf_format(
-    request: BufFormatRequest.SubPartition, buf: BufSubsystem, platform: Platform
+    request: BufFormatRequest.Batch, buf: BufSubsystem, platform: Platform
 ) -> FmtResult:
     diff_binary = await Get(DiffBinary, DiffBinaryRequest())
     download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -28,7 +28,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [BufFormatRequest.SubPartition]),
+            QueryRule(FmtResult, [BufFormatRequest.Batch]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
         ],
         target_types=[ProtobufSourcesGeneratorTarget],
@@ -62,7 +62,7 @@ def run_buf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BufFormatRequest.SubPartition(
+            BufFormatRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -63,7 +63,10 @@ def run_buf(
         FmtResult,
         [
             BufFormatRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -53,7 +53,7 @@ async def partition_buf(
 
 @rule(desc="Lint with buf lint", level=LogLevel.DEBUG)
 async def run_buf(
-    request: BufLintRequest.SubPartition[Any, BufFieldSet], buf: BufSubsystem, platform: Platform
+    request: BufLintRequest.Batch[Any, BufFieldSet], buf: BufSubsystem, platform: Platform
 ) -> LintResult:
     transitive_targets = await Get(
         TransitiveTargets,

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
@@ -60,10 +60,10 @@ def run_buf(
         [BufLintRequest.PartitionRequest(tuple(BufFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BufLintRequest.Batch("", Batch, key)],
+            [BufLintRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *stripped_source_files.rules(),
             *target_types_rules(),
             QueryRule(Partitions, [BufLintRequest.PartitionRequest]),
-            QueryRule(LintResult, [BufLintRequest.SubPartition]),
+            QueryRule(LintResult, [BufLintRequest.Batch]),
         ],
         target_types=[ProtobufSourcesGeneratorTarget],
     )
@@ -60,10 +60,10 @@ def run_buf(
         [BufLintRequest.PartitionRequest(tuple(BufFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BufLintRequest.SubPartition("", subpartition, key)],
+            [BufLintRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/docker/lint/hadolint/rules.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules.py
@@ -52,7 +52,7 @@ def generate_argv(
 
 @rule(desc="Lint with Hadolint", level=LogLevel.DEBUG)
 async def run_hadolint(
-    request: HadolintRequest.SubPartition[Any, HadolintFieldSet],
+    request: HadolintRequest.Batch[Any, HadolintFieldSet],
     hadolint: Hadolint,
     platform: Platform,
 ) -> LintResult:

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -53,10 +53,10 @@ def run_hadolint(
         [HadolintRequest.PartitionRequest(tuple(HadolintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HadolintRequest.Batch("", Batch, key)],
+            [HadolintRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             package.find_all_packageable_targets,
             *source_files.rules(),
             QueryRule(Partitions, [HadolintRequest.PartitionRequest]),
-            QueryRule(LintResult, [HadolintRequest.SubPartition]),
+            QueryRule(LintResult, [HadolintRequest.Batch]),
         ],
         target_types=[DockerImageTarget],
     )
@@ -53,10 +53,10 @@ def run_hadolint(
         [HadolintRequest.PartitionRequest(tuple(HadolintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HadolintRequest.SubPartition("", subpartition, key)],
+            [HadolintRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -39,7 +39,7 @@ class GofmtRequest(FmtTargetsRequest):
 
 
 @rule(desc="Format with gofmt")
-async def gofmt_fmt(request: GofmtRequest.SubPartition, goroot: GoRoot) -> FmtResult:
+async def gofmt_fmt(request: GofmtRequest.Batch, goroot: GoRoot) -> FmtResult:
     argv = (
         os.path.join(goroot.path, "bin/gofmt"),
         "-w",

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *link.rules(),
             *assembly.rules(),
-            QueryRule(FmtResult, (GofmtRequest.SubPartition,)),
+            QueryRule(FmtResult, (GofmtRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
@@ -120,7 +120,7 @@ def run_gofmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GofmtRequest.SubPartition(
+            GofmtRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -121,7 +121,10 @@ def run_gofmt(
         FmtResult,
         [
             GofmtRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -56,7 +56,7 @@ class GolangciLintRequest(LintTargetsRequest):
 
 @rule(desc="Lint with golangci-lint", level=LogLevel.DEBUG)
 async def run_golangci_lint(
-    request: GolangciLintRequest.SubPartition[Any, GolangciLintFieldSet],
+    request: GolangciLintRequest.Batch[Any, GolangciLintFieldSet],
     golangci_lint: GolangciLint,
     goroot: GoRoot,
     bash: BashBinary,

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -108,8 +108,8 @@ def run_golangci_lint(
         ],
     )
     results = []
-    for key, Batch in partition.items():
-        result = rule_runner.request(LintResult, [GolangciLintRequest.Batch("", Batch, key)])
+    for key, batch in partition.items():
+        result = rule_runner.request(LintResult, [GolangciLintRequest.Batch("", batch, key)])
         results.append(result)
     return tuple(results)
 

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -53,7 +53,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             *third_party_pkg.rules(),
             QueryRule(Partitions, [GolangciLintRequest.PartitionRequest]),
-            QueryRule(LintResult, [GolangciLintRequest.SubPartition]),
+            QueryRule(LintResult, [GolangciLintRequest.Batch]),
             SubsystemRule(GolangciLint),
         ],
     )
@@ -108,10 +108,8 @@ def run_golangci_lint(
         ],
     )
     results = []
-    for key, subpartition in partition.items():
-        result = rule_runner.request(
-            LintResult, [GolangciLintRequest.SubPartition("", subpartition, key)]
-        )
+    for key, Batch in partition.items():
+        result = rule_runner.request(LintResult, [GolangciLintRequest.Batch("", Batch, key)])
         results.append(result)
     return tuple(results)
 

--- a/src/python/pants/backend/go/lint/vet/rules.py
+++ b/src/python/pants/backend/go/lint/vet/rules.py
@@ -47,7 +47,7 @@ class GoVetRequest(LintTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG)
-async def run_go_vet(request: GoVetRequest.SubPartition[Any, GoVetFieldSet]) -> LintResult:
+async def run_go_vet(request: GoVetRequest.Batch[Any, GoVetFieldSet]) -> LintResult:
     source_files = await Get(
         SourceFiles,
         SourceFilesRequest(field_set.sources for field_set in request.elements),

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -100,10 +100,10 @@ def run_go_vet(
         [GoVetRequest.PartitionRequest(tuple(GoVetFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [GoVetRequest.Batch("", Batch, key)],
+            [GoVetRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             *build_pkg.rules(),
             *assembly.rules(),
             QueryRule(Partitions, [GoVetRequest.PartitionRequest]),
-            QueryRule(LintResult, [GoVetRequest.SubPartition]),
+            QueryRule(LintResult, [GoVetRequest.Batch]),
             SubsystemRule(GoVetSubsystem),
         ],
     )
@@ -100,10 +100,10 @@ def run_go_vet(
         [GoVetRequest.PartitionRequest(tuple(GoVetFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [GoVetRequest.SubPartition("", subpartition, key)],
+            [GoVetRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -47,7 +47,7 @@ async def partition_helm_lint(
 
 @rule(desc="Lint Helm charts", level=LogLevel.DEBUG)
 async def run_helm_lint(
-    request: HelmLintRequest.SubPartition[HelmChart, HelmLintFieldSet],
+    request: HelmLintRequest.Batch[HelmChart, HelmLintFieldSet],
     helm_subsystem: HelmSubsystem,
 ) -> LintResult:
     assert len(request.elements) == 1

--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -52,7 +52,7 @@ async def run_helm_lint(
 ) -> LintResult:
     assert len(request.elements) == 1
     field_set = request.elements[0]
-    chart = request.key
+    chart = request.partition_key
 
     argv = ["lint", chart.name]
 

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -61,10 +61,10 @@ def run_helm_lint(
         [HelmLintRequest.PartitionRequest(tuple(HelmLintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HelmLintRequest.Batch("", Batch, key)],
+            [HelmLintRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/helm/goals/lint_test.py
+++ b/src/python/pants/backend/helm/goals/lint_test.py
@@ -43,7 +43,7 @@ def rule_runner() -> RuleRunner:
             *target_types_rules(),
             SubsystemRule(HelmSubsystem),
             QueryRule(Partitions, [HelmLintRequest.PartitionRequest]),
-            QueryRule(LintResult, [HelmLintRequest.SubPartition]),
+            QueryRule(LintResult, [HelmLintRequest.Batch]),
         ],
     )
     return rule_runner
@@ -61,10 +61,10 @@ def run_helm_lint(
         [HelmLintRequest.PartitionRequest(tuple(HelmLintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [HelmLintRequest.SubPartition("", subpartition, key)],
+            [HelmLintRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -47,7 +47,7 @@ class GoogleJavaFormatToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
 
 @rule(desc="Format with Google Java Format", level=LogLevel.DEBUG)
 async def google_java_format_fmt(
-    request: GoogleJavaFormatRequest.SubPartition,
+    request: GoogleJavaFormatRequest.Batch,
     tool: GoogleJavaFormatSubsystem,
     jdk: InternalJdk,
 ) -> FmtResult:

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -46,7 +46,7 @@ def rule_runner() -> RuleRunner:
             *target_types_rules(),
             *gjf_fmt_rules.rules(),
             *skip_field.rules(),
-            QueryRule(FmtResult, (GoogleJavaFormatRequest.SubPartition,)),
+            QueryRule(FmtResult, (GoogleJavaFormatRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[JavaSourceTarget, JavaSourcesGeneratorTarget],
@@ -94,7 +94,7 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            GoogleJavaFormatRequest.SubPartition(
+            GoogleJavaFormatRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules_integration_test.py
@@ -95,7 +95,10 @@ def run_google_java_format(rule_runner: RuleRunner, targets: list[Target]) -> Fm
         FmtResult,
         [
             GoogleJavaFormatRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -38,7 +38,7 @@ class PrettierFmtRequest(FmtTargetsRequest):
 
 
 @rule(level=LogLevel.DEBUG)
-async def prettier_fmt(request: PrettierFmtRequest.SubPartition, prettier: Prettier) -> FmtResult:
+async def prettier_fmt(request: PrettierFmtRequest.Batch, prettier: Prettier) -> FmtResult:
 
     # Look for any/all of the Prettier configuration files
     config_files = await Get(

--- a/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
@@ -103,7 +103,10 @@ def run_prettier(
         FmtResult,
         [
             PrettierFmtRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules_integration_test.py
@@ -32,7 +32,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (PrettierFmtRequest.SubPartition,)),
+            QueryRule(FmtResult, (PrettierFmtRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[JSSourcesGeneratorTarget],
@@ -102,7 +102,7 @@ def run_prettier(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            PrettierFmtRequest.SubPartition(
+            PrettierFmtRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -47,7 +47,7 @@ class KtlintToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
 
 @rule(desc="Format with Ktlint", level=LogLevel.DEBUG)
 async def ktlint_fmt(
-    request: KtlintRequest.SubPartition, tool: KtlintSubsystem, jdk: InternalJdk
+    request: KtlintRequest.Batch, tool: KtlintSubsystem, jdk: InternalJdk
 ) -> FmtResult:
     lockfile_request = await Get(GenerateJvmLockfileFromTool, KtlintToolLockfileSentinel())
     tool_classpath = await Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request))

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
@@ -94,7 +94,10 @@ def run_ktlint(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
         FmtResult,
         [
             KtlintRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules_integration_test.py
@@ -45,7 +45,7 @@ def rule_runner() -> RuleRunner:
             *skip_field.rules(),
             *system_binaries.rules(),
             *source_files.rules(),
-            QueryRule(FmtResult, (KtlintRequest.SubPartition,)),
+            QueryRule(FmtResult, (KtlintRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[KotlinSourceTarget, KotlinSourcesGeneratorTarget],
@@ -93,7 +93,7 @@ def run_ktlint(rule_runner: RuleRunner, targets: list[Target]) -> FmtResult:
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            KtlintRequest.SubPartition(
+            KtlintRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/openapi/lint/spectral/rules.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules.py
@@ -43,7 +43,7 @@ class SpectralRequest(LintTargetsRequest):
 
 @rule(desc="Lint with Spectral", level=LogLevel.DEBUG)
 async def run_spectral(
-    request: SpectralRequest.SubPartition[Any, SpectralFieldSet],
+    request: SpectralRequest.Batch[Any, SpectralFieldSet],
     spectral: SpectralSubsystem,
     platform: Platform,
 ) -> LintResult:

--- a/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
@@ -68,10 +68,10 @@ def run_spectral(
         [SpectralRequest.PartitionRequest(tuple(SpectralFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [SpectralRequest.Batch("", Batch, key)],
+            [SpectralRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules_integration_test.py
@@ -33,7 +33,7 @@ def rule_runner() -> RuleRunner:
             *stripped_source_files.rules(),
             *target_types_rules(),
             QueryRule(Partitions, [SpectralRequest.PartitionRequest]),
-            QueryRule(LintResult, [SpectralRequest.SubPartition]),
+            QueryRule(LintResult, [SpectralRequest.Batch]),
         ],
         target_types=[OpenApiDocumentGeneratorTarget, OpenApiSourceGeneratorTarget],
     )
@@ -68,10 +68,10 @@ def run_spectral(
         [SpectralRequest.PartitionRequest(tuple(SpectralFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [SpectralRequest.SubPartition("", subpartition, key)],
+            [SpectralRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -278,7 +278,7 @@ async def partition_inputs(
 
 @rule(desc="Lint with regex patterns", level=LogLevel.DEBUG)
 async def lint_with_regex_patterns(
-    request: RegexLintRequest.SubPartition[Any, str], regex_lint_subsystem: RegexLintSubsystem
+    request: RegexLintRequest.Batch[Any, str], regex_lint_subsystem: RegexLintSubsystem
 ) -> LintResult:
     multi_matcher = regex_lint_subsystem.get_multi_matcher()
     assert multi_matcher is not None

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -36,7 +36,7 @@ class AddTrailingCommaRequest(FmtTargetsRequest):
 
 @rule(desc="Format with add-trailing-comma", level=LogLevel.DEBUG)
 async def add_trailing_comma_fmt(
-    request: AddTrailingCommaRequest.SubPartition, add_trailing_comma: AddTrailingComma
+    request: AddTrailingCommaRequest.Batch, add_trailing_comma: AddTrailingComma
 ) -> FmtResult:
     add_trailing_comma_pex = await Get(VenvPex, PexRequest, add_trailing_comma.to_pex_request())
 

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
@@ -68,7 +68,10 @@ def run_add_trailing_comma(
         FmtResult,
         [
             AddTrailingCommaRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
@@ -36,7 +36,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (AddTrailingCommaRequest.SubPartition,)),
+            QueryRule(FmtResult, (AddTrailingCommaRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -67,7 +67,7 @@ def run_add_trailing_comma(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            AddTrailingCommaRequest.SubPartition(
+            AddTrailingCommaRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -35,7 +35,7 @@ class AutoflakeRequest(FixTargetsRequest):
 
 
 @rule(desc="Fix with Autoflake", level=LogLevel.DEBUG)
-async def autoflake_fix(request: AutoflakeRequest.SubPartition, autoflake: Autoflake) -> FixResult:
+async def autoflake_fix(request: AutoflakeRequest.Batch, autoflake: Autoflake) -> FixResult:
     autoflake_pex = await Get(VenvPex, PexRequest, autoflake.to_pex_request())
 
     result = await Get(

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -64,7 +64,10 @@ def run_autoflake(
         FixResult,
         [
             AutoflakeRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FixResult, (AutoflakeRequest.SubPartition,)),
+            QueryRule(FixResult, (AutoflakeRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -63,7 +63,7 @@ def run_autoflake(
     fix_result = rule_runner.request(
         FixResult,
         [
-            AutoflakeRequest.SubPartition(
+            AutoflakeRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -58,7 +58,7 @@ async def partition_bandit(
 async def bandit_lint(
     request: BanditRequest.Batch[InterpreterConstraints, BanditFieldSet], bandit: Bandit
 ) -> LintResult:
-    interpreter_constraints = request.key
+    interpreter_constraints = request.partition_key
     bandit_pex_get = Get(
         VenvPex,
         PexRequest,

--- a/src/python/pants/backend/python/lint/bandit/rules.py
+++ b/src/python/pants/backend/python/lint/bandit/rules.py
@@ -56,7 +56,7 @@ async def partition_bandit(
 
 @rule(desc="Lint with Bandit", level=LogLevel.DEBUG)
 async def bandit_lint(
-    request: BanditRequest.SubPartition[InterpreterConstraints, BanditFieldSet], bandit: Bandit
+    request: BanditRequest.Batch[InterpreterConstraints, BanditFieldSet], bandit: Bandit
 ) -> LintResult:
     interpreter_constraints = request.key
     bandit_pex_get = Get(

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -64,10 +64,10 @@ def run_bandit(
         [BanditRequest.PartitionRequest(tuple(BanditFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BanditRequest.Batch("", Batch, key)],
+            [BanditRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -39,7 +39,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *target_types_rules.rules(),
             QueryRule(Partitions, [BanditRequest.PartitionRequest]),
-            QueryRule(LintResult, [BanditRequest.SubPartition]),
+            QueryRule(LintResult, [BanditRequest.Batch]),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -64,10 +64,10 @@ def run_bandit(
         [BanditRequest.PartitionRequest(tuple(BanditFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [BanditRequest.SubPartition("", subpartition, key)],
+            [BanditRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -26,7 +26,7 @@ class BlackRequest(FmtTargetsRequest):
 
 @rule_helper
 async def _run_black(
-    request: FmtRequest.SubPartition,
+    request: FmtRequest.Batch,
     black: Black,
     interpreter_constraints: InterpreterConstraints,
 ) -> FmtResult:
@@ -110,7 +110,7 @@ async def partition_black(
 
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
-async def black_fmt(request: BlackRequest.SubPartition, black: Black) -> FmtResult:
+async def black_fmt(request: BlackRequest.Batch, black: Black) -> FmtResult:
     return await _run_black(request, black, cast(InterpreterConstraints, request.key))
 
 

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -111,7 +111,7 @@ async def partition_black(
 
 @rule(desc="Format with Black", level=LogLevel.DEBUG)
 async def black_fmt(request: BlackRequest.Batch, black: Black) -> FmtResult:
-    return await _run_black(request, black, cast(InterpreterConstraints, request.key))
+    return await _run_black(request, black, cast(InterpreterConstraints, request.partition_key))
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -95,7 +95,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.Batch("", partition, key=key, snapshot=input_sources.snapshot),
+            BlackRequest.Batch("", partition, partition_key=key, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/black/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/black/rules_integration_test.py
@@ -39,7 +39,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *target_types_rules.rules(),
             QueryRule(Partitions, (BlackRequest.PartitionRequest,)),
-            QueryRule(FmtResult, (BlackRequest.SubPartition,)),
+            QueryRule(FmtResult, (BlackRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -95,7 +95,7 @@ def run_black(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            BlackRequest.SubPartition("", partition, key=key, snapshot=input_sources.snapshot),
+            BlackRequest.Batch("", partition, key=key, snapshot=input_sources.snapshot),
         ],
     )
     return fmt_result

--- a/src/python/pants/backend/python/lint/docformatter/rules.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules.py
@@ -36,7 +36,7 @@ class DocformatterRequest(FmtTargetsRequest):
 
 @rule(desc="Format with docformatter", level=LogLevel.DEBUG)
 async def docformatter_fmt(
-    request: DocformatterRequest.SubPartition, docformatter: Docformatter
+    request: DocformatterRequest.Batch, docformatter: Docformatter
 ) -> FmtResult:
     docformatter_pex = await Get(VenvPex, PexRequest, docformatter.to_pex_request())
     result = await Get(

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *docformatter_subsystem_rules(),
             *source_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (DocformatterRequest.SubPartition,)),
+            QueryRule(FmtResult, (DocformatterRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -59,7 +59,7 @@ def run_docformatter(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            DocformatterRequest.SubPartition(
+            DocformatterRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/docformatter/rules_integration_test.py
@@ -60,7 +60,10 @@ def run_docformatter(
         FmtResult,
         [
             DocformatterRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -71,7 +71,7 @@ async def run_flake8(
     flake8: Flake8,
     first_party_plugins: Flake8FirstPartyPlugins,
 ) -> LintResult:
-    interpreter_constraints = request.key
+    interpreter_constraints = request.partition_key
     flake8_pex_get = Get(
         VenvPex,
         PexRequest,

--- a/src/python/pants/backend/python/lint/flake8/rules.py
+++ b/src/python/pants/backend/python/lint/flake8/rules.py
@@ -67,7 +67,7 @@ async def partition_flake8(
 
 @rule(desc="Lint with Flake8", level=LogLevel.DEBUG)
 async def run_flake8(
-    request: Flake8Request.SubPartition[InterpreterConstraints, Flake8FieldSet],
+    request: Flake8Request.Batch[InterpreterConstraints, Flake8FieldSet],
     flake8: Flake8,
     first_party_plugins: Flake8FirstPartyPlugins,
 ) -> LintResult:

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *target_types_rules.rules(),
             QueryRule(Partitions, [Flake8Request.PartitionRequest]),
-            QueryRule(LintResult, [Flake8Request.SubPartition]),
+            QueryRule(LintResult, [Flake8Request.Batch]),
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
@@ -60,10 +60,10 @@ def run_flake8(
         [Flake8Request.PartitionRequest(tuple(Flake8FieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [Flake8Request.SubPartition("", subpartition, key)],
+            [Flake8Request.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -60,10 +60,10 @@ def run_flake8(
         [Flake8Request.PartitionRequest(tuple(Flake8FieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [Flake8Request.Batch("", Batch, key)],
+            [Flake8Request.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -62,7 +62,7 @@ def generate_argv(
 
 
 @rule(desc="Format with isort", level=LogLevel.DEBUG)
-async def isort_fmt(request: IsortRequest.SubPartition, isort: Isort) -> FmtResult:
+async def isort_fmt(request: IsortRequest.Batch, isort: Isort) -> FmtResult:
     isort_pex_get = Get(VenvPex, PexRequest, isort.to_pex_request())
     config_files_get = Get(
         ConfigFiles, ConfigFilesRequest, isort.config_request(request.snapshot.dirs)

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -68,7 +68,10 @@ def run_isort(
         FmtResult,
         [
             IsortRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (IsortRequest.SubPartition,)),
+            QueryRule(FmtResult, (IsortRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -67,7 +67,7 @@ def run_isort(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            IsortRequest.SubPartition(
+            IsortRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -111,7 +111,7 @@ async def partition_pylint(
 
 @rule(desc="Lint using Pylint", level=LogLevel.DEBUG)
 async def run_pylint(
-    request: PylintRequest.SubPartition[PartitionKey, PylintFieldSet],
+    request: PylintRequest.Batch[PartitionKey, PylintFieldSet],
     pylint: Pylint,
     first_party_plugins: PylintFirstPartyPlugins,
 ) -> LintResult:

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -75,10 +75,10 @@ def run_pylint(
         [PylintRequest.PartitionRequest(tuple(PylintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [PylintRequest.Batch("", Batch, key)],
+            [PylintRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -41,7 +41,7 @@ def rule_runner() -> RuleRunner:
             *config_files.rules(),
             *target_types_rules.rules(),
             QueryRule(Partitions, [PylintRequest.PartitionRequest]),
-            QueryRule(LintResult, [PylintRequest.SubPartition]),
+            QueryRule(LintResult, [PylintRequest.Batch]),
         ],
         target_types=[PythonSourceTarget, PythonSourcesGeneratorTarget, PythonRequirementTarget],
     )
@@ -75,10 +75,10 @@ def run_pylint(
         [PylintRequest.PartitionRequest(tuple(PylintFieldSet.create(tgt) for tgt in targets))],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [PylintRequest.SubPartition("", subpartition, key)],
+            [PylintRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/python/lint/pyupgrade/rules.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules.py
@@ -36,7 +36,7 @@ class PyUpgradeRequest(FixTargetsRequest):
 
 
 @rule(desc="Fix with pyupgrade", level=LogLevel.DEBUG)
-async def pyupgrade_fix(request: PyUpgradeRequest.SubPartition, pyupgrade: PyUpgrade) -> FixResult:
+async def pyupgrade_fix(request: PyUpgradeRequest.Batch, pyupgrade: PyUpgrade) -> FixResult:
     pyupgrade_pex = await Get(VenvPex, PexRequest, pyupgrade.to_pex_request())
 
     result = await Get(

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FixResult, (PyUpgradeRequest.SubPartition,)),
+            QueryRule(FixResult, (PyUpgradeRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -73,7 +73,7 @@ def run_pyupgrade(
     fix_result = rule_runner.request(
         FixResult,
         [
-            PyUpgradeRequest.SubPartition(
+            PyUpgradeRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -74,7 +74,10 @@ def run_pyupgrade(
         FixResult,
         [
             PyUpgradeRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/python/lint/yapf/rules.py
+++ b/src/python/pants/backend/python/lint/yapf/rules.py
@@ -41,7 +41,7 @@ class YapfRequest(FmtTargetsRequest):
 
 @rule_helper
 async def _run_yapf(
-    request: FmtRequest.SubPartition,
+    request: FmtRequest.Batch,
     yapf: Yapf,
     interpreter_constraints: InterpreterConstraints | None = None,
 ) -> FmtResult:
@@ -77,7 +77,7 @@ async def _run_yapf(
 
 
 @rule(desc="Format with yapf", level=LogLevel.DEBUG)
-async def yapf_fmt(request: YapfRequest.SubPartition, yapf: Yapf) -> FmtResult:
+async def yapf_fmt(request: YapfRequest.Batch, yapf: Yapf) -> FmtResult:
     return await _run_yapf(request, yapf)
 
 

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -31,7 +31,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(FmtResult, (YapfRequest.SubPartition,)),
+            QueryRule(FmtResult, (YapfRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
         target_types=[PythonSourcesGeneratorTarget],
@@ -69,7 +69,7 @@ def run_yapf(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            YapfRequest.SubPartition(
+            YapfRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/yapf/rules_integration_test.py
@@ -70,7 +70,10 @@ def run_yapf(
         FmtResult,
         [
             YapfRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -175,7 +175,7 @@ async def partition_scalafmt(
 async def scalafmt_fmt(
     request: ScalafmtRequest.Batch, jdk: InternalJdk, tool: ScalafmtSubsystem
 ) -> FmtResult:
-    partition_info = cast(PartitionInfo, request.key)
+    partition_info = cast(PartitionInfo, request.partition_key)
     merged_digest = await Get(
         Digest,
         MergeDigests([partition_info.config_snapshot.digest, request.snapshot.digest]),

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -173,7 +173,7 @@ async def partition_scalafmt(
 
 @rule(desc="Format with scalafmt", level=LogLevel.DEBUG)
 async def scalafmt_fmt(
-    request: ScalafmtRequest.SubPartition, jdk: InternalJdk, tool: ScalafmtSubsystem
+    request: ScalafmtRequest.Batch, jdk: InternalJdk, tool: ScalafmtSubsystem
 ) -> FmtResult:
     partition_info = cast(PartitionInfo, request.key)
     merged_digest = await Get(

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -54,7 +54,7 @@ def rule_runner() -> RuleRunner:
             *scalafmt_rules(),
             *skip_field.rules(),
             QueryRule(Partitions, (ScalafmtRequest.PartitionRequest,)),
-            QueryRule(FmtResult, (ScalafmtRequest.SubPartition,)),
+            QueryRule(FmtResult, (ScalafmtRequest.Batch,)),
             QueryRule(Snapshot, (PathGlobs,)),
             QueryRule(ScalafmtConfigFiles, (GatherScalafmtConfigFilesRequest,)),
         ],
@@ -140,7 +140,7 @@ def run_scalafmt(
         rule_runner.request(
             FmtResult,
             [
-                ScalafmtRequest.SubPartition(
+                ScalafmtRequest.Batch(
                     "",
                     partition,
                     key=key,

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -143,7 +143,7 @@ def run_scalafmt(
                 ScalafmtRequest.Batch(
                     "",
                     partition,
-                    key=key,
+                    partition_key=key,
                     snapshot=rule_runner.request(Snapshot, [PathGlobs(partition)]),
                 )
             ],

--- a/src/python/pants/backend/shell/lint/shellcheck/rules.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules.py
@@ -41,7 +41,7 @@ class ShellcheckRequest(LintTargetsRequest):
 
 @rule(desc="Lint with Shellcheck", level=LogLevel.DEBUG)
 async def run_shellcheck(
-    request: ShellcheckRequest.SubPartition[Any, ShellcheckFieldSet],
+    request: ShellcheckRequest.Batch[Any, ShellcheckFieldSet],
     shellcheck: Shellcheck,
     platform: Platform,
 ) -> LintResult:

--- a/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
@@ -55,10 +55,10 @@ def run_shellcheck(
         ],
     )
     results = []
-    for key, Batch in partition.items():
+    for key, batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [ShellcheckRequest.Batch("", Batch, key)],
+            [ShellcheckRequest.Batch("", batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/rules_integration_test.py
@@ -29,7 +29,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *target_types_rules(),
             QueryRule(Partitions, [ShellcheckRequest.PartitionRequest]),
-            QueryRule(LintResult, [ShellcheckRequest.SubPartition]),
+            QueryRule(LintResult, [ShellcheckRequest.Batch]),
         ],
         target_types=[ShellSourcesGeneratorTarget],
     )
@@ -55,10 +55,10 @@ def run_shellcheck(
         ],
     )
     results = []
-    for key, subpartition in partition.items():
+    for key, Batch in partition.items():
         result = rule_runner.request(
             LintResult,
-            [ShellcheckRequest.SubPartition("", subpartition, key)],
+            [ShellcheckRequest.Batch("", Batch, key)],
         )
         results.append(result)
     return tuple(results)

--- a/src/python/pants/backend/shell/lint/shfmt/rules.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules.py
@@ -37,9 +37,7 @@ class ShfmtRequest(FmtTargetsRequest):
 
 
 @rule(desc="Format with shfmt", level=LogLevel.DEBUG)
-async def shfmt_fmt(
-    request: ShfmtRequest.SubPartition, shfmt: Shfmt, platform: Platform
-) -> FmtResult:
+async def shfmt_fmt(request: ShfmtRequest.Batch, shfmt: Shfmt, platform: Platform) -> FmtResult:
     download_shfmt_get = Get(
         DownloadedExternalTool, ExternalToolRequest, shfmt.get_request(platform)
     )

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -88,7 +88,10 @@ def run_shfmt(
         FmtResult,
         [
             ShfmtRequest.Batch(
-                "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
+                "",
+                input_sources.snapshot.files,
+                partition_key=None,
+                snapshot=input_sources.snapshot,
             ),
         ],
     )

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
             *external_tool.rules(),
             *source_files.rules(),
             *target_types_rules(),
-            QueryRule(FmtResult, [ShfmtRequest.SubPartition]),
+            QueryRule(FmtResult, [ShfmtRequest.Batch]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
         ],
         target_types=[ShellSourcesGeneratorTarget],
@@ -87,7 +87,7 @@ def run_shfmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            ShfmtRequest.SubPartition(
+            ShfmtRequest.Batch(
                 "", input_sources.snapshot.files, key=None, snapshot=input_sources.snapshot
             ),
         ],

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -64,7 +64,7 @@ async def partition_tffmt(
 
 @rule(desc="Format with `terraform fmt`")
 async def tffmt_fmt(request: TffmtRequest.Batch, tffmt: TfFmtSubsystem) -> FmtResult:
-    directory = cast(PartitionKey, request.key).directory
+    directory = cast(PartitionKey, request.partition_key).directory
     result = await Get(
         ProcessResult,
         TerraformProcess(

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt.py
@@ -63,7 +63,7 @@ async def partition_tffmt(
 
 
 @rule(desc="Format with `terraform fmt`")
-async def tffmt_fmt(request: TffmtRequest.SubPartition, tffmt: TfFmtSubsystem) -> FmtResult:
+async def tffmt_fmt(request: TffmtRequest.Batch, tffmt: TfFmtSubsystem) -> FmtResult:
     directory = cast(PartitionKey, request.key).directory
     result = await Get(
         ProcessResult,

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -147,7 +147,7 @@ def run_tffmt(
             TffmtRequest.Batch(
                 "",
                 files,
-                key=key,
+                partition_key=key,
                 snapshot=input_sources.snapshot,
             ),
         ],

--- a/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py
@@ -56,7 +56,7 @@ def rule_runner() -> RuleRunner:
             *tool.rules(),
             *source_files.rules(),
             QueryRule(Partitions, (TffmtRequest.PartitionRequest,)),
-            QueryRule(FmtResult, (TffmtRequest.SubPartition,)),
+            QueryRule(FmtResult, (TffmtRequest.Batch,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],
     )
@@ -144,7 +144,7 @@ def run_tffmt(
     fmt_result = rule_runner.request(
         FmtResult,
         [
-            TffmtRequest.SubPartition(
+            TffmtRequest.Batch(
                 "",
                 files,
                 key=key,

--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -49,7 +49,7 @@ class FixResult(EngineAwareReturnType):
     @staticmethod
     @rule_helper(_public=True)
     async def create(
-        request: FixRequest.SubPartition,
+        request: FixRequest.Batch,
         process_result: ProcessResult | FallibleProcessResult,
         *,
         strip_chroot_path: bool = False,
@@ -120,7 +120,7 @@ class FixRequest(LintRequest):
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
     @frozen_after_init
     @dataclass(unsafe_hash=True)
-    class SubPartition(LintRequest.SubPartition):
+    class Batch(LintRequest.Batch):
         snapshot: Snapshot
 
         @property
@@ -131,7 +131,7 @@ class FixRequest(LintRequest):
     def _get_rules(cls) -> Iterable[UnionRule]:
         yield from super()._get_rules()
         yield UnionRule(FixRequest, cls)
-        yield UnionRule(FixRequest.SubPartition, cls.SubPartition)
+        yield UnionRule(FixRequest.Batch, cls.Batch)
 
 
 class FixTargetsRequest(FixRequest, LintTargetsRequest):
@@ -162,15 +162,15 @@ class FixFilesRequest(FixRequest, LintFilesRequest):
         yield UnionRule(FixFilesRequest.PartitionRequest, cls.PartitionRequest)
 
 
-class _FixSubpartitionBatchElement(NamedTuple):
-    request_type: type[FixRequest.SubPartition]
+class _FixBatchBatchElement(NamedTuple):
+    request_type: type[FixRequest.Batch]
     tool_name: str
     files: tuple[str, ...]
     key: Any
 
 
-class _FixSubpartitionBatchRequest(Collection[_FixSubpartitionBatchElement]):
-    """Request to serially fix all the subpartitions in the given batch."""
+class _FixBatchBatchRequest(Collection[_FixBatchBatchElement]):
+    """Request to serially fix all the Batchs in the given batch."""
 
 
 @dataclass(frozen=True)
@@ -272,7 +272,7 @@ async def fix(
         for batch in batches:
             yield tuple(batch)
 
-    def _make_disjoint_subpartition_batch_requests() -> Iterable[_FixSubpartitionBatchRequest]:
+    def _make_disjoint_Batch_batch_requests() -> Iterable[_FixBatchBatchRequest]:
         partition_infos: Sequence[Tuple[Type[FixRequest], Any]]
         files: Sequence[str]
 
@@ -288,20 +288,20 @@ async def fix(
             files_by_partition_info[tuple(partition_infos)].append(file)
 
         for partition_infos, files in files_by_partition_info.items():
-            for subpartition in batch(files):
-                yield _FixSubpartitionBatchRequest(
-                    _FixSubpartitionBatchElement(
-                        request_type.SubPartition,
+            for Batch in batch(files):
+                yield _FixBatchBatchRequest(
+                    _FixBatchBatchElement(
+                        request_type.Batch,
                         request_type.tool_name,
-                        subpartition,
+                        Batch,
                         partition_key,
                     )
                     for request_type, partition_key in partition_infos
                 )
 
     all_results = await MultiGet(
-        Get(_FixBatchResult, _FixSubpartitionBatchRequest, request)
-        for request in _make_disjoint_subpartition_batch_requests()
+        Get(_FixBatchResult, _FixBatchBatchRequest, request)
+        for request in _make_disjoint_Batch_batch_requests()
     )
 
     individual_results = list(
@@ -318,19 +318,19 @@ async def fix(
 
 @rule
 async def fix_batch(
-    request: _FixSubpartitionBatchRequest,
+    request: _FixBatchBatchRequest,
 ) -> _FixBatchResult:
     current_snapshot = await Get(Snapshot, PathGlobs(request[0].files))
 
     results = []
     for request_type, tool_name, files, key in request:
-        subpartition = request_type(tool_name, files, key, current_snapshot)
-        result = await Get(FixResult, FixRequest.SubPartition, subpartition)
+        Batch = request_type(tool_name, files, key, current_snapshot)
+        result = await Get(FixResult, FixRequest.Batch, Batch)
         results.append(result)
 
         assert set(result.output.files) == set(
-            subpartition.files
-        ), f"Expected {result.output.files} to match {subpartition.files}"
+            Batch.files
+        ), f"Expected {result.output.files} to match {Batch.files}"
         current_snapshot = result.output
     return _FixBatchResult(tuple(results))
 

--- a/src/python/pants/core/goals/fix_test.py
+++ b/src/python/pants/core/goals/fix_test.py
@@ -79,7 +79,7 @@ async def fortran_partition(request: FortranFixRequest.PartitionRequest) -> Part
 
 
 @rule
-async def fortran_fix(request: FortranFixRequest.SubPartition) -> FixResult:
+async def fortran_fix(request: FortranFixRequest.Batch) -> FixResult:
     input = request.snapshot
     output = await Get(
         Snapshot, CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
@@ -119,7 +119,7 @@ async def smalltalk_noop_partition(request: SmalltalkNoopRequest.PartitionReques
 
 
 @rule
-async def smalltalk_noop(request: SmalltalkNoopRequest.SubPartition) -> FixResult:
+async def smalltalk_noop(request: SmalltalkNoopRequest.Batch) -> FixResult:
     assert request.snapshot != EMPTY_SNAPSHOT
     return FixResult(
         input=request.snapshot,
@@ -144,7 +144,7 @@ async def smalltalk_skip_partition(request: SmalltalkSkipRequest.PartitionReques
 
 
 @rule
-async def smalltalk_skip(request: SmalltalkSkipRequest.SubPartition) -> FixResult:
+async def smalltalk_skip(request: SmalltalkSkipRequest.Batch) -> FixResult:
     assert False
 
 
@@ -164,7 +164,7 @@ async def bricky_partition(request: BrickyBuildFileFixer.PartitionRequest) -> Pa
 
 
 @rule
-async def fix_with_bricky(request: BrickyBuildFileFixer.SubPartition) -> FixResult:
+async def fix_with_bricky(request: BrickyBuildFileFixer.Batch) -> FixResult:
     def brickify(contents: bytes) -> bytes:
         content_str = contents.decode("ascii")
         new_lines = []

--- a/src/python/pants/core/goals/fmt_test.py
+++ b/src/python/pants/core/goals/fmt_test.py
@@ -79,7 +79,7 @@ async def fortran_partition(request: FortranFmtRequest.PartitionRequest) -> Part
 
 
 @rule
-async def fortran_fmt(request: FortranFmtRequest.SubPartition) -> FmtResult:
+async def fortran_fmt(request: FortranFmtRequest.Batch) -> FmtResult:
     input = request.snapshot
     output = await Get(
         Snapshot, CreateDigest([FileContent(file, FORTRAN_FILE.content) for file in request.files])
@@ -119,7 +119,7 @@ async def smalltalk_noop_partition(request: SmalltalkNoopRequest.PartitionReques
 
 
 @rule
-async def smalltalk_noop(request: SmalltalkNoopRequest.SubPartition) -> FmtResult:
+async def smalltalk_noop(request: SmalltalkNoopRequest.Batch) -> FmtResult:
     assert request.snapshot != EMPTY_SNAPSHOT
     return FmtResult(
         input=request.snapshot,
@@ -144,7 +144,7 @@ async def smalltalk_skip_partition(request: SmalltalkSkipRequest.PartitionReques
 
 
 @rule
-async def smalltalk_skip(request: SmalltalkSkipRequest.SubPartition) -> FmtResult:
+async def smalltalk_skip(request: SmalltalkSkipRequest.Batch) -> FmtResult:
     assert False
 
 
@@ -164,7 +164,7 @@ async def bricky_partition(request: BrickyBuildFileFormatter.PartitionRequest) -
 
 
 @rule
-async def fmt_with_bricky(request: BrickyBuildFileFormatter.SubPartition) -> FmtResult:
+async def fmt_with_bricky(request: BrickyBuildFileFormatter.Batch) -> FmtResult:
     def brickify(contents: bytes) -> bytes:
         content_str = contents.decode("ascii")
         new_lines = []

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -77,7 +77,9 @@ class LintResult(EngineAwareReturnType):
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
             linter_name=request.tool_name,
-            partition_description=request.key.description if request.key else None,
+            partition_description=request.partition_key.description
+            if request.partition_key
+            else None,
             report=report,
         )
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -179,7 +179,7 @@ def mock_file_partitioner(request: MockFilesRequest.PartitionRequest) -> Partiti
 
 
 def mock_lint_partition(request: Any) -> LintResult:
-    request_type = {cls.SubPartition: cls for cls in _all_lint_requests()}[type(request)]
+    request_type = {cls.Batch: cls for cls in _all_lint_requests()}[type(request)]
     return request_type.get_lint_result(request.elements)
 
 
@@ -273,7 +273,7 @@ def run_lint_rule(
     union_membership = UnionMembership(
         {
             LintRequest: lint_request_types,
-            LintRequest.SubPartition: [rt.SubPartition for rt in lint_request_types],
+            LintRequest.Batch: [rt.Batch for rt in lint_request_types],
             LintTargetsRequest.PartitionRequest: [
                 rt.PartitionRequest
                 for rt in lint_request_types
@@ -315,7 +315,7 @@ def run_lint_rule(
                 ),
                 MockGet(
                     output_type=LintResult,
-                    input_types=(LintRequest.SubPartition,),
+                    input_types=(LintRequest.Batch,),
                     mock=mock_lint_partition,
                 ),
                 MockGet(

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -314,7 +314,7 @@ async def format_build_file_with_yapf(
     yapf_ics = await Yapf._find_python_interpreter_constraints_from_lockfile(yapf)
     result = await _run_yapf(
         YapfRequest.Batch(
-            Yapf.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
+            Yapf.options_scope, input_snapshot.files, partition_key=None, snapshot=input_snapshot
         ),
         yapf,
         yapf_ics,
@@ -345,7 +345,7 @@ async def format_build_file_with_black(
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
     result = await _run_black(
         BlackRequest.Batch(
-            Black.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
+            Black.options_scope, input_snapshot.files, partition_key=None, snapshot=input_snapshot
         ),
         black,
         black_ics,

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -313,7 +313,7 @@ async def format_build_file_with_yapf(
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     yapf_ics = await Yapf._find_python_interpreter_constraints_from_lockfile(yapf)
     result = await _run_yapf(
-        YapfRequest.SubPartition(
+        YapfRequest.Batch(
             Yapf.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
         ),
         yapf,
@@ -344,7 +344,7 @@ async def format_build_file_with_black(
     input_snapshot = await Get(Snapshot, CreateDigest([request.to_file_content()]))
     black_ics = await Black._find_python_interpreter_constraints_from_lockfile(black)
     result = await _run_black(
-        BlackRequest.SubPartition(
+        BlackRequest.Batch(
             Black.options_scope, input_snapshot.files, key=None, snapshot=input_snapshot
         ),
         black,

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -84,7 +84,7 @@ class Partitions(FrozenDict["PartitionKeyT", "tuple[PartitionElementT, ...]"]):
 @dataclass(unsafe_hash=True)
 @runtime_ignore_subscripts
 class _BatchBase(Generic[PartitionKeyT, PartitionElementT]):
-    """Base class for a collection of elements that should all be processed in a single process.
+    """Base class for a collection of elements that should all be processed together.
 
     For example, a collection of strings pointing to files that should be linted in one process, or
     a collection of field-sets pointing at tests that should all execute in the same process.
@@ -92,7 +92,7 @@ class _BatchBase(Generic[PartitionKeyT, PartitionElementT]):
 
     tool_name: str
     elements: tuple[PartitionElementT, ...]
-    key: PartitionKeyT
+    partition_key: PartitionKeyT
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -68,7 +68,7 @@ class Partitions(FrozenDict["PartitionKeyT", "tuple[PartitionElementT, ...]"]):
     The partition key can be of any type able to cross a rule-boundary, and will be provided to the
     rule which "runs" your tool. If it isn't `None` it should implement the `PartitionKey` protocol.
 
-    NOTE: The partition may be divided further into multiple sub-partitions.
+    NOTE: The partition may be divided further into multiple batches.
     """
 
     @classmethod
@@ -83,7 +83,13 @@ class Partitions(FrozenDict["PartitionKeyT", "tuple[PartitionElementT, ...]"]):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 @runtime_ignore_subscripts
-class _SubPartitionBase(Generic[PartitionKeyT, PartitionElementT]):
+class _BatchBase(Generic[PartitionKeyT, PartitionElementT]):
+    """Base class for a collection of elements that should all be processed in a single process.
+
+    For example, a collection of strings pointing to files that should be linted in one process, or
+    a collection of field-sets pointing at tests that should all execute in the same process.
+    """
+
     tool_name: str
     elements: tuple[PartitionElementT, ...]
     key: PartitionKeyT


### PR DESCRIPTION
We've been mixing terminology a bit in subsystems that partition inputs. After this commit, we use terms (more) consistently to mean:

  1. "Partition": a set of compatible inputs that _can_ be processed together, but might not be depending on other settings
  2. "Batch": a set of inputs that are actually processed together