### PR TITLE
Fix `EnvironmentName` used in `test` runs

### DIFF
--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -39,7 +39,10 @@ from pants.core.goals.test import (
 )
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import ChosenLocalEnvironmentName
+from pants.core.util_rules.environments import (
+    ChosenLocalEnvironmentName,
+    SingleEnvironmentNameRequest,
+)
 from pants.core.util_rules.partitions import Partition, Partitions
 from pants.engine.addresses import Address
 from pants.engine.console import Console
@@ -301,8 +304,8 @@ def run_test_rule(
                 ),
                 MockGet(
                     output_type=EnvironmentName,
-                    input_types=(TestRequest.Batch, EnvironmentName),
-                    mock=lambda _b, _e: EnvironmentName(None),
+                    input_types=(SingleEnvironmentNameRequest,),
+                    mock=lambda _a: EnvironmentName(None),
                 ),
                 MockGet(
                     output_type=TestResult,

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -43,7 +43,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.enums import match
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized
-from pants.util.strutil import softwrap
+from pants.util.strutil import bullet_list, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -502,6 +502,18 @@ class EnvironmentTarget:
         )
 
 
+def _compute_env_field(field_set: FieldSet) -> EnvironmentField:
+    for attr in dir(field_set):
+        # Skip what look like dunder methods, which are unlikely to be an
+        # EnvironmentField value on FieldSet class declarations.
+        if attr.startswith("__"):
+            continue
+        val = getattr(field_set, attr)
+        if isinstance(val, EnvironmentField):
+            return val
+    return EnvironmentField(None, address=field_set.address)
+
+
 @dataclass(frozen=True)
 class EnvironmentNameRequest(EngineAwareParameter):
     f"""Normalize the value into a name from `[environments-preview].names`, such as by
@@ -522,18 +534,7 @@ class EnvironmentNameRequest(EngineAwareParameter):
         then pass `{{resulting_environment_name: EnvironmentName}}` into a `Get` to change which
         environment is used for the subgraph.
         """
-        for attr in dir(field_set):
-            # Skip what look like dunder methods, which are unlikely to be an
-            # EnvironmentField value on FieldSet class declarations.
-            if attr.startswith("__"):
-                continue
-            val = getattr(field_set, attr)
-            if isinstance(val, EnvironmentField):
-                env_field = val
-                break
-        else:
-            env_field = EnvironmentField(None, address=field_set.address)
-
+        env_field = _compute_env_field(field_set)
         return EnvironmentNameRequest(
             env_field.value,
             # Note that if the field was not registered, we will have fallen back to the default
@@ -547,6 +548,28 @@ class EnvironmentNameRequest(EngineAwareParameter):
 
     def debug_hint(self) -> str:
         return self.raw_value
+
+
+@dataclass(frozen=True)
+class SingleEnvironmentNameRequest(EngineAwareParameter):
+    """Asserts that all of the given environment strings resolve to the same EnvironmentName."""
+
+    raw_values: tuple[str, ...]
+    description_of_origin: str = dataclasses.field(hash=False, compare=False)
+
+    @classmethod
+    def from_field_sets(
+        cls, field_sets: Sequence[FieldSet], description_of_origin: str
+    ) -> SingleEnvironmentNameRequest:
+        """See `EnvironmentNameRequest.from_field_set`."""
+
+        return SingleEnvironmentNameRequest(
+            tuple(sorted({_compute_env_field(field_set).value for field_set in field_sets})),
+            description_of_origin=description_of_origin,
+        )
+
+    def debug_hint(self) -> str:
+        return ", ".join(self.raw_values)
 
 
 @rule
@@ -615,6 +638,25 @@ async def determine_local_environment(
             """
         )
     )
+
+
+@rule
+async def resolve_single_environment_name(
+    request: SingleEnvironmentNameRequest,
+) -> EnvironmentName:
+    environment_names = await MultiGet(
+        Get(EnvironmentName, EnvironmentNameRequest(name, request.description_of_origin))
+        for name in request.raw_values
+    )
+
+    unique_environments = sorted({name.val or "<None>" for name in environment_names})
+    if len(unique_environments) != 1:
+        raise AssertionError(
+            f"Needed 1 unique environment, but {request.description_of_origin} contained "
+            f"{len(unique_environments)}:\n\n"
+            f"{bullet_list(unique_environments)}"
+        )
+    return environment_names[0]
 
 
 @rule_helper


### PR DESCRIPTION
#17134 moved `EnvironmentName` calculation into [a `@rule` that took a `TestRequest.Batch` as an argument](https://github.com/pantsbuild/pants/blob/44acec126c3b8d1968f5adc91597828618e080d9/src/python/pants/core/goals/test.py#L756-L757).

But since `TestRequest.Batch` is a `@union`, [the callsite](https://github.com/pantsbuild/pants/blob/44acec126c3b8d1968f5adc91597828618e080d9/src/python/pants/core/goals/test.py#L825-L830) could not directly call it with a subclass of `TestRequest.Batch`: the effect was instead that each implementation of `TestRequest.Batch` must have a way to compute an `EnvironmentName` _given_ an `EnvironmentName`... i.e., `QueryRule(EnvironmentName, [EnvironmentName, Shunit2TestRequest.Batch])`, etc. The effect was always to use the `ChosenLocalEnvironmentName` which was input at the callsite.

This change adds a dedicated `@rule` (and more importantly: argument type) for unifying the environment names of multiple `FieldSet`s.