### PR TITLE
support Go data race detector

### DIFF
--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -69,15 +69,15 @@ class GoTestSubsystem(Subsystem):
 
     skip = SkipOption("test")
 
-    with_race = BoolOption(
+    force_race = BoolOption(
         default=False,
         help=softwrap(
             f"""
-            If true, then enable the Go data race detector when running tests. The use of the race detector can also
-            be controlled on a test-by-test basis by setting the `{GoTestRaceDetectorEnabledField.alias}` field to
-            `True` on the relevant `{GoPackageTarget.alias}` target.
+            If true, then always enable the Go data race detector when running tests regardless of the
+            test-by-test `{GoTestRaceDetectorEnabledField.alias}` field on the relevant `{GoPackageTarget.alias}`
+            target.
 
-            See https://go.dev/doc/articles/race_detector for additional information about the data race detector.
+            See https://go.dev/doc/articles/race_detector for additional information about the Go data race detector.
             """
         ),
     )

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import PurePath
 
+from pants.backend.go.target_types import GoPackageTarget, GoTestRaceDetectorEnabledField
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.core.util_rules.distdir import DistDir
 from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, SkipOption, StrOption
@@ -67,6 +68,19 @@ class GoTestSubsystem(Subsystem):
     )
 
     skip = SkipOption("test")
+
+    with_race = BoolOption(
+        default=False,
+        help=softwrap(
+            f"""
+            If true, then enable the Go data race detector when running tests. The use of the race detector can also
+            be controlled on a test-by-test basis by setting the `{GoTestRaceDetectorEnabledField.alias}` field to
+            `True` on the relevant `{GoPackageTarget.alias}` target.
+
+            See https://go.dev/doc/articles/race_detector for additional information about the data race detector.
+            """
+        ),
+    )
 
     def coverage_output_dir(self, distdir: DistDir, import_path: str) -> PurePath:
         import_path_escaped = import_path.replace("/", "_")

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -304,6 +304,7 @@ class GoBinaryTarget(Target):
         GoBinaryMainPackageField,
         GoBinaryDependenciesField,
         GoCgoEnabledField,
+        GoRaceDetectorEnabledField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -53,6 +53,23 @@ class GoCgoEnabledField(TriBoolField):
     )
 
 
+class GoRaceDetectorEnabledField(TriBoolField):
+    """Enables the Go data race detector."""
+
+    alias = "with_race"
+    help = softwrap(
+        """
+        Enable compiling the binary with the Go data race detector.
+
+        See https://go.dev/doc/articles/race_detector for additional information about the data race detector.
+        """
+    )
+
+
+class GoTestRaceDetectorEnabledField(GoRaceDetectorEnabledField):
+    alias = "test_with_race"
+
+
 # -----------------------------------------------------------------------------------------------
 # `go_third_party_package` target
 # -----------------------------------------------------------------------------------------------
@@ -164,6 +181,7 @@ class GoModTarget(TargetGenerator):
         GoModDependenciesField,
         GoModSourcesField,
         GoCgoEnabledField,
+        GoRaceDetectorEnabledField,
     )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = ()
@@ -241,6 +259,7 @@ class GoPackageTarget(Target):
         GoPackageSourcesField,
         GoTestExtraEnvVarsField,
         GoTestTimeoutField,
