### PR TITLE
adds `EnvironmentField` to `pex_binary` and related generators (Cherry-pick of #17435)

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -95,7 +95,7 @@ def complete_platform(rule_runner: RuleRunner) -> bytes:
         {
             "pex_exe/BUILD": dedent(
                 """\
-                python_requirement(name="req", requirements=["pex==2.1.66"])
+                python_requirement(name="req", requirements=["pex==2.1.112"])
                 pex_binary(dependencies=[":req"], script="pex")
                 """
             ),

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -145,7 +145,7 @@ def pex_executable(rule_runner: RuleRunner) -> str:
         {
             "pex_exe/BUILD": dedent(
                 """\
-                python_requirement(name="req", requirements=["pex==2.1.66"])
+                python_requirement(name="req", requirements=["pex==2.1.112"])
                 pex_binary(dependencies=[":req"], script="pex")
                 """
             ),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -615,6 +615,7 @@ class PexIncludeToolsField(BoolField):
 
 
 _PEX_BINARY_COMMON_FIELDS = (
+    EnvironmentField,
     InterpreterConstraintsField,
     PythonResolveField,
     PexBinaryDependenciesField,


### PR DESCRIPTION
This adds an `environment` field to `pex_binary`/`pex_binaries` etc.

The `package` goal already injects the `EnvironmentName` from the `EnvironmentField` into the relevant pex rules by way of `EnvironmentAwarePackageRequest`, this change just makes it possible to supply that value.

Closes #17428 
