### PR TITLE
Do not box workunit `Future`s.

### DIFF
--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -873,7 +873,6 @@ macro_rules! in_workunit {
       $workunit.complete();
       result
     })
-    .boxed()
   }};
 }
 


### PR DESCRIPTION
Runs with https://github.com/nnethercote/dhat-rs/issues/19 fixed highlighted that the boxed future allocated by the workunit macro at:
```
#4: 0x107203187: <engine::nodes::NodeKey as graph::node::Node>::run::{{closure}} (engine/src/nodes.rs:1395:5)
```
... represented one of the largest contributors to peak memory usage.