### PR TITLE
create append-only caches in remote execution

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -513,6 +513,8 @@ class ExecutionOptions:
     remote_execution_overall_deadline_secs: int
     remote_execution_rpc_concurrency: int
 
+    remote_execution_append_only_caches_base_path: str | None
+
     @classmethod
     def from_options(
         cls,
@@ -555,6 +557,7 @@ class ExecutionOptions:
             remote_execution_headers=dynamic_remote_options.execution_headers,
             remote_execution_overall_deadline_secs=bootstrap_options.remote_execution_overall_deadline_secs,
             remote_execution_rpc_concurrency=dynamic_remote_options.execution_rpc_concurrency,
+            remote_execution_append_only_caches_base_path=bootstrap_options.remote_execution_append_only_caches_base_path,
         )
 
 
@@ -642,6 +645,7 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     },
     remote_execution_overall_deadline_secs=60 * 60,  # one hour
     remote_execution_rpc_concurrency=128,
+    remote_execution_append_only_caches_base_path=None,
 )
 
 DEFAULT_LOCAL_STORE_OPTIONS = LocalStoreOptions()
@@ -1548,6 +1552,18 @@ class BootstrapOptions:
         advanced=True,
         default=DEFAULT_EXECUTION_OPTIONS.remote_execution_rpc_concurrency,
         help="The number of concurrent requests allowed to the remote execution service.",
