### PR TITLE
Adds warning if lint/fmt/fix runs on a target using a non-local environment.

### DIFF
--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -210,7 +210,7 @@ class FixSubsystem(GoalSubsystem):
 
 class Fix(Goal):
     subsystem_cls = FixSubsystem
-    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @rule_helper

--- a/src/python/pants/core/goals/fmt.py
+++ b/src/python/pants/core/goals/fmt.py
@@ -63,7 +63,7 @@ class FmtSubsystem(GoalSubsystem):
 
 class Fmt(Goal):
     subsystem_cls = FmtSubsystem
-    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -19,6 +19,7 @@ from pants.core.goals.multi_tool_goal_helper import (
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.environments import _warn_on_non_local_environments
 from pants.core.util_rules.partitions import PartitionElementT, PartitionerType, PartitionMetadataT
 from pants.core.util_rules.partitions import Partitions as Partitions  # re-export
 from pants.core.util_rules.partitions import (
@@ -267,7 +268,7 @@ class LintSubsystem(GoalSubsystem):
 
 class Lint(Goal):
     subsystem_cls = LintSubsystem
-    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 def _print_results(
@@ -364,6 +365,8 @@ async def _get_partitions_by_request_type(
     _get_specs_paths = Get(SpecsPaths, Specs, specs if file_partitioners else Specs.empty())
 
     targets, specs_paths = await MultiGet(_get_targets, _get_specs_paths)
+
+    await _warn_on_non_local_environments(targets, f"the {subsystem.name} goal")
 
     def partition_request_get(request_type: type[LintRequest]) -> Get[Partitions]:
         partition_request_type: type = getattr(request_type, "PartitionRequest")

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -25,8 +25,10 @@ from pants.core.goals.lint import (
     lint,
 )
 from pants.core.util_rules.distdir import DistDir
+from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.core.util_rules.partitions import Partition, PartitionerType
 from pants.engine.addresses import Address
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, SpecsPaths, Workspace
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT, Snapshot
 from pants.engine.rules import QueryRule
@@ -307,6 +309,11 @@ def run_lint_rule(
                     output_type=Partitions,
                     input_types=(LintTargetsRequest.PartitionRequest,),
                     mock=mock_target_partitioner,
+                ),
+                MockGet(
+                    output_type=EnvironmentName,
+                    input_types=(EnvironmentNameRequest,),
+                    mock=lambda _: EnvironmentName(None),
                 ),
                 MockGet(
                     output_type=Partitions,


### PR DESCRIPTION
This adds a warning if a target-based `fmt`/`lint`/`fix` operation runs against a target that specifies a non-local environment. 

To property use environments, we'll need a way of making the partitioning rules a bit more pluggable, or decide that individual back-end implementations will be responsible for deciding where they run (which is probably also not great).

Addresses #17129.