### PR TITLE
peek: add serialization of PythonArtifact object

### DIFF
--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -6,9 +6,8 @@ from __future__ import annotations
 import collections
 import json
 from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
 
-from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
@@ -25,6 +24,14 @@ from pants.engine.target import (
     UnexpandedTargets,
 )
 from pants.option.option_types import BoolOption
+
+
+@runtime_checkable
+class Dictable(Protocol):
+    """Makes possible to avoid adding concrete types to serialize objects."""
+
+    def asdict(self) -> Mapping[str, Any]:
+        ...
 
 
 class PeekSubsystem(Outputting, GoalSubsystem):
@@ -107,7 +114,7 @@ class _PeekJsonEncoder(json.JSONEncoder):
             return list(o)
         if isinstance(o, Field):
             return self.default(o.value)
-        if isinstance(o, PythonArtifact):
+        if isinstance(o, Dictable):
             return o.asdict()
         try:
             return super().default(o)

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -28,7 +28,7 @@ from pants.option.option_types import BoolOption
 
 @runtime_checkable
 class Dictable(Protocol):
-    """Makes possible to avoid adding concrete types to serialize objects."""
+    """Make possible to avoid adding concrete types to serialize objects."""
 
     def asdict(self) -> Mapping[str, Any]:
         ...

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -8,6 +8,7 @@ import json
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any, Iterable
 
+from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
@@ -24,7 +25,6 @@ from pants.engine.target import (
     UnexpandedTargets,
 )
 from pants.option.option_types import BoolOption
-from pants.backend.python.macros.python_artifact import PythonArtifact
 
 
 class PeekSubsystem(Outputting, GoalSubsystem):

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -24,6 +24,7 @@ from pants.engine.target import (
     UnexpandedTargets,
 )
 from pants.option.option_types import BoolOption
+from pants.backend.python.macros.python_artifact import PythonArtifact
 
 
 class PeekSubsystem(Outputting, GoalSubsystem):
@@ -106,6 +107,8 @@ class _PeekJsonEncoder(json.JSONEncoder):
             return list(o)
         if isinstance(o, Field):
             return self.default(o.value)
+        if isinstance(o, PythonArtifact):
+            return o.asdict()
         try:
             return super().default(o)
         except TypeError:

--- a/src/python/pants/backend/project_info/peek.py
+++ b/src/python/pants/backend/project_info/peek.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 import collections
 import json
 from dataclasses import asdict, dataclass, is_dataclass
-from typing import Any, Iterable, Mapping, Protocol, runtime_checkable
+from typing import Any, Iterable, Mapping
+
+from typing_extensions import Protocol, runtime_checkable
 
 from pants.engine.collection import Collection
 from pants.engine.console import Console

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -79,6 +79,9 @@ class PythonArtifact:
     def kwargs(self) -> Dict[str, Any]:
         return self._kw
 
+    def asdict(self) -> Dict[str, Any]:
+        return self.kwargs
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, PythonArtifact):
             return False
@@ -87,5 +90,5 @@ class PythonArtifact:
     def __hash__(self) -> int:
         return self._hash
 
-    def asdict(self) -> Dict[str, Any]:
-        return self.kwargs
+    def __str__(self) -> str:
+        return self.name

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -89,6 +89,3 @@ class PythonArtifact:
 
     def __hash__(self) -> int:
         return self._hash
-
-    def __str__(self) -> str:
-        return self.name

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -60,7 +60,7 @@ class PythonArtifact:
     def __init__(self, **kwargs):
         """
         :param kwargs: Passed to `setuptools.setup
-          <https://pythonhosted.org/setuptools/setuptools.html>`_.
+          <https://setuptools.pypa.io/en/latest/setuptools.html>`_.
         """
         if "entry_points" in kwargs:
             # coerce entry points from Dict[str, List[str]] to Dict[str, Dict[str, str]]
@@ -86,3 +86,6 @@ class PythonArtifact:
 
     def __hash__(self) -> int:
         return self._hash
+
+    def asdict(self) -> Dict[str, Any]:
+        return self.kwargs


### PR DESCRIPTION
With the current implementation, `provides` object representing a container of keyword arguments to pass to the `setuptools.setup()`, is shown as a name (based on its string representation).

With [this target](https://github.com/pantsbuild/example-python/blob/280c28a8f231469793242c7b39047abed2a5271d/helloworld/translator/BUILD#L20-L30), it is impossible to introspect the arguments values (e.g. getting a version of Python wheel):

```
$ ./pants peek helloworld/translator:dist | jq '.[] | .provides'
"helloworld.translator"
```

It can be useful to be able to get the `setup()` metadata, such as version, when it's being used in other places (e.g. checking that the version matches certain semantics or a Git tag or if using this version to fill any other metadata when, for instance, uploading the wheels to a binary repository manager).

Modifying the `__str__` would give us the kwargs, however, it would be a string rather than a JSON object which would make querying the fields more cumbersome:

```
$ ./pants_from_sources peek helloworld/translator:dist | grep "0.0.1"
"provides": "{'name': 'helloworld.translator', 'version': '0.0.1', 'description': 'A language translator.'}",
```

By adding an additional helper method `asdict`, we can get a JSON-like representation of the object:

```
$ ./pants_from_sources peek helloworld/translator:dist | jq '.[] | .provides'
{
  "name": "helloworld.translator",
  "version": "0.0.1",
  "description": "A language translator."
}
```

I suggest using `asdict` method to provide the way to serialize objects; the method name should be familiar to a developer as it's used in other Python libraries and also the builtin `dataclass` module has [`asdict`](https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict) method.