### PR TITLE
modify `make_execute_request` to be async and return the input root's `DirectoryDigest`

### DIFF
--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -76,7 +76,11 @@ impl crate::CommandRunner for CommandRunner {
     let cache_lookup_start = Instant::now();
     let write_failures_to_cache = req.cache_scope == ProcessCacheScope::Always;
     let key = CacheKey {
-      digest: Some(crate::digest(&req, None, self.process_cache_namespace.clone()).into()),
+      digest: Some(
+        crate::digest(&req, None, self.process_cache_namespace.clone())
+          .await
+          .into(),
+      ),
       key_type: CacheKeyType::Process.into(),
     };
 

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -77,9 +77,14 @@ impl crate::CommandRunner for CommandRunner {
     let write_failures_to_cache = req.cache_scope == ProcessCacheScope::Always;
     let key = CacheKey {
       digest: Some(
-        crate::digest(&req, None, self.process_cache_namespace.clone())
-          .await
-          .into(),
+        crate::digest(
+          &req,
+          None,
+          self.process_cache_namespace.clone(),
+          &self.file_store,
+        )
+        .await
+        .into(),
       ),
       key_type: CacheKeyType::Process.into(),
     };

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -961,10 +961,11 @@ pub async fn digest(
   process: &Process,
   instance_name: Option<String>,
   process_cache_namespace: Option<String>,
+  store: &Store,
 ) -> Digest {
   let EntireExecuteRequest {
     execute_request, ..
-  } = remote::make_execute_request(process, instance_name, process_cache_namespace)
+  } = remote::make_execute_request(process, instance_name, process_cache_namespace, store)
     .await
     .unwrap();
   execute_request.action_digest.unwrap().try_into().unwrap()

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -957,14 +957,16 @@ impl<T: CommandRunner + ?Sized> CommandRunner for Arc<T> {
 }
 
 // TODO(#8513) possibly move to the MEPR struct, or to the hashing crate?
-pub fn digest(
+pub async fn digest(
   process: &Process,
   instance_name: Option<String>,
   process_cache_namespace: Option<String>,
 ) -> Digest {
   let EntireExecuteRequest {
     execute_request, ..
-  } = remote::make_execute_request(process, instance_name, process_cache_namespace).unwrap();
+  } = remote::make_execute_request(process, instance_name, process_cache_namespace)
+    .await
+    .unwrap();
   execute_request.action_digest.unwrap().try_into().unwrap()
 }
 

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -91,7 +91,8 @@ impl NailgunPool {
     immutable_inputs: &ImmutableInputs,
   ) -> Result<BorrowedNailgunProcess, ProcessError> {
     let name = server_process.description.clone();
-    let requested_fingerprint = NailgunProcessFingerprint::new(name.clone(), &server_process)?;
+    let requested_fingerprint =
+      NailgunProcessFingerprint::new(name.clone(), &server_process).await?;
     let semaphore_acquisition = self.sema.clone().acquire_owned();
     let permit = in_workunit!(
       "acquire_nailgun_process",
@@ -426,8 +427,8 @@ struct NailgunProcessFingerprint {
 }
 
 impl NailgunProcessFingerprint {
-  pub fn new(name: String, nailgun_req: &Process) -> Result<Self, String> {
-    let nailgun_req_digest = crate::digest(nailgun_req, None, None);
+  pub async fn new(name: String, nailgun_req: &Process) -> Result<Self, String> {
+    let nailgun_req_digest = crate::digest(nailgun_req, None, None).await;
     Ok(NailgunProcessFingerprint {
       name,
       fingerprint: nailgun_req_digest.hash,

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -92,7 +92,7 @@ impl NailgunPool {
   ) -> Result<BorrowedNailgunProcess, ProcessError> {
     let name = server_process.description.clone();
     let requested_fingerprint =
-      NailgunProcessFingerprint::new(name.clone(), &server_process).await?;
+      NailgunProcessFingerprint::new(name.clone(), &server_process, &self.store).await?;
     let semaphore_acquisition = self.sema.clone().acquire_owned();
     let permit = in_workunit!(
       "acquire_nailgun_process",
@@ -427,8 +427,8 @@ struct NailgunProcessFingerprint {
 }
 
 impl NailgunProcessFingerprint {
-  pub async fn new(name: String, nailgun_req: &Process) -> Result<Self, String> {
-    let nailgun_req_digest = crate::digest(nailgun_req, None, None).await;
+  pub async fn new(name: String, nailgun_req: &Process, store: &Store) -> Result<Self, String> {
+    let nailgun_req_digest = crate::digest(nailgun_req, None, None, store).await;
     Ok(NailgunProcessFingerprint {
       name,
       fingerprint: nailgun_req_digest.hash,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -810,6 +810,7 @@ impl crate::CommandRunner for CommandRunner {
       action,
       command,
       execute_request,
+      input_root_digest,
     } = make_execute_request(
       &request,
       self.instance_name.clone(),
@@ -838,7 +839,7 @@ impl crate::CommandRunner for CommandRunner {
       &self.store,
       command_digest,
       action_digest,
-      Some(request.input_digests.complete.clone()),
+      Some(input_root_digest),
     )
     .await?;
 
@@ -923,6 +924,7 @@ pub struct EntireExecuteRequest {
   pub action: Action,
   pub command: Command,
   pub execute_request: ExecuteRequest,
+  pub input_root_digest: DirectoryDigest,
 }
 
 pub async fn make_execute_request(
@@ -1086,9 +1088,11 @@ pub async fn make_execute_request(
     .environment_variables
     .sort_by(|x, y| x.name.cmp(&y.name));
 
+  let input_root_digest = req.input_digests.complete.clone();
+
   let mut action = remexec::Action {
     command_digest: Some((&digest(&command)?).into()),
-    input_root_digest: Some((&req.input_digests.complete.as_digest()).into()),
+    input_root_digest: Some(input_root_digest.as_digest().into()),
     ..remexec::Action::default()
   };
 
@@ -1111,6 +1115,7 @@ pub async fn make_execute_request(
     action,
     command,
     execute_request,
+    input_root_digest,
   })
 }
 

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -814,7 +814,8 @@ impl crate::CommandRunner for CommandRunner {
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
-    )?;
+    )
+    .await?;
     let build_id = context.build_id.clone();
 
     debug!("Remote execution: {}", request.description);
@@ -923,7 +924,7 @@ pub struct EntireExecuteRequest {
   pub execute_request: ExecuteRequest,
 }
 
-pub fn make_execute_request(
+pub async fn make_execute_request(
   req: &Process,
   instance_name: Option<String>,
   cache_key_gen_version: Option<String>,

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -814,6 +814,7 @@ impl crate::CommandRunner for CommandRunner {
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
+      &self.store,
     )
     .await?;
     let build_id = context.build_id.clone();
@@ -928,6 +929,7 @@ pub async fn make_execute_request(
   req: &Process,
   instance_name: Option<String>,
   cache_key_gen_version: Option<String>,
+  _store: &Store,
 ) -> Result<EntireExecuteRequest, String> {
   let mut command = remexec::Command {
     arguments: req.argv.clone(),

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -474,6 +474,7 @@ impl crate::CommandRunner for CommandRunner {
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
+      &self.store,
     )
     .await?;
     let failures_cached = request.cache_scope == ProcessCacheScope::Always;

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -474,7 +474,8 @@ impl crate::CommandRunner for CommandRunner {
       &request,
       self.instance_name.clone(),
       self.process_cache_namespace.clone(),
-    )?;
+    )
+    .await?;
     let failures_cached = request.cache_scope == ProcessCacheScope::Always;
 
     // Ensure the action and command are stored locally.

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -162,7 +162,7 @@ async fn create_process(store_setup: &StoreSetup) -> (Process, Digest) {
   ]);
   let EntireExecuteRequest {
     action, command, ..
-  } = make_execute_request(&process, None, None).unwrap();
+  } = make_execute_request(&process, None, None).await.unwrap();
   let (_command_digest, action_digest) =
     ensure_action_stored_locally(&store_setup.store, &command, &action)
       .await

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -162,7 +162,9 @@ async fn create_process(store_setup: &StoreSetup) -> (Process, Digest) {
   ]);
   let EntireExecuteRequest {
     action, command, ..
-  } = make_execute_request(&process, None, None).await.unwrap();
+  } = make_execute_request(&process, None, None, &store_setup.store)
+    .await
+    .unwrap();
   let (_command_digest, action_digest) =
     ensure_action_stored_locally(&store_setup.store, &command, &action)
       .await

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -147,7 +147,7 @@ async fn make_execute_request() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None),
+    crate::remote::make_execute_request(&req, None, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -244,7 +244,7 @@ async fn make_execute_request_with_instance_name() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, Some("dark-tower".to_owned()), None,),
+    crate::remote::make_execute_request(&req, Some("dark-tower".to_owned()), None,).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -339,7 +339,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, Some("meep".to_owned()),),
+    crate::remote::make_execute_request(&req, None, Some("meep".to_owned()),).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -409,7 +409,7 @@ async fn make_execute_request_with_jdk() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None),
+    crate::remote::make_execute_request(&req, None, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -503,7 +503,7 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None),
+    crate::remote::make_execute_request(&req, None, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -592,7 +592,7 @@ async fn make_execute_request_with_timeout() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None),
+    crate::remote::make_execute_request(&req, None, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -707,7 +707,7 @@ async fn make_execute_request_using_immutable_inputs() {
   };
 
   assert_eq!(
-    crate::remote::make_execute_request(&req, None, None),
+    crate::remote::make_execute_request(&req, None, None).await,
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
@@ -727,6 +727,7 @@ async fn successful_with_only_call_to_execute() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -768,6 +769,7 @@ async fn successful_after_reconnect_with_wait_execution() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -813,6 +815,7 @@ async fn successful_after_reconnect_from_retryable_error() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     let execute_request_2 = execute_request.clone();
@@ -868,6 +871,7 @@ async fn dropped_request_cancels() {
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
         execute_request: crate::remote::make_execute_request(&request, None, None)
+          .await
           .unwrap()
           .execute_request,
         stream_responses: Ok(vec![
@@ -922,6 +926,7 @@ async fn server_rejecting_execute_request_gives_error() {
         None,
         None,
       )
+      .await
       .unwrap()
       .execute_request,
       stream_responses: Err(Status::invalid_argument("".to_owned())),
@@ -947,6 +952,7 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -976,6 +982,7 @@ async fn sends_headers() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1169,6 +1176,7 @@ async fn ensure_inline_stdio_is_stored() {
     let EntireExecuteRequest {
       execute_request, ..
     } = crate::remote::make_execute_request(&echo_roland_request().try_into().unwrap(), None, None)
+      .await
       .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1267,6 +1275,7 @@ async fn bad_result_bytes() {
           None,
           None,
         )
+        .await
         .unwrap()
         .execute_request,
         stream_responses: Ok(vec![
@@ -1306,6 +1315,7 @@ async fn initial_response_error() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1348,6 +1358,7 @@ async fn initial_response_missing_response_and_error() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1385,6 +1396,7 @@ async fn fails_after_retry_limit_exceeded() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1439,6 +1451,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
       execute_request, ..
     } =
       crate::remote::make_execute_request(&execute_request.clone().try_into().unwrap(), None, None)
+        .await
         .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1495,6 +1508,7 @@ async fn execute_missing_file_uploads_if_known() {
     let EntireExecuteRequest {
       execute_request, ..
     } = crate::remote::make_execute_request(&cat_roland_request().try_into().unwrap(), None, None)
+      .await
       .unwrap();
 
     mock::execution_server::TestServer::new(
@@ -1514,6 +1528,7 @@ async fn execute_missing_file_uploads_if_known() {
             None,
             None,
           )
+          .await
           .unwrap()
           .execute_request,
           stream_responses: Ok(vec![

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -155,7 +155,8 @@ async fn make_execute_request() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -256,7 +257,8 @@ async fn make_execute_request_with_instance_name() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -355,7 +357,8 @@ async fn make_execute_request_with_cache_key_gen_version() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -429,7 +432,8 @@ async fn make_execute_request_with_jdk() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -527,7 +531,8 @@ async fn make_execute_request_with_jdk_and_extra_platform_properties() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -620,7 +625,8 @@ async fn make_execute_request_with_timeout() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: input_directory.directory_digest(),
     })
   );
 }
@@ -735,7 +741,8 @@ async fn make_execute_request_using_immutable_inputs() {
     Ok(EntireExecuteRequest {
       action: want_action,
       command: want_command,
-      execute_request: want_execute_request
+      execute_request: want_execute_request,
+      input_root_digest: expected_digest,
     })
   );
 }


### PR DESCRIPTION
Modify `make_execute_request` to be async, take a `Store` as a parameter, and to return the input root to use. This is prework for https://github.com/pantsbuild/pants/pull/17290 which needs the ability to make a new input root digest if a wrapper script needs to be added to the input root. (It will also be useful for other wrapper script applications, such as to solve the issue at  https://github.com/pantsbuild/pants/pull/17367#discussion_r1006760027 for remote execution.)