### PR TITLE
Refactor optional typing in generic partitioning utils.

### DIFF
--- a/src/python/pants/core/goals/fix_test.py
+++ b/src/python/pants/core/goals/fix_test.py
@@ -26,7 +26,7 @@ from pants.core.goals.fix import (
 from pants.core.goals.fix import rules as fix_rules
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules import source_files
-from pants.core.util_rules.partitions import Partition, PartitionerType
+from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.fs import (
     EMPTY_DIGEST,
     EMPTY_SNAPSHOT,
@@ -500,17 +500,8 @@ def test_default_single_partition_partitioner(kitchen_field_set_type, field_sets
     rule_runner = RuleRunner(rules=rules)
     print(rule_runner.write_files({"BUILD": "", "knife.utensil": "", "bowl.utensil": ""}))
     partitions = rule_runner.request(Partitions, [FixKitchenRequest.PartitionRequest(field_sets)])
-    assert partitions == Partitions(
-        [
-            Partition(
-                (
-                    "bowl.utensil",
-                    "knife.utensil",
-                ),
-                None,
-            )
-        ]
-    )
+    assert len(partitions) == 1
+    assert partitions[0].elements == ("bowl.utensil", "knife.utensil")
 
     rule_runner.set_options(["--kitchen-skip"])
     partitions = rule_runner.request(Partitions, [FixKitchenRequest.PartitionRequest(field_sets)])

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -76,9 +76,7 @@ class LintResult(EngineAwareReturnType):
             stdout=prep_output(process_result.stdout),
             stderr=prep_output(process_result.stderr),
             linter_name=request.tool_name,
-            partition_description=request.partition_metadata.description
-            if request.partition_metadata
-            else None,
+            partition_description=request.partition_metadata.description,
             report=report,
         )
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -25,7 +25,7 @@ from pants.core.goals.lint import (
     lint,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.partitions import Partition, PartitionerType
+from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.addresses import Address
 from pants.engine.fs import PathGlobs, SpecsPaths, Workspace
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT, Snapshot
@@ -508,7 +508,8 @@ def test_default_single_partition_partitioner() -> None:
         MockLinterFieldSet(Address("bowl"), MultipleSourcesField(["bowl"], Address("bowl"))),
     )
     partitions = rule_runner.request(Partitions, [LintKitchenRequest.PartitionRequest(field_sets)])
-    assert partitions == Partitions([Partition(field_sets, None)])
+    assert len(partitions) == 1
+    assert partitions[0].elements == field_sets
 
     rule_runner.set_options(["--kitchen-skip"])
     partitions = rule_runner.request(Partitions, [LintKitchenRequest.PartitionRequest(field_sets)])

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -118,9 +118,7 @@ class TestResult(EngineAwareReturnType):
             addresses=tuple(field_set.address for field_set in batch.elements),
             output_setting=output_setting,
             result_metadata=None,
-            partition_description=(
-                batch.partition_metadata.description if batch.partition_metadata else None
-            ),
+            partition_description=batch.partition_metadata.description,
         )
 
     @staticmethod
@@ -169,9 +167,7 @@ class TestResult(EngineAwareReturnType):
             coverage_data=coverage_data,
             xml_results=xml_results,
             extra_output=extra_output,
-            partition_description=(
-                batch.partition_metadata.description if batch.partition_metadata else None
-            ),
+            partition_description=batch.partition_metadata.description,
         )
 
     @property
@@ -330,7 +326,7 @@ class TestRequest:
 
             if len(self.elements) != 1:
                 description = ""
