### PR TITLE
New dependency rules Plugin API

### DIFF
--- a/src/python/pants/base/parse_context.py
+++ b/src/python/pants/base/parse_context.py
@@ -1,13 +1,14 @@
 # Copyright 2014 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 from typing import Any, Mapping
 
 from typing_extensions import Protocol
 
 
-class RelPathOracle(Protocol):
-    def rel_path(self) -> str:
+class FilePathOracle(Protocol):
+    def filepath(self) -> str:
         ...
 
 
@@ -20,17 +21,17 @@ class ParseContext:
     """
 
     def __init__(
-        self, build_root: str, type_aliases: Mapping[str, Any], rel_path_oracle: RelPathOracle
+        self, build_root: str, type_aliases: Mapping[str, Any], filepath_oracle: FilePathOracle
     ) -> None:
         """Create a ParseContext.
 
         :param build_root: The absolute path to the build root.
         :param type_aliases: A dictionary of BUILD file symbols.
-        :param rel_path_oracle: An oracle than can be queried for the current BUILD file path.
+        :param filepath_oracle: An oracle than can be queried for the current BUILD file name.
         """
         self._build_root = build_root
         self._type_aliases = type_aliases
-        self._rel_path_oracle = rel_path_oracle
+        self._filepath_oracle = filepath_oracle
 
     def create_object(self, alias: str, *args: Any, **kwargs: Any) -> Any:
         """Constructs the type with the given alias using the given args and kwargs.
@@ -54,11 +55,11 @@ class ParseContext:
 
     @property
     def rel_path(self) -> str:
