### PR TITLE
Emit a __run.sh into InteractiveProcess sandboxes.

### DIFF
--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -425,7 +425,13 @@ impl<'a> super::CommandRunner for CommandRunner<'a> {
             && res.as_ref().map(|r| r.exit_code).unwrap_or(1) != 0
         {
           workdir.keep(&req.description);
-          setup_run_sh_script(&req.env, &req.working_directory, &req.argv, workdir.path())?;
+          setup_run_sh_script(
+            workdir.path(),
+            &req.env,
+            &req.working_directory,
+            &req.argv,
+            workdir.path(),
+          )?;
         }
 
         res

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -317,7 +317,13 @@ impl super::CommandRunner for CommandRunner {
             && res.as_ref().map(|r| r.exit_code).unwrap_or(1) != 0
         {
           workdir.keep(&req.description);
-          setup_run_sh_script(&req.env, &req.working_directory, &req.argv, workdir.path())?;
+          setup_run_sh_script(
+            workdir.path(),
+            &req.env,
+            &req.working_directory,
+            &req.argv,
+            workdir.path(),
+          )?;
         }
 
         res
@@ -839,6 +845,7 @@ impl Drop for AsyncDropSandbox {
 
 /// Create a file called __run.sh with the env, cwd and argv used by Pants to facilitate debugging.
 pub fn setup_run_sh_script(
+  sandbox_path: &Path,
   env: &BTreeMap<String, String>,
   working_directory: &Option<RelativePath>,
   argv: &[String],
@@ -888,7 +895,7 @@ cd {}
     stringified_env_vars, stringified_cwd, stringified_command_line,
   );
 
-  let full_file_path = workdir_path.join("__run.sh");
+  let full_file_path = sandbox_path.join("__run.sh");
 
   std::fs::OpenOptions::new()
     .create_new(true)

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -31,7 +31,9 @@ use tokio::process;
 use fs::{DigestTrie, DirectoryDigest, RelativePath, TypedPath};
 use hashing::{Digest, EMPTY_DIGEST};
 use process_execution::docker::{ImagePullPolicy, ImagePullScope, DOCKER, IMAGE_PULL_CACHE};
-use process_execution::local::{apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, KeepSandboxes};
+use process_execution::local::{
+  apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, KeepSandboxes,
+};
 use process_execution::{ManagedChild, Platform, ProcessExecutionStrategy};
 use rule_graph::DependencyKey;
 use stdio::TryCloneAsFile;

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::HashMap;
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::str::FromStr;
@@ -30,7 +31,9 @@ use tokio::process;
 use fs::{DigestTrie, DirectoryDigest, RelativePath, TypedPath};
 use hashing::{Digest, EMPTY_DIGEST};
 use process_execution::docker::{ImagePullPolicy, ImagePullScope, DOCKER, IMAGE_PULL_CACHE};
-use process_execution::local::{apply_chroot, create_sandbox, prepare_workdir, KeepSandboxes};
+use process_execution::local::{
+  apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, KeepSandboxes,
+};
 use process_execution::{ManagedChild, Platform, ProcessExecutionStrategy};
 use rule_graph::DependencyKey;
 use stdio::TryCloneAsFile;
@@ -586,7 +589,7 @@ fn interactive_process(
     }
 
     command.env_clear();
-    command.envs(process.env);
+    command.envs(&process.env);
 
     if !restartable {
         task_side_effected()?;
@@ -641,8 +644,13 @@ fn interactive_process(
       .await?;
 
     let code = exit_status.code().unwrap_or(-1);
-    if keep_sandboxes == KeepSandboxes::OnFailure && code != 0 {
+    if keep_sandboxes == KeepSandboxes::Always
+        || keep_sandboxes == KeepSandboxes::OnFailure && code != 0 {
       tempdir.keep("interactive process");
+      let cwd = current_dir()
+          .map_err(|e| format!("Could not detect current working directory: {err}", err = e))?;
+      let workdir_path = if run_in_workspace { cwd.as_path() } else { tempdir.path() };
+      setup_run_sh_script(tempdir.path(), &process.env, &process.working_directory, &process.argv, workdir_path)?;
     }
 
     let result = {


### PR DESCRIPTION
Previously we only did so for non-interactive processes.

This is helpful when debugging issues with `./pants run`.