### PR TITLE
Fix an unactionable `InteractiveProcessRequest` deprecation

### DIFF
--- a/src/python/pants/backend/docker/goals/publish.py
+++ b/src/python/pants/backend/docker/goals/publish.py
@@ -21,8 +21,8 @@ from pants.core.goals.publish import (
     PublishRequest,
 )
 from pants.engine.environment import Environment, EnvironmentRequest
-from pants.engine.process import InteractiveProcess, InteractiveProcessRequest
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.process import InteractiveProcess
+from pants.engine.rules import Get, collect_rules, rule
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +75,7 @@ async def push_docker_images(
     skip_push = defaultdict(set)
     jobs: list[PublishPackages] = []
     refs: list[str] = []
-    processes: list[Get] = []
+    interactive_processes: list[InteractiveProcess] = []
 
     for tag in tags:
         for registry in options.registries().registries.values():
@@ -84,11 +84,10 @@ async def push_docker_images(
                 break
         else:
             refs.append(tag)
-            processes.append(
-                Get(InteractiveProcess, InteractiveProcessRequest(docker.push_image(tag, env)))
+            interactive_processes.append(
+                InteractiveProcess.from_process(docker.push_image(tag, env))
             )
 
-    interactive_processes = await MultiGet(processes)
     for ref, process in zip(refs, interactive_processes):
         jobs.append(
             PublishPackages(

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -28,7 +28,6 @@ from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Remov
 from pants.engine.process import (
     FallibleProcessResult,
     InteractiveProcess,
-    InteractiveProcessRequest,
     Process,
     ProcessCacheScope,
 )
@@ -190,11 +189,9 @@ async def setup_scalatest_debug_request(field_set: ScalatestTestFieldSet) -> Tes
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
 
     process = await Get(Process, JvmProcess, setup.process)
-    interactive_process = await Get(
-        InteractiveProcess,
-        InteractiveProcessRequest(process, forward_signals_to_process=False, restartable=True),
+    return TestDebugRequest(
+        InteractiveProcess.from_process(process, forward_signals_to_process=False, restartable=True)
     )
-    return TestDebugRequest(interactive_process)
 
 
 @rule

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -25,7 +25,6 @@ from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Remov
 from pants.engine.process import (
     FallibleProcessResult,
     InteractiveProcess,
-    InteractiveProcessRequest,
     Process,
     ProcessCacheScope,
 )
@@ -188,11 +187,9 @@ async def run_junit_test(
 async def setup_junit_debug_request(field_set: JunitTestFieldSet) -> TestDebugRequest:
     setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=True))
     process = await Get(Process, JvmProcess, setup.process)
-    interactive_process = await Get(
-        InteractiveProcess,
-        InteractiveProcessRequest(process, forward_signals_to_process=False, restartable=True),
+    return TestDebugRequest(
+        InteractiveProcess.from_process(process, forward_signals_to_process=False, restartable=True)
     )
-    return TestDebugRequest(interactive_process)
 
 
 @rule


### PR DESCRIPTION
As reported in #17543: a few codepaths are triggering a deprecation in the `2.14.x` branch that users aren't supposed to see.

Fixes #17543.