+    )
+    remote_execution_append_only_caches_base_path = StrOption(
+        default=None,
+        advanced=True,
+        help=softwrap(
+            """
+            Sets the base path to use when setting up an append-only cache for a process running remotely.
+            If this option is not set, then append-only caches will not be used with remote execution.
+            The option should be set to the absolute path of a writable directory in the remote execution
+            environment where Pants can create append-only caches for use with remotely executing processes.
+            """
+        ),
     )
     watch_filesystem = BoolOption(
         default=True,

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -82,6 +82,7 @@ impl crate::CommandRunner for CommandRunner {
           None,
           self.process_cache_namespace.clone(),
           &self.file_store,
+          None,
         )
         .await
         .into(),

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -962,12 +962,19 @@ pub async fn digest(
   instance_name: Option<String>,
   process_cache_namespace: Option<String>,
   store: &Store,
+  append_only_caches_base_path: Option<&str>,
 ) -> Digest {
   let EntireExecuteRequest {
     execute_request, ..
-  } = remote::make_execute_request(process, instance_name, process_cache_namespace, store)
-    .await
-    .unwrap();
+  } = remote::make_execute_request(
+    process,
+    instance_name,
+    process_cache_namespace,
+    store,
+    append_only_caches_base_path,
+  )
+  .await
+  .unwrap();
   execute_request.action_digest.unwrap().try_into().unwrap()
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -428,7 +428,7 @@ struct NailgunProcessFingerprint {
 
 impl NailgunProcessFingerprint {
   pub async fn new(name: String, nailgun_req: &Process, store: &Store) -> Result<Self, String> {
-    let nailgun_req_digest = crate::digest(nailgun_req, None, None, store).await;
+    let nailgun_req_digest = crate::digest(nailgun_req, None, None, store, None).await;
     Ok(NailgunProcessFingerprint {
       name,
       fingerprint: nailgun_req_digest.hash,

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -24,6 +24,10 @@ impl CacheName {
       ))
     }
   }
+
+  pub fn name(&self) -> &str {
+    &self.0
+  }
 }
 
 #[derive(Clone)]

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -939,18 +939,18 @@ fn make_wrapper_for_append_only_caches(
   for (cache_name, path) in caches {
     writeln!(
       &mut script,
-      "mkdir -p '{}/{}'",
+      "/bin/mkdir -p '{}/{}'",
       base_path,
       cache_name.name()
     )
     .map_err(|err| format!("write! failed: {err:?}"))?;
     if let Some(parent) = path.parent() {
-      writeln!(&mut script, "mkdir -p '{}'", parent.to_string_lossy())
+      writeln!(&mut script, "/bin/mkdir -p '{}'", parent.to_string_lossy())
         .map_err(|err| format!("write! failed: {err}"))?;
     }
     writeln!(
       &mut script,
-      "ln -s '{}/{}' '{}'",
+      "/bin/ln -s '{}/{}' '{}'",
       base_path,
       cache_name.name(),
       path.as_path().to_string_lossy()

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -51,6 +51,7 @@ pub struct CommandRunner {
   inner: Arc<dyn crate::CommandRunner>,
   instance_name: Option<String>,
   process_cache_namespace: Option<String>,
+  append_only_caches_base_path: Option<String>,
   executor: task_executor::Executor,
   store: Store,
   action_cache_client: Arc<ActionCacheClient<LayeredService>>,
@@ -79,6 +80,7 @@ impl CommandRunner {
     cache_content_behavior: CacheContentBehavior,
     concurrency_limit: usize,
     read_timeout: Duration,
+    append_only_caches_base_path: Option<String>,
   ) -> Result<Self, String> {
     let tls_client_config = if action_cache_address.starts_with("https://") {
       Some(grpc_util::tls::Config::new_without_mtls(root_ca_certs).try_into()?)
@@ -103,6 +105,7 @@ impl CommandRunner {
       inner,
       instance_name,
       process_cache_namespace,
+      append_only_caches_base_path,
       executor,
       store,
       action_cache_client,
@@ -475,6 +478,10 @@ impl crate::CommandRunner for CommandRunner {
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
       &self.store,
+      self
+        .append_only_caches_base_path
+        .as_ref()
+        .map(|s| s.as_ref()),
     )
     .await?;
     let failures_cached = request.cache_scope == ProcessCacheScope::Always;

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -149,6 +149,7 @@ fn create_cached_runner(
       cache_content_behavior,
       256,
       CACHE_READ_TIMEOUT,
+      None,
     )
     .expect("caching command runner"),
   )
@@ -162,7 +163,7 @@ async fn create_process(store_setup: &StoreSetup) -> (Process, Digest) {
   ]);
   let EntireExecuteRequest {
     action, command, ..
-  } = make_execute_request(&process, None, None, &store_setup.store)
+  } = make_execute_request(&process, None, None, &store_setup.store, None)
     .await
     .unwrap();
   let (_command_digest, action_digest) =
@@ -733,6 +734,7 @@ async fn make_action_result_basic() {
     CacheContentBehavior::Defer,
     256,
     CACHE_READ_TIMEOUT,
+    None,
   )
   .expect("caching command runner");
 

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -151,7 +151,7 @@ async fn make_execute_request() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None, &store).await,
+    crate::remote::make_execute_request(&req, None, None, &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -253,7 +253,8 @@ async fn make_execute_request_with_instance_name() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, Some("dark-tower".to_owned()), None, &store).await,
+    crate::remote::make_execute_request(&req, Some("dark-tower".to_owned()), None, &store, None)
+      .await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -353,7 +354,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, Some("meep".to_owned()), &store).await,
+    crate::remote::make_execute_request(&req, None, Some("meep".to_owned()), &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -428,7 +429,7 @@ async fn make_execute_request_with_jdk() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None, &store).await,
+    crate::remote::make_execute_request(&req, None, None, &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -527,7 +528,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None, &store).await,
+    crate::remote::make_execute_request(&req, None, None, &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -621,7 +622,7 @@ async fn make_execute_request_with_timeout() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None, &store).await,
+    crate::remote::make_execute_request(&req, None, None, &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -737,7 +738,7 @@ async fn make_execute_request_using_immutable_inputs() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None, &store).await,
+    crate::remote::make_execute_request(&req, None, None, &store, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -765,6 +766,7 @@ async fn successful_with_only_call_to_execute() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -815,6 +817,7 @@ async fn successful_after_reconnect_with_wait_execution() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -869,6 +872,7 @@ async fn successful_after_reconnect_from_retryable_error() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -929,7 +933,7 @@ async fn dropped_request_cancels() {
   let mock_server = {
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
-        execute_request: crate::remote::make_execute_request(&request, None, None, &store)
+        execute_request: crate::remote::make_execute_request(&request, None, None, &store, None)
           .await
           .unwrap()
           .execute_request,
@@ -988,6 +992,7 @@ async fn server_rejecting_execute_request_gives_error() {
         None,
         None,
         &store,
+        None,
       )
       .await
       .unwrap()
@@ -1021,6 +1026,7 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1074,6 +1080,7 @@ async fn sends_headers() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1097,6 +1104,7 @@ async fn sends_headers() {
 
   let command_runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -1274,6 +1282,7 @@ async fn ensure_inline_stdio_is_stored() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1297,6 +1306,7 @@ async fn ensure_inline_stdio_is_stored() {
 
   let cmd_runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -1358,6 +1368,7 @@ async fn bad_result_bytes() {
           None,
           None,
           &store,
+          None,
         )
         .await
         .unwrap()
@@ -1406,6 +1417,7 @@ async fn initial_response_error() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1460,6 +1472,7 @@ async fn initial_response_missing_response_and_error() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1505,6 +1518,7 @@ async fn fails_after_retry_limit_exceeded() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1568,6 +1582,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1650,6 +1665,7 @@ async fn execute_missing_file_uploads_if_known() {
       None,
       None,
       &store,
+      None,
     )
     .await
     .unwrap();
@@ -1671,6 +1687,7 @@ async fn execute_missing_file_uploads_if_known() {
             None,
             None,
             &store,
+            None,
           )
           .await
           .unwrap()
@@ -1700,6 +1717,7 @@ async fn execute_missing_file_uploads_if_known() {
     .expect("Saving directory bytes to store");
   let command_runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -1761,6 +1779,7 @@ async fn execute_missing_file_errors_if_unknown() {
 
   let runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -2440,6 +2459,7 @@ fn create_command_runner(execution_address: String, cas: &mock::StubCAS) -> (Com
   let store = make_store(store_dir.path(), cas, runtime.clone());
   let command_runner = CommandRunner::new(
     &execution_address,
+    None,
     None,
     None,
     None,

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -24,10 +24,10 @@ use workunit_store::{RunId, WorkunitStore};
 
 use crate::remote::{CommandRunner, EntireExecuteRequest, ExecutionError, OperationOrStatus};
 use crate::{
-  CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform, InputDigests,
-  Platform, Process, ProcessCacheScope, ProcessError, ProcessExecutionStrategy,
+  CacheName, CommandRunner as CommandRunnerTrait, Context, FallibleProcessResultWithPlatform,
+  InputDigests, Platform, Process, ProcessCacheScope, ProcessError, ProcessExecutionStrategy,
 };
-use fs::{RelativePath, EMPTY_DIRECTORY_DIGEST};
+use fs::{DirectoryDigest, RelativePath, EMPTY_DIRECTORY_DIGEST};
 use std::any::type_name;
 use std::io::Cursor;
 use tonic::{Code, Status};
@@ -630,6 +630,144 @@ async fn make_execute_request_with_timeout() {
       input_root_digest: input_directory.directory_digest(),
     })
   );
+}
+
+#[tokio::test]
+async fn make_execute_request_with_append_only_caches() {
+  let executor = task_executor::Executor::new();
+  let store_dir = TempDir::new().unwrap();
+  let store = Store::local_only(executor, store_dir).unwrap();
+
+  let input_directory = TestDirectory::containing_roland();
+  store
+    .record_directory(&input_directory.directory(), false)
+    .await
+    .unwrap();
+
+  let req = Process {
+    argv: owned_string_vec(&["/bin/cat", "../.cache/xyzzy/foo.txt"]),
+    env: vec![("SOME".to_owned(), "value".to_owned())]
+      .into_iter()
+      .collect(),
+    working_directory: Some(RelativePath::new(Path::new("animals")).unwrap()),
+    input_digests: InputDigests::with_input_files(input_directory.directory_digest()),
+    output_files: BTreeSet::new(),
+    output_directories: BTreeSet::new(),
+    timeout: one_second(),
+    description: "some description".to_owned(),
+    level: log::Level::Info,
+    append_only_caches: btreemap! {
+      CacheName::new(String::from("xyzzy")).unwrap() => RelativePath::new(Path::new(".cache/xyzzy")).unwrap(),
+    },
+    jdk_home: None,
+    platform: Platform::Linux_x86_64,
+    execution_slot_variable: None,
+    concurrency_available: 0,
+    cache_scope: ProcessCacheScope::Always,
+    execution_strategy: ProcessExecutionStrategy::RemoteExecution(vec![]),
+    remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+  };
+
+  let want_command = remexec::Command {
+    arguments: vec![
+      "./__pants_wrapper__".to_owned(),
+      "/bin/cat".to_owned(),
+      "../.cache/xyzzy/foo.txt".to_owned(),
+    ],
+    environment_variables: vec![
+      remexec::command::EnvironmentVariable {
+        name: crate::remote::CACHE_KEY_EXECUTION_STRATEGY.to_owned(),
+        value: ProcessExecutionStrategy::RemoteExecution(vec![]).cache_value(),
+      },
+      remexec::command::EnvironmentVariable {
+        name: crate::remote::CACHE_KEY_TARGET_PLATFORM_ENV_VAR_NAME.to_owned(),
+        value: "linux_x86_64".to_owned(),
+      },
+      remexec::command::EnvironmentVariable {
+        name: "SOME".to_owned(),
+        value: "value".to_owned(),
+      },
+    ],
+    platform: Some(remexec::Platform::default()),
+    ..Default::default()
+  };
+
+  let want_action = remexec::Action {
+    command_digest: Some(
+      (&Digest::new(
+        Fingerprint::from_hex_string(
+          "1deb19eddcefd5074263064a7df2a19caeb4e6d86a849bc07e23a5d856f886ec",
+        )
+        .unwrap(),
+        178,
+      ))
+        .into(),
+    ),
+    input_root_digest: Some(
+      (Digest::new(
+        Fingerprint::from_hex_string(
+          "92f5d2ff07cb6cdf4a70f2d6392781b482cd587b9dd69d6729ac73eb54110a69",
+        )
+        .unwrap(),
+        178,
+      ))
+      .into(),
+    ),
+    timeout: Some(prost_types::Duration::from(Duration::from_secs(1))),
+    ..Default::default()
+  };
+
+  let want_execute_request = remexec::ExecuteRequest {
+    action_digest: Some(
+      (&Digest::new(
+        Fingerprint::from_hex_string(
+          "e4196db365556cbeed4941845f448cfafc1fabb76b3c476c3f378f358235d3c4",
+        )
+        .unwrap(),
+        146,
+      ))
+        .into(),
+    ),
+    skip_cache_lookup: true,
+    ..Default::default()
+  };
+
+  let want_input_root_digest = DirectoryDigest::from_persisted_digest(Digest::new(
+    Fingerprint::from_hex_string(
+      "92f5d2ff07cb6cdf4a70f2d6392781b482cd587b9dd69d6729ac73eb54110a69",
+    )
+    .unwrap(),
+    178,
+  ));
+
+  let got_execute_request =
+    crate::remote::make_execute_request(&req, None, None, &store, Some("/append-only-caches"))
+      .await
+      .unwrap();
+  assert_eq!(
+    got_execute_request,
+    EntireExecuteRequest {
+      action: want_action,
+      command: want_command,
+      execute_request: want_execute_request,
+      input_root_digest: want_input_root_digest,
+    }
+  );
+
+  // Ensure that the wrapper script was added to the input root.
+  let mut files = store
+    .load_digest_trie(got_execute_request.input_root_digest)
+    .await
+    .unwrap()
+    .files();
+  files.sort();
+  assert_eq!(
+    files,
+    vec![
+      Path::new("__pants_wrapper__").to_path_buf(),
+      Path::new("roland.ext").to_path_buf()
+    ]
+  )
 }
 
 #[tokio::test]

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -301,6 +301,7 @@ async fn main() {
         &address,
         process_metadata.instance_name.clone(),
         process_metadata.cache_key_gen_version.clone(),
+        None,
         root_ca_certs.clone(),
         headers.clone(),
         store.clone(),
@@ -329,6 +330,9 @@ async fn main() {
             CacheContentBehavior::Defer,
             args.cache_rpc_concurrency,
             Duration::from_secs(2),
+            args
+              .named_cache_path
+              .map(|p| p.to_string_lossy().to_string()),
           )
           .expect("Failed to make remote cache command runner"),
         )

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -102,6 +102,7 @@ pub struct RemotingOptions {
   pub execution_headers: BTreeMap<String, String>,
   pub execution_overall_deadline: Duration,
   pub execution_rpc_concurrency: usize,
+  pub append_only_caches_base_path: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -265,6 +266,7 @@ impl Core {
         remoting_opts.execution_address.as_ref().unwrap(),
         instance_name,
         process_cache_namespace,
+        remoting_opts.append_only_caches_base_path.clone(),
         root_ca_certs.clone(),
         remoting_opts.execution_headers.clone(),
         full_store.clone(),
@@ -330,6 +332,7 @@ impl Core {
         remoting_opts.cache_content_behavior,
         remoting_opts.cache_rpc_concurrency,
         remoting_opts.cache_read_timeout,
+        remoting_opts.append_only_caches_base_path.clone(),
       )?);
     }
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -307,6 +307,7 @@ impl PyRemotingOptions {
     execution_headers: BTreeMap<String, String>,
     execution_overall_deadline_secs: u64,
     execution_rpc_concurrency: usize,
+    append_only_caches_base_path: Option<String>,
   ) -> Self {
     Self(RemotingOptions {
       execution_enable,
@@ -329,6 +330,7 @@ impl PyRemotingOptions {
       execution_headers,
       execution_overall_deadline: Duration::from_secs(execution_overall_deadline_secs),
       execution_rpc_concurrency,
+      append_only_caches_base_path,
     })
   }
 }


### PR DESCRIPTION
Use a wrapper script to create append-only caches in remote execution.