### PR TITLE
go: address sanitizer support

### DIFF
--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 from pathlib import PurePath
 
-from pants.backend.go.target_types import GoPackageTarget, GoTestRaceDetectorEnabledField
+from pants.backend.go.target_types import (
+    GoAddressSanitizerEnabledField,
+    GoMemorySanitizerEnabledField,
+    GoPackageTarget,
+    GoTestRaceDetectorEnabledField,
+)
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.core.util_rules.distdir import DistDir
 from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, SkipOption, StrOption
@@ -87,11 +92,25 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             f"""
             If true, then always enable interoperation between Go and the C/C++ "memory sanitizer" when running tests
-            regardless of the test-by-test `{GoTestRaceDetectorEnabledField.alias}` field on the relevant
+            regardless of the test-by-test `{GoMemorySanitizerEnabledField.alias}` field on the relevant
             `{GoPackageTarget.alias}` target.
 
             See https://github.com/google/sanitizers/wiki/MemorySanitizer for additional information about
             the C/C++ memory sanitizer.
+            """
+        ),
+    )
+
+    force_asan = BoolOption(
+        default=False,
+        help=softwrap(
+            f"""
+            If true, then always enable interoperation between Go and the C/C++ "address sanitizer" when running tests
+            regardless of the test-by-test `{GoAddressSanitizerEnabledField.alias}` field on the relevant
+            `{GoPackageTarget.alias}` target.
+
+            See https://github.com/google/sanitizers/wiki/AddressSanitizer for additional information about
+            the C/C++ address sanitizer.
             """
         ),
     )

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -78,7 +78,7 @@ class GoTestRaceDetectorEnabledField(GoRaceDetectorEnabledField):
 
 
 class GoMemorySanitizerEnabledField(TriBoolField):
-    """Enables the Go data race detector."""
+    """Enables the C/C++ memory sanitizer."""
 
     alias = "msan"
     help = softwrap(
@@ -100,6 +100,33 @@ class GoTestMemorySanitizerEnabledField(GoRaceDetectorEnabledField):
 
         See https://github.com/google/sanitizers/wiki/MemorySanitizer for additional information about
         the C/C++ memory sanitizer.
+        """
+    )
+
+
+class GoAddressSanitizerEnabledField(TriBoolField):
+    """Enables the C/C++ address sanitizer."""
+
+    alias = "asan"
+    help = softwrap(
+        """
+        Enable interoperation between Go code and the C/C++ "address sanitizer."
+
+        See https://github.com/google/sanitizers/wiki/AddressSanitizer for additional information about
+        the C/C++ address sanitizer.
+        """
+    )
+
+
+class GoTestAddressSanitizerEnabledField(GoRaceDetectorEnabledField):
+    alias = "test_asan"
+    help = softwrap(
+        """
+        Enable interoperation between Go code and the C/C++ "address sanitizer" when building this package's
+        test binary.
+
+        See https://github.com/google/sanitizers/wiki/AddressSanitizer for additional information about
+        the C/C++ address sanitizer.
         """
     )
 
@@ -217,6 +244,7 @@ class GoModTarget(TargetGenerator):
         GoCgoEnabledField,
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
+        GoAddressSanitizerEnabledField,
     )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = ()
@@ -296,6 +324,7 @@ class GoPackageTarget(Target):
         GoTestTimeoutField,
         GoTestRaceDetectorEnabledField,
         GoTestMemorySanitizerEnabledField,
+        GoTestAddressSanitizerEnabledField,
         SkipGoTestsField,
     )
     help = softwrap(
@@ -342,6 +371,7 @@ class GoBinaryTarget(Target):
         GoCgoEnabledField,
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
+        GoAddressSanitizerEnabledField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -30,6 +30,7 @@ from pants.backend.go.util_rules import (
 from pants.backend.go.util_rules.build_opts import (
     GoBuildOptions,
     GoBuildOptionsFromTargetRequest,
+    asan_supported,
     msan_supported,
     race_detector_supported,
 )
@@ -74,6 +75,7 @@ def rule_runner() -> RuleRunner:
     (
         ("race", lambda opts: opts.with_race_detector, race_detector_supported),
         ("msan", lambda opts: opts.with_msan, msan_supported),
+        ("asan", lambda opts: opts.with_asan, asan_supported),
     ),
 )
 def test_race_detector_fields_work_as_expected(

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -552,6 +552,9 @@ async def build_go_package(
     if request.build_opts.with_msan:
         compile_args.append("-msan")
 
+    if request.build_opts.with_asan:
+        compile_args.append("-asan")
+
     # If there are no loose object files to add to the package archive later or assembly files to assemble,
     # then pass -complete flag which tells the compiler that the provided Go files constitute the entire package.
     if not objects and not s_files:

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -681,7 +681,12 @@ async def cgo_compile_request(
             ldflags=flags.ldflags + ("-fsanitize=memory",),
         )
 
-    # TODO(#16837): Add ASan (address sanitizer) option.
+    if request.build_opts.with_asan:
+        flags = dataclasses.replace(
+            flags,
+            cflags=flags.cflags + ("-fsanitize=address",),
+            ldflags=flags.ldflags + ("-fsanitize=address",),
+        )
 
     # Allows including _cgo_export.h, as well as the user's .h files,
     # from .[ch] files in the package.

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -35,6 +35,7 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
     link_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("link"))
     maybe_race_arg = ["-race"] if request.build_opts.with_race_detector else []
     maybe_msan_arg = ["-msan"] if request.build_opts.with_msan else []
+    maybe_asan_arg = ["-asan"] if request.build_opts.with_asan else []
     result = await Get(
         ProcessResult,
         GoSdkProcess(
@@ -44,6 +45,7 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
                 "link",
                 *maybe_race_arg,
                 *maybe_msan_arg,
+                *maybe_asan_arg,
                 "-importcfg",
                 request.import_config_path,
                 "-o",


### PR DESCRIPTION
Add support for the C/C++ address sanitizer with Go code. This is activated in `go` via the `-asan` option. For Pants, it is activated by setting `asan=True` on either a `go_binary` or `go_mod` target.

See https://github.com/google/sanitizers/wiki/AddressSanitizer for more information.

Fixes https://github.com/pantsbuild/pants/issues/16837.