### PR TITLE
Dep rules spec selector syntax

### DIFF
--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 import os.path
 import re
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Pattern
+from typing import Any, Pattern
+
+from pants.util.strutil import softwrap
 
 
 class PathGlobAnchorMode(Enum):
@@ -29,14 +32,24 @@ class PathGlob:
     anchor_mode: PathGlobAnchorMode = field(compare=False)
     glob: Pattern = field(compare=False)
 
+    def __str__(self) -> str:
+        if self.anchor_mode is PathGlobAnchorMode.INVOKED_PATH and self.raw:
+            return f"./{self.raw}"
+        elif self.anchor_mode is PathGlobAnchorMode.DECLARED_PATH:
+            return self.raw
+        else:
+            return f"{self.anchor_mode.value}{self.raw}"
+
     @classmethod
     def parse(cls, pattern: str, base: str) -> PathGlob:
+        if not isinstance(pattern, str):
+            raise ValueError(f"invalid path glob, expected string but got: {pattern!r}")
         anchor_mode = PathGlobAnchorMode.parse(pattern)
         glob = os.path.normpath(pattern).lstrip("./")
         if anchor_mode is PathGlobAnchorMode.DECLARED_PATH:
             glob = os.path.join(base, glob)
         return cls(
-            raw=pattern,
+            raw=glob,
             anchor_mode=anchor_mode,
             glob=cls._parse_pattern(glob),
         )
@@ -74,3 +87,104 @@ class PathGlob:
                 )
             )
         )
+
+
+@dataclass(frozen=True)
+class TargetGlob:
+    type_: str | None
+    path: PathGlob | None
+    tags: tuple[str, ...] | None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.type_, (str, type(None))):
+            raise ValueError(f"invalid target type, expected glob but got: {self.type_!r}")
+        if not isinstance(self.path, (PathGlob, type(None))):
+            raise ValueError(f"invalid target path, expected glob but got: {self.path!r}")
+        if not isinstance(self.tags, (tuple, type(None))):
+            raise ValueError(
+                f"invalid target tags, expected sequence of values but got: {self.tags!r}"
+            )
+
+    def __str__(self) -> str:
+        # Note: when there are more selection criteria used than is supported as a single text
+        # value, switch over to a dict based representation.
+        tags = (
+            f"({', '.join(str(tag) if ',' not in tag else repr(tag) for tag in self.tags)})"
+            if self.tags is not None
+            else ""
+        )
+        path = f"[{self.path}]" if self.path is not None else ""
+        return f"{self.type_ or ''}{tags}{path}" or "*"
+
+    @classmethod
+    def parse(cls, spec: str | Mapping[str, Any], relpath: str) -> TargetGlob:
+        if isinstance(spec, str):
+            spec_dict = cls._parse_string(spec)
+            from pprint import pprint
+
+            pprint(spec_dict)
+        elif isinstance(spec, Mapping):
+            spec_dict = spec
+        else:
+            raise ValueError(f"invalid target spec, expected string or dict but got: {spec!r}")
+
+        return cls(
+            type_=spec_dict.get("type"),
+            path=PathGlob.parse(spec_dict["path"], relpath)
+            if spec_dict.get("path") is not None
+            else None,
+            tags=cls._parse_tags(spec_dict.get("tags")),
+        )
+
+    @staticmethod
+    def _parse_string(spec: str) -> Mapping[str, Any]:
+        match = re.match(
+            r"""
+            (?P<type>[^([]*)
+            (?:
+              \(
+                (?P<tags>[^)]*)
+              \)
+            )?
+            (?:
+              \[
+                (?P<path>[^]]*)
+              \]
+            )?
+            $
+            """,
+            spec,
+            re.VERBOSE,
+        )
+        if not match:
+            raise ValueError(
+                f"invalid target spec string with optional parts of 'target-glob(tag-value, ...)[path-glob]' "
+                f"but got: {spec!r}"
+            )
+        print(match, match.groups())
+        return match.groupdict()
+
+    @staticmethod
+    def _parse_tags(tags: str | Sequence[str] | None) -> tuple[Any, ...] | None:
+        if tags is None:
+            return None
+        if isinstance(tags, str):
+            if "'" in tags or '"' in tags:
+                raise ValueError(
+                    softwrap(
+                        f"""
+                        Quotes not supported for tags rule selector in string form, quotes only
+                        needed for tag values with commas in them otherwise simply remove the
+                        quotes. For embedded commas, use the dictionary syntax:
+
+                          {{"tags": [{tags!r}, ...], ...}}
+                        """
+                    )
+                )
+            tags = tags.split(",")
+        if not isinstance(tags, Sequence):
+            raise ValueError(
+                f"invalid tags, expected a tag or a list of tags but got: {type(tags).__name__}"
+            )
+        tags = tuple(str(tag).strip() for tag in tags)
+        return tags

