### PR TITLE
Add support for batched `pytest` execution

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -57,6 +57,7 @@ SOURCES = {
         python_tests(
             name="tests",
             dependencies=[":project"],
+            batch_compatibility_tag="default",
         )
         """
     ),
@@ -107,7 +108,7 @@ SOURCES = {
            assert True is True
         """
     ),
-    "tests/python/project_test/no_src/BUILD.py": "python_tests()",
+    "tests/python/project_test/no_src/BUILD.py": "python_tests(batch_compatibility_tag='default')",
 }
 
 

--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -1,6 +1,8 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import sqlite3
 from pathlib import Path
 from textwrap import dedent
@@ -12,12 +14,14 @@ from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 
-SOURCES = {
-    # Only `lib.py` will actually be tested, but we still expect `random.py` t`o show up in
-    # the final report correctly.
-    "src/python/project/__init__.py": "",
-    "src/python/project/lib.py": dedent(
-        """\
+
+def sources(batched: bool) -> dict[str, str]:
+    return {
+        # Only `lib.py` will actually be tested, but we still expect `random.py` t`o show up in
+        # the final report correctly.
+        "src/python/project/__init__.py": "",
+        "src/python/project/lib.py": dedent(
+            """\
         def add(x, y):
             return x + y
 
@@ -27,65 +31,65 @@ SOURCES = {
         def multiply(x, y):
             return x * y
         """
-    ),
-    # Include a type stub to ensure that we can handle it. We expect it to be ignored because the
-    # test run does not use the file.
-    "src/python/project/lib.pyi": dedent(
-        """\
+        ),
+        # Include a type stub to ensure that we can handle it. We expect it to be ignored because the
+        # test run does not use the file.
+        "src/python/project/lib.pyi": dedent(
+            """\
         def add(x: int, y: int) -> None:
             return x + y
         """
-    ),
-    "src/python/project/random.py": dedent(
-        """\
+        ),
+        "src/python/project/random.py": dedent(
+            """\
         def capitalize(s):
             return s.capitalize()
         """
-    ),
-    # Only test half of the library.
-    "src/python/project/lib_test.py": dedent(
-        """\
+        ),
+        # Only test half of the library.
+        "src/python/project/lib_test.py": dedent(
+            """\
         from project.lib import add
 
         def test_add():
             assert add(2, 3) == 5
         """
-    ),
-    "src/python/project/BUILD": dedent(
-        """\
+        ),
+        "src/python/project/BUILD": dedent(
+            f"""\
         python_sources()
         python_tests(
             name="tests",
             dependencies=[":project"],
-            batch_compatibility_tag="default",
+            {'batch_compatibility_tag="default",' if batched else ''}
         )
         """
-    ),
-    "src/python/core/BUILD": "python_sources()",
-    "src/python/core/__init__.py": "",
-    "src/python/core/untested.py": "CONSTANT = 42",
-    "foo/bar.py": "BAZ = True",
-    # Test that a `tests/` source root accurately gets coverage data for the `src/`
-    # root.
-    "tests/python/project_test/__init__.py": "",
-    "tests/python/project_test/test_multiply.py": dedent(
-        """\
+        ),
+        "src/python/core/BUILD": "python_sources()",
+        "src/python/core/__init__.py": "",
+        "src/python/core/untested.py": "CONSTANT = 42",
+        "foo/bar.py": "BAZ = True",
+        # Test that a `tests/` source root accurately gets coverage data for the `src/`
+        # root.
+        "tests/python/project_test/__init__.py": "",
+        "tests/python/project_test/test_multiply.py": dedent(
+            """\
         from project.lib import multiply
 
         def test_multiply():
             assert multiply(2, 3) == 6
         """
-    ),
-    "tests/python/project_test/test_arithmetic.py": dedent(
-        """\
+        ),
+        "tests/python/project_test/test_arithmetic.py": dedent(
+            """\
         from project.lib import add, subtract
 
         def test_arithmetic():
             assert add(4, 3) == 7 == subtract(10, 3)
         """
-    ),
-    "tests/python/project_test/BUILD": dedent(
-        """\
+        ),
+        "tests/python/project_test/BUILD": dedent(
+            """\
         python_tests(
             name="multiply",
             sources=["test_multiply.py"],
@@ -98,18 +102,18 @@ SOURCES = {
             dependencies=['{tmpdir}/src/python/project'],
         )
         """
-    ),
-    # Test a file that does not cover any src code. While this is unlikely to happen,
-    # this tests that we can properly handle the edge case.
-    "tests/python/project_test/no_src/__init__.py": "",
-    "tests/python/project_test/no_src/test_no_src.py": dedent(
-        """\
+        ),
+        # Test a file that does not cover any src code. While this is unlikely to happen,
+        # this tests that we can properly handle the edge case.
+        "tests/python/project_test/no_src/__init__.py": "",
+        "tests/python/project_test/no_src/test_no_src.py": dedent(
+            """\
         def test_true():
            assert True is True
         """
-    ),
-    "tests/python/project_test/no_src/BUILD.py": "python_tests(batch_compatibility_tag='default')",
-}
+        ),
+        "tests/python/project_test/no_src/BUILD.py": f"""python_tests({'batch_compatibility_tag="default"' if batched else ''})""",
+    }
 
 
 def run_coverage_that_may_fail(tmpdir: str, *extra_args: str) -> PantsResult:
@@ -144,7 +148,7 @@ def run_coverage(tmpdir: str, *extra_args: str) -> PantsResult:
     all_major_minor_python_versions(CoverageSubsystem.default_interpreter_constraints),
 )
 def test_coverage(major_minor_interpreter: str) -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+    with setup_tmpdir(sources(False)) as tmpdir:
         result = run_coverage(
             tmpdir, f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']"
         )
@@ -170,16 +174,50 @@ def test_coverage(major_minor_interpreter: str) -> None:
     )
 
 
-def test_coverage_fail_under() -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+@pytest.mark.platform_specific_behavior
+@pytest.mark.parametrize(
+    "major_minor_interpreter",
+    all_major_minor_python_versions(CoverageSubsystem.default_interpreter_constraints),
+)
+def test_coverage_batched(major_minor_interpreter: str) -> None:
+    with setup_tmpdir(sources(True)) as tmpdir:
+        result = run_coverage(
+            tmpdir, f"--coverage-py-interpreter-constraints=['=={major_minor_interpreter}.*']"
+        )
+    assert (
+        dedent(
+            f"""\
+            Name                                                          Stmts   Miss  Cover
+            ---------------------------------------------------------------------------------
+            {tmpdir}/src/python/project/__init__.py                        0      0   100%
+            {tmpdir}/src/python/project/lib.py                             6      0   100%
+            {tmpdir}/src/python/project/lib_test.py                        3      0   100%
+            {tmpdir}/src/python/project/random.py                          2      2     0%
+            {tmpdir}/tests/python/project_test/__init__.py                 0      0   100%
+            {tmpdir}/tests/python/project_test/no_src/__init__.py          0      0   100%
+            {tmpdir}/tests/python/project_test/no_src/test_no_src.py       2      0   100%
+            {tmpdir}/tests/python/project_test/test_arithmetic.py          3      0   100%
+            {tmpdir}/tests/python/project_test/test_multiply.py            3      0   100%
+            ---------------------------------------------------------------------------------
+            TOTAL                                                            19      2    89%
+            """
+        )
+        in result.stderr
+    )
+
+
+@pytest.mark.parametrize("batched", (True, False))
+def test_coverage_fail_under(batched: bool) -> None:
+    with setup_tmpdir(sources(batched)) as tmpdir:
         result = run_coverage(tmpdir, "--coverage-py-fail-under=89")
         result.assert_success()
         result = run_coverage_that_may_fail(tmpdir, "--coverage-py-fail-under=90")
         result.assert_failure()
 
 
-def test_coverage_global() -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+@pytest.mark.parametrize("batched", (True, False))
+def test_coverage_global(batched: bool) -> None:
+    with setup_tmpdir(sources(batched)) as tmpdir:
         result = run_coverage(tmpdir, "--coverage-py-global-report")
     assert (
         dedent(
@@ -207,8 +245,9 @@ def test_coverage_global() -> None:
     ), result.stderr
 
 
-def test_coverage_with_filter() -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+@pytest.mark.parametrize("batched", (True, False))
+def test_coverage_with_filter(batched: bool) -> None:
+    with setup_tmpdir(sources(batched)) as tmpdir:
         result = run_coverage(tmpdir, "--coverage-py-filter=['project.lib', 'project_test.no_src']")
     assert (
         dedent(
@@ -226,8 +265,9 @@ def test_coverage_with_filter() -> None:
     )
 
 
-def test_coverage_raw() -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+@pytest.mark.parametrize("batched", (True, False))
+def test_coverage_raw(batched: bool) -> None:
+    with setup_tmpdir(sources(batched)) as tmpdir:
         result = run_coverage(tmpdir, "--coverage-py-report=raw")
     assert "Wrote raw coverage report to `dist/coverage/python`" in result.stderr
     coverage_data = Path(get_buildroot(), "dist", "coverage", "python", ".coverage")
@@ -246,8 +286,9 @@ def test_coverage_raw() -> None:
     }
 
 
-def test_coverage_html_xml_json_lcov() -> None:
-    with setup_tmpdir(SOURCES) as tmpdir:
+@pytest.mark.parametrize("batched", (True, False))
+def test_coverage_html_xml_json_lcov(batched: bool) -> None:
+    with setup_tmpdir(sources(batched)) as tmpdir:
         result = run_coverage(tmpdir, "--coverage-py-report=['xml', 'html', 'json', 'lcov']")
     coverage_path = Path(get_buildroot(), "dist", "coverage", "python")
     assert coverage_path.exists() is True

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -468,13 +468,13 @@ async def run_python_tests(
     )
     result = await Get(FallibleProcessResult, Process, setup.process)
 
-    warning_description = batch.elements[0].address.spec
-    if len(batch.elements) > 1:
-        warning_description = (
-            f"batch containing {warning_description} and {len(batch.elements)-1} other files"
-        )
-    if batch.partition_metadata.description:
-        warning_description = f"{warning_description} ({batch.partition_metadata.description})"
+    def warning_description() -> str:
+        description = batch.elements[0].address.spec
+        if len(batch.elements) > 1:
+            description = f"batch containing {description} and {len(batch.elements)-1} other files"
+        if batch.partition_metadata.description:
+            description = f"{description} ({batch.partition_metadata.description})"
+        return description
 
     coverage_data = None
     if test_subsystem.use_coverage:
@@ -486,7 +486,7 @@ async def run_python_tests(
                 tuple(field_set.address for field_set in batch.elements), coverage_snapshot.digest
             )
         else:
-            logger.warning(f"Failed to generate coverage data for {warning_description}.")
+            logger.warning(f"Failed to generate coverage data for {warning_description()}.")
 
     xml_results_snapshot = None
     if setup.results_file_name:
@@ -494,7 +494,7 @@ async def run_python_tests(
             Snapshot, DigestSubset(result.output_digest, PathGlobs([setup.results_file_name]))
         )
         if xml_results_snapshot.files != (setup.results_file_name,):
-            logger.warning(f"Failed to generate JUnit XML data for {warning_description}.")
+            logger.warning(f"Failed to generate JUnit XML data for {warning_description()}.")
     extra_output_snapshot = await Get(
         Snapshot, DigestSubset(result.output_digest, PathGlobs([f"{_EXTRA_OUTPUT_DIR}/**"]))
     )

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -438,7 +438,7 @@ async def partition_python_tests(
             interpreter_constraints=InterpreterConstraints.create_from_compatibility_fields(
                 [field_set.interpreter_constraints], python_setup
             ),
-            extra_env_vars=field_set.extra_env_vars.value or (),
+            extra_env_vars=tuple(sorted(field_set.extra_env_vars.value or ())),
             xdist_concurrency=field_set.xdist_concurrency.value,
             resolve=field_set.resolve.normalized_value(python_setup),
             compatability_tag=field_set.batch_compatibility_tag.value,

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -164,6 +164,7 @@ class TestMetadata:
     extra_env_vars: tuple[str, ...]
     xdist_concurrency: int | None
     resolve: str
+    environment: str
     compatability_tag: str | None = None
 
     # Prevent this class from being detected by pytest as a test class.
@@ -441,6 +442,7 @@ async def partition_python_tests(
             extra_env_vars=tuple(sorted(field_set.extra_env_vars.value or ())),
             xdist_concurrency=field_set.xdist_concurrency.value,
             resolve=field_set.resolve.normalized_value(python_setup),
+            environment=field_set.environment.value,
             compatability_tag=field_set.batch_compatibility_tag.value,
         )
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -396,7 +396,7 @@ async def run_python_test(
             Snapshot, DigestSubset(result.output_digest, PathGlobs([".coverage"]))
         )
         if coverage_snapshot.files == (".coverage",):
-            coverage_data = PytestCoverageData(field_set.address, coverage_snapshot.digest)
+            coverage_data = PytestCoverageData((field_set.address,), coverage_snapshot.digest)
         else:
             logger.warning(f"Failed to generate coverage data for {field_set.address}.")
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -7,7 +7,7 @@ import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import Optional, Tuple
 
 from pants.backend.python.goals.coverage_py import (
     CoverageConfig,
@@ -41,6 +41,7 @@ from pants.core.goals.test import (
 )
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
+from pants.core.util_rules.partitions import Partition, PartitionerType, Partitions
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
@@ -155,8 +156,25 @@ _EXTRA_OUTPUT_DIR = "extra-output"
 
 
 @dataclass(frozen=True)
+class TestMetadata:
+    """Parameters that must be constant for all test targets in a `pytest` batch."""
+
+    interpreter_constraints: InterpreterConstraints
+    extra_env_vars: tuple[str, ...]
+    xdist_concurrency: int | None
+
+    # Prevent this class from being detected by pytest as a test class.
+    __test__ = False
+
+    @property
+    def description(self) -> str | None:
+        return None
+
+
+@dataclass(frozen=True)
 class TestSetupRequest:
-    field_set: PythonTestFieldSet
+    field_sets: Tuple[PythonTestFieldSet, ...]
+    metadata: TestMetadata
     is_debug: bool
     main: Optional[MainSpecification] = None  # Defaults to pytest.main
     prepend_argv: Tuple[str, ...] = ()
@@ -184,23 +202,22 @@ async def setup_pytest_for_target(
     request: TestSetupRequest,
     pytest: PyTest,
     test_subsystem: TestSubsystem,
-    python_setup: PythonSetup,
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
     test_extra_env: TestExtraEnv,
     global_options: GlobalOptions,
 ) -> TestSetup:
+    addresses = tuple(field_set.address for field_set in request.field_sets)
+
     transitive_targets, plugin_setups = await MultiGet(
-        Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),
-        Get(AllPytestPluginSetups, AllPytestPluginSetupsRequest((request.field_set.address,))),
+        Get(TransitiveTargets, TransitiveTargetsRequest(addresses)),
+        Get(AllPytestPluginSetups, AllPytestPluginSetupsRequest(addresses)),
     )
     all_targets = transitive_targets.closure
 
-    interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
-        [request.field_set.interpreter_constraints], python_setup
-    )
+    interpreter_constraints = request.metadata.interpreter_constraints
 
-    requirements_pex_get = Get(Pex, RequirementsPexRequest([request.field_set.address]))
+    requirements_pex_get = Get(Pex, RequirementsPexRequest(addresses))
     pytest_pex_get = Get(
         Pex,
         PexRequest(
@@ -220,10 +237,12 @@ async def setup_pytest_for_target(
 
     # Get the file names for the test_target so that we can specify to Pytest precisely which files
     # to test, rather than using auto-discovery.
-    field_set_source_files_get = Get(SourceFiles, SourceFilesRequest([request.field_set.source]))
+    field_set_source_files_get = Get(
+        SourceFiles, SourceFilesRequest([field_set.source for field_set in request.field_sets])
+    )
 
     field_set_extra_env_get = Get(
-        EnvironmentVars, EnvironmentVarsRequest(request.field_set.extra_env_vars.value or ())
+        EnvironmentVars, EnvironmentVarsRequest(request.metadata.extra_env_vars)
     )
 
     (
@@ -245,7 +264,7 @@ async def setup_pytest_for_target(
     local_dists = await Get(
         LocalDistsPex,
         LocalDistsPexRequest(
-            [request.field_set.address],
+            addresses,
             internal_only=True,
             interpreter_constraints=interpreter_constraints,
             sources=prepared_sources,
@@ -300,7 +319,12 @@ async def setup_pytest_for_target(
 
     results_file_name = None
     if not request.is_debug:
-        results_file_name = f"{request.field_set.address.path_safe_spec}.xml"
+        results_file_prefix = request.field_sets[0].address.path_safe_spec
+        if len(request.field_sets) > 1:
+            results_file_prefix = (
+                f"batch-of-{results_file_prefix}+{len(request.field_sets)-1}-files"
+            )
+        results_file_name = f"{results_file_prefix}.xml"
         add_opts.extend(
             (f"--junitxml={results_file_name}", "-o", f"junit_family={pytest.junit_family}")
         )
@@ -343,12 +367,24 @@ async def setup_pytest_for_target(
 
     xdist_concurrency = 0
     if pytest.xdist_enabled and not request.is_debug:
-        concurrency = request.field_set.xdist_concurrency.value
+        concurrency = request.metadata.xdist_concurrency
         if concurrency is None:
             contents = await Get(DigestContents, Digest, field_set_source_files.snapshot.digest)
             concurrency = _count_pytest_tests(contents)
         xdist_concurrency = concurrency
 
+    timeout_seconds: int | None = None
+    for field_set in request.field_sets:
+        timeout = field_set.timeout.calculate_from_global_options(test_subsystem, pytest)
+        if timeout:
+            if timeout_seconds:
+                timeout_seconds += timeout
+            else:
+                timeout_seconds = timeout
+
+    run_description = request.field_sets[0].address.spec
+    if len(request.field_sets) > 1:
+        run_description = f"batch of {run_description} and {len(request.field_sets)-1} other files"
     process = await Get(
         Process,
         VenvPexProcess(
@@ -365,12 +401,10 @@ async def setup_pytest_for_target(
             input_digest=input_digest,
             output_directories=(_EXTRA_OUTPUT_DIR,),
             output_files=output_files,
-            timeout_seconds=request.field_set.timeout.calculate_from_global_options(
-                test_subsystem, pytest
-            ),
+            timeout_seconds=timeout_seconds,
             execution_slot_variable=pytest.execution_slot_var,
             concurrency_available=xdist_concurrency,
-            description=f"Run Pytest for {request.field_set.address}",
+            description=f"Run Pytest for {run_description}",
             level=LogLevel.DEBUG,
             cache_scope=cache_scope,
         ),
@@ -381,17 +415,46 @@ async def setup_pytest_for_target(
 class PyTestRequest(TestRequest):
     tool_subsystem = PyTest
     field_set_type = PythonTestFieldSet
+    partitioner_type = PartitionerType.CUSTOM
+
+
+@rule(desc="Partition Pytest", level=LogLevel.DEBUG)
+async def partition_python_tests(
+    request: PyTestRequest.PartitionRequest[PythonTestFieldSet],
+    python_setup: PythonSetup,
+) -> Partitions[PythonTestFieldSet, TestMetadata]:
+    partitions = []
+    for field_set in request.field_sets:
+        metadata = TestMetadata(
+            interpreter_constraints=InterpreterConstraints.create_from_compatibility_fields(
+                [field_set.interpreter_constraints], python_setup
+            ),
+            extra_env_vars=field_set.extra_env_vars.value or (),
+            xdist_concurrency=field_set.xdist_concurrency.value,
+        )
+        partitions.append(Partition((field_set,), metadata))
+
+    return Partitions(partitions)
 
 
 @rule(desc="Run Pytest", level=LogLevel.DEBUG)
-async def run_python_test(
-    batch: PyTestRequest.Batch[PythonTestFieldSet, Any],
+async def run_python_tests(
+    batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata],
     test_subsystem: TestSubsystem,
 ) -> TestResult:
-    field_set = batch.single_element
 
-    setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
+    setup = await Get(
+        TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
+    )
     result = await Get(FallibleProcessResult, Process, setup.process)
+
+    warning_description = batch.elements[0].address.spec
+    if len(batch.elements) > 1:
+        warning_description = (
+            f"batch containing {warning_description} and {len(batch.elements)-1} other files"
+        )
+    if batch.partition_metadata.description:
+        warning_description = f"{warning_description} ({batch.partition_metadata.description})"
 
     coverage_data = None
     if test_subsystem.use_coverage:
@@ -399,9 +462,11 @@ async def run_python_test(
             Snapshot, DigestSubset(result.output_digest, PathGlobs([".coverage"]))
         )
         if coverage_snapshot.files == (".coverage",):
-            coverage_data = PytestCoverageData((field_set.address,), coverage_snapshot.digest)
+            coverage_data = PytestCoverageData(
+                tuple(field_set.address for field_set in batch.elements), coverage_snapshot.digest
+            )
         else:
-            logger.warning(f"Failed to generate coverage data for {field_set.address}.")
+            logger.warning(f"Failed to generate coverage data for {warning_description}.")
 
     xml_results_snapshot = None
     if setup.results_file_name:
@@ -409,7 +474,7 @@ async def run_python_test(
             Snapshot, DigestSubset(result.output_digest, PathGlobs([setup.results_file_name]))
         )
         if xml_results_snapshot.files != (setup.results_file_name,):
-            logger.warning(f"Failed to generate JUnit XML data for {field_set.address}.")
+            logger.warning(f"Failed to generate JUnit XML data for {warning_description}.")
     extra_output_snapshot = await Get(
         Snapshot, DigestSubset(result.output_digest, PathGlobs([f"{_EXTRA_OUTPUT_DIR}/**"]))
     )
@@ -417,9 +482,9 @@ async def run_python_test(
         Snapshot, RemovePrefix(extra_output_snapshot.digest, _EXTRA_OUTPUT_DIR)
     )
 
-    return TestResult.from_fallible_process_result(
+    return TestResult.from_batched_fallible_process_result(
         result,
-        address=field_set.address,
+        batch=batch,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
@@ -429,9 +494,11 @@ async def run_python_test(
 
 @rule(desc="Set up Pytest to run interactively", level=LogLevel.DEBUG)
 async def debug_python_test(
-    batch: PyTestRequest.Batch[PythonTestFieldSet, Any]
+    batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata]
 ) -> TestDebugRequest:
-    setup = await Get(TestSetup, TestSetupRequest(batch.single_element, is_debug=True))
+    setup = await Get(
+        TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=True)
+    )
     return TestDebugRequest(
         InteractiveProcess.from_process(
             setup.process, forward_signals_to_process=False, restartable=True
@@ -441,7 +508,7 @@ async def debug_python_test(
 
 @rule(desc="Set up debugpy to run an interactive Pytest session", level=LogLevel.DEBUG)
 async def debugpy_python_test(
-    batch: PyTestRequest.Batch[PythonTestFieldSet, Any],
+    batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata],
     debugpy: DebugPy,
     debug_adapter: DebugAdapterSubsystem,
     pytest: PyTest,
@@ -451,7 +518,8 @@ async def debugpy_python_test(
     setup = await Get(
         TestSetup,
         TestSetupRequest(
-            batch.single_element,
+            batch.elements,
+            batch.partition_metadata,
             is_debug=True,
             main=debugpy.main,
             prepend_argv=debugpy.get_args(debug_adapter, pytest.main),

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -771,6 +771,12 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
             "python_tests(overrides={'test_2.py': {'extra_env_vars': []}})",
             [[f"{PACKAGE}/test_1.py", f"{PACKAGE}/test_3.py"], [f"{PACKAGE}/test_2.py"]],
         ],
+        # Order of extra_env_vars shouldn't affect partitioning:
+        [
+            "__defaults__(dict(python_tests=dict(batch_compatibility_tag='default', extra_env_vars=['FOO', 'BAR'])))",
+            "python_tests(overrides={'test_2.py': {'extra_env_vars': ['BAR', 'FOO']}})",
+            [[f"{PACKAGE}/test_1.py", f"{PACKAGE}/test_2.py", f"{PACKAGE}/test_3.py"]],
+        ],
     ),
 )
 def test_partition(

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -778,6 +778,12 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
             "python_tests(overrides={'test_2.py': {'extra_env_vars': ['BAR', 'FOO']}})",
             [[f"{PACKAGE}/test_1.py", f"{PACKAGE}/test_2.py", f"{PACKAGE}/test_3.py"]],
         ],
+        # Partition on different environments:
+        [
+            "__defaults__(dict(python_tests=dict(batch_compatibility_tag='default')))",
+            "python_tests(overrides={'test_2.py': {'environment': 'remote'}})",
+            [[f"{PACKAGE}/test_1.py", f"{PACKAGE}/test_3.py"], [f"{PACKAGE}/test_2.py"]],
+        ],
     ),
 )
 def test_partition(

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -21,6 +21,8 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     ConsoleScript,
     InterpreterConstraintsField,
+    PythonResolveField,
+    PythonTestsBatchCompatibilityTagField,
     PythonTestsExtraEnvVarsField,
     PythonTestSourceField,
     PythonTestsTimeoutField,
@@ -52,6 +54,8 @@ class PythonTestFieldSet(TestFieldSet):
     runtime_package_dependencies: RuntimePackageDependenciesField
     extra_env_vars: PythonTestsExtraEnvVarsField
     xdist_concurrency: PythonTestsXdistConcurrencyField
+    batch_compatibility_tag: PythonTestsBatchCompatibilityTagField
+    resolve: PythonResolveField
     environment: EnvironmentField
 
     @classmethod

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -878,6 +878,37 @@ class PythonTestsXdistConcurrencyField(IntField):
     )
 
 
+class PythonTestsBatchCompatibilityTagField(StringField):
+    alias = "batch_compatibility_tag"
+    help = softwrap(
+        """
+        An arbitrary value used to mark the test files belonging to this target as valid for
+        batched execution.
+
+        By default, Pants will test one `python_test` per `pytest` process. This can cause
+        high-level `pytest` fixtures to execute more often than expected. To reduce overhead
+        and share expensive test setup/teardown logic between multiple test modules, you can
+        set this field to an arbitrary non-empty string on all the `python_test` targets that
+        are safe/compatible to run in the same process.
+
+        `python_test` targets with different values for this field will _never_ execute in the
+        same `pytest` process. This is useful when your monorepo contains multiple incompatible
+        test-setup processes (for example, multiple `conftest.py`s that call `django.setup()`
+        using different settings).
+
+        Pants will make a best-effort attempt to run `python_test` targets with the same value
+        for this field in the same `pytest` process. Compatible tests may not ultimately end up
+        in the same batch if the total number of those tests is larger than the configured value
+        of `[test].batch_size`, or if they have differing values for other `python_test` fields:
+
+          * `resolve`
+          * `interpreter_constraints`
+          * `extra_env_vars`
+          * `xdist_concurrency`
+        """
+    )
+
+
 class SkipPythonTestsField(BoolField):
     alias = "skip_tests"
     default = False
@@ -890,6 +921,7 @@ _PYTHON_TEST_MOVED_FIELDS = (
     PythonRunGoalUseSandboxField,
     PythonTestsTimeoutField,
     PythonTestsXdistConcurrencyField,
+    PythonTestsBatchCompatibilityTagField,
     RuntimePackageDependenciesField,
     PythonTestsExtraEnvVarsField,
     InterpreterConstraintsField,


### PR DESCRIPTION
Closes #14941 

It's _sometimes_ safe to run multiple `python_test`s within a single `pytest` process, and doing so can give significant wins by allowing reuse of expensive test setup/teardown logic. To allow users to opt into this behavior we introduce a new `batch_compatibility_tag` field on `python_test`, with semantics:

  * If unset, the test is assumed to be incompatible with all others and will run it a dedicated `pytest` process
  * If set and != the value on some other `python_test`, the test is explicitly incompatible with the other and is guaranteed to not run in the same `pytest` process
  * If set and == the value on some other `python_test`, the tests are explicitly compatible and _may_ run in the same `pytest` process

Compatible tests may not end up in the same `pytest` batch if:
  * There are "too many" compatible tests in a partition, as determined by `[test].batch_size`
  * Compatible tests have some incompatibility in Pants metadata (i.e. different `resolve` or `extra_env_vars`)

When tests with the same `batch_compatibility_tag` have incompatibilities in some other Pants metadata, the custom partitioning rule will split them into separate partitions. We'd previously discussed raising an error in this case when calling the field `batch_key`/`batch_tag`, but IMO that approach will have a worse UX - this way users can set a high-level `batch_compatibility_tag` using `__defaults__` and then have things continue to Just Work as they add/remove `extra_env_vars` and parameterize `resolve`s on lower-level targets.