### PR TITLE
Fix propagation of the remote-execution-append-only-caches path  (Cherry-pick of #17469)

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -189,6 +189,7 @@ class Scheduler:
             execution_headers=execution_options.remote_execution_headers,
             execution_overall_deadline_secs=execution_options.remote_execution_overall_deadline_secs,
             execution_rpc_concurrency=execution_options.remote_execution_rpc_concurrency,
+            append_only_caches_base_path=execution_options.remote_execution_append_only_caches_base_path,
         )
         py_local_store_options = PyLocalStoreOptions(
             store_dir=local_store_options.store_dir,


### PR DESCRIPTION
PyO3 will (generally helpfully) default all trailing `Option` arguments of a function to `None`.

It would definitely be worth the time to port [ExecutionOptions](https://github.com/pantsbuild/pants/blob/7ffcc21c916b7d884513d36cd2bb3cb1f5989c10/src/python/pants/option/global_options.py#L472-L473) to a PyO3 type to skip this manual conversion, but best for a followup.
