### PR TITLE
Fix deprecation message for `threading.Event`

### DIFF
--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -289,7 +289,7 @@ class _InnerHandler(threading.Thread):
         # First, set the thread's thread locals to the parent thread's in order to propagate the
         # console, workunit stores, etc.
         self.thread_locals.set_for_current_thread()
-        while not self.stop_request.isSet():
+        while not self.stop_request.is_set():
             self.poll_workunits(finished=False)
             self.stop_request.wait(timeout=self.report_interval)
         else:


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/17551#issuecomment-1315562857.