### PR TITLE
WIP: Immutably symlink "large" files in a sandbox

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -46,7 +46,7 @@ use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
 use protos::require_digest;
 use serde_derive::Serialize;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use store::{
   Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest, SubsetParams, UploadSummary,
 };
@@ -535,7 +535,13 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           output_digest_opt.ok_or_else(|| ExitError("not found".into(), ExitCode::NotFound))?;
         Ok(
           store
-            .materialize_directory(destination, output_digest, Permissions::Writable)
+            .materialize_directory(
+              destination,
+              output_digest,
+              &BTreeSet::new(),
+              None,
+              Permissions::Writable,
+            )
             .await?,
         )
       }
@@ -553,7 +559,13 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         let digest = DirectoryDigest::from_persisted_digest(Digest::new(fingerprint, size_bytes));
         Ok(
           store
-            .materialize_directory(destination, digest, Permissions::Writable)
+            .materialize_directory(
+              destination,
+              digest,
+              &BTreeSet::new(),
+              None,
+              Permissions::Writable,
+            )
             .await?,
         )
       }

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -74,7 +74,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
               let dest = new_temp.path().to_path_buf();
               std::mem::forget(new_temp);
               let _ = executor
-                .block_on(store.materialize_directory(dest, digest.clone(), perms))
+                .block_on(store.materialize_directory(dest, digest.clone(), None, perms))
                 .unwrap();
             })
           },

--- a/src/rust/engine/fs/store/src/immutable_inputs.rs
+++ b/src/rust/engine/fs/store/src/immutable_inputs.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -6,10 +6,16 @@ use async_oncecell::OnceCell;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::Digest;
 use parking_lot::Mutex;
-use store::{Store, StoreError};
 use tempfile::TempDir;
 
