### PR TITLE
Helpers to generate python lockfile rules

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-helpers.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-helpers.md
@@ -1,0 +1,28 @@
+---
+title: "Plugin helpers"
+slug: "plugins-helpers"
+excerpt: "Helpers which make writing plugins easier."
+hidden: false
+createdAt: "2023-01-07T22:23:00.000Z"
+---
+Pants has helpers to make writing plugins easier.
+
+# Python
+
+## Lockfiles
+
+The lockfiles for most Python tools fit into common categories. Pants has helpers to generate the rules for lockfile generation.
+
+- A single Python package that could be installed with `pip install my_tool`
+
+```python
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolBase,
+)
+
+class Isort(PythonToolBase):
+    options_scope = "isort"
+    ...
+    lockfile_rules_type = LockfileRules.SIMPLE
+```

--- a/src/python/pants/backend/BUILD
+++ b/src/python/pants/backend/BUILD
@@ -37,6 +37,7 @@ __dependents_rules__(
             "[/python/lint/black/subsystem.py]",
             "[/python/lint/yapf/rules.py]",
             "[/python/lint/yapf/subsystem.py]",
+            "[src/python/pants/backend/python/goals/lockfile.py]",
         ),
         "src/python/pants/core/goals/update_build_files.py",
         DEFAULT_DEPENDENTS_RULES,

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -7,9 +7,12 @@ import os
 from typing import Iterable
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -6,15 +6,10 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -47,6 +42,7 @@ class ClangFormat(PythonToolBase):
     default_lockfile_resource = ("pants.backend.cc.lint.clangformat", "clangformat.lock")
     default_lockfile_path = "src/python/pants/backend/cc/lint/clangformat/clangformat.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     export = ExportToolOption()
 
@@ -62,17 +58,6 @@ class ClangFormat(PythonToolBase):
             discovery=True,
             check_existence=check_existence,
         )
-
-
-class ClangFormatLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = ClangFormat.options_scope
-
-
-@rule
-def setup_clangformat_lockfile(
-    _: ClangFormatLockfileSentinel, clangformat: ClangFormat
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(clangformat)
 
 
 class ClangFormatExportSentinel(ExportPythonToolSentinel):
@@ -91,7 +76,5 @@ def clangformat_export(_: ClangFormatExportSentinel, clangformat: ClangFormat) -
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, ClangFormatLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, ClangFormatExportSentinel),
     )

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -42,7 +42,7 @@ class ClangFormat(PythonToolBase):
     default_lockfile_resource = ("pants.backend.cc.lint.clangformat", "clangformat.lock")
     default_lockfile_path = "src/python/pants/backend/cc/lint/clangformat/clangformat.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     export = ExportToolOption()
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -77,7 +77,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     default_lockfile_resource = ("pants.backend.codegen.protobuf.python", "mypy_protobuf.lock")
     default_lockfile_path = "src/python/pants/backend/codegen/protobuf/python/mypy_protobuf.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -10,9 +10,11 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.backend.codegen.utils import find_python_runtime_library_or_raise_error
 from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, InferDependenciesRequest, InferredDependencies
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -46,7 +46,7 @@ class DockerfileParser(PythonToolRequirementsBase):
     default_lockfile_resource = (_DOCKERFILE_PACKAGE, "dockerfile.lock")
     default_lockfile_path = f"src/python/{_DOCKERFILE_PACKAGE.replace('.', '/')}/dockerfile.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -9,10 +9,12 @@ from pathlib import PurePath
 
 from pants.backend.docker.target_types import DockerImageSourceField
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -9,16 +9,11 @@ from pathlib import PurePath
 
 from pants.backend.docker.target_types import DockerImageSourceField
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.addresses import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.process import Process, ProcessResult
@@ -30,7 +25,6 @@ from pants.engine.target import (
     WrappedTarget,
     WrappedTargetRequest,
 )
-from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
@@ -52,17 +46,7 @@ class DockerfileParser(PythonToolRequirementsBase):
     default_lockfile_resource = (_DOCKERFILE_PACKAGE, "dockerfile.lock")
     default_lockfile_path = f"src/python/{_DOCKERFILE_PACKAGE.replace('.', '/')}/dockerfile.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class DockerfileParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = DockerfileParser.options_scope
-
-
-@rule
-def setup_lockfile_request(
-    _: DockerfileParserLockfileSentinel, dockerfile_parser: DockerfileParser
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(dockerfile_parser)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 @dataclass(frozen=True)
@@ -204,7 +188,5 @@ async def parse_dockerfile(request: DockerfileInfoRequest) -> DockerfileInfo:
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         *pex.rules(),
-        UnionRule(GenerateToolLockfileSentinel, DockerfileParserLockfileSentinel),
     )

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -44,7 +44,7 @@ class HelmKubeParserSubsystem(PythonToolRequirementsBase):
         f"src/python/{_HELM_K8S_PARSER_PACKAGE.replace('.', '/')}/k8s_parser.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -10,10 +10,12 @@ from pathlib import PurePath
 from typing import Any
 
 from pants.backend.helm.utils.yaml import YamlPath
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileEntry

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -10,19 +10,15 @@ from pathlib import PurePath
 from typing import Any
 
 from pants.backend.helm.utils.yaml import YamlPath
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnType
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileEntry
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize, softwrap
@@ -48,17 +44,7 @@ class HelmKubeParserSubsystem(PythonToolRequirementsBase):
         f"src/python/{_HELM_K8S_PARSER_PACKAGE.replace('.', '/')}/k8s_parser.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class HelmKubeParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = HelmKubeParserSubsystem.options_scope
-
-
-@rule
-def setup_k8s_parser_lockfile_request(
-    _: HelmKubeParserLockfileSentinel, post_renderer: HelmKubeParserSubsystem
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(post_renderer)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 @dataclass(frozen=True)
@@ -169,6 +155,4 @@ def rules():
     return [
         *collect_rules(),
         *pex.rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, HelmKubeParserLockfileSentinel),
     ]

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -15,10 +15,12 @@ from typing import Any, Iterable, Mapping
 import yaml
 
 from pants.backend.helm.utils.yaml import FrozenYamlIndex
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import CatBinary

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -58,7 +58,7 @@ class HelmPostRendererSubsystem(PythonToolRequirementsBase):
         f"src/python/{_HELM_POSTRENDERER_PACKAGE.replace('.', '/')}/post_renderer.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 _HELM_POST_RENDERER_TOOL = "__pants_helm_post_renderer.py"

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -15,14 +15,11 @@ from typing import Any, Iterable, Mapping
 import yaml
 
 from pants.backend.helm.utils.yaml import FrozenYamlIndex
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules import pex
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
-from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import CatBinary
 from pants.engine.addresses import UnparsedAddressInputs
