### PR TITLE
Fix pex request description for python resolve export.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -236,7 +236,7 @@ async def export_virtualenv_for_resolve(
         )
 
         pex_request = PexRequest(
-            description="chosen_resolve.name",
+            description=f"Build pex for resolve `{resolve}`",
             output_filename=f"{path_safe(resolve)}.pex",
             internal_only=True,
             requirements=EntireLockfile(lockfile),


### PR DESCRIPTION
Labeled as internal as I don't think we'd care to have this in the changelog..?

Does the message make sense? I first thought it was just a missed `f` for an f-string, but see it was more of a TODO placeholder.. so aren't 100 if this message makes sense.

Closes #17589 