### PR TITLE
WIP: Use Toolchain remote execution in CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: github.repository_owner == 'pantsbuild'
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
     runs-on:
@@ -127,6 +128,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: github.repository_owner == 'pantsbuild'
     name: Bootstrap Pants, test Rust (macOS11-x86_64)
     runs-on:
@@ -509,6 +511,7 @@ jobs:
   test_python_macos11_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
+      PANTS_REMOTE_EXECUTION: 'false'
     if: github.repository_owner == 'pantsbuild'
     name: Test Python (macOS11-x86_64)
     needs: bootstrap_pants_macos11_x86_64

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != 'true')
     name: Bootstrap Pants, test and lint Rust (Linux-x86_64)
@@ -129,6 +130,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != 'true')
     name: Bootstrap Pants, test Rust (macOS11-x86_64)
@@ -238,6 +240,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
       || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -298,6 +301,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
       || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -364,6 +368,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
       || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -426,6 +431,7 @@ jobs:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
+      PANTS_REMOTE_EXECUTION: 'false'
     if: ((github.repository_owner == 'pantsbuild') && (github.event_name == 'push'
       || needs.classify_changes.outputs.release == 'true')) && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -845,6 +851,7 @@ jobs:
   test_python_macos11_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
+      PANTS_REMOTE_EXECUTION: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != 'true')
     name: Test Python (macOS11-x86_64)

--- a/BUILD
+++ b/BUILD
@@ -1,6 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+__defaults__(all={"environment": "remote"})
+
 shell_sources(name="scripts", sources=["cargo", "pants"])
 
 # We use `BUILD_ROOT` to establish the build root, rather than `./pants`, per
@@ -19,5 +21,13 @@ docker_environment(
 # for internal testing.
 remote_environment(
     name="buildgrid_remote",
+    python_bootstrap_search_path=["<PATH>"],
+)
+
+remote_environment(
+    name="toolchain_remote",
+    # We fallback to local because not every Pants contributor will have remote execution available
+    # to them.
+    fallback_environment="__local__",
     python_bootstrap_search_path=["<PATH>"],
 )

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,6 +1,12 @@
 [GLOBAL]
 colors = true
 
+# These options will be dynamically disabled by the Toolchain plugin when auth fails, e.g. a new
+# contributor not allowlisted.
+#
+# It's important that our macOS and Build Wheels jobs run locally, so we override the remote
+# execution option in those jobs to false.
+remote_execution = true
 remote_cache_read = true
 remote_cache_write = true
 

--- a/pants.toml
+++ b/pants.toml
@@ -99,8 +99,8 @@ root_patterns = [
 [environments-preview.names]
 # We don't define any local environments because the options system covers our cases adequately.
 docker = "//:docker_env"
-# Used for iterating on remote-execution.
-remote = "//:buildgrid_remote"
+# You can change this to `//:buildgrid_remote` when iterating.
+remote = "//:toolchain_remote"
 
 [tailor]
 build_file_header = """\


### PR DESCRIPTION
Toolchain would like to donate remote execution to Pantsbuild/pants to get better parallelism and to help the project better dogfood remote execution, so we can make client improvements.

Same as how Toolchain remote caching works, this is not used with every single CI run. We limit who can use Toolchain services to authorized Pantsbuild community members, e.g. maintainers. Everyone else uses the typical GitHub runners.  Thus, we still keep the same shape of our CI like having 3 shards for tests.

If remote execution ends up not being a net positive, e.g. has stability issues, then we will keep this PR but update `pants.ci.toml` to set `remote_execution = false`.