### PR TITLE
Makes `check` a `USES_ENVIRONMENTS` goal

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Generic, Iterable, Set, TypeVar, cast
+from typing import Any, ClassVar, Generic, Iterable, TypeVar, cast
 
 import colors
 
@@ -221,15 +221,10 @@ async def check(
         for (request, _), env_name in zip(request_to_field_set, environment_names)
     )
 
-    exploded_requests: Dict[CheckRequest, Set[EnvironmentName]] = defaultdict(set)
-    for request, env_name in request_to_env_name:
-        exploded_requests[request].add(env_name)
-
     # Run each check request in each valid environment (potentially multiple runs per tool)
     all_results = await MultiGet(
         Get(CheckResults, {request: CheckRequest, env_name: EnvironmentName})
-        for (request, env_names) in exploded_requests.items()
-        for env_name in env_names
+        for (request, env_name) in request_to_env_name
     )
 
     results_by_tool: dict[str, list[CheckResult]] = defaultdict(list)

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -216,10 +216,10 @@ async def check(
         for (_, field_set) in request_to_field_set
     )
 
-    request_to_env_name = (
+    request_to_env_name = {
         (request, env_name)
         for (request, _), env_name in zip(request_to_field_set, environment_names)
-    )
+    }
 
     # Run each check request in each valid environment (potentially multiple runs per tool)
     all_results = await MultiGet(

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -19,7 +19,9 @@ from pants.core.goals.check import (
     check,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.engine.addresses import Address
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_DIGEST, EMPTY_FILE_DIGEST, Workspace
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, ProcessResultMetadata
@@ -144,8 +146,16 @@ def run_typecheck_rule(
             mock_gets=[
                 MockGet(
                     output_type=CheckResults,
-                    input_types=(CheckRequest,),
-                    mock=lambda field_set_collection: field_set_collection.check_results,
+                    input_types=(
+                        CheckRequest,
+                        EnvironmentName,
+                    ),
+                    mock=lambda field_set_collection, _: field_set_collection.check_results,
+                ),
+                MockGet(
+                    output_type=EnvironmentName,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda a: EnvironmentName(a.raw_value),
                 ),
             ],
             union_membership=union_membership,


### PR DESCRIPTION
`check` will now run each `CheckRequest` in each specified environment per the `field_sets` in the `CheckRequest`. It looks like the remainder of the `check` infrastructure already successfully handles dealing with multiple `CheckRequest`s.

See #17129 