### PR TITLE
Remove deprecated remote auth plugin option

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import enum
-import importlib
 import logging
 import os
 import re
@@ -139,7 +138,7 @@ class AuthPluginState(Enum):
 
 @dataclass(frozen=True)
 class AuthPluginResult:
-    """The return type for a function specified via `[GLOBAL].remote_auth_plugin`.
+    """The return type for a function specified via the remote auth plugin`.
 
     The returned `store_headers` and `execution_headers` will replace whatever headers Pants would
     have used normally, e.g. what is set with `[GLOBAL].remote_store_headers`. This allows you to control
@@ -168,7 +167,7 @@ class AuthPluginResult:
                 name = self.plugin_name or ""
                 raise ValueError(
                     f"Invalid `{field_name}` in `AuthPluginResult` returned from "
-                    f"`[GLOBAL].remote_auth_plugin` {name}. Must start with `grpc://` or `grpcs://`, but was "
+                    f"`remote auth plugin {name}. Must start with `grpc://` or `grpcs://`, but was "
                     f"{addr}."
                 )
 
@@ -247,18 +246,6 @@ class DynamicRemoteOptions:
         )
 
     @classmethod
-    def _get_auth_plugin_from_option(cls, remote_auth_plugin_option_value: str) -> Callable:
-        if ":" not in remote_auth_plugin_option_value:
-            raise OptionsError(
-                "Invalid value for `--remote-auth-plugin`: "
-                f"{remote_auth_plugin_option_value}. Please use the format "
-                "`path.to.module:my_func`."
-            )
-        auth_plugin_path, auth_plugin_func = remote_auth_plugin_option_value.split(":")
-        auth_plugin_module = importlib.import_module(auth_plugin_path)
-        return cast(Callable, getattr(auth_plugin_module, auth_plugin_func))
-
-    @classmethod
     def _use_oauth_token(cls, bootstrap_options: OptionValueContainer) -> DynamicRemoteOptions:
         oauth_token = (
             Path(bootstrap_options.remote_oauth_bearer_token_path).resolve().read_text().strip()
@@ -267,10 +254,6 @@ class DynamicRemoteOptions:
             raise OptionsError(
                 f"OAuth bearer token path {bootstrap_options.remote_oauth_bearer_token_path} "
                 "must not contain multiple lines."
-            )
-        if bootstrap_options.remote_auth_plugin:
-            raise OptionsError(
-                "OAuth bearer token path can not be used when setting the `[GLOBAL].remote_auth_plugin` option"
             )
 
         token_header = {"authorization": f"Bearer {oauth_token}"}
@@ -318,22 +301,15 @@ class DynamicRemoteOptions:
         cache_write = cast(bool, bootstrap_options.remote_cache_write)
         if not (execution or cache_read or cache_write):
             return cls.disabled(), None
-        if (
-            bootstrap_options.remote_auth_plugin
-            and bootstrap_options.remote_oauth_bearer_token_path
-        ):
-            raise OptionsError(
-                "Both `[GLOBAL].remote_auth_plugin` and `[GLOBAL].remote_auth_plugin` `[GLOBAL].remote_oauth_bearer_token_path` are set. This is not supported. Only one of those should be set in order to provide auth information for remote cache."
-            )
         if bootstrap_options.remote_oauth_bearer_token_path:
             return cls._use_oauth_token(bootstrap_options), None
-        if bootstrap_options.remote_auth_plugin or remote_auth_plugin_func is not None:
+        if remote_auth_plugin_func is not None:
             return cls._use_auth_plugin(
                 bootstrap_options,
                 full_options=full_options,
                 env=env,
                 prior_result=prior_result,
-                remote_auth_plugin_func_from_entry_point=remote_auth_plugin_func,
+                remote_auth_plugin_func=remote_auth_plugin_func,
             )
         return cls._use_no_auth(bootstrap_options), None
 
@@ -373,19 +349,8 @@ class DynamicRemoteOptions:
         full_options: Options,
         env: CompleteEnvironmentVars,
         prior_result: AuthPluginResult | None,
-        remote_auth_plugin_func_from_entry_point: Callable | None,
+        remote_auth_plugin_func: Callable,
     ) -> tuple[DynamicRemoteOptions, AuthPluginResult | None]:
-        if not remote_auth_plugin_func_from_entry_point:
-            remote_auth_plugin_func = cls._get_auth_plugin_from_option(
-                bootstrap_options.remote_auth_plugin
-            )
-        else:
-            remote_auth_plugin_func = remote_auth_plugin_func_from_entry_point
-            if bootstrap_options.remote_auth_plugin:
-                raise OptionsError(
-                    "remote auth plugin already provided via entry point of a plugin. `[GLOBAL].remote_auth_plugin` should not be specified in options."
-                )
-
         execution = cast(bool, bootstrap_options.remote_execution)
         cache_read = cast(bool, bootstrap_options.remote_cache_read)
         cache_write = cast(bool, bootstrap_options.remote_cache_write)
