### PR TITLE
Fix incomplete cherry-pick of #17177.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -192,7 +192,7 @@ async def export_tool(
                     os.path.join("{digest_root}", pex.name),
                     "venv",
                     "--collisions-ok",
-                    "--remove=all",
+                    "--remove=pex",
                     f"{{digest_root}}/{request.resolve_name}",
                 ],
                 {

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -141,7 +141,7 @@ async def export_virtualenv(
                     "venv",
                     "--pip",
                     "--collisions-ok",
-                    "--remove=all",
+                    "--remove=pex",
                     f"{{digest_root}}/{py_version}",
                 ],
                 {

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -84,7 +84,7 @@ def test_export_venvs(rule_runner: RuleRunner) -> None:
                 "venv",
                 "--pip",
                 "--collisions-ok",
-                "--remove=all",
+                "--remove=pex",
                 f"{{digest_root}}/{current_interpreter}",
             )
             assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"


### PR DESCRIPTION
That cherry-pick was done in #17200 and missed a crucial line which led
to `~/.cache/pants/named_caches/pex_root` being nuked on any run of
`./pants export` instead of the prior behavior of nuking `~/.pex`.

Fixes #17221

[ci skip-rust]
[ci skip-build-wheels]