### PR TITLE
correct docs: direnv can't save ulimit

### DIFF
--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -233,8 +233,7 @@ This can be fixed by setting `ulimit -n 10000`. (10,000 should work in all cases
 > We recommend permanently setting this by either:
 > 
 > 1. Adding `ulimit -n 10000` to your `./pants` script.
-> 2. Using a tool like [Direnv](https://direnv.net) to run `ulimit -n 10000` everytime the project is loaded.
-> 3. Adding `ulimit -n 10000` to your global `.bashrc` or equivalent.
+> 2. Adding `ulimit -n 10000` to your global `.bashrc` or equivalent.
 > 
 > The first two approaches have the benefit that they will be checked into version control, so every developer at your organization can use the same setting.
 

--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -232,7 +232,7 @@ This can be fixed by setting `ulimit -n 10000`. (10,000 should work in all cases
 > 
 > We recommend permanently setting this by either:
 > 
-> 1. Adding `ulimit -n 10000` to your `./pants` script.
+> 1. Adding `ulimit -n 10000` to your `./pants.bootstrap` script.
 > 2. Adding `ulimit -n 10000` to your global `.bashrc` or equivalent.
 > 
 > The first two approaches have the benefit that they will be checked into version control, so every developer at your organization can use the same setting.


### PR DESCRIPTION
direnv can only cache env variables, not ulimit settings

see https://github.com/direnv/direnv/issues/777