### PR TITLE
Persist digests before emitting them in `fs_util`

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -586,10 +586,10 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         )
         .await?;
 
-        store
-          .ensure_directory_digest_persisted(snapshot.clone().into())
-          .await?;
-        let report = ensure_uploaded_to_remote(&store, store_has_remote, snapshot.digest).await?;
+        let ((), report) = futures::try_join!(
+          store.ensure_directory_digest_persisted(snapshot.clone().into()),
+          ensure_uploaded_to_remote(&store, store_has_remote, snapshot.digest),
+        )?;
         print_upload_summary(args.value_of("output-mode"), &report);
 
         Ok(())

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -586,6 +586,9 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         )
         .await?;
 
+        store
+          .ensure_directory_digest_persisted(snapshot.clone().into())
+          .await?;
         let report = ensure_uploaded_to_remote(&store, store_has_remote, snapshot.digest).await?;
         print_upload_summary(args.value_of("output-mode"), &report);
 


### PR DESCRIPTION
Otherwise they will not have been written to the LMDB store (although they will have been uploaded to any configured remote stores via the `ensure_uploaded_to_remote`).