### PR TITLE
Enable running third-party Go `main` packages

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -21,7 +21,6 @@ from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysisRequest,
 )
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
-from pants.backend.go.util_rules.import_config import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
@@ -70,9 +69,10 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
             ThirdPartyPkgAnalysis,
             ThirdPartyPkgAnalysisRequest(
                 main_pkg.import_path,
+                go_mod_address,
                 go_mod_info.digest,
                 go_mod_info.mod_path,
-                build_opts,
+                build_opts=build_opts,
             ),
         )
 

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -21,7 +21,7 @@ from pants.backend.go.util_rules.first_party_pkg import (
     FirstPartyPkgAnalysisRequest,
 )
 from pants.backend.go.util_rules.go_mod import GoModInfo, GoModInfoRequest
-from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
+from pants.backend.go.util_rules.import_config import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import cast
 
 from pants.backend.go.target_types import (
     GoBinaryMainPackageField,
@@ -62,7 +61,7 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
     )
 
     if main_pkg.is_third_party:
-        import_path = cast(str, main_pkg.import_path)
+        assert isinstance(main_pkg.import_path, str)
 
         go_mod_address = main_pkg.address.maybe_convert_to_target_generator()
         go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
@@ -70,7 +69,7 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
         analysis = await Get(
             ThirdPartyPkgAnalysis,
             ThirdPartyPkgAnalysisRequest(
-                import_path,
+                main_pkg.import_path,
                 go_mod_info.digest,
                 go_mod_info.mod_path,
                 build_opts,

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -3,9 +3,15 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import io
+import json
 import os.path
 import subprocess
+import zipfile
 from textwrap import dedent
+from typing import Iterable
 
 import pytest
 
@@ -106,49 +112,188 @@ def test_package_simple(rule_runner: RuleRunner) -> None:
     assert result.stdout == b"Hello world!\n"
 
 
+def _gen_third_party_pkg():
+    # Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
+    def _compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
+        sorted_files = sorted(files, key=lambda x: x[0])
+        summary = ""
+        for name, content in sorted_files:
+            h = hashlib.sha256(content.encode())
+            summary += f"{h.hexdigest()}  {name}\n"
+
+        h = hashlib.sha256(summary.encode())
+        summary_digest = base64.standard_b64encode(h.digest()).decode()
+        return f"h1:{summary_digest}"
+
+    import_path = "pantsbuild.org/go-embed-sample-for-test"
+    version = "v0.0.1"
+    go_mod_content = dedent(
+        f"""\
+        module {import_path}
+        go 1.16
+        """
+    )
+    go_mod_sum = _compute_module_hash([("go.mod", go_mod_content)])
+
+    prefix = f"{import_path}@{version}"
+    files_in_zip = (
+        (f"{prefix}/go.mod", go_mod_content),
+        (
+            f"{prefix}/pkg/hello/hello.go",
+            dedent(
+                """\
+        package hello
+        import "fmt"
+
+
+        func Hello() {
+            fmt.Println("Hello world!")
+        }
+        """
+            ),
+        ),
+        (
+            f"{prefix}/cmd/hello/main.go",
+            dedent(
+                """\
+        package main
+        import "pantsbuild.org/go-embed-sample-for-test/pkg/hello"
+
+
+        func main() {
+            hello.Hello()
+        }
+        """
+            ),
+        ),
+    )
+
+    mod_zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
+        for name, content in files_in_zip:
+            mod_zip.writestr(name, content)
+
+    mod_zip_sum = _compute_module_hash(files_in_zip)
+    return mod_zip_sum, go_mod_sum, import_path, version, go_mod_content, mod_zip_bytes
+
+
 def test_package_third_party_requires_main(rule_runner: RuleRunner) -> None:
+    (
+        mod_zip_sum,
+        go_mod_sum,
+        import_path,
+        version,
+        go_mod_content,
+        mod_zip_bytes,
+    ) = _gen_third_party_pkg()
     rule_runner.write_files(
         {
-            "go.mod": dedent(
-                """\
-                module foo.example.com
-                go 1.17
-
-                require github.com/tgolsson/example-pants-third-party v0.0.0-20221101220057-1a7167a87ec5 // indirect
-                """
-            ),
             "BUILD": dedent(
-                """\
+                f"""\
                 go_mod(name='mod')
-                go_binary(name="bin", main='//:mod#github.com/tgolsson/example-pants-third-party/pkg/hello')
+                go_binary(name="bin", main='//:mod#{import_path}/pkg/hello')
                 """
             ),
+            "go.mod": dedent(
+                f"""\
+                module go.example.com/foo
+                go 1.16
+
+                require (
+                \t{import_path} {version}
+                )
+                """
+            ),
+            "go.sum": dedent(
+                f"""\
+                {import_path} {version} {mod_zip_sum}
+                {import_path} {version}/go.mod {go_mod_sum}
+                """
+            ),
+            # Setup the third-party dependency as a custom Go module proxy site.
+            # See https://go.dev/ref/mod#goproxy-protocol for details.
+            f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
+            f"go-mod-proxy/{import_path}/@v/{version}.info": json.dumps(
+                {
+                    "Version": version,
+                    "Time": "2022-01-01T01:00:00Z",
+                }
+            ),
+            f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
+            f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
         }
     )
+
+    rule_runner.set_options(
+        [
+            "--go-test-args=-v -bench=.",
+            f"--golang-subprocess-env-vars=GOPROXY=file://{rule_runner.build_root}/go-mod-proxy",
+            "--golang-subprocess-env-vars=GOSUMDB=off",
+        ],
+        env_inherit={"PATH"},
+    )
+
     binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
     with engine_error(ValueError, contains="but uses package name `hello` instead of `main`"):
         build_package(rule_runner, binary_tgt)
 
 
 def test_package_third_party_can_run(rule_runner: RuleRunner) -> None:
+    (
+        mod_zip_sum,
+        go_mod_sum,
+        import_path,
+        version,
+        go_mod_content,
+        mod_zip_bytes,
+    ) = _gen_third_party_pkg()
     rule_runner.write_files(
         {
-            "go.mod": dedent(
-                """\
-                module foo.example.com
-                go 1.17
-
-                require github.com/tgolsson/example-pants-third-party v0.0.0-20221101220057-1a7167a87ec5 // indirect
-                """
-            ),
             "BUILD": dedent(
-                """\
+                f"""\
                 go_mod(name='mod')
-                go_binary(name="bin", main='//:mod#github.com/tgolsson/example-pants-third-party/cmd/hello')
+                go_binary(name="bin", main='//:mod#{import_path}/cmd/hello')
                 """
             ),
+            "go.mod": dedent(
+                f"""\
+                module go.example.com/foo
+                go 1.16
+
+                require (
+                \t{import_path} {version}
+                )
+                """
+            ),
+            "go.sum": dedent(
+                f"""\
+                {import_path} {version} {mod_zip_sum}
+                {import_path} {version}/go.mod {go_mod_sum}
+                """
+            ),
+            # Setup the third-party dependency as a custom Go module proxy site.
+            # See https://go.dev/ref/mod#goproxy-protocol for details.
+            f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
+            f"go-mod-proxy/{import_path}/@v/{version}.info": json.dumps(
+                {
+                    "Version": version,
+                    "Time": "2022-01-01T01:00:00Z",
+                }
+            ),
+            f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
+            f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
         }
     )
+
+    rule_runner.set_options(
+        [
+            "--go-test-args=-v -bench=.",
+            f"--golang-subprocess-env-vars=GOPROXY=file://{rule_runner.build_root}/go-mod-proxy",
+            "--golang-subprocess-env-vars=GOSUMDB=off",
+        ],
+        env_inherit={"PATH"},
+    )
+
     binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
     built_package = build_package(rule_runner, binary_tgt)
     assert len(built_package.artifacts) == 1

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -54,3 +54,35 @@ def test_run_binary() -> None:
     assert "Hola mundo!\n" in result.stderr
     assert result.stdout == "Hello world!\n"
     assert result.exit_code == 23
+
+
+def test_run_binary_third_party() -> None:
+    sources = {
+        "go.mod": dedent(
+            """\
+                module foo.example.com
+                go 1.17
+
+                require github.com/tgolsson/example-pants-third-party v0.0.0-20221101220057-1a7167a87ec5 // indirect
+                """
+        ),
+        "BUILD": dedent(
+            """\
+                go_mod(name='mod')
+                go_binary(name='bin', main=":mod#github.com/tgolsson/example-pants-third-party/cmd/hello")
+                """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        result = run_pants(
+            [
+                "--backend-packages=pants.backend.experimental.go",
+                "--pants-ignore=__pycache__",
+                "run",
+                f"{tmpdir}:bin",
+            ]
+        )
+
+    assert result.stdout == "Hello world!\n"
+    assert result.exit_code == 0

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -3,7 +3,14 @@
 
 from __future__ import annotations
 
+import base64
+import hashlib
+import io
+import json
+import os
+import zipfile
 from textwrap import dedent
+from typing import Iterable
 
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
@@ -57,32 +64,121 @@ def test_run_binary() -> None:
 
 
 def test_run_binary_third_party() -> None:
-    sources = {
-        "go.mod": dedent(
-            """\
-                module foo.example.com
-                go 1.17
+    # Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
+    def _compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
+        sorted_files = sorted(files, key=lambda x: x[0])
+        summary = ""
+        for name, content in sorted_files:
+            h = hashlib.sha256(content.encode())
+            summary += f"{h.hexdigest()}  {name}\n"
 
-                require github.com/tgolsson/example-pants-third-party v0.0.0-20221101220057-1a7167a87ec5 // indirect
-                """
+        h = hashlib.sha256(summary.encode())
+        summary_digest = base64.standard_b64encode(h.digest()).decode()
+        return f"h1:{summary_digest}"
+
+    import_path = "pantsbuild.org/go-embed-sample-for-test"
+    version = "v0.0.1"
+    go_mod_content = dedent(
+        f"""\
+        module {import_path}
+        go 1.16
+        """
+    )
+    go_mod_sum = _compute_module_hash([("go.mod", go_mod_content)])
+
+    prefix = f"{import_path}@{version}"
+    files_in_zip = (
+        (f"{prefix}/go.mod", go_mod_content),
+        (
+            f"{prefix}/pkg/hello/hello.go",
+            dedent(
+                """\
+        package hello
+        import "fmt"
+
+
+        func Hello() {
+            fmt.Println("Hello world!")
+        }
+        """
+            ),
         ),
+        (
+            f"{prefix}/cmd/hello/main.go",
+            dedent(
+                """\
+        package main
+        import "pantsbuild.org/go-embed-sample-for-test/pkg/hello"
+
+
+        func main() {
+            hello.Hello()
+        }
+        """
+            ),
+        ),
+    )
+
+    mod_zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
+        for name, content in files_in_zip:
+            mod_zip.writestr(name, content)
+
+    mod_zip_sum = _compute_module_hash(files_in_zip)
+
+    sources = {
         "BUILD": dedent(
-            """\
+            f"""\
                 go_mod(name='mod')
-                go_binary(name='bin', main=":mod#github.com/tgolsson/example-pants-third-party/cmd/hello")
+                go_binary(name="bin", main=':mod#{import_path}/cmd/hello')
                 """
         ),
+        "go.mod": dedent(
+            f"""\
+                module go.example.com/foo
+                go 1.16
+
+                require (
+                \t{import_path} {version}
+                )
+                """
+        ),
+        "go.sum": dedent(
+            f"""\
+                {import_path} {version} {mod_zip_sum}
+                {import_path} {version}/go.mod {go_mod_sum}
+                """
+        ),
+        # Setup the third-party dependency as a custom Go module proxy site.
+        # See https://go.dev/ref/mod#goproxy-protocol for details.
+        f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
+        f"go-mod-proxy/{import_path}/@v/{version}.info": f"""{{{json.dumps(
+            {
+                "Version": version,
+                "Time": "2022-01-01T01:00:00Z",
+            }
+        )}}}""",
+        f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
     }
 
-    with setup_tmpdir(sources) as tmpdir:
+    raw_files = {
+        f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
+    }
+
+    with setup_tmpdir(sources, raw_files) as tmpdir:
+        abspath = os.path.abspath(tmpdir)
+
         result = run_pants(
             [
                 "--backend-packages=pants.backend.experimental.go",
                 "--pants-ignore=__pycache__",
+                "--golang-subprocess-env-vars=GOSUMDB=off",
+                f"--golang-subprocess-env-vars=GOPROXY=file://{abspath}/go-mod-proxy",
                 "run",
-                f"{tmpdir}:bin",
+                f"//{tmpdir}:bin",
             ]
         )
 
     assert result.stdout == "Hello world!\n"
+
     assert result.exit_code == 0

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from textwrap import dedent
-from typing import Dict, cast
+from typing import cast
 
 from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
@@ -129,7 +129,7 @@ def test_run_binary_third_party() -> None:
     }
 
     with setup_tmpdir(
-        cast(Dict[str, str], fake_gomod), cast(Dict[str, bytes], raw_files)
+        cast("dict[str, str]", fake_gomod), cast("dict[str, bytes]", raw_files)
     ) as tmpdir:
         # required for GOPROXY to work correctly when the go-mod-proxy
         # is in a subdir of the cwd.

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -3,15 +3,11 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import io
-import json
 import os
-import zipfile
 from textwrap import dedent
-from typing import Iterable
+from typing import cast
 
+from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 
@@ -64,35 +60,17 @@ def test_run_binary() -> None:
 
 
 def test_run_binary_third_party() -> None:
-    # Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
-    def _compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
-        sorted_files = sorted(files, key=lambda x: x[0])
-        summary = ""
-        for name, content in sorted_files:
-            h = hashlib.sha256(content.encode())
-            summary += f"{h.hexdigest()}  {name}\n"
-
-        h = hashlib.sha256(summary.encode())
-        summary_digest = base64.standard_b64encode(h.digest()).decode()
-        return f"h1:{summary_digest}"
-
-    import_path = "pantsbuild.org/go-embed-sample-for-test"
+    import_path = "pantsbuild.org/go-sample-for-test"
     version = "v0.0.1"
-    go_mod_content = dedent(
-        f"""\
-        module {import_path}
-        go 1.16
-        """
-    )
-    go_mod_sum = _compute_module_hash([("go.mod", go_mod_content)])
 
-    prefix = f"{import_path}@{version}"
-    files_in_zip = (
-        (f"{prefix}/go.mod", go_mod_content),
+    fake_gomod = gen_module_gomodproxy(
+        version,
+        import_path,
         (
-            f"{prefix}/pkg/hello/hello.go",
-            dedent(
-                """\
+            (
+                "pkg/hello/hello.go",
+                dedent(
+                    """\
         package hello
         import "fmt"
 
@@ -101,40 +79,35 @@ def test_run_binary_third_party() -> None:
             fmt.Println("Hello world!")
         }
         """
+                ),
             ),
-        ),
-        (
-            f"{prefix}/cmd/hello/main.go",
-            dedent(
-                """\
+            (
+                "cmd/hello/main.go",
+                dedent(
+                    """\
         package main
-        import "pantsbuild.org/go-embed-sample-for-test/pkg/hello"
+        import "pantsbuild.org/go-sample-for-test/pkg/hello"
 
 
         func main() {
             hello.Hello()
         }
         """
+                ),
             ),
         ),
     )
 
-    mod_zip_bytes = io.BytesIO()
-    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
-        for name, content in files_in_zip:
-            mod_zip.writestr(name, content)
-
-    mod_zip_sum = _compute_module_hash(files_in_zip)
-
-    sources = {
-        "BUILD": dedent(
-            f"""\
+    fake_gomod.update(
+        {
+            "BUILD": dedent(
+                f"""\
                 go_mod(name='mod')
                 go_binary(name="bin", main=':mod#{import_path}/cmd/hello')
                 """
-        ),
-        "go.mod": dedent(
-            f"""\
+            ),
+            "go.mod": dedent(
+                f"""\
                 module go.example.com/foo
                 go 1.16
 
@@ -142,32 +115,25 @@ def test_run_binary_third_party() -> None:
                 \t{import_path} {version}
                 )
                 """
-        ),
-        "go.sum": dedent(
-            f"""\
-                {import_path} {version} {mod_zip_sum}
-                {import_path} {version}/go.mod {go_mod_sum}
-                """
-        ),
-        # Setup the third-party dependency as a custom Go module proxy site.
-        # See https://go.dev/ref/mod#goproxy-protocol for details.
-        f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
-        f"go-mod-proxy/{import_path}/@v/{version}.info": f"""{{{json.dumps(
-            {
-                "Version": version,
-                "Time": "2022-01-01T01:00:00Z",
-            }
-        )}}}""",
-        f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
-    }
+            ),
+        }
+    )
 
     raw_files = {
-        f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
+        f"go-mod-proxy/{import_path}/@v/{version}.zip": fake_gomod.pop(
+            f"go-mod-proxy/{import_path}/@v/{version}.zip"
+        ),
+        f"go-mod-proxy/{import_path}/@v/{version}.info": cast(
+            str, fake_gomod.pop(f"go-mod-proxy/{import_path}/@v/{version}.info")
+        ).encode("utf-8"),
     }
 
-    with setup_tmpdir(sources, raw_files) as tmpdir:
+    with setup_tmpdir(
+        cast(dict[str, str], fake_gomod), cast(dict[str, bytes], raw_files)
+    ) as tmpdir:
+        # required for GOPROXY to work correctly when the go-mod-proxy
+        # is in a subdir of the cwd.
         abspath = os.path.abspath(tmpdir)
-
         result = run_pants(
             [
                 "--backend-packages=pants.backend.experimental.go",
@@ -180,5 +146,4 @@ def test_run_binary_third_party() -> None:
         )
 
     assert result.stdout == "Hello world!\n"
-
     assert result.exit_code == 0

--- a/src/python/pants/backend/go/goals/run_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/run_binary_integration_test.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import os
 from textwrap import dedent
-from typing import cast
+from typing import Dict, cast
 
 from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
@@ -129,7 +129,7 @@ def test_run_binary_third_party() -> None:
     }
 
     with setup_tmpdir(
-        cast(dict[str, str], fake_gomod), cast(dict[str, bytes], raw_files)
+        cast(Dict[str, str], fake_gomod), cast(Dict[str, bytes], raw_files)
     ) as tmpdir:
         # required for GOPROXY to work correctly when the go-mod-proxy
         # is in a subdir of the cwd.

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -3,13 +3,7 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
-import io
-import json
-import zipfile
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 
@@ -23,6 +17,7 @@ from pants.backend.go.target_types import (
     GoPackageTarget,
     GoThirdPartyPackageTarget,
 )
+from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -272,35 +267,17 @@ def test_third_party_package_targets_cannot_be_manually_created() -> None:
 
 
 def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
-    # Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
-    def _compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
-        sorted_files = sorted(files, key=lambda x: x[0])
-        summary = ""
-        for name, content in sorted_files:
-            h = hashlib.sha256(content.encode())
-            summary += f"{h.hexdigest()}  {name}\n"
-
-        h = hashlib.sha256(summary.encode())
-        summary_digest = base64.standard_b64encode(h.digest()).decode()
-        return f"h1:{summary_digest}"
-
-    import_path = "pantsbuild.org/go-embed-sample-for-test"
+    import_path = "pantsbuild.org/go-sample-for-test"
     version = "v0.0.1"
-    go_mod_content = dedent(
-        f"""\
-        module {import_path}
-        go 1.16
-        """
-    )
-    go_mod_sum = _compute_module_hash([("go.mod", go_mod_content)])
 
-    prefix = f"{import_path}@{version}"
-    files_in_zip = (
-        (f"{prefix}/go.mod", go_mod_content),
+    fake_gomod = gen_module_gomodproxy(
+        version,
+        import_path,
         (
-            f"{prefix}/pkg/hello/hello.go",
-            dedent(
-                """\
+            (
+                "pkg/hello/hello.go",
+                dedent(
+                    """\
         package hello
         import "fmt"
 
@@ -309,32 +286,27 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
             fmt.Println("Hello world!")
         }
         """
+                ),
             ),
-        ),
-        (
-            f"{prefix}/cmd/hello/main.go",
-            dedent(
-                """\
+            (
+                "cmd/hello/main.go",
+                dedent(
+                    f"""\
         package main
-        import "pantsbuild.org/go-embed-sample-for-test/pkg/hello"
+        import "{import_path}/pkg/hello"
 
 
-        func main() {
+        func main() {{
             hello.Hello()
-        }
+        }}
         """
+                ),
             ),
         ),
     )
 
-    mod_zip_bytes = io.BytesIO()
-    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
-        for name, content in files_in_zip:
-            mod_zip.writestr(name, content)
-
-    mod_zip_sum = _compute_module_hash(files_in_zip)
-
-    rule_runner.write_files(
+    # mypy gets sad if update is reversed or ** is used here
+    fake_gomod.update(
         {
             "go.mod": dedent(
                 f"""\
@@ -344,12 +316,6 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
                 require (
                 \t{import_path} {version}
                 )
-                """
-            ),
-            "go.sum": dedent(
-                f"""\
-                {import_path} {version} {mod_zip_sum}
-                {import_path} {version}/go.mod {go_mod_sum}
                 """
             ),
             "BUILD": "go_mod(name='mod')",
@@ -368,19 +334,10 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
                 go_binary(main=':dep')
                 """
             ),
-            # Setup the third-party dependency as a custom Go module proxy site.
-            # See https://go.dev/ref/mod#goproxy-protocol for details.
-            f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
-            f"go-mod-proxy/{import_path}/@v/{version}.info": json.dumps(
-                {
-                    "Version": version,
-                    "Time": "2022-01-01T01:00:00Z",
-                }
-            ),
-            f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
-            f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
         }
     )
+
+    rule_runner.write_files(fake_gomod)
 
     rule_runner.set_options(
         [
@@ -412,7 +369,7 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
     assert get_main(Address("external")) == Address(
         "",
         target_name="mod",
-        generated_name="pantsbuild.org/go-embed-sample-for-test/cmd/hello",
+        generated_name="pantsbuild.org/go-sample-for-test/cmd/hello",
     )
 
     with engine_error(ResolveError, contains="none were found"):

--- a/src/python/pants/backend/go/testutil.py
+++ b/src/python/pants/backend/go/testutil.py
@@ -1,0 +1,70 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import json
+import zipfile
+from textwrap import dedent  # noqa: PNT20
+from typing import Dict, Iterable, Tuple
+
+
+# Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
+def compute_module_hash(files: Iterable[Tuple[str, str]]) -> str:
+    """Compute a module hash that can be used in go.sum for an emulated remote package."""
+    sorted_files = sorted(files, key=lambda x: x[0])
+    summary = ""
+    for name, content in sorted_files:
+        h = hashlib.sha256(content.encode())
+        summary += f"{h.hexdigest()}  {name}\n"
+
+    h = hashlib.sha256(summary.encode())
+    summary_digest = base64.standard_b64encode(h.digest()).decode()
+    return f"h1:{summary_digest}"
+
+
+def gen_module_gomodproxy(
+    version: str, import_path: str, files: Iterable[Tuple[str, str]]
+) -> Dict[str, str | bytes]:
+    go_mod_content = dedent(
+        f"""\
+        module {import_path}
+        go 1.16
+        """
+    )
+
+    go_mod_sum = compute_module_hash([("go.mod", go_mod_content)])
+    prefix = f"{import_path}@{version}"
+
+    all_files = [(f"{prefix}/go.mod", go_mod_content)]
+    all_files.extend(((f"{prefix}/{path}", contents) for (path, contents) in files))
+
+    mod_zip_bytes = io.BytesIO()
+    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
+        for name, content in all_files:
+            mod_zip.writestr(name, content)
+
+    mod_zip_sum = compute_module_hash(all_files)
+
+    return {
+        "go.sum": dedent(
+            f"""\
+                {import_path} {version} {mod_zip_sum}
+                {import_path} {version}/go.mod {go_mod_sum}
+                """
+        ),
+        # Setup the third-party dependency as a custom Go module proxy site.
+        # See https://go.dev/ref/mod#goproxy-protocol for details.
+        f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
+        f"go-mod-proxy/{import_path}/@v/{version}.info": json.dumps(
+            {
+                "Version": version,
+                "Time": "2022-01-01T01:00:00Z",
+            }
+        ),
+        f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
+        f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
+    }

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -81,7 +81,7 @@ async def determine_main_pkg_for_go_binary(
             return GoBinaryMainPackage(
                 wrapped_specified_tgt.target.address,
                 True,
-                wrapped_specified_tgt.target.get(GoImportPathField),
+                wrapped_specified_tgt.target.get(GoImportPathField).value,
             )
         return GoBinaryMainPackage(wrapped_specified_tgt.target.address, False)
 

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -80,10 +80,10 @@ async def determine_main_pkg_for_go_binary(
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):
             return GoBinaryMainPackage(
                 wrapped_specified_tgt.target.address,
-                True,
-                wrapped_specified_tgt.target.get(GoImportPathField).value,
+                is_third_party=True,
+                import_path=wrapped_specified_tgt.target.get(GoImportPathField).value,
             )
-        return GoBinaryMainPackage(wrapped_specified_tgt.target.address, False)
+        return GoBinaryMainPackage(wrapped_specified_tgt.target.address, is_third_party=False)
 
     candidate_targets = await Get(
         Targets,
@@ -98,7 +98,7 @@ async def determine_main_pkg_for_go_binary(
         if tgt.has_field(GoPackageSourcesField) and tgt.residence_dir == addr.spec_path
     ]
     if len(relevant_pkg_targets) == 1:
-        return GoBinaryMainPackage(relevant_pkg_targets[0].address, False)
+        return GoBinaryMainPackage(relevant_pkg_targets[0].address, is_third_party=False)
 
     if not relevant_pkg_targets:
         raise ResolveError(

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -83,7 +83,7 @@ async def determine_main_pkg_for_go_binary(
                 True,
                 wrapped_specified_tgt.target.get(GoImportPathField),
             )
-        return GoBinaryMainPackage(wrapped_specified_tgt.target.address, True)
+        return GoBinaryMainPackage(wrapped_specified_tgt.target.address, False)
 
     candidate_targets = await Get(
         Targets,

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -73,8 +73,9 @@ async def determine_main_pkg_for_go_binary(
                 f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
                 "a `go_package` or `go_third_party_package` target, but was the address for a "
                 f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
-                "Hint: you should normally not specify this field for local packages so that Pants "
-                "will find the `go_package` target for you."
+                "Hint: unless the package is a `go_third_party_package` target, you should normally "
+                "not specify this field for local packages so that Pants will find the `go_package` "
+                "target for you."
             )
 
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):

--- a/src/python/pants/backend/go/util_rules/binary.py
+++ b/src/python/pants/backend/go/util_rules/binary.py
@@ -71,10 +71,10 @@ async def determine_main_pkg_for_go_binary(
         ) and not wrapped_specified_tgt.target.has_field(GoImportPathField):
             raise InvalidFieldException(
                 f"The {repr(GoBinaryMainPackageField.alias)} field in target {addr} must point to "
-                "a `go_package` target, but was the address for a "
+                "a `go_package` or `go_third_party_package` target, but was the address for a "
                 f"`{wrapped_specified_tgt.target.alias}` target.\n\n"
-                "Hint: you should normally not specify this field so that Pants will find the "
-                "`go_package` target for you."
+                "Hint: you should normally not specify this field for local packages so that Pants "
+                "will find the `go_package` target for you."
             )
 
         if not wrapped_specified_tgt.target.has_field(GoPackageSourcesField):

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -3,14 +3,8 @@
 
 from __future__ import annotations
 
-import base64
-import hashlib
 import inspect
-import io
-import json
-import zipfile
 from textwrap import dedent
-from typing import Iterable
 
 import pytest
 
@@ -18,6 +12,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as _test_rules
 from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.testutil import gen_module_gomodproxy
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -265,57 +260,32 @@ def test_embed_in_external_test(rule_runner: RuleRunner) -> None:
     _assert_test_result_success(result)
 
 
-# Implements hashing algorithm from https://cs.opensource.google/go/x/mod/+/refs/tags/v0.5.0:sumdb/dirhash/hash.go.
-def _compute_module_hash(files: Iterable[tuple[str, str]]) -> str:
-    sorted_files = sorted(files, key=lambda x: x[0])
-    summary = ""
-    for name, content in sorted_files:
-        h = hashlib.sha256(content.encode())
-        summary += f"{h.hexdigest()}  {name}\n"
-
-    h = hashlib.sha256(summary.encode())
-    summary_digest = base64.standard_b64encode(h.digest()).decode()
-    return f"h1:{summary_digest}"
-
-
 def test_third_party_package_embed(rule_runner: RuleRunner) -> None:
     # Build the zip file and other content needed to simulate a third-party module.
     import_path = "pantsbuild.org/go-embed-sample-for-test"
     version = "v0.0.1"
-    go_mod_content = dedent(
-        f"""\
-        module {import_path}
-        go 1.16
-        """
-    )
-    go_mod_sum = _compute_module_hash([("go.mod", go_mod_content)])
-
     embed_content = "This message comes from an embedded file."
-    prefix = f"{import_path}@{version}"
-    files_in_zip = (
-        (f"{prefix}/go.mod", go_mod_content),
+    fake_gomod = gen_module_gomodproxy(
+        version,
+        import_path,
         (
-            f"{prefix}/pkg/message.go",
-            dedent(
-                """\
+            (
+                "pkg/message.go",
+                dedent(
+                    """\
         package pkg
         import _ "embed"
         //go:embed message.txt
         var Message string
         """
+                ),
             ),
+            ("pkg/message.txt", embed_content),
         ),
-        (f"{prefix}/pkg/message.txt", embed_content),
     )
 
-    mod_zip_bytes = io.BytesIO()
-    with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:
-        for name, content in files_in_zip:
-            mod_zip.writestr(name, content)
-
-    mod_zip_sum = _compute_module_hash(files_in_zip)
-
-    rule_runner.write_files(
+    # mypy gets sad if update is reversed or ** is used here
+    fake_gomod.update(
         {
             "BUILD": dedent(
                 """
@@ -331,12 +301,6 @@ def test_third_party_package_embed(rule_runner: RuleRunner) -> None:
                 require (
                 \t{import_path} {version}
                 )
-                """
-            ),
-            "go.sum": dedent(
-                f"""\
-                {import_path} {version} {mod_zip_sum}
-                {import_path} {version}/go.mod {go_mod_sum}
                 """
             ),
             # Note: At least one Go file is necessary due to bug in Go backend even if package is only for tests.
@@ -356,19 +320,10 @@ def test_third_party_package_embed(rule_runner: RuleRunner) -> None:
                 }}
                 """
             ),
-            # Setup the third-party dependency as a custom Go module proxy site.
-            # See https://go.dev/ref/mod#goproxy-protocol for details.
-            f"go-mod-proxy/{import_path}/@v/list": f"{version}\n",
-            f"go-mod-proxy/{import_path}/@v/{version}.info": json.dumps(
-                {
-                    "Version": version,
-                    "Time": "2022-01-01T01:00:00Z",
-                }
-            ),
-            f"go-mod-proxy/{import_path}/@v/{version}.mod": go_mod_content,
-            f"go-mod-proxy/{import_path}/@v/{version}.zip": mod_zip_bytes.getvalue(),
         }
     )
+
+    rule_runner.write_files(fake_gomod)
 
     rule_runner.set_options(
         [

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -248,7 +248,6 @@ def setup_tmpdir(
 
     This is useful to set up controlled test environments, such as setting up source files and
     BUILD files.
-
     """
 
     raw_files = raw_files or {}

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -232,7 +232,9 @@ def run_pants(
 
 
 @contextmanager
-def setup_tmpdir(files: Mapping[str, str]) -> Iterator[str]:
+def setup_tmpdir(
+    files: Mapping[str, str], raw_files: Mapping[str, bytes] | None = None
+) -> Iterator[str]:
     """Create a temporary directory with the given files and return the tmpdir (relative to the
     build root).
 
@@ -240,15 +242,27 @@ def setup_tmpdir(files: Mapping[str, str]) -> Iterator[str]:
     with the tmpdir. The file content can use `{tmpdir}` to have it substituted with the actual
     tmpdir via a format string.
 
+    The `raw_files` parameter can be used to write binary files. These
+    files will not go through formatting in any way.
+
+
     This is useful to set up controlled test environments, such as setting up source files and
     BUILD files.
+
     """
+
+    raw_files = raw_files or {}
+
     with temporary_dir(root_dir=get_buildroot()) as tmpdir:
         rel_tmpdir = os.path.relpath(tmpdir, get_buildroot())
         for path, content in files.items():
             safe_file_dump(
                 os.path.join(tmpdir, path), content.format(tmpdir=rel_tmpdir), makedirs=True
             )
+
+        for path, data in raw_files.items():
+            safe_file_dump(os.path.join(tmpdir, path), data, makedirs=True, mode="wb")
+
         yield rel_tmpdir
 
 


### PR DESCRIPTION
Minimal fix for #17427.

This allows `go_third_party_package` to be treated as a potential main, analyzed and executed. I tried to stick to the shape of the code as much as possible so nothing really interesting to say about it. Simply a few branches based on whether the target has a `GoImportPath` instead of a `GoPackageSourcesField` field.

I'm not happy about the test-case using my repo, but didn't find a way of "mocking" a third-party package. If a better method exists, please let me know. Otherwise I can keep the repo around for the foreseeable future, or we can transfer it to the pants org as a test util.