### PR TITLE
Restore debug hints for `test` execution (Cherry-pick of #17406)

### DIFF
--- a/src/python/pants/base/specs_integration_test.py
+++ b/src/python/pants/base/specs_integration_test.py
@@ -80,8 +80,8 @@ def test_address_literal() -> None:
         assert run(["list", *list_specs]).stdout.splitlines() == list_specs
 
         test_result = run(["test", f"{tmpdir}/py:tests"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded" in test_result
-        assert f"{tmpdir}/py/base/common_test.py:../tests succeeded" in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
+        assert f"{tmpdir}/py/base/common_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
 
@@ -109,14 +109,14 @@ def test_sibling_addresses() -> None:
         # Even though no `python_test` targets are explicitly defined in `util/`, a generated
         # target is resident there.
         test_result = run(["test", f"{tmpdir}/py/utils:"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded" in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" not in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
         # Even though no `_test.py` files live in this dir, we match the `python_tests` target
         # and replace it with its generated targets.
         test_result = run(["test", f"{tmpdir}/py:"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded" in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 
@@ -137,7 +137,7 @@ def test_descendent_addresses() -> None:
         ]
 
         test_result = run(["test", f"{tmpdir}/py::"]).stderr
-        assert f"{tmpdir}/py/utils/strutil_test.py:../tests succeeded" in test_result
+        assert f"{tmpdir}/py/utils/strutil_test.py:../tests - succeeded." in test_result
         assert f"{tmpdir}/py/base/common_test.py:../tests" in test_result
         assert f"{tmpdir}/py:tests" not in test_result
 

--- a/src/python/pants/core/util_rules/partitions.py
+++ b/src/python/pants/core/util_rules/partitions.py
@@ -14,6 +14,7 @@ from typing_extensions import Protocol
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.engine.collection import Collection
+from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
@@ -154,7 +155,7 @@ class Partitions(Collection[Partition[PartitionElementT, PartitionMetadataT]]):
 @frozen_after_init
 @dataclass(unsafe_hash=True)
 @runtime_ignore_subscripts
-class _BatchBase(Generic[PartitionElementT, PartitionMetadataT]):
+class _BatchBase(Generic[PartitionElementT, PartitionMetadataT], EngineAwareParameter):
     """Base class for a collection of elements that should all be processed together.
 
     For example, a collection of strings pointing to files that should be linted in one process, or
@@ -168,7 +169,7 @@ class _BatchBase(Generic[PartitionElementT, PartitionMetadataT]):
 
 @dataclass(frozen=True)
 @runtime_ignore_subscripts
-class _PartitionFieldSetsRequestBase(Generic[_FieldSetT]):
+class _PartitionFieldSetsRequestBase(Generic[_FieldSetT], EngineAwareParameter):
     """Returns a unique type per calling type.
 
     This serves us 2 purposes:
@@ -180,7 +181,7 @@ class _PartitionFieldSetsRequestBase(Generic[_FieldSetT]):
 
 
 @dataclass(frozen=True)
-class _PartitionFilesRequestBase:
+class _PartitionFilesRequestBase(EngineAwareParameter):
     """Returns a unique type per calling type.
 
     This serves us 2 purposes:


### PR DESCRIPTION
Closes #17386

91d68f1949e73db7529c13c5b8ba754b82994876 broke streaming output for `test`. This commit should fix the problem by having the new partitioning API's types subclass `EngineAwareParameter`.

For now I've only implemented `debug_hint` for the `TestRequest.Batch` type, because it's the direct replacement for the old `TestFieldSet`-driven API.
