### PR TITLE
Fix dep inference from shuint2_tests targets.

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -108,7 +108,7 @@ class Shunit2Shell(Enum):
         return BinaryPathTest((arg,))
 
 
-class Shunit2TestDependenciesField(Dependencies):
+class Shunit2TestDependenciesField(ShellDependenciesField):
     supports_transitive_excludes = True
 
 
@@ -269,8 +269,8 @@ class ShellCommandOutputsField(StringSequenceField):
     )
 
 
-class ShellCommandDependenciesField(Dependencies):
-    pass
+class ShellCommandDependenciesField(ShellDependenciesField):
+    supports_transitive_excludes = True
 
 
 class ShellCommandSourcesField(MultipleSourcesField):


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/issues/16949 for details on the breakage.