### PR TITLE
go: use debug log level when checking C compiler option support

### DIFF
--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -129,7 +129,8 @@ async def check_compiler_supports_flag(
             env={
                 "LC_ALL": "C",
             },
-            description=f"Check whether CC supports flag: {request.flag}",
+            description=f"Check whether compiler `{request.cc}` for Cgo supports flag `{request.flag}`",
+            level=LogLevel.DEBUG,
         ),
     )
 


### PR DESCRIPTION
Use `debug` log level when invoking the C compiler to be used for Cgo compilation to check whether it supports the option. Otherwise the task is logged at `info` level.