### PR TITLE
[internal] Explorer dep rules

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -15,3 +15,19 @@ python_requirements(
 # Useful when using IntelliJ/PyCharm remote debugging. Importing `pydevd_pycharm` at
 # the breakpoint will cause dep inference to add this dep on the remote debugger client.
 python_requirement(name="pydevd-pycharm", requirements=["pydevd-pycharm==203.5419.8"])
+
+
+__dependents_rules__(
+    (  # Only the explorer server may depend on these libraries
+        (
+            "[fastapi]",
+            "[starlette]",
+            "[strawberry-graphql]",
+            "[uvicorn]",
+        ),
+        "src/python/pants/explorer/server/**",
+        "!*",
+    ),
+    # Free for all on the rest
+    ("*", "*"),
+)

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -588,8 +588,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "WARN: type:target name:joker path:'src/a' relpath:'src/a/a2' address:src/a:a "
-                "rule:'?*' src/a/a2/BUILD: ?*",
+                "WARN: type=target address=src/a/a2:joker other=src/a:a rule='?*' "
+                "src/a/a2/BUILD: ?*",
             ),
         ],
         exclusively=False,
@@ -610,8 +610,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "DENY: type:resources name:internal path:'src/b' relpath:'src/a' "
-                "address:src/b:b rule:'!*' src/a/BUILD: ., !*",
+                "DENY: type=resources address=src/a:internal other=src/b:b rule='!*' "
+                "src/a/BUILD: ., !*",
             ),
         ],
         exclusively=False,
@@ -629,8 +629,8 @@ def test_dependency_rules(rule_runner: RuleRunner, caplog) -> None:
         expect_logged=[
             (
                 logging.DEBUG,
-                "DENY: type:resources name:internal path:'src/b' relpath:'src/a' address:src/b:b "
-                "rule:'!*' src/a/BUILD: ., !*",
+                "DENY: type=resources address=src/a:internal other=src/b:b rule='!*' "
+                "src/a/BUILD: ., !*",
             ),
         ],
         exclusively=False,
@@ -787,20 +787,14 @@ def test_file_specific_rules(rule_runner: RuleRunner) -> None:
             "src/lib/pub/BUILD": dedent(
                 """
                 __dependents_rules__(
-                  # Allow all to depend on files from lib/pub/
-                  # TODO: support to except one file. work around now is to have the rule in
-                  # src/app/BUILD
+                  # Allow all to depend on files from lib/pub/ except for one file in particular.
+                  ("[/exception.txt]", "//src/lib/**", "!*"),
                   ("*", "*"),
                 )
                 """
             ),
             "src/app/BUILD": dedent(
                 """
-                __dependencies_rules__(
-                  # TODO: this exception should live in src/lib/pub/BUILD
-                  ("*", "!//src/lib/pub/exception.txt", "*"),
-                )
-
                 files(sources=["**/*.txt"])
                 """
             ),
@@ -836,10 +830,6 @@ def test_file_specific_rules(rule_runner: RuleRunner) -> None:
 
 
 def test_relpath_for_file_targets(rule_runner: RuleRunner) -> None:
-    # Testing purpose:
-    #
-    # When a file is owned by a target declared in a parent directory, make sure the correct BUILD
-    # file is consulted for the rules set to apply, and with the correct relpath for the matching.
     rule_runner.write_files(
         {
             "anchor-mode/invoked/BUILD": dedent(

--- a/src/python/pants/explorer/server/BUILD
+++ b/src/python/pants/explorer/server/BUILD
@@ -26,9 +26,11 @@ python_tests(
 __dependents_rules__(
     # Block any outside sources from pulling in code from this backend, as it is self contained and
     # have 3rd party dependencies that we don't want to leak to the core Pants distribution.
+    # N.B. although we have dependents rules in place for these 3rd party deps, those only block
+    # direct dependencies to them, not transient ones, such as importing modules from this subtree.
     (
         "*",
-        build_file_dir() / "**",
+        "/**",
         "!*",
     ),
 )


### PR DESCRIPTION
(only the BUILD file changes belong to this PR, the other changes are from #17629 )

Now this was neat. We effectively block any code outside of the `pants.explorer.server` namespace to import any of the 3rd party libs for the explorer as well as any of the explorer modules.

cc @ryanking @danxmoran for ref on how you may work with rules for 3rd party deps once #17629 has landed.
cc @cognifloyd fyi :) 