### PR TITLE
go: introduce `GoBuildOptions` and `cgo_enabled` field

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -36,6 +36,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     FallibleBuildGoPackageRequest,
@@ -212,6 +213,7 @@ class _SetupGoProtobufPackageBuildRequest:
 
     addresses: tuple[Address, ...]
     import_path: str
+    build_opts: GoBuildOptions
 
 
 @rule
@@ -377,7 +379,7 @@ async def setup_full_package_build_request(
                 dep_build_request_addrs.extend(candidate_addresses.addresses)
 
     dep_build_requests = await MultiGet(
-        Get(BuildGoPackageRequest, BuildGoPackageTargetRequest(addr))
+        Get(BuildGoPackageRequest, BuildGoPackageTargetRequest(addr, build_opts=request.build_opts))
         for addr in dep_build_request_addrs
     )
 
@@ -391,6 +393,7 @@ async def setup_full_package_build_request(
             s_files=analysis.s_files,
             direct_dependencies=dep_build_requests,
             minimum_go_version=analysis.minimum_go_version,
+            build_opts=request.build_opts,
         ),
         import_path=request.import_path,
     )
@@ -439,6 +442,7 @@ async def setup_build_go_package_request_for_protobuf(
         _SetupGoProtobufPackageBuildRequest(
             addresses=protobuf_target_addrs_set_for_import_path.addresses,
             import_path=import_path,
+            build_opts=request.build_opts,
         ),
     )
 

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -15,6 +15,7 @@ from pants.backend.go.target_types import (
 from pants.backend.go.util_rules import (
     assembly,
     binary,
+    build_opts,
     build_pkg,
     build_pkg_target,
     cgo,
@@ -41,6 +42,7 @@ def rules():
     return [
         *assembly.rules(),
         *binary.rules(),
+        *build_opts.rules(),
         *build_pkg.rules(),
         *build_pkg_target.rules(),
         *check.rules(),

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
@@ -55,6 +56,7 @@ async def setup_go_binary(request: LoadedGoBinaryRequest) -> LoadedGoBinary:
             import_path="main",
             pkg_name="main",
             dir_path="",
+            build_opts=GoBuildOptions(),
             digest=source_digest,
             go_files=tuple(fc.path for fc in file_contents),
             s_files=(),

--- a/src/python/pants/backend/go/goals/debug_goals.py
+++ b/src/python/pants/backend/go/goals/debug_goals.py
@@ -7,7 +7,6 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
-from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.target_type_rules import GoImportPathMappingRequest
 from pants.backend.go.target_types import (
     GoImportPathField,
@@ -57,18 +56,22 @@ async def go_show_package_analysis(targets: Targets, console: Console) -> ShowGo
     first_party_analysis_gets = []
     third_party_analysis_gets = []
 
-    for target in targets:
+    build_opts_by_target = await MultiGet(
+        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(tgt.address)) for tgt in targets
+    )
+
+    for target, build_opts in zip(targets, build_opts_by_target):
         if target.has_field(GoPackageSourcesField):
             first_party_analysis_gets.append(
-                Get(FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(target.address))
+                Get(
+                    FallibleFirstPartyPkgAnalysis,
+                    FirstPartyPkgAnalysisRequest(target.address, build_opts=build_opts),
+                )
             )
         elif target.has_field(GoThirdPartyPackageDependenciesField):
             import_path = target[GoImportPathField].value
             go_mod_address = target.address.maybe_convert_to_target_generator()
-            go_mod_info, build_opts = await MultiGet(
-                Get(GoModInfo, GoModInfoRequest(go_mod_address)),
-                Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(go_mod_address)),
-            )
+            go_mod_info = await Get(GoModInfo, GoModInfoRequest(go_mod_address))
             third_party_analysis_gets.append(
                 Get(
                     ThirdPartyPkgAnalysis,
@@ -145,6 +148,7 @@ class GoExportCgoCodegen(Goal):
 @dataclass(frozen=True)
 class ExportCgoPackageRequest:
     address: Address
+    build_opts: GoBuildOptions
 
 
 @dataclass(frozen=True)
@@ -158,7 +162,8 @@ class ExportCgoPackageResult:
 async def export_cgo_package(request: ExportCgoPackageRequest) -> ExportCgoPackageResult:
     # Analyze the package and ensure it is actually contains cgo code.
     analysis_wrapper = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(request.address)
+        FallibleFirstPartyPkgAnalysis,
+        FirstPartyPkgAnalysisRequest(request.address, build_opts=request.build_opts),
     )
     if not analysis_wrapper.analysis:
         return ExportCgoPackageResult(error=f"Failed to analyze target: {analysis_wrapper.stderr}")
@@ -168,7 +173,8 @@ async def export_cgo_package(request: ExportCgoPackageRequest) -> ExportCgoPacka
         return ExportCgoPackageResult(skip=True)
 
     fallible_digest_info = await Get(
-        FallibleFirstPartyPkgDigest, FirstPartyPkgDigestRequest(request.address)
+        FallibleFirstPartyPkgDigest,
+        FirstPartyPkgDigestRequest(request.address, build_opts=request.build_opts),
     )
     if not fallible_digest_info.pkg_digest:
         return ExportCgoPackageResult(
@@ -197,20 +203,26 @@ async def go_export_cgo_codegen(
     targets: Targets,
     distdir_path: DistDir,
     workspace: Workspace,
-    golang_subsystem: GolangSubsystem,
 ) -> GoExportCgoCodegen:
-    if not golang_subsystem.cgo_enabled:
-        raise ValueError(
-            "Nothing to export since cgo is disabled, which is set by the option [golang].cgo_enabled"
-        )
-
     go_package_targets = [tgt for tgt in targets if tgt.has_field(GoPackageSourcesField)]
-    cgo_results = await MultiGet(
-        Get(ExportCgoPackageResult, ExportCgoPackageRequest(tgt.address))
-        for tgt in go_package_targets
+
+    build_opts_by_target = await MultiGet(
+        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(tgt.address)) for tgt in targets
     )
 
-    for tgt, cgo_result in zip(go_package_targets, cgo_results):
+    targets_to_process = []
+    for tgt, build_opts in zip(go_package_targets, build_opts_by_target):
+        if not build_opts.cgo_enabled:
+            logger.warning(f"Skipping target {tgt.address} because Cgo is not enabled for it.")
+            continue
+        targets_to_process.append((tgt, build_opts))
+
+    cgo_results = await MultiGet(
+        Get(ExportCgoPackageResult, ExportCgoPackageRequest(tgt.address, build_opts=build_opts))
+        for tgt, build_opts in targets_to_process
+    )
+
+    for (tgt, build_opts), cgo_result in zip(targets_to_process, cgo_results):
         if cgo_result.skip:
             continue
         if cgo_result.error:
@@ -219,7 +231,7 @@ async def go_export_cgo_codegen(
 
         export_dir = distdir_path.relpath / "cgo" / tgt.address.path_safe_spec
         workspace.write_digest(cgo_result.digest, path_prefix=str(export_dir))
-        logger.info(f"{tgt.address}: Exported cgo files to `{export_dir}`\n")
+        logger.info(f"{tgt.address}: Exported Cgo files to `{export_dir}`\n")
 
     return GoExportCgoCodegen(exit_code=0)
 

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -44,7 +44,8 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
         Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(field_set.address)),
     )
     main_pkg_analysis = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(main_pkg.address)
+        FallibleFirstPartyPkgAnalysis,
+        FirstPartyPkgAnalysisRequest(main_pkg.address, build_opts=build_opts),
     )
     analysis = main_pkg_analysis.analysis
     if not analysis:

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -176,11 +176,18 @@ async def run_go_tests(
 ) -> TestResult:
     field_set = batch.single_element
 
-    maybe_pkg_analysis, maybe_pkg_digest, dependencies, build_opts = await MultiGet(
-        Get(FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(field_set.address)),
-        Get(FallibleFirstPartyPkgDigest, FirstPartyPkgDigestRequest(field_set.address)),
+    build_opts = await Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(field_set.address))
+
+    maybe_pkg_analysis, maybe_pkg_digest, dependencies = await MultiGet(
+        Get(
+            FallibleFirstPartyPkgAnalysis,
+            FirstPartyPkgAnalysisRequest(field_set.address, build_opts=build_opts),
+        ),
+        Get(
+            FallibleFirstPartyPkgDigest,
+            FirstPartyPkgDigestRequest(field_set.address, build_opts=build_opts),
+        ),
         Get(Targets, DependenciesRequest(field_set.dependencies)),
-        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(field_set.address)),
     )
 
     def compilation_failure(exit_code: int, stdout: str | None, stderr: str | None) -> TestResult:

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -209,9 +209,6 @@ class GolangSubsystem(Subsystem):
             Enable Cgo support, which allows Go and C code to interact. This option must be enabled for any
             packages making use of Cgo to actually be compiled with Cgo support.
 
-            TODO: Future Pants changes may also require enabling Cgo via fields on relevant Go targets.
-            See https://github.com/pantsbuild/pants/issues/16833.
-
             See https://go.dev/blog/cgo and https://pkg.go.dev/cmd/cgo for additional information about Cgo.
             """
         ),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -220,13 +220,14 @@ async def infer_go_dependencies(
     std_lib_imports: GoStdLibImports,
 ) -> InferredDependencies:
     go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.field_set.address))
-    package_mapping = await Get(
-        GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)
+    package_mapping, build_opts = await MultiGet(
+        Get(GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_addr.address)),
+        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(go_mod_addr.address)),
     )
 
     addr = request.field_set.address
     maybe_pkg_analysis = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr)
+        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr, build_opts=build_opts)
     )
     if maybe_pkg_analysis.analysis is None:
         logger.error(

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -22,7 +22,7 @@ from pants.backend.go.target_types import (
     GoThirdPartyPackageDependenciesField,
     GoThirdPartyPackageTarget,
 )
-from pants.backend.go.util_rules import first_party_pkg, import_analysis, build_opts
+from pants.backend.go.util_rules import build_opts, first_party_pkg, import_analysis
 from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
@@ -361,9 +361,10 @@ async def generate_targets_from_go_mod(
     all_packages = await Get(
         AllThirdPartyPackages,
         AllThirdPartyPackagesRequest(
-            go_mod_info.digest, go_mod_info.mod_path,
+            go_mod_info.digest,
+            go_mod_info.mod_path,
             # TODO: Figure out how to avoid rule graph cycle and properly extract these options.
-            build_opts=GoBuildOptions()
+            build_opts=GoBuildOptions(),
         ),
     )
 

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -364,7 +364,9 @@ async def generate_targets_from_go_mod(
         AllThirdPartyPackagesRequest(
             go_mod_info.digest,
             go_mod_info.mod_path,
-            # TODO: Figure out how to avoid rule graph cycle and properly extract these options.
+            # TODO: There is a rule graph cycle in this rule if this rule tries to use GoBuildOptionsFromTargetRequest.
+            # For now, just use a default set of options to facilitate analyzing third-party dependencies and
+            # generating targets.
             build_opts=GoBuildOptions(),
         ),
     )

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -22,7 +22,8 @@ from pants.backend.go.target_types import (
     GoThirdPartyPackageDependenciesField,
     GoThirdPartyPackageTarget,
 )
-from pants.backend.go.util_rules import first_party_pkg, import_analysis
+from pants.backend.go.util_rules import first_party_pkg, import_analysis, build_opts
+from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
     FirstPartyPkgAnalysisRequest,
@@ -292,15 +293,19 @@ async def infer_go_third_party_package_dependencies(
     addr = request.field_set.address
     go_mod_address = addr.maybe_convert_to_target_generator()
 
-    package_mapping, go_mod_info = await MultiGet(
+    package_mapping, go_mod_info, build_opts = await MultiGet(
         Get(GoModuleImportPathsMapping, GoImportPathMappingRequest(go_mod_address)),
         Get(GoModInfo, GoModInfoRequest(go_mod_address)),
+        Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(go_mod_address)),
     )
 
     pkg_info = await Get(
         ThirdPartyPkgAnalysis,
         ThirdPartyPkgAnalysisRequest(
-            request.field_set.import_path.value, go_mod_info.digest, go_mod_info.mod_path
+            request.field_set.import_path.value,
+            go_mod_info.digest,
+            go_mod_info.mod_path,
+            build_opts=build_opts,
         ),
     )
 
@@ -355,7 +360,11 @@ async def generate_targets_from_go_mod(
     go_mod_snapshot = await Get(Snapshot, Digest, go_mod_info.digest)
     all_packages = await Get(
         AllThirdPartyPackages,
-        AllThirdPartyPackagesRequest(go_mod_info.digest, go_mod_info.mod_path),
+        AllThirdPartyPackagesRequest(
+            go_mod_info.digest, go_mod_info.mod_path,
+            # TODO: Figure out how to avoid rule graph cycle and properly extract these options.
+            build_opts=GoBuildOptions()
+        ),
     )
 
     def gen_file_tgt(fp: str) -> TargetGeneratorSourcesHelperTarget:
@@ -391,6 +400,7 @@ async def generate_targets_from_go_mod(
 def rules():
     return (
         *collect_rules(),
+        *build_opts.rules(),
         *first_party_pkg.rules(),
         *import_analysis.rules(),
         UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -33,7 +33,7 @@ from pants.util.strutil import softwrap
 
 
 class GoCgoEnabledField(TriBoolField):
-    """Enables whether Cgo support will be enabled for a binary."""
+    """Enables whether Cgo support will be enabled."""
 
     alias = "cgo_enabled"
     help = softwrap(
@@ -41,8 +41,12 @@ class GoCgoEnabledField(TriBoolField):
         Enable Cgo support, which allows Go and C code to interact. This option must be enabled for any
         packages making use of Cgo to actually be compiled with Cgo support.
 
-        If this field is not specified, then the value will be taken from the value of the
-        `[golang].cgo_enabled` option. (That option will be deprecated in a future Pants version.)
+        This field can be specified on several different target types, including `go_binary` and `go_mod` target
+        types. If this field is specified on a `go_binary` target, then that instance takes precedence over other
+        configuration when building the applicable executable. The applicable `go_mod` target will be checked next
+        as a fallback. Finally, if neither target specifies this field, then the value will be taken from
+        the value of the `[golang].cgo_enabled` option. (Note: That option will be deprecated in a future Pants
+        version.)
 
         See https://go.dev/blog/cgo and https://pkg.go.dev/cmd/cgo for additional information about Cgo.
         """

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -28,12 +28,12 @@ from pants.engine.target import (
 from pants.util.strutil import softwrap
 
 # -----------------------------------------------------------------------------------------------
-# Build option fieklds
+# Build option fields
 # -----------------------------------------------------------------------------------------------
 
 
 class GoCgoEnabledField(TriBoolField):
-    """Enables whether Cgo support will be enabled."""
+    """Enables Cgo support."""
 
     alias = "cgo_enabled"
     help = softwrap(

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -21,10 +21,33 @@ from pants.engine.target import (
     StringField,
     Target,
     TargetGenerator,
+    TriBoolField,
     ValidNumbers,
     generate_multiple_sources_field_help_message,
 )
 from pants.util.strutil import softwrap
+
+# -----------------------------------------------------------------------------------------------
+# Build option fieklds
+# -----------------------------------------------------------------------------------------------
+
+
+class GoCgoEnabledField(TriBoolField):
+    """Enables whether Cgo support will be enabled for a binary."""
+
+    alias = "cgo_enabled"
+    help = softwrap(
+        """
+        Enable Cgo support, which allows Go and C code to interact. This option must be enabled for any
+        packages making use of Cgo to actually be compiled with Cgo support.
+
+        If this field is not specified, then the value will be taken from the value of the
+        `[golang].cgo_enabled` option. (That option will be deprecated in a future Pants version.)
+
+        See https://go.dev/blog/cgo and https://pkg.go.dev/cmd/cgo for additional information about Cgo.
+        """
+    )
+
 
 # -----------------------------------------------------------------------------------------------
 # `go_third_party_package` target
@@ -136,6 +159,7 @@ class GoModTarget(TargetGenerator):
         *COMMON_TARGET_FIELDS,
         GoModDependenciesField,
         GoModSourcesField,
+        GoCgoEnabledField,
     )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = ()
@@ -256,6 +280,7 @@ class GoBinaryTarget(Target):
         OutputPathField,
         GoBinaryMainPackageField,
         GoBinaryDependenciesField,
+        GoCgoEnabledField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -26,6 +26,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, FallibleBuiltGoPackage
 from pants.core.goals.package import BuiltPackage
 from pants.engine.addresses import Address
@@ -138,6 +139,7 @@ def test_build_invalid_package(rule_runner: RuleRunner) -> None:
         import_path="example.com/assembly",
         pkg_name="main",
         dir_path="",
+        build_opts=GoBuildOptions(),
         go_files=("add_amd64.go", "add_arm64.go"),
         digest=rule_runner.make_snapshot(
             {

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -1,0 +1,81 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.go.subsystems.golang import GolangSubsystem
+from pants.backend.go.target_types import GoCgoEnabledField
+from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
+from pants.build_graph.address import Address
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals import graph
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import FieldSet, WrappedTarget, WrappedTargetRequest
+
+
+@dataclass(frozen=True)
+class GoBuildOptions:
+    # Controls whether cgo support is enabled.
+    cgo_enabled: bool = True
+
+
+@dataclass(frozen=True)
+class GoBuildOptionsFromTargetRequest(EngineAwareParameter):
+    address: Address
+
+    def debug_hint(self) -> str | None:
+        return self.address.spec
+
+
+@dataclass(frozen=True)
+class GoBuildOptionsFieldSet(FieldSet):
+    required_fields = (GoCgoEnabledField,)
+
+    cgo_enabled: GoCgoEnabledField
+
+
+@rule
+async def go_extract_build_options_from_target(
+    request: GoBuildOptionsFromTargetRequest, golang: GolangSubsystem
+) -> GoBuildOptions:
+    wrapped_target = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(
+            request.address, description_of_origin="the `go_extract_build_options_from_target` rule"
+        ),
+    )
+    target = wrapped_target.target
+
+    # If this target does not have build option fields, then find the owning `go_mod` target and
+    # use its fields.
+    if not GoBuildOptionsFieldSet.is_applicable(target):
+        owning_go_mod = await Get(OwningGoMod, OwningGoModRequest(request.address))
+        wrapped_target_go_mod = await Get(
+            WrappedTarget,
+            WrappedTargetRequest(
+                owning_go_mod.address,
+                description_of_origin="the `go_extract_build_options_from_target` rule",
+            ),
+        )
+        target = wrapped_target_go_mod.target
+
+    opts_field_set = GoBuildOptionsFieldSet.create(target)
+
+    cgo_enabled: bool | None = None
+    if opts_field_set.cgo_enabled.value is not None:
+        cgo_enabled = opts_field_set.cgo_enabled.value
+    if cgo_enabled is None:
+        cgo_enabled = golang.cgo_enabled
+
+    return GoBuildOptions(
+        cgo_enabled=cgo_enabled,
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *graph.rules(),
+    )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -13,6 +13,7 @@ from pants.backend.go.util_rules.assembly import (
     AssemblyCompilationRequest,
     FallibleAssemblyCompilationResult,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompileRequest, CGoCompileResult, CGoCompilerFlags
 from pants.backend.go.util_rules.coverage import (
     ApplyCodeCoverageRequest,
@@ -53,6 +54,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         pkg_name: str,
         digest: Digest,
         dir_path: str,
+        build_opts: GoBuildOptions,
         go_files: tuple[str, ...],
         s_files: tuple[str, ...],
         direct_dependencies: tuple[BuildGoPackageRequest, ...],
@@ -78,6 +80,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self.pkg_name = pkg_name
         self.digest = digest
         self.dir_path = dir_path
+        self.build_opts = build_opts
         self.go_files = go_files
         self.s_files = s_files
         self.direct_dependencies = direct_dependencies
@@ -98,6 +101,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
                 self.pkg_name,
                 self.digest,
                 self.dir_path,
+                self.build_opts,
                 self.go_files,
                 self.s_files,
                 self.direct_dependencies,
@@ -124,6 +128,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
             f"pkg_name={self.pkg_name}, "
             f"digest={self.digest}, "
             f"dir_path={self.dir_path}, "
+            f"build_opts={self.build_opts}, "
             f"go_files={self.go_files}, "
             f"s_files={self.s_files}, "
             f"direct_dependencies={[dep.import_path for dep in self.direct_dependencies]}, "
@@ -153,6 +158,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
             and self.pkg_name == other.pkg_name
             and self.digest == other.digest
             and self.dir_path == other.dir_path
+            and self.build_opts == other.build_opts
             and self.go_files == other.go_files
             and self.s_files == other.s_files
             and self.minimum_go_version == other.minimum_go_version

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -159,7 +159,10 @@ async def setup_build_go_package_target_request(
                 FallibleFirstPartyPkgAnalysis,
                 FirstPartyPkgAnalysisRequest(target.address, build_opts=request.build_opts),
             ),
-            Get(FallibleFirstPartyPkgDigest, FirstPartyPkgDigestRequest(target.address)),
+            Get(
+                FallibleFirstPartyPkgDigest,
+                FirstPartyPkgDigestRequest(target.address, build_opts=request.build_opts),
+            ),
         )
         if _maybe_first_party_pkg_analysis.analysis is None:
             return FallibleBuildGoPackageRequest(

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -20,6 +20,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import (
     BuildGoPackageRequest,
     BuiltGoPackage,
@@ -71,6 +72,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
         import_path="example.com/foo/dep/transitive",
         pkg_name="transitive",
         dir_path="dep/transitive",
+        build_opts=GoBuildOptions(),
         go_files=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -95,6 +97,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
         import_path="example.com/foo/dep",
         pkg_name="dep",
         dir_path="dep",
+        build_opts=GoBuildOptions(),
         go_files=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -119,6 +122,7 @@ def test_build_pkg(rule_runner: RuleRunner) -> None:
         import_path="example.com/foo",
         pkg_name="foo",
         dir_path="",
+        build_opts=GoBuildOptions(),
         go_files=("f.go",),
         digest=rule_runner.make_snapshot(
             {
@@ -165,6 +169,7 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
         import_path="example.com/foo/dep",
         pkg_name="dep",
         dir_path="dep",
+        build_opts=GoBuildOptions(),
         go_files=("f.go",),
         digest=rule_runner.make_snapshot({"dep/f.go": "invalid!!!"}).digest,
         s_files=(),
@@ -175,6 +180,7 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
         import_path="example.com/foo",
         pkg_name="main",
         dir_path="",
+        build_opts=GoBuildOptions(),
         go_files=("f.go",),
         digest=rule_runner.make_snapshot(
             {

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -27,6 +27,7 @@ from pants.backend.go.util_rules import (
     tests_analysis,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompileRequest, CGoCompileResult
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
@@ -137,14 +138,16 @@ def test_cgo_compile(rule_runner: RuleRunner) -> None:
 
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     maybe_analysis = rule_runner.request(
-        FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest(tgt.address)]
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is not None
     analysis = maybe_analysis.analysis
     assert analysis.cgo_files == ("printer.go",)
 
     maybe_digest = rule_runner.request(
-        FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest(tgt.address)]
+        FallibleFirstPartyPkgDigest,
+        [FirstPartyPkgDigestRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is not None
     pkg_digest = maybe_digest.pkg_digest
@@ -239,7 +242,8 @@ def test_cgo_with_cxx_source(rule_runner: RuleRunner) -> None:
 
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     maybe_analysis = rule_runner.request(
-        FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest(tgt.address)]
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is not None
     analysis = maybe_analysis.analysis
@@ -247,7 +251,8 @@ def test_cgo_with_cxx_source(rule_runner: RuleRunner) -> None:
     assert analysis.cxx_files == ("print.cxx",)
 
     maybe_digest = rule_runner.request(
-        FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest(tgt.address)]
+        FallibleFirstPartyPkgDigest,
+        [FirstPartyPkgDigestRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is not None
     pkg_digest = maybe_digest.pkg_digest
@@ -340,7 +345,8 @@ def test_cgo_with_objc_source(rule_runner: RuleRunner) -> None:
 
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     maybe_analysis = rule_runner.request(
-        FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest(tgt.address)]
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is not None
     analysis = maybe_analysis.analysis
@@ -348,7 +354,8 @@ def test_cgo_with_objc_source(rule_runner: RuleRunner) -> None:
     assert analysis.m_files == ("print.m",)
 
     maybe_digest = rule_runner.request(
-        FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest(tgt.address)]
+        FallibleFirstPartyPkgDigest,
+        [FirstPartyPkgDigestRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is not None
     pkg_digest = maybe_digest.pkg_digest
@@ -445,7 +452,8 @@ def test_cgo_with_fortran_source(rule_runner: RuleRunner) -> None:
 
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     maybe_analysis = rule_runner.request(
-        FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest(tgt.address)]
+        FallibleFirstPartyPkgAnalysis,
+        [FirstPartyPkgAnalysisRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is not None
     analysis = maybe_analysis.analysis
@@ -453,7 +461,8 @@ def test_cgo_with_fortran_source(rule_runner: RuleRunner) -> None:
     assert analysis.f_files == ("answer.f90",)
 
     maybe_digest = rule_runner.request(
-        FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest(tgt.address)]
+        FallibleFirstPartyPkgDigest,
+        [FirstPartyPkgDigestRequest(tgt.address, build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is not None
     pkg_digest = maybe_digest.pkg_digest

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -19,6 +19,7 @@ from pants.backend.go.util_rules import (
     sdk,
     third_party_pkg,
 )
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
@@ -158,7 +159,8 @@ def test_package_analysis(rule_runner: RuleRunner) -> None:
     ) -> None:
         addr = Address(os.path.join("foo", dir_path))
         maybe_analysis = rule_runner.request(
-            FallibleFirstPartyPkgAnalysis, [FirstPartyPkgAnalysisRequest(addr)]
+            FallibleFirstPartyPkgAnalysis,
+            [FirstPartyPkgAnalysisRequest(addr, build_opts=GoBuildOptions())],
         )
         assert maybe_analysis.analysis is not None
         analysis = maybe_analysis.analysis
@@ -178,7 +180,8 @@ def test_package_analysis(rule_runner: RuleRunner) -> None:
         assert analysis.xtest_embed_patterns == ()
 
         maybe_digest = rule_runner.request(
-            FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest(addr)]
+            FallibleFirstPartyPkgDigest,
+            [FirstPartyPkgDigestRequest(addr, build_opts=GoBuildOptions())],
         )
         assert maybe_digest.pkg_digest is not None
         pkg_digest = maybe_digest.pkg_digest
@@ -224,7 +227,7 @@ def test_invalid_package(rule_runner) -> None:
     )
     maybe_analysis = rule_runner.request(
         FallibleFirstPartyPkgAnalysis,
-        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
+        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"), build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is None
     assert maybe_analysis.exit_code == 1
@@ -264,7 +267,11 @@ def test_cgo_not_supported(rule_runner: RuleRunner) -> None:
     with engine_error(NotImplementedError):
         rule_runner.request(
             FallibleFirstPartyPkgAnalysis,
-            [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
+            [
+                FirstPartyPkgAnalysisRequest(
+                    Address("", target_name="pkg"), build_opts=GoBuildOptions()
+                )
+            ],
         )
 
 
@@ -324,7 +331,7 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
     )
     maybe_analysis = rule_runner.request(
         FallibleFirstPartyPkgAnalysis,
-        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"))],
+        [FirstPartyPkgAnalysisRequest(Address("", target_name="pkg"), build_opts=GoBuildOptions())],
     )
     assert maybe_analysis.analysis is not None
     analysis = maybe_analysis.analysis
@@ -334,7 +341,7 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
 
     maybe_digest = rule_runner.request(
         FallibleFirstPartyPkgDigest,
-        [FirstPartyPkgDigestRequest(Address("", target_name="pkg"))],
+        [FirstPartyPkgDigestRequest(Address("", target_name="pkg"), build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is not None
     pkg_digest = maybe_digest.pkg_digest
@@ -387,7 +394,7 @@ def test_missing_embeds(rule_runner: RuleRunner) -> None:
     )
     maybe_digest = rule_runner.request(
         FallibleFirstPartyPkgDigest,
-        [FirstPartyPkgDigestRequest(Address("", target_name="pkg"))],
+        [FirstPartyPkgDigestRequest(Address("", target_name="pkg"), build_opts=GoBuildOptions())],
     )
     assert maybe_digest.pkg_digest is None
     assert maybe_digest.exit_code != 0

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -13,8 +13,8 @@ from typing import Any
 import ijson
 
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
-from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules import pkg_analyzer
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
@@ -98,6 +98,7 @@ class ThirdPartyPkgAnalysisRequest(EngineAwareParameter):
     import_path: str
     go_mod_digest: Digest
     go_mod_path: str
+    build_opts: GoBuildOptions
 
     def debug_hint(self) -> str:
         return f"{self.import_path} from {self.go_mod_path}"
@@ -120,6 +121,7 @@ class AllThirdPartyPackages(FrozenDict[str, ThirdPartyPkgAnalysis]):
 class AllThirdPartyPackagesRequest:
     go_mod_digest: Digest
     go_mod_path: str
+    build_opts: GoBuildOptions
 
 
 @dataclass(frozen=True)
@@ -151,6 +153,7 @@ class AnalyzeThirdPartyModuleRequest:
     name: str
     version: str
     minimum_go_version: str | None
+    build_opts: GoBuildOptions
 
 
 @dataclass(frozen=True)
@@ -279,7 +282,6 @@ def _freeze_json_dict(d: dict[Any, Any]) -> FrozenDict[str, Any]:
 async def analyze_go_third_party_module(
     request: AnalyzeThirdPartyModuleRequest,
     analyzer: PackageAnalyzerSetup,
-    golang_subsystem: GolangSubsystem,
 ) -> AnalyzedThirdPartyModule:
     # Download the module.
     download_result = await Get(
@@ -346,7 +348,7 @@ async def analyze_go_third_party_module(
             },
             description=f"Analyze metadata for Go third-party module: {request.name}@{request.version}",
             level=LogLevel.DEBUG,
-            env={"CGO_ENABLED": "1" if golang_subsystem.cgo_enabled else "0"},
+            env={"CGO_ENABLED": "1" if request.build_opts.cgo_enabled else "0"},
         ),
     )
 
@@ -546,6 +548,7 @@ async def download_and_analyze_third_party_packages(
                 name=mod.name,
                 version=mod.version,
                 minimum_go_version=mod.minimum_go_version,
+                build_opts=request.build_opts,
             ),
         )
         for mod in module_analysis.modules
@@ -564,7 +567,9 @@ async def download_and_analyze_third_party_packages(
 async def extract_package_info(request: ThirdPartyPkgAnalysisRequest) -> ThirdPartyPkgAnalysis:
     all_packages = await Get(
         AllThirdPartyPackages,
-        AllThirdPartyPackagesRequest(request.go_mod_digest, request.go_mod_path),
+        AllThirdPartyPackagesRequest(
+            request.go_mod_digest, request.go_mod_path, build_opts=request.build_opts
+        ),
     )
     pkg_info = all_packages.import_paths_to_pkg_info.get(request.import_path)
     if pkg_info:


### PR DESCRIPTION
Introduce `GoBuildOptions` to carry around build options for Go code.

Add `cgo_enabled` as the first build option to support. It is a new field on `go_binary` (to override on a per binary basis) and `go_mod` (to set a default for module).

Fixes https://github.com/pantsbuild/pants/issues/16833

[ci skip-rust]

[ci skip-build-wheels]