### PR TITLE
go: allow use of `go_asm.h` assembly header in assembly files

### DIFF
--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -133,10 +133,10 @@ async def assemble_go_assembly_files(
         ["-p", request.import_path] if goroot.is_compatible_version("1.19") else []
     )
 
-    obj_dir_path = str(PurePath(".", request.dir_path, "__obj__"))
+    obj_dir_path = PurePath(".", request.dir_path, "__obj__")
     asm_tool_id, obj_dir_digest = await MultiGet(
         Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
-        Get(Digest, CreateDigest([Directory(obj_dir_path)])),
+        Get(Digest, CreateDigest([Directory(str(obj_dir_path))])),
     )
 
     input_digest = await Get(Digest, MergeDigests([request.input_digest, obj_dir_digest]))
@@ -146,7 +146,7 @@ async def assemble_go_assembly_files(
     )
 
     def obj_output_path(s_file: str) -> str:
-        return str(PurePath(".", request.dir_path, PurePath(s_file).with_suffix(".o")))
+        return str(obj_dir_path / PurePath(s_file).with_suffix(".o"))
 
     assembly_results = await MultiGet(
         Get(

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -9,29 +9,15 @@ from pathlib import PurePath
 
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.fs import CreateDigest, Digest, Directory, FileContent, MergeDigests
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 
 
 @dataclass(frozen=True)
-class FallibleAssemblyCompilationResult:
-    result: AssemblyCompilationResult | None
-    exit_code: int = 0
-    stdout: str | None = None
-    stderr: str | None = None
-
-
-@dataclass(frozen=True)
-class AssemblyCompilationResult:
-    symabis_digest: Digest
-    symabis_path: str
-    assembly_outputs: tuple[tuple[str, Digest], ...]
-
-
-@dataclass(frozen=True)
-class AssemblyCompilationRequest:
-    """Add a `symabis` file for consumption by Go compiler and assemble all `.s` files.
+class GenerateAssemblySymabisRequest:
+    """Generate a `symabis` file with metadata about the assemnbly files for consumption by Go
+    compiler.
 
     See https://github.com/bazelbuild/rules_go/issues/1893.
     """
@@ -39,28 +25,67 @@ class AssemblyCompilationRequest:
     compilation_input: Digest
     s_files: tuple[str, ...]
     dir_path: str
+
+
+@dataclass(frozen=True)
+class GenerateAssemblySymabisResult:
+    symabis_digest: Digest
+    symabis_path: str
+
+
+@dataclass(frozen=True)
+class FallibleGenerateAssemblySymabisResult:
+    result: GenerateAssemblySymabisResult | None
+    exit_code: int = 0
+    stdout: str | None = None
+    stderr: str | None = None
+
+
+@dataclass(frozen=True)
+class AssembleGoAssemblyFilesRequest:
+    """Assemble Go assembly files to object files."""
+
+    input_digest: Digest
+    s_files: tuple[str, ...]
+    dir_path: str
+    asm_header_path: str | None
     import_path: str
 
 
+@dataclass(frozen=True)
+class AssembleGoAssemblyFilesResult:
+    assembly_outputs: tuple[tuple[str, Digest], ...]
+
+
+@dataclass(frozen=True)
+class FallibleAssembleGoAssemblyFilesResult:
+    result: AssembleGoAssemblyFilesResult | None
+    exit_code: int = 0
+    stdout: str | None = None
+    stderr: str | None = None
+
+
 @rule
-async def setup_assembly_pre_compilation(
-    request: AssemblyCompilationRequest,
+async def generate_go_assembly_symabisfile(
+    request: GenerateAssemblySymabisRequest,
     goroot: GoRoot,
-) -> FallibleAssemblyCompilationResult:
+) -> FallibleGenerateAssemblySymabisResult:
     # From Go tooling comments:
     #
     #   Supply an empty go_asm.h as if the compiler had been run. -symabis parsing is lax enough
     #   that we don't need the actual definitions that would appear in go_asm.h.
     #
     # See https://go-review.googlesource.com/c/go/+/146999/8/src/cmd/go/internal/work/gc.go
-    go_asm_h_digest, asm_tool_id = await MultiGet(
+    obj_dir_path = PurePath(".", request.dir_path, "__obj__")
+    symabis_path = str(obj_dir_path / "symabis")
+    go_asm_h_digest, asm_tool_id, obj_dir_digest = await MultiGet(
         Get(Digest, CreateDigest([FileContent("go_asm.h", b"")])),
         Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
+        Get(Digest, CreateDigest([Directory(str(obj_dir_path))])),
     )
     symabis_input_digest = await Get(
-        Digest, MergeDigests([request.compilation_input, go_asm_h_digest])
+        Digest, MergeDigests([request.compilation_input, go_asm_h_digest, obj_dir_digest])
     )
-    symabis_path = "symabis"
     symabis_result = await Get(
         FallibleProcessResult,
         GoSdkProcess(
@@ -74,7 +99,7 @@ async def setup_assembly_pre_compilation(
                 "-o",
                 symabis_path,
                 "--",
-                *(f"./{request.dir_path}/{name}" for name in request.s_files),
+                *(str(PurePath(".", request.dir_path, s_file)) for s_file in request.s_files),
             ),
             env={
                 "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
@@ -84,37 +109,66 @@ async def setup_assembly_pre_compilation(
         ),
     )
     if symabis_result.exit_code != 0:
-        return FallibleAssemblyCompilationResult(
+        return FallibleGenerateAssemblySymabisResult(
             None, symabis_result.exit_code, symabis_result.stderr.decode("utf-8")
         )
 
+    return FallibleGenerateAssemblySymabisResult(
+        result=GenerateAssemblySymabisResult(
+            symabis_digest=symabis_result.output_digest,
+            symabis_path=symabis_path,
+        ),
+    )
+
+
+@rule
+async def assemble_go_assembly_files(
+    request: AssembleGoAssemblyFilesRequest,
+    goroot: GoRoot,
+) -> FallibleAssembleGoAssemblyFilesResult:
     # On Go 1.19+, the import path must be supplied via the `-p` option to `go tool asm`.
     # See https://go.dev/doc/go1.19#assembler and
     # https://github.com/bazelbuild/rules_go/commit/cde7d7bc27a34547c014369790ddaa95b932d08d (Bazel rules_go).
-    maybe_package_path_args = (
+    maybe_package_import_path_args = (
         ["-p", request.import_path] if goroot.is_compatible_version("1.19") else []
     )
+
+    obj_dir_path = str(PurePath(".", request.dir_path, "__obj__"))
+    asm_tool_id, obj_dir_digest = await MultiGet(
+        Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
+        Get(Digest, CreateDigest([Directory(obj_dir_path)])),
+    )
+
+    input_digest = await Get(Digest, MergeDigests([request.input_digest, obj_dir_digest]))
+
+    maybe_asm_header_path_args = (
+        ["-I", str(PurePath(request.asm_header_path).parent)] if request.asm_header_path else []
+    )
+
+    def obj_output_path(s_file: str) -> str:
+        return str(PurePath(".", request.dir_path, PurePath(s_file).with_suffix(".o")))
 
     assembly_results = await MultiGet(
         Get(
             FallibleProcessResult,
             GoSdkProcess(
-                input_digest=request.compilation_input,
+                input_digest=input_digest,
                 command=(
                     "tool",
                     "asm",
                     "-I",
                     os.path.join(goroot.path, "pkg", "include"),
-                    *maybe_package_path_args,
+                    *maybe_asm_header_path_args,
+                    *maybe_package_import_path_args,
                     "-o",
-                    f"./{request.dir_path}/{PurePath(s_file).with_suffix('.o')}",
-                    f"./{request.dir_path}/{s_file}",
+                    obj_output_path(s_file),
+                    str(os.path.normpath(PurePath(".", request.dir_path, s_file))),
                 ),
                 env={
                     "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
                 },
                 description=f"Assemble {s_file} with Go",
-                output_files=(f"./{request.dir_path}/{PurePath(s_file).with_suffix('.o')}",),
+                output_files=(obj_output_path(s_file),),
             ),
         )
         for s_file in request.s_files
@@ -127,17 +181,15 @@ async def setup_assembly_pre_compilation(
         stderr = "\n\n".join(
             result.stderr.decode("utf-8") for result in assembly_results if result.stderr
         )
-        return FallibleAssemblyCompilationResult(None, exit_code, stdout, stderr)
+        return FallibleAssembleGoAssemblyFilesResult(None, exit_code, stdout, stderr)
 
     assembly_outputs = tuple(
-        (f"./{request.dir_path}/{PurePath(s_file).with_suffix('.o')}", result.output_digest)
+        (obj_output_path(s_file), result.output_digest)
         for s_file, result in zip(request.s_files, assembly_results)
     )
 
-    return FallibleAssemblyCompilationResult(
-        AssemblyCompilationResult(
-            symabis_digest=symabis_result.output_digest,
-            symabis_path=symabis_path,
+    return FallibleAssembleGoAssemblyFilesResult(
+        AssembleGoAssemblyFilesResult(
             assembly_outputs=assembly_outputs,
         )
     )

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -156,10 +156,7 @@ def test_build_invalid_package(rule_runner: RuleRunner) -> None:
     result = rule_runner.request(FallibleBuiltGoPackage, [request])
     assert result.output is None
     assert result.exit_code == 1
-    assert (
-        result.stdout
-        == ".//add_amd64.s:1: unexpected EOF\nasm: assembly of .//add_amd64.s failed\n"
-    )
+    assert result.stdout == "add_amd64.s:1: unexpected EOF\nasm: assembly of add_amd64.s failed\n"
 
 
 def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -278,7 +278,6 @@ def test_build_package_using_api_metdata(rule_runner: RuleRunner) -> None:
             ),
             "add_amd64.go": "package main\nfunc add_magic(x int64) int64",
             "add_arm64.go": "package main\nfunc add_magic(x int64) int64",
-            # Based on https://davidwong.fr/goasm/add.
             "add_amd64.s": dedent(
                 """\
                 #include "textflag.h"  // for NOSPLIT
@@ -292,8 +291,6 @@ def test_build_package_using_api_metdata(rule_runner: RuleRunner) -> None:
                     RET
                 """
             ),
-            # Based on combining https://davidwong.fr/goasm/add and `go tool compile -S` to get
-            # ARM instructions.
             "add_arm64.s": dedent(
                 """\
                 #include "textflag.h"  // for NOSPLIT

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -252,3 +252,76 @@ def test_build_package_with_prebuilt_object_files(rule_runner: RuleRunner) -> No
     result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
     assert result.returncode == 0
     assert result.stdout == b"42\n"
+
+
+def test_build_package_using_api_metdata(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/assembly
+                go 1.17
+                """
+            ),
+            "main.go": dedent(
+                """\
+                package main
+
+                import "fmt"
+
+                const MagicValueToBeUsedByAssembly int = 42
+
+                func main() {
+                    fmt.Println(add_magic(10))
+                }
+                """
+            ),
+            "add_amd64.go": "package main\nfunc add_magic(x int64) int64",
+            "add_arm64.go": "package main\nfunc add_magic(x int64) int64",
+            # Based on https://davidwong.fr/goasm/add.
+            "add_amd64.s": dedent(
+                """\
+                #include "textflag.h"  // for NOSPLIT
+                #include "go_asm.h"  // for const_MagicValueToBeUsedByAssembly
+                TEXT ·add_magic(SB),NOSPLIT,$0
+                    MOVQ  x+0(FP), BX
+                    MOVQ  $const_MagicValueToBeUsedByAssembly, BP
+
+                    ADDQ  BP, BX
+                    MOVQ  BX, ret+8(FP)
+                    RET
+                """
+            ),
+            # Based on combining https://davidwong.fr/goasm/add and `go tool compile -S` to get
+            # ARM instructions.
+            "add_arm64.s": dedent(
+                """\
+                #include "textflag.h"  // for NOSPLIT
+                #include "go_asm.h"  // for const_MagicValueToBeUsedByAssembly
+                TEXT ·add_magic(SB),NOSPLIT,$0
+                    MOVD  x+0(FP), R0
+                    MOVD  $const_MagicValueToBeUsedByAssembly, R1
+
+                    ADD   R1, R0, R0
+                    MOVD  R0, ret+8(FP)
+                    RET
+                """
+            ),
+            "BUILD": dedent(
+                """\
+                go_mod(name="mod")
+                go_package(name="pkg", sources=["*.go", "*.s"])
+                go_binary(name="bin")
+                """
+            ),
+        }
+    )
+
+    binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
+    assert len(built_package.artifacts) == 1
+    assert built_package.artifacts[0].relpath == "bin"
+
+    result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
+    assert result.returncode == 0
+    assert result.stdout == b"52\n"  # should be 10 + the 42 "magic" value

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -580,7 +580,15 @@ async def build_go_package(
         # Extract the `go_asm.h` header from the compilation output and merge into the original compilation input.
         assert asm_header_path is not None
         asm_header_digest = await Get(
-            Digest, DigestSubset(compilation_digest, PathGlobs([asm_header_path]))
+            Digest,
+            DigestSubset(
+                compilation_digest,
+                PathGlobs(
+                    [asm_header_path],
+                    glob_match_error_behavior=GlobMatchErrorBehavior.error,
+                    description_of_origin="the `build_go_package` rule",
+                ),
+            ),
         )
         assembly_input_digest = await Get(Digest, MergeDigests([input_digest, asm_header_digest]))
         assembly_fallible_result = await Get(

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -6,12 +6,15 @@ import dataclasses
 import hashlib
 import os.path
 from dataclasses import dataclass
+from pathlib import PurePath
 from typing import Iterable
 
 from pants.backend.go.util_rules import cgo, coverage
 from pants.backend.go.util_rules.assembly import (
-    AssemblyCompilationRequest,
-    FallibleAssemblyCompilationResult,
+    AssembleGoAssemblyFilesRequest,
+    FallibleAssembleGoAssemblyFilesResult,
+    FallibleGenerateAssemblySymabisResult,
+    GenerateAssemblySymabisRequest,
 )
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompileRequest, CGoCompileResult, CGoCompilerFlags
@@ -35,6 +38,7 @@ from pants.engine.fs import (
     Digest,
     DigestContents,
     DigestSubset,
+    Directory,
     FileContent,
     MergeDigests,
     PathGlobs,
@@ -469,34 +473,37 @@ async def build_go_package(
         MergeDigests(unmerged_input_digests),
     )
 
-    # Process any assembly files and add the result to `objects` for linking into the package archive.
-    # The `symabis` file generated with API information is added to the input digest for use in compilation.
+    # If any assembly files are present, generate a "symabis" file containing API metadata about those files.
+    # The "symabis" file is passed to the Go compiler when building Go code so that the compiler is aware of
+    # any API exported by the assembly.
+    #
+    # Note: The assembly files cannot be assembled at this point because a similar process happens from Go to
+    # assembly: The Go compiler generates a `go_asm.h` header file with metadata about the Go code in the package.
     symabis_path: str | None = None
     if s_files:
-        assembly_setup = await Get(
-            FallibleAssemblyCompilationResult,
-            AssemblyCompilationRequest(
+        symabis_fallible_result = await Get(
+            FallibleGenerateAssemblySymabisResult,
+            GenerateAssemblySymabisRequest(
                 compilation_input=input_digest,
                 s_files=tuple(s_files),
                 dir_path=request.dir_path,
-                import_path=request.import_path,
             ),
         )
-        assembly_result = assembly_setup.result
-        if assembly_result is None:
+        symabis_result = symabis_fallible_result.result
+        if symabis_result is None:
             return FallibleBuiltGoPackage(
                 None,
                 request.import_path,
-                assembly_setup.exit_code,
-                stdout=assembly_setup.stdout,
-                stderr=assembly_setup.stderr,
+                symabis_fallible_result.exit_code,
+                stdout=symabis_fallible_result.stdout,
+                stderr=symabis_fallible_result.stderr,
             )
         input_digest = await Get(
-            Digest, MergeDigests([input_digest, assembly_result.symabis_digest])
+            Digest, MergeDigests([input_digest, symabis_result.symabis_digest])
         )
-        symabis_path = assembly_result.symabis_path
-        objects.extend(assembly_result.assembly_outputs)
+        symabis_path = symabis_result.symabis_path
 
+    # Build the arguments for compiling the Go coe in this package.
     compile_args = [
         "tool",
         "compile",
@@ -520,15 +527,25 @@ async def build_go_package(
     if symabis_path:
         compile_args.extend(["-symabis", symabis_path])
 
+    # If any assembly files are present, request the compiler write an "assembly header" with API metadata
+    # about the Go code that can be used by assembly files.
+    asm_header_path: str | None = None
+    if s_files:
+        obj_dir_path = PurePath(".", request.dir_path, "__obj__")
+        asm_header_path = str(obj_dir_path / "go_asm.h")
+        obj_dir_digest = await Get(Digest, CreateDigest([Directory(str(obj_dir_path))]))
+        input_digest = await Get(Digest, MergeDigests([input_digest, obj_dir_digest]))
+        compile_args.extend(["-asmhdr", asm_header_path])
+
     if embedcfg.digest != EMPTY_DIGEST:
         compile_args.extend(["-embedcfg", RenderedEmbedConfig.PATH])
 
     if request.build_opts.with_race_detector:
         compile_args.append("-race")
 
-    # If there are no loose object files to add to the package archive later, then pass -complete flag which
-    # tells the compiler that the provided Go files constitute the entire package.
-    if not objects:
+    # If there are no loose object files to add to the package archive later or assembly files to assemble,
+    # then pass -complete flag which tells the compiler that the provided Go files constitute the entire package.
+    if not objects and not s_files:
         compile_args.append("-complete")
 
     relativized_sources = (
@@ -542,7 +559,7 @@ async def build_go_package(
             input_digest=input_digest,
             command=tuple(compile_args),
             description=f"Compile Go package: {request.import_path}",
-            output_files=("__pkg__.a",),
+            output_files=("__pkg__.a", *([asm_header_path] if asm_header_path else [])),
             env={"__PANTS_GO_COMPILE_ACTION_ID": action_id_result.action_id},
         ),
     )
@@ -556,6 +573,38 @@ async def build_go_package(
         )
 
     compilation_digest = compile_result.output_digest
+
+    # If any assembly files are present, then assemble them. The `compilation_digest` will contain the
+    # assembly header `go_asm.h` in the object directory.
+    if s_files:
+        # Extract the `go_asm.h` header from the compilation output and merge into the original compilation input.
+        assert asm_header_path is not None
+        asm_header_digest = await Get(
+            Digest, DigestSubset(compilation_digest, PathGlobs([asm_header_path]))
+        )
+        assembly_input_digest = await Get(Digest, MergeDigests([input_digest, asm_header_digest]))
+        assembly_fallible_result = await Get(
+            FallibleAssembleGoAssemblyFilesResult,
+            AssembleGoAssemblyFilesRequest(
+                input_digest=assembly_input_digest,
+                s_files=tuple(sorted(s_files)),
+                dir_path=request.dir_path,
+                asm_header_path=asm_header_path,
+                import_path=request.import_path,
+            ),
+        )
+        assembly_result = assembly_fallible_result.result
+        if assembly_result is None:
+            return FallibleBuiltGoPackage(
+                None,
+                request.import_path,
+                assembly_fallible_result.exit_code,
+                stdout=assembly_fallible_result.stdout,
+                stderr=assembly_fallible_result.stderr,
+            )
+        objects.extend(assembly_result.assembly_outputs)
+
+    # If there are any loose object files, link them into the package archive.
     if objects:
         assembly_link_input_digest = await Get(
             Digest,


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/12943, Go assembly files expect an "assembly header" called `go_asm.h` to exist and be available for inclusion via `#include "go_asm.h"`. The assembly header contains macros generated based on constants and type metadata from the package's Go code. The Go backend currently does not request that the compiler generate this header.

This PR splits the `symabis` generation step and assembly step into two different phases:
- `symabis` generation continues to happen _before_ compilation of the package's Go code since it contains API metadata needed by the Go compiler about the assembly code.
- The Go compiler will now generate the `go_asm.h` assembly header and make it available to Go assembly files. The assembly files are now assembled _after_ the package's Go code has been compiled so they can consume `go_asm.h` if need be.

Fixes https://github.com/pantsbuild/pants/issues/12943.

Note: `symabis` and `go_asm.h` serve similar purposes; they differ mainly around which part of a Go package they are metadata for.