--- a/src/python/pants/backend/visibility/glob_test.py
+++ b/src/python/pants/backend/visibility/glob_test.py
@@ -2,26 +2,33 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from typing import Any, Mapping
+
 import pytest
 
-from pants.backend.visibility.glob import PathGlob
+from pants.backend.visibility.glob import PathGlob, TargetGlob
 
 
 @pytest.mark.parametrize(
-    "pattern, base, anchor_mode, glob",
+    "pattern, base, anchor_mode, raw, glob, text",
     [
-        ("foo", "base", "", "foo$"),
-        (".", "base", ".", "$"),
-        ("./foo", "base", ".", "foo$"),
-        ("/foo", "base", "/", "base/foo$"),
-        ("//foo", "base", "//", "foo$"),
+        ("foo", "base", "", "foo", "foo$", "foo"),
+        (".", "base", ".", "", "$", "."),
+        ("./foo", "base", ".", "foo", "foo$", "./foo"),
+        ("/foo", "base", "/", "base/foo", "base/foo$", "base/foo"),
+        ("//foo", "base", "//", "foo", "foo$", "//foo"),
+        ("foo/**/bar", "base", "", "foo/**/bar", "foo(/.*)?/bar$", "foo/**/bar"),
+        ("foo/../bar", "base", "", "bar", "bar$", "bar"),
     ],
 )
-def test_parse_pattern(pattern: str, base: str, anchor_mode: str, glob: str) -> None:
+def test_parse_pattern(
+    pattern: str, base: str, anchor_mode: str, raw: str, glob: str, text: str
+) -> None:
     parsed = PathGlob.parse(pattern, base)
-    assert pattern == parsed.raw
+    assert raw == parsed.raw
     assert anchor_mode == parsed.anchor_mode.value
     assert glob == parsed.glob.pattern
