### PR TITLE
Created an `NpxToolBase` as an inheritable Subsystem for `nodejs` tools

### DIFF
--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -61,7 +61,7 @@ async def prettier_fmt(request: PrettierFmtRequest.Batch, prettier: Prettier) ->
     result = await Get(
         ProcessResult,
         NpxProcess(
-            npm_package=prettier.default_version,
+            npm_package=prettier.version,
             args=(
                 "--write",
                 *request.files,

--- a/src/python/pants/backend/javascript/lint/prettier/subsystem.py
+++ b/src/python/pants/backend/javascript/lint/prettier/subsystem.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 import os
 from typing import Iterable
 
+from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
 
-class Prettier(Subsystem):
+class Prettier(NpxToolBase):
     options_scope = "prettier"
     name = "Prettier"
     help = softwrap(

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -11,6 +11,7 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
+from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import Process
@@ -109,4 +110,7 @@ async def setup_npx_process(
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return collect_rules()
+    return (
+        *collect_rules(),
+        *external_tool_rules(),
+    )

--- a/src/python/pants/backend/javascript/subsystems/npx_tool.py
+++ b/src/python/pants/backend/javascript/subsystems/npx_tool.py
@@ -1,0 +1,20 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from pants.option.option_types import StrOption
+from pants.option.subsystem import Subsystem
+
+
+class NpxToolBase(Subsystem):
+    # Subclasses must set.
+    default_version: ClassVar[str]
+
+    version = StrOption(
+        advanced=True,
+        default=lambda cls: cls.default_version,
+        help="Version string for the tool in the form package@version (e.g. prettier@2.6.2)",
+    )

--- a/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
@@ -1,0 +1,42 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.javascript.subsystems import nodejs
+from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
+from pants.engine.rules import SubsystemRule
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+class CowsayTool(NpxToolBase):
+    options_scope = "cowsay"
+    name = "Cowsay"
+    # Intentionally older version.
+    default_version = "cowsay@1.4.0"
+    help = "The Cowsay utility for printing cowsay messages"
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *nodejs.rules(),
+            SubsystemRule(CowsayTool),
+            QueryRule(CowsayTool, []),
+        ],
+    )
+
+
+def test_version_option_overrides_default(rule_runner: RuleRunner):
+    rule_runner.set_options(
+        [
+            "--backend-packages=['pants.backend.experimental.javascript']",
+            "--cowsay-version=cowsay@1.5.0",
+        ]
+    )
+    tool = rule_runner.request(CowsayTool, [])
+    assert tool.default_version == "cowsay@1.4.0"
+    assert tool.version == "cowsay@1.5.0"

--- a/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
@@ -7,7 +7,6 @@ import pytest
 
 from pants.backend.javascript.subsystems import nodejs
 from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
-from pants.engine.rules import SubsystemRule
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
 
@@ -24,7 +23,7 @@ def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
             *nodejs.rules(),
-            SubsystemRule(CowsayTool),
+            *CowsayTool.rules(),  # type: ignore[call-arg]
             QueryRule(CowsayTool, []),
         ],
     )

--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -138,7 +138,7 @@ async def pyright_typecheck_partition(
     process = await Get(
         Process,
         NpxProcess(
-            npm_package=pyright.default_version,
+            npm_package=pyright.version,
             args=(
                 f"--venv-path={complete_pex_env.pex_root}",  # Used with `venv` in config
                 *pyright.args,  # User-added arguments

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -3,13 +3,13 @@
 
 from __future__ import annotations
 
+from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
-from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
 
-class Pyright(Subsystem):
+class Pyright(NpxToolBase):
     options_scope = "pyright"
     name = "Pyright"
     help = softwrap(


### PR DESCRIPTION
Added support for a `version` option to Prettier and Pyright via an `NpxToolBase`. 

Some day in the future, I would like to see Subsystem mixins for this type of common, repeated functionality - but that's a longer discussion.

Closes (#17557)

[ci skip-rust]
[ci skip-build-wheels]