### PR TITLE
shell: add `experimental_test_shell_command` for arbitrary shell-driven tests

### DIFF
--- a/src/python/pants/backend/shell/goals/BUILD
+++ b/src/python/pants/backend/shell/goals/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()
+python_tests(name="tests")

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -27,6 +27,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
+from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -99,4 +100,5 @@ def rules():
         *collect_rules(),
         *shell_command.rules(),
         *ShellTestRequest.rules(),
+        UnionRule(TestFieldSet, TestShellCommandFieldSet),
     )

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -1,0 +1,102 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from pants.backend.shell import shell_command
+from pants.backend.shell.shell_command import ShellCommandProcessRequest
+from pants.backend.shell.subsystems.shell_test_subsys import ShellTestSubsystem
+from pants.backend.shell.target_types import (
+    ShellCommandCommandField,
+    ShellCommandTestDependenciesField,
+    SkipShellCommandTestsField,
+)
+from pants.core.goals.test import (
+    TestDebugAdapterRequest,
+    TestDebugRequest,
+    TestExtraEnv,
+    TestFieldSet,
+    TestRequest,
+    TestResult,
+    TestSubsystem,
+)
+from pants.engine.internals.selectors import Get
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
+from pants.util.frozendict import FrozenDict
+from pants.util.logging import LogLevel
+
+
+class TestShellCommandFieldSet(TestFieldSet):
+    required_fields = (
+        ShellCommandCommandField,
+        ShellCommandTestDependenciesField,
+    )
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipShellCommandTestsField).value
+
+
+class ShellTestRequest(TestRequest):
+    tool_subsystem = ShellTestSubsystem
+    field_set_type = TestShellCommandFieldSet
+
+
+@rule(desc="Test with shell command", level=LogLevel.DEBUG)
+async def test_shell_command(
+    batch: ShellTestRequest.Batch[TestShellCommandFieldSet, Any],
+    test_subsystem: TestSubsystem,
+    test_extra_env: TestExtraEnv,
+) -> TestResult:
+    field_set = batch.single_element
+    wrapped_tgt = await Get(
+        WrappedTarget,
+        WrappedTargetRequest(field_set.address, description_of_origin="<infallible>"),
+    )
+
+    shell_process = await Get(Process, ShellCommandProcessRequest(wrapped_tgt.target))
+
+    shell_process = dataclasses.replace(
+        shell_process,
+        cache_scope=(
+            ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
+        ),
+        env=FrozenDict(
+            {
+                **test_extra_env.env,
+                **shell_process.env,
+            }
+        ),
+    )
+
+    shell_result = await Get(FallibleProcessResult, Process, shell_process)
+    return TestResult.from_fallible_process_result(
+        process_result=shell_result,
+        address=field_set.address,
+        output_setting=test_subsystem.output,
+    )
+
+
+@rule
+async def generate_shell_tests_debug_request(_: ShellTestRequest.Batch) -> TestDebugRequest:
+    raise NotImplementedError("This is a stub.")
+
+
+@rule
+async def generate_shell_tests_debug_adapter_request(
+    _: ShellTestRequest.Batch,
+) -> TestDebugAdapterRequest:
+    raise NotImplementedError("This is a stub.")
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *shell_command.rules(),
+        *ShellTestRequest.rules(),
+    )

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -16,8 +16,8 @@ from pants.backend.shell.target_types import (
     ShellSourcesGeneratorTarget,
 )
 from pants.build_graph.address import Address
