### PR TITLE
Extend default module mapping for Python 3rd-party dependency inference: pysocks and atlassian-python-api

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -135,7 +135,7 @@ DEFAULT_MODULE_MAPPING = {
     "pyopenssl": ("OpenSSL",),
     "pypdf2": ("PyPDF2",),
     "pypi-kenlm": ("kenlm",),
-    "PySocks": ("socks",),
+    "pysocks": ("socks",),
     "pytest": ("pytest", "_pytest"),
     "python-dateutil": ("dateutil",),
     "python-docx": ("docx",),

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -7,6 +7,7 @@ DEFAULT_MODULE_MAPPING = {
     "absl-py": ("absl",),
     "ansicolors": ("colors",),
     "apache-airflow": ("airflow",),
+    "atlassian-python-api": ("atlassian",),
     "attrs": ("attr",),
     # Azure
     "azure-common": ("azure.common",),
@@ -134,6 +135,7 @@ DEFAULT_MODULE_MAPPING = {
     "pyopenssl": ("OpenSSL",),
     "pypdf2": ("PyPDF2",),
     "pypi-kenlm": ("kenlm",),
+    "PySocks": ("socks",),
     "pytest": ("pytest", "_pytest"),
     "python-dateutil": ("dateutil",),
     "python-docx": ("docx",),


### PR DESCRIPTION
Add package name mapping for more Python packages:

- https://github.com/Anorov/PySocks
- https://github.com/atlassian-api/atlassian-python-api