### PR TITLE
remote: refactor `make_execute_request` to return a struct instead of tuple

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -89,6 +89,8 @@ pub use crate::immutable_inputs::ImmutableInputs;
 pub use crate::named_caches::{CacheName, NamedCaches};
 pub use crate::remote_cache::RemoteCacheWarningsBehavior;
 
+use crate::remote::EntireExecuteRequest;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProcessError {
   /// A Digest was not present in either of the local or remote Stores.
@@ -960,8 +962,9 @@ pub fn digest(
   instance_name: Option<String>,
   process_cache_namespace: Option<String>,
 ) -> Digest {
-  let (_, _, execute_request) =
-    remote::make_execute_request(process, instance_name, process_cache_namespace).unwrap();
+  let EntireExecuteRequest {
+    execute_request, ..
+  } = remote::make_execute_request(process, instance_name, process_cache_namespace).unwrap();
   execute_request.action_digest.unwrap().try_into().unwrap()
 }
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -910,11 +910,20 @@ fn maybe_add_workunit(
   }
 }
 
+/// Return type for `make_execute_request`. Contains all of the generated REAPI protobufs for
+/// a particular `Process`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct EntireExecuteRequest {
+  pub action: Action,
+  pub command: Command,
+  pub execute_request: ExecuteRequest,
+}
+
 pub fn make_execute_request(
   req: &Process,
   instance_name: Option<String>,
   cache_key_gen_version: Option<String>,
-) -> Result<(remexec::Action, remexec::Command, remexec::ExecuteRequest), String> {
+) -> Result<EntireExecuteRequest, String> {
   let mut command = remexec::Command {
     arguments: req.argv.clone(),
     ..remexec::Command::default()
@@ -1091,7 +1100,11 @@ pub fn make_execute_request(
     ..remexec::ExecuteRequest::default()
   };
 
-  Ok((action, command, execute_request))
+  Ok(EntireExecuteRequest {
+    action,
+    command,
+    execute_request,
+  })
 }
 
 async fn populate_fallible_execution_result_for_timeout(

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -806,7 +806,11 @@ impl crate::CommandRunner for CommandRunner {
     trace!("RE capabilities: {:?}", &capabilities);
 
     // Construct the REv2 ExecuteRequest and related data for this execution request.
-    let (action, command, execute_request) = make_execute_request(
+    let EntireExecuteRequest {
+      action,
+      command,
+      execute_request,
+    } = make_execute_request(
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -21,7 +21,9 @@ use workunit_store::{
   in_workunit, Level, Metric, ObservationMetric, RunningWorkunit, WorkunitMetadata,
 };
 
-use crate::remote::{apply_headers, make_execute_request, populate_fallible_execution_result};
+use crate::remote::{
+  apply_headers, make_execute_request, populate_fallible_execution_result, EntireExecuteRequest,
+};
 use crate::{
   check_cache_content, CacheContentBehavior, Context, FallibleProcessResultWithPlatform, Platform,
   Process, ProcessCacheScope, ProcessError, ProcessResultSource,
@@ -466,7 +468,9 @@ impl crate::CommandRunner for CommandRunner {
   ) -> Result<FallibleProcessResultWithPlatform, ProcessError> {
     let cache_lookup_start = Instant::now();
     // Construct the REv2 ExecuteRequest and related data for this execution request.
-    let (action, command, _execute_request) = make_execute_request(
+    let EntireExecuteRequest {
+      action, command, ..
+    } = make_execute_request(
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -18,7 +18,7 @@ use store::Store;
 use testutil::data::{TestData, TestDirectory, TestTree};
 use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
-use crate::remote::{ensure_action_stored_locally, make_execute_request};
+use crate::remote::{ensure_action_stored_locally, make_execute_request, EntireExecuteRequest};
 use crate::{
   CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
   FallibleProcessResultWithPlatform, Platform, Process, ProcessCacheScope, ProcessError,
@@ -160,7 +160,9 @@ async fn create_process(store_setup: &StoreSetup) -> (Process, Digest) {
   let process = Process::new(vec![
     "this process will not execute: see MockLocalCommandRunner".to_string(),
   ]);
-  let (action, command, _exec_request) = make_execute_request(&process, None, None).unwrap();
+  let EntireExecuteRequest {
+    action, command, ..
+  } = make_execute_request(&process, None, None).unwrap();
   let (_command_digest, action_digest) =
     ensure_action_stored_locally(&store_setup.store, &command, &action)
       .await


### PR DESCRIPTION
Refactor `make_execute_request` to return a struct instead of tuple so that (1) it is easier to refer to the returned instances by a more descriptive name than `.2`; (2) avoid call sites needing to know the order in which the values are returned if they are unpacking the result; and (3) make it easier to add new fields later (for example, the `input_root_digest` field to be added by https://github.com/pantsbuild/pants/pull/17290).