### PR TITLE
Do not try to create `""` output directory in `CreateArchive`

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -64,6 +64,7 @@ async def create_archive(request: CreateArchive) -> Digest:
     )
     file_list_file_digest = await Get(Digest, CreateDigest([file_list_file]))
     files_digests = [file_list_file_digest, request.snapshot.digest]
+    input_digests = []
 
     if request.format == ArchiveFormat.ZIP:
         zip_binary, bash_binary = await MultiGet(
@@ -71,7 +72,6 @@ async def create_archive(request: CreateArchive) -> Digest:
             Get(BashBinary, BashBinaryRequest()),
         )
         env = {}
-        input_digests = []
         argv: tuple[str, ...] = (
             bash_binary.path,
             "-c",
@@ -92,7 +92,6 @@ async def create_archive(request: CreateArchive) -> Digest:
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
 
-        input_digests = []
         # `tar` requires that the output filename's parent directory exists,so if the caller
         # wants the output in a directory we explicitly create it here.
         # We have to guard this path as the Rust code will crash if we give it empty paths.

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -170,7 +170,16 @@ def test_create_tar_archive(rule_runner: RuleRunner, format: ArchiveFormat) -> N
 @pytest.mark.parametrize(
     "format", [ArchiveFormat.TAR, ArchiveFormat.TGZ, ArchiveFormat.TXZ, ArchiveFormat.TBZ2]
 )
-def test_create_tar_archive_raw_filename(rule_runner: RuleRunner, format: ArchiveFormat) -> None:
+def test_create_tar_archive_in_root_dir(rule_runner: RuleRunner, format: ArchiveFormat) -> None:
+    """Validates that a .tar archive can be created with only a filename.
+
+    The specific requirements of creating a tar led to a situation where the CreateArchive code
+    assumed the output file had a directory component, attempting to create a directory called ""
+    if this assumption didn't hold. In 2.14 creating the "" directory became an error, which meant
+    CreateArchive broke. This guards against that break reoccuring.
+
+    Issue: https://github.com/pantsbuild/pants/issues/17545
+    """
     output_filename = f"a.{format.value}"
     input_snapshot = rule_runner.make_snapshot(FILES)
     created_digest = rule_runner.request(

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -10,6 +10,7 @@ from io import BytesIO
 from typing import Callable, cast
 
 import pytest
+
 from pants.core.util_rules import archive, system_binaries
 from pants.core.util_rules.archive import (
     CreateArchive,


### PR DESCRIPTION
This fixes a bug/regression in 2.13 -> 2.14 where `CreateArchive` requires an output directory. In 2.13 this'd pass `""` as a create-directory request, and that'd... do something. In 2.14 the Rust code uses `DigestTries` to improve performance, but an empty trie component generates an error:

```
15:00:12.12 [ERROR] 1 Exception encountered:

Engine traceback:
  in select
  in pants.core.goals.package.package_asset
  in pants_backend_oci.goals.package.package_oci_image (examples:oci)
  in pants_backend_oci.util_rules.build_image_bundle.build_oci_bundle_package
  in pants.core.util_rules.archive.create_archive
Traceback (no traceback):
  <pants native internals>
Exception: Path `` was unexpectedly empty
```

I believe this change in behavior comes from this optimization by @Eric-Arellano: https://github.com/pantsbuild/pants/pull/16648/files#diff-78b61c9a9b42b3895a2c71b90e31aceee5a5f38780edddbd4daec17ee4386d98R475. 

I believe backporting this to the 2.14 series makes sense to fix the regression. If the output directory should be required, a proper breaking change might be in order for 2.15 with a renaming of the parameter (<code>output_file**name** -> output_file**path**</code>) and proper diagnostic.