### PR TITLE
adds `EnvironmentField` to `pex_binary` and related generators

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -625,6 +625,7 @@ class PexVenvSitePackagesCopies(BoolField):
 
 
 _PEX_BINARY_COMMON_FIELDS = (
+    EnvironmentField,
     InterpreterConstraintsField,
     PythonResolveField,
     PexBinaryDependenciesField,


### PR DESCRIPTION
This adds an `environment` field to `pex_binary`/`pex_binaries` etc.

The `package` goal already injects the `EnvironmentName` from the `EnvironmentField` into the relevant pex rules by way of `EnvironmentAwarePackageRequest`, this change just makes it possible to supply that value.

Closes #17428 