### PR TITLE
Remove `--venv` from pyton source run

### DIFF
--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -44,8 +44,6 @@ async def create_python_source_run_request(
         entry_point_field=PexEntryPointField(field_set.source.value, field_set.address),
         pex_env=pex_env,
         run_in_sandbox=run_goal_use_sandbox,
-        # Setting --venv is kosher because the PEX we create is just for the thirdparty deps.
-        additional_pex_args=["--venv"],
     )
 
 


### PR DESCRIPTION
Fixes #17372

I can't for the life of me seem to get this working in an integration test. `sys.path` inside the interactive process always contains the buildroot for some reason (not `""`, but literally the build root) :sob: 