### PR TITLE
Stabilize python interpreter lookups for bootstrap (Cherry-pick of #17311)

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -49,8 +49,7 @@ function git_merge_base() {
 
 function determine_python() {
   if [[ -n "${PY:-}" ]]; then
-    echo "${PY}"
-    return 0
+    which "${PY}" && return 0
   fi
 
   local candidate_versions

--- a/src/rust/engine/build.rs
+++ b/src/rust/engine/build.rs
@@ -31,4 +31,7 @@ fn main() {
   // NB: The native extension only works with the Python interpreter version it was built with
   // (e.g. Python 3.7 vs 3.8).
   println!("cargo:rerun-if-env-changed=PY");
+  if let Ok(py_var) = std::env::var("PY") {
+    println!("cargo:rerun-if-changed={py_var}");
+  }
 }


### PR DESCRIPTION
Absolutize the `PY` variable, which is directly used to set `PYO3_PYTHON` in the `cargo` script. `PYO3_PYTHON` ends up driving which version of Python is linked against: a mismatch between the expected (`3.7.15`) and used (`3.7.14`) version [caused issues](https://github.com/pantsbuild/pants/actions/runs/3299445766/jobs/5442827462) in a cherry pick.
