### PR TITLE
Dep rules: improve error messages. report all failures for a target not just one.

### DIFF
--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -260,7 +260,7 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
         ruleset = self.get_ruleset(target)
         if ruleset is None:
             return None, None, None
-        path = str(address) if address.is_file_target else address.spec_path
+        path = address.filename if address.is_file_target else address.spec_path
         for visibility_rule in ruleset.rules:
             if visibility_rule.match(path, relpath):
                 if visibility_rule.action != DependencyRuleAction.ALLOW:

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -8,22 +8,55 @@ import os.path
 from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import PurePath
+from pprint import pformat
 from typing import Any, Iterable, Iterator, Sequence, cast
 
 from pants.backend.visibility.glob import PathGlob
+from pants.engine.addresses import Address
 from pants.engine.internals.dep_rules import (
     BuildFileDependencyRules,
     BuildFileDependencyRulesParserState,
     DependencyRuleAction,
+    DependencyRuleApplication,
     DependencyRulesError,
 )
 from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
 
 class BuildFileVisibilityRulesError(DependencyRulesError):
-    pass
+    @classmethod
+    def create(
+        cls,
+        kind: str,
+        rules: BuildFileVisibilityRules,
+        ruleset: VisibilityRuleSet | None,
+        origin_address: Address,
+        origin_adaptor: TargetAdaptor,
+        dependency_address: Address,
+        dependency_adaptor: TargetAdaptor,
+    ) -> BuildFileVisibilityRulesError:
+        example = (
+            pformat((ruleset.target_type_patterns, *map(str, ruleset.rules), "!*"))
+            if ruleset is not None
+            else '(<target patterns>, <existing rules...>, "!*"),'
+        )
+        return cls(
+            softwrap(
+                f"""
+                There is no matching rule from the `{kind}` defined in {rules.path} for the
+                `{origin_adaptor.type_alias}` target {origin_address} for the dependency on the
+                `{dependency_adaptor.type_alias}` target {dependency_address}
+
+                Consider adding the required catch-all rule at the end of the rules spec.  Example
+                adding a "deny all" at the end:
+
+                  {example}
+                """
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -61,7 +94,7 @@ class VisibilityRule:
             prefix = "!"
         elif self.action is DependencyRuleAction.WARN:
             prefix = "?"
-        return repr(f"{prefix}{self.glob.raw}")
+        return f"{prefix}{self.glob.raw}"
 
 
 def flatten(xs) -> Iterator[str]:
@@ -80,11 +113,12 @@ def flatten(xs) -> Iterator[str]:
 class VisibilityRuleSet:
     """An ordered set of rules that applies to some set of target types."""
 
+    build_file: str
     target_type_patterns: Sequence[str]
     rules: Sequence[VisibilityRule]
 
     @classmethod
-    def parse(cls, arg: Any, relpath: str) -> VisibilityRuleSet:
+    def parse(cls, build_file: str, arg: Any) -> VisibilityRuleSet:
         """Translate input `arg` from BUILD file call.
 
         The arg is a rule spec tuple with two or more elements, where the first is the target type
@@ -96,9 +130,11 @@ class VisibilityRuleSet:
                 f"but got: {arg!r}"
             )
 
+        relpath = os.path.dirname(build_file)
         try:
             targets, rules = flatten(arg[0]), flatten(arg[1:])
             return cls(
+                build_file,
                 tuple(targets),
                 tuple(
                     VisibilityRule.parse(rule, relpath)
@@ -108,6 +144,9 @@ class VisibilityRuleSet:
             )
         except ValueError as e:
             raise ValueError(f"Invalid rule spec, {e}") from e
+
+    def __str__(self) -> str:
+        return self.build_file
 
     @staticmethod
     def _noop_rule(rule: str) -> bool:
@@ -131,82 +170,97 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
     @staticmethod
     def check_dependency_rules(
         *,
-        source_adaptor: TargetAdaptor,
-        source_path: str,
+        origin_address: Address,
+        origin_adaptor: TargetAdaptor,
         dependencies_rules: BuildFileDependencyRules | None,
-        target_adaptor: TargetAdaptor,
-        target_path: str,
+        dependency_address: Address,
+        dependency_adaptor: TargetAdaptor,
         dependents_rules: BuildFileDependencyRules | None,
-    ) -> DependencyRuleAction:
-        """The source of the dependency has the dependencies field, the target of the dependency is
-        the one listed as a value in the dependencies field.
+    ) -> DependencyRuleApplication:
+        """Check all rules for any that apply to the relation between the two targets.
 
-        The `__dependencies_rules__` are the rules applicable for the source path.
-        The `__dependents_rules__` are the rules applicable for the target path.
+        The `__dependencies_rules__` are the rules applicable for the origin target.
+        The `__dependents_rules__` are the rules applicable for the dependency target.
 
-        Return dependency rule action ALLOW, DENY or WARN. WARN is effectively the same as ALLOW,
-        but with a logged warning.
+        Return dependency rule application describing the resulting action to take: ALLOW, DENY or
+        WARN. WARN is effectively the same as ALLOW, but with a logged warning.
         """
         # We can safely cast the `dependencies_rules` and `dependents_rules` here as they're the
         # same type as the class being used to call `check_dependency_rules()`.
 
         # Check outgoing dependency action
-        outgoing = (
+        out_ruleset, out_action, out_pattern = (
             cast(BuildFileVisibilityRules, dependencies_rules).get_action(
-                source_adaptor,
-                target_path,
-                relpath=source_path,
+                target=origin_adaptor,
+                address=dependency_address,
+                relpath=origin_address.spec_path,
                 outgoing_dependency=True,
             )
             if dependencies_rules is not None
-            else DependencyRuleAction.ALLOW
+            else (None, DependencyRuleAction.ALLOW, None)
         )
-        if outgoing is None:
-            dep_rules = cast(BuildFileVisibilityRules, dependencies_rules)
-            raise BuildFileVisibilityRulesError(
-                f"There is no matching dependencies rule for the `{source_adaptor.type_alias}` "
-                f"target {source_path}:{source_adaptor.name or os.path.basename(source_path)} "
-                f"for the dependency on the `{target_adaptor.type_alias}` target {target_path}:"
-                f"{target_adaptor.name or os.path.basename(target_path)} in {dep_rules.path}"
+        if out_action is None:
+            raise BuildFileVisibilityRulesError.create(
+                kind="__dependencies_rules__",
+                rules=cast(BuildFileVisibilityRules, dependencies_rules),
+                ruleset=out_ruleset,
+                origin_address=origin_address,
+                origin_adaptor=origin_adaptor,
+                dependency_address=dependency_address,
+                dependency_adaptor=dependency_adaptor,
             )
-        if outgoing == DependencyRuleAction.DENY:
-            return outgoing
 
         # Check incoming dependency action
-        incoming = (
+        in_ruleset, in_action, in_pattern = (
             cast(BuildFileVisibilityRules, dependents_rules).get_action(
-                target_adaptor,
-                source_path,
-                relpath=target_path,
+                target=dependency_adaptor,
+                address=origin_address,
+                relpath=dependency_address.spec_path,
                 outgoing_dependency=False,
             )
             if dependents_rules is not None
-            else DependencyRuleAction.ALLOW
+            else (None, DependencyRuleAction.ALLOW, None)
         )
-        if incoming is None:
-            dep_rules = cast(BuildFileVisibilityRules, dependents_rules)
-            raise BuildFileVisibilityRulesError(
-                f"There is no matching dependents rule for the `{target_adaptor.type_alias}` "
-                f"target {target_path}:{target_adaptor.name or os.path.basename(target_path)} "
-                f"for the dependency from the `{source_adaptor.type_alias}` target {source_path}:"
-                f"{source_adaptor.name or os.path.basename(source_path)} in {dep_rules.path}"
+        if in_action is None:
+            raise BuildFileVisibilityRulesError.create(
+                kind="__dependents_rules__",
+                rules=cast(BuildFileVisibilityRules, dependents_rules),
+                ruleset=in_ruleset,
+                origin_address=origin_address,
+                origin_adaptor=origin_adaptor,
+                dependency_address=dependency_address,
+                dependency_adaptor=dependency_adaptor,
             )
-        return incoming if incoming != DependencyRuleAction.ALLOW else outgoing
+        if in_action is DependencyRuleAction.DENY or out_action is DependencyRuleAction.ALLOW:
+            action = in_action
+        else:
+            action = out_action
+        source_rule = f"{out_ruleset}[{out_pattern}]" if out_ruleset else origin_address.spec_path
+        target_rule = f"{in_ruleset}[{in_pattern}]" if in_ruleset else dependency_address.spec_path
+        return DependencyRuleApplication(
+            action=action,
+            rule_description=f"{source_rule} -> {target_rule}",
+            origin_address=origin_address,
+            origin_type=origin_adaptor.type_alias,
+            dependency_address=dependency_address,
+            dependency_type=dependency_adaptor.type_alias,
+        )
 
     def get_action(
         self,
         target: TargetAdaptor,
-        path: str,
+        address: Address,
         relpath: str,
         outgoing_dependency: bool,
-    ) -> DependencyRuleAction | None:
+    ) -> tuple[VisibilityRuleSet | None, DependencyRuleAction | None, str | None]:
         """Get applicable rule for target type from `path`.
 
         The rules are declared in `relpath`.
         """
         ruleset = self.get_ruleset(target)
         if ruleset is None:
-            return None
+            return None, None, None
+        path = str(address) if address.is_file_target else address.spec_path
         for visibility_rule in ruleset.rules:
             if visibility_rule.match(path, relpath):
                 if visibility_rule.action != DependencyRuleAction.ALLOW:
@@ -216,16 +270,16 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
                         logger.debug(
                             f"{visibility_rule.action.name}: the `{target_type}` target "
                             f"{target_addr} dependency to a target at {path} by dependency rule "
-                            f"{visibility_rule} declared in {self.path}"
+                            f"{str(visibility_rule)!r} declared in {self.path}"
                         )
                     else:
                         logger.debug(
                             f"{visibility_rule.action.name}: dependency on the `{target_type}` "
                             f"target {target_addr} from a target at {path} by dependent rule "
-                            f"{visibility_rule} declared in {self.path}"
+                            f"{str(visibility_rule)!r} declared in {self.path}"
                         )
-                return visibility_rule.action
-        return None
+                return ruleset, visibility_rule.action, str(visibility_rule)
+        return ruleset, None, None
 
     def get_ruleset(self, target: TargetAdaptor) -> VisibilityRuleSet | None:
         for ruleset in self.rulesets:
@@ -254,9 +308,7 @@ class BuildFileVisibilityRulesParserState(BuildFileDependencyRulesParserState):
         **kwargs,
     ) -> None:
         try:
-            self.rulesets = [
-                VisibilityRuleSet.parse(arg, os.path.dirname(build_file)) for arg in args if arg
-            ]
+            self.rulesets = [VisibilityRuleSet.parse(build_file, arg) for arg in args if arg]
             self.path = build_file
         except ValueError as e:
             raise BuildFileVisibilityRulesError(f"{build_file}: {e}") from e

--- a/src/python/pants/backend/visibility/rules.py
+++ b/src/python/pants/backend/visibility/rules.py
@@ -10,8 +10,8 @@ from pants.engine.internals.dep_rules import (
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
-    DependenciesRuleAction,
-    DependenciesRuleActionRequest,
+    DependenciesRuleApplication,
+    DependenciesRuleApplicationRequest,
     FieldSet,
     ValidatedDependencies,
     ValidateDependenciesRequest,
@@ -44,8 +44,8 @@ async def visibility_validate_dependencies(
 ) -> ValidatedDependencies:
     address = request.field_set.address
     dependencies_rule_action = await Get(
-        DependenciesRuleAction,
-        DependenciesRuleActionRequest(
+        DependenciesRuleApplication,
+        DependenciesRuleApplicationRequest(
             address=address,
             dependencies=request.dependencies,
             description_of_origin=f"get dependency rules for {address}",

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -152,12 +152,15 @@ class OptionalAddressFamily:
     path: str
     address_family: AddressFamily | None = None
 
+    def ensure(self) -> AddressFamily:
+        if self.address_family is not None:
+            return self.address_family
+        raise ResolveError(f"Directory '{self.path}' does not contain any BUILD files.")
+
 
 @rule
 async def ensure_address_family(request: OptionalAddressFamily) -> AddressFamily:
-    if request.address_family is None:
-        raise ResolveError(f"Directory '{request.path}' does not contain any BUILD files.")
-    return request.address_family
+    return request.ensure()
 
 
 @rule(desc="Search for addresses in BUILD files")
@@ -318,6 +321,14 @@ async def find_target_adaptor(request: TargetAdaptorRequest) -> TargetAdaptor:
     return target_adaptor
 
 
+def _rules_path(address: Address) -> str:
+    if address.is_file_target and os.path.sep in address._relative_file_path:  # type: ignore[operator]
+        # The file is in a subdirectory of spec_path
+        return os.path.dirname(address.filename)
+    else:
+        return address.spec_path
+
+
 @rule
 async def get_dependencies_rule_application(
     request: DependenciesRuleApplicationRequest,
@@ -329,34 +340,50 @@ async def get_dependencies_rule_application(
     if build_file_dependency_rules_class is None:
         return DependenciesRuleApplication.allow_all()
 
-    spec_paths = {address.spec_path for address in (request.address, *request.dependencies)}
-    address_families = await MultiGet(
-        Get(AddressFamily, AddressFamilyDir(spec_path)) for spec_path in spec_paths
+    # Fetch up to 4 sets of address families, one each for the target adaptors, and then one each
+    # for the dep rules (as we want the rules from the directory the file is in rather than the
+    # directory where the target generator was declared, if not the same)
+    rules_paths = set(
+        itertools.chain.from_iterable(
+            {address.spec_path, _rules_path(address)}
+            for address in (request.address, *request.dependencies)
+        )
     )
-    families = {address_family.namespace: address_family for address_family in address_families}
-    origin_family = families[request.address.spec_path]
+    maybe_address_families = await MultiGet(
+        Get(OptionalAddressFamily, AddressFamilyDir(rules_path)) for rules_path in rules_paths
+    )
+    maybe_families = {maybe.path: maybe for maybe in maybe_address_families}
+    origin_tgt_address = request.address.maybe_convert_to_target_generator()
     origin_target = _get_target_adaptor(
-        request.address.maybe_convert_to_target_generator(),
-        origin_family,
+        origin_tgt_address,
+        maybe_families[origin_tgt_address.spec_path].ensure(),
         request.description_of_origin,
+    )
+    origin_rules_family = (
+        maybe_families[_rules_path(request.address)].address_family
+        or maybe_families[request.address.spec_path].ensure()
     )
     dependencies_rule: dict[Address, DependencyRuleApplication] = {}
     for dependency_address in request.dependencies:
-        dependency_family = families[dependency_address.spec_path]
+        dependency_tgt_address = dependency_address.maybe_convert_to_target_generator()
         dependency_target = _get_target_adaptor(
-            dependency_address.maybe_convert_to_target_generator(),
-            dependency_family,
+            dependency_tgt_address,
+            maybe_families[dependency_tgt_address.spec_path].ensure(),
             f"{request.description_of_origin} on {dependency_address}",
+        )
+        dependency_rules_family = (
+            maybe_families[_rules_path(dependency_address)].address_family
+            or maybe_families[dependency_address.spec_path].ensure()
         )
         dependencies_rule[
             dependency_address
         ] = build_file_dependency_rules_class.check_dependency_rules(
             origin_address=request.address,
             origin_adaptor=origin_target,
-            dependencies_rules=origin_family.dependencies_rules,
+            dependencies_rules=origin_rules_family.dependencies_rules,
             dependency_address=dependency_address,
             dependency_adaptor=dependency_target,
-            dependents_rules=dependency_family.dependents_rules,
+            dependents_rules=dependency_rules_family.dependents_rules,
         )
     return DependenciesRuleApplication(request.address, FrozenDict(dependencies_rule))
 


### PR DESCRIPTION
Labeled as internal as I don't know if we care for this change in the changelog..?

OK, there's quite a bit going on in here, but mostly is related to improving the message contents with more context and information.

Actually got in a change so that for file target addresses, the file path is used in the rule rather than just the directory of it, so it is still not using target addresses in full (although we could add that if file paths are not enough) - didn't want to pile more into this PR. Only I forgot to add a test case for it, will do in a follow up.