-from pants.core.goals.test import TestResult
-from pants.core.util_rules import source_files
+from pants.core.goals.test import TestResult, get_filtered_environment
+from pants.core.util_rules import archive, source_files
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
@@ -29,6 +29,8 @@ def rule_runner() -> RuleRunner:
         rules=[
             *test.rules(),
             *source_files.rules(),
+            *archive.rules(),
+            get_filtered_environment,
             QueryRule(TestResult, (ShellTestRequest.Batch,)),
         ],
         target_types=[

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -1,0 +1,103 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.shell.goals import test
+from pants.backend.shell.goals.test import ShellTestRequest, TestShellCommandFieldSet
+from pants.backend.shell.target_types import (
+    ShellCommandTarget,
+    ShellCommandTestTarget,
+    ShellSourcesGeneratorTarget,
+)
+from pants.build_graph.address import Address
+from pants.core.goals.test import TestResult
+from pants.core.util_rules import source_files
+from pants.engine.rules import QueryRule
+from pants.engine.target import Target
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *test.rules(),
+            *source_files.rules(),
+            QueryRule(TestResult, (ShellTestRequest.Batch,)),
+        ],
+        target_types=[
+            ShellSourcesGeneratorTarget,
+            ShellCommandTarget,
+            ShellCommandTestTarget,
+        ],
+    )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
+
+
+def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                shell_sources(name="src")
+
+                experimental_shell_command(
+                  name="msg-gen",
+                  command="echo message > msg.txt",
+                  tools=["echo"],
+                  outputs=["msg.txt"],
+                )
+
+                experimental_test_shell_command(
+                  name="pass",
+                  dependencies=[":msg-gen", ":src"],
+                  tools=["tr"],
+                  command="./test.sh msg.txt message",
+                )
+
+                experimental_test_shell_command(
+                  name="fail",
+                  dependencies=[":msg-gen", ":src"],
+                  tools=["tr"],
+                  command="./test.sh msg.txt xyzzy",
+                )
+                """
+            ),
+            "test.sh": dedent(
+                """\
+                contents="$(<$1)"
+                if [ "$contents" = "$2" ]; then
+                  echo "contains '$2'"
+                  exit 0
+                else
+                  echo "does not contain '$2'"
+                  exit 1
+                fi
+                """
+            ),
+        }
+    )
+    (Path(rule_runner.build_root) / "test.sh").chmod(0o555)
+
+    def run_test(test_target: Target) -> TestResult:
+        input: ShellTestRequest.Batch = ShellTestRequest.Batch(
+            "", (TestShellCommandFieldSet.create(test_target),), None
+        )
+        return rule_runner.request(TestResult, [input])
+
+    pass_target = rule_runner.get_target(Address("", target_name="pass"))
+    pass_result = run_test(pass_target)
+    assert pass_result.exit_code == 0
+    assert pass_result.stdout == "contains 'message'\n"
+
+    fail_target = rule_runner.get_target(Address("", target_name="fail"))
+    fail_result = run_test(fail_target)
+    assert fail_result.exit_code != 0
+    assert fail_result.stdout == "does not contain 'xyzzy'\n"

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -60,14 +60,14 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
                 experimental_test_shell_command(
                   name="pass",
                   dependencies=[":msg-gen", ":src"],
-                  tools=["tr"],
+                  tools=["echo"],
                   command="./test.sh msg.txt message",
                 )
 
                 experimental_test_shell_command(
                   name="fail",
                   dependencies=[":msg-gen", ":src"],
-                  tools=["tr"],
+                  tools=["echo"],
                   command="./test.sh msg.txt xyzzy",
                 )
                 """

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -101,5 +101,5 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
 
     fail_target = rule_runner.get_target(Address("", target_name="fail"))
     fail_result = run_test(fail_target)
-    assert fail_result.exit_code != 0
+    assert fail_result.exit_code == 1
     assert fail_result.stdout == "does not contain 'xyzzy'\n"

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -8,6 +8,7 @@ from pants.backend.shell import (
     shunit2_test_runner,
     tailor,
 )
