### PR TITLE
Enrich remote execution errors and workunits with their action digests

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -40,8 +40,8 @@ use hashing::{Digest, Fingerprint};
 use store::{Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest};
 use task_executor::Executor;
 use workunit_store::{
-  in_workunit, Metric, ObservationMetric, RunId, RunningWorkunit, SpanId, WorkunitMetadata,
-  WorkunitStore,
+  in_workunit, Metric, ObservationMetric, RunId, RunningWorkunit, SpanId, UserMetadataItem,
+  WorkunitMetadata, WorkunitStore,
 };
 
 use crate::{
@@ -853,6 +853,10 @@ impl crate::CommandRunner for CommandRunner {
       // renders at the Process's level.
       request.level,
       desc = Some(request.description.clone()),
+      user_metadata = vec![(
+        "action_digest".to_owned(),
+        UserMetadataItem::String(format!("{action_digest:?}")),
+      )],
       |workunit| async move {
         workunit.increment_counter(Metric::RemoteExecutionRequests, 1);
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -860,39 +860,36 @@ impl crate::CommandRunner for CommandRunner {
       |workunit| async move {
         workunit.increment_counter(Metric::RemoteExecutionRequests, 1);
         let result_fut = self.run_execute_request(execute_request, request, &context2, workunit);
-        let result = tokio::time::timeout(deadline_duration, result_fut).await;
-        if result.is_err() {
-          workunit.update_metadata(|initial| {
-            let initial = initial.map(|(m, _)| m).unwrap_or_default();
-            Some((
-              WorkunitMetadata {
-                desc: Some(format!(
-                  "remote execution timed out after {:?}",
-                  deadline_duration
-                )),
-                ..initial
-              },
-              Level::Error,
-            ))
-          })
-        }
 
         // Detect whether the operation ran or hit the deadline timeout.
-        match result {
-          Ok(result) => {
-            if result.is_ok() {
-              workunit.increment_counter(Metric::RemoteExecutionSuccess, 1);
-            } else {
-              workunit.increment_counter(Metric::RemoteExecutionErrors, 1);
-            }
-            result
+        match tokio::time::timeout(deadline_duration, result_fut).await {
+          Ok(Ok(result)) => {
+            workunit.increment_counter(Metric::RemoteExecutionSuccess, 1);
+            Ok(result)
           }
-          Err(_) => {
+          Ok(Err(err)) => {
+            workunit.increment_counter(Metric::RemoteExecutionErrors, 1);
+            Err(err.enrich(&format!("For action {action_digest:?}")))
+          }
+          Err(tokio::time::error::Elapsed { .. }) => {
             // The Err in this match arm originates from the timeout future.
             debug!(
               "remote execution for build_id={} timed out after {:?}",
               &build_id, deadline_duration
             );
+            workunit.update_metadata(|initial| {
+              let initial = initial.map(|(m, _)| m).unwrap_or_default();
+              Some((
+                WorkunitMetadata {
+                  desc: Some(format!(
+                    "remote execution timed out after {:?}",
+                    deadline_duration
+                  )),
+                  ..initial
+                },
+                Level::Error,
+              ))
+            });
             workunit.increment_counter(Metric::RemoteExecutionTimeouts, 1);
             Err(format!("remote execution timed out after {:?}", deadline_duration).into())
           }

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -1436,10 +1436,10 @@ async fn initial_response_error() {
     .await
     .expect_err("Want Err");
 
-  assert_eq!(
-    result.to_string(),
-    "Error from remote execution: InvalidArgument: \"Execute endpoint called. Did not expect this call.\""
-  );
+  assert!(result.to_string().ends_with(
+    "Error from remote execution: \
+     InvalidArgument: \"Execute endpoint called. Did not expect this call.\""
+  ));
 }
 
 #[tokio::test]
@@ -1483,10 +1483,9 @@ async fn initial_response_missing_response_and_error() {
     .await
     .expect_err("Want Err");
 
-  assert_eq!(
-    result.to_string(),
-    "Operation finished but no response supplied"
-  );
+  assert!(result
+    .to_string()
+    .ends_with("Operation finished but no response supplied"));
 }
 
 #[tokio::test]
@@ -1545,10 +1544,10 @@ async fn fails_after_retry_limit_exceeded() {
     .await
     .expect_err("Expected error");
 
-  assert_eq!(
-    result.to_string(),
-    "Too many failures from server. The last error was: the bot running the task appears to be lost"
-  );
+  assert!(result.to_string().ends_with(
+    "Too many failures from server. \
+     The last error was: the bot running the task appears to be lost"
+  ));
 }
 
 #[tokio::test]
@@ -1608,10 +1607,10 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     .await
     .expect_err("Expected error");
 
-  assert_eq!(
-    result.to_string(),
-    "Too many failures from server. The last event was the server disconnecting with no error given."
-  );
+  assert!(result.to_string().ends_with(
+    "Too many failures from server. \
+     The last event was the server disconnecting with no error given."
+  ));
 }
 
 #[tokio::test]

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -844,8 +844,8 @@ async fn workunit_to_py_value(
   let mut user_metadata_entries = Vec::with_capacity(metadata.user_metadata.len());
   for (user_metadata_key, user_metadata_item) in metadata.user_metadata.iter() {
     let value = match user_metadata_item {
-      UserMetadataItem::ImmediateString(v) => v.into_py(py),
-      UserMetadataItem::ImmediateInt(n) => n.into_py(py),
+      UserMetadataItem::String(v) => v.into_py(py),
+      UserMetadataItem::Int(n) => n.into_py(py),
       UserMetadataItem::PyValue(py_val_handle) => (**py_val_handle)
         .as_any()
         .downcast_ref::<Value>()

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -466,15 +466,15 @@ impl ExecuteProcess {
             user_metadata: vec![
               (
                 "definition".to_string(),
-                UserMetadataItem::ImmediateString(definition),
+                UserMetadataItem::String(definition),
               ),
               (
                 "source".to_string(),
-                UserMetadataItem::ImmediateString(format!("{:?}", res.metadata.source)),
+                UserMetadataItem::String(format!("{:?}", res.metadata.source)),
               ),
               (
                 "exit_code".to_string(),
-                UserMetadataItem::ImmediateInt(res.exit_code as i64),
+                UserMetadataItem::Int(res.exit_code as i64),
               ),
             ],
             ..initial

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -362,8 +362,8 @@ pub struct WorkunitMetadata {
 #[derive(Clone, Debug)]
 pub enum UserMetadataItem {
   PyValue(Arc<dyn Value>),
-  ImmediateInt(i64),
-  ImmediateString(String),
+  Int(i64),
+  String(String),
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
Currently action digests are only used in debug level logging, but in case of fatal/infrastructure errors, they are very useful for correlating with serverside logs.