### PR TITLE
go: properly handle xtest packages when building (Cherry pick of #17307)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -186,6 +186,13 @@ async def map_import_paths_of_all_go_protobuf_targets(
                             for import_path, addresses in import_path_mapping.items()
                         }
                     ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
                 )
                 for go_mod_addr, import_path_mapping in import_paths_by_module.items()
             }

--- a/src/python/pants/backend/go/dependency_inference.py
+++ b/src/python/pants/backend/go/dependency_inference.py
@@ -31,6 +31,7 @@ class GoModuleImportPathsMapping:
     path(s) for a single Go module."""
 
     mapping: FrozenDict[str, GoImportPathsMappingAddressSet]
+    address_to_import_path: FrozenDict[Address, str]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -55,7 +55,7 @@ from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.ordered_set import FrozenOrderedSet
 
 # Known options to Go test binaries. Only these options will be transformed by `transform_test_args`.
 # The bool value represents whether the option is expected to take a value or not.
@@ -246,32 +246,18 @@ async def run_go_tests(
     if testmain.has_xtests:
         # Build a synthetic package for xtests where the import path is the same as the package under test
         # but with "_test" appended.
-        #
-        # Subset the direct dependencies to only the dependencies used by the xtest code. (Dependency
-        # inference will have included all of the regular, test, and xtest dependencies of the package in
-        # the build graph.) Moreover, ensure that any import of the package under test is on the _test_
-        # version of the package that was just built.
-        dep_by_import_path = {
-            dep.import_path: dep for dep in test_pkg_build_request.direct_dependencies
-        }
-        direct_dependencies: OrderedSet[BuildGoPackageRequest] = OrderedSet()
-        for xtest_import in pkg_analysis.xtest_imports:
-            if xtest_import == pkg_analysis.import_path:
-                direct_dependencies.add(test_pkg_build_request)
-            elif xtest_import in dep_by_import_path:
-                direct_dependencies.add(dep_by_import_path[xtest_import])
-
-        xtest_pkg_build_request = BuildGoPackageRequest(
-            import_path=f"{import_path}_test",
-            digest=pkg_digest.digest,
-            dir_path=pkg_analysis.dir_path,
-            go_file_names=pkg_analysis.xtest_go_files,
-            s_file_names=(),  # TODO: Are there .s files for xtest?
-            direct_dependencies=tuple(direct_dependencies),
-            minimum_go_version=pkg_analysis.minimum_go_version,
-            embed_config=pkg_digest.xtest_embed_config,
-            coverage_config=coverage_config,
+        maybe_xtest_pkg_build_request = await Get(
+            FallibleBuildGoPackageRequest,
+            BuildGoPackageTargetRequest(
+                field_set.address, for_xtests=True, coverage_config=coverage_config
+            ),
         )
+        if maybe_xtest_pkg_build_request.request is None:
+            assert maybe_xtest_pkg_build_request.stderr is not None
+            return compilation_failure(
+                maybe_xtest_pkg_build_request.exit_code, None, maybe_xtest_pkg_build_request.stderr
+            )
+        xtest_pkg_build_request = maybe_xtest_pkg_build_request.request
         main_direct_deps.append(xtest_pkg_build_request)
 
     # Generate coverage setup code for the test main if coverage is enabled.

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -128,6 +128,13 @@ async def go_map_import_paths_by_module(
                             for import_path, addresses in import_path_mapping.items()
                         }
                     ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
                 )
                 for go_mod_addr, import_path_mapping in import_paths_by_module.items()
             }
@@ -171,6 +178,13 @@ async def go_merge_import_paths_analysis(
                                 infer_all=infer_all_by_module[go_mod_addr][import_path],
                             )
                             for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
                         }
                     ),
                 )

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -7,6 +7,8 @@ import dataclasses
 from dataclasses import dataclass
 from typing import ClassVar, Type, cast
 
+from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
+from pants.backend.go.target_type_rules import GoImportPathMappingRequest
 from pants.backend.go.target_types import (
     GoImportPathField,
     GoPackageSourcesField,
@@ -16,6 +18,7 @@ from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
 )
+from pants.backend.go.util_rules.cgo import CGoCompilerFlags
 from pants.backend.go.util_rules.coverage import GoCoverageConfig
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
@@ -23,8 +26,15 @@ from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgDigest,
     FirstPartyPkgAnalysisRequest,
     FirstPartyPkgDigestRequest,
+    FirstPartyPkgImportPath,
+    FirstPartyPkgImportPathRequest,
 )
-from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
+from pants.backend.go.util_rules.go_mod import (
+    GoModInfo,
+    GoModInfoRequest,
+    OwningGoMod,
+    OwningGoModRequest,
+)
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
@@ -57,10 +67,18 @@ class BuildGoPackageTargetRequest(EngineAwareParameter):
     address: Address
     is_main: bool = False
     for_tests: bool = False
+    for_xtests: bool = False
     coverage_config: GoCoverageConfig | None = None
 
     def debug_hint(self) -> str:
         return str(self.address)
+
+    def __post_init__(self):
+        if self.for_tests and self.for_xtests:
+            raise ValueError(
+                "`BuildGoPackageTargetRequest.for_tests` and `BuildGoPackageTargetRequest.for_xtests` "
+                "cannot be set together."
+            )
 
 
 @union
@@ -153,6 +171,10 @@ async def setup_build_go_package_target_request(
 
         digest = _first_party_pkg_digest.digest
         import_path = _first_party_pkg_analysis.import_path
+        base_import_path = import_path
+        imports = set(_first_party_pkg_analysis.imports)
+        if request.for_tests:
+            imports.update(_first_party_pkg_analysis.test_imports)
         dir_path = _first_party_pkg_analysis.dir_path
         minimum_go_version = _first_party_pkg_analysis.minimum_go_version
 
@@ -171,8 +193,31 @@ async def setup_build_go_package_target_request(
                     embed_config = _first_party_pkg_digest.test_embed_config
         s_file_names = _first_party_pkg_analysis.s_files
 
+        # If the xtest package was requested, then replace analysis with the xtest values.
+        if request.for_xtests:
+            import_path = f"{import_path}_test"
+            pkg_name = f"{pkg_name}_test"
+            imports = set(_first_party_pkg_analysis.xtest_imports)
+            go_file_names = _first_party_pkg_analysis.xtest_go_files
+            s_files = ()
+            cgo_files = ()
+            cgo_flags = CGoCompilerFlags(
+                cflags=(),
+                cppflags=(),
+                cxxflags=(),
+                fflags=(),
+                ldflags=(),
+                pkg_config=(),
+            )
+            c_files = ()
+            cxx_files = ()
+            objc_files = ()
+            fortran_files = ()
+            embed_config = _first_party_pkg_digest.xtest_embed_config
+
     elif target.has_field(GoThirdPartyPackageDependenciesField):
         import_path = target[GoImportPathField].value
+        base_import_path = import_path
 
         _go_mod_address = target.address.maybe_convert_to_target_generator()
         _go_mod_info = await Get(GoModInfo, GoModInfoRequest(_go_mod_address))
@@ -186,6 +231,7 @@ async def setup_build_go_package_target_request(
         if _third_party_pkg_info.error:
             raise _third_party_pkg_info.error
 
+        imports = set(_third_party_pkg_info.imports)
         dir_path = _third_party_pkg_info.dir_path
         digest = _third_party_pkg_info.digest
         minimum_go_version = _third_party_pkg_info.minimum_go_version
@@ -200,25 +246,84 @@ async def setup_build_go_package_target_request(
             "message!"
         )
 
-    all_deps = await Get(Targets, DependenciesRequest(target[Dependencies]))
-    maybe_direct_dependencies = await MultiGet(
-        Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(tgt.address))
-        for tgt in all_deps
-        if (
-            tgt.has_field(GoPackageSourcesField)
-            or tgt.has_field(GoThirdPartyPackageDependenciesField)
-            or bool(maybe_get_codegen_request_type(tgt, union_membership))
-        )
+    all_direct_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
+
+    first_party_dep_import_path_targets = []
+    third_party_dep_import_path_targets = []
+    codegen_dep_import_path_targets = []
+    for dep in all_direct_dependencies:
+        if dep.has_field(GoPackageSourcesField):
+            first_party_dep_import_path_targets.append(dep)
+        elif dep.has_field(GoThirdPartyPackageDependenciesField):
+            third_party_dep_import_path_targets.append(dep)
+        elif bool(maybe_get_codegen_request_type(dep, union_membership)):
+            codegen_dep_import_path_targets.append(dep)
+
+    first_party_dep_import_path_results = await MultiGet(
+        Get(FirstPartyPkgImportPath, FirstPartyPkgImportPathRequest(tgt.address))
+        for tgt in first_party_dep_import_path_targets
     )
-    direct_dependencies = []
-    for maybe_dep in maybe_direct_dependencies:
-        if maybe_dep.request is None:
+    first_party_dep_import_paths = {
+        result.import_path: tgt.address
+        for tgt, result in zip(
+            first_party_dep_import_path_targets, first_party_dep_import_path_results
+        )
+    }
+
+    pkg_dependency_addresses_set = {
+        address
+        for dep_import_path, address in first_party_dep_import_paths.items()
+        if dep_import_path in imports
+    }
+    pkg_dependency_addresses_set.update(
+        dep_tgt.address
+        for dep_tgt in third_party_dep_import_path_targets
+        if dep_tgt[GoImportPathField].value in imports
+    )
+    if codegen_dep_import_path_targets:
+        go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.address))
+        import_paths_mapping = await Get(
+            GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
+        )
+        for dep_tgt in codegen_dep_import_path_targets:
+            codegen_dep_import_path = import_paths_mapping.address_to_import_path.get(
+                dep_tgt.address
+            )
+            if codegen_dep_import_path is None:
+                # TODO: Emit warning?
+                continue
+            if codegen_dep_import_path in imports:
+                pkg_dependency_addresses_set.add(dep_tgt.address)
+
+    pkg_dependency_addresses = sorted(pkg_dependency_addresses_set)
+    maybe_pkg_direct_dependencies = await MultiGet(
+        Get(FallibleBuildGoPackageRequest, BuildGoPackageTargetRequest(address))
+        for address in pkg_dependency_addresses
+    )
+
+    pkg_direct_dependencies = []
+    for maybe_pkg_dep in maybe_pkg_direct_dependencies:
+        if maybe_pkg_dep.request is None:
             return dataclasses.replace(
-                maybe_dep,
-                import_path="main" if request.is_main else import_path,
+                maybe_pkg_dep,
                 dependency_failed=True,
             )
-        direct_dependencies.append(maybe_dep.request)
+        pkg_direct_dependencies.append(maybe_pkg_dep.request)
+
+    # Allow xtest packages to depend on the base package (with tests).
+    if request.for_xtests and any(
+        dep_import_path == base_import_path for dep_import_path in imports
+    ):
+        maybe_base_pkg_dep = await Get(
+            FallibleBuildGoPackageRequest,
+            BuildGoPackageTargetRequest(request.address, for_tests=True),
+        )
+        if maybe_base_pkg_dep.request is None:
+            return dataclasses.replace(
+                maybe_base_pkg_dep,
+                dependency_failed=True,
+            )
+        pkg_direct_dependencies.append(maybe_base_pkg_dep.request)
 
     result = BuildGoPackageRequest(
         digest=digest,
@@ -227,7 +332,7 @@ async def setup_build_go_package_target_request(
         go_file_names=go_file_names,
         s_file_names=s_file_names,
         minimum_go_version=minimum_go_version,
-        direct_dependencies=tuple(direct_dependencies),
+        direct_dependencies=tuple(pkg_direct_dependencies),
         for_tests=request.for_tests,
         embed_config=embed_config,
         coverage_config=request.coverage_config,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -4,12 +4,19 @@
 from __future__ import annotations
 
 import os
+from collections import defaultdict
 from textwrap import dedent
 
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.dependency_inference import (
+    GoImportPathsMappingAddressSet,
+    GoModuleImportPathsMapping,
+    GoModuleImportPathsMappings,
+    GoModuleImportPathsMappingsHook,
+)
+from pants.backend.go.target_types import GoModTarget, GoOwningGoModAddressField, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -31,13 +38,17 @@ from pants.backend.go.util_rules.build_pkg_target import (
     BuildGoPackageTargetRequest,
     GoCodegenBuildRequest,
 )
-from pants.core.target_types import FilesGeneratorTarget, FileSourceField
+from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
+from pants.core.target_types import FilesGeneratorTarget, FileSourceField, FileTarget
 from pants.engine.addresses import Address, Addresses
 from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot
+from pants.engine.internals.selectors import MultiGet
 from pants.engine.rules import Get, QueryRule, rule
-from pants.engine.target import Dependencies, DependenciesRequest
+from pants.engine.target import AllTargets, Dependencies, DependenciesRequest
 from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
 from pants.util.strutil import path_safe
 
 
@@ -46,6 +57,54 @@ from pants.util.strutil import path_safe
 # is common for codegen plugins to need to do.
 class GoCodegenBuildFilesRequest(GoCodegenBuildRequest):
     generate_from = FileSourceField
+
+
+class GenerateFromFileImportPathsMappingHook(GoModuleImportPathsMappingsHook):
+    pass
+
+
+@rule(desc="Map import paths for all 'generate from file' targets.", level=LogLevel.DEBUG)
+async def map_import_paths(
+    _request: GenerateFromFileImportPathsMappingHook,
+    all_targets: AllTargets,
+) -> GoModuleImportPathsMappings:
+    file_targets = [tgt for tgt in all_targets if tgt.has_field(FileSourceField)]
+
+    owning_go_mod_targets = await MultiGet(
+        Get(OwningGoMod, OwningGoModRequest(tgt.address)) for tgt in file_targets
+    )
+
+    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+
+    for owning_go_mod, tgt in zip(owning_go_mod_targets, file_targets):
+        import_paths_by_module[owning_go_mod.address]["codegen.com/gen"].add(tgt.address)
+
+    return GoModuleImportPathsMappings(
+        FrozenDict(
+            {
+                go_mod_addr: GoModuleImportPathsMapping(
+                    mapping=FrozenDict(
+                        {
+                            import_path: GoImportPathsMappingAddressSet(
+                                addresses=tuple(sorted(addresses)), infer_all=True
+                            )
+                            for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
+                )
+                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
+            }
+        )
+    )
 
 
 @rule
@@ -100,11 +159,15 @@ def rule_runner() -> RuleRunner:
             *third_party_pkg.rules(),
             *target_type_rules.rules(),
             generate_from_file,
+            map_import_paths,
             QueryRule(BuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(FallibleBuiltGoPackage, [BuildGoPackageRequest]),
             QueryRule(BuildGoPackageRequest, [BuildGoPackageTargetRequest]),
             QueryRule(FallibleBuildGoPackageRequest, [BuildGoPackageTargetRequest]),
             UnionRule(GoCodegenBuildRequest, GoCodegenBuildFilesRequest),
+            UnionRule(GoModuleImportPathsMappingsHook, GenerateFromFileImportPathsMappingHook),
+            FileTarget.register_plugin_field(GoOwningGoModAddressField),
+            FilesGeneratorTarget.register_plugin_field(GoOwningGoModAddressField),
         ],
         target_types=[GoModTarget, GoPackageTarget, FilesGeneratorTarget],
     )
@@ -140,9 +203,9 @@ def assert_pkg_target_built(
     assert build_request.dir_path == expected_dir_path
     assert build_request.go_file_names == tuple(expected_go_file_names)
     assert not build_request.s_file_names
-    assert [
+    assert sorted([
         dep.import_path for dep in build_request.direct_dependencies
-    ] == expected_direct_dependency_import_paths
+    ]) == sorted(expected_direct_dependency_import_paths)
     assert_built(
         rule_runner,
         build_request,
@@ -473,4 +536,59 @@ def test_build_codegen_target(rule_runner: RuleRunner) -> None:
         expected_go_file_names=["greeter.go"],
         expected_direct_dependency_import_paths=["codegen.com/gen"],
         expected_transitive_dependency_import_paths=["github.com/google/uuid"],
+    )
+
+
+def test_xtest_deps(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": "module example.pantsbuild.org",
+            "BUILD": "go_mod(name='mod')\n",
+            "pkg/BUILD": "go_package()\n",
+            "pkg/example.go": dedent(
+                """\
+            package pkg
+
+            const ExampleValue = 2137
+            """
+            ),
+            "pkg/example_test.go": dedent(
+                """\
+            package pkg_test
+
+            import (
+                "example.pantsbuild.org/pkg"
+                "example.pantsbuild.org/pkg/testutils"
+                "testing"
+            )
+
+            func TestValue(t *testing.T) {
+                t.Run("Test", func(t *testing.T) {
+                    if pkg.ExampleValue != testutils.ExampleValueFromTestutils {
+                        t.Error("Not equal")
+                    }
+                })
+            }
+            """
+            ),
+            "pkg/testutils/BUILD": "go_package()\n",
+            "pkg/testutils/testutils.go": dedent(
+                """\
+            package testutils
+
+            import "example.pantsbuild.org/pkg"
+
+            const ExampleValueFromTestutils = pkg.ExampleValue
+            """
+            ),
+        }
+    )
+    assert_pkg_target_built(
+        rule_runner,
+        Address("pkg"),
+        expected_dir_path="pkg",
+        expected_import_path="example.pantsbuild.org/pkg",
+        expected_go_file_names=["example.go"],
+        expected_direct_dependency_import_paths=[],
+        expected_transitive_dependency_import_paths=[],
     )


### PR DESCRIPTION
External test ("xtest") packages are distinct from their base package. While this distinction does appear in the Go package analysis types, it was not modeled in the dependencies among Go targets (e.g., `go_package`). This caused dependencies for base and xtest packages to be conflated, causing the issue in https://github.com/pantsbuild/pants/issues/17236.

Model dependencies correctly when building `BuildGoPackageRequest` trees so that dependencies of the base package do not become dependencies of the xtest package and vice versa.

Fixes https://github.com/pantsbuild/pants/issues/17236

[ci skip-build-wheels]