-        """Relative path from the build root to the BUILD file being parsed.
+        """Relative path from the build root to the directory of the BUILD file being parsed.
 
         :API: public
         """
-        return self._rel_path_oracle.rel_path()
+        return os.path.dirname(self._filepath_oracle.filepath())
 
     @property
     def build_root(self) -> str:

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -21,6 +21,7 @@ from pants.engine.internals.build_files import (
     parse_address_family,
 )
 from pants.engine.internals.defaults import ParametrizeDefault
+from pants.engine.internals.dep_rules import MaybeBuildFileDependencyRulesImplementation
 from pants.engine.internals.parametrize import Parametrize
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.scheduler import ExecutionError
@@ -64,6 +65,7 @@ def test_parse_address_family_empty() -> None:
             AddressFamilyDir("/dev/null"),
             RegisteredTargetTypes({}),
             UnionMembership({}),
+            MaybeBuildFileDependencyRulesImplementation(None),
         ],
         mock_gets=[
             MockGet(

--- a/src/python/pants/engine/internals/dep_rules.py
+++ b/src/python/pants/engine/internals/dep_rules.py
@@ -1,0 +1,127 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.unions import UnionMembership, union
+
+logger = logging.getLogger(__name__)
+
+
+class DependencyRulesError(Exception):
+    pass
+
+
+class DependencyRuleActionDeniedError(DependencyRulesError):
+    def __init__(self, description_of_origin: str):
+        super().__init__(self.violation_msg(description_of_origin))
+
+    def violation_msg(self, description_of_origin: str) -> str:
+        return f"Dependency rule violation for {description_of_origin}"
+
+
+class DependencyRuleAction(Enum):
+    ALLOW = "allow"
+    DENY = "deny"
+    WARN = "warn"
+
+    def execute(self, *, description_of_origin: str) -> None:
+        if self is DependencyRuleAction.ALLOW:
+            return
+        err = DependencyRuleActionDeniedError(description_of_origin)
+        if self is DependencyRuleAction.DENY:
+            raise err
+        if self is DependencyRuleAction.WARN:
+            logger.warning(str(err))
+        else:
+            raise NotImplementedError(f"{type(self).__name__}.execute() not implemented for {self}")
+
+
+class BuildFileDependencyRules(ABC):
+    @staticmethod
+    @abstractmethod
+    def create_parser_state(
+        path: str, parent: BuildFileDependencyRules | None
+    ) -> BuildFileDependencyRulesParserState:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def check_dependency_rules(
+        *,
+        source_adaptor: TargetAdaptor,
+        source_path: str,
+        dependencies_rules: BuildFileDependencyRules | None,
+        target_adaptor: TargetAdaptor,
+        target_path: str,
+        dependents_rules: BuildFileDependencyRules | None,
+    ) -> DependencyRuleAction:
+        """The source of the dependency has the dependencies field, the target of the dependency is
+        the one listed as a value in the dependencies field.
+
+        The `__dependencies_rules__` are the rules applicable for the source path.
+        The `__dependents_rules__` are the rules applicable for the target path.
+
+        Return dependency rule action ALLOW, DENY or WARN. WARN is effectively the same as ALLOW,
+        but with a logged warning.
+        """
+
+
+class BuildFileDependencyRulesParserState(ABC):
+    @abstractmethod
+    def get_frozen_dependency_rules(self) -> BuildFileDependencyRules | None:
+        pass
+
+    @abstractmethod
+    def set_dependency_rules(
+        self,
+        build_file: str,
+        *args,
+        **kwargs,
+    ) -> None:
+        pass
+
+
+@union
+class BuildFileDependencyRulesImplementationRequest:
+    pass
+
+
+@dataclass(frozen=True)
+class BuildFileDependencyRulesImplementation:
+    build_file_dependency_rules_class: type[BuildFileDependencyRules]
+
+
+@dataclass(frozen=True)
+class MaybeBuildFileDependencyRulesImplementation:
+    build_file_dependency_rules_class: type[BuildFileDependencyRules] | None
+
+
+@rule
+async def get_build_file_dependency_rules_implementation(
+    union_membership: UnionMembership,
+) -> MaybeBuildFileDependencyRulesImplementation:
+    request_types = union_membership.get(BuildFileDependencyRulesImplementationRequest)
+    if len(request_types) > 1:
+        impls = ", ".join(map(str, request_types))
+        raise AssertionError(
+            f"There must be at most one BUILD file dependency rules implementation, got: {impls}"
+        )
+    for request_type in request_types:
+        impl = await Get(
+            BuildFileDependencyRulesImplementation,
+            BuildFileDependencyRulesImplementationRequest,
+            request_type(),
+        )
+        return MaybeBuildFileDependencyRulesImplementation(impl.build_file_dependency_rules_class)
+    return MaybeBuildFileDependencyRulesImplementation(None)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/engine/internals/dep_rules_test.py
+++ b/src/python/pants/engine/internals/dep_rules_test.py
@@ -1,0 +1,27 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from pants.engine.internals.dep_rules import DependencyRuleAction, DependencyRuleActionDeniedError
+from pants.testutil.pytest_util import assert_logged
+
+
+def test_dependency_rule_action(caplog) -> None:
+    violation_msg = "Dependency rule violation for test"
+
+    DependencyRuleAction("allow").execute(description_of_origin="test")
+    assert_logged(caplog, expect_logged=None)
+    caplog.clear()
+
+    DependencyRuleAction("warn").execute(description_of_origin="test")
+    assert_logged(caplog, expect_logged=[(logging.WARNING, violation_msg)])
+    caplog.clear()
+
+    with pytest.raises(DependencyRuleActionDeniedError, match=violation_msg):
+        DependencyRuleAction("deny").execute(description_of_origin="test")
+    assert_logged(caplog, expect_logged=None)

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -11,6 +11,10 @@ from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.base.exceptions import MappingError
 from pants.build_graph.address import Address, BuildFileAddress
 from pants.engine.internals.defaults import BuildFileDefaults, BuildFileDefaultsParserState
+from pants.engine.internals.dep_rules import (
+    BuildFileDependencyRules,
+    BuildFileDependencyRulesParserState,
+)
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.target import RegisteredTargetTypes, Tags, Target
@@ -40,6 +44,8 @@ class AddressMap:
         parser: Parser,
         extra_symbols: BuildFilePreludeSymbols,
         defaults: BuildFileDefaultsParserState,
+        dependents_rules: BuildFileDependencyRulesParserState | None,
+        dependencies_rules: BuildFileDependencyRulesParserState | None,
     ) -> AddressMap:
         """Parses a source for targets.
 
@@ -47,7 +53,14 @@ class AddressMap:
         the same namespace but from a separate source are left as unresolved pointers.
         """
         try:
-            target_adaptors = parser.parse(filepath, build_file_content, extra_symbols, defaults)
+            target_adaptors = parser.parse(
+                filepath,
+                build_file_content,
+                extra_symbols,
+                defaults,
+                dependents_rules,
+                dependencies_rules,
+            )
         except Exception as e:
             raise MappingError(f"Failed to parse ./{filepath}:\n{e}")
         return cls.create(filepath, target_adaptors)
@@ -87,12 +100,16 @@ class AddressFamily:
     :param namespace: The namespace path of this address family.
     :param name_to_target_adaptors: A dict mapping from name to the target adaptor.
     :param defaults: The default target field values, per target type, applicable for this address family.
+    :param dependents_rules: The rules to apply on incoming dependencies to targets in this family.
+    :param dependencies_rules: The rules to apply on the outgoing dependencies from targets in this family.
     """
 
     # The directory from which the adaptors were parsed.
     namespace: str
     name_to_target_adaptors: dict[str, tuple[str, TargetAdaptor]]
     defaults: BuildFileDefaults
