### PR TITLE
Replace uses of deprecated GHA set-output command (Cherry-pick of #17287)

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -17,7 +17,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}

--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -50,16 +50,12 @@ jobs:
         workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
-      run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
-
-        '
+      run: echo "hash=$(./build-support/bin/rust/print_engine_hash.sh)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-
-          '
+        key: Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -137,7 +133,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -166,16 +162,12 @@ jobs:
         workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
-      run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
-
-        '
+      run: echo "hash=$(./build-support/bin/rust/print_engine_hash.sh)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-
-          '
+        key: macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -257,7 +249,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -326,7 +318,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -397,7 +389,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -468,7 +460,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -525,7 +517,7 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -53,16 +53,12 @@ jobs:
         workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
-      run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
-
-        '
+      run: echo "hash=$(./build-support/bin/rust/print_engine_hash.sh)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-
-          '
+        key: Linux-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -142,7 +138,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -171,16 +167,12 @@ jobs:
         workspaces: src/rust/engine
     - id: get-engine-hash
       name: Get native engine hash
-      run: 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"
-
-        '
+      run: echo "hash=$(./build-support/bin/rust/print_engine_hash.sh)" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: 'macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
-
-          '
+        key: macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: '.pants
 
           src/python/pants/engine/internals/native_engine.so
@@ -532,9 +524,9 @@ jobs:
       name: Classify changed files
       run: "affected=$(python build-support/bin/classify_changed_files.py \"${{ steps.files.outputs.all_modified_files\
         \ }}\")\necho \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n\
-        \  echo \"::set-output name=docs_only::true\"\n  echo \"docs_only\"\nfi\n\
-        for i in ${affected}; do\n  echo \"::set-output name=${i}::true\"\n  echo\
-        \ \"${i}\"\ndone\n"
+        \  echo \"docs_only=true\" >> $GITHUB_OUTPUT\n  echo \"docs_only\"\nfi\nfor\
+        \ i in ${affected}; do\n  echo \"${i}=true\" >> $GITHUB_OUTPUT\n  echo \"\
+        ${i}\"\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -550,7 +542,7 @@ jobs:
       with:
         fetch-depth: 10
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -622,7 +614,7 @@ jobs:
     - ubuntu-20.04
     steps:
     - id: set_merge_ok
-      run: echo '::set-output name=merge_ok::true'
+      run: echo 'merge_ok=true' >> ${GITHUB_OUTPUT}
   test_python_linux_x86_64_0:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only
       != 'true')
@@ -659,7 +651,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -732,7 +724,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -805,7 +797,7 @@ jobs:
 
         '
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}
@@ -864,7 +856,7 @@ jobs:
         distribution: adopt
         java-version: '11'
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Tell Pants to use Python ${{ matrix.python-version }}

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -120,11 +120,11 @@ def classify_changes() -> Jobs:
                         affected=$(python build-support/bin/classify_changed_files.py "{gha_expr("steps.files.outputs.all_modified_files")}")
                         echo "Affected:"
                         if [[ "${{affected}}" == "docs" ]]; then
-                          echo "::set-output name=docs_only::true"
+                          echo "docs_only=true" >> $GITHUB_OUTPUT
                           echo "docs_only"
                         fi
                         for i in ${{affected}}; do
-                          echo "::set-output name=${{i}}::true"
+                          echo "${{i}}=true" >> $GITHUB_OUTPUT
                           echo "${{i}}"
                         done
                         """
@@ -258,7 +258,7 @@ def setup_primary_python(install_python: bool = True) -> Sequence[Step]:
         ret.append(
             {
                 "name": f"Set up Python {gha_expr('matrix.python-version')}",
-                "uses": "actions/setup-python@v3",
+                "uses": "actions/setup-python@v4",
                 "with": {"python-version": f"{gha_expr('matrix.python-version')}"},
             }
         )
@@ -389,7 +389,7 @@ class Helper:
             {
                 "name": "Get native engine hash",
                 "id": "get-engine-hash",
-                "run": 'echo "::set-output name=hash::$(./build-support/bin/rust/print_engine_hash.sh)"\n',
+                "run": 'echo "hash=$(./build-support/bin/rust/print_engine_hash.sh)" >> $GITHUB_OUTPUT',
                 "shell": "bash",
             },
             {
@@ -397,7 +397,7 @@ class Helper:
                 "uses": "actions/cache@v3",
                 "with": {
                     "path": "\n".join(NATIVE_FILES),
-                    "key": f"{self.platform_name()}-engine-{gha_expr('steps.get-engine-hash.outputs.hash')}-v1\n",
+                    "key": f"{self.platform_name()}-engine-{gha_expr('steps.get-engine-hash.outputs.hash')}-v1",
                 },
             },
         ]
@@ -834,7 +834,7 @@ def merge_ok(pr_jobs: list[str]) -> Jobs:
             "steps": [
                 {
                     "id": "set_merge_ok",
-                    "run": "echo '::set-output name=merge_ok::true'",
+                    "run": "echo 'merge_ok=true' >> ${GITHUB_OUTPUT}",
                 },
             ],
         },


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Also removes a superfluous newline from a cache key.
