### PR TITLE
Ensure correct eq/hash semantics for PythonArtifact. (Cherry-pick of #17484)

### DIFF
--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -292,8 +292,10 @@ class SetupKwargsRequest(ABC):
         """Whether the kwargs implementation should be used for this target or not."""
 
     @property
-    def explicit_kwargs(self) -> dict[str, Any]:
-        return self.target[PythonProvidesField].value.kwargs
+    def explicit_kwargs(self) -> Dict[str, Any]:
+        # We return a dict copy of the underlying FrozenDict, because the caller expects a
+        # dict (and we have documented as much).
+        return dict(self.target[PythonProvidesField].value.kwargs)
 
 
 class FinalizedSetupKwargs(SetupKwargs):

--- a/src/python/pants/backend/python/macros/python_artifact_test.py
+++ b/src/python/pants/backend/python/macros/python_artifact_test.py
@@ -68,6 +68,6 @@ from pants.testutil.pytest_util import no_exception
         ),
     ],
 )
-def test_normalize_entry_points(entry_points, normalized, expect):
+def test_normalize_entry_points(entry_points, normalized, expect) -> None:
     with expect:
         assert _normalize_entry_points(entry_points) == normalized


### PR DESCRIPTION
This caused intermittent test failures when comparing expected and actual target structures.

It's unclear if this could have affected user-observable behavior.
