### PR TITLE
Support newer pip versions.

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -134,7 +134,9 @@ async def _setup_pip_args_and_constraints_file(resolve_name: str) -> _PipArgsAnd
 
 @rule(desc="Generate Python lockfile", level=LogLevel.DEBUG)
 async def generate_lockfile(
-    req: GeneratePythonLockfile, generate_lockfiles_subsystem: GenerateLockfilesSubsystem
+    req: GeneratePythonLockfile,
+    generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
+    python_setup: PythonSetup,
 ) -> GenerateLockfileResult:
     pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
 
@@ -150,6 +152,8 @@ async def generate_lockfile(
                 # generate universal locks because they have the best compatibility. We may
                 # want to let users change this, as `style=strict` is safer.
                 "--style=universal",
+                "--pip-version",
+                python_setup.pip_version.value,
                 "--resolver-version",
                 "pip-2020-resolver",
                 # PEX files currently only run on Linux and Mac machines; so we hard code this

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -27,6 +27,13 @@ logger = logging.getLogger(__name__)
 
 
 @enum.unique
+class PipVersion(enum.Enum):
+    V20_3_4 = "20.3.4-patched"
+    V22_2_2 = "22.2.2"
+    V22_3 = "22.3"
+
+
+@enum.unique
 class InvalidLockfileBehavior(enum.Enum):
     error = "error"
     ignore = "ignore"
@@ -179,6 +186,11 @@ class PythonSetup(Subsystem):
             relevant field for more details.
             """
         ),
+    )
+    pip_version = EnumOption(
+        default=PipVersion.V22_3,
+        help="Use this version of Pip for resolving requirements and generating lockfiles.",
+        advanced=True,
     )
     _resolves_to_interpreter_constraints = DictOption["list[str]"](
         help=softwrap(

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -188,7 +188,7 @@ class PythonSetup(Subsystem):
         ),
     )
     pip_version = EnumOption(
-        default=PipVersion.V22_3,
+        default=PipVersion.V20_3_4,
         help="Use this version of Pip for resolving requirements and generating lockfiles.",
         advanced=True,
     )

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -34,7 +34,7 @@ def test_custom_ca_certs(tmp_path: Path, rule_runner: RuleRunner) -> None:
         Process,
         [PexCliProcess(subcommand=(), extra_args=("some", "--args"), description="")],
     )
-    assert proc.argv[4:6] == ("--cert", "certsfile")
+    assert proc.argv[6:8] == ("--cert", "certsfile")
     files = rule_runner.request(DigestContents, [proc.input_digest])
     chrooted_certs_file = [f for f in files if f.path == "certsfile"]
     assert len(chrooted_certs_file) == 1

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -493,6 +493,8 @@ def test_local_requirements_and_path_mappings(
                 ),
                 f"--python-repos-path-mappings=WHEEL_DIR|{path_mappings_dir}",
                 f"--named-caches-dir={tmp_path}",
+                # Use the vendored pip, so we don't have to set up a wheel for it in dir1_path.
+                "--python-pip-version=20.3.4-patched",
             )
 
         rule_runner.set_options(options(dir1_path), env_inherit=PYTHON_BOOTSTRAP_ENV)

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -321,7 +321,7 @@ def filter_tool_lockfile_requests(
 
 class GenerateLockfilesSubsystem(GoalSubsystem):
     name = "generate-lockfiles"
-    help = "Generate lockfiles for Python third-party dependencies."
+    help = "Generate lockfiles for third-party dependencies."
 
     @classmethod
     def activated(cls, union_membership: UnionMembership) -> bool:


### PR DESCRIPTION
Plumbs --pip-version through to pex commands that support it.

Newer pips have perf improvements that may benefit users, in particular for very long-running resolves.

Does not change the default. We can do that via deprecation in a followup.