### PR TITLE
Replace `skip` placeholders with real `SkipOption`s in test subsystems.

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -106,8 +106,7 @@ class GoTestFieldSet(TestFieldSet):
 
 
 class GoTestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = GoTestSubsystem  # type: ignore[assignment]
+    tool_subsystem = GoTestSubsystem
     field_set_type = GoTestFieldSet
 
 

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -7,7 +7,7 @@ from pathlib import PurePath
 
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.core.util_rules.distdir import DistDir
-from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, StrOption
+from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, SkipOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -66,8 +66,7 @@ class GoTestSubsystem(Subsystem):
         ),
     )
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")
 
     def coverage_output_dir(self, distdir: DistDir, import_path: str) -> PurePath:
         import_path_escaped = import_path.replace("/", "_")

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -11,7 +11,7 @@ from pants.backend.helm.util_rules.tool import (
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import BoolOption, EnumOption
+from pants.option.option_types import BoolOption, EnumOption, SkipOption
 
 
 class HelmUnitTestReportFormat(Enum):
@@ -53,8 +53,7 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         help="Output type used for the test report.",
     )
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")
 
     def generate_exe(self, _: Platform) -> str:
         return "./untt"

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -72,8 +72,7 @@ class HelmUnitTestFieldSet(TestFieldSet):
 
 
 class HelmUnitTestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = HelmUnitTestSubsystem  # type: ignore[assignment]
+    tool_subsystem = HelmUnitTestSubsystem
     field_set_type = HelmUnitTestFieldSet
 
 

--- a/src/python/pants/backend/java/subsystems/junit.py
+++ b/src/python/pants/backend/java/subsystems/junit.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import ArgsListOption
+from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.docutil import git_url
 
 
@@ -23,5 +23,4 @@ class JUnit(JvmToolBase):
 
     args = ArgsListOption(example="--disable-ansi-colors", passthrough=True)
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -376,8 +376,7 @@ async def setup_pytest_for_target(
 
 
 class PyTestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = PyTest  # type: ignore[assignment]
+    tool_subsystem = PyTest
     field_set_type = PythonTestFieldSet
 
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -35,7 +35,7 @@ from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, BoolOption, FileOption, StrOption
+from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
 from pants.util.docutil import bin_name, doc_url, git_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
@@ -146,8 +146,7 @@ class PyTest(PythonToolBase):
 
     export = ExportToolOption()
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")
 
     @property
     def all_requirements(self) -> tuple[str, ...]:

--- a/src/python/pants/backend/scala/subsystems/scalatest.py
+++ b/src/python/pants/backend/scala/subsystems/scalatest.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import ArgsListOption
+from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.docutil import git_url
 
 
@@ -25,5 +25,4 @@ class Scalatest(JvmToolBase):
         extra_help="See https://www.scalatest.org/user_guide/using_the_runner for supported arguments.",
     )
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -63,8 +63,7 @@ class ScalatestTestFieldSet(TestFieldSet):
 
 
 class ScalatestTestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = Scalatest  # type: ignore[assignment]
+    tool_subsystem = Scalatest
     field_set_type = ScalatestTestFieldSet
 
 

--- a/src/python/pants/backend/shell/shunit2.py
+++ b/src/python/pants/backend/shell/shunit2.py
@@ -4,6 +4,7 @@
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.rules import collect_rules
+from pants.option.option_types import SkipOption
 from pants.util.meta import classproperty
 
 
@@ -16,8 +17,7 @@ class Shunit2(TemplatedExternalTool):
     default_version = "b9102bb763cc603b3115ed30a5648bf950548097"
     default_url_template = "https://raw.githubusercontent.com/kward/shunit2/{version}/shunit2"
 
-    # TODO: Replace with a proper `SkipOption`.
-    skip = False
+    skip = SkipOption("test")
 
     @classproperty
     def default_known_versions(cls):

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -70,8 +70,7 @@ class Shunit2FieldSet(TestFieldSet):
 
 
 class Shunit2TestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = Shunit2  # type: ignore[assignment]
+    tool_subsystem = Shunit2
     field_set_type = Shunit2FieldSet
 
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -65,8 +65,7 @@ class JunitTestFieldSet(TestFieldSet):
 
 
 class JunitTestRequest(TestRequest):
-    # TODO: Remove the type-ignore after adding a `skip` option to the subsystem.
-    tool_subsystem = JUnit  # type: ignore[assignment]
+    tool_subsystem = JUnit
     field_set_type = JunitTestFieldSet
 
 


### PR DESCRIPTION
Closes #17338 

The hard-coded `skip` placeholders were added to all of our test subsystems as part of the migration to a partition-based API. Replacing the placeholders will enable users to run things like `./pants --pytest-skip test ::`.

Using proper options also lets us delete a handful of `type: ignore` comments.