### PR TITLE
reproduce ignore rules inconsistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ GTAGS
 /.pants.rc
 /.venv
 .tool-versions
+
+/ignored_dir/

--- a/code_using_ignored_dir/BUILD
+++ b/code_using_ignored_dir/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_tests(
+    name="tests",
+)

--- a/code_using_ignored_dir/test_writing_files.py
+++ b/code_using_ignored_dir/test_writing_files.py
@@ -1,0 +1,9 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os
+from pathlib import Path
+
+
+def test_touch_ignored_dir() -> None:
+    ignored_dir = Path(os.environ["IGNORED_DIR"]).resolve()
+    ignored_dir.touch()

--- a/pants.toml
+++ b/pants.toml
@@ -58,6 +58,8 @@ pants_ignore.add = [
   "!/pants.pex",
   # Ignore node modules for docs processing tools
   "/docs/node_modules",
+  # Remove or comment this line to see the bug
+  "/ignored_dir",
 ]
 
 build_ignore.add = [


### PR DESCRIPTION
There's an inconsistency between patterns defined in .gitignore and
patterns defined in pants_ignore for how the filesystem watcher is
invalidating ignored paths.  For paths only in .gitignore, if you
`touch` that node, and the parent directory is not ignored, it still
invalidates ongoing build graph steps.  However, if this path is in
pants_ignore, it is ignored properly.

To reproduce on this branch, comment out the `#/ignored_dir` line
from pants.toml and run the following command:

```
./pants test \
  --extra-env-vars=IGNORED_DIR="$(pwd)"/ignored_dir \
  code_using_ignored_dir/test_writing_files.py
```

You'll see the test never complete because the `touch` inside the test
invalidates the graph.  Comment the line in pants.toml again, and re-run
the command, and you'll see the test run fine.

This is just a demo PR, it is not intended to be merged ever

[ci skip-rust]
