### PR TITLE
Dep rules: support for generated targets, such as python requirements.

### DIFF
--- a/build-support/bin/check_inits.py
+++ b/build-support/bin/check_inits.py
@@ -8,24 +8,26 @@ from pathlib import Path
 from common import die
 
 DIRS_TO_CHECK = (
-    "src",
-    "tests",
+    "src/python",
+    "tests/python",
     "pants-plugins",
-    "examples",
     "build-support/bin",
     "build-support/migration-support",
 )
 
 
 def main() -> None:
+    exclude_check = {
+        "src/python/pants/__init__.py",
+    }
     files = itertools.chain.from_iterable(
         [Path().glob(f"{d}/**/__init__.py") for d in DIRS_TO_CHECK]
     )
-    non_empty_inits = [f for f in files if bool(f.read_text())]
-    if non_empty_inits:
+    non_empty_inits = {str(f) for f in files if bool(f.read_text())}
+    if non_empty_inits - exclude_check:
         die(
             "All `__init__.py` file should be empty, but the following had content: "
-            f"{', '.join(str(f) for f in non_empty_inits)}"
+            f"{', '.join(f for f in non_empty_inits)}"
         )
 
 

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -246,6 +246,14 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
             dependency_type=dependency_adaptor.type_alias,
         )
 
+    @staticmethod
+    def _get_address_path(address: Address) -> str:
+        if address.is_file_target:
+            return address.filename
+        if address.is_generated_target:
+            return address.spec
+        return address.spec_path
+
     def get_action(
         self,
         target: TargetAdaptor,
@@ -260,7 +268,7 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
         ruleset = self.get_ruleset(target)
         if ruleset is None:
             return None, None, None
-        path = address.filename if address.is_file_target else address.spec_path
+        path = self._get_address_path(address)
         for visibility_rule in ruleset.rules:
             if visibility_rule.match(path, relpath):
                 if visibility_rule.action != DependencyRuleAction.ALLOW:


### PR DESCRIPTION
Keeping these changes as internal for the changelog still...

Adds support for generator address syntax, in particular to support filtering 3rdparty requirements :) 
