### PR TITLE
Dep rules: fix address mixup for matching with rulesets selector.

### DIFF
--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -588,8 +588,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "WARN: type:target name:joker path:'src/a' relpath:'src/a/a2' address:src/a:a "
-                "rule:'?*' src/a/a2/BUILD: ?*",
+                "WARN: type=target address=src/a/a2:joker other=src/a:a rule='?*' "
+                "src/a/a2/BUILD: ?*",
             ),
         ],
         exclusively=False,
@@ -610,8 +610,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "DENY: type:resources name:internal path:'src/b' relpath:'src/a' "
-                "address:src/b:b rule:'!*' src/a/BUILD: ., !*",
+                "DENY: type=resources address=src/a:internal other=src/b:b rule='!*' "
+                "src/a/BUILD: ., !*",
             ),
         ],
         exclusively=False,
@@ -629,8 +629,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "DENY: type:resources name:internal path:'src/b' relpath:'src/a' address:src/b:b "
-                "rule:'!*' src/a/BUILD: ., !*",
+                "DENY: type=resources address=src/a:internal other=src/b:b rule='!*' "
+                "src/a/BUILD: ., !*",
             ),
         ],
         exclusively=False,
@@ -787,20 +787,14 @@ def test_file_specific_rules(rule_runner: RuleRunner) -> None:
             "src/lib/pub/BUILD": dedent(
                 """
                 __dependents_rules__(
-                  # Allow all to depend on files from lib/pub/
-                  # TODO: support to except one file. work around now is to have the rule in
-                  # src/app/BUILD
+                  # Allow all to depend on files from lib/pub/ except for one file in particular.
+                  ("[/exception.txt]", "//src/lib/**", "!*"),
                   ("*", "*"),
                 )
                 """
             ),
             "src/app/BUILD": dedent(
                 """
-                __dependencies_rules__(
-                  # TODO: this exception should live in src/lib/pub/BUILD
-                  ("*", "!//src/lib/pub/exception.txt", "*"),
-                )
-
                 files(sources=["**/*.txt"])
                 """
             ),
@@ -836,10 +830,6 @@ def test_file_specific_rules(rule_runner: RuleRunner) -> None:
 
 
 def test_relpath_for_file_targets(rule_runner: RuleRunner) -> None:
-    # Testing purpose:
-    #
-    # When a file is owned by a target declared in a parent directory, make sure the correct BUILD
-    # file is consulted for the rules set to apply, and with the correct relpath for the matching.
     rule_runner.write_files(
         {
             "anchor-mode/invoked/BUILD": dedent(


### PR DESCRIPTION
Fixing the test TODO surfaced an issue with mixed up addresses for `get_ruleset()`.