+        GoTestRaceDetectorEnabledField,
         SkipGoTestsField,
     )
     help = softwrap(

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -56,18 +56,25 @@ class GoCgoEnabledField(TriBoolField):
 class GoRaceDetectorEnabledField(TriBoolField):
     """Enables the Go data race detector."""
 
-    alias = "with_race"
+    alias = "race"
     help = softwrap(
         """
         Enable compiling the binary with the Go data race detector.
 
-        See https://go.dev/doc/articles/race_detector for additional information about the data race detector.
+        See https://go.dev/doc/articles/race_detector for additional information about the Go data race detector.
         """
     )
 
 
 class GoTestRaceDetectorEnabledField(GoRaceDetectorEnabledField):
-    alias = "test_with_race"
+    alias = "test_race"
+    help = softwrap(
+        """
+        Enable compiling this package's test binary with the Go data race detector.
+
+        See https://go.dev/doc/articles/race_detector for additional information about the Go data race detector.
+        """
+    )
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -99,8 +99,10 @@ async def go_extract_build_options_from_target(
     if cgo_enabled is None:
         cgo_enabled = golang.cgo_enabled
 
-    # Extract the `with_race` value for this target.
+    # Extract the `with_race_detector` value for this target.
     with_race_detector: bool | None = None
+    if go_test_subsystem.force_race:
+        with_race_detector = True
     if test_target_fields is not None and test_target_fields.test_race.value is not None:
         with_race_detector = test_target_fields.test_race.value
     if with_race_detector is None:
@@ -110,7 +112,7 @@ async def go_extract_build_options_from_target(
         if go_mod_target_fields.race is not None:
             with_race_detector = go_mod_target_fields.race.value
     if with_race_detector is None:
-        with_race_detector = go_test_subsystem.with_race
+        with_race_detector = False
 
     return GoBuildOptions(
         cgo_enabled=cgo_enabled,

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -43,14 +43,14 @@ class GoBuildOptionsFieldSet(FieldSet):
     required_fields = (GoCgoEnabledField,)
 
     cgo_enabled: GoCgoEnabledField
-    with_race: GoRaceDetectorEnabledField
+    race: GoRaceDetectorEnabledField
 
 
 @dataclass(frozen=True)
 class GoTestBuildOptionsFieldSet(FieldSet):
     required_fields = (GoTestRaceDetectorEnabledField,)
 
-    with_race: GoTestRaceDetectorEnabledField
+    test_race: GoTestRaceDetectorEnabledField
 
 
 @rule
@@ -101,14 +101,14 @@ async def go_extract_build_options_from_target(
 
     # Extract the `with_race` value for this target.
     with_race_detector: bool | None = None
-    if test_target_fields is not None and test_target_fields.with_race.value is not None:
-        with_race_detector = test_target_fields.with_race.value
+    if test_target_fields is not None and test_target_fields.test_race.value is not None:
+        with_race_detector = test_target_fields.test_race.value
     if with_race_detector is None:
-        if target_fields is not None and target_fields.with_race.value is not None:
-            with_race_detector = target_fields.with_race.value
+        if target_fields is not None and target_fields.race.value is not None:
+            with_race_detector = target_fields.race.value
     if with_race_detector is None:
-        if go_mod_target_fields.with_race is not None:
-            with_race_detector = go_mod_target_fields.with_race.value
+        if go_mod_target_fields.race is not None:
+            with_race_detector = go_mod_target_fields.race.value
     if with_race_detector is None:
         with_race_detector = go_test_subsystem.with_race
 

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -110,13 +110,15 @@ async def go_extract_build_options_from_target(
         cgo_enabled = golang.cgo_enabled
 
     # Extract the `with_race_detector` value for this target.
-    with_race_detector = _first_non_none_value([
-        True if go_test_subsystem.force_race and test_target_fields else None,
-        test_target_fields.test_race.value if test_target_fields else None ,
-        target_fields.race.value if target_fields else None,
-        go_mod_target_fields.race.value if go_mod_target_fields else None,
-        False,
-    ])
+    with_race_detector = _first_non_none_value(
+        [
+            True if go_test_subsystem.force_race and test_target_fields else None,
+            test_target_fields.test_race.value if test_target_fields else None,
+            target_fields.race.value if target_fields else None,
+            go_mod_target_fields.race.value if go_mod_target_fields else None,
+            False,
+        ]
+    )
 
     return GoBuildOptions(
         cgo_enabled=cgo_enabled,

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -47,6 +47,10 @@ def test_race_detector_fields_work_as_expected(rule_runner: RuleRunner) -> None:
             func main() {}
             """
             ),
+            f"{dir_path}/pkg_race_false/BUILD": "go_package(test_race=False)\n",
+            f"{dir_path}/pkg_race_false/foo.go": "package pkg_race_false\n",
+            f"{dir_path}/pkg_race_true/BUILD": "go_package(test_race=True)\n",
+            f"{dir_path}/pkg_race_true/foo.go": "package pkg_race_true\n",
         }
 
     rule_runner.write_files(
@@ -87,7 +91,20 @@ def test_race_detector_fields_work_as_expected(rule_runner: RuleRunner) -> None:
     assert_value(
         Address("mod_race_unspecified", target_name="pkg"),
         False,
+        for_tests=True,
         msg="for go_package when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified/pkg_race_false"),
+        False,
+        for_tests=True,
+        msg="for go_package(test_race=False) when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified/pkg_race_true"),
+        True,
+        for_tests=True,
+        msg="for go_package(test_race=True) when unspecified on go_mod",
     )
     assert_value(
         Address("mod_race_unspecified", target_name="mod"),
@@ -114,7 +131,20 @@ def test_race_detector_fields_work_as_expected(rule_runner: RuleRunner) -> None:
     assert_value(
         Address("mod_race_false", target_name="pkg"),
         False,
+        for_tests=True,
         msg="for go_package when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false/pkg_race_false"),
+        False,
+        for_tests=True,
+        msg="for go_package(test_race=False) when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false/pkg_race_true"),
+        True,
+        for_tests=True,
+        msg="for go_package(test_race=True) when race=False on go_mod",
     )
     assert_value(
         Address("mod_race_false", target_name="mod"),
@@ -141,10 +171,38 @@ def test_race_detector_fields_work_as_expected(rule_runner: RuleRunner) -> None:
     assert_value(
         Address("mod_race_true", target_name="pkg"),
         True,
+        for_tests=True,
         msg="for go_package when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true/pkg_race_false"),
+        False,
+        for_tests=True,
+        msg="for go_package(test_race=False) when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true/pkg_race_true"),
+        True,
+        for_tests=True,
+        msg="for go_package(test_race=True) when race=True on go_mod",
     )
     assert_value(
         Address("mod_race_true", target_name="mod"),
         True,
         msg="for go_mod when race=True on go_mod",
+    )
+
+    # Test when `--go-test-force-race` is in effect.
+    rule_runner.set_options(["--go-test-force-race"], env_inherit={"PATH"})
+    assert_value(
+        Address("mod_race_unspecified", target_name="pkg"),
+        True,
+        for_tests=True,
+        msg="for go_package when --go-test-force-race and when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false", target_name="pkg"),
+        True,
+        for_tests=True,
+        msg="for go_package when --go-test-force-race and when race=False on go_mod",
     )

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -1,0 +1,150 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.util_rules import build_opts
+from pants.backend.go.util_rules.build_opts import GoBuildOptions, GoBuildOptionsFromTargetRequest
+from pants.build_graph.address import Address
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *build_opts.rules(),
+            QueryRule(GoBuildOptions, (GoBuildOptionsFromTargetRequest,)),
+        ],
+        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_race_detector_fields_work_as_expected(rule_runner: RuleRunner) -> None:
+    def module_files(dir_path: str, value: bool | None) -> dict:
+        race_field = f", race={value}" if value is not None else ""
+        return {
+            f"{dir_path}/BUILD": dedent(
+                f"""\
+            go_mod(name="mod"{race_field})
+            go_package(name="pkg")
+            go_binary(name="bin_with_race_unspecified")
+            go_binary(name="bin_with_race_false", race=False)
+            go_binary(name="bin_with_race_true", race=True)
+            """
+            ),
+            f"{dir_path}/go.mod": f"module test.pantsbuild.org/{dir_path}\n",
+            f"{dir_path}/main.go": dedent(
+                """\
+            package main
+            func main() {}
+            """
+            ),
+        }
+
+    rule_runner.write_files(
+        {
+            **module_files("mod_race_unspecified", None),
+            **module_files("mod_race_false", False),
+            **module_files("mod_race_true", True),
+        }
+    )
+
+    def assert_value(
+        address: Address, expected_value: bool, *, for_tests: bool = False, msg: str
+    ) -> None:
+        opts = rule_runner.request(
+            GoBuildOptions,
+            (GoBuildOptionsFromTargetRequest(address=address, for_tests=for_tests),),
+        )
+        assert (
+            opts.with_race_detector is expected_value
+        ), f"{address}: expected {expected_value} {msg}"
+
+    # go_mod does not specify a value for `race`
+    assert_value(
+        Address("mod_race_unspecified", target_name="bin_with_race_unspecified"),
+        False,
+        msg="when unspecified on go_binary and when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified", target_name="bin_with_race_false"),
+        False,
+        msg="when race=False on go_binary and when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified", target_name="bin_with_race_true"),
+        True,
+        msg="when race=True on go_binary and when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified", target_name="pkg"),
+        False,
+        msg="for go_package when unspecified on go_mod",
+    )
+    assert_value(
+        Address("mod_race_unspecified", target_name="mod"),
+        False,
+        msg="for go_mod when unspecified on go_mod",
+    )
+
+    # go_mod specifies False for `race`
+    assert_value(
+        Address("mod_race_false", target_name="bin_with_race_unspecified"),
+        False,
+        msg="when unspecified on go_binary and when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false", target_name="bin_with_race_false"),
+        False,
+        msg="when race=False on go_binary and when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false", target_name="bin_with_race_true"),
+        True,
+        msg="when race=True on go_binary and when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false", target_name="pkg"),
+        False,
+        msg="for go_package when race=False on go_mod",
+    )
+    assert_value(
+        Address("mod_race_false", target_name="mod"),
+        False,
+        msg="for go_mod when race=False on go_mod",
+    )
+
+    # go_mod specifies True for `race`
+    assert_value(
+        Address("mod_race_true", target_name="bin_with_race_unspecified"),
+        True,
+        msg="when unspecified on go_binary and when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true", target_name="bin_with_race_false"),
+        False,
+        msg="when race=False on go_binary and when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true", target_name="bin_with_race_true"),
+        True,
+        msg="when race=True on go_binary and when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true", target_name="pkg"),
+        True,
+        msg="for go_package when race=True on go_mod",
+    )
+    assert_value(
+        Address("mod_race_true", target_name="mod"),
+        True,
+        msg="for go_mod when race=True on go_mod",
+    )

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -523,6 +523,9 @@ async def build_go_package(
     if embedcfg.digest != EMPTY_DIGEST:
         compile_args.extend(["-embedcfg", RenderedEmbedConfig.PATH])
 
+    if request.build_opts.with_race_detector:
+        compile_args.append("-race")
+
     # If there are no loose object files to add to the package archive later, then pass -complete flag which
     # tells the compiler that the provided Go files constitute the entire package.
     if not objects:


### PR DESCRIPTION
Support the Go data race detector.

Adds a `race` field to the `go_mod` and `go_binary` target types and a `test_race` field to for `go_package` for tests. The `--go-test-force-race` option will enable the race detector for tests regardless of the fields. The "outermost" relevant field will take effect; that is, a `race` field on `go_binary` will override any `race` field on the relevant `go_mod`,  and with tests a `test_race` field on the relevant `go_package` will override any `race` field on the relevant `go_mod`.

See https://go.dev/doc/articles/race_detector for additional information about the Go data race detector.

Fixes https://github.com/pantsbuild/pants/issues/17437.