+    assert text == str(parsed)
 
 
 @pytest.mark.parametrize(
@@ -103,3 +110,26 @@ def test_match(glob: PathGlob, tests: tuple[tuple[str, str, bool], ...]) -> None
     for path, base, expected in tests:
         print(path, base)
         assert expected == glob.match(path, base)
+
+
+@pytest.mark.parametrize(
+    "target_spec, expected",
+    [
+        ({}, "*"),
+        ("", "*"),
+        (dict(type="resources"), "resources"),
+        (dict(type="file", path="glob/*/this.ext"), "file[glob/*/this.ext]"),
+        (dict(path="glob/*/this.ext"), "[glob/*/this.ext]"),
+        (dict(tags=["tagged"]), "(tagged)"),
+        (dict(tags=["tag-a", "tag-b , b", "c"]), "(tag-a, 'tag-b , b', c)"),
+        (dict(type="file*", tags=["foo", "bar"], path="baz.txt"), "file*(foo, bar)[baz.txt]"),
+        ("resources", "resources"),
+        ("file[glob/*/this.ext]", "file[glob/*/this.ext]"),
+        ("[glob/*/this.ext]", "[glob/*/this.ext]"),
+        ("(tag-a)", "(tag-a)"),
+        ("(tag-a  ,  tag-b)", "(tag-a, tag-b)"),
+        ("file*(foo, bar)[baz.txt]", "file*(foo, bar)[baz.txt]"),
+    ],
+)
+def test_target_glob_parse_spec(target_spec: str | Mapping[str, Any], expected: str) -> None:
+    assert expected == str(TargetGlob.parse(target_spec, "base"))

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -6,12 +6,11 @@ import itertools
 import logging
 import os.path
 from dataclasses import dataclass, field
-from fnmatch import fnmatchcase
 from pathlib import PurePath
 from pprint import pformat
 from typing import Any, Iterable, Iterator, Sequence, cast
 
-from pants.backend.visibility.glob import PathGlob
+from pants.backend.visibility.glob import PathGlob, TargetGlob
 from pants.engine.addresses import Address
 from pants.engine.internals.dep_rules import (
     BuildFileDependencyRules,
@@ -39,7 +38,7 @@ class BuildFileVisibilityRulesError(DependencyRulesError):
         dependency_adaptor: TargetAdaptor,
     ) -> BuildFileVisibilityRulesError:
         example = (
-            pformat((ruleset.target_type_patterns, *map(str, ruleset.rules), "!*"))
+            pformat((tuple(map(str, ruleset.selectors)), *map(str, ruleset.rules), "!*"))
             if ruleset is not None
             else '(<target patterns>, <existing rules...>, "!*"),'
         )
@@ -94,19 +93,22 @@ class VisibilityRule:
             prefix = "!"
         elif self.action is DependencyRuleAction.WARN:
             prefix = "?"
-        return f"{prefix}{self.glob.raw}"
+        return f"{prefix}{self.glob}"
 
 
-def flatten(xs) -> Iterator[str]:
+def flatten(xs, *types: type) -> Iterator:
     """Return an iterator with values, regardless of the nesting of the input."""
-    if isinstance(xs, str):
+    assert types
+    if str in types and isinstance(xs, str):
         yield from (x.strip() for x in xs.splitlines())
+    elif isinstance(xs, types):
+        yield xs
     elif isinstance(xs, Iterable):
-        yield from itertools.chain.from_iterable(flatten(x) for x in xs)
+        yield from itertools.chain.from_iterable(flatten(x, *types) for x in xs)
     elif type(xs).__name__ == "Registrar" or isinstance(xs, PurePath):
         yield str(xs)
     else:
-        raise ValueError(f"expected a string but got: {xs!r}")
+        raise ValueError(f"expected {' or '.join(typ.__name__ for typ in types)} but got: {xs!r}")
 
 
 @dataclass(frozen=True)
@@ -114,8 +116,8 @@ class VisibilityRuleSet:
     """An ordered set of rules that applies to some set of target types."""
 
     build_file: str
-    target_type_patterns: Sequence[str]
-    rules: Sequence[VisibilityRule]
+    selectors: tuple[TargetGlob, ...]
+    rules: tuple[VisibilityRule, ...]
 
     @classmethod
     def parse(cls, build_file: str, arg: Any) -> VisibilityRuleSet:
@@ -132,10 +134,11 @@ class VisibilityRuleSet:
 
         relpath = os.path.dirname(build_file)
         try:
-            targets, rules = flatten(arg[0]), flatten(arg[1:])
+            selectors = cast("Iterator[str | dict]", flatten(arg[0], str, dict))
+            rules = cast("Iterator[str]", flatten(arg[1:], str))
             return cls(
                 build_file,
-                tuple(targets),
+                tuple(TargetGlob.parse(selector, relpath) for selector in selectors),
                 tuple(
                     VisibilityRule.parse(rule, relpath)
                     for rule in rules
@@ -152,14 +155,14 @@ class VisibilityRuleSet:
     def _noop_rule(rule: str) -> bool:
         return not rule or rule.startswith("#")
 
-    def match(self, target: TargetAdaptor) -> bool:
-        return any(fnmatchcase(target.type_alias, pattern) for pattern in self.target_type_patterns)
+    def match(self, address: Address, adaptor: TargetAdaptor, relpath: str) -> bool:
+        return any(selector.match(address, adaptor, relpath) for selector in self.selectors)
 
 
 @dataclass(frozen=True)
 class BuildFileVisibilityRules(BuildFileDependencyRules):
     path: str
-    rulesets: Sequence[VisibilityRuleSet]
+    rulesets: tuple[VisibilityRuleSet, ...]
 
     @staticmethod
     def create_parser_state(
@@ -265,7 +268,7 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
 
         The rules are declared in `relpath`.
         """
-        ruleset = self.get_ruleset(target)
+        ruleset = self.get_ruleset(address, target, relpath)
         if ruleset is None:
             return None, None, None
         path = self._get_address_path(address)
@@ -289,9 +292,11 @@ class BuildFileVisibilityRules(BuildFileDependencyRules):
                 return ruleset, visibility_rule.action, str(visibility_rule)
         return ruleset, None, None
 
-    def get_ruleset(self, target: TargetAdaptor) -> VisibilityRuleSet | None:
+    def get_ruleset(
+        self, address: Address, target: TargetAdaptor, relpath: str
+    ) -> VisibilityRuleSet | None:
         for ruleset in self.rulesets:
-            if ruleset.match(target):
+            if ruleset.match(address, target, relpath):
                 return ruleset
         return None
 

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pytest
 
+from pants.backend.visibility.glob import TargetGlob
 from pants.backend.visibility.rule_types import (
     BuildFileVisibilityRules,
     BuildFileVisibilityRulesError,
@@ -107,7 +108,7 @@ def parse_ruleset(rules: Any, build_file: str = "test/path/BUILD") -> Visibility
     ],
 )
 def test_flatten(expected, xs) -> None:
-    assert expected == list(flatten(xs))
+    assert expected == list(flatten(xs, str))
 
 
 @pytest.mark.parametrize(
@@ -143,7 +144,7 @@ def test_visibility_rule(expected: bool, rule: str, path: str, relpath: str) -> 
         (
             VisibilityRuleSet(
                 "test/path/BUILD",
-                ("target",),
+                (TargetGlob.parse("target", ""),),
                 (parse_rule("src/*"),),
             ),
             ("target", "src/*"),
@@ -151,7 +152,7 @@ def test_visibility_rule(expected: bool, rule: str, path: str, relpath: str) -> 
         (
             VisibilityRuleSet(
                 "test/path/BUILD",
-                ("files", "resources"),
+                (TargetGlob.parse("files", ""), TargetGlob.parse("resources", "")),
                 (
                     parse_rule(
                         "src/*",
@@ -200,7 +201,9 @@ def test_visibility_rule_set_parse(expected: VisibilityRuleSet, arg: Any) -> Non
     ],
 )
 def test_visibility_rule_set_match(expected: bool, target: str, rule_spec: tuple) -> None:
-    assert expected == parse_ruleset(rule_spec).match(TargetAdaptor(target, None))
+    assert expected == parse_ruleset(rule_spec, "").match(
+        Address(""), TargetAdaptor(target, None), ""
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
Implements the suggestion from GH discussion https://github.com/pantsbuild/pants/discussions/17389#discussioncomment-4207796

This allows us to filter rules based on target tags and file paths in addition to target types.
```python
__dependencies_rules__(
  (
    # Select `.img` file `resources` tagged `"foo-tag"` in a `res/` folder
    "resources(foo-tag)[./res/*.img]",
    # .. to use these rules:
    "rule/*", ...
  ),
  (
    (
      # All `python_*` files that are tagged with both `"bar"` *and* `"tag"` that has an `.pyi` extension.
      "python_*(bar, tag)[*.pyi]",

      # All targets with a `"bar"` tag
      "(bar)",

      # All files with an `.arc` extension
      "[*.arc]".
    ),
    # Will use these rule:
    "rule/*", ...
  ),
)