@@ -416,12 +381,12 @@ class DynamicRemoteOptions:
         if not auth_plugin_result.is_available:
             # NB: This is debug because we expect plugins to log more informative messages.
             logger.debug(
-                f"Disabling remote caching and remote execution because authentication was not available via the plugin {plugin_name} (from `[GLOBAL].remote_auth_plugin`)."
+                f"Disabling remote caching and remote execution because authentication was not available via the plugin {plugin_name} (from remote auth plugin)."
             )
             return cls.disabled(), None
 
         logger.debug(
-            f"`[GLOBAL].remote_auth_plugin` {plugin_name} succeeded. Remote caching/execution will be attempted."
+            f"remote auth plugin {plugin_name} succeeded. Remote caching/execution will be attempted."
         )
         execution_headers = auth_plugin_result.execution_headers
         store_headers = auth_plugin_result.store_headers
@@ -1361,7 +1326,7 @@ class BootstrapOptions:
             This is used by some remote servers for routing. Consult your remote server for
             whether this should be set.
 
-            You can also use `[GLOBAL].remote_auth_plugin` to provide a plugin to dynamically set this value.
+            You can also use remote auth plugin to provide a plugin to dynamically set this value.
             """
         ),
     )
@@ -1388,54 +1353,8 @@ class BootstrapOptions:
 
             If specified, Pants will add a header in the format `authorization: Bearer <token>`.
             You can also manually add this header via `[GLOBAL].remote_execution_headers` and
-            `[GLOBAL].remote_store_headers`, or use `[GLOBAL].remote_auth_plugin` to provide a plugin to
+            `[GLOBAL].remote_store_headers`, or use the remote auth plugin to provide a plugin to
             dynamically set the relevant headers. Otherwise, no authorization will be performed.
-            """
-        ),
-    )
-    remote_auth_plugin = StrOption(
-        default=None,
-        advanced=True,
-        deprecation_start_version="2.15.0.dev2",
-        removal_version="2.16.0.dev1",
-        removal_hint=softwrap(
-            """
-            Remote auth plugins should now provide the function by implementing an entry point called remote_auth.
-
-            If you are developing a plugin, switch to using an entry point.
-
-            If you are only consuming a plugin from someone else, you can delete the remote_auth_plugin option
-            and now only need the plugin to be included in [GLOBAL].plugins
-            """
-        ),
-        help=softwrap(
-            """
-            Path to a plugin to dynamically configure remote caching and execution options.
-
-            Format: `path.to.module:my_func`. Pants will import your module and run your
-            function. Update the `--pythonpath` option to ensure your file is loadable.
-
-            The function should take the kwargs `initial_store_headers: dict[str, str]`,
-            `initial_execution_headers: dict[str, str]`, `options: Options` (from
-            pants.option.options), `env: dict[str, str]`, and
-            `prior_result: AuthPluginResult | None`. It should return an instance of
-            `AuthPluginResult` from `pants.option.global_options`.
-
-            Pants will replace the headers it would normally use with whatever your plugin
-            returns; usually, you should include the `initial_store_headers` and
-            `initial_execution_headers` in your result so that options like
-            `[GLOBAL].remote_store_headers` still work.
-
-            If you return `instance_name`, Pants will replace `[GLOBAL].remote_instance_name`
-            with this value.
-
-            If the returned auth state is `AuthPluginState.UNAVAILABLE`, Pants will disable
-            remote caching and execution.
-
-            If Pantsd is in use, `prior_result` will be the previous
-            `AuthPluginResult` returned by your plugin, which allows you to reuse the result.
-            Otherwise, if Pantsd has been restarted or is not used, the `prior_result` will
-            be `None`.
             """
         ),
     )

--- a/src/python/pants/option/global_options_test.py
+++ b/src/python/pants/option/global_options_test.py
@@ -3,9 +3,8 @@
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
-from textwrap import dedent
+from typing import Callable
 
 import pytest
 
@@ -14,9 +13,37 @@ from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.unions import UnionMembership
 from pants.init.options_initializer import OptionsInitializer
-from pants.option.global_options import DynamicRemoteOptions, GlobalOptions
+from pants.option.global_options import (
+    AuthPluginResult,
+    AuthPluginState,
+    DynamicRemoteOptions,
+    GlobalOptions,
+)
 from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.option_util import create_options_bootstrapper