@@ -32,7 +29,6 @@ from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.process import Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSetsPerTarget, FieldSetsPerTargetRequest, Targets
-from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -62,17 +58,7 @@ class HelmPostRendererSubsystem(PythonToolRequirementsBase):
         f"src/python/{_HELM_POSTRENDERER_PACKAGE.replace('.', '/')}/post_renderer.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class HelmPostRendererLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = HelmPostRendererSubsystem.options_scope
-
-
-@rule
-def setup_postrenderer_lockfile_request(
-    _: HelmPostRendererLockfileSentinel, post_renderer: HelmPostRendererSubsystem
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(post_renderer)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 _HELM_POST_RENDERER_TOOL = "__pants_helm_post_renderer.py"
@@ -316,6 +302,4 @@ def rules():
     return [
         *collect_rules(),
         *pex.rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, HelmPostRendererLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -12,19 +12,14 @@ from typing import Any, MutableMapping, cast
 
 import toml
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
@@ -125,6 +120,7 @@ class CoverageSubsystem(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "coverage_py.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/coverage_py.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     filter = StrListOption(
         help=softwrap(
@@ -227,17 +223,6 @@ class CoverageSubsystem(PythonToolBase):
                 "pyproject.toml": b"[tool.coverage",
             },
         )
-
-
-class CoveragePyLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = CoverageSubsystem.options_scope
-
-
-@rule
-def setup_coverage_lockfile(
-    _: CoveragePyLockfileSentinel, coverage: CoverageSubsystem
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(coverage)
 
 
 @dataclass(frozen=True)
@@ -620,7 +605,5 @@ def _get_coverage_report(
 def rules():
     return [
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
-        UnionRule(GenerateToolLockfileSentinel, CoveragePyLockfileSentinel),
     ]

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -120,7 +120,7 @@ class CoverageSubsystem(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "coverage_py.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/coverage_py.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     filter = StrListOption(
         help=softwrap(

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -12,9 +12,8 @@ from typing import Any, MutableMapping, cast
 
 import toml
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -8,10 +8,9 @@ import os.path
 from collections import defaultdict
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonRequirementResolveField, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -47,6 +46,9 @@ from pants.engine.unions import UnionRule
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
+
+if TYPE_CHECKING:
+    from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -8,10 +8,8 @@ import os.path
 from collections import defaultdict
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import Iterable
 
 from pants.backend.python.pip_requirement import PipRequirement
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonRequirementResolveField, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -53,39 +51,6 @@ from pants.util.ordered_set import FrozenOrderedSet
 class GeneratePythonLockfile(GenerateLockfile):
     requirements: FrozenOrderedSet[str]
     interpreter_constraints: InterpreterConstraints
-
-    @classmethod
-    def from_tool(
-        cls,
-        subsystem: "PythonToolRequirementsBase",
-        interpreter_constraints: InterpreterConstraints | None = None,
-        extra_requirements: Iterable[str] = (),
-    ) -> GeneratePythonLockfile:
-        """Create a request for a dedicated lockfile for the tool.
-
-        If the tool determines its interpreter constraints by using the constraints of user code,
-        rather than the option `--interpreter-constraints`, you must pass the arg
-        `interpreter_constraints`.
-        """
-        if not subsystem.uses_custom_lockfile:
-            return cls(
-                requirements=FrozenOrderedSet(),
-                interpreter_constraints=InterpreterConstraints(),
-                resolve_name=subsystem.options_scope,
-                lockfile_dest=subsystem.lockfile,
-                diff=False,
-            )
-        return cls(
-            requirements=FrozenOrderedSet((*subsystem.all_requirements, *extra_requirements)),
-            interpreter_constraints=(
-                interpreter_constraints
-                if interpreter_constraints is not None
-                else subsystem.interpreter_constraints
-            ),
-            resolve_name=subsystem.options_scope,
-            lockfile_dest=subsystem.lockfile,
-            diff=False,
-        )
 
     @property
     def requirements_hex_digest(self) -> str:

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -57,7 +57,7 @@ class GeneratePythonLockfile(GenerateLockfile):
     @classmethod
     def from_tool(
         cls,
-        subsystem: PythonToolRequirementsBase,
+        subsystem: "PythonToolRequirementsBase",
         interpreter_constraints: InterpreterConstraints | None = None,
         extra_requirements: Iterable[str] = (),
     ) -> GeneratePythonLockfile:

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -8,9 +8,10 @@ import os.path
 from collections import defaultdict
 from dataclasses import dataclass
 from operator import itemgetter
-from typing import TYPE_CHECKING, Iterable
+from typing import Iterable
 
 from pants.backend.python.pip_requirement import PipRequirement
+from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PythonRequirementResolveField, PythonRequirementsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
@@ -46,9 +47,6 @@ from pants.engine.unions import UnionRule
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
-
-if TYPE_CHECKING:
-    from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -33,7 +33,7 @@ class AddTrailingComma(PythonToolBase):
         "src/python/pants/backend/python/lint/add_trailing_comma/add_trailing_comma.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py36-plus")

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -3,15 +3,10 @@
 
 from __future__ import annotations
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
@@ -38,21 +33,11 @@ class AddTrailingComma(PythonToolBase):
         "src/python/pants/backend/python/lint/add_trailing_comma/add_trailing_comma.lock"
     )
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py36-plus")
     export = ExportToolOption()
-
-
-class AddTrailingCommaLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = AddTrailingComma.options_scope
-
-
-@rule()
-async def setup_add_trailing_comma_lockfile(
-    _: AddTrailingCommaLockfileSentinel, add_trailing_comma: AddTrailingComma
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(add_trailing_comma)
 
 
 class AddTrailingCommaExportSentinel(ExportPythonToolSentinel):
@@ -75,7 +60,5 @@ def add_trailing_comma_export(
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, AddTrailingCommaLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, AddTrailingCommaExportSentinel),
     )

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -28,7 +28,7 @@ class Autoflake(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.autoflake", "autoflake.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/autoflake/autoflake.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -3,15 +3,10 @@
 
 from __future__ import annotations
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
@@ -33,6 +28,7 @@ class Autoflake(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.autoflake", "autoflake.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/autoflake/autoflake.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(
@@ -43,17 +39,6 @@ class Autoflake(PythonToolBase):
         default=["--remove-all-unused-imports"],
     )
     export = ExportToolOption()
-
-
-class AutoflakeLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = Autoflake.options_scope
-
-
-@rule()
-async def setup_autoflake_lockfile(
-    _: AutoflakeLockfileSentinel, autoflake: Autoflake
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(autoflake)
 
 
 class AutoflakeExportSentinel(ExportPythonToolSentinel):
@@ -72,7 +57,5 @@ def autoflake_export(_: AutoflakeExportSentinel, autoflake: Autoflake) -> Export
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, AutoflakeLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, AutoflakeExportSentinel),
     )

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -100,10 +100,10 @@ async def setup_bandit_lockfile(
     _: BanditLockfileSentinel, bandit: Bandit, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not bandit.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(bandit)
+        return bandit.to_lockfile_request()
 
     constraints = await _find_all_unique_interpreter_constraints(python_setup, BanditFieldSet)
-    return GeneratePythonLockfile.from_tool(bandit, constraints)
+    return bandit.to_lockfile_request(interpreter_constraints=constraints)
 
 
 class BanditExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -131,10 +131,10 @@ async def setup_black_lockfile(
     _: BlackLockfileSentinel, black: Black, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not black.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(black)
+        return black.to_lockfile_request()
 
     constraints = await _black_interpreter_constraints(black, python_setup)
-    return GeneratePythonLockfile.from_tool(black, constraints)
+    return black.to_lockfile_request(interpreter_constraints=constraints)
 
 
 class BlackExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -3,9 +3,12 @@
 
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -27,7 +27,7 @@ class Docformatter(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.docformatter", "docformatter.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/docformatter/docformatter.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--wrap-summaries=100 --pre-summary-newline")

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -2,15 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
@@ -32,21 +27,11 @@ class Docformatter(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.docformatter", "docformatter.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/docformatter/docformatter.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--wrap-summaries=100 --pre-summary-newline")
     export = ExportToolOption()
-
-
-class DocformatterLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = Docformatter.options_scope
-
-
-@rule
-def setup_lockfile_request(
-    _: DocformatterLockfileSentinel, docformatter: Docformatter
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(docformatter)
 
 
 class DocformatterExportSentinel(ExportPythonToolSentinel):
@@ -67,7 +52,5 @@ def docformatter_export(
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, DocformatterLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, DocformatterExportSentinel),
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -254,16 +254,15 @@ async def setup_flake8_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not flake8.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(flake8)
+        return flake8.to_lockfile_request()
 
     constraints = await _find_all_unique_interpreter_constraints(
         python_setup,
         Flake8FieldSet,
         extra_constraints_per_tgt=first_party_plugins.interpreter_constraints_fields,
     )
-    return GeneratePythonLockfile.from_tool(
-        flake8,
-        constraints,
+    return flake8.to_lockfile_request(
+        interpreter_constraints=constraints,
         extra_requirements=first_party_plugins.requirement_strings,
     )
 

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -33,7 +33,7 @@ class Isort(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.isort", "isort.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/isort/isort.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--case-sensitive --trailing-comma")

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -7,9 +7,12 @@ import os.path
 from typing import Iterable
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -6,15 +6,10 @@ from __future__ import annotations
 import os.path
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -38,6 +33,7 @@ class Isort(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.isort", "isort.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/isort/isort.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--case-sensitive --trailing-comma")
@@ -104,15 +100,6 @@ class Isort(PythonToolBase):
         )
 
 
-class IsortLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = Isort.options_scope
-
-
-@rule
-def setup_isort_lockfile(_: IsortLockfileSentinel, isort: Isort) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(isort)
-
-
 class IsortExportSentinel(ExportPythonToolSentinel):
     pass
 
@@ -127,7 +114,5 @@ def isort_export(_: IsortExportSentinel, isort: Isort) -> ExportPythonTool:
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, IsortLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, IsortExportSentinel),
     )

--- a/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
@@ -119,10 +119,10 @@ async def setup_pydocstyle_lockfile(
     _: PydocstyleLockfileSentinel, pydocstyle: Pydocstyle, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not pydocstyle.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(pydocstyle)
+        return pydocstyle.to_lockfile_request()
 
     constraints = await _find_all_unique_interpreter_constraints(python_setup, PydocstyleFieldSet)
-    return GeneratePythonLockfile.from_tool(pydocstyle, constraints)
+    return pydocstyle.to_lockfile_request(constraints)
 
 
 class PydocstyleExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -244,16 +244,15 @@ async def setup_pylint_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not pylint.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(pylint)
+        return pylint.to_lockfile_request()
 
     constraints = await _find_all_unique_interpreter_constraints(
         python_setup,
         PylintFieldSet,
         extra_constraints_per_tgt=first_party_plugins.interpreter_constraints_fields,
     )
-    return GeneratePythonLockfile.from_tool(
-        pylint,
-        constraints,
+    return pylint.to_lockfile_request(
+        interpreter_constraints=constraints,
         extra_requirements=first_party_plugins.requirement_strings,
     )
 

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -3,15 +3,10 @@
 
 from __future__ import annotations
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
@@ -35,21 +30,11 @@ class PyUpgrade(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.pyupgrade", "pyupgrade.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py39-plus --keep-runtime-typing")
     export = ExportToolOption()
-
-
-class PyUpgradeLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = PyUpgrade.options_scope
-
-
-@rule
-def setup_pyupgrade_lockfile(
-    _: PyUpgradeLockfileSentinel, pyupgrade: PyUpgrade
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(pyupgrade)
 
 
 class PyUpgradeExportSentinel(ExportPythonToolSentinel):
@@ -68,7 +53,5 @@ def pyupgrade_export(_: PyUpgradeExportSentinel, pyupgrade: PyUpgrade) -> Export
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, PyUpgradeLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, PyUpgradeExportSentinel),
     )

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -30,7 +30,7 @@ class PyUpgrade(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.pyupgrade", "pyupgrade.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--py39-plus --keep-runtime-typing")

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -9,7 +9,11 @@ from typing import Iterable
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
 from pants.backend.python.lint.ruff.skip_field import SkipRuffField
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import (
     ConsoleScript,
     InterpreterConstraintsField,
@@ -17,7 +21,6 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules import python_sources
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -61,7 +61,7 @@ class Ruff(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.ruff", "ruff.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/ruff/ruff.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--exclude=foo --ignore=E501")

--- a/src/python/pants/backend/python/lint/ruff/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem_test.py
@@ -10,11 +10,12 @@ import pytest
 from pants.backend.python import target_types_rules
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.lint.ruff import skip_field
-from pants.backend.python.lint.ruff.subsystem import Ruff, RuffLockfileSentinel
+from pants.backend.python.lint.ruff.subsystem import Ruff
 from pants.backend.python.lint.ruff.subsystem import rules as subsystem_rules
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
 from pants.backend.python.util_rules import python_sources
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.lockfile_test import _get_generated_lockfile_sentinel
 from pants.core.target_types import GenericTarget
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
@@ -22,13 +23,16 @@ from pants.util.ordered_set import FrozenOrderedSet
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
+
+    ruff_lockfile_sentinel = _get_generated_lockfile_sentinel(subsystem_rules(), Ruff)
+
     return RuleRunner(
         rules=[
             *subsystem_rules(),
             *skip_field.rules(),
             *python_sources.rules(),
             *target_types_rules.rules(),
-            QueryRule(GeneratePythonLockfile, [RuffLockfileSentinel]),
+            QueryRule(GeneratePythonLockfile, [ruff_lockfile_sentinel]),
         ],
         target_types=[PythonSourcesGeneratorTarget, GenericTarget, PythonRequirementTarget],
     )
@@ -36,6 +40,8 @@ def rule_runner() -> RuleRunner:
 
 def test_setup_lockfile(rule_runner) -> None:
     global_constraint = "CPython<4,>=3.7"
+
+    ruff_lockfile_sentinel = _get_generated_lockfile_sentinel(subsystem_rules(), Ruff)
 
     def assert_lockfile_request(
         build_file: str,
@@ -50,7 +56,7 @@ def test_setup_lockfile(rule_runner) -> None:
             env={"PANTS_PYTHON_INTERPRETER_CONSTRAINTS": f"['{global_constraint}']"},
             env_inherit={"PATH", "PYENV_ROOT", "HOME"},
         )
-        lockfile_request = rule_runner.request(GeneratePythonLockfile, [RuffLockfileSentinel()])
+        lockfile_request = rule_runner.request(GeneratePythonLockfile, [ruff_lockfile_sentinel()])
         assert lockfile_request.interpreter_constraints == InterpreterConstraints(expected_ics)
         assert lockfile_request.requirements == FrozenOrderedSet(
             [

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -34,7 +34,7 @@ class Yapf(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.yapf", "yapf.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/yapf/yapf.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -7,9 +7,12 @@ import os.path
 from typing import Iterable
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -1,14 +1,10 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.backend.python.util_rules.lockfile import LockfileRules
+from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url
 from pants.util.strutil import help_text
@@ -36,24 +32,10 @@ class PyOxidizer(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.packaging.pyoxidizer", "pyoxidizer.lock")
     default_lockfile_path = "src/python/pants/backend/python/packaging/pyoxidizer/pyoxidizer.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     args = ArgsListOption(example="--release")
 
 
-class PyoxidizerLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = PyOxidizer.options_scope
-
-
-@rule
-def setup_lockfile_request(
-    _: PyoxidizerLockfileSentinel, pyoxidizer: PyOxidizer
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(pyoxidizer)
-
-
 def rules():
-    return (
-        *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, PyoxidizerLockfileSentinel),
-    )
+    return collect_rules()

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -32,7 +32,7 @@ class PyOxidizer(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.packaging.pyoxidizer", "pyoxidizer.lock")
     default_lockfile_path = "src/python/pants/backend/python/packaging/pyoxidizer/pyoxidizer.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     args = ArgsListOption(example="--release")
 

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -1,9 +1,8 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -3,9 +3,8 @@
 
 from __future__ import annotations
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -27,7 +27,7 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     args = ArgsListOption(example="--log-to-stderr")
 

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -3,17 +3,11 @@
 
 from __future__ import annotations
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import EntryPoint
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
-from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url
 
@@ -33,6 +27,7 @@ class DebugPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     args = ArgsListOption(example="--log-to-stderr")
 
@@ -50,18 +45,5 @@ class DebugPy(PythonToolBase):
         )
 
 
-class DebugPyLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = DebugPy.options_scope
-
-
-@rule
-def setup_debugpy_lockfile(_: DebugPyLockfileSentinel, debugpy: DebugPy) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(debugpy)
-
-
 def rules():
-    return (
-        *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, DebugPyLockfileSentinel),
-    )
+    return collect_rules()

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -73,12 +73,12 @@ async def setup_ipython_lockfile(
     _: IPythonLockfileSentinel, ipython: IPython, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not ipython.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(ipython)
+        return ipython.to_lockfile_request()
 
     interpreter_constraints = await _find_all_unique_interpreter_constraints(
         python_setup, _IpythonFieldSetForLockfiles
     )
-    return GeneratePythonLockfile.from_tool(ipython, interpreter_constraints)
+    return ipython.to_lockfile_request(interpreter_constraints)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -22,7 +22,7 @@ class Lambdex(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/lambdex.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -1,9 +1,8 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules
 from pants.util.docutil import git_url
 

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -1,16 +1,10 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.backend.python.util_rules.lockfile import LockfileRules
+from pants.engine.rules import collect_rules
 from pants.util.docutil import git_url
 
 
@@ -28,20 +22,8 @@ class Lambdex(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/lambdex.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class LambdexLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = Lambdex.options_scope
-
-
-@rule
-def setup_lambdex_lockfile(_: LambdexLockfileSentinel, lambdex: Lambdex) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(lambdex)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 def rules():
-    return (
-        *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, LambdexLockfileSentinel),
-    )
+    return collect_rules()

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -218,10 +218,10 @@ async def setup_pytest_lockfile(
     _: PytestLockfileSentinel, pytest: PyTest, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not pytest.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(pytest)
+        return pytest.to_lockfile_request()
 
     constraints = await _find_all_unique_interpreter_constraints(python_setup, PythonTestFieldSet)
-    return GeneratePythonLockfile.from_tool(pytest, constraints)
+    return pytest.to_lockfile_request(constraints)
 
 
 class PytestExportSentinel(ExportPythonToolSentinel):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -53,7 +53,7 @@ class PythonToolRequirementsBase(Subsystem):
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None
     default_lockfile_url: ClassVar[str | None] = None
-    lockfile_rules_type: LockfileRules = LockfileRules.SIMPLE
+    lockfile_rules_type: LockfileRules = LockfileRules.CUSTOM
 
     install_from_resolve = StrOption(
         advanced=True,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from typing import Any, ClassVar, Iterable, Sequence
 
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
+from pants.backend.python.util_rules import lockfile
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex import PexRequest
 from pants.backend.python.util_rules.pex_requirements import (
@@ -29,17 +29,7 @@ from pants.util.docutil import bin_name, doc_url
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
-
-class LockfileRules(Enum):
-    """The type of lockfile generation strategy to use for a tool.
-
-    - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
-    - SIMPLE : A python tool that can be installed with pip simply with `pip install mytool`.
-        It does not need other information about the code it operates on, such as their interpreter constraints.
-    """
-
-    CUSTOM = "custom"
-    SIMPLE = "simple"
+LockfileRules = lockfile.LockfileRules  # explicit re-export
 
 
 class PythonToolRequirementsBase(Subsystem):
@@ -311,7 +301,6 @@ class PythonToolRequirementsBase(Subsystem):
     @classmethod
     def rules(cls: Any) -> Iterable[Any]:
         yield from super().rules()
-        from pants.backend.python.util_rules import lockfile
 
         yield from lockfile.default_rules(cls)
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -52,7 +52,7 @@ class PythonToolRequirementsBase(Subsystem):
     # If this tool does not mix with user requirements you should set this to True.
     #
     # You also need to subclass `GeneratePythonToolLockfileSentinel` and create a rule that goes
-    # from it -> GeneratePythonLockfile by calling `GeneratePythonLockfile.from_python_tool()`.
+    # from it -> GeneratePythonLockfile by calling `to_lockfile_request`.
     # Register the UnionRule.
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -53,7 +53,7 @@ class PythonToolRequirementsBase(Subsystem):
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None
     default_lockfile_url: ClassVar[str | None] = None
-    lockfile_rules_type: LockfileRules = LockfileRules.PYTHON
+    lockfile_rules_type: LockfileRules = LockfileRules.SIMPLE
 
     install_from_resolve = StrOption(
         advanced=True,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -3,11 +3,11 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, ClassVar, Iterable, Sequence
 
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest
 from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
@@ -26,6 +26,18 @@ from pants.option.option_types import BoolOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import bin_name, doc_url
 from pants.util.strutil import softwrap
+
+
+class LockfileRules(Enum):
+    """The type of lockfile generation strategy to use for a tool.
+
+    - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
+    - SIMPLE : A python tool that can be installed with pip simply with `pip install mytool`.
+        It does not need other information about the code it operates on, such as their interpreter constraints.
+    """
+
+    CUSTOM = "custom"
+    SIMPLE = "simple"
 
 
 class PythonToolRequirementsBase(Subsystem):
@@ -266,7 +278,9 @@ class PythonToolRequirementsBase(Subsystem):
     @classmethod
     def rules(cls: Any) -> Iterable[Any]:
         yield from super().rules()
-        yield from cls.lockfile_rules_type.default_rules(cls)
+        from pants.backend.python.util_rules import lockfile
+
+        yield from lockfile.default_rules(cls)
 
 
 class PythonToolBase(PythonToolRequirementsBase):

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -3,10 +3,11 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Iterable, Sequence
+from typing import Any, ClassVar, Iterable, Sequence
 
 from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest
 from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
@@ -52,6 +53,7 @@ class PythonToolRequirementsBase(Subsystem):
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None
     default_lockfile_url: ClassVar[str | None] = None
+    lockfile_rules_type: LockfileRules = LockfileRules.PYTHON
 
     install_from_resolve = StrOption(
         advanced=True,
@@ -260,6 +262,11 @@ class PythonToolRequirementsBase(Subsystem):
             main=main,
             sources=sources,
         )
+
+    @classmethod
+    def rules(cls: Any) -> Iterable[Any]:
+        yield from super().rules()
+        yield from cls.lockfile_rules_type.default_rules(cls)
 
 
 class PythonToolBase(PythonToolRequirementsBase):

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -58,12 +58,12 @@ async def setup_setuptools_lockfile(
     _: SetuptoolsLockfileSentinel, setuptools: Setuptools, python_setup: PythonSetup
 ) -> GeneratePythonLockfile:
     if not setuptools.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(setuptools)
+        return setuptools.to_lockfile_request()
 
     interpreter_constraints = await _find_all_unique_interpreter_constraints(
         python_setup, PythonDistributionFieldSet
     )
-    return GeneratePythonLockfile.from_tool(setuptools, interpreter_constraints)
+    return setuptools.to_lockfile_request(interpreter_constraints)
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -25,7 +25,7 @@ class SetuptoolsSCM(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "setuptools_scm.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/setuptools_scm.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 def rules():

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -1,9 +1,8 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import collect_rules
 from pants.util.docutil import git_url
 

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -1,16 +1,10 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import EntryPoint
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+from pants.backend.python.util_rules.lockfile import LockfileRules
+from pants.engine.rules import collect_rules
 from pants.util.docutil import git_url
 
 
@@ -31,22 +25,8 @@ class SetuptoolsSCM(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "setuptools_scm.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/setuptools_scm.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class SetuptoolsSCMLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = SetuptoolsSCM.options_scope
-
-
-@rule
-def setup_setuptools_scm_lockfile(
-    _: SetuptoolsSCMLockfileSentinel, setuptools_scm: SetuptoolsSCM
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(setuptools_scm)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 def rules():
-    return (
-        *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, SetuptoolsSCMLockfileSentinel),
-    )
+    return collect_rules()

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -3,9 +3,8 @@
 
 from __future__ import annotations
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.fs import CreateDigest
 from pants.engine.rules import collect_rules

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -36,7 +36,7 @@ class TwineSubsystem(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.subsystems", "twine.lock")
     default_lockfile_path = "src/python/pants/backend/python/subsystems/twine.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("publish")
     args = ArgsListOption(example="--skip-existing")

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -381,11 +381,12 @@ async def setup_mypy_lockfile(
     python_setup: PythonSetup,
 ) -> GeneratePythonLockfile:
     if not mypy.uses_custom_lockfile:
-        return GeneratePythonLockfile.from_tool(mypy)
+        return mypy.to_lockfile_request()
 
     constraints = await _mypy_interpreter_constraints(mypy, python_setup)
-    return GeneratePythonLockfile.from_tool(
-        mypy, constraints, extra_requirements=first_party_plugins.requirement_strings
+    return mypy.to_lockfile_request(
+        interpreter_constraints=constraints,
+        extra_requirements=first_party_plugins.requirement_strings,
     )
 
 

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Iterable, Protocol, Type
+from typing import Iterable, Type
+
+from typing_extensions import Protocol
 
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -3,21 +3,33 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Type
+from typing import Iterable, Protocol, Type
 
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import (
     LockfileRules,
     PythonToolRequirementsBase,
 )
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import rule
 from pants.engine.unions import UnionRule
 from pants.util.memo import memoized
 
 
+class LockfileRequestable(Protocol):
+    options_scope: str
+
+    def to_lockfile_request(
+        self,
+        interpreter_constraints: InterpreterConstraints | None = None,
+        extra_requirements: Iterable[str] = (),
+    ) -> GeneratePythonLockfile:
+        ...
+
+
 @memoized
-def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) -> Iterable:
+def _pex_simple_lockfile_rules(python_tool: Type[LockfileRequestable]) -> Iterable:
     class SimplePexLockfileSentinel(GenerateToolLockfileSentinel):
         resolve_name = python_tool.options_scope
 
@@ -27,9 +39,9 @@ def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) 
     @rule(_param_type_overrides={"request": SimplePexLockfileSentinel, "tool": python_tool})
     async def lockfile_generator(
         request: GenerateToolLockfileSentinel,
-        tool: "PythonToolRequirementsBase",
+        tool: LockfileRequestable,
     ) -> GeneratePythonLockfile:
-        return GeneratePythonLockfile.from_tool(tool)
+        return tool.to_lockfile_request()
 
     return (
         UnionRule(GenerateToolLockfileSentinel, SimplePexLockfileSentinel),

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Iterable, Type, TypeVar, Protocol
+from typing import TYPE_CHECKING, Iterable, Type
 
 from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
@@ -13,21 +13,19 @@ from pants.engine.rules import rule
 from pants.engine.unions import UnionRule
 from pants.util.memo import memoized
 
-
-class PythonToolBase(Protocol):
-    """Projection of necessary fields, avoids import cycle"""
-    options_scope: str
+if TYPE_CHECKING:
+    from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
 @memoized
-def _pex_simple_lockfile_rules(python_tool: Type[PythonToolBase]) -> Iterable:
+def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) -> Iterable:
     class SimplePexLockfileSentinel(GenerateToolLockfileSentinel):
         resolve_name = python_tool.options_scope
 
     @rule(_param_type_overrides={"request": SimplePexLockfileSentinel, "tool": python_tool})
     async def lockfile_generator(
         request: GenerateToolLockfileSentinel,
-        tool: PythonToolBase,
+        tool: "PythonToolRequirementsBase",
     ) -> GeneratePythonLockfile:
         return GeneratePythonLockfile.from_tool(tool)
 

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -64,5 +64,9 @@ def _pex_simple_lockfile_rules(python_tool: Type[LockfileRequestable]) -> Iterab
 def default_rules(cls: Type[LockfileRequestable]) -> Iterable:
     if cls.lockfile_rules_type == LockfileRules.SIMPLE:
         yield from _pex_simple_lockfile_rules(cls)
-    else:
+    elif cls.lockfile_rules_type == LockfileRules.CUSTOM:
         return
+    else:
+        raise NotImplementedError(
+            f"Lockfile rule generator of type {cls.lockfile_rules_type} is missing default rules!"
+        )

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -21,6 +21,9 @@ def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) 
     class SimplePexLockfileSentinel(GenerateToolLockfileSentinel):
         resolve_name = python_tool.options_scope
 
+    SimplePexLockfileSentinel.__name__ = f"{python_tool.__name__}LockfileSentinel"
+    SimplePexLockfileSentinel.__qualname__ = f"{__name__}.{python_tool.__name__}LockfileSentinel"
+
     @rule(_param_type_overrides={"request": SimplePexLockfileSentinel, "tool": python_tool})
     async def lockfile_generator(
         request: GenerateToolLockfileSentinel,

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -38,15 +38,15 @@ class LockfileRules(Enum):
     """The type of lockfile generation strategy to use for a tool.
 
     - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
-    - PYTHON : A tool that can be installed with pip simply with `pip install mytool`.
-        It does not need other information about the code it operates on
+    - SIMPLE : A python tool that can be installed with pip simply with `pip install mytool`.
+        It does not need other information about the code it operates on, such as their interpreter constraints.
     """
 
     CUSTOM = "custom"
-    PYTHON = "python"
+    SIMPLE = "simple"
 
     def default_rules(self, cls) -> Iterable:
-        if self == LockfileRules.PYTHON:
+        if self == LockfileRules.SIMPLE:
             yield from _pex_simple_lockfile_rules(cls)
         else:
             return

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -3,17 +3,17 @@
 
 from __future__ import annotations
 
-from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Type
+from typing import Iterable, Type
 
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import rule
 from pants.engine.unions import UnionRule
 from pants.util.memo import memoized
-
-if TYPE_CHECKING:
-    from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 
 
 @memoized
@@ -37,19 +37,8 @@ def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) 
     )
 
 
-class LockfileRules(Enum):
-    """The type of lockfile generation strategy to use for a tool.
-
-    - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
-    - SIMPLE : A python tool that can be installed with pip simply with `pip install mytool`.
-        It does not need other information about the code it operates on, such as their interpreter constraints.
-    """
-
-    CUSTOM = "custom"
-    SIMPLE = "simple"
-
-    def default_rules(self, cls) -> Iterable:
-        if self == LockfileRules.SIMPLE:
-            yield from _pex_simple_lockfile_rules(cls)
-        else:
-            return
+def default_rules(cls: Type[PythonToolRequirementsBase]) -> Iterable:
+    if cls.lockfile_rules_type == LockfileRules.SIMPLE:
+        yield from _pex_simple_lockfile_rules(cls)
+    else:
+        return

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from enum import Enum
 from typing import TYPE_CHECKING, Iterable, Type
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import rule
@@ -38,21 +37,16 @@ def _pex_simple_lockfile_rules(python_tool: Type["PythonToolRequirementsBase"]) 
 class LockfileRules(Enum):
     """The type of lockfile generation strategy to use for a tool.
 
-    - NONE : Does not import Python lockfile rules
     - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
     - PYTHON : A tool that can be installed with pip simply with `pip install mytool`.
         It does not need other information about the code it operates on
     """
 
-    NONE = "none"
     CUSTOM = "custom"
     PYTHON = "python"
 
     def default_rules(self, cls) -> Iterable:
-        if self == LockfileRules.NONE:
-            return
-
-        yield from lockfile.rules()
-
         if self == LockfileRules.PYTHON:
             yield from _pex_simple_lockfile_rules(cls)
+        else:
+            return

--- a/src/python/pants/backend/python/util_rules/lockfile.py
+++ b/src/python/pants/backend/python/util_rules/lockfile.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Iterable, Type, TypeVar, Protocol
+
+from pants.backend.python.goals import lockfile
+from pants.backend.python.goals.lockfile import GeneratePythonLockfile
+from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.engine.rules import rule
+from pants.engine.unions import UnionRule
+from pants.util.memo import memoized
+
+
+class PythonToolBase(Protocol):
+    """Projection of necessary fields, avoids import cycle"""
+    options_scope: str
+
+
+@memoized
+def _pex_simple_lockfile_rules(python_tool: Type[PythonToolBase]) -> Iterable:
+    class SimplePexLockfileSentinel(GenerateToolLockfileSentinel):
+        resolve_name = python_tool.options_scope
+
+    @rule(_param_type_overrides={"request": SimplePexLockfileSentinel, "tool": python_tool})
+    async def lockfile_generator(
+        request: GenerateToolLockfileSentinel,
+        tool: PythonToolBase,
+    ) -> GeneratePythonLockfile:
+        return GeneratePythonLockfile.from_tool(tool)
+
+    return (
+        UnionRule(GenerateToolLockfileSentinel, SimplePexLockfileSentinel),
+        lockfile_generator,
+    )
+
+
+class LockfileRules(Enum):
+    """The type of lockfile generation strategy to use for a tool.
+
+    - NONE : Does not import Python lockfile rules
+    - CUSTOM : Only Python lockfile rules are added, the rest are implemented by the tool
+    - PYTHON : A tool that can be installed with pip simply with `pip install mytool`.
+        It does not need other information about the code it operates on
+    """
+
+    NONE = "none"
+    CUSTOM = "custom"
+    PYTHON = "python"
+
+    def default_rules(self, cls) -> Iterable:
+        if self == LockfileRules.NONE:
+            return
+
+        yield from lockfile.rules()
+
+        if self == LockfileRules.PYTHON:
+            yield from _pex_simple_lockfile_rules(cls)

--- a/src/python/pants/backend/python/util_rules/lockfile_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_test.py
@@ -1,0 +1,101 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from textwrap import dedent
+from typing import Iterable, Type
+
+import pytest
+
+from pants.backend.python.dependency_inference.rules import import_rules
+from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals import generate_lockfiles
+from pants.core.goals.generate_lockfiles import GenerateLockfilesGoal, GenerateToolLockfileSentinel
+from pants.engine.target import Dependencies, SingleSourceField, Target
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+def _get_generated_lockfile_sentinel(
+    rules: Iterable, subsystem: Type[PythonToolBase]
+) -> Type[GenerateToolLockfileSentinel]:
+    """Fish the generated lockfile sentinel out of the pool of rules so it can be used in a
+    QueryRule."""
+    return next(
+        r
+        for r in rules
+        if isinstance(r, UnionRule)
+        and r.union_base == GenerateToolLockfileSentinel
+        and issubclass(r.union_member, GenerateToolLockfileSentinel)
+        and r.union_member.resolve_name == subsystem.options_scope
+    ).union_member
+
+
+class FakeTool(PythonToolBase):
+    options_scope = "cowsay"
+    name = "Cowsay"
+    help = "A tool to test pants"
+
+    default_version = "cowsay==5.0"
+    default_main = ConsoleScript("cowsay")
+
+    register_interpreter_constraints = True
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
+
+    register_lockfile = True
+    default_lockfile_path = "cowsay.lock"
+    default_lockfile_resource = ("", "")
+    default_lockfile_url = " "
+
+
+class MockSourceField(SingleSourceField):
+    pass
+
+
+class MockDependencies(Dependencies):
+    pass
+
+
+class MockTarget(Target):
+    alias = "tgt"
+    core_fields = (MockSourceField, MockDependencies)
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *generate_lockfiles.rules(),
+            *import_rules(),
+            *FakeTool.rules(),
+        ],
+        target_types=[MockTarget],
+    )
+
+    rule_runner.write_files(
+        {"project/example.ext": "", "project/BUILD": "tgt(source='example.ext')"}
+    )
+    return rule_runner
+
+
+def test_simple_python_lockfile(rule_runner):
+    """Test that the `LockfileType.PEX_SIMPLE` resolved the graph and generates the lockfile."""
+    result = rule_runner.run_goal_rule(
+        GenerateLockfilesGoal,
+        args=[
+            "--resolve=cowsay",
+            "--cowsay-lockfile=aaa.lock",
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+    assert result
+    lockfile_content = rule_runner.read_file("aaa.lock")
+    assert (
+        dedent(
+            f"""\
+             //   "generated_with_requirements": [
+             //     "{FakeTool.default_version}"
+             //   ],
+             """
+        )
+        in lockfile_content
+    )

--- a/src/python/pants/backend/python/util_rules/lockfile_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_test.py
@@ -9,6 +9,7 @@ from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.goals import generate_lockfiles
 from pants.core.goals.generate_lockfiles import GenerateLockfilesGoal, GenerateToolLockfileSentinel
 from pants.engine.target import Dependencies, SingleSourceField, Target
@@ -46,6 +47,7 @@ class FakeTool(PythonToolBase):
     default_lockfile_path = "cowsay.lock"
     default_lockfile_resource = ("", "")
     default_lockfile_url = " "
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 class MockSourceField(SingleSourceField):

--- a/src/python/pants/backend/python/util_rules/lockfile_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_test.py
@@ -6,6 +6,7 @@ from typing import Iterable, Type
 import pytest
 
 from pants.backend.python.dependency_inference.rules import import_rules
+from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals import generate_lockfiles
@@ -64,6 +65,7 @@ class MockTarget(Target):
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
+            *lockfile.rules(),
             *generate_lockfiles.rules(),
             *import_rules(),
             *FakeTool.rules(),

--- a/src/python/pants/backend/python/util_rules/lockfile_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_test.py
@@ -7,9 +7,8 @@ import pytest
 
 from pants.backend.python.dependency_inference.rules import import_rules
 from pants.backend.python.goals import lockfile
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.core.goals import generate_lockfiles
 from pants.core.goals.generate_lockfiles import GenerateLockfilesGoal, GenerateToolLockfileSentinel
 from pants.engine.target import Dependencies, SingleSourceField, Target

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -45,7 +45,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     default_lockfile_resource = ("pants.backend.terraform", "hcl2.lock")
     default_lockfile_path = "src/python/pants/backend/terraform/hcl2.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -5,18 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.python.goals import lockfile
-from pants.backend.python.goals.lockfile import (
-    GeneratePythonLockfile,
-    GeneratePythonToolLockfileSentinel,
-)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
@@ -50,17 +45,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     default_lockfile_resource = ("pants.backend.terraform", "hcl2.lock")
     default_lockfile_path = "src/python/pants/backend/terraform/hcl2.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-
-
-class TerraformHcl2ParserLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = TerraformHcl2Parser.options_scope
-
-
-@rule
-def setup_lockfile_request(
-    _: TerraformHcl2ParserLockfileSentinel, hcl2_parser: TerraformHcl2Parser
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(hcl2_parser)
+    lockfile_rules_type = LockfileRules.PYTHON
 
 
 @dataclass(frozen=True)
@@ -163,7 +148,5 @@ async def infer_terraform_module_dependencies(
 def rules():
     return [
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(InferDependenciesRequest, InferTerraformModuleDependenciesRequest),
-        UnionRule(GenerateToolLockfileSentinel, TerraformHcl2ParserLockfileSentinel),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import PurePath
 
-from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
+from pants.backend.python.subsystems.python_tool_base import (
+    LockfileRules,
+    PythonToolRequirementsBase,
+)
 from pants.backend.python.target_types import EntryPoint
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -5,13 +5,10 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.goals.lockfile import GeneratePythonLockfile
 from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.pex_requirements import GeneratePythonToolLockfileSentinel
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption, StrOption
@@ -34,6 +31,7 @@ class Yamllint(PythonToolBase):
     default_lockfile_resource = ("pants.backend.tools.yamllint", "yamllint.lock")
     default_lockfile_path = "src/python/pants/backend/tools/yamllint/yamllint.lock"
     default_lockfile_url = git_url(default_lockfile_path)
+    lockfile_rules_type = LockfileRules.PYTHON
 
     export = ExportToolOption()
 
@@ -66,17 +64,6 @@ class Yamllint(PythonToolBase):
     skip = SkipOption("lint")
 
 
-class YamllintLockfileSentinel(GeneratePythonToolLockfileSentinel):
-    resolve_name = Yamllint.options_scope
-
-
-@rule
-def setup_yamllint_lockfile(
-    _: YamllintLockfileSentinel, yamllint: Yamllint
-) -> GeneratePythonLockfile:
-    return GeneratePythonLockfile.from_tool(yamllint)
-
-
 class YamllintExportSentinel(ExportPythonToolSentinel):
     pass
 
@@ -93,7 +80,5 @@ def yamllint_export(_: YamllintExportSentinel, yamllint: Yamllint) -> ExportPyth
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
-        *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, YamllintLockfileSentinel),
         UnionRule(ExportPythonToolSentinel, YamllintExportSentinel),
     )

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 from typing import Iterable
 
 from pants.backend.python.goals.export import ExportPythonTool, ExportPythonToolSentinel
-from pants.backend.python.subsystems.python_tool_base import ExportToolOption, PythonToolBase
+from pants.backend.python.subsystems.python_tool_base import (
+    ExportToolOption,
+    LockfileRules,
+    PythonToolBase,
+)
 from pants.backend.python.target_types import ConsoleScript
-from pants.backend.python.util_rules.lockfile import LockfileRules
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption, StrOption

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -31,7 +31,7 @@ class Yamllint(PythonToolBase):
     default_lockfile_resource = ("pants.backend.tools.yamllint", "yamllint.lock")
     default_lockfile_path = "src/python/pants/backend/tools/yamllint/yamllint.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    lockfile_rules_type = LockfileRules.PYTHON
+    lockfile_rules_type = LockfileRules.SIMPLE
 
     export = ExportToolOption()
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -19,6 +19,7 @@ from pants.backend.build_files.fix.deprecations import renamed_fields_rules, ren
 from pants.backend.build_files.fix.deprecations.base import FixedBUILDFile
 from pants.backend.build_files.fmt.black.register import BlackRequest
 from pants.backend.build_files.fmt.yapf.register import YapfRequest
+from pants.backend.python.goals import lockfile
 from pants.backend.python.lint.black.rules import _run_black
 from pants.backend.python.lint.black.subsystem import Black
 from pants.backend.python.lint.yapf.rules import _run_yapf
@@ -427,6 +428,7 @@ def rules():
         *collect_rules(renamed_fields_rules),
         *collect_rules(renamed_targets_rules),
         *pex.rules(),
+        *lockfile.rules(),
         UnionRule(RewrittenBuildFileRequest, RenameDeprecatedTargetsRequest),
         UnionRule(RewrittenBuildFileRequest, RenameDeprecatedFieldsRequest),
         # NB: We want this to come at the end so that running Black or Yapf happens

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -6,6 +6,7 @@
 These are always activated and cannot be disabled.
 """
 from pants.backend.codegen import export_codegen_goal
+from pants.backend.python.goals import lockfile as python_lockfile
 from pants.bsp.rules import rules as bsp_rules
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals import (
@@ -71,6 +72,7 @@ def rules():
         *export_codegen_goal.rules(),
         *fmt.rules(),
         *fix.rules(),
+        *python_lockfile.rules(),
         *generate_lockfiles.rules(),
         *lint.rules(),
         *update_build_files.rules(),

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -6,7 +6,6 @@
 These are always activated and cannot be disabled.
 """
 from pants.backend.codegen import export_codegen_goal
-from pants.backend.python.goals import lockfile as python_lockfile
 from pants.bsp.rules import rules as bsp_rules
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals import (
@@ -72,7 +71,6 @@ def rules():
         *export_codegen_goal.rules(),
         *fmt.rules(),
         *fix.rules(),
-        *python_lockfile.rules(),
         *generate_lockfiles.rules(),
         *lint.rules(),
         *update_build_files.rules(),

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -541,6 +541,14 @@ class RuleRunner:
             )
         return tuple(paths)
 
+    def read_file(self, file: str | PurePath, mode: str = "r") -> str | bytes:
+        """Read a file that was written to the build root, useful for testing."""
+        path = os.path.join(self.build_root, file)
+        with safe_open(path, mode=mode) as fp:
+            if "b" in mode:
+                return bytes(fp.read())
+            return str(fp.read())
+
     def make_snapshot(self, files: Mapping[str, str | bytes]) -> Snapshot:
         """Makes a snapshot from a map of file name to file content.
 


### PR DESCRIPTION
Breakout from #16412

Adds helpers to generate common python lockfile rules. includes:
- [x] tool that can just use `GeneratePythonLockfile.from_tool`
- [ ] tool that needs to gather interpreter constraints
- [ ] tool that needs to install 1st-party plugins

I threw together some documentation, but I'm not sure where these would go or even if they're what we want.
I'm also not sure how we want to fail generating rules if the fields we need aren't present. For example, for tools which need interpreter constraints, their `FieldSet` needs to have an `InterpreterConstraintsField` attribute; how should we warn if that field isn't present?

Talking things over with @thejcannon , we think that we'd need to do some prework to support a design similar to the other rule generators. Having a declarative field on the class would be ideal. However, we would need to tether a tool to its fieldset to support usecases 2 and 3, which is where the prework would come in. 
This MR now deals only with the first case. This is basically 60% of usecases and probably most of the uses in plugins.