### PR TITLE
Process output capturing is symlink-aware

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -36,7 +36,7 @@ use bytes::Bytes;
 use clap::{Arg, Command};
 use fs::{
   DirectoryDigest, GlobExpansionConjunction, GlobMatching, Permissions, PreparedPathGlobs,
-  RelativePath, StrictGlobMatching,
+  RelativePath, StrictGlobMatching, SymlinkBehavior,
 };
 use futures::future::{self, BoxFuture};
 use futures::FutureExt;
@@ -576,7 +576,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         )
         .parse()?;
         let paths = posix_fs
-          .expand_globs(path_globs, None)
+          .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
           .await
           .map_err(|e| format!("Error expanding globs: {:?}", e))?;
 

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -387,6 +387,10 @@ impl<'a> From<&'a PathStat> for TypedPath<'a> {
         path,
         is_executable: stat.is_executable,
       },
+      PathStat::Link { path, stat } => TypedPath::Link {
+        path,
+        target: &stat.target,
+      },
       PathStat::Dir { path, .. } => TypedPath::Dir(path),
     }
   }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -677,7 +677,14 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
   ) -> Result<bool, E> {
     // Filter directory listing to append PathStats, with no continuation.
     let path_stats = self
-      .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude, symlink_behavior, link_depth)
+      .directory_listing(
+        canonical_dir,
+        symbolic_path,
+        wildcard,
+        &exclude,
+        symlink_behavior,
+        link_depth,
+      )
       .await?;
 
     let mut result = result.lock();
@@ -700,7 +707,14 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
     // Filter directory listing and recurse for matched Dirs.
     let context = self.clone();
     let path_stats = self
