### PR TITLE
Ensure correct eq/hash semantics for PythonArtifact.

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -292,7 +292,7 @@ class SetupKwargsRequest(ABC):
         """Whether the kwargs implementation should be used for this target or not."""
 
     @property
-    def explicit_kwargs(self) -> dict[str, Any]:
+    def explicit_kwargs(self) -> FrozenDict[str, Any]:
         return self.target[PythonProvidesField].value.kwargs
 
 

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -292,8 +292,10 @@ class SetupKwargsRequest(ABC):
         """Whether the kwargs implementation should be used for this target or not."""
 
     @property
-    def explicit_kwargs(self) -> FrozenDict[str, Any]:
-        return self.target[PythonProvidesField].value.kwargs
+    def explicit_kwargs(self) -> Dict[str, Any]:
+        # We return a dict copy of the underlying FrozenDict, because the caller expects a
+        # dict (and we have documented as much).
+        return dict(self.target[PythonProvidesField].value.kwargs)
 
 
 class FinalizedSetupKwargs(SetupKwargs):

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -2,9 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections.abc
+import copy
+import json
 from typing import Any, Dict, List, Union
 
-from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap
 
 
@@ -53,16 +54,6 @@ def _normalize_entry_points(
     }
 
 
-def immutable(obj: Any) -> Any:
-    if isinstance(obj, Dict):
-        return FrozenDict(**{str(k): immutable(v) for (k, v) in obj.items()})
-    if isinstance(obj, (list, tuple)):
-        return tuple(immutable(x) for x in obj)
-    if isinstance(obj, (str, int, float, bool)):
-        return obj
-    raise ValueError(f"Invalid type in python_artifact: {type(obj)}, value={obj}")
-
-
 class PythonArtifact:
     """Represents a Python setup.py-based project."""
 
@@ -88,7 +79,14 @@ class PythonArtifact:
             # coerce entry points from Dict[str, List[str]] to Dict[str, Dict[str, str]]
             kwargs["entry_points"] = _normalize_entry_points(kwargs["entry_points"])
 
-        self._kw: FrozenDict[str, Any] = immutable(kwargs)
+        self._kw: Dict[str, Any] = copy.deepcopy(kwargs)
+        # The kwargs come from a BUILD file, and can contain somewhat arbitrary nested structures,
+        # so we don't have a principled way to make them into a hashable data structure.
+        # E.g., we can't naively turn all lists into tuples because distutils checks that some
+        # fields (such as ext_modules) are lists, and doesn't accept tuples.
+        # Instead we stringify and precompute a hash to use in our own __hash__, since we know
+        # that this object is immutable.
+        self._hash: int = hash(json.dumps(kwargs, sort_keys=True))
         self._name: str = name
 
     @property
@@ -96,7 +94,7 @@ class PythonArtifact:
         return self._name
 
     @property
-    def kwargs(self) -> FrozenDict[str, Any]:
+    def kwargs(self) -> Dict[str, Any]:
         return self._kw
 
     def __eq__(self, other: Any) -> bool:
@@ -105,7 +103,7 @@ class PythonArtifact:
         return self._kw == other._kw
 
     def __hash__(self) -> int:
-        return hash(self._kw)
+        return self._hash
 
     def __str__(self) -> str:
         return self.name

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import collections.abc
+import copy
 from typing import Any, Dict, List, Union
 
 from pants.util.strutil import softwrap
@@ -77,7 +78,12 @@ class PythonArtifact:
             # coerce entry points from Dict[str, List[str]] to Dict[str, Dict[str, str]]
             kwargs["entry_points"] = _normalize_entry_points(kwargs["entry_points"])
 
-        self._kw: Dict[str, Any] = kwargs
+        self._kw: Dict[str, Any] = copy.deepcopy(kwargs)
+        # The kwargs come from a BUILD file, and can contain somewhat arbitrary nested structures,
+        # so we don't have a principled way to make them into a hashable data structure.
+        # Instead we stringify and precompute a hash to use in our own __hash__, since we know
+        # that our
+        self._hash: int = hash(str(kwargs))
         self._binaries = {}
         self._name: str = name
 
