### PR TITLE
Rename --changed-dependees to --changed-dependents

### DIFF
--- a/build-support/githooks/pre-commit
+++ b/build-support/githooks/pre-commit
@@ -21,7 +21,7 @@ if git diff "${MERGE_BASE}" --name-only | grep '\.rs$' > /dev/null; then
 fi
 
 echo "* Typechecking"
-./pants --changed-since="${MERGE_BASE}" --changed-dependees=transitive check
+./pants --changed-since="${MERGE_BASE}" --changed-dependents=transitive check
 
 echo "* Checking linters, formatters, and headers"
 ./pants --changed-since="${MERGE_BASE}" lint ||

--- a/docs/markdown/Python/python-goals/python-check-goal.md
+++ b/docs/markdown/Python/python-goals/python-check-goal.md
@@ -265,13 +265,13 @@ If you're using a version of MyPy older than `0.700`, consider upgrading to unlo
 Additionally consider not providing `python_version` in your config or args.
 
 
-Tip: only run over changed files and their dependees
-----------------------------------------------------
+Tip: only run over changed files and their dependents
+-----------------------------------------------------
 
 When changing type hints code, you not only need to run over the changed files, but also any code that depends on the changed files:
 
 ```bash
-$ ./pants --changed-since=HEAD --changed-dependees=transitive check
+$ ./pants --changed-since=HEAD --changed-dependents=transitive check
 ```
 
 See [Advanced target selection](doc:advanced-target-selection) for more information.

--- a/docs/markdown/Using Pants/advanced-target-selection.md
+++ b/docs/markdown/Using Pants/advanced-target-selection.md
@@ -29,12 +29,12 @@ To run against another branch, run:
 ./pants --changed-since=origin/main lint
 ```
 
-By default, `--changed-since` will only run over files directly changed. Often, though, you will want to run over any [dependees](doc:project-introspection) of those changed files, meaning any targets that depend on the changed files. Use ` --changed-dependees=direct` or ` --changed-dependees=transitive` for this:
+By default, `--changed-since` will only run over files directly changed. Often, though, you will want to run over any [dependents](doc:project-introspection) of those changed files, meaning any targets that depend on the changed files. Use ` --changed-dependents=direct` or ` --changed-dependents=transitive` for this:
 
 ```bash
 ❯ ./pants \
   --changed-since=origin/main \
-  --changed-dependees=transitive \
+  --changed-dependents=transitive \
   test
 ```
 

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -99,13 +99,13 @@ We recommend running these commands in CI:
   lint
 ❯ ./pants \
   --changed-since=origin/main \
-  --changed-dependees=transitive \
+  --changed-dependents=transitive \
   check test
 ```
 
-Because most linters do not care about a target's dependencies, we lint all changed files and targets, but not any dependees of those changes.
+Because most linters do not care about a target's dependencies, we lint all changed files and targets, but not any dependents of those changes.
 
-Meanwhile, tests should be rerun when any changes are made to the tests _or_ to dependencies of those tests, so we use the option `--changed-dependees=transitive`. `check` should also run on any transitive changes.
+Meanwhile, tests should be rerun when any changes are made to the tests _or_ to dependencies of those tests, so we use the option `--changed-dependents=transitive`. `check` should also run on any transitive changes.
 
 See [Advanced target selection](doc:advanced-target-selection) for more information on `--changed-since` and alternative techniques to select targets to run in CI.
 

--- a/pants.toml
+++ b/pants.toml
@@ -79,7 +79,7 @@ repo_id = "7775F8D5-FC58-4DBC-9302-D00AE4A1505F"
 
 
 [cli.alias]
-all-changed = "--changed-since=HEAD --changed-dependees=transitive"
+all-changed = "--changed-since=HEAD --changed-dependents=transitive"
 run-pyupgrade = "--backend-packages=pants.backend.experimental.python.lint.pyupgrade fmt"
 
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -591,7 +591,7 @@ class TargetGeneratorSourcesHelperTarget(Target):
         """
         A private helper target type used by some target generators.
 
-        This tracks their `source` / `sources` field so that `--changed-since --changed-dependees`
+        This tracks their `source` / `sources` field so that `--changed-since --changed-dependents`
         works properly for generated targets.
         """
     )
