### PR TITLE
Do not try to create `""` output directory in `CreateArchive` (Cherry-pick of #17538)

### DIFF
--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -63,6 +63,7 @@ async def create_archive(request: CreateArchive) -> Digest:
     )
     file_list_file_digest = await Get(Digest, CreateDigest([file_list_file]))
     files_digests = [file_list_file_digest, request.snapshot.digest]
+    input_digests = []
 
     if request.format == ArchiveFormat.ZIP:
         zip_binary, bash_binary = await MultiGet(
@@ -70,7 +71,6 @@ async def create_archive(request: CreateArchive) -> Digest:
             Get(BashBinary, BashBinaryRequest()),
         )
         env = {}
-        input_digests = []
         argv: tuple[str, ...] = (
             bash_binary.path,
             "-c",
@@ -88,11 +88,14 @@ async def create_archive(request: CreateArchive) -> Digest:
         )
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
-        # `tar` requires that the output filename's parent directory exists.
-        output_dir_digest = await Get(
-            Digest, CreateDigest([Directory(os.path.dirname(request.output_filename))])
-        )
-        input_digests = [output_dir_digest]
+
+        # `tar` requires that the output filename's parent directory exists,so if the caller
+        # wants the output in a directory we explicitly create it here.
+        # We have to guard this path as the Rust code will crash if we give it empty paths.
+        output_dir = os.path.dirname(request.output_filename)
+        if output_dir != "":
+            output_dir_digest = await Get(Digest, CreateDigest([Directory(output_dir)]))
+            input_digests.append(output_dir_digest)
 
     input_digest = await Get(Digest, MergeDigests([*files_digests, *input_digests]))
 

--- a/src/python/pants/core/util_rules/archive_test.py
+++ b/src/python/pants/core/util_rules/archive_test.py
@@ -165,3 +165,38 @@ def test_create_tar_archive(rule_runner: RuleRunner, format: ArchiveFormat) -> N
     extracted_archive = rule_runner.request(ExtractedArchive, [created_digest])
     digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
     assert digest_contents == EXPECTED_DIGEST_CONTENTS
+
+
+@pytest.mark.parametrize(
+    "format", [ArchiveFormat.TAR, ArchiveFormat.TGZ, ArchiveFormat.TXZ, ArchiveFormat.TBZ2]
+)
+def test_create_tar_archive_in_root_dir(rule_runner: RuleRunner, format: ArchiveFormat) -> None:
+    """Validates that a .tar archive can be created with only a filename.
+
+    The specific requirements of creating a tar led to a situation where the CreateArchive code
+    assumed the output file had a directory component, attempting to create a directory called ""
+    if this assumption didn't hold. In 2.14 creating the "" directory became an error, which meant
+    CreateArchive broke. This guards against that break reoccuring.
+
+    Issue: https://github.com/pantsbuild/pants/issues/17545
+    """
+    output_filename = f"a.{format.value}"
+    input_snapshot = rule_runner.make_snapshot(FILES)
+    created_digest = rule_runner.request(
+        Digest,
+        [CreateArchive(input_snapshot, output_filename=output_filename, format=format)],
+    )
+
+    digest_contents = rule_runner.request(DigestContents, [created_digest])
+    assert len(digest_contents) == 1
+    io = BytesIO()
+    io.write(digest_contents[0].content)
+    io.seek(0)
+    compression = "" if format == ArchiveFormat.TAR else f"{format.value[4:]}"  # Strip `tar.`.
+    with tarfile.open(fileobj=io, mode=f"r:{compression}") as tf:
+        assert set(tf.getnames()) == set(FILES.keys())
+
+    # We also use Pants to extract the created archive, which checks for idempotency.
+    extracted_archive = rule_runner.request(ExtractedArchive, [created_digest])
+    digest_contents = rule_runner.request(DigestContents, [extracted_archive.digest])
+    assert digest_contents == EXPECTED_DIGEST_CONTENTS


### PR DESCRIPTION
This fixes a bug/regression in 2.13 -> 2.14 where `CreateArchive` requires an output directory. In 2.13 this'd pass `""` as a create-directory request, and that'd... do something. In 2.14 the Rust code uses `DigestTries` to improve performance, but an empty trie component generates an error:

```
15:00:12.12 [ERROR] 1 Exception encountered:

Engine traceback:
  in select
  in pants.core.goals.package.package_asset
  in pants_backend_oci.goals.package.package_oci_image (examples:oci)
  in pants_backend_oci.util_rules.build_image_bundle.build_oci_bundle_package
  in pants.core.util_rules.archive.create_archive
Traceback (no traceback):
  <pants native internals>
Exception: Path `` was unexpectedly empty
```

I believe this change in behavior comes from this optimization by @Eric-Arellano: https://github.com/pantsbuild/pants/pull/16648/files#diff-78b61c9a9b42b3895a2c71b90e31aceee5a5f38780edddbd4daec17ee4386d98R475. 

I believe backporting this to the 2.14 series makes sense to fix the regression. If the output directory should be required, a proper breaking change might be in order for 2.15 with a renaming of the parameter (<code>output_file**name** -> output_file**path**</code>) and proper diagnostic.

Co-authored-by: Tom Solberg <mail@tomolsson.se>