### PR TITLE
Updates `publish` to `USES_ENVIRONMENTS`

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import itertools
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
@@ -18,7 +17,6 @@ from pants.core.goals.multi_tool_goal_helper import (
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
@@ -177,7 +175,7 @@ class CheckSubsystem(GoalSubsystem):
 
 class Check(Goal):
     subsystem_cls = CheckSubsystem
-    environment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
 
 
 @goal_rule
@@ -203,33 +201,8 @@ async def check(
         )
         for request_type in request_types
     )
-
-    environment_names = await MultiGet(
-        Get(
-            EnvironmentName,
-            EnvironmentNameRequest,
-            EnvironmentNameRequest.from_field_set(field_set),
-        )
-        for request in requests
-        for field_set in request.field_sets
-    )
-    request_for_each_environment_name = (
-        # this is actually correct:
-        request
-        for request in requests
-        for _ in request.field_sets
-    )
-    grouped = itertools.groupby(
-        zip(request_for_each_environment_name, environment_names), lambda x: x[0]
-    )
-    exploded_requests = [
-        (request, {env_name for (_, env_name) in env_names}) for request, env_names in grouped
-    ]
-
     all_results = await MultiGet(
-        Get(CheckResults, {request: CheckRequest, env_name: EnvironmentName})
-        for (request, env_names) in exploded_requests
-        for env_name in env_names
+        Get(CheckResults, CheckRequest, request) for request in requests if request.field_sets
     )
 
     results_by_tool: dict[str, list[CheckResult]] = defaultdict(list)

--- a/src/python/pants/core/goals/publish.py
+++ b/src/python/pants/core/goals/publish.py
@@ -29,11 +29,11 @@ from typing import ClassVar, Generic, Type, TypeVar
 
 from typing_extensions import final
 
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.console import Console
-from pants.engine.environment import EnvironmentName
+from pants.engine.environment import ChosenLocalEnvironmentName, EnvironmentName
 from pants.engine.goal import Goal, GoalSubsystem
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import Effect, Get, MultiGet, collect_rules, goal_rule, rule
@@ -180,11 +180,13 @@ class PublishSubsystem(GoalSubsystem):
 
 class Publish(Goal):
     subsystem_cls = PublishSubsystem
-    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
+    environment_behavior = Goal.EnvironmentBehavior.USES_ENVIRONMENTS
 
 
 @goal_rule
-async def run_publish(console: Console, publish: PublishSubsystem) -> Publish:
+async def run_publish(
+    console: Console, publish: PublishSubsystem, local_environment: ChosenLocalEnvironmentName
+) -> Publish:
     target_roots_to_package_field_sets, target_roots_to_publish_field_sets = await MultiGet(
         Get(
             TargetRootsToFieldSets,
@@ -242,7 +244,10 @@ async def run_publish(console: Console, publish: PublishSubsystem) -> Publish:
             continue
 
         logger.debug(f"Execute {pub.process}")
-        res = await Effect(InteractiveProcessResult, InteractiveProcess, pub.process)
+        res = await Effect(
+            InteractiveProcessResult,
+            {pub.process: InteractiveProcess, local_environment.val: EnvironmentName},
+        )
         if res.exit_code == 0:
             sigil = console.sigil_succeeded()
             status = "published"
@@ -305,9 +310,12 @@ class _PublishJsonEncoder(json.JSONEncoder):
 
 
 @rule
-async def package_for_publish(request: PublishProcessesRequest) -> PublishProcesses:
+async def package_for_publish(
+    request: PublishProcessesRequest, local_environment: ChosenLocalEnvironmentName
+) -> PublishProcesses:
     packages = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set) for field_set in request.package_field_sets
+        Get(BuiltPackage, EnvironmentAwarePackageRequest(field_set))
+        for field_set in request.package_field_sets
     )
 
     for pkg in packages:
@@ -320,8 +328,10 @@ async def package_for_publish(request: PublishProcessesRequest) -> PublishProces
     publish = await MultiGet(
         Get(
             PublishProcesses,
-            PublishRequest,
-            field_set._request(packages),
+            {
+                field_set._request(packages): PublishRequest,
+                local_environment.val: EnvironmentName,
+            },
         )
         for field_set in request.publish_field_sets
     )


### PR DESCRIPTION
This migrates `publish` to create the `BuiltPackage` asset in a correct environment, and run the `publish` executable in the local environment.

Also adds a helper rule, `EnvironmentAwarePackageRequest`, which consolidates the `EnvironmentName` request and `BuiltPackage` request, since `BuiltPackage` is requested all over the place.

See #17129.