### PR TITLE
Filter coarsened targets to only those that are relevant in `pylint` runner rule

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -42,6 +42,7 @@ from pants.util.strutil import pluralize
 
 @dataclass(frozen=True)
 class PartitionMetadata:
+    coarsened_targets: CoarsenedTargets
     # NB: These are the same across every element in a partition
     resolve_description: str | None
     interpreter_constraints: InterpreterConstraints
@@ -85,10 +86,19 @@ async def partition_pylint(
         _partition_by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
     )
 
+    coarsened_targets = await Get(
+        CoarsenedTargets,
+        CoarsenedTargetsRequest(field_set.address for field_set in request.field_sets),
+    )
+    coarsened_targets_by_address = coarsened_targets.by_address()
+
     return Partitions(
         Partition(
             tuple(field_sets),
             PartitionMetadata(
+                CoarsenedTargets(
+                    coarsened_targets_by_address[field_set.address] for field_set in field_sets
+                ),
                 resolve if len(python_setup.resolves) > 1 else None,
                 InterpreterConstraints.merge((interpreter_constraints, first_party_ics)),
             ),
@@ -108,16 +118,10 @@ async def run_pylint(
 ) -> LintResult:
     assert request.partition_metadata is not None
 
-    coarsened_targets = await Get(
-        CoarsenedTargets,
-        CoarsenedTargetsRequest(field_set.address for field_set in request.elements),
-    )
-    coarsened_closure = tuple(coarsened_targets.closure())
-
     requirements_pex_get = Get(
         Pex,
         RequirementsPexRequest(
-            (target.address for target in coarsened_closure),
+            (target.address for target in request.partition_metadata.coarsened_targets.closure()),
             # NB: These constraints must be identical to the other PEXes. Otherwise, we risk using
             # a different version for the requirements than the other two PEXes, which can result
             # in a PEX runtime error about missing dependencies.
@@ -136,7 +140,7 @@ async def run_pylint(
 
     sources_get = Get(
         PythonSourceFiles,
-        PythonSourceFilesRequest(coarsened_closure),
+        PythonSourceFilesRequest(request.partition_metadata.coarsened_targets.closure()),
     )
     # Ensure that the empty report dir exists.
     report_directory_digest_get = Get(Digest, CreateDigest([Directory(REPORT_DIR)]))


### PR DESCRIPTION
Closes #17486

Prior to this commit on the 2.15.x line, calculation of coarsened targets for `pylint` inputs would run as part of the "partitioner" rule. The computed targets were tracked as part of partition metadata and passed to the "runner" rule, where they were used to build the transitive requirements pex / to hydrate sources in the `pylint` sandbox.

This approach did not account for the fact that `lint` partitions get re-batched according to `[lint].batch_size`. Re-batching doesn't modify partition metadata, so we would end up trying to hydrate a full partition's worth of transitive dependencies for each ~small `pylint` batch, instead of only those transitive dependencies relevant to each batch's final elements. In my large monorepo, this consistently caused `pantsd` to freeze and eventually be OOM killed.

Resolving coarsened targets once in the "partitioner" rule is good to avoid other performance issues, so we keep that logic and add a secondary filter in the "runner" rule to select only the CTs that are needed for the batch of files that ultimately get submitted as an input.