### PR TITLE
Add a `batch_size` parameter to the `test` subsystem.

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -570,10 +570,10 @@ class TestSubsystem(GoalSubsystem):
             The target maximum number of files to be included in each run of batch-enabled
             test runners.
 
-            Some test runners can execute tests from multiple files in a single run. Plugins
-            that implement this behavior will return all tests that _can_ run together as a
-            single group - the core `test` goal will then divide that group into smaller batches
-            according to this parameter. This is done:
+            Some test runners can execute tests from multiple files in a single run. Test
+            implementations will return all tests that _can_ run together as a single group -
+            and then this may be further divided into smaller batches, based on this option.
+            This is done:
 
                 1. to avoid OS argument length limits (in processes which don't support argument files)
                 2. to support more stable cache keys than would be possible if all files were operated \

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -220,6 +220,7 @@ def run_test_rule(
         output=output,
         extra_env_vars=[],
         shard="",
+        batch_size=1,
     )
     debug_adapter_subsystem = create_subsystem(
         DebugAdapterSubsystem,


### PR DESCRIPTION
Closes #17339 

The initial implementation of batched testing hard-coded a max batch size into the core `test` goal. This commit replaces the hard-coded value with a new subsystem parameter, so users can tweak batch sizes if needed for caching / performance.