### PR TITLE
Revise the error message associated with OOM-killed events

### DIFF
--- a/src/rust/engine/nailgun/src/client.rs
+++ b/src/rust/engine/nailgun/src/client.rs
@@ -143,7 +143,7 @@ pub async fn client_execute(
           (i.e. OOM-killed). If you keep seeing this error message, try the troubleshooting steps below. \
           If none of those help, please consider filing a GitHub issue or reaching out on Slack so that we can \
           investigate the possible memory overconsumption (https://www.pantsbuild.org/docs/getting-help).\n \
-          - Exit all other applications, including applications running in the background.\n \
+          - Exit other applications, including applications running in the background.\n \
           - Set the global option `--pantsd-max-memory-usage` to reduce Pantsd's memory consumption by retaining \
             less in its in-memory cache (run `./pants help-advanced global`).\n \
           - Disable pantsd with the global option `--no-pantsd` to avoid persisting memory across Pants runs, \

--- a/src/rust/engine/nailgun/src/client.rs
+++ b/src/rust/engine/nailgun/src/client.rs
@@ -140,13 +140,14 @@ pub async fn client_execute(
       "Client exited before the server's result could be returned." => {
         "The pantsd process was killed during the run.\n\nIf this was not intentionally done by you, \
           Pants may have been killed by the operating system due to memory overconsumption \
-          (i.e. OOM-killed). You can set the global option `--pantsd-max-memory-usage` to reduce \
-          Pantsd's memory consumption by retaining less in its in-memory cache \
-          (run `./pants help-advanced global`). You can also disable pantsd with the global \
-          option `--no-pantsd` to avoid persisting memory across Pants runs, although you will miss \
-          out on additional caching.\n\nIf neither of those help, please consider filing a \
-          GitHub issue or reaching out on Slack so that we can investigate the possible memory \
-          overconsumption (https://www.pantsbuild.org/docs/getting-help)."
+          (i.e. OOM-killed). If you keep seeing this error message, try the troubleshooting steps below. \
+          If none of those help, please consider filing a GitHub issue or reaching out on Slack so that we can \
+          investigate the possible memory overconsumption (https://www.pantsbuild.org/docs/getting-help).\n \
+          - Exit all other applications, including applications running in the background.\n \
+          - Set the global option `--pantsd-max-memory-usage` to reduce Pantsd's memory consumption by retaining \
+            less in its in-memory cache (run `./pants help-advanced global`).\n \
+          - Disable pantsd with the global option `--no-pantsd` to avoid persisting memory across Pants runs, \
+            although you will miss out on additional caching."
           .to_owned()
       }
       _ => format!("Failed during execution: {}", err),


### PR DESCRIPTION
#12107 rewrote the error message associated with OOM-killed events. In my experience following the prescribed advice, I was completely unable to prevent Pants from crashing. Only after I exited all applications did the crashing go away. Based on my experience, I revised the error message to suggest exiting other applications because other applications can starve Pants of the memory it needs to run.