-use crate::WorkdirSymlink;
+use crate::{Store, StoreError};
+
+/// A symlink from a relative src to an absolute dst (outside of the workdir).
+#[derive(Debug)]
+pub struct WorkdirSymlink {
+  pub src: RelativePath,
+  pub dst: PathBuf,
+}
 
 struct Inner {
   store: Store,
@@ -49,7 +55,74 @@ impl ImmutableInputs {
   }
 
   /// Returns an absolute Path to immutably consume the given Digest from.
-  async fn path(&self, directory_digest: DirectoryDigest) -> Result<PathBuf, StoreError> {
+  pub(crate) async fn path_for_file(
+    &self,
+    digest: Digest,
+    mode: u32,
+  ) -> Result<PathBuf, StoreError> {
+    let cell = self.0.contents.lock().entry(digest).or_default().clone();
+
+    // We (might) need to initialize the value.
+    //
+    // Because this code executes a side-effect which could be observed elsewhere within this
+    // process (other threads can observe the contents of the temporary directory), we need to
+    // ensure that if this method is cancelled (via async Drop), whether the cell has been
+    // initialized or not stays in sync with whether the side-effect is visible.
+    //
+    // Making the initialization "cancellation safe", involves either:
+    //
+    //   1. Adding a Drop guard to "undo" the side-effect if we're dropped before we fully
+    //      initialize the cell.
+    //       * This is challenging to do correctly in this case, because the `Drop` guard cannot
+    //         be created until after initialization begins, but cannot be cleared until after the
+    //         cell has been initialized (i.e., after `get_or_try_init` returns).
+    //   2. Shielding ourselves from cancellation by `spawn`ing a new Task to guarantee that the
+    //      cell initialization always runs to completion.
+    //       * This would work, but would mean that we would finish initializing cells even when
+    //         work was cancelled. Cancellation usually means that the work is no longer necessary,
+    //         and so that could result in a lot of spurious IO (in e.g. warm cache cases which
+    //         never end up actually needing any inputs).
+    //       * An advanced variant of this approach would be to _pause_ work on materializing a
+    //         Digest when demand for it disappeared, and resume the work if another caller
+    //         requested that Digest.
+    //   3. Using anonymous destination paths, such that multiple attempts to initialize cannot
+    //      collide.
+    //       * This means that although the side-effect is visible, it can never collide.
+    //
+    // We take the final approach here currently (for simplicity's sake), but the advanced variant
+    // of approach 2 might eventually be worthwhile.
+    cell
+      .get_or_try_init(async {
+        let chroot = TempDir::new_in(self.0.workdir.path()).map_err(|e| {
+          format!(
+            "Failed to create a temporary directory for materialization of immutable input \
+          digest {:?}: {}",
+            digest, e
+          )
+        })?;
+
+        let dest = chroot.path().join(digest.hash.to_hex());
+        self
+          .0
+          .store
+          .materialize_file(dest.clone(), digest, mode)
+          .await?;
+
+        // Now that we've successfully initialized the destination, forget the TempDir so that it
+        // is not cleaned up.
+        let _ = chroot.into_path();
+
+        Ok(dest)
+      })
+      .await
+      .cloned()
+  }
+
+  /// Returns an absolute Path to immutably consume the given Digest from.
+  pub(crate) async fn path_for_dir(
+    &self,
+    directory_digest: DirectoryDigest,
+  ) -> Result<PathBuf, StoreError> {
     let digest = directory_digest.as_digest();
     let cell = self.0.contents.lock().entry(digest).or_default().clone();
 
@@ -96,7 +169,13 @@ impl ImmutableInputs {
         self
           .0
           .store
-          .materialize_directory(dest.clone(), directory_digest, Permissions::ReadOnly)
+          .materialize_directory(
+            dest.clone(),
+            directory_digest,
+            &BTreeSet::new(),
+            Some(self),
+            Permissions::ReadOnly,
+          )
           .await?;
 
         // Now that we've successfully initialized the destination, forget the TempDir so that it
@@ -112,14 +191,14 @@ impl ImmutableInputs {
   ///
   /// Returns symlinks to create for the given set of immutable cache paths.
   ///
-  pub(crate) async fn local_paths(
+  pub async fn local_paths(
     &self,
     immutable_inputs: &BTreeMap<RelativePath, DirectoryDigest>,
   ) -> Result<Vec<WorkdirSymlink>, StoreError> {
     let dsts = futures::future::try_join_all(
       immutable_inputs
         .values()
-        .map(|d| self.path(d.clone()))
+        .map(|d| self.path_for_dir(d.clone()))
         .collect::<Vec<_>>(),
     )
     .await?;

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use cache::PersistentCache;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
-use store::Store;
+use store::{ImmutableInputs, Store};
 use tempfile::TempDir;
 use testutil::data::TestData;
 use testutil::relative_paths;
@@ -12,7 +12,7 @@ use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
   local::KeepSandboxes, CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
-  FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Process, ProcessError,
+  FallibleProcessResultWithPlatform, NamedCaches, Process, ProcessError,
 };
 
 struct RoundtripResults {

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -16,7 +16,7 @@ use log::Level;
 use nails::execution::ExitCode;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
-use store::Store;
+use store::{ImmutableInputs, Store};
 use task_executor::Executor;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
@@ -25,8 +25,8 @@ use crate::local::{
   KeepSandboxes,
 };
 use crate::{
-  Context, FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Platform, Process,
-  ProcessError, ProcessExecutionStrategy,
+  Context, FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, ProcessError,
+  ProcessExecutionStrategy,
 };
 
 pub(crate) const SANDBOX_BASE_PATH_IN_CONTAINER: &str = "/pants-sandbox";

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -64,8 +64,6 @@ pub mod docker;
 #[cfg(test)]
 mod docker_tests;
 
-pub mod immutable_inputs;
-
 pub mod local;
 #[cfg(test)]
 mod local_tests;
@@ -85,7 +83,6 @@ mod remote_cache_tests;
 extern crate uname;
 
 pub use crate::children::ManagedChild;
-pub use crate::immutable_inputs::ImmutableInputs;
 pub use crate::named_caches::{CacheName, NamedCaches};
 pub use crate::remote_cache::RemoteCacheWarningsBehavior;
 
@@ -252,13 +249,6 @@ impl TryFrom<String> for ProcessCacheScope {
 
 fn serialize_level<S: serde::Serializer>(level: &log::Level, s: S) -> Result<S::Ok, S::Error> {
   s.serialize_str(&level.to_string())
-}
-
-/// A symlink from a relative src to an absolute dst (outside of the workdir).
-#[derive(Debug)]
-pub struct WorkdirSymlink {
-  pub src: RelativePath,
-  pub dst: PathBuf,
 }
 
 /// Input Digests for a process execution.

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -25,7 +25,9 @@ use futures::{try_join, FutureExt, TryFutureExt};
 use log::{debug, info};
 use nails::execution::ExitCode;
 use shell_quote::bash;
-use store::{OneOffStoreFileByDigest, Snapshot, Store, StoreError};
+use store::{
+  ImmutableInputs, OneOffStoreFileByDigest, Snapshot, Store, StoreError, WorkdirSymlink,
+};
 use task_executor::Executor;
 use tempfile::TempDir;
 use tokio::process::{Child, Command};
@@ -35,8 +37,8 @@ use tokio_util::codec::{BytesCodec, FramedRead};
 use workunit_store::{in_workunit, Level, Metric, RunningWorkunit};
 
 use crate::{
-  Context, FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Platform, Process,
-  ProcessError, ProcessResultMetadata, ProcessResultSource, WorkdirSymlink,
+  Context, FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, ProcessError,
+  ProcessResultMetadata, ProcessResultSource,
 };
 
 pub const USER_EXECUTABLE_MODE: u32 = 0o100755;
@@ -704,11 +706,15 @@ pub async fn prepare_workdir(
   // non-determinism when paths overlap: see the method doc.
   let store2 = store.clone();
   let workdir_path_2 = workdir_path.clone();
+  let mut mutable_paths = req.output_files.clone();
+  mutable_paths.append(&mut req.output_directories.clone());
   in_workunit!("setup_sandbox", Level::Debug, |_workunit| async move {
     store2
       .materialize_directory(
         workdir_path_2,
         materialized_input_digest,
+        &mutable_paths,
+        Some(immutable_inputs),
         Permissions::Writable,
       )
       .await

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -9,7 +9,7 @@ use spectral::{assert_that, string::StrAssertions};
 use tempfile::TempDir;
 
 use fs::EMPTY_DIRECTORY_DIGEST;
-use store::Store;
+use store::{ImmutableInputs, Store};
 use testutil::data::{TestData, TestDirectory};
 use testutil::path::{find_bash, which};
 use testutil::{owned_string_vec, relative_paths};
@@ -17,8 +17,8 @@ use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
   local, local::KeepSandboxes, CacheName, CommandRunner as CommandRunnerTrait, Context,
-  FallibleProcessResultWithPlatform, ImmutableInputs, InputDigests, NamedCaches, Platform, Process,
-  ProcessError, RelativePath,
+  FallibleProcessResultWithPlatform, InputDigests, NamedCaches, Platform, Process, ProcessError,
+  RelativePath,
 };
 
 #[derive(PartialEq, Debug)]

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -8,15 +8,15 @@ use futures::future::{FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt};
 use log::{debug, trace};
 use nails::execution::{self, child_channel, ChildInput, Command};
-use store::Store;
+use store::{ImmutableInputs, Store};
 use task_executor::Executor;
 use tokio::net::TcpStream;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{prepare_workdir, CapturedWorkdir, ChildOutput};
 use crate::{
-  Context, FallibleProcessResultWithPlatform, ImmutableInputs, InputDigests, NamedCaches, Platform,
-  Process, ProcessError,
+  Context, FallibleProcessResultWithPlatform, InputDigests, NamedCaches, Platform, Process,
+  ProcessError,
 };
 
 #[cfg(test)]

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -20,12 +20,12 @@ use tempfile::TempDir;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use hashing::Fingerprint;
-use store::Store;
+use store::{ImmutableInputs, Store};
 use task_executor::Executor;
 use workunit_store::{in_workunit, Level};
 
 use crate::local::prepare_workdir;
-use crate::{ImmutableInputs, NamedCaches, Process, ProcessError};
+use crate::{NamedCaches, Process, ProcessError};
 
 lazy_static! {
   static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
-use store::Store;
+use store::{ImmutableInputs, Store};
 use task_executor::Executor;
 use tempfile::TempDir;
 use testutil::owned_string_vec;
 use workunit_store::WorkunitStore;
 
 use crate::nailgun::NailgunPool;
-use crate::{ImmutableInputs, NamedCaches, Process};
+use crate::{NamedCaches, Process};
 
 fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let _ = WorkunitStore::setup_for_tests();

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use deepsize::DeepSizeOf;
 use serde::Serialize;
 
-use crate::WorkdirSymlink;
 use fs::{default_cache_path, safe_create_dir_all_ioerror, RelativePath};
+use store::WorkdirSymlink;
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize)]
 pub struct CacheName(String);

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,14 +36,14 @@ use std::time::Duration;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  local::KeepSandboxes, CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches,
-  Platform, ProcessCacheScope, ProcessExecutionStrategy,
+  local::KeepSandboxes, CacheContentBehavior, Context, InputDigests, NamedCaches, Platform,
+  ProcessCacheScope, ProcessExecutionStrategy,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
 use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
-use store::Store;
+use store::{ImmutableInputs, Store};
 use structopt::StructOpt;
 use workunit_store::{in_workunit, Level, WorkunitStore};
 
@@ -362,7 +362,13 @@ async fn main() {
 
   if let Some(output) = args.materialize_output_to {
     store
-      .materialize_directory(output, result.output_directory, Permissions::Writable)
+      .materialize_directory(
+        output,
+        result.output_directory,
+        &BTreeSet::new(),
+        None,
+        Permissions::Writable,
+      )
       .await
       .unwrap();
   }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -30,12 +30,12 @@ use process_execution::docker::{DOCKER, IMAGE_PULL_CACHE};
 use process_execution::switched::SwitchedCommandRunner;
 use process_execution::{
   self, bounded, docker, local, nailgun, remote, remote_cache, CacheContentBehavior, CommandRunner,
-  ImmutableInputs, NamedCaches, ProcessExecutionStrategy, RemoteCacheWarningsBehavior,
+  NamedCaches, ProcessExecutionStrategy, RemoteCacheWarningsBehavior,
 };
 use protos::gen::build::bazel::remote::execution::v2::ServerCapabilities;
 use regex::Regex;
 use rule_graph::RuleGraph;
-use store::{self, Store};
+use store::{self, ImmutableInputs, Store};
 use task_executor::Executor;
 use watch::{Invalidatable, InvalidationWatcher};
 use workunit_store::{Metric, RunId, RunningWorkunit};
@@ -144,6 +144,7 @@ impl Core {
   fn make_store(
     executor: &Executor,
     local_store_options: &LocalStoreOptions,
+    local_execution_root_dir: &Path,
     enable_remote: bool,
     remoting_opts: &RemotingOptions,
     remote_store_address: &Option<String>,
@@ -153,6 +154,7 @@ impl Core {
     let local_only = Store::local_only_with_options(
       executor.clone(),
       local_store_options.store_dir.clone(),
+      local_execution_root_dir,
       local_store_options.into(),
     )?;
     if enable_remote {
@@ -498,6 +500,7 @@ impl Core {
     let full_store = Self::make_store(
       &executor,
       &local_store_options,
+      &local_execution_root_dir,
       need_remote_store,
       &remoting_opts,
       &remoting_opts.store_address,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -8,7 +8,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::hash_map::HashMap;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::convert::TryInto;
 use std::fs::File;
 use std::hash::Hasher;
@@ -1644,6 +1644,8 @@ fn write_digest(
         .materialize_directory(
           destination.clone(),
           lifted_digest,
+          &BTreeSet::new(),
+          None,
           fs::Permissions::Writable,
         )
         .await


### PR DESCRIPTION
Fixes #17282 and fixes #14070

This change represents the smallest footprint change to get support in for treating "large" files as immutable inputs.

- `immutable_inputs.rs` has been moved to `store` (to avoid circular reference)
- An additional method was added to support a symlink _file_
- Directory materialization takes an `ImmutableInputs` ref and a list of paths to ensure mutable
- When materializing a file, if its above our threshold and not being forced mutable, we symlink it to the immutable inputs
- Process running seeds the mutable paths with the capture outputs

The future is primed for changes like:
- Eventually removing the `immutable_input_digests` to a process, and letting the heuristic take over
- And then cleaning the code up after that's ripped out
- Adding more facilities to includelist/excludelist files from a `Process` object (e.g. we could includelist most/all PEXs since those shouldn't be mutated and we'd just have one top-level symlink)
- IDK more shenanigans :smile: 