+from pants.backend.shell.goals.test import rules as test_goal_rules
 from pants.backend.shell.target_types import (
     ShellCommandRunTarget,
     ShellCommandTarget,
@@ -38,4 +39,5 @@ def rules():
         *shunit2_test_runner.rules(),
         *tailor.rules(),
         *target_types_rules(),
+        *test_goal_rules(),
     ]

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -12,6 +12,7 @@ from pants.backend.shell.goals.test import rules as test_goal_rules
 from pants.backend.shell.target_types import (
     ShellCommandRunTarget,
     ShellCommandTarget,
+    ShellCommandTestTarget,
     ShellSourcesGeneratorTarget,
     ShellSourceTarget,
     Shunit2TestsGeneratorTarget,
@@ -24,6 +25,7 @@ def target_types():
     return [
         ShellCommandTarget,
         ShellCommandRunTarget,
+        ShellCommandTestTarget,
         ShellSourcesGeneratorTarget,
         Shunit2TestsGeneratorTarget,
         ShellSourceTarget,

--- a/src/python/pants/backend/shell/shell_command_test.py
+++ b/src/python/pants/backend/shell/shell_command_test.py
@@ -17,6 +17,7 @@ from pants.backend.shell.shell_command import rules as shell_command_rules
 from pants.backend.shell.target_types import (
     ShellCommandRunTarget,
     ShellCommandTarget,
+    ShellCommandTestTarget,
     ShellSourcesGeneratorTarget,
 )
 from pants.core.goals.run import RunRequest
@@ -53,6 +54,7 @@ def rule_runner() -> RuleRunner:
         target_types=[
             ShellCommandTarget,
             ShellCommandRunTarget,
+            ShellCommandTestTarget,
             ShellSourcesGeneratorTarget,
             ArchiveTarget,
             FilesGeneratorTarget,

--- a/src/python/pants/backend/shell/subsystems/BUILD
+++ b/src/python/pants/backend/shell/subsystems/BUILD
@@ -1,0 +1,4 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/shell/subsystems/shell_test_subsys.py
+++ b/src/python/pants/backend/shell/subsystems/shell_test_subsys.py
@@ -1,0 +1,15 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import SkipOption
+from pants.option.subsystem import Subsystem
+
+
+class ShellTestSubsystem(Subsystem):
+    options_scope = "shell-test"
+    name = "Test with shell scripts"
+    help = "Options for Pants' Shell test support."
+
+    skip = SkipOption("test")

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -325,6 +325,16 @@ class ShellCommandRunWorkdirField(StringField):
     help = "Sets the current working directory of the command, relative to the project root."
 
 
+class ShellCommandTestDependenciesField(ShellCommandDependenciesField):
+    pass
+
+
+class SkipShellCommandTestsField(BoolField):
+    alias = "skip_tests"
+    default = False
+    help = "If true, don't run this tests for target."
+
+
 class ShellCommandTarget(Target):
     alias = "experimental_shell_command"
     core_fields = (
@@ -389,6 +399,42 @@ class ShellCommandRunTarget(Target):
         the `command` and `dependencies` fields as the `tools` you are going to use are already
         on the PATH which is inherited from the Pants environment. Also, the `outputs` does not
         apply, as any output files produced will end up directly in your project tree.
+        """
+    )
+
+
+class ShellCommandTestTarget(Target):
+    alias = "experimental_test_shell_command"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        ShellCommandTestDependenciesField,
+        ShellCommandCommandField,
+        ShellCommandLogOutputField,
+        ShellCommandSourcesField,
+        ShellCommandTimeoutField,
+        ShellCommandToolsField,
+        ShellCommandExtraEnvVarsField,
+        EnvironmentField,
+        SkipShellCommandTestsField,
+    )
+    help = softwrap(
+        """
+        Run a script as a test via the `test` goal, with all dependencies packaged/copied available in the chroot.
+
+        Example BUILD file:
+
+            experimental_test_shell_command(
+                name="test",
+                tools=["test"],
+                command="test -r $CHROOT/some-data-file.txt",
+                dependencies=["src/project/files:data"],
+            )
+
+        The `command` may use either `{chroot}` on the command line, or the `$CHROOT`
+        environment variable to get the root directory for where any dependencies are located.
+
+        In contrast to the `experimental_run_shell_command`, this target is intended to run shell commands as tests
+        and will only run them via the `test` goal.
         """
     )
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class   TestResult(EngineAwareReturnType):
+class TestResult(EngineAwareReturnType):
     exit_code: int | None
     stdout: str
     stdout_digest: FileDigest

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -70,7 +70,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class TestResult(EngineAwareReturnType):
+class   TestResult(EngineAwareReturnType):
     exit_code: int | None
     stdout: str
     stdout_digest: FileDigest


### PR DESCRIPTION
Add an `experimental_test_shell_command` target type to enable defining arbitrary tests using shell code.

Note: This target is not a unit test of shell sources like `shunit2_tests`; rather, it is a test defined in shell which could test anything which can be packaged and consumed by the other shell targets (e.g., `experimental_shell_command` and `experimental_run_shell_command`).  It is basically `experimental_run_shell_command` but for the `test` goal instead of the `run` goal.