### PR TITLE
Fix memoization of `CoarsenedTarget.closure`

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -816,7 +816,7 @@ class CoarsenedTarget(EngineAwareParameter):
     ) -> Iterator[CoarsenedTarget]:
         """All CoarsenedTargets reachable from this root."""
 
-        visited = visited or set()
+        visited = set() if visited is None else visited
         queue = deque([self])
         while queue:
             ct = queue.popleft()


### PR DESCRIPTION
Memoization of `CoarsenedTargets.closure()` relies on shared memoization across a walk in each `CoarsenedTarget`. That memoization was not working.

Fixes #17509.