+    dependents_rules: BuildFileDependencyRules | None
+    dependencies_rules: BuildFileDependencyRules | None
 
     @classmethod
     def create(
@@ -100,6 +117,8 @@ class AddressFamily:
         spec_path: str,
         address_maps: Iterable[AddressMap],
         defaults: BuildFileDefaults = BuildFileDefaults({}),
+        dependents_rules: BuildFileDependencyRules | None = None,
+        dependencies_rules: BuildFileDependencyRules | None = None,
     ) -> AddressFamily:
         """Creates an address family from the given set of address maps.
 
@@ -131,6 +150,8 @@ class AddressFamily:
             namespace=spec_path,
             name_to_target_adaptors=dict(sorted(name_to_target_adaptors.items())),
             defaults=defaults,
+            dependents_rules=dependents_rules,
+            dependencies_rules=dependencies_rules,
         )
 
     @memoized_property

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -43,6 +43,8 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         BuildFileDefaultsParserState.create(
             "", BuildFileDefaults({}), RegisteredTargetTypes({}), UnionMembership({})
         ),
+        dependents_rules=None,
+        dependencies_rules=None,
     )
     assert path == address_map.path
     return address_map

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -40,6 +40,8 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
             "\nx = 'hello'\n\nimport os\n",
             BuildFilePreludeSymbols(FrozenDict()),
             defaults_parser_state,
+            dependents_rules=None,
+            dependencies_rules=None,
         )
     assert "Import used in dir/BUILD at line 4" in str(exc.value)
 
@@ -65,13 +67,16 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
                 "fake",
                 prelude_symbols,
                 defaults_parser_state,
+                dependents_rules=None,
+                dependencies_rules=None,
             )
         assert str(exc.value) == (
             f"Name 'fake' is not defined.\n\n{dym}"
             "If you expect to see more symbols activated in the below list,"
             f" refer to {doc_url('enabling-backends')} for all available"
             " backends to activate.\n\n"
-            f"All registered symbols: ['__defaults__', 'build_file_dir', 'caof', {fmt_extra_sym}"
+            "All registered symbols: ['__defaults__', '__dependencies_rules__', "
+            f"'__dependents_rules__', 'build_file_dir', 'caof', {fmt_extra_sym}"
             "'obj', 'prelude', 'tgt']"
         )
 
@@ -87,6 +92,8 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
                 "fake",
                 prelude_symbols,
                 defaults_parser_state,
+                dependents_rules=None,
+                dependencies_rules=None,
             )
 
     test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]

--- a/src/python/pants/engine/internals/target_adaptor.py
+++ b/src/python/pants/engine/internals/target_adaptor.py
@@ -15,6 +15,8 @@ from pants.engine.engine_aware import EngineAwareParameter
 
 @dataclass(frozen=True)
 class TargetAdaptorRequest(EngineAwareParameter):
+    """Lookup the TargetAdaptor for an Address."""
+
     address: Address
     description_of_origin: str = dataclasses.field(hash=False, compare=False)
 

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -23,6 +23,7 @@ from pants.engine.fs import PathGlobs, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import (
     build_files,
+    dep_rules,
     graph,
     options_parsing,
     platform_rules,
@@ -268,6 +269,7 @@ class EngineInitializer:
                 *collect_rules(locals()),
                 *build_files.rules(),
                 *fs.rules(),
+                *dep_rules.rules(),
                 *desktop.rules(),
                 *git_rules(),
                 *graph.rules(),


### PR DESCRIPTION
This is split out from #17401 for the core API part.
The second part will include the visibility backend implementation.

Implementations for this API need to provide concrete classes of these two `ABC`s, using the `BuildFileDependencyRulesImplementationRequest` union to register them:

```python
class BuildFileDependencyRules(ABC):
    @staticmethod
    @abstractmethod
    def create_parser_state(
        path: str, parent: BuildFileDependencyRules | None
    ) -> BuildFileDependencyRulesParserState:
        ...

    @staticmethod
    @abstractmethod
    def check_dependency_rules(
        *,
        source_adaptor: TargetAdaptor,
        source_path: str,
        dependencies_rules: BuildFileDependencyRules | None,
        target_adaptor: TargetAdaptor,
        target_path: str,
        dependents_rules: BuildFileDependencyRules | None,
    ) -> DependencyRuleAction:
        ...

class BuildFileDependencyRulesParserState(ABC):
    @abstractmethod
    def get_frozen_dependency_rules(self) -> BuildFileDependencyRules | None:
        ...

    @abstractmethod
    def set_dependency_rules(
        self,
        build_file: str,
        *args,
        **kwargs,
    ) -> None:
        ...
```