### PR TITLE
Allow for `run --debug-adapter` to match breakpoints when source is running in a sandbox

### DIFF
--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -154,7 +154,7 @@ async def _create_python_source_run_dap_request(
                     FileContent(
                         "__debugpy_launcher.py",
                         textwrap.dedent(
-                            f"""
+                            """
                             import os
                             CHROOT = os.environ["PANTS_CHROOT"]
 

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -170,12 +170,10 @@ async def _create_python_source_run_dap_request(
                             from _pydevd_bundle.pydevd_process_net_command_json import PyDevJsonCommandProcessor
                             orig_resolve_remote_root = PyDevJsonCommandProcessor._resolve_remote_root
 
-                            def patched_resolve_remote_root(*args, **kwargs):
-                                remote_root = orig_resolve_remote_root(*args, **kwargs)
-                                cwd = os.getcwd()
-                                if remote_root.startswith(cwd):
-                                    remote_root = remote_root.replace(cwd, CHROOT)
-                                return remote_root
+                            def patched_resolve_remote_root(self, local_root, remote_root):
+                                if remote_root == ".":
+                                    remote_root = CHROOT
+                                return orig_resolve_remote_root(self, local_root, remote_root)
 
                             PyDevJsonCommandProcessor._resolve_remote_root = patched_resolve_remote_root
 

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -15,7 +15,6 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
-from pants.base.build_root import BuildRoot
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.internals.selectors import Get

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -15,6 +15,7 @@ from pants.backend.python.target_types import (
     PythonSourceField,
 )
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.base.build_root import BuildRoot
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.internals.selectors import Get


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/17540

The key is that the DAP client is sending `pathMappings`, which normally sets `remoteRoot` to `"."` which for `run` isn't true.
There's no easy way to have the server set it's own mapping so we monkeypatch.