### PR TITLE
Symlink site-packages into `pylint` venvs when possible. (Cherry-pick of #17488)

### DIFF
--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Tuple
 
+import packaging
+
 from pants.backend.python.lint.pylint.subsystem import (
     Pylint,
     PylintFieldSet,
@@ -20,6 +22,7 @@ from pants.backend.python.util_rules.partition import (
 from pants.backend.python.util_rules.pex import (
     Pex,
     PexRequest,
+    PexResolveInfo,
     VenvPex,
     VenvPexProcess,
     VenvPexRequest,
@@ -162,6 +165,11 @@ async def run_pylint(
         report_directory_digest_get,
     )
 
+    pylint_pex_info = await Get(PexResolveInfo, Pex, pylint_pex)
+    astroid_info = pylint_pex_info.find("astroid")
+    # Astroid is a transitive dependency of pylint and should always be available in the pex.
+    assert astroid_info
+
     pylint_runner_pex, config_files = await MultiGet(
         Get(
             VenvPex,
@@ -173,10 +181,9 @@ async def run_pylint(
                     internal_only=True,
                     pex_path=[pylint_pex, requirements_pex],
                 ),
-                # TODO(John Sirois): Remove this (change to the default of symlinks) when we can
-                #  upgrade to a version of Pylint with https://github.com/PyCQA/pylint/issues/1470
-                #  resolved.
-                site_packages_copies=True,
+                # Astroid < 2.9.1 had a regression that prevented the use of symlinks:
+                # https://github.com/PyCQA/pylint/issues/1470
+                site_packages_copies=(astroid_info.version < packaging.version.Version("2.9.1")),
             ),
         ),
         Get(


### PR DESCRIPTION
Older versions of `astroid` (a transitive dep of `pylint`) didn't work well when processing symlinks. To avoid problems from this, we've been unconditionally copying/hard-linking files into `pylint` venvs. The incompatibility was fixed in `astroid` v2.9.1.

This commit updates our `pylint` setup logic to extract the `astroid` version from the `pylint` Pex metadata, and symlink site-packages into the venv if the dependency is >= v2.9.1.
