### PR TITLE
Register synthetic lockfile targets for jvm.

### DIFF
--- a/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
@@ -82,7 +82,7 @@ def rule_runner() -> RuleRunner:
         ],
     )
     rule_runner.set_options(
-        ["--source-roots=['src/jvm','src/avro']", "-ltrace"],
+        ["--no-jvm-enable-lockfile-targets", "--source-roots=['src/jvm','src/avro']", "-ltrace"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner

--- a/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/avro/java/rules_integration_test.py
@@ -109,7 +109,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: Iterable[str] = (),
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *extra_args]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *extra_args,
+    ]
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/java/rules_integration_test.py
@@ -99,7 +99,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
+    ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules_integration_test.py
@@ -120,7 +120,7 @@ def rule_runner() -> RuleRunner:
         ],
     )
     rule_runner.set_options(
-        [],
+        ["--no-jvm-enable-lockfile-targets"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner
@@ -134,7 +134,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: Iterable[str] = (),
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *extra_args]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *extra_args,
+    ]
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/soap/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/soap/java/rules_integration_test.py
@@ -88,7 +88,12 @@ def rule_runner() -> RuleRunner:
             WsdlSourcesGeneratorTarget,
         ],
     )
-    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        [
+            "--no-jvm-enable-lockfile-targets",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     return rule_runner
 
 
@@ -100,7 +105,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: Iterable[str] = (),
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *extra_args]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *extra_args,
+    ]
     rule_runner.set_options(args, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(address)
     protocol_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/apache/java/rules_integration_test.py
@@ -100,7 +100,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
+    ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     thrift_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/thrift/scrooge/java/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/rules_integration_test.py
@@ -80,7 +80,7 @@ def rule_runner() -> RuleRunner:
         ],
     )
     rule_runner.set_options(
-        [],
+        ["--no-jvm-enable-lockfile-targets"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner
@@ -109,7 +109,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
+    ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     thrift_sources = rule_runner.request(

--- a/src/python/pants/backend/codegen/thrift/scrooge/scala/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scala/rules_integration_test.py
@@ -74,7 +74,7 @@ def rule_runner() -> RuleRunner:
         ],
     )
     rule_runner.set_options(
-        [],
+        ["--no-jvm-enable-lockfile-targets"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner
@@ -103,7 +103,11 @@ def assert_files_generated(
     source_roots: list[str],
     extra_args: list[str] | None = None,
 ) -> None:
-    args = [f"--source-root-patterns={repr(source_roots)}", *(extra_args or ())]
+    args = [
+        "--no-jvm-enable-lockfile-targets",
+        f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
+    ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     tgt = rule_runner.get_target(address)
     thrift_sources = rule_runner.request(

--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -67,7 +67,7 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JavaSourcesGeneratorTarget, JvmArtifactTarget],
     )
-    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
 
 
@@ -168,13 +168,19 @@ def test_compile_jdk_versions(rule_runner: RuleRunner) -> None:
         ),
         resolve=make_resolve(rule_runner),
     )
-    rule_runner.set_options(["--jvm-jdk=zulu:8.0.312"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        ["--no-jvm-enable-lockfile-targets", "--jvm-jdk=zulu:8.0.312"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     classpath = rule_runner.request(RenderedClasspath, [request])
     assert classpath.content == {
         ".ExampleLib.java.lib.javac.jar": {"org/pantsbuild/example/lib/ExampleLib.class"}
     }
 
-    rule_runner.set_options(["--jvm-jdk=bogusjdk:999"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        ["--no-jvm-enable-lockfile-targets", "--jvm-jdk=bogusjdk:999"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
     with pytest.raises(ExecutionError, match=expected_exception_msg):
         rule_runner.request(ClasspathEntry, [request])

--- a/src/python/pants/backend/java/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/java/dependency_inference/rules_test.py
@@ -61,7 +61,9 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JavaSourcesGeneratorTarget, JunitTestsGeneratorTarget, JvmArtifactTarget],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/backend/kotlin/compile/kotlinc_test.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_test.py
@@ -65,7 +65,9 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JvmArtifactTarget, KotlinSourcesGeneratorTarget, KotlincPluginTarget],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 
@@ -447,6 +449,7 @@ def test_compile_with_kotlinc_plugin(
     )
     rule_runner.set_options(
         args=[
+            "--no-jvm-enable-lockfile-targets",
             "--kotlin-version-for-resolve={'jvm-default': '1.6.20'}",
             "--kotlinc-plugins-for-resolve={'jvm-default': 'org.jetbrains.kotlin.allopen'}",
         ],

--- a/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules_test.py
@@ -55,7 +55,9 @@ def rule_runner() -> RuleRunner:
         target_types=[KotlinSourcesGeneratorTarget],
         objects={"parametrize": Parametrize},
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/backend/kotlin/test/junit_test.py
+++ b/src/python/pants/backend/kotlin/test/junit_test.py
@@ -93,7 +93,10 @@ def rule_runner() -> RuleRunner:
     )
     rule_runner.set_options(
         # Makes JUnit output predictable and parseable across versions (#12933):
-        args=["--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']"],
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+            "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner

--- a/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
@@ -56,7 +56,12 @@ def rule_runner() -> RuleRunner:
             QueryRule(Addresses, (DependenciesRequest,)),
         ],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     return rule_runner
 
 
@@ -94,7 +99,7 @@ def _assert_generated_files(
     source_roots: Iterable[str] | None = None,
     extra_args: Iterable[str] = (),
 ) -> None:
-    args = []
+    args = ["--no-jvm-enable-lockfile-targets"]
     if source_roots:
         args.append(f"--source-root-patterns={repr(source_roots)}")
     args.extend(extra_args)

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -63,7 +63,10 @@ def rule_runner() -> RuleRunner:
         target_types=[JvmArtifactTarget, ScalaSourcesGeneratorTarget, ScalacPluginTarget],
     )
     rule_runner.set_options(
-        args=["--scala-version-for-resolve={'jvm-default':'2.13.8'}"],
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+            "--scala-version-for-resolve={'jvm-default':'2.13.8'}",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -541,6 +541,7 @@ def test_compile_with_scalac_plugin(
     )
     rule_runner.set_options(
         args=[
+            "--no-jvm-enable-lockfile-targets",
             "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
             "--scalac-plugins-for-resolve={'jvm-default': 'acyclic'}",
         ],
@@ -601,6 +602,7 @@ def test_compile_with_local_scalac_plugin(
     )
     rule_runner.set_options(
         args=[
+            "--no-jvm-enable-lockfile-targets",
             "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
@@ -701,6 +703,7 @@ def test_compile_with_multiple_scalac_plugins(
     )
     rule_runner.set_options(
         args=[
+            "--no-jvm-enable-lockfile-targets",
             "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
             "--scalac-plugins-for-resolve={'jvm-default': 'bm4,kind-projector'}",
         ],
@@ -761,6 +764,7 @@ def test_compile_with_multiple_scala_versions(
     )
     rule_runner.set_options(
         [
+            "--no-jvm-enable-lockfile-targets",
             '--scala-version-for-resolve={"scala2.12":"2.12.15","scala2.13":"2.13.8"}',
             '--jvm-resolves={"scala2.12":"3rdparty/jvm/scala2.12.lock","scala2.13":"3rdparty/jvm/scala2.13.lock"}',
         ],

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -341,7 +341,8 @@ def test_multi_resolve_dependency_inference(rule_runner: RuleRunner) -> None:
     )
     rule_runner.set_options(
         [
-            '--jvm-resolves={"scala-2.13":"3rdparty/jvm/scala-2.13.lock", "scala-2.12":"3rdparty/jvm/scala-2.12.lock"}'
+            "--no-jvm-enable-lockfile-targets",
+            '--jvm-resolves={"scala-2.13":"3rdparty/jvm/scala-2.13.lock", "scala-2.12":"3rdparty/jvm/scala-2.12.lock"}',
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )

--- a/src/python/pants/backend/scala/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/rules_test.py
@@ -51,7 +51,9 @@ def rule_runner() -> RuleRunner:
         target_types=[ScalaSourcesGeneratorTarget],
         objects={"parametrize": Parametrize},
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/backend/scala/test/scalatest_test.py
+++ b/src/python/pants/backend/scala/test/scalatest_test.py
@@ -271,7 +271,7 @@ def run_scalatest_test(
     extra_args: Iterable[str] | None = None,
     env: Mapping[str, str] | None = None,
 ) -> TestResult:
-    args = extra_args or []
+    args = ["--no-jvm-enable-lockfile-targets", *(extra_args or ())]
     rule_runner.set_options(args, env=env, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(
         Address(spec_path="", target_name=target_name, relative_file_path=relative_file_path)

--- a/src/python/pants/bsp/protocol_test.py
+++ b/src/python/pants/bsp/protocol_test.py
@@ -116,6 +116,7 @@ def jvm_rule_runner() -> RuleRunner:
     )
     rule_runner.set_options(
         args=[
+            "--no-jvm-enable-lockfile-targets",
             "--experimental-bsp-groups-config-files=bsp-groups.toml",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -138,7 +138,10 @@ def rule_runner() -> RuleRunner:
         ],
     )
     rule_runner.set_options(
-        args=["--scala-version-for-resolve={'jvm-default': '2.13.8'}"],
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+            "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -96,7 +96,8 @@ def test_trie_node_merge_basic() -> None:
 def test_third_party_mapping_parsing(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
-            "--java-infer-third-party-import-mapping={'io.github.frenchtoast.savory.**': 'github-frenchtoast:savory'}"
+            "--no-jvm-enable-lockfile-targets",
+            "--java-infer-third-party-import-mapping={'io.github.frenchtoast.savory.**': 'github-frenchtoast:savory'}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
@@ -179,6 +180,7 @@ def test_third_party_dep_inference_resolve(rule_runner: RuleRunner) -> None:
     """Dependencies are only resolved on artifacts in the relevant resolves."""
     rule_runner.set_options(
         [
+            "--no-jvm-enable-lockfile-targets",
             "--java-infer-third-party-import-mapping={'org.joda.time.**': 'joda-time:joda-time'}",
             "--jvm-resolves={'a': '', 'b': '', 'c': ''}",
         ],
@@ -227,7 +229,10 @@ def test_third_party_dep_inference_resolve(rule_runner: RuleRunner) -> None:
 @maybe_skip_jdk_test
 def test_third_party_dep_inference_fqtn(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
-        ["--java-infer-third-party-import-mapping={'org.joda.time.**': 'joda-time:joda-time'}"],
+        [
+            "--no-jvm-enable-lockfile-targets",
+            "--java-infer-third-party-import-mapping={'org.joda.time.**': 'joda-time:joda-time'}",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     rule_runner.write_files(
@@ -271,6 +276,7 @@ def test_third_party_dep_inference_fqtn(rule_runner: RuleRunner) -> None:
 def test_third_party_dep_inference_nonrecursive(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
+            "--no-jvm-enable-lockfile-targets",
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
@@ -350,6 +356,7 @@ def test_third_party_dep_inference_nonrecursive(rule_runner: RuleRunner) -> None
 def test_third_party_dep_inference_with_provides(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
+            "--no-jvm-enable-lockfile-targets",
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
@@ -417,6 +424,7 @@ def test_third_party_dep_inference_with_provides(rule_runner: RuleRunner) -> Non
 def test_third_party_dep_inference_with_incorrect_provides(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(
         [
+            "--no-jvm-enable-lockfile-targets",
             "--java-infer-third-party-import-mapping={'org.joda.time.**':'joda-time:joda-time', 'org.joda.time.DateTime':'joda-time:joda-time-2'}",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper_test.py
@@ -62,7 +62,9 @@ def rule_runner() -> RuleRunner:
             JvmArtifactTarget,
         ],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
+++ b/src/python/pants/jvm/dependency_inference/java_scala_interop_test.py
@@ -53,7 +53,9 @@ def rule_runner() -> RuleRunner:
             ScalaSourceTarget,
         ],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -9,6 +9,7 @@ from typing import cast
 import pytest
 
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
+from pants.core.target_types import LockfilesGeneratorTarget
 from pants.core.util_rules import source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.engine.fs import DigestContents, FileDigest
@@ -44,7 +45,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(UserGenerateLockfiles, [RequestedJVMUserResolveNames]),
             QueryRule(GenerateLockfileResult, [GenerateJvmLockfile]),
         ],
-        target_types=[JvmArtifactTarget],
+        target_types=[JvmArtifactTarget, LockfilesGeneratorTarget],
         objects={"parametrize": Parametrize},
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/jvm/package/deploy_jar_test.py
+++ b/src/python/pants/jvm/package/deploy_jar_test.py
@@ -427,7 +427,10 @@ def test_deploy_jar_shaded(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_deploy_jar_reproducible(rule_runner: RuleRunner) -> None:
-    rule_runner.set_options(args=["--jvm-reproducible-jars"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets", "--jvm-reproducible-jars"],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -482,7 +485,9 @@ def test_deploy_jar_reproducible(rule_runner: RuleRunner) -> None:
 def _deploy_jar_test(
     rule_runner: RuleRunner, target_name: str, args: Iterable[str] | None = None
 ) -> None:
-    rule_runner.set_options(args=(args or ()), env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets", *(args or ())], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
 
     tgt = rule_runner.get_target(Address("", target_name=target_name))
     jdk = rule_runner.request(InternalJdk, [])

--- a/src/python/pants/jvm/package/deploy_jar_test.py
+++ b/src/python/pants/jvm/package/deploy_jar_test.py
@@ -71,7 +71,12 @@ def rule_runner() -> RuleRunner:
             **{rule.alias: rule for rule in JVM_SHADING_RULE_TYPES},
         },
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     return rule_runner
 
 

--- a/src/python/pants/jvm/shading/rules_integration_test.py
+++ b/src/python/pants/jvm/shading/rules_integration_test.py
@@ -66,7 +66,9 @@ def rule_runner() -> RuleRunner:
             QueryRule(ExtractedArchive, (MaybeExtractArchiveRequest,)),
         ],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=["--no-jvm-enable-lockfile-targets"], env_inherit=PYTHON_BOOTSTRAP_ENV
+    )
     return rule_runner
 
 

--- a/src/python/pants/jvm/strip_jar/strip_jar_test.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar_test.py
@@ -57,7 +57,12 @@ def rule_runner() -> RuleRunner:
             JavaSourcesGeneratorTarget,
         ],
     )
-    rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    rule_runner.set_options(
+        args=[
+            "--no-jvm-enable-lockfile-targets",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
     return rule_runner
 
 

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -78,6 +78,21 @@ class JvmSubsystem(Subsystem):
             """
         ),
     )
+    enable_lockfile_targets = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            Create targets for all JVM lockfiles defined in `[jvm].resolves`.
+
+            The lockfile targets will then be used as dependencies to the targets that use them,
+            invalidating source targets per resolve when the lockfile changes.
+
+            If another targets address is in conflict with the created lockfile target, it will
+            shadow the lockfile target and it will not be available as a dependency.
+            """
+        ),
+        advanced=True,
+    )
     debug_args = StrListOption(
         help=softwrap(
             """

--- a/src/python/pants/jvm/test/junit_test.py
+++ b/src/python/pants/jvm/test/junit_test.py
@@ -633,6 +633,7 @@ def run_junit_test(
     env: Mapping[str, str] | None = None,
 ) -> TestResult:
     args = [
+        "--no-jvm-enable-lockfile-targets",
         "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
         *(extra_args or ()),
     ]


### PR DESCRIPTION
Register synthetic lockfile targets for JVM.

TODO: Add dependency on relevant jvm targets that consume lockfiles. 
Perhaps in a dedicated PR?