@@ -742,7 +742,7 @@ class LockfileTarget(Target):
         """
         A target for lockfiles in order to include them in the dependency graph of other targets.
 
-        This tracks them so that `--changed-since --changed-dependees` works properly for targets
+        This tracks them so that `--changed-since --changed-dependents` works properly for targets
         relying on a particular lockfile.
         """
     )

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -53,7 +53,7 @@ PANTS_RULES_MODULE_KEY = "__pants_rules__"
 def SubsystemRule(subsystem: Type[Subsystem]) -> Rule:
     """Returns a TaskRule that constructs an instance of the subsystem."""
     warn_or_error(
-        removal_version="2.17.0dev0",
+        removal_version="2.17.0.dev0",
         entity=f"using `SubsystemRule({subsystem.__name__})`",
         hint=f"Use `*{subsystem.__name__}.rules()` instead.",
     )

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -71,7 +71,7 @@ def calculate_specs(
     changed_files = tuple(changed_options.changed_files(maybe_git_worktree.git_worktree))
     file_literal_specs = tuple(FileLiteralSpec(f) for f in changed_files)
 
-    changed_request = ChangedRequest(changed_files, changed_options.dependees)
+    changed_request = ChangedRequest(changed_files, changed_options.dependents)
     (changed_addresses,) = session.product_request(
         ChangedAddresses,
         [Params(changed_request, options_bootstrapper, bootstrap_environment)],

--- a/src/python/pants/option/alias.py
+++ b/src/python/pants/option/alias.py
@@ -46,11 +46,11 @@ class CliOptions(Subsystem):
 
                 [cli.alias]
                 green = "fmt lint check"
-                all-changed = "--changed-since=HEAD --changed-dependees=transitive"
+                all-changed = "--changed-since=HEAD --changed-dependents=transitive"
 
 
             This would allow you to run `{bin_name()} green all-changed`, which is shorthand for
-            `{bin_name()} fmt lint check --changed-since=HEAD --changed-dependees=transitive`.
+            `{bin_name()} fmt lint check --changed-since=HEAD --changed-dependents=transitive`.
 
             Notice: this option must be placed in a config file (e.g. `pants.toml` or `pantsrc`)
             to have any effect.

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -25,7 +25,7 @@ from pants.util.strutil import softwrap
 from pants.vcs.git import GitWorktree
 
 
-class DependeesOption(Enum):
+class DependentsOption(Enum):
     NONE = "none"
     DIRECT = "direct"
     TRANSITIVE = "transitive"
@@ -34,7 +34,7 @@ class DependeesOption(Enum):
 @dataclass(frozen=True)
 class ChangedRequest:
     sources: tuple[str, ...]
-    dependees: DependeesOption
+    dependents: DependentsOption
 
 
 class ChangedAddresses(Collection[Address]):
@@ -45,20 +45,20 @@ class ChangedAddresses(Collection[Address]):
 async def find_changed_owners(
     request: ChangedRequest, specs_filter: SpecsFilter
 ) -> ChangedAddresses:
-    no_dependees = request.dependees == DependeesOption.NONE
+    no_dependents = request.dependents == DependentsOption.NONE
     owners = await Get(
         Owners,
         OwnersRequest(
             request.sources,
-            # If `--changed-dependees` is used, we cannot eagerly filter out root targets. We
-            # need to first find their dependees, and only then should we filter. See
+            # If `--changed-dependents` is used, we cannot eagerly filter out root targets. We
+            # need to first find their dependents, and only then should we filter. See
             # https://github.com/pantsbuild/pants/issues/15544
-            filter_by_global_options=no_dependees,
+            filter_by_global_options=no_dependents,
             # Changing a BUILD file might impact the targets it defines.
             match_if_owning_build_file_included_in_sources=True,
         ),
     )
-    if no_dependees:
+    if no_dependents:
         return ChangedAddresses(owners)
 
     # See https://github.com/pantsbuild/pants/issues/15313. We filter out target generators because
@@ -71,15 +71,15 @@ async def find_changed_owners(
     owner_target_generators = FrozenOrderedSet(
         addr.maybe_convert_to_target_generator() for addr in owners if addr.is_generated_target
     )
-    dependees = await Get(
+    dependents = await Get(
         Dependents,
         DependentsRequest(
             owners,
-            transitive=request.dependees == DependeesOption.TRANSITIVE,
+            transitive=request.dependents == DependentsOption.TRANSITIVE,
             include_roots=False,
         ),
     )
-    result = FrozenOrderedSet(owners) | (dependees - owner_target_generators)
+    result = FrozenOrderedSet(owners) | (dependents - owner_target_generators)
     if specs_filter.is_specified:
         # Finally, we must now filter out the result to only include what matches our tags, as the
         # last step of https://github.com/pantsbuild/pants/issues/15544.
@@ -104,11 +104,17 @@ class ChangedOptions:
 
     since: str | None
     diffspec: str | None
-    dependees: DependeesOption
+    dependents: DependentsOption
 
     @classmethod
     def from_options(cls, options: OptionValueContainer) -> ChangedOptions:
-        return cls(options.since, options.diffspec, options.dependees)
+        return cls(
+            options.since,
+            options.diffspec,
+            options.dependees
+            if options.dependents == DependentsOption.NONE
+            else options.dependents,
+        )
 
     @property
     def provided(self) -> bool:
@@ -148,9 +154,15 @@ class Changed(Subsystem):
         default=None,
         help="Calculate changes contained within a given Git spec (commit range/SHA/ref).",
     )
+    dependents = EnumOption(
+        default=DependentsOption.NONE,
+        help="Include direct or transitive dependents of changed targets.",
+    )
     dependees = EnumOption(
-        default=DependeesOption.NONE,
-        help="Include direct or transitive dependees of changed targets.",
+        default=DependentsOption.NONE,
+        help="Include direct or transitive dependents of changed targets.",
+        removal_version="2.17.0.dev0",
+        removal_hint="Use --dependents instead",
     )
 
 

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -13,7 +13,7 @@ import pytest
 from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_integration_test import PantsResult, run_pants_with_workdir
 from pants.util.contextutil import temporary_dir
-from pants.vcs.changed import DependeesOption
+from pants.vcs.changed import DependentsOption
 
 
 def _run_git(command: list[str]) -> None:
@@ -92,7 +92,7 @@ def reset_edits() -> None:
 def _run_pants_goal(
     workdir: str,
     goal: str,
-    dependees: DependeesOption = DependeesOption.NONE,
+    dependents: DependentsOption = DependentsOption.NONE,
     *,
     extra_args: list[str] | None = None,
 ) -> PantsResult:
@@ -101,7 +101,7 @@ def _run_pants_goal(
             *(extra_args or ()),
             "--changed-since=HEAD",
             "--print-stacktrace",
-            f"--changed-dependees={dependees.value}",
+            f"--changed-dependents={dependents.value}",
             goal,
         ],
         workdir=workdir,
@@ -112,23 +112,23 @@ def _run_pants_goal(
 def assert_list_stdout(
     workdir: str,
     expected: list[str],
-    dependees: DependeesOption = DependeesOption.NONE,
+    dependents: DependentsOption = DependentsOption.NONE,
     *,
     extra_args: list[str] | None = None,
 ) -> None:
-    result = _run_pants_goal(workdir, "list", dependees=dependees, extra_args=extra_args)
+    result = _run_pants_goal(workdir, "list", dependents=dependents, extra_args=extra_args)
     result.assert_success()
     assert sorted(result.stdout.strip().splitlines()) == sorted(expected)
 
 
 def assert_count_loc(
     workdir: str,
-    dependees: DependeesOption = DependeesOption.NONE,
+    dependents: DependentsOption = DependentsOption.NONE,
     *,
     expected_num_files: int,
     extra_args: list[str] | None = None,
 ) -> None:
-    result = _run_pants_goal(workdir, "count-loc", dependees=dependees, extra_args=extra_args)
+    result = _run_pants_goal(workdir, "count-loc", dependents=dependents, extra_args=extra_args)
     result.assert_success()
     if expected_num_files:
         assert f"Total                        {expected_num_files}" in result.stdout
@@ -143,8 +143,8 @@ def test_no_changes(repo: str) -> None:
 
 def test_change_no_deps(repo: str) -> None:
     append_to_file("standalone.sh", "# foo")
-    for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:standalone"], dependees)
+    for dependents in DependentsOption:
+        assert_list_stdout(repo, ["//:standalone"], dependents)
         assert_count_loc(repo, expected_num_files=1)
 
 
@@ -153,14 +153,14 @@ def test_change_transitive_dep(repo: str) -> None:
     assert_list_stdout(repo, ["//transitive.sh:lib"])
     assert_count_loc(repo, expected_num_files=1)
 
-    assert_list_stdout(repo, ["//dep.sh:lib", "//transitive.sh:lib"], DependeesOption.DIRECT)
-    assert_count_loc(repo, DependeesOption.DIRECT, expected_num_files=2)
+    assert_list_stdout(repo, ["//dep.sh:lib", "//transitive.sh:lib"], DependentsOption.DIRECT)
+    assert_count_loc(repo, DependentsOption.DIRECT, expected_num_files=2)
 
     assert_list_stdout(
-        repo, ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib"], DependeesOption.TRANSITIVE
+        repo, ["//app.sh:lib", "//dep.sh:lib", "//transitive.sh:lib"], DependentsOption.TRANSITIVE
     )
 
-    assert_count_loc(repo, DependeesOption.TRANSITIVE, expected_num_files=3)
+    assert_count_loc(repo, DependentsOption.TRANSITIVE, expected_num_files=3)
 
 
 def test_unowned_file(repo: str) -> None:
@@ -184,22 +184,22 @@ def test_delete_generated_target(repo: str) -> None:
     * https://github.com/pantsbuild/pants/issues/14975
     """
     delete_file("transitive.sh")
-    for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:lib"], dependees)
-        assert_count_loc(repo, dependees, expected_num_files=2)
+    for dependents in DependentsOption:
+        assert_list_stdout(repo, ["//:lib"], dependents)
+        assert_count_loc(repo, dependents, expected_num_files=2)
 
     # Make sure that our fix for https://github.com/pantsbuild/pants/issues/15544 does not break
     # this test when using `--tag`.
-    for dependees in (DependeesOption.NONE, DependeesOption.TRANSITIVE):
-        assert_list_stdout(repo, ["//:lib"], dependees, extra_args=["--tag=a"])
-        assert_count_loc(repo, dependees, expected_num_files=1, extra_args=["--tag=a"])
+    for dependents in (DependentsOption.NONE, DependentsOption.TRANSITIVE):
+        assert_list_stdout(repo, ["//:lib"], dependents, extra_args=["--tag=a"])
+        assert_count_loc(repo, dependents, expected_num_files=1, extra_args=["--tag=a"])
 
     # If we also edit a sibling generated target, we should still (for now at least) include the
     # target generator.
     append_to_file("app.sh", "# foo")
-    for dependees in DependeesOption:
-        assert_list_stdout(repo, ["//:lib", "//app.sh:lib"], dependees)
-        assert_count_loc(repo, dependees, expected_num_files=2)
+    for dependents in DependentsOption:
+        assert_list_stdout(repo, ["//:lib", "//app.sh:lib"], dependents)
+        assert_count_loc(repo, dependents, expected_num_files=2)
 
 
 def test_delete_atom_target(repo: str) -> None:
@@ -250,9 +250,9 @@ def test_tag_filtering(repo: str) -> None:
     assert_list_stdout(repo, ["//:standalone"], extra_args=["--tag=-b"])
     assert_count_loc(repo, expected_num_files=1, extra_args=["--tag=-b"])
 
-    assert_list_stdout(repo, ["//dep.sh:lib"], DependeesOption.TRANSITIVE, extra_args=["--tag=+b"])
+    assert_list_stdout(repo, ["//dep.sh:lib"], DependentsOption.TRANSITIVE, extra_args=["--tag=+b"])
     assert_count_loc(
-        repo, DependeesOption.TRANSITIVE, expected_num_files=1, extra_args=["--tag=+b"]
+        repo, DependentsOption.TRANSITIVE, expected_num_files=1, extra_args=["--tag=+b"]
     )
 
     # Regression test for https://github.com/pantsbuild/pants/issues/14977: make sure a generated
@@ -262,31 +262,33 @@ def test_tag_filtering(repo: str) -> None:
     assert_list_stdout(
         repo,
         ["//app.sh:lib", "//transitive.sh:lib"],
-        DependeesOption.TRANSITIVE,
+        DependentsOption.TRANSITIVE,
         extra_args=["--tag=-b"],
     )
     assert_count_loc(
-        repo, DependeesOption.TRANSITIVE, expected_num_files=2, extra_args=["--tag=-b"]
+        repo, DependentsOption.TRANSITIVE, expected_num_files=2, extra_args=["--tag=-b"]
     )
 
     # Regression test for https://github.com/pantsbuild/pants/issues/15544. Don't filter
-    # `--changed-since` roots until the very end if using `--changed-dependees`.
+    # `--changed-since` roots until the very end if using `--changed-dependents`.
     #
     # We change `dep.sh`, which has the tag `b`. When we filter for only tag `a`, we should still
-    # find the dependees of `dep.sh`, like `app.sh`, and only then apply the filter.
+    # find the dependents of `dep.sh`, like `app.sh`, and only then apply the filter.
     reset_edits()
     append_to_file("dep.sh", "# foo")
-    assert_list_stdout(repo, [], DependeesOption.NONE, extra_args=["--tag=a"])
-    assert_count_loc(repo, DependeesOption.NONE, expected_num_files=0, extra_args=["--tag=a"])
+    assert_list_stdout(repo, [], DependentsOption.NONE, extra_args=["--tag=a"])
+    assert_count_loc(repo, DependentsOption.NONE, expected_num_files=0, extra_args=["--tag=a"])
 
-    assert_list_stdout(repo, ["//app.sh:lib"], DependeesOption.TRANSITIVE, extra_args=["--tag=a"])
-    assert_count_loc(repo, DependeesOption.TRANSITIVE, expected_num_files=1, extra_args=["--tag=a"])
+    assert_list_stdout(repo, ["//app.sh:lib"], DependentsOption.TRANSITIVE, extra_args=["--tag=a"])
+    assert_count_loc(
+        repo, DependentsOption.TRANSITIVE, expected_num_files=1, extra_args=["--tag=a"]
+    )
 
 
 def test_pants_ignored_file(repo: str) -> None:
     """Regression test for
     https://github.com/pantsbuild/pants/issues/15655#issuecomment-1140081185."""
     create_file(".ignored/f.txt", "")
-    for dependees in (DependeesOption.NONE, DependeesOption.DIRECT):
-        assert_list_stdout(repo, [], dependees)
-        assert_count_loc(repo, dependees, expected_num_files=0)
+    for dependents in (DependentsOption.NONE, DependentsOption.DIRECT):
+        assert_list_stdout(repo, [], dependents)
+        assert_count_loc(repo, dependents, expected_num_files=0)


### PR DESCRIPTION
Deprecates the old name.