@@ -92,6 +98,14 @@ class PythonArtifact:
     @property
     def binaries(self):
         return self._binaries
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, PythonArtifact):
+            return False
+        return self._kw == other._kw
+
+    def __hash__(self) -> int:
+        return self._hash
 
     def __str__(self) -> str:
         return self.name

--- a/src/python/pants/backend/python/macros/python_artifact_test.py
+++ b/src/python/pants/backend/python/macros/python_artifact_test.py
@@ -5,9 +5,8 @@ import re
 
 import pytest
 
-from pants.backend.python.macros.python_artifact import _normalize_entry_points, immutable
+from pants.backend.python.macros.python_artifact import _normalize_entry_points
 from pants.testutil.pytest_util import no_exception
-from pants.util.frozendict import FrozenDict
 
 
 @pytest.mark.parametrize(
@@ -72,30 +71,3 @@ from pants.util.frozendict import FrozenDict
 def test_normalize_entry_points(entry_points, normalized, expect) -> None:
     with expect:
         assert _normalize_entry_points(entry_points) == normalized
-
-
-def test_immutable() -> None:
-    assert immutable(
-        {
-            "a": "aa",
-            "b": ["bb", "bbb", 22, False, [{"b4": "b5"}], {"b6": ["b7", "b8"]}],
-            "c": True,
-            "d": {"e": ("ee",), "f": [1, 2.3, "g", {"gg": ""}]},
-            12: "12",
-        }
-    ) == FrozenDict(
-        {
-            "a": "aa",
-            "b": (
-                "bb",
-                "bbb",
-                22,
-                False,
-                (FrozenDict({"b4": "b5"}),),
-                FrozenDict({"b6": ("b7", "b8")}),
-            ),
-            "c": True,
-            "d": FrozenDict({"e": ("ee",), "f": (1, 2.3, "g", FrozenDict({"gg": ""}))}),
-            "12": "12",
-        }
-    )

--- a/src/python/pants/backend/python/macros/python_artifact_test.py
+++ b/src/python/pants/backend/python/macros/python_artifact_test.py
@@ -5,8 +5,9 @@ import re
 
 import pytest
 
-from pants.backend.python.macros.python_artifact import _normalize_entry_points
+from pants.backend.python.macros.python_artifact import _normalize_entry_points, immutable
 from pants.testutil.pytest_util import no_exception
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.mark.parametrize(
@@ -68,6 +69,33 @@ from pants.testutil.pytest_util import no_exception
         ),
     ],
 )
-def test_normalize_entry_points(entry_points, normalized, expect):
+def test_normalize_entry_points(entry_points, normalized, expect) -> None:
     with expect:
         assert _normalize_entry_points(entry_points) == normalized
+
+
+def test_immutable() -> None:
+    assert immutable(
+        {
+            "a": "aa",
+            "b": ["bb", "bbb", 22, False, [{"b4": "b5"}], {"b6": ["b7", "b8"]}],
+            "c": True,
+            "d": {"e": ("ee",), "f": [1, 2.3, "g", {"gg": ""}]},
+            12: "12",
+        }
+    ) == FrozenDict(
+        {
+            "a": "aa",
+            "b": (
+                "bb",
+                "bbb",
+                22,
+                False,
+                (FrozenDict({"b4": "b5"}),),
+                FrozenDict({"b6": ("b7", "b8")}),
+            ),
+            "c": True,
+            "d": FrozenDict({"e": ("ee",), "f": (1, 2.3, "g", FrozenDict({"gg": ""}))}),
+            "12": "12",
+        }
+    )


### PR DESCRIPTION
This caused intermittent test failures when comparing expected and actual target structures.

It's unclear if this could have affected user-observable behavior.