### PR TITLE
Support PurePath values in visibility rules.

### DIFF
--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -7,6 +7,7 @@ import logging
 import os.path
 from dataclasses import dataclass, field
 from fnmatch import fnmatch, fnmatchcase
+from pathlib import PurePath
 from typing import Any, Iterable, Iterator, Sequence, cast
 
 from pants.engine.internals.dep_rules import (
@@ -67,7 +68,7 @@ def flatten(xs) -> Iterator[str]:
         yield xs
     elif isinstance(xs, Iterable):
         yield from itertools.chain.from_iterable(flatten(x) for x in xs)
-    elif type(xs).__name__ == "Registrar":
+    elif type(xs).__name__ == "Registrar" or isinstance(xs, PurePath):
         yield str(xs)
     else:
         raise ValueError(f"expected a string but got: {xs!r}")

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import PurePath
 from textwrap import dedent
 from typing import Any
 
@@ -70,6 +71,10 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
                     "baz",
                 ),
             ),
+        ),
+        (
+            ["src/test"],
+            PurePath("src/test"),
         ),
     ],
 )


### PR DESCRIPTION
In order to make the use of `build_file_dir()` stream lined so that this works without having to convert it to `str()` explicitly:
```python
__dependencies_rules__(
  ("*", build_file_dir() / "*", "!*"),
)
```

Labeling as internal, reasoning that this could've been included in #17401.