### PR TITLE
Register synthetic targets for subsystems.

### DIFF
--- a/src/python/pants/core/goals/deploy_test.py
+++ b/src/python/pants/core/goals/deploy_test.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.core import register as register_core
 from pants.core.goals.deploy import Deploy, DeployFieldSet, DeployProcess
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.goals.publish import (
@@ -14,7 +15,6 @@ from pants.core.goals.publish import (
     PublishProcesses,
     PublishRequest,
 )
-from pants.core.register import rules as core_rules
 from pants.engine import process
 from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.internals.scheduler import ExecutionError
@@ -144,7 +144,7 @@ async def mock_deploy(field_set: MockDeployFieldSet) -> DeployProcess:
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            *core_rules(),
+            *register_core.rules(),
             *process.rules(),
             mock_publish,
             mock_deploy,
@@ -153,7 +153,7 @@ def rule_runner() -> RuleRunner:
             UnionRule(PackageFieldSet, MockPackageFieldSet),
             UnionRule(DeployFieldSet, MockDeployFieldSet),
         ],
-        target_types=[MockDeployTarget, MockPackageTarget],
+        target_types=[MockDeployTarget, MockPackageTarget, *register_core.target_types()],
     )
 
 

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -33,6 +33,7 @@ from pants.core.target_types import (
     RelocatedFiles,
     ResourcesGeneratorTarget,
     ResourceTarget,
+    SubsystemTarget,
     http_source,
     per_platform,
 )
@@ -44,6 +45,7 @@ from pants.core.util_rules import (
     source_files,
     stripped_source_files,
     subprocess_environment,
+    synthetic_targets,
     system_binaries,
 )
 from pants.core.util_rules.environments import (
@@ -86,6 +88,7 @@ def rules():
         *stats_aggregator.rules(),
         *stripped_source_files.rules(),
         *subprocess_environment.rules(),
+        *synthetic_targets.rules(),
         *system_binaries.rules(),
         *target_type_rules(),
     ]
@@ -105,6 +108,7 @@ def target_types():
         RemoteEnvironmentTarget,
         ResourcesGeneratorTarget,
         ResourceTarget,
+        SubsystemTarget,
     ]
 
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -893,6 +893,28 @@ class LockfilesGeneratorTarget(TargetFilesGenerator):
     help = "Generate a `_lockfile` target for each file in the `sources` field."
 
 
+# -----------------------------------------------------------------------------------------------
+# `_subsystem` target
+# -----------------------------------------------------------------------------------------------
+
+
+class SubsystemDependenciesField(Dependencies):
+    pass
+
+
+class SubsystemTarget(Target):
+    alias = "_subsystem"
+    core_fields = (*COMMON_TARGET_FIELDS, SubsystemDependenciesField)
+    help = softwrap(
+        """
+        A target for subsystems in order to include them in the dependency graph of other targets.
+
+        This tracks them so that `--changed-since --changed-dependents` works properly for targets
+        relying on a particular subsystem.
+        """
+    )
+
+
 def rules():
     return (
         *collect_rules(),

--- a/src/python/pants/core/util_rules/synthetic_targets.py
+++ b/src/python/pants/core/util_rules/synthetic_targets.py
@@ -1,0 +1,54 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.build_graph.build_configuration import BuildConfiguration
+from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
+from pants.engine.internals.target_adaptor import TargetAdaptor
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+
+
+@dataclass(frozen=True)
+class SyntheticSubsystemTargetsRequest(SyntheticTargetsRequest):
+    """Register the type used to create synthetic targets for all subsystems.
+
+    As the paths for all subsystems are known up-front, we set the `path` field to
+    `SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS` so that we get a single request for all
+    our synthetic targets rather than one request per directory.
+    """
+
+    path: str = SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS
+
+
+@rule
+async def get_synthetic_subsystem_targets(
+    request: SyntheticSubsystemTargetsRequest,
+    build_configuration: BuildConfiguration,
+) -> SyntheticAddressMaps:
+    return SyntheticAddressMaps.for_targets_request(
+        request,
+        [
+            (
+                "BUILD.subsystems",
+                tuple(
+                    TargetAdaptor(
+                        "_subsystem",
+                        name=f"subsystem-{subsystem.options_scope}",
+                        description=subsystem.help,
+                    )
+                    for subsystem in build_configuration.all_subsystems
+                    if subsystem.options_scope and not subsystem.options_scope.startswith("_")
+                ),
+            )
+        ],
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(SyntheticTargetsRequest, SyntheticSubsystemTargetsRequest),
+    )


### PR DESCRIPTION
This is the first step towards having proper dependencies to subsystem configurations.

Planned next step is to add a dependency on synthesized configuration targets based on option value sources per subsystem.

Can eventually be used to address things like #14724


Example config source info as available already:
<img width="456" alt="image" src="https://user-images.githubusercontent.com/72965/204144054-6d5fef05-4275-40a3-9817-5f4e372d70e3.png">


This adds quite a number of targets to the root, which can easily be filtered out however:
```
╰─❯ ./pants list //
//:buildgrid_remote
//:docker_env
//:subsystem-anonymous-telemetry
//:subsystem-auth
//:subsystem-auth-acquire
//:subsystem-auth-token-check
//:subsystem-auth-token-info
//:subsystem-autoflake
//:subsystem-black
...

╰─❯ ./pants list --filter-target-type=-_subsystem //
//:buildgrid_remote
//:docker_env
//BUILD_ROOT:files
//cargo:scripts
//conftest.py:test_utils
//pants:scripts
//pants.toml:files
╰─❯ 
```
