### PR TITLE
go: properly handle xtest packages when building

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -186,6 +186,13 @@ async def map_import_paths_of_all_go_protobuf_targets(
                             for import_path, addresses in import_path_mapping.items()
                         }
                     ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
                 )
                 for go_mod_addr, import_path_mapping in import_paths_by_module.items()
             }

--- a/src/python/pants/backend/go/dependency_inference.py
+++ b/src/python/pants/backend/go/dependency_inference.py
@@ -32,6 +32,7 @@ class GoModuleImportPathsMapping:
     path(s) for a single Go module."""
 
     mapping: FrozenDict[str, GoImportPathsMappingAddressSet]
+    address_to_import_path: FrozenDict[Address, str]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -55,7 +55,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.ordered_set import FrozenOrderedSet
 
 # Known options to Go test binaries. Only these options will be transformed by `transform_test_args`.
 # The bool value represents whether the option is expected to take a value or not.
@@ -246,33 +246,20 @@ async def run_go_tests(
     if testmain.has_xtests:
         # Build a synthetic package for xtests where the import path is the same as the package under test
         # but with "_test" appended.
-        #
-        # Subset the direct dependencies to only the dependencies used by the xtest code. (Dependency
-        # inference will have included all of the regular, test, and xtest dependencies of the package in
-        # the build graph.) Moreover, ensure that any import of the package under test is on the _test_
-        # version of the package that was just built.
-        dep_by_import_path = {
-            dep.import_path: dep for dep in test_pkg_build_request.direct_dependencies
-        }
-        direct_dependencies: OrderedSet[BuildGoPackageRequest] = OrderedSet()
-        for xtest_import in pkg_analysis.xtest_imports:
-            if xtest_import == pkg_analysis.import_path:
-                direct_dependencies.add(test_pkg_build_request)
-            elif xtest_import in dep_by_import_path:
-                direct_dependencies.add(dep_by_import_path[xtest_import])
-
-        xtest_pkg_build_request = BuildGoPackageRequest(
-            import_path=f"{import_path}_test",
-            pkg_name=f"{pkg_analysis.name}_test",
-            digest=pkg_digest.digest,
-            dir_path=pkg_analysis.dir_path,
-            go_files=pkg_analysis.xtest_go_files,
-            s_files=(),  # TODO: Are there .s files for xtest?
-            direct_dependencies=tuple(direct_dependencies),
-            minimum_go_version=pkg_analysis.minimum_go_version,
-            embed_config=pkg_digest.xtest_embed_config,
-            coverage_config=coverage_config,
+        maybe_xtest_pkg_build_request = await Get(
+            FallibleBuildGoPackageRequest,
+            BuildGoPackageTargetRequest(
+                field_set.address, for_xtests=True, coverage_config=coverage_config
+            ),
         )
+        print(f"maybe_xtest_pkg_build_request={maybe_xtest_pkg_build_request}")
+        if maybe_xtest_pkg_build_request.request is None:
+            assert maybe_xtest_pkg_build_request.stderr is not None
+            return compilation_failure(
+                maybe_xtest_pkg_build_request.exit_code, None, maybe_xtest_pkg_build_request.stderr
+            )
+        xtest_pkg_build_request = maybe_xtest_pkg_build_request.request
+        print(f"xtest_pkg_build_request={xtest_pkg_build_request}")
         main_direct_deps.append(xtest_pkg_build_request)
 
     # Generate coverage setup code for the test main if coverage is enabled.

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -252,14 +252,12 @@ async def run_go_tests(
                 field_set.address, for_xtests=True, coverage_config=coverage_config
             ),
         )
-        print(f"maybe_xtest_pkg_build_request={maybe_xtest_pkg_build_request}")
         if maybe_xtest_pkg_build_request.request is None:
             assert maybe_xtest_pkg_build_request.stderr is not None
             return compilation_failure(
                 maybe_xtest_pkg_build_request.exit_code, None, maybe_xtest_pkg_build_request.stderr
             )
         xtest_pkg_build_request = maybe_xtest_pkg_build_request.request
-        print(f"xtest_pkg_build_request={xtest_pkg_build_request}")
         main_direct_deps.append(xtest_pkg_build_request)
 
     # Generate coverage setup code for the test main if coverage is enabled.

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -128,6 +128,13 @@ async def go_map_import_paths_by_module(
                             for import_path, addresses in import_path_mapping.items()
                         }
                     ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
                 )
                 for go_mod_addr, import_path_mapping in import_paths_by_module.items()
             }
@@ -171,6 +178,13 @@ async def go_merge_import_paths_analysis(
                                 infer_all=infer_all_by_module[go_mod_addr][import_path],
                             )
                             for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
                         }
                     ),
                 )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -74,6 +74,13 @@ class BuildGoPackageTargetRequest(EngineAwareParameter):
     def debug_hint(self) -> str:
         return str(self.address)
 
+    def __post_init__(self):
+        if self.for_tests and self.for_xtests:
+            raise ValueError(
+                "`BuildGoPackageTargetRequest.for_tests` and `BuildGoPackageTargetRequest.for_xtests` "
+                "cannot be set together."
+            )
+
 
 @union(in_scope_types=[EnvironmentName])
 @dataclass(frozen=True)
@@ -127,10 +134,6 @@ def maybe_get_codegen_request_type(
 async def setup_build_go_package_target_request(
     request: BuildGoPackageTargetRequest, union_membership: UnionMembership
 ) -> FallibleBuildGoPackageRequest:
-    assert not (
-        request.for_tests and request.for_xtests
-    ), "for_tests and for_xtests cannot be set together"
-
     wrapped_target = await Get(
         WrappedTarget,
         WrappedTargetRequest(request.address, description_of_origin="<build_pkg_target.py>"),

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -540,7 +540,6 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
     )
 
 
-@pytest.mark.xfail(reason="dependency cycle")
 def test_xtest_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
External test ("xtest") packages are distinct from their base package. While this distinction does appear in the Go package analysis types, it was not modeled in the dependencies among Go targets (e.g., `go_package`). This caused dependencies for base and xtest packages to be conflated, causing the issue in https://github.com/pantsbuild/pants/issues/17236.

Model dependencies correctly when building `BuildGoPackageRequest` trees so that dependencies of the base package do not become dependencies of the xtest package and vice versa.

Fixes https://github.com/pantsbuild/pants/issues/17236