### PR TITLE
Docs: improve docs on handling option values in cli

### DIFF
--- a/docs/markdown/Using Pants/concepts/options.md
+++ b/docs/markdown/Using Pants/concepts/options.md
@@ -184,6 +184,8 @@ You can also leave off the `[]` to _append_ elements. So we can rewrite the abov
 ./pants --scope-listopt=foo --scope-listopt=bar
 ```
 
+Appending will add to any values from lower-precedence sources, such as config files (`pants.toml`) and possibly Pants's `default`. Otherwise, using `[]` will override any lower-precedence sources.
+
 ### Environment variables:
 
 ```bash


### PR DESCRIPTION
Resurrection of https://github.com/pantsbuild/pants/pull/16738/

---



This PR explains how to override/complement any list values that may have been provided in lower-precedence sources. Current documentation page is here.

For example, having

```
[coverage-py]
report = ["xml"]
```

and running

```
./pants test --use-coverage --coverage-py-report=html ::
...
Wrote xml coverage report to `dist/coverage_results`
Wrote html coverage report to `dist/coverage_results`
```

I found this behaviour not obvious (thinking that only the HTML report will be produced), hence the PR.

[ci skip-rust]
[ci skip-build-wheels]
