### PR TITLE
Rename dependees -> dependents internally.

### DIFF
--- a/src/python/pants/backend/project_info/dependents_test.py
+++ b/src/python/pants/backend/project_info/dependents_test.py
@@ -5,8 +5,8 @@ from typing import List
 
 import pytest
 
-from pants.backend.project_info.dependees import DependeesGoal
-from pants.backend.project_info.dependees import rules as dependee_rules
+from pants.backend.project_info.dependents import DependeesGoal
+from pants.backend.project_info.dependents import rules as dependee_rules
 from pants.engine.target import Dependencies, SpecialCasedDependencies, Target
 from pants.testutil.rule_runner import RuleRunner
 
@@ -37,7 +37,7 @@ def rule_runner() -> RuleRunner:
     return runner
 
 
-def assert_dependees(
+def assert_dependents(
     rule_runner: RuleRunner,
     *,
     targets: List[str],
@@ -55,23 +55,23 @@ def assert_dependees(
 
 
 def test_no_targets(rule_runner: RuleRunner) -> None:
-    assert_dependees(rule_runner, targets=[], expected=[])
+    assert_dependents(rule_runner, targets=[], expected=[])
 
 
 def test_normal(rule_runner: RuleRunner) -> None:
-    assert_dependees(rule_runner, targets=["base"], expected=["intermediate:intermediate"])
+    assert_dependents(rule_runner, targets=["base"], expected=["intermediate:intermediate"])
 
 
 def test_no_dependees(rule_runner: RuleRunner) -> None:
-    assert_dependees(rule_runner, targets=["leaf"], expected=[])
+    assert_dependents(rule_runner, targets=["leaf"], expected=[])
 
 
 def test_closed(rule_runner: RuleRunner) -> None:
-    assert_dependees(rule_runner, targets=["leaf"], closed=True, expected=["leaf:leaf"])
+    assert_dependents(rule_runner, targets=["leaf"], closed=True, expected=["leaf:leaf"])
 
 
 def test_transitive(rule_runner: RuleRunner) -> None:
-    assert_dependees(
+    assert_dependents(
         rule_runner,
         targets=["base"],
         transitive=True,
@@ -82,7 +82,7 @@ def test_transitive(rule_runner: RuleRunner) -> None:
 def test_multiple_specified_targets(rule_runner: RuleRunner) -> None:
     # This tests that --output-format=text will deduplicate which dependee belongs to which
     # specified target.
-    assert_dependees(
+    assert_dependents(
         rule_runner,
         targets=["base", "intermediate"],
         transitive=True,
@@ -93,10 +93,10 @@ def test_multiple_specified_targets(rule_runner: RuleRunner) -> None:
 
 def test_special_cased_dependencies(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"special/BUILD": "tgt(special_deps=['intermediate'])"})
-    assert_dependees(
+    assert_dependents(
         rule_runner, targets=["intermediate"], expected=["leaf:leaf", "special:special"]
     )
-    assert_dependees(
+    assert_dependents(
         rule_runner,
         targets=["base"],
         transitive=True,

--- a/src/python/pants/backend/project_info/register.py
+++ b/src/python/pants/backend/project_info/register.py
@@ -5,8 +5,8 @@
 
 from pants.backend.project_info import (
     count_loc,
-    dependees,
     dependencies,
+    dependents,
     filedeps,
     filter_targets,
     list_roots,
@@ -20,8 +20,8 @@ from pants.backend.project_info import (
 def rules():
     return [
         *count_loc.rules(),
-        *dependees.rules(),
         *dependencies.rules(),
+        *dependents.rules(),
         *filedeps.rules(),
         *filter_targets.rules(),
         *list_roots.rules(),

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -975,7 +975,7 @@ async def get_exporting_owner(owned_dependency: OwnedDependency) -> ExportedTarg
                     softwrap(
                         f"""
                         Found multiple sibling python_distribution targets that are the closest
-                        ancestor dependees of {target.address} and are therefore candidates to
+                        ancestor dependents of {target.address} and are therefore candidates to
                         own it: {', '.join(o.address.spec for o in all_owners)}. Only a
                         single such owner is allowed, to avoid ambiguity.
                         """

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from textwrap import fill, indent
 
-from pants.backend.project_info.dependees import Dependees, DependeesRequest
+from pants.backend.project_info.dependents import Dependents, DependentsRequest
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -99,7 +99,7 @@ async def py_constraints(
         ]
 
         dependees_per_root = await MultiGet(
-            Get(Dependees, DependeesRequest([tgt.address], transitive=True, include_roots=False))
+            Get(Dependents, DependentsRequest([tgt.address], transitive=True, include_roots=False))
             for tgt in all_python_targets
         )
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -315,7 +315,7 @@ class PluginAPITypeInfo:
     union_type: str | None
     union_members: tuple[str, ...]
     dependencies: tuple[str, ...]
-    dependees: tuple[str, ...]
+    dependents: tuple[str, ...]
     returned_by_rules: tuple[str, ...]
     consumed_by_rules: tuple[str, ...]
     used_in_rules: tuple[str, ...]
@@ -699,7 +699,7 @@ class HelpInfoExtracter:
 
         # Calculate type graph.
         for api_type in all_types:
-            # Collect all providers first, as we need them up-front for the dependencies/dependees.
+            # Collect all providers first, as we need them up-front for the dependencies/dependents.
             type_graph[api_type]["providers"] = tuple(
                 sorted(
                     {
@@ -731,19 +731,19 @@ class HelpInfoExtracter:
                 )
             )
 
-        # Add a dependee on the target type for each dependency.
-        type_dependees: DefaultDict[type, set[str]] = defaultdict(set)
+        # Add a dependent on the target type for each dependency.
+        type_dependents: DefaultDict[type, set[str]] = defaultdict(set)
         for _, provider, dependencies in all_types_with_dependencies:
             if not provider:
                 continue
             for target_type in dependencies:
-                type_dependees[target_type].add(provider)
-        for api_type, dependees in type_dependees.items():
-            type_graph[api_type]["dependees"] = tuple(
+                type_dependents[target_type].add(provider)
+        for api_type, dependents in type_dependents.items():
+            type_graph[api_type]["dependents"] = tuple(
                 sorted(
-                    dependees
+                    dependents
                     - set(
-                        # Exclude providers from list of dependees.
+                        # Exclude providers from list of dependents.
                         type_graph[api_type]["providers"][0]
                     )
                 )
@@ -766,7 +766,7 @@ class HelpInfoExtracter:
                     rules,
                     provider=", ".join(type_graph[api_type]["providers"]),
                     dependencies=type_graph[api_type]["dependencies"],
-                    dependees=type_graph[api_type].get("dependees", ()),
+                    dependents=type_graph[api_type].get("dependents", ()),
                     union_members=tuple(
                         sorted(member.__name__ for member in union_membership.get(api_type))
                     ),

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -479,7 +479,7 @@ def test_get_all_help_info():
                 "consumed_by_rules": (
                     "pants.help.help_info_extracter_test.test_get_all_help_info.rule_info_test",
                 ),
-                "dependees": ("help_info_extracter_test",),
+                "dependents": ("help_info_extracter_test",),
                 "dependencies": ("pants.option.scope",),
                 "documentation": None,
                 "is_union": False,
@@ -493,7 +493,7 @@ def test_get_all_help_info():
             },
             "pants.engine.target.Target": {
                 "consumed_by_rules": (),
-                "dependees": (),
+                "dependents": (),
                 "dependencies": (),
                 "documentation": (
                     "A Target represents an addressable set of metadata.\n\n    Set the `help` "
@@ -515,7 +515,7 @@ def test_get_all_help_info():
             },
             "pants.option.scope.Scope": {
                 "consumed_by_rules": (),
-                "dependees": (),
+                "dependents": (),
                 "dependencies": (),
                 "documentation": "An options scope.",
                 "is_union": False,

--- a/src/python/pants/help/help_printer.py
+++ b/src/python/pants/help/help_printer.py
@@ -433,7 +433,7 @@ class HelpPrinter(MaybeColor):
                 "union type": type_info.union_type,
                 "union members": "\n".join(type_info.union_members) if type_info.is_union else None,
                 "dependencies": "\n".join(type_info.dependencies) if show_advanced else None,
-                "dependees": "\n".join(type_info.dependees) if show_advanced else None,
+                "dependents": "\n".join(type_info.dependents) if show_advanced else None,
                 f"returned by {pluralize(len(type_info.returned_by_rules), 'rule')}": "\n".join(
                     type_info.returned_by_rules
                 )

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -123,7 +123,7 @@ class ClasspathEntryRequestFactory:
         if len(compatible) == 1:
             if not root and compatible[0].root_only:
                 raise ClasspathRootOnlyWasInner(
-                    "The following targets had dependees, but can only be used as roots in a "
+                    "The following targets had dependents, but can only be used as roots in a "
                     f"build graph:\n{component.bullet_list()}"
                 )
             return compatible[0](component, resolve, None)

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -167,7 +167,7 @@ class Options:
     ) -> None:
         """The low-level constructor for an Options instance.
 
-        Dependees should use `Options.create` instead.
+        Dependents should use `Options.create` instead.
         """
         self._builtin_goal = builtin_goal
         self._goals = goals

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, cast
 
-from pants.backend.project_info import dependees
-from pants.backend.project_info.dependees import Dependees, DependeesRequest
+from pants.backend.project_info import dependents
+from pants.backend.project_info.dependents import Dependents, DependentsRequest
 from pants.base.build_environment import get_buildroot
 from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import Collection
@@ -72,8 +72,8 @@ async def find_changed_owners(
         addr.maybe_convert_to_target_generator() for addr in owners if addr.is_generated_target
     )
     dependees = await Get(
-        Dependees,
-        DependeesRequest(
+        Dependents,
+        DependentsRequest(
             owners,
             transitive=request.dependees == DependeesOption.TRANSITIVE,
             include_roots=False,
@@ -155,4 +155,4 @@ class Changed(Subsystem):
 
 
 def rules():
-    return [*collect_rules(), *dependees.rules()]
+    return [*collect_rules(), *dependents.rules()]

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -260,7 +260,7 @@ impl<N: Node> InnerGraph<N> {
 
     // And their transitive dependencies, which will be dirtied.
     //
-    // NB: We only dirty "through" a Node and into its dependees if it is Node::restartable.
+    // NB: We only dirty "through" a Node and into its dependents if it is Node::restartable.
     let transitive_ids: Vec<_> = self
       .walk(
         root_ids.iter().cloned().collect(),

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -395,7 +395,7 @@ async fn non_restartable_node_only_runs_once() {
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
   // TNode(0) is cleared before completing, and so will run twice. But the non_restartable node and its
-  // dependee each run once.
+  // dependent each run once.
   assert_eq!(
     context.runs(),
     vec![TNode::new(2), TNode::new(1), TNode::new(0), TNode::new(0),]


### PR DESCRIPTION
It turns out that dependee means the opposite of how we were using it...

Note that this doesn't modify external uses of the term, in the `dependees` goal, the `--changed-dependees` option, or the `# Dependees` column header reported by py_constraints.

A future change will do so, and deprecate the old names. For now this just changes internal uses of the wrong term, in comments and var names.