### PR TITLE
WIP: respect dep rules in python inference

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -181,6 +181,7 @@ class FirstPartyPythonModuleMapping:
         If `resolve` is None, will not consider resolves, i.e. any `python_source` et al can be
         used. Otherwise, providers can only come from first-party targets with the resolve.
         """
+        # TODO: a way to filter the providers
         if resolve:
             return self._providers_for_resolve(module, resolve)
         return tuple(
@@ -418,6 +419,8 @@ async def map_module_to_address(
     first_party_mapping: FirstPartyPythonModuleMapping,
     third_party_mapping: ThirdPartyPythonModuleMapping,
 ) -> PythonModuleOwners:
+    # TODO: a way to filter the providers
+    # we need to filter the FirstPartyPythonModuleMapping here
     possible_providers: tuple[PossibleModuleProvider, ...] = (
         *third_party_mapping.providers_for_module(request.module, resolve=request.resolve),
         *first_party_mapping.providers_for_module(request.module, resolve=request.resolve),
@@ -445,6 +448,8 @@ async def map_module_to_address(
         itertools.chain(*[val[1] for val in type_to_closest_providers.values()])
     )
     addresses = tuple(provider.addr for provider in closest_providers)
+
+    # respect dep rules here?
 
     # Check that we have at most one closest provider for each provider type.
     # If we have more than one, signal ambiguity.


### PR DESCRIPTION
Now we have the new `__dependency_rules__` / `__dependents_rules__` feature, and the experimental visibility backend.

I think this could be another source of input for the python inference subsystem.

Here are my thoughts about this:
- If a dependency is unambiguous, but breaks one or more of the dependency rules, then let the visibility backend (or other implementation) handle warning or erroring. As far as the python-infer subsystem is concerned, the dependency is still unambiguous.
- If a dependency is ambiguous, then the dependency rules can provide an additional signal that can be used to disambiguate.
  - if one dep's rule action is `allow`, and any others are `warn` or `deny`, then treat the allowed one as an unambiguous inferred dep, ignoring the deny/warn one.
  - if more than one dep rule action is `allow`, then it is still ambiguous. It may be less ambiguous if one or more other deps could be excluded based on the dependency rules, but it is still ambiguous. Maybe this can be used to improve the ambiguous deps error message (eventually).

This is an untested draft. It's hear to get feedback on the idea. I expect this PR to be closed in favor of a more complete one at some later point.