### PR TITLE
[internal] Ignore empty rule sets.

### DIFF
--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -241,7 +241,7 @@ class BuildFileVisibilityRulesParserState(BuildFileDependencyRulesParserState):
         **kwargs,
     ) -> None:
         try:
-            self.rulesets = [VisibilityRuleSet.parse(arg) for arg in args]
+            self.rulesets = [VisibilityRuleSet.parse(arg) for arg in args if arg]
             self.path = build_file
         except ValueError as e:
             raise BuildFileVisibilityRulesError(f"{build_file}: {e}") from e

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -367,6 +367,10 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
 
           # Allow all by default, with a warning
           ("*", "?*"),
+
+          # Ignore (accept) empty values as no-op
+          None,
+          (),
         )
 
         __dependents_rules__(


### PR DESCRIPTION
Motivation being to ease incremental adoption, where rules may be filtered through some applicability function.