### PR TITLE
Fix leftover `todo!()`

### DIFF
--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -222,6 +222,10 @@ class PathGlobsAndRoot:
 class DigestSubset:
     """A request to get a subset of a digest.
 
+    The digest will be traversed symlink-oblivious to match the provided globs. If you require a
+    symlink-aware subset, you can access the digest's entries `Get(DigestEntries, Digest, digest)`,
+    filter them out, and create a new digest: `Get(Digest, CreateDigest(...))`.
+
     Example:
 
         result = await Get(Digest, DigestSubset(original_digest, PathGlobs(["subdir1", "f.txt"]))

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -58,6 +58,7 @@ async fn merge_directories<T: SnapshotOps + 'static>(
 
   Ok(tree.into())
 }
+
 ///
 /// Render a directory::MergeError (or fail with a less specific error if some content cannot be
 /// loaded).

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -58,7 +58,6 @@ async fn merge_directories<T: SnapshotOps + 'static>(
 
   Ok(tree.into())
 }
-
 ///
 /// Render a directory::MergeError (or fail with a less specific error if some content cannot be
 /// loaded).
@@ -229,7 +228,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, Self::Error> {
     let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
     let path_stats = input_tree
-      .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
+      .expand_globs(params.globs, SymlinkBehavior::Aware, None)
       .await
       .map_err(|err| format!("Error matching globs against {directory_digest:?}: {}", err))?;
 
@@ -238,7 +237,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
       directory::Entry::File(f) => {
         files.insert(path.to_owned(), f.digest());
       }
-      directory::Entry::Symlink(_) => todo!(),
+      directory::Entry::Symlink(_) => (),
       directory::Entry::Directory(_) => (),
     });
 

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -229,16 +229,16 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, Self::Error> {
     let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
     let path_stats = input_tree
-      .expand_globs(params.globs, SymlinkBehavior::Aware, None)
+      .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
       .await
       .map_err(|err| format!("Error matching globs against {directory_digest:?}: {}", err))?;
 
     let mut files = HashMap::new();
-    input_tree.walk(SymlinkBehavior::Aware, &mut |path, entry| match entry {
+    input_tree.walk(SymlinkBehavior::Oblivious, &mut |path, entry| match entry {
       directory::Entry::File(f) => {
         files.insert(path.to_owned(), f.digest());
       }
-      directory::Entry::Symlink(_) => (),
+      directory::Entry::Symlink(_) => panic!("Unexpected symlink"),
       directory::Entry::Directory(_) => (),
     });
 


### PR DESCRIPTION
Fixes the TODO by making subsetting always oblivious