### PR TITLE
go: link with race detector variant of standard library

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -65,7 +65,8 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
     )
     main_pkg_a_file_path = built_package.import_paths_to_pkg_a_files["main"]
     import_config = await Get(
-        ImportConfig, ImportConfigRequest(built_package.import_paths_to_pkg_a_files)
+        ImportConfig,
+        ImportConfigRequest(built_package.import_paths_to_pkg_a_files, build_opts=build_opts),
     )
     input_digest = await Get(Digest, MergeDigests([built_package.digest, import_config.digest]))
 

--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -76,6 +76,7 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
         LinkGoBinaryRequest(
             input_digest=input_digest,
             archives=(main_pkg_a_file_path,),
+            build_opts=build_opts,
             import_config_path=import_config.CONFIG_PATH,
             output_filename=f"./{output_filename.name}",
             description=f"Link Go binary for {field_set.address}",

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -348,6 +348,7 @@ async def run_go_tests(
         LinkGoBinaryRequest(
             input_digest=linker_input_digest,
             archives=(main_pkg_a_file_path,),
+            build_opts=build_opts,
             import_config_path=import_config.CONFIG_PATH,
             output_filename="./test_runner",  # TODO: Name test binary the way that `go` does?
             description=f"Link Go test binary for {field_set.address}",

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -337,7 +337,8 @@ async def run_go_tests(
 
     main_pkg_a_file_path = built_main_pkg.import_paths_to_pkg_a_files["main"]
     import_config = await Get(
-        ImportConfig, ImportConfigRequest(built_main_pkg.import_paths_to_pkg_a_files)
+        ImportConfig,
+        ImportConfigRequest(built_main_pkg.import_paths_to_pkg_a_files, build_opts=build_opts),
     )
     linker_input_digest = await Get(
         Digest, MergeDigests([built_main_pkg.digest, import_config.digest])

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -36,7 +36,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoMod,
     OwningGoModRequest,
 )
-from pants.backend.go.util_rules.import_analysis import GoStdLibImports
+from pants.backend.go.util_rules.import_analysis import GoStdLibImports, GoStdLibImportsRequest
 from pants.backend.go.util_rules.third_party_pkg import (
     AllThirdPartyPackages,
     AllThirdPartyPackagesRequest,
@@ -217,7 +217,6 @@ class InferGoPackageDependenciesRequest(InferDependenciesRequest):
 @rule(desc="Infer dependencies for first-party Go packages", level=LogLevel.DEBUG)
 async def infer_go_dependencies(
     request: InferGoPackageDependenciesRequest,
-    std_lib_imports: GoStdLibImports,
 ) -> InferredDependencies:
     go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.field_set.address))
     package_mapping, build_opts = await MultiGet(
@@ -226,9 +225,16 @@ async def infer_go_dependencies(
     )
 
     addr = request.field_set.address
-    maybe_pkg_analysis = await Get(
-        FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr, build_opts=build_opts)
+    maybe_pkg_analysis, std_lib_imports = await MultiGet(
+        Get(
+            FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr, build_opts=build_opts)
+        ),
+        Get(
+            GoStdLibImports,
+            GoStdLibImportsRequest(with_race_detector=build_opts.with_race_detector),
+        ),
     )
+
     if maybe_pkg_analysis.analysis is None:
         logger.error(
             f"Failed to analyze {maybe_pkg_analysis.import_path} for dependency inference:\n"
@@ -289,7 +295,6 @@ class InferGoThirdPartyPackageDependenciesRequest(InferDependenciesRequest):
 @rule(desc="Infer dependencies for third-party Go packages", level=LogLevel.DEBUG)
 async def infer_go_third_party_package_dependencies(
     request: InferGoThirdPartyPackageDependenciesRequest,
-    std_lib_imports: GoStdLibImports,
 ) -> InferredDependencies:
     addr = request.field_set.address
     go_mod_address = addr.maybe_convert_to_target_generator()
@@ -300,13 +305,19 @@ async def infer_go_third_party_package_dependencies(
         Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(go_mod_address)),
     )
 
-    pkg_info = await Get(
-        ThirdPartyPkgAnalysis,
-        ThirdPartyPkgAnalysisRequest(
-            request.field_set.import_path.value,
-            go_mod_info.digest,
-            go_mod_info.mod_path,
-            build_opts=build_opts,
+    pkg_info, std_lib_imports = await MultiGet(
+        Get(
+            ThirdPartyPkgAnalysis,
+            ThirdPartyPkgAnalysisRequest(
+                request.field_set.import_path.value,
+                go_mod_info.digest,
+                go_mod_info.mod_path,
+                build_opts=build_opts,
+            ),
+        ),
+        Get(
+            GoStdLibImports,
+            GoStdLibImportsRequest(with_race_detector=build_opts.with_race_detector),
         ),
     )
 

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -381,7 +381,12 @@ async def build_go_package(
 
     merged_deps_digest, import_config, embedcfg, action_id_result = await MultiGet(
         Get(Digest, MergeDigests(dep_digests)),
-        Get(ImportConfig, ImportConfigRequest(FrozenDict(import_paths_to_pkg_a_files))),
+        Get(
+            ImportConfig,
+            ImportConfigRequest(
+                FrozenDict(import_paths_to_pkg_a_files), build_opts=request.build_opts
+            ),
+        ),
         Get(RenderedEmbedConfig, RenderEmbedConfigRequest(request.embed_config)),
         Get(GoCompileActionIdResult, GoCompileActionIdRequest(request)),
     )

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -73,8 +73,8 @@ class ImportConfigRequest:
     include_stdlib: bool = True
 
     @classmethod
-    def stdlib_only(cls) -> ImportConfigRequest:
-        return cls(FrozenDict(), build_opts=GoBuildOptions(), include_stdlib=True)
+    def stdlib_only(cls, build_opts: GoBuildOptions) -> ImportConfigRequest:
+        return cls(FrozenDict(), build_opts=build_opts, include_stdlib=True)
 
 
 @rule

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 
 import ijson
 
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
@@ -28,13 +29,19 @@ class GoStdLibImports(FrozenDict[str, str]):
     """
 
 
+@dataclass(frozen=True)
+class GoStdLibImportsRequest:
+    with_race_detector: bool
+
+
 @rule(desc="Determine Go std lib's imports", level=LogLevel.DEBUG)
-async def determine_go_std_lib_imports() -> GoStdLibImports:
+async def determine_go_std_lib_imports(request: GoStdLibImportsRequest) -> GoStdLibImports:
+    maybe_race_arg = ["-race"] if request.with_race_detector else []
     list_result = await Get(
         ProcessResult,
         GoSdkProcess(
             # "-find" skips determining dependencies and imports for each package.
-            command=("list", "-find", "-json", "std"),
+            command=("list", "-find", *maybe_race_arg, "-json", "std"),
             description="Ask Go for its available import paths",
         ),
     )
@@ -62,17 +69,16 @@ class ImportConfigRequest:
     """Create an `importcfg` file associating import paths to their `__pkg__.a` files."""
 
     import_paths_to_pkg_a_files: FrozenDict[str, str]
+    build_opts: GoBuildOptions
     include_stdlib: bool = True
 
     @classmethod
     def stdlib_only(cls) -> ImportConfigRequest:
-        return cls(FrozenDict(), include_stdlib=True)
+        return cls(FrozenDict(), build_opts=GoBuildOptions(), include_stdlib=True)
 
 
 @rule
-async def generate_import_config(
-    request: ImportConfigRequest, stdlib_imports: GoStdLibImports
-) -> ImportConfig:
+async def generate_import_config(request: ImportConfigRequest) -> ImportConfig:
     lines = [
         "# import config",
         *(
@@ -81,9 +87,13 @@ async def generate_import_config(
         ),
     ]
     if request.include_stdlib:
+        std_lib_imports = await Get(
+            GoStdLibImports,
+            GoStdLibImportsRequest(with_race_detector=request.build_opts.with_race_detector),
+        )
         lines.extend(
             f"packagefile {import_path}={static_file_path}"
-            for import_path, static_file_path in stdlib_imports.items()
+            for import_path, static_file_path in std_lib_imports.items()
         )
     content = "\n".join(lines).encode("utf-8")
     result = await Get(Digest, CreateDigest([FileContent(ImportConfig.CONFIG_PATH, content)]))

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.engine.fs import Digest
 from pants.engine.process import ProcessResult
@@ -16,6 +17,7 @@ class LinkGoBinaryRequest:
 
     input_digest: Digest
     archives: tuple[str, ...]
+    build_opts: GoBuildOptions
     import_config_path: str
     output_filename: str
     description: str
@@ -31,6 +33,7 @@ class LinkedGoBinary:
 @rule
 async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
     link_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("link"))
+    maybe_race_arg = ["-race"] if request.build_opts.with_race_detector else []
     result = await Get(
         ProcessResult,
         GoSdkProcess(
@@ -38,6 +41,7 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
             command=(
                 "tool",
                 "link",
+                *maybe_race_arg,
                 "-importcfg",
                 request.import_config_path,
                 "-o",


### PR DESCRIPTION
When the Go data race detector is enabled, there is a separate copy of the standard library that must be used because it is compiled with race detector support.

Pass the `with_race_detector` build option down through `ImportConfigRequest` and pass `-race` to the `go list` invocation used to analyze the standard library so that the "race" version of the standard library is selected in that case.