### PR TITLE
Fix dep inference with empty lines in multiline imports.

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
@@ -352,6 +352,34 @@ def test_real_import_beats_tryexcept_import(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_issue_17283(rule_runner: RuleRunner) -> None:
+    assert_deps_parsed(
+        rule_runner,
+        dedent(
+            """\
+                import foo
+
+                from one.two import (
+
+                  three,
+
+                  four,  # pants: no-infer-dep
+
+                  five,
+                )
+
+                from bar import baz
+            """
+        ),
+        expected_imports={
+            "foo": ImpInfo(lineno=1, weak=False),
+            "one.two.three": ImpInfo(lineno=5, weak=False),
+            "one.two.five": ImpInfo(lineno=9, weak=False),
+            "bar.baz": ImpInfo(lineno=12, weak=False),
+        },
+    )
+
+
 def test_gracefully_handle_syntax_errors(rule_runner: RuleRunner) -> None:
     assert_deps_parsed(rule_runner, "x =", expected_imports={})
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/dependency_parser_py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/dependency_parser_py
@@ -78,7 +78,11 @@ class AstVisitor(ast.NodeVisitor):
         # However, `ast` doesn't expose the exact lines each specific import is on,
         # so we are forced to tokenize the import statement to tease out which imported
         # name is on which line so we can check for the ignore pragma.
-        node_lines_iter = itertools.islice(self._contents_lines, node.lineno - 1, None)
+        # Note that we ensure we don't pass an empty string to generate_tokens,
+        # see https://github.com/pantsbuild/pants/issues/17283.
+        node_lines_iter = (
+            line or " " for line in itertools.islice(self._contents_lines, node.lineno - 1, None)
+        )
         token_iter = tokenize.generate_tokens(lambda: next(node_lines_iter))
 
         def find_token(string):


### PR DESCRIPTION
The error happens because the stdlib tokenizer.generate_tokens() chokes on empty strings.

Fixes #17283