+
+
+def get_remote_auth_plugin_func(expected_state: AuthPluginState):
+    def auth_func(initial_execution_headers, initial_store_headers, options, **kwargs):
+
+        return AuthPluginResult(
+            plugin_name="pants-unit-tests",
+            state=expected_state,
+            execution_headers={
+                **{k: "baz" for k in initial_execution_headers},
+                "exec": "xyz",
+            },
+            store_headers={
+                **{k: "baz" for k in initial_store_headers},
+                "store": "abc",
+                "store_url": options.for_global_scope().remote_store_address,
+            },
+            instance_name="custom_instance",
+            store_address="grpc://custom_store",
+            execution_address="grpc://custom_exec",
+        )
+
+    return auth_func
 
 
 def create_dynamic_remote_options(
@@ -24,7 +51,7 @@ def create_dynamic_remote_options(
     initial_headers: dict[str, str] | None = None,
     address: str | None = "grpc://fake.url:10",
     token_path: str | None = None,
-    plugin: str | None = None,
+    remote_auth_plugin_func: Callable | None = None,
 ) -> DynamicRemoteOptions:
     if initial_headers is None:
         initial_headers = {}
@@ -38,15 +65,13 @@ def create_dynamic_remote_options(
     ]
     if token_path:
         args.append(f"--remote-oauth-bearer-token-path={token_path}")
-    if plugin:
-        args.append(f"--remote-auth-plugin={plugin}")
     ob = create_options_bootstrapper(args)
     env = CompleteEnvironmentVars({})
     oi = OptionsInitializer(ob)
     _build_config = oi.build_config(ob, env)
     options = oi.options(ob, env, _build_config, union_membership=UnionMembership({}), raise_=False)
     return DynamicRemoteOptions.from_options(
-        options, env, remote_auth_plugin_func=_build_config.remote_auth_plugin_func
+        options, env, remote_auth_plugin_func=remote_auth_plugin_func
     )[0]
 
 
@@ -63,43 +88,10 @@ def test_dynamic_remote_options_oauth_bearer_token_path(tmp_path: Path) -> None:
 
 
 def test_dynamic_remote_options_auth_plugin(tmp_path: Path) -> None:
-    def compute_options(state: str, tempdir: Path) -> DynamicRemoteOptions:
-        # NB: For an unknown reason, if we use the same file name for multiple runs, the plugin
-        # result gets memoized. So, we use a distinct file name.
-        plugin_path = tempdir / f"auth_plugin_{state}.py"
-        plugin_path.touch()
-        plugin_path.write_text(
-            dedent(
-                f"""\
-                from pants.option.global_options import AuthPluginState, AuthPluginResult
-
-                def auth_func(initial_execution_headers, initial_store_headers, options, **kwargs):
-                    return AuthPluginResult(
-                        state=AuthPluginState.{state},
-                        execution_headers={{
-                            **{{k: "baz" for k in initial_execution_headers}},
-                            "exec": "xyz",
-                        }},
-                        store_headers={{
-                            **{{k: "baz" for k in initial_store_headers}},
-                            "store": "abc",
-                            "store_url": options.for_global_scope().remote_store_address,
-                        }},
-                        instance_name="custom_instance",
-                        store_address="grpc://custom_store",
-                        execution_address="grpc://custom_exec",
-                    )
-                """
-            )
-        )
-        sys.path.append(tempdir.as_posix())
-        result = create_dynamic_remote_options(
-            initial_headers={"foo": "bar"}, plugin=f"auth_plugin_{state}:auth_func"
-        )
-        sys.path.pop()
-        return result
-
-    opts = compute_options("OK", tmp_path)
+    opts = create_dynamic_remote_options(
+        initial_headers={"foo": "bar"},
+        remote_auth_plugin_func=get_remote_auth_plugin_func(AuthPluginState.OK),
+    )
     assert opts.store_headers == {
         "store": "abc",
         "foo": "baz",
@@ -114,7 +106,10 @@ def test_dynamic_remote_options_auth_plugin(tmp_path: Path) -> None:
     assert opts.store_address == "http://custom_store"
     assert opts.execution_address == "http://custom_exec"
 
-    opts = compute_options("UNAVAILABLE", tmp_path)
+    opts = create_dynamic_remote_options(
+        initial_headers={"foo": "bar"},
+        remote_auth_plugin_func=get_remote_auth_plugin_func(AuthPluginState.UNAVAILABLE),
+    )
     assert opts.cache_read is False
     assert opts.cache_write is False
     assert opts.execution is False


### PR DESCRIPTION

More context:
https://github.com/pantsbuild/pants/pull/16691
https://github.com/pantsbuild/pants/pull/16212