### PR TITLE
Disambiguate Python module providers by level of ancestry.

### DIFF
--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -32,11 +32,11 @@ def find_python_runtime_library_or_raise_error(
     disable_inference_option: str,
 ) -> Address:
     addresses = [
-        module_provider.addr
-        for module_provider in module_mapping.providers_for_module(
+        possible_module_provider.provider.addr
+        for possible_module_provider in module_mapping.providers_for_module(
             runtime_library_module, resolve=resolve
         )
-        if module_provider.typ == ModuleProviderType.IMPL
+        if possible_module_provider.provider.typ == ModuleProviderType.IMPL
     ]
     if len(addresses) == 1:
         return addresses[0]

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -59,6 +59,13 @@ class ModuleProvider:
     typ: ModuleProviderType
 
 
+@dataclass(frozen=True, order=True)
+class PossibleModuleProvider:
+    provider: ModuleProvider
+    # 0 = The provider mapped to the module itself, 1 = the provider mapped to its parent, etc.
+    ancestry: int
+
+
 def module_from_stripped_path(path: PurePath) -> str:
     module_name_with_slashes = (
         path.parent if path.name in ("__init__.py", "__init__.pyi") else path.with_suffix("")
@@ -127,9 +134,12 @@ class FirstPartyPythonMappingImplMarker:
     """
 
 
-class FirstPartyPythonModuleMapping(
-    FrozenDict[ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]]
-):
+@dataclass(frozen=True)
+class FirstPartyPythonModuleMapping:
+    resolves_to_modules_to_providers: FrozenDict[
+        ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]
+    ]
+
     """A merged mapping of each resolve name to the first-party module names contained and their
     owning addresses.
 
@@ -137,28 +147,35 @@ class FirstPartyPythonModuleMapping(
     implementations for each codegen backends.
     """
 
-    def _providers_for_resolve(self, module: str, resolve: str) -> tuple[ModuleProvider, ...]:
-        mapping = self.get(resolve)
+    def _providers_for_resolve(
+        self, module: str, resolve: str
+    ) -> tuple[PossibleModuleProvider, ...]:
+        mapping = self.resolves_to_modules_to_providers.get(resolve)
         if not mapping:
             return ()
 
         result = mapping.get(module, ())
         if result:
-            return result
+            return tuple(PossibleModuleProvider(provider, 0) for provider in result)
 
-        # If the module is not found, try the parent, if any. This is to accommodate `from`
-        # imports, where we don't care about the specific symbol, but only the module. For example,
-        # with `from my_project.app import App`, we only care about the `my_project.app` part.
+        # If the module is not found, try the parent, if any. This is to handle `from` imports
+        # where the "module" we were handed was actually a symbol inside the module.
+        # E.g., with `from my_project.app import App`, we would be passed "my_project.app.App".
         #
         # We do not look past the direct parent, as this could cause multiple ambiguous owners to
         # be resolved. This contrasts with the third-party module mapping, which will try every
         # ancestor.
+        # TODO: Now that we capture the ancestry, we could look past the direct parent.
+        #  One reason to do so would be to unify more of the FirstParty and ThirdParty impls.
         if "." not in module:
             return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        return mapping.get(parent_module, ())
+        parent_providers = mapping.get(parent_module, ())
+        return tuple(PossibleModuleProvider(mp, 1) for mp in parent_providers)
 
-    def providers_for_module(self, module: str, resolve: str | None) -> tuple[ModuleProvider, ...]:
+    def providers_for_module(
+        self, module: str, resolve: str | None
+    ) -> tuple[PossibleModuleProvider, ...]:
         """Find all providers for the module.
 
         If `resolve` is None, will not consider resolves, i.e. any `python_source` et al can be
@@ -168,7 +185,8 @@ class FirstPartyPythonModuleMapping(
             return self._providers_for_resolve(module, resolve)
         return tuple(
             itertools.chain.from_iterable(
-                self._providers_for_resolve(module, resolve) for resolve in list(self.keys())
+                self._providers_for_resolve(module, resolve)
+                for resolve in list(self.resolves_to_modules_to_providers.keys())
             )
         )
 
@@ -193,13 +211,15 @@ async def merge_first_party_module_mappings(
             for module, providers in modules_to_providers.items():
                 resolves_to_modules_to_providers[resolve][module].extend(providers)
     return FirstPartyPythonModuleMapping(
-        (
-            resolve,
-            FrozenDict(
-                (mod, tuple(sorted(providers))) for mod, providers in sorted(mapping.items())
-            ),
+        FrozenDict(
+            (
+                resolve,
+                FrozenDict(
+                    (mod, tuple(sorted(providers))) for mod, providers in sorted(mapping.items())
+                ),
+            )
+            for resolve, mapping in sorted(resolves_to_modules_to_providers.items())
         )
-        for resolve, mapping in sorted(resolves_to_modules_to_providers.items())
     )
 
 
@@ -242,29 +262,36 @@ async def map_first_party_python_targets_to_modules(
 # -----------------------------------------------------------------------------------------------
 
 
-class ThirdPartyPythonModuleMapping(
-    FrozenDict[ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]]
-):
+@dataclass(frozen=True)
+class ThirdPartyPythonModuleMapping:
     """A mapping of each resolve to the modules they contain and the addresses providing those
     modules."""
 
-    def _providers_for_resolve(self, module: str, resolve: str) -> tuple[ModuleProvider, ...]:
-        mapping = self.get(resolve)
+    resolves_to_modules_to_providers: FrozenDict[
+        ResolveName, FrozenDict[str, Tuple[ModuleProvider, ...]]
+    ]
+
+    def _providers_for_resolve(
+        self, module: str, resolve: str, ancestry: int = 0
+    ) -> tuple[PossibleModuleProvider, ...]:
+        mapping = self.resolves_to_modules_to_providers.get(resolve)
         if not mapping:
             return ()
 
         result = mapping.get(module, ())
         if result:
-            return result
+            return tuple(PossibleModuleProvider(mp, ancestry) for mp in result)
 
         # If the module is not found, recursively try the ancestor modules, if any. For example,
         # pants.task.task.Task -> pants.task.task -> pants.task -> pants
         if "." not in module:
             return ()
         parent_module = module.rsplit(".", maxsplit=1)[0]
-        return self._providers_for_resolve(parent_module, resolve)
+        return self._providers_for_resolve(parent_module, resolve, ancestry + 1)
 
-    def providers_for_module(self, module: str, resolve: str | None) -> tuple[ModuleProvider, ...]:
+    def providers_for_module(
+        self, module: str, resolve: str | None
+    ) -> tuple[PossibleModuleProvider, ...]:
         """Find all providers for the module.
 
         If `resolve` is None, will not consider resolves, i.e. any `python_requirement` can be
@@ -274,21 +301,22 @@ class ThirdPartyPythonModuleMapping(
             return self._providers_for_resolve(module, resolve)
         return tuple(
             itertools.chain.from_iterable(
-                self._providers_for_resolve(module, resolve) for resolve in list(self.keys())
+                self._providers_for_resolve(module, resolve)
+                for resolve in list(self.resolves_to_modules_to_providers.keys())
             )
         )
 
 
 @rule(desc="Creating map of third party targets to Python modules", level=LogLevel.DEBUG)
 async def map_third_party_modules_to_addresses(
-    all_python_tgts: AllPythonTargets,
+    all_python_targets: AllPythonTargets,
     python_setup: PythonSetup,
 ) -> ThirdPartyPythonModuleMapping:
     resolves_to_modules_to_providers: DefaultDict[
         ResolveName, DefaultDict[str, list[ModuleProvider]]
     ] = defaultdict(lambda: defaultdict(list))
 
-    for tgt in all_python_tgts.third_party:
+    for tgt in all_python_targets.third_party:
         resolve = tgt[PythonRequirementResolveField].normalized_value(python_setup)
 
         def add_modules(modules: Iterable[str], *, type_stub: bool = False) -> None:
@@ -335,13 +363,15 @@ async def map_third_party_modules_to_addresses(
                 add_modules(DEFAULT_MODULE_MAPPING.get(proj_name, (fallback_value,)))
 
     return ThirdPartyPythonModuleMapping(
-        (
-            resolve,
-            FrozenDict(
-                (mod, tuple(sorted(providers))) for mod, providers in sorted(mapping.items())
-            ),
+        FrozenDict(
+            (
+                resolve,
+                FrozenDict(
+                    (mod, tuple(sorted(providers))) for mod, providers in sorted(mapping.items())
+                ),
+            )
+            for resolve, mapping in sorted(resolves_to_modules_to_providers.items())
         )
-        for resolve, mapping in sorted(resolves_to_modules_to_providers.items())
     )
 
 
@@ -386,24 +416,38 @@ async def map_module_to_address(
     first_party_mapping: FirstPartyPythonModuleMapping,
     third_party_mapping: ThirdPartyPythonModuleMapping,
 ) -> PythonModuleOwners:
-    providers = [
+    possible_providers: tuple[PossibleModuleProvider, ...] = (
         *third_party_mapping.providers_for_module(request.module, resolve=request.resolve),
         *first_party_mapping.providers_for_module(request.module, resolve=request.resolve),
-    ]
-    addresses = tuple(provider.addr for provider in providers)
+    )
 
-    # There's no ambiguity if there are only 0-1 providers.
-    if len(providers) < 2:
-        return PythonModuleOwners(addresses)
+    # We attempt to disambiguate conflicting providers by taking only the ones for the
+    # closest ancestors to the requested modules. This prevents issues with namespace
+    # packages that are split between first-party and third-party
+    # (e.g., https://github.com/pantsbuild/pants/discussions/17286).
 
-    # Else, it's ambiguous unless there are exactly two providers and one is a type stub and the
-    # other an implementation.
-    if len(providers) == 2 and (providers[0].typ == ModuleProviderType.TYPE_STUB) ^ (
-        providers[1].typ == ModuleProviderType.TYPE_STUB
-    ):
-        return PythonModuleOwners(addresses)
+    # Map from provider type to mutable pair of
+    # [closest ancestry found, list of provider of that type at that ancestry level].
+    type_to_closest_providers: dict[ModuleProviderType, list] = defaultdict(lambda: [999, []])
+    for possible_provider in possible_providers:
+        val = type_to_closest_providers[possible_provider.provider.typ]
+        if possible_provider.ancestry < val[0]:
+            val[0] = possible_provider.ancestry
+            val[1] = []
+        # NB This must come after the < check above, so we handle the possible_provider
+        # that caused that check to pass.
+        if possible_provider.ancestry == val[0]:
+            val[1].append(possible_provider.provider)
 
-    return PythonModuleOwners((), ambiguous=addresses)
+    closest_providers: list[ModuleProvider] = list(
+        itertools.chain(*[val[1] for val in type_to_closest_providers.values()])
+    )
+    addresses = tuple(provider.addr for provider in closest_providers)
+
+    if any(len(val[1]) > 1 for val in type_to_closest_providers.values()):
+        return PythonModuleOwners((), ambiguous=addresses)
+
+    return PythonModuleOwners(addresses)
 
 
 def rules():

--- a/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper_test.py
@@ -24,6 +24,7 @@ from pants.backend.python.dependency_inference.module_mapper import (
     FirstPartyPythonModuleMapping,
     ModuleProvider,
     ModuleProviderType,
+    PossibleModuleProvider,
     PythonModuleOwners,
     PythonModuleOwnersRequest,
     ThirdPartyPythonModuleMapping,
@@ -105,36 +106,45 @@ def test_first_party_modules_mapping() -> None:
     )
 
     def assert_addresses(
-        mod: str, expected: tuple[ModuleProvider, ...], *, resolve: str | None = None
+        mod: str, expected: tuple[PossibleModuleProvider, ...], *, resolve: str | None = None
     ) -> None:
         assert mapping.providers_for_module(mod, resolve=resolve) == expected
 
-    assert_addresses("root", (root_provider,))
-    assert_addresses("root.func", (root_provider,))
+    root_provider0 = PossibleModuleProvider(root_provider, 0)
+    root_provider1 = PossibleModuleProvider(root_provider, 1)
+    util_provider0 = PossibleModuleProvider(util_provider, 0)
+    util_provider1 = PossibleModuleProvider(util_provider, 1)
+    util_stubs_provider0 = PossibleModuleProvider(util_stubs_provider, 0)
+    util_stubs_provider1 = PossibleModuleProvider(util_stubs_provider, 1)
+    test_provider0 = PossibleModuleProvider(test_provider, 0)
+    test_provider1 = PossibleModuleProvider(test_provider, 1)
+
+    assert_addresses("root", (root_provider0,))
+    assert_addresses("root.func", (root_provider1,))
     assert_addresses("root.submodule.func", ())
 
-    assert_addresses("util.strutil", (util_provider, util_stubs_provider))
-    assert_addresses("util.strutil.ensure_text", (util_provider, util_stubs_provider))
+    assert_addresses("util.strutil", (util_provider0, util_stubs_provider0))
+    assert_addresses("util.strutil.ensure_text", (util_provider1, util_stubs_provider1))
     assert_addresses("util", ())
 
-    assert_addresses("project_test.test", (test_provider,))
-    assert_addresses("project_test.test.TestDemo", (test_provider,))
+    assert_addresses("project_test.test", (test_provider0,))
+    assert_addresses("project_test.test.TestDemo", (test_provider1,))
     assert_addresses("project_test", ())
     assert_addresses("project.test", ())
 
-    assert_addresses("ambiguous", (root_provider, util_provider))
-    assert_addresses("ambiguous.func", (root_provider, util_provider))
+    assert_addresses("ambiguous", (root_provider0, util_provider0))
+    assert_addresses("ambiguous.func", (root_provider1, util_provider1))
     assert_addresses("ambiguous.submodule.func", ())
 
-    assert_addresses("util.ambiguous", (util_provider, test_provider))
-    assert_addresses("util.ambiguous.Foo", (util_provider, test_provider))
+    assert_addresses("util.ambiguous", (util_provider0, test_provider0))
+    assert_addresses("util.ambiguous.Foo", (util_provider1, test_provider1))
     assert_addresses("util.ambiguous.Foo.method", ())
 
-    assert_addresses("two_resolves", (root_provider, test_provider), resolve=None)
-    assert_addresses("two_resolves.foo", (root_provider, test_provider), resolve=None)
+    assert_addresses("two_resolves", (root_provider0, test_provider0), resolve=None)
+    assert_addresses("two_resolves.foo", (root_provider1, test_provider1), resolve=None)
     assert_addresses("two_resolves.foo.bar", (), resolve=None)
-    assert_addresses("two_resolves", (root_provider,), resolve="default")
-    assert_addresses("two_resolves", (test_provider,), resolve="another")
+    assert_addresses("two_resolves", (root_provider0,), resolve="default")
+    assert_addresses("two_resolves", (test_provider0,), resolve="another")
 
 
 def test_third_party_modules_mapping() -> None:
@@ -150,49 +160,65 @@ def test_third_party_modules_mapping() -> None:
         Address("", target_name="submodule"), ModuleProviderType.IMPL
     )
     mapping = ThirdPartyPythonModuleMapping(
-        {
-            "default-resolve": FrozenDict(
-                {
-                    "colors": (colors_provider, colors_stubs_provider),
-                    "pants": (pants_provider,),
-                    "req.submodule": (submodule_provider,),
-                    "pants.testutil": (pants_testutil_provider,),
-                    "two_resolves": (colors_provider,),
-                }
-            ),
-            "another-resolve": FrozenDict({"two_resolves": (pants_provider,)}),
-        }
+        FrozenDict(
+            {
+                "default-resolve": FrozenDict(
+                    {
+                        "colors": (colors_provider, colors_stubs_provider),
+                        "pants": (pants_provider,),
+                        "req.submodule": (submodule_provider,),
+                        "pants.testutil": (pants_testutil_provider,),
+                        "two_resolves": (colors_provider,),
+                    }
+                ),
+                "another-resolve": FrozenDict({"two_resolves": (pants_provider,)}),
+            }
+        )
     )
 
     def assert_addresses(
-        mod: str, expected: tuple[ModuleProvider, ...], *, resolve: str | None = None
+        mod: str, expected: tuple[PossibleModuleProvider, ...], *, resolve: str | None = None
     ) -> None:
         assert mapping.providers_for_module(mod, resolve) == expected
 
-    assert_addresses("colors", (colors_provider, colors_stubs_provider))
-    assert_addresses("colors.red", (colors_provider, colors_stubs_provider))
+    colors_provider0 = PossibleModuleProvider(colors_provider, 0)
+    colors_provider1 = PossibleModuleProvider(colors_provider, 1)
+    colors_provider2 = PossibleModuleProvider(colors_provider, 2)
+    colors_stubs_provider0 = PossibleModuleProvider(colors_stubs_provider, 0)
+    colors_stubs_provider1 = PossibleModuleProvider(colors_stubs_provider, 1)
+    pants_provider0 = PossibleModuleProvider(pants_provider, 0)
+    pants_provider1 = PossibleModuleProvider(pants_provider, 1)
+    pants_provider2 = PossibleModuleProvider(pants_provider, 2)
+    pants_provider3 = PossibleModuleProvider(pants_provider, 3)
+    pants_testutil_provider0 = PossibleModuleProvider(pants_testutil_provider, 0)
+    pants_testutil_provider1 = PossibleModuleProvider(pants_testutil_provider, 1)
+    submodule_provider0 = PossibleModuleProvider(submodule_provider, 0)
+    submodule_provider1 = PossibleModuleProvider(submodule_provider, 1)
 
-    assert_addresses("pants", (pants_provider,))
-    assert_addresses("pants.task", (pants_provider,))
-    assert_addresses("pants.task.task", (pants_provider,))
-    assert_addresses("pants.task.task.Task", (pants_provider,))
+    assert_addresses("colors", (colors_provider0, colors_stubs_provider0))
+    assert_addresses("colors.red", (colors_provider1, colors_stubs_provider1))
 
-    assert_addresses("pants.testutil", (pants_testutil_provider,))
-    assert_addresses("pants.testutil.foo", (pants_testutil_provider,))
+    assert_addresses("pants", (pants_provider0,))
+    assert_addresses("pants.task", (pants_provider1,))
+    assert_addresses("pants.task.task", (pants_provider2,))
+    assert_addresses("pants.task.task.Task", (pants_provider3,))
 
-    assert_addresses("req.submodule", (submodule_provider,))
-    assert_addresses("req.submodule.foo", (submodule_provider,))
+    assert_addresses("pants.testutil", (pants_testutil_provider0,))
+    assert_addresses("pants.testutil.foo", (pants_testutil_provider1,))
+
+    assert_addresses("req.submodule", (submodule_provider0,))
+    assert_addresses("req.submodule.foo", (submodule_provider1,))
     assert_addresses("req.another", ())
     assert_addresses("req", ())
 
     assert_addresses("unknown", ())
     assert_addresses("unknown.pants", ())
 
-    assert_addresses("two_resolves", (colors_provider, pants_provider), resolve=None)
-    assert_addresses("two_resolves.foo", (colors_provider, pants_provider), resolve=None)
-    assert_addresses("two_resolves.foo.bar", (colors_provider, pants_provider), resolve=None)
-    assert_addresses("two_resolves", (colors_provider,), resolve="default-resolve")
-    assert_addresses("two_resolves", (pants_provider,), resolve="another-resolve")
+    assert_addresses("two_resolves", (colors_provider0, pants_provider0), resolve=None)
+    assert_addresses("two_resolves.foo", (colors_provider1, pants_provider1), resolve=None)
+    assert_addresses("two_resolves.foo.bar", (colors_provider2, pants_provider2), resolve=None)
+    assert_addresses("two_resolves", (colors_provider0,), resolve="default-resolve")
+    assert_addresses("two_resolves", (pants_provider0,), resolve="another-resolve")
 
 
 @pytest.fixture
@@ -375,81 +401,87 @@ def test_map_third_party_modules_to_addresses(rule_runner: RuleRunner) -> None:
     )
     result = rule_runner.request(ThirdPartyPythonModuleMapping, [])
     assert result == ThirdPartyPythonModuleMapping(
-        {
-            "another": FrozenDict(
-                {
-                    "multiple_owners": (
-                        ModuleProvider(
-                            Address("", target_name="multiple_owners2"), ModuleProviderType.IMPL
+        FrozenDict(
+            {
+                "another": FrozenDict(
+                    {
+                        "multiple_owners": (
+                            ModuleProvider(
+                                Address("", target_name="multiple_owners2"), ModuleProviderType.IMPL
+                            ),
+                            ModuleProvider(
+                                Address("", target_name="multiple_owners_types"),
+                                ModuleProviderType.TYPE_STUB,
+                            ),
                         ),
-                        ModuleProvider(
-                            Address("", target_name="multiple_owners_types"),
-                            ModuleProviderType.TYPE_STUB,
+                    }
+                ),
+                "default": FrozenDict(
+                    {
+                        "file_dist": (
+                            ModuleProvider(
+                                Address("", target_name="file_dist"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                }
-            ),
-            "default": FrozenDict(
-                {
-                    "file_dist": (
-                        ModuleProvider(
-                            Address("", target_name="file_dist"), ModuleProviderType.IMPL
+                        "looks_like_stubs": (
+                            ModuleProvider(
+                                Address("", target_name="looks_like_stubs"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                    "looks_like_stubs": (
-                        ModuleProvider(
-                            Address("", target_name="looks_like_stubs"), ModuleProviderType.IMPL
+                        "mapped_module": (
+                            ModuleProvider(
+                                Address("", target_name="modules"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                    "mapped_module": (
-                        ModuleProvider(Address("", target_name="modules"), ModuleProviderType.IMPL),
-                    ),
-                    "multiple_owners": (
-                        ModuleProvider(
-                            Address("", target_name="multiple_owners1"), ModuleProviderType.IMPL
+                        "multiple_owners": (
+                            ModuleProvider(
+                                Address("", target_name="multiple_owners1"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                    "req1": (
-                        ModuleProvider(Address("", target_name="req1"), ModuleProviderType.IMPL),
-                    ),
-                    "typed_dep1": (
-                        ModuleProvider(
-                            Address("", target_name="typed-dep1"), ModuleProviderType.TYPE_STUB
+                        "req1": (
+                            ModuleProvider(
+                                Address("", target_name="req1"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                    "typed_dep2": (
-                        ModuleProvider(
-                            Address("", target_name="typed-dep2"), ModuleProviderType.TYPE_STUB
+                        "typed_dep1": (
+                            ModuleProvider(
+                                Address("", target_name="typed-dep1"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                    "typed_dep3": (
-                        ModuleProvider(
-                            Address("", target_name="typed-dep3"), ModuleProviderType.TYPE_STUB
+                        "typed_dep2": (
+                            ModuleProvider(
+                                Address("", target_name="typed-dep2"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                    "typed_dep4": (
-                        ModuleProvider(
-                            Address("", target_name="typed-dep4"), ModuleProviderType.TYPE_STUB
+                        "typed_dep3": (
+                            ModuleProvider(
+                                Address("", target_name="typed-dep3"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                    "typed_dep5": (
-                        ModuleProvider(
-                            Address("", target_name="typed-dep5"), ModuleProviderType.TYPE_STUB
+                        "typed_dep4": (
+                            ModuleProvider(
+                                Address("", target_name="typed-dep4"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                    "un_normalized_project": (
-                        ModuleProvider(
-                            Address("", target_name="un_normalized"), ModuleProviderType.IMPL
+                        "typed_dep5": (
+                            ModuleProvider(
+                                Address("", target_name="typed-dep5"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                    "vcs_dist": (
-                        ModuleProvider(
-                            Address("", target_name="vcs_dist"), ModuleProviderType.IMPL
+                        "un_normalized_project": (
+                            ModuleProvider(
+                                Address("", target_name="un_normalized"), ModuleProviderType.IMPL
+                            ),
                         ),
-                    ),
-                }
-            ),
-        }
+                        "vcs_dist": (
+                            ModuleProvider(
+                                Address("", target_name="vcs_dist"), ModuleProviderType.IMPL
+                            ),
+                        ),
+                    }
+                ),
+            }
+        )
     )
 
 
@@ -500,6 +532,14 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
                 """\
                 python_sources()
                 python_requirement(name="dep", requirements=["dep_with_stub"])
+                """
+            ),
+            # Namespace package split between first- and third-party, disambiguated by ancestry level.
+            "root/namespace/__init__.py": "",
+            "root/namespace/BUILD": dedent(
+                """\
+                python_requirement(name="thirdparty", requirements=["namespace.thirdparty"])
+                python_source(name="init", source="__init__.py")
                 """
             ),
             # Ambiguity.
@@ -579,6 +619,7 @@ def test_map_module_to_address(rule_runner: RuleRunner) -> None:
             Address("root", relative_file_path="dep_with_stub.pyi"),
         ],
     )
+    assert_owners("namespace.thirdparty", [Address("root/namespace", target_name="thirdparty")])
 
     assert_owners(
         "ambiguous_3rdparty",
@@ -671,16 +712,18 @@ def test_issue_15111(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--python-enable-resolves"])
     result = rule_runner.request(ThirdPartyPythonModuleMapping, [])
     assert result == ThirdPartyPythonModuleMapping(
-        {
-            "python-default": FrozenDict(
-                {
-                    "docopt": (
-                        ModuleProvider(Address("", target_name="req"), ModuleProviderType.IMPL),
-                        ModuleProvider(
-                            Address("", target_name="req"), ModuleProviderType.TYPE_STUB
+        FrozenDict(
+            {
+                "python-default": FrozenDict(
+                    {
+                        "docopt": (
+                            ModuleProvider(Address("", target_name="req"), ModuleProviderType.IMPL),
+                            ModuleProvider(
+                                Address("", target_name="req"), ModuleProviderType.TYPE_STUB
+                            ),
                         ),
-                    ),
-                }
-            )
-        }
+                    }
+                )
+            }
+        )
     )


### PR DESCRIPTION
I.e., if we're looking for a provider for foo.bar, and we have one for foo.bar 
and one for foo, take the former over the latter.

Previously we would see this as an ambiguity, and not infer a dep. This 
happened to a real user, in a situation where a namespace package was split 
between first-party and third-party code: 
https://github.com/pantsbuild/pants/discussions/17286

This change involves a distinction between ModuleProvider and a new 
PossibleModuleProvider class, which also tracks the ancestry. Therefore {First,Third}PartyPythonModuleMapping now encapsulate the underlying dict 
instead of extending the dict. This clarifies that their role is to use the dict
 to produce other data, and they are not intended to be queried like dicts.

Co-authored-by: Tal Amuyal <TalAmuyal@gmail.com>