-                if self.partition_metadata:
+                if self.partition_metadata.description:
                     description = f" from partition '{self.partition_metadata.description}'"
                 raise TypeError(
                     f"Expected a single element in batch{description}, but found {len(self.elements)}"
@@ -728,7 +724,7 @@ async def get_batch_environment(batch: TestRequest.Batch) -> EnvironmentName:
     unique_environments = len({name.val for name in environment_names_per_element})
     if unique_environments != 1:
         batch_description = "Test batch"
-        if batch.partition_metadata:
+        if batch.partition_metadata.description:
             batch_description = f"{batch_description} '{batch.partition_metadata.description}'"
 
         raise AssertionError(

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -128,28 +128,23 @@ class Partitions(Collection[Partition[PartitionElementT, PartitionMetadataT]]):
             and files ABC with Py2.
     """
 
-    # NOTE: We have to redefine type-vars here for use in the `classmethod`s below because in this scope
-    # `PartitionElementT` and `PartitionMetadataT` are no longer generic.
-    _MetadataT = TypeVar("_MetadataT", bound=PartitionMetadata)
-    _ElementT = TypeVar("_ElementT")
-
     @overload
     @classmethod
     def single_partition(
-        cls, elements: Iterable[_ElementT]
-    ) -> Partitions[_ElementT, _EmptyMetadata]:
+        cls, elements: Iterable[PartitionElementT]
+    ) -> Partitions[PartitionElementT, _EmptyMetadata]:
         ...
 
     @overload
     @classmethod
     def single_partition(
-        cls, elements: Iterable[_ElementT], *, metadata: _MetadataT
-    ) -> Partitions[_ElementT, _MetadataT]:
+        cls, elements: Iterable[PartitionElementT], *, metadata: PartitionMetadataT
+    ) -> Partitions[PartitionElementT, PartitionMetadataT]:
         ...
 
     @classmethod
     def single_partition(
-        cls, elements: Iterable[_ElementT], *, metadata: _MetadataT | None = None
+        cls, elements: Iterable[PartitionElementT], *, metadata: PartitionMetadataT | None = None
     ) -> Partitions:
         """Helper constructor for implementations that have only one partition."""
         return Partitions([Partition(tuple(elements), metadata or _EmptyMetadata())])

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import itertools
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Generic, Iterable, TypeVar
+from typing import Generic, Iterable, TypeVar, overload
 
 from typing_extensions import Protocol
 
@@ -76,8 +76,14 @@ class PartitionerType(Enum):
 
 class PartitionMetadata(Protocol):
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         ...
+
+
+class _EmptyMetadata:
+    @property
+    def description(self) -> None:
+        return None
 
 
 PartitionMetadataT = TypeVar("PartitionMetadataT", bound=PartitionMetadata)
@@ -102,7 +108,7 @@ class Partition(Generic[PartitionElementT, PartitionMetadataT]):
     """
 
     elements: tuple[PartitionElementT, ...]
-    metadata: PartitionMetadataT | None
+    metadata: PartitionMetadataT
 
 
 @runtime_ignore_subscripts
@@ -122,12 +128,31 @@ class Partitions(Collection[Partition[PartitionElementT, PartitionMetadataT]]):
             and files ABC with Py2.
     """
 
+    # NOTE: We have to redefine type-vars here for use in the `classmethod`s below because in this scope
+    # `PartitionElementT` and `PartitionMetadataT` are no longer generic.
+    _MetadataT = TypeVar("_MetadataT", bound=PartitionMetadata)
+    _ElementT = TypeVar("_ElementT")
+
+    @overload
     @classmethod
     def single_partition(
-        cls, elements: Iterable[PartitionElementT], metadata: PartitionMetadataT | None = None
-    ) -> Partitions[PartitionElementT, PartitionMetadataT]:
+        cls, elements: Iterable[_ElementT]
+    ) -> Partitions[_ElementT, _EmptyMetadata]:
+        ...
+
+    @overload
+    @classmethod
+    def single_partition(
+        cls, elements: Iterable[_ElementT], *, metadata: _MetadataT
+    ) -> Partitions[_ElementT, _MetadataT]:
+        ...
+
+    @classmethod
+    def single_partition(
+        cls, elements: Iterable[_ElementT], *, metadata: _MetadataT | None = None
+    ) -> Partitions:
         """Helper constructor for implementations that have only one partition."""
-        return Partitions([Partition(tuple(elements), metadata)])
+        return Partitions([Partition(tuple(elements), metadata or _EmptyMetadata())])
 
 
 # NB: Not frozen so it can be subclassed
@@ -143,7 +168,7 @@ class _BatchBase(Generic[PartitionElementT, PartitionMetadataT]):
 
     tool_name: str
     elements: tuple[PartitionElementT, ...]
-    partition_metadata: PartitionMetadataT | None
+    partition_metadata: PartitionMetadataT
 
 
 @dataclass(frozen=True)
@@ -184,7 +209,7 @@ def _single_partition_field_set_rules(cls) -> Iterable:
     )
     async def partitioner(
         request: _PartitionFieldSetsRequestBase, subsystem: SkippableSubsystem
-    ) -> Partitions[FieldSet, Any]:
+    ) -> Partitions[FieldSet, _EmptyMetadata]:
         return Partitions() if subsystem.skip else Partitions.single_partition(request.field_sets)
 
     return collect_rules(locals())
@@ -207,7 +232,7 @@ def _single_partition_file_rules(cls) -> Iterable:
     )
     async def partitioner(
         request: _PartitionFieldSetsRequestBase, subsystem: SkippableSubsystem
-    ) -> Partitions[str, Any]:
+    ) -> Partitions[str, _EmptyMetadata]:
         assert sources_field_name is not None
         all_sources_paths = await MultiGet(
             Get(SourcesPaths, SourcesPathsRequest(getattr(field_set, sources_field_name)))
@@ -240,11 +265,13 @@ def _partition_per_input_field_set_rules(cls) -> Iterable:
     )
     async def partitioner(
         request: _PartitionFieldSetsRequestBase, subsystem: SkippableSubsystem
-    ) -> Partitions[FieldSet, Any]:
+    ) -> Partitions[FieldSet, _EmptyMetadata]:
         return (
             Partitions()
             if subsystem.skip
-            else Partitions(Partition((field_set,), None) for field_set in request.field_sets)
+            else Partitions(
+                Partition((field_set,), _EmptyMetadata()) for field_set in request.field_sets
+            )
         )
 
     return collect_rules(locals())
@@ -267,7 +294,7 @@ def _partition_per_input_file_rules(cls) -> Iterable:
     )
     async def partitioner(
         request: _PartitionFieldSetsRequestBase, subsystem: SkippableSubsystem
-    ) -> Partitions[str, Any]:
+    ) -> Partitions[str, _EmptyMetadata]:
         assert sources_field_name is not None
         all_sources_paths = await MultiGet(
             Get(SourcesPaths, SourcesPathsRequest(getattr(field_set, sources_field_name)))
@@ -278,7 +305,7 @@ def _partition_per_input_file_rules(cls) -> Iterable:
             Partitions()
             if subsystem.skip
             else Partitions(
-                Partition((path,), None)
+                Partition((path,), _EmptyMetadata())
                 for path in itertools.chain.from_iterable(
                     sources_paths.files for sources_paths in all_sources_paths
                 )

--- a/src/python/pants/core/util_rules/partitions_test.py
+++ b/src/python/pants/core/util_rules/partitions_test.py
@@ -8,11 +8,7 @@ import pytest
 
 from pants.build_graph.address import Address
 from pants.core.goals.fix import Partitions
-from pants.core.util_rules.partitions import (
-    Partition,
-    PartitionerType,
-    _PartitionFieldSetsRequestBase,
-)
+from pants.core.util_rules.partitions import PartitionerType, _PartitionFieldSetsRequestBase
 from pants.engine.rules import QueryRule
 from pants.engine.target import FieldSet, MultipleSourcesField, SingleSourceField
 from pants.option.option_types import SkipOption
@@ -85,17 +81,9 @@ def test_default_single_partition_partitioner(kitchen_field_set_type, field_sets
     rule_runner = RuleRunner(rules=rules)
     rule_runner.write_files({"BUILD": "", "knife.utensil": "", "bowl.utensil": ""})
     partitions = rule_runner.request(Partitions, [CookRequest.PartitionRequest(field_sets)])
-    assert partitions == Partitions(
-        [
-            Partition(
-                (
-                    "bowl.utensil",
-                    "knife.utensil",
-                ),
-                None,
-            )
-        ]
-    )
+    assert len(partitions) == 1
+    assert partitions[0].elements == ("bowl.utensil", "knife.utensil")
+    assert partitions[0].metadata.description is None
 
     rule_runner.set_options(["--kitchen-skip"])
     partitions = rule_runner.request(Partitions, [CookRequest.PartitionRequest(field_sets)])
@@ -142,12 +130,10 @@ def test_default_one_partition_per_input_partitioner(kitchen_field_set_type, fie
     rule_runner = RuleRunner(rules=rules)
     rule_runner.write_files({"BUILD": "", "knife.utensil": "", "bowl.utensil": ""})
     partitions = rule_runner.request(Partitions, [CookRequest.PartitionRequest(field_sets)])
-    assert partitions == Partitions(
-        [
-            Partition(("bowl.utensil",), None),
-            Partition(("knife.utensil",), None),
-        ]
-    )
+    assert len(partitions) == 2
+    assert [len(partition.elements) for partition in partitions] == [1, 1]
+    assert [partition.elements[0] for partition in partitions] == ["bowl.utensil", "knife.utensil"]
+    assert [partition.metadata.description for partition in partitions] == [None, None]
 
     rule_runner.set_options(["--kitchen-skip"])
     partitions = rule_runner.request(Partitions, [CookRequest.PartitionRequest(field_sets)])


### PR DESCRIPTION
Prior to this commit, the generic partitioning code was typed so:

  * Partitions could have `None` metadata, and
  * If partition metadata was non-`None`, it had to implement a `description(self) -> str` property

While working on batched `pytest`, I've found these type constraints to be a bit too restrictive. Pytest batches will either be:

  * A collection of files all marked as compatible
  * A single file, with no compatibility tag

In the 1st case, we can use the compatibility tag as the partition's metadata description. In the 2nd case there is no meaningful metadata description - we could use the single file's address spec, but that would produce significant noise in our logging. Ideally we could return `None` in the 2nd case, but the types don't currently allow it because all the `Partition`s returned by a plugin must have the same type (or be `None`).

This commit attempts to fix the UX problem by rearranging where we allow optional values. Metadata is now always required, but the `description` property is allowed to return `None`. A new "empty" placeholder type is used by our default rules, so users still won't have to think about it unless they choose to customize their partitioning logic.