### PR TITLE
go: support ".syso" prebuilt object files

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -166,6 +166,7 @@ class GoPackageSourcesField(MultipleSourcesField):
         ".F",
         ".for",
         ".f90",
+        ".syso",
     )
     ban_subdirectories = True
     help = generate_multiple_sources_field_help_message(

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -24,8 +24,9 @@ class FallibleAssemblyPreCompilation:
 
 @dataclass(frozen=True)
 class AssemblyPreCompilation:
-    merged_compilation_input_digest: Digest
-    assembly_digests: tuple[Digest, ...]
+    symabis_digest: Digest
+    symabis_path: str
+    assembly_outputs: tuple[tuple[str, Digest], ...]
 
 
 @dataclass(frozen=True)
@@ -39,22 +40,6 @@ class AssemblyPreCompilationRequest:
     s_files: tuple[str, ...]
     dir_path: str
     import_path: str
-
-
-@dataclass(frozen=True)
-class AssemblyPostCompilation:
-    result: FallibleProcessResult
-    merged_output_digest: Digest | None
-
-
-@dataclass(frozen=True)
-class AssemblyPostCompilationRequest:
-    """Link the assembly_digests into the compilation_result."""
-
-    compilation_result: Digest
-    assembly_digests: tuple[Digest, ...]
-    s_files: tuple[str, ...]
-    dir_path: str
 
 
 @rule
@@ -75,6 +60,7 @@ async def setup_assembly_pre_compilation(
     symabis_input_digest = await Get(
         Digest, MergeDigests([request.compilation_input, go_asm_h_digest])
     )
+    symabis_path = "symabis"
     symabis_result = await Get(
         FallibleProcessResult,
         GoSdkProcess(
@@ -86,7 +72,7 @@ async def setup_assembly_pre_compilation(
                 os.path.join(goroot.path, "pkg", "include"),
                 "-gensymabis",
                 "-o",
-                "symabis",
+                symabis_path,
                 "--",
                 *(f"./{request.dir_path}/{name}" for name in request.s_files),
             ),
@@ -94,18 +80,13 @@ async def setup_assembly_pre_compilation(
                 "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
             },
             description=f"Generate symabis metadata for assembly files for {request.dir_path}",
-            output_files=("symabis",),
+            output_files=(symabis_path,),
         ),
     )
     if symabis_result.exit_code != 0:
         return FallibleAssemblyPreCompilation(
             None, symabis_result.exit_code, symabis_result.stderr.decode("utf-8")
         )
-
-    merged = await Get(
-        Digest,
-        MergeDigests([request.compilation_input, symabis_result.output_digest]),
-    )
 
     # On Go 1.19+, the import path must be supplied via the `-p` option to `go tool asm`.
     # See https://go.dev/doc/go1.19#assembler and
@@ -148,47 +129,17 @@ async def setup_assembly_pre_compilation(
         )
         return FallibleAssemblyPreCompilation(None, exit_code, stdout, stderr)
 
+    assembly_outputs = tuple(
+        (f"./{request.dir_path}/{PurePath(s_file).with_suffix('.o')}", result.output_digest)
+        for s_file, result in zip(request.s_files, assembly_results)
+    )
+
     return FallibleAssemblyPreCompilation(
-        AssemblyPreCompilation(merged, tuple(result.output_digest for result in assembly_results))
-    )
-
-
-# TODO(#16831): Refactor this to share logic with similar cgo logic.
-@rule
-async def link_assembly_post_compilation(
-    request: AssemblyPostCompilationRequest,
-) -> AssemblyPostCompilation:
-    merged_digest, asm_tool_id = await MultiGet(
-        Get(
-            Digest,
-            MergeDigests([request.compilation_result, *request.assembly_digests]),
-        ),
-        # Use `go tool asm` tool ID since `go tool pack` does not have a version argument.
-        Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
-    )
-    pack_result = await Get(
-        FallibleProcessResult,
-        GoSdkProcess(
-            input_digest=merged_digest,
-            command=(
-                "tool",
-                "pack",
-                "r",
-                "__pkg__.a",
-                *(
-                    f"./{request.dir_path}/{PurePath(name).with_suffix('.o')}"
-                    for name in request.s_files
-                ),
-            ),
-            env={
-                "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
-            },
-            description=f"Link assembly objects to Go package archive for {request.dir_path}",
-            output_files=("__pkg__.a",),
-        ),
-    )
-    return AssemblyPostCompilation(
-        pack_result, pack_result.output_digest if pack_result.exit_code == 0 else None
+        AssemblyPreCompilation(
+            symabis_digest=symabis_result.output_digest,
+            symabis_path=symabis_path,
+            assembly_outputs=assembly_outputs,
+        )
     )
 
 

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -199,7 +199,7 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
         pytest.skip(f"Unsupported architecture for test: {machine}")
 
     with temporary_dir() as tempdir:
-        source_path = Path(tempdir) / "fortytwo.s"
+        source_path = Path(tempdir) / "fortytwo.S"
         source_path.write_text(assembly_text)
         output_path = source_path.with_suffix(".o")
         subprocess.check_call(["gcc", "-c", "-o", str(output_path), str(source_path)])

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -166,9 +166,15 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
     if machine == "x86_64":
         assembly_text = dedent(
             """\
+            /* Apple still insists on underscore prefixes for C function names. */
+            #if defined(__APPLE__)
+            #define EXT(s) _##s
+            #else
+            #define EXT(s) s
+            #endif
             .align 4
-            .globl _fortytwo
-            _fortytwo:
+            .globl EXT(fortytwo)
+            EXT(fortytwo):
               movl $42, %eax
               ret
             """
@@ -176,9 +182,15 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
     elif machine == "arm64":
         assembly_text = dedent(
             """\
+            /* Apple still insists on underscore prefixes for C function names. */
+            #if defined(__APPLE__)
+            #define EXT(s) _##s
+            #else
+            #define EXT(s) s
+            #endif
             .align 4
-            .globl _fortytwo
-            _fortytwo:
+            .globl EXT(fortytwo)
+            EXT(fortytwo):
               mov x0, #42
               ret
         """

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import os.path
+import platform
 import subprocess
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -30,6 +32,7 @@ from pants.engine.addresses import Address
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.contextutil import temporary_dir
 
 
 @pytest.fixture()
@@ -155,3 +158,86 @@ def test_build_invalid_package(rule_runner: RuleRunner) -> None:
         result.stdout
         == ".//add_amd64.s:1: unexpected EOF\nasm: assembly of .//add_amd64.s failed\n"
     )
+
+
+def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> None:
+    # Compile helper assembly into a prebuilt .syso object file.
+    machine = platform.uname().machine
+    if machine == "x86_64":
+        assembly_text = dedent(
+            """\
+            .align 4
+            .globl _fortytwo
+            _fortytwo:
+              mov x0, #42
+              ret
+            """
+        )
+    elif machine == "arm64":
+        assembly_text = dedent(
+            """\
+            .align 4
+            .globl _fortytwo
+            _fortytwo:
+              mov x0, #42
+              ret
+        """
+        )
+    else:
+        pytest.skip(f"Unsupported architecture for test: {machine}")
+
+    with temporary_dir() as tempdir:
+        source_path = Path(tempdir) / "fortytwo.s"
+        source_path.write_text(assembly_text)
+        output_path = source_path.with_suffix(".o")
+        subprocess.check_call(["gcc", "-c", "-o", str(output_path), str(source_path)])
+        object_bytes = output_path.read_bytes()
+
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/syso_files
+                go 1.17
+                """
+            ),
+            "main.go": dedent(
+                """\
+                package main
+
+                import "fmt"
+
+                func main() {
+                    fmt.Println(value())
+                }
+                """
+            ),
+            "value.go": dedent(
+                """\
+                package main
+                // extern int fortytwo();
+                import "C"
+                func value() int {
+                    return int(C.fortytwo())
+                }
+                """
+            ),
+            "value.syso": object_bytes,
+            "BUILD": dedent(
+                """\
+                go_mod(name="mod")
+                go_package(name="pkg", sources=["*.go", "*.syso"])
+                go_binary(name="bin")
+                """
+            ),
+        }
+    )
+
+    binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
+    assert len(built_package.artifacts) == 1
+    assert built_package.artifacts[0].relpath == "bin"
+
+    result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
+    assert result.returncode == 0
+    assert result.stdout == b"42\n"

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -169,7 +169,7 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
             .align 4
             .globl _fortytwo
             _fortytwo:
-              movl $42, eax
+              movl $42, %eax
               ret
             """
         )

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -169,7 +169,7 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
             .align 4
             .globl _fortytwo
             _fortytwo:
-              mov x0, #42
+              movl $42, eax
               ret
             """
         )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -10,8 +10,8 @@ from typing import Iterable
 
 from pants.backend.go.util_rules import cgo, coverage
 from pants.backend.go.util_rules.assembly import (
-    AssemblyPreCompilationRequest,
-    FallibleAssemblyPreCompilation,
+    AssemblyCompilationRequest,
+    FallibleAssemblyCompilationResult,
 )
 from pants.backend.go.util_rules.cgo import CGoCompileRequest, CGoCompileResult, CGoCompilerFlags
 from pants.backend.go.util_rules.coverage import (
@@ -468,8 +468,8 @@ async def build_go_package(
     symabis_path: str | None = None
     if s_files:
         assembly_setup = await Get(
-            FallibleAssemblyPreCompilation,
-            AssemblyPreCompilationRequest(
+            FallibleAssemblyCompilationResult,
+            AssemblyCompilationRequest(
                 compilation_input=input_digest,
                 s_files=tuple(s_files),
                 dir_path=request.dir_path,

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -10,8 +10,6 @@ from typing import Iterable
 
 from pants.backend.go.util_rules import cgo, coverage
 from pants.backend.go.util_rules.assembly import (
-    AssemblyPostCompilation,
-    AssemblyPostCompilationRequest,
     AssemblyPreCompilationRequest,
     FallibleAssemblyPreCompilation,
 )
@@ -68,6 +66,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         cxx_files: tuple[str, ...] = (),
         objc_files: tuple[str, ...] = (),
         fortran_files: tuple[str, ...] = (),
+        prebuilt_object_files: tuple[str, ...] = (),
     ) -> None:
         """Build a package and its dependencies as `__pkg__.a` files.
 
@@ -92,6 +91,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self.cxx_files = cxx_files
         self.objc_files = objc_files
         self.fortran_files = fortran_files
+        self.prebuilt_object_files = prebuilt_object_files
         self._hashcode = hash(
             (
                 self.import_path,
@@ -111,6 +111,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
                 self.cxx_files,
                 self.objc_files,
                 self.fortran_files,
+                self.prebuilt_object_files,
             )
         )
 
@@ -135,7 +136,8 @@ class BuildGoPackageRequest(EngineAwareParameter):
             f"c_files={self.c_files}, "
             f"cxx_files={self.cxx_files}, "
             f"objc_files={self.objc_files}, "
-            f"fortran_files={self.fortran_files}"
+            f"fortran_files={self.fortran_files}, "
+            f"prebuilt_object_files={self.prebuilt_object_files}"
             ")"
         )
 
@@ -163,6 +165,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
             and self.cxx_files == other.cxx_files
             and self.objc_files == other.objc_files
             and self.fortran_files == other.fortran_files
+            and self.prebuilt_object_files == other.prebuilt_object_files
             # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
             and self.direct_dependencies == other.direct_dependencies
         )
@@ -405,6 +408,18 @@ async def build_go_package(
         cgo_files = coverage_result.cgo_files
         cover_file_metadatas = coverage_result.cover_file_metadatas
 
+    # Track loose object files to link into final package archive. These can come from Cgo outputs, regular
+    # assembly files, or regular C files.
+    objects: list[tuple[str, Digest]] = []
+
+    # Add any prebuilt object files (".syso" extension) to the list of objects to link into the package.
+    if request.prebuilt_object_files:
+        objects.extend(
+            (f"./{request.dir_path}/{prebuilt_object_file}", request.digest)
+            for prebuilt_object_file in request.prebuilt_object_files
+        )
+
+    # Process any Cgo files.
     cgo_compile_result: CGoCompileResult | None = None
     if cgo_files:
         # Check if any assembly files contain gcc assembly, and not Go assembly. Raise an exception if any are
@@ -435,6 +450,12 @@ async def build_go_package(
         )
         assert cgo_compile_result is not None
         unmerged_input_digests.append(cgo_compile_result.digest)
+        objects.extend(
+            [
+                (obj_file, cgo_compile_result.digest)
+                for obj_file in cgo_compile_result.output_obj_files
+            ]
+        )
         s_files = []  # Clear s_files since assembly has already been handled in cgo rules.
 
     input_digest = await Get(
@@ -442,8 +463,9 @@ async def build_go_package(
         MergeDigests(unmerged_input_digests),
     )
 
-    assembly_digests = None
-    symabis_path = None
+    # Process any assembly files and add the result to `objects` for linking into the package archive.
+    # The `symabis` file generated with API information is added to the input digest for use in compilation.
+    symabis_path: str | None = None
     if s_files:
         assembly_setup = await Get(
             FallibleAssemblyPreCompilation,
@@ -454,7 +476,8 @@ async def build_go_package(
                 import_path=request.import_path,
             ),
         )
-        if assembly_setup.result is None:
+        assembly_result = assembly_setup.result
+        if assembly_result is None:
             return FallibleBuiltGoPackage(
                 None,
                 request.import_path,
@@ -462,9 +485,11 @@ async def build_go_package(
                 stdout=assembly_setup.stdout,
                 stderr=assembly_setup.stderr,
             )
-        input_digest = assembly_setup.result.merged_compilation_input_digest
-        assembly_digests = assembly_setup.result.assembly_digests
-        symabis_path = "./symabis"
+        input_digest = await Get(
+            Digest, MergeDigests([input_digest, assembly_result.symabis_digest])
+        )
+        symabis_path = assembly_result.symabis_path
+        objects.extend(assembly_result.assembly_outputs)
 
     compile_args = [
         "tool",
@@ -492,9 +517,9 @@ async def build_go_package(
     if embedcfg.digest != EMPTY_DIGEST:
         compile_args.extend(["-embedcfg", RenderedEmbedConfig.PATH])
 
-    if not s_files:
-        # If there are no non-Go sources, then pass -complete flag which tells the compiler that the provided
-        # Go files are the entire package.
+    # If there are no loose object files to add to the package archive later, then pass -complete flag which
+    # tells the compiler that the provided Go files constitute the entire package.
+    if not objects:
         compile_args.append("-complete")
 
     relativized_sources = (
@@ -522,43 +547,22 @@ async def build_go_package(
         )
 
     compilation_digest = compile_result.output_digest
-    if assembly_digests:
-        assembly_result = await Get(
-            AssemblyPostCompilation,
-            AssemblyPostCompilationRequest(
-                compilation_result=compilation_digest,
-                assembly_digests=assembly_digests,
-                s_files=tuple(s_files),
-                dir_path=request.dir_path,
-            ),
-        )
-        if assembly_result.result.exit_code != 0:
-            return FallibleBuiltGoPackage(
-                None,
-                request.import_path,
-                assembly_result.result.exit_code,
-                stdout=assembly_result.result.stdout.decode("utf-8"),
-                stderr=assembly_result.result.stderr.decode("utf-8"),
-            )
-        assert assembly_result.merged_output_digest
-        compilation_digest = assembly_result.merged_output_digest
-
-    if cgo_compile_result:
-        cgo_link_input_digest = await Get(
+    if objects:
+        assembly_link_input_digest = await Get(
             Digest,
             MergeDigests(
                 [
                     compilation_digest,
-                    cgo_compile_result.digest,
+                    *(digest for obj_file, digest in objects),
                 ]
             ),
         )
-        cgo_link_result = await _add_objects_to_archive(
-            input_digest=cgo_link_input_digest,
+        assembly_link_result = await _add_objects_to_archive(
+            input_digest=assembly_link_input_digest,
             pkg_archive_path="__pkg__.a",
-            obj_file_paths=cgo_compile_result.output_obj_files,
+            obj_file_paths=sorted(obj_file for obj_file, digest in objects),
         )
-        compilation_digest = cgo_link_result.output_digest
+        compilation_digest = assembly_link_result.output_digest
 
     path_prefix = os.path.join("__pkgs__", path_safe(request.import_path))
     import_paths_to_pkg_a_files[request.import_path] = os.path.join(path_prefix, "__pkg__.a")

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -200,6 +200,7 @@ async def setup_build_go_package_target_request(
         cxx_files = _first_party_pkg_analysis.cxx_files
         objc_files = _first_party_pkg_analysis.m_files
         fortran_files = _first_party_pkg_analysis.f_files
+        prebuilt_object_files = _first_party_pkg_analysis.syso_files
 
         # If the xtest package was requested, then replace analysis with the xtest values.
         if request.for_xtests:
@@ -253,6 +254,7 @@ async def setup_build_go_package_target_request(
         cxx_files = _third_party_pkg_info.cxx_files
         objc_files = _third_party_pkg_info.m_files
         fortran_files = _third_party_pkg_info.f_files
+        prebuilt_object_files = _third_party_pkg_info.syso_files
     else:
         raise AssertionError(
             f"Unknown how to build `{target.alias}` target at address {request.address} with Go. "
@@ -352,6 +354,7 @@ async def setup_build_go_package_target_request(
         cxx_files=cxx_files,
         objc_files=objc_files,
         fortran_files=fortran_files,
+        prebuilt_object_files=prebuilt_object_files,
         minimum_go_version=minimum_go_version,
         direct_dependencies=tuple(pkg_direct_dependencies),
         for_tests=request.for_tests,

--- a/src/python/pants/backend/go/util_rules/first_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg.py
@@ -98,6 +98,8 @@ class FirstPartyPkgAnalysis:
     f_files: tuple[str, ...]
     s_files: tuple[str, ...]
 
+    syso_files: tuple[str, ...]
+
     minimum_go_version: str | None
 
     embed_patterns: tuple[str, ...]
@@ -184,6 +186,7 @@ class FallibleFirstPartyPkgAnalysis:
             h_files=tuple(metadata.get("HFiles", [])),
             f_files=tuple(metadata.get("FFiles", [])),
             s_files=tuple(metadata.get("SFiles", [])),
+            syso_files=tuple(metadata.get("SysoFiles", ())),
             minimum_go_version=minimum_go_version,
             embed_patterns=tuple(metadata.get("EmbedPatterns", [])),
             test_embed_patterns=tuple(metadata.get("TestEmbedPatterns", [])),

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -73,6 +73,8 @@ class ThirdPartyPkgAnalysis:
     f_files: tuple[str, ...]
     s_files: tuple[str, ...]
 
+    syso_files: tuple[str, ...]
+
     minimum_go_version: str | None
 
     embed_patterns: tuple[str, ...]
@@ -416,7 +418,6 @@ async def analyze_go_third_party_package(
         "CompiledGoFiles",
         "SwigFiles",
         "SwigCXXFiles",
-        "SysoFiles",
     ):
         if key in request.pkg_json:
             maybe_error = GoThirdPartyPkgError(
@@ -452,6 +453,7 @@ async def analyze_go_third_party_package(
         h_files=tuple(request.pkg_json.get("HFiles", ())),
         f_files=tuple(request.pkg_json.get("FFiles", ())),
         s_files=tuple(request.pkg_json.get("SFiles", ())),
+        syso_files=tuple(request.pkg_json.get("SysoFiles", ())),
         cgo_files=tuple(request.pkg_json.get("CgoFiles", ())),
         minimum_go_version=request.minimum_go_version,
         embed_patterns=tuple(request.pkg_json.get("EmbedPatterns", [])),
@@ -618,6 +620,7 @@ def maybe_raise_or_create_error_or_create_failed_pkg_info(
             m_files=(),
             f_files=(),
             s_files=(),
+            syso_files=(),
             minimum_go_version=None,
             embed_patterns=(),
             test_embed_patterns=(),


### PR DESCRIPTION
Add prebuilt `.syso` object files to object files to link into the package archive. Refactors object file linking so that Cgo and Go assembly files are linked in the same step.

Fixes https://github.com/pantsbuild/pants/issues/16827