-      .directory_listing(canonical_dir, symbolic_path, wildcard, &exclude, symlink_behavior, link_depth)
+      .directory_listing(
+        canonical_dir,
+        symbolic_path,
+        wildcard,
+        &exclude,
+        symlink_behavior,
+        link_depth,
+      )
       .await?;
 
     let path_globs = path_stats

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -351,7 +351,9 @@ async fn memfs_expand_basic() {
   .unwrap();
 
   assert_eq!(
-    fs.expand_globs(globs, None).await.unwrap(),
+    fs.expand_globs(globs, SymlinkBehavior::Oblivious, None)
+      .await
+      .unwrap(),
     vec![
       PathStat::file(
         p1.clone(),

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -87,10 +87,13 @@ async fn stat_symlink() {
   make_file(&dir.path().join(&path), &[], 0o600);
 
   let link_path = PathBuf::from("remarkably_similar_marmoset");
-  std::os::unix::fs::symlink(&dir.path().join(path), dir.path().join(&link_path)).unwrap();
+  std::os::unix::fs::symlink(&dir.path().join(path.clone()), dir.path().join(&link_path)).unwrap();
   assert_eq!(
     posix_fs.stat_sync(link_path.clone()).unwrap().unwrap(),
-    super::Stat::Link(Link(link_path))
+    super::Stat::Link(Link {
+      path: link_path,
+      target: dir.path().join(path)
+    })
   )
 }
 
@@ -190,7 +193,10 @@ async fn scandir() {
         is_executable: true,
       }),
       Stat::Dir(Dir(hammock.clone())),
-      Stat::Link(Link(remarkably_similar_marmoset.clone())),
+      Stat::Link(Link {
+        path: remarkably_similar_marmoset.clone(),
+        target: dir.path().join(&a_marmoset)
+      }),
       Stat::File(File {
         path: sneaky_marmoset.clone(),
         is_executable: false,
@@ -406,6 +412,7 @@ async fn read_mock_files(input: Vec<PathBuf>, posix_fs: &Arc<PosixFS>) -> Vec<St
       let path_stat: PathStat = item.unwrap();
       match path_stat {
         PathStat::Dir { stat, .. } => Stat::Dir(stat),
+        PathStat::Link { stat, .. } => Stat::Link(stat),
         PathStat::File { stat, .. } => Stat::File(stat),
       }
     })

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -166,7 +166,7 @@ impl Snapshot {
       )?);
 
       let path_stats = posix_fs
-        .expand_globs(path_globs, None)
+        .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
         .await
         .map_err(|err| format!("Error expanding globs: {}", err))?;
       Snapshot::from_path_stats(

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -229,7 +229,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, Self::Error> {
     let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
     let path_stats = input_tree
-      .expand_globs(params.globs, None)
+      .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
       .await
       .map_err(|err| format!("Error matching globs against {directory_digest:?}: {}", err))?;
 

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -11,7 +11,7 @@ use testutil::make_file;
 use crate::{OneOffStoreFileByDigest, RelativePath, Snapshot, SnapshotOps, Store, StoreError};
 use fs::{
   Dir, DirectoryDigest, File, GitignoreStyleExcludes, GlobExpansionConjunction, GlobMatching,
-  PathGlobs, PathStat, PosixFS, StrictGlobMatching,
+  PathGlobs, PathStat, PosixFS, StrictGlobMatching, SymlinkBehavior,
 };
 
 pub const STR: &str = "European Burmese";
@@ -559,7 +559,10 @@ pub async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
   )
   .parse()
   .unwrap();
-  let mut v = posix_fs.expand_globs(path_globs, None).await.unwrap();
+  let mut v = posix_fs
+    .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
+    .await
+    .unwrap();
   v.sort_by(|a, b| a.path().cmp(b.path()));
   v
 }

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -125,7 +125,7 @@ impl CommandRunner {
     .parse()?;
 
     let path_stats = posix_fs
-      .expand_globs(output_globs, SymlinkBehavior::Oblivious, None)
+      .expand_globs(output_globs, SymlinkBehavior::Aware, None)
       .map_err(|err| format!("Error expanding output globs: {}", err))
       .await?;
     Snapshot::from_path_stats(

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
 use fs::{
   self, DirectoryDigest, GlobExpansionConjunction, GlobMatching, PathGlobs, Permissions,
-  RelativePath, StrictGlobMatching, EMPTY_DIRECTORY_DIGEST,
+  RelativePath, StrictGlobMatching, SymlinkBehavior, EMPTY_DIRECTORY_DIGEST,
 };
 use futures::stream::{BoxStream, StreamExt, TryStreamExt};
 use futures::{try_join, FutureExt, TryFutureExt};
@@ -125,7 +125,7 @@ impl CommandRunner {
     .parse()?;
 
     let path_stats = posix_fs
-      .expand_globs(output_globs, None)
+      .expand_globs(output_globs, SymlinkBehavior::Oblivious, None)
       .map_err(|err| format!("Error expanding output globs: {}", err))
       .await?;
     Snapshot::from_path_stats(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -29,7 +29,7 @@ use crate::tasks::{self, Rule};
 use fs::{
   self, DigestEntry, Dir, DirectoryDigest, DirectoryListing, File, FileContent, FileEntry,
   GlobExpansionConjunction, GlobMatching, Link, PathGlobs, PathStat, PreparedPathGlobs,
-  RelativePath, StrictGlobMatching, SymlinkEntry, Vfs,
+  RelativePath, StrictGlobMatching, SymlinkBehavior, SymlinkEntry, Vfs,
 };
 use process_execution::{
   self, CacheName, InputDigests, Process, ProcessCacheScope, ProcessResultSource,
@@ -664,7 +664,11 @@ impl Paths {
 
   async fn create(context: Context, path_globs: PreparedPathGlobs) -> NodeResult<Vec<PathStat>> {
     context
-      .expand_globs(path_globs, unmatched_globs_additional_context())
+      .expand_globs(
+        path_globs,
+        SymlinkBehavior::Oblivious,
+        unmatched_globs_additional_context(),
+      )
       .map_err(|e| throw(format!("{}", e)))
       .await
   }
@@ -676,6 +680,9 @@ impl Paths {
       match ps {
         &PathStat::File { ref path, .. } => {
           files.push(Snapshot::store_path(py, path)?);
+        }
+        &PathStat::Link { ref path, .. } => {
+          panic!("Paths shouldn't be symlink-aware {path:?}");
         }
         &PathStat::Dir { ref path, .. } => {
           dirs.push(Snapshot::store_path(py, path)?);
@@ -919,7 +926,11 @@ impl Snapshot {
     // We rely on Context::expand_globs to track dependencies for scandirs,
     // and `context.get(DigestFile)` to track dependencies for file digests.
     let path_stats = context
-      .expand_globs(path_globs, unmatched_globs_additional_context())
+      .expand_globs(
+        path_globs,
+        SymlinkBehavior::Oblivious,
+        unmatched_globs_additional_context(),
+      )
       .map_err(|e| throw(format!("{}", e)))
       .await?;
 
@@ -1261,7 +1272,7 @@ impl NodeKey {
   pub fn fs_subject(&self) -> Option<&Path> {
     match self {
       &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
-      &NodeKey::ReadLink(ref s) => Some((s.0).0.as_path()),
+      &NodeKey::ReadLink(ref s) => Some((s.0).path.as_path()),
       &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
 
       // Not FS operations:
@@ -1352,7 +1363,9 @@ impl NodeKey {
       NodeKey::DigestFile(DigestFile(File { path, .. })) => {
         Some(format!("Fingerprinting: {}", path.display()))
       }
-      NodeKey::ReadLink(ReadLink(Link(path))) => Some(format!("Reading link: {}", path.display())),
+      NodeKey::ReadLink(ReadLink(Link { path, .. })) => {
+        Some(format!("Reading link: {}", path.display()))
+      }
       NodeKey::Scandir(Scandir(Dir(path))) => {
         Some(format!("Reading directory: {}", path.display()))
       }
@@ -1543,7 +1556,7 @@ impl Display for NodeKey {
       &NodeKey::ExecuteProcess(ref s) => {
         write!(f, "Process({})", s.process.description)
       }
-      &NodeKey::ReadLink(ref s) => write!(f, "ReadLink({})", (s.0).0.display()),
+      &NodeKey::ReadLink(ref s) => write!(f, "ReadLink({})", (s.0).path.display()),
       &NodeKey::Scandir(ref s) => write!(f, "Scandir({})", (s.0).0.display()),
       &NodeKey::Select(ref s) => write!(f, "{}", s.product),
       &NodeKey::Task(ref task) => {


### PR DESCRIPTION
Fixes #16854 

Change is minimal, wire `symlink_behavior` through the Rust code, setting it to `Oblivious` most places except process output collection. Then when we are collecting path stats and are told to be `Aware`, we return a `Symlink` stat.

Easy peasy.