### PR TITLE
Update nuke_if_too_big documentation (Cherry-pick of #17429)

### DIFF
--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -39,17 +39,17 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 > You can use this script to nuke the cache when it gets too big:
 > 
 > ```bash
-> function nuke_if_too_big() {
->   path=$1
->   limit_mb=$2
->   size_mb=$(du -m -d0 ${path} | cut -f 1)
->   if (( ${size_mb} > ${limit_mb} )); then
->     echo "${path} is too large (${size_mb}mb), nuking it."
->     rm -rf ${path}
->   fi
-> }
+>  function nuke_if_too_big() {
+>    path=$1
+>    limit_mb=$2
+>    size_mb=$(du -m -d0 "${path}" | cut -f 1)
+>    if (( size_mb > limit_mb )); then
+>      echo "${path} is too large (${size_mb}mb), nuking it."
+>      rm -rf "${path}"
+>    fi
+>  }
 >
-> nuke_if_too_big ~/.cache/pants/setup 256
+> nuke_if_too_big ~/.cache/pants/setup 512
 > nuke_if_too_big ~/.cache/pants/named_caches 1024
 > ```
 


### PR DESCRIPTION
- As of pants 2.13 the .pants/setup directory is approximately 300mb big, resulting in the example always clearing the directory.
- Updated the script to pass shellcheck.

Previous implementation failed with:
```
Line 4:
    size_mb=$(du -m -d0 ${path} | cut -f 1)
                        ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

  Did you mean: (apply this, apply all SC2086)
    size_mb=$(du -m -d0 "${path}" | cut -f 1)

  Line 5:
    if (( ${size_mb} > ${limit_mb} )); then
          ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.
                       ^-- SC2004 (style): $/${} is unnecessary on arithmetic variables.

  Line 7:
      rm -rf ${path}
             ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

  Did you mean: (apply this, apply all SC2086)
      rm -rf "${path}"
```
