### PR TITLE
Flip the default for `pull` on `docker_image` to `False`

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_integration_test.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+
 import pytest
 
 from pants.backend.docker.goals.package_image import DockerFieldSet
@@ -46,12 +48,39 @@ def run_docker(
     return result
 
 
-def test_docker_build(rule_runner) -> None:
+def test_docker_build(rule_runner: RuleRunner) -> None:
     """This test requires a running docker daemon."""
     rule_runner.write_files(
         {
             "src/BUILD": "docker_image(name='test-image', image_tags=['1.0'])",
             "src/Dockerfile": "FROM python:3.8",
+        }
+    )
+    target = rule_runner.get_target(Address("src", target_name="test-image"))
+    result = run_docker(rule_runner, target)
+    assert len(result.artifacts) == 1
+    assert len(result.artifacts[0].extra_log_lines) == 2
+    assert "Built docker image: test-image:1.0" == result.artifacts[0].extra_log_lines[0]
+    assert "Docker image ID:" in result.artifacts[0].extra_log_lines[1]
+    assert "<unknown>" not in result.artifacts[0].extra_log_lines[1]
+
+
+def test_docker_build_multi_layer(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                """\
+                docker_image(name='test-image', image_tags=['1.0'])
+                docker_image(name='base', source='Dockerfile.base')
+                """
+            ),
+            "src/Dockerfile": dedent(
+                """\
+                ARG BASE=src:base
+                FROM $BASE
+                """
+            ),
+            "src/Dockerfile.base": "FROM python:3.8",
         }
     )
     target = rule_runner.get_target(Address("src", target_name="test-image"))

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -450,7 +450,7 @@ def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "env1:1.2.3",
             "--file",
@@ -473,13 +473,13 @@ def test_docker_build_process_environment(rule_runner: RuleRunner) -> None:
 
 
 def test_docker_build_pull(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({"docker/test/BUILD": 'docker_image(name="args1", pull=False)'})
+    rule_runner.write_files({"docker/test/BUILD": 'docker_image(name="args1", pull=True)'})
 
     def check_docker_proc(process: Process):
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=False",
+            "--pull=True",
             "--tag",
             "args1:latest",
             "--file",
@@ -510,7 +510,7 @@ def test_docker_build_squash(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--squash",
             "--tag",
             "args1:latest",
@@ -523,7 +523,7 @@ def test_docker_build_squash(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "args2:latest",
             "--file",
@@ -559,7 +559,7 @@ def test_docker_build_args(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "args1:1.2.3",
             "--build-arg",
@@ -654,7 +654,7 @@ def test_docker_extra_build_args_field(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "img1:latest",
             "--build-arg",
@@ -712,7 +712,7 @@ def test_docker_build_secrets_option(rule_runner: RuleRunner) -> None:
             f"id=project-secret,src={rule_runner.build_root}/secrets/mysecret",
             "--secret",
             f"id=target-secret,src={rule_runner.build_root}/docker/test/mysecret",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "img1:latest",
             "--file",
@@ -747,7 +747,7 @@ def test_docker_build_ssh_option(rule_runner: RuleRunner) -> None:
             "build",
             "--ssh",
             "default",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "img1:latest",
             "--file",
@@ -791,7 +791,7 @@ def test_docker_build_labels_option(rule_runner: RuleRunner) -> None:
             "build.host=tbs06",
             "--label",
             "build.job=13934",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "img1:latest",
             "--build-arg",
@@ -932,7 +932,7 @@ def test_build_target_stage(
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--target",
             expected_target,
             "--tag",
@@ -1151,7 +1151,7 @@ def test_docker_image_tags_from_plugin_hook(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
-            "--pull=True",
+            "--pull=False",
             "--tag",
             "plugin:latest",
             "--tag",

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -348,12 +348,13 @@ class DockerBuildOptionFieldValueMixin(Field):
 
 class DockerImageBuildPullOptionField(DockerBuildOptionFieldValueMixin, BoolField):
     alias = "pull"
-    default = True
+    default = False
     help = softwrap(
         """
         If true, then docker will always attempt to pull a newer version of the image.
 
-        Useful to disable it when building images from other intermediate goals.
+        NOTE: This option cannot be used on images that build off of "transient" base images
+        referenced by address (i.e. `FROM path/to/your/base/Dockerfile`).
         """
     )
     docker_build_option = "--pull"


### PR DESCRIPTION
Closes #17458

57746408819a19862123600447ea28cee8021064 added the `pull` field to `docker_image`, with a default of `True`. Changing the default behavior in that way caused multi-stage builds with "transient" base images to break, because Docker can't pull the base images that only exist locally. This commit fixes the problem by flipping the default to `False`.

IMO a default of `False` makes sense regardless of the bug it fixes, because it aligns with the default behavior of `docker build`. Users who want to always pull by default can use `__defaults__` to achieve the same effect.

I've added a simple integration test to guard against regressions here in the future.