### PR TITLE
Fix bug in Go test result exit code interpretation.

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -236,7 +236,7 @@ async def run_go_tests(
         return compilation_failure(_exit_code, None, _stderr)
 
     if not testmain.has_tests and not testmain.has_xtests:
-        return TestResult.skip(field_set.address, output_setting=test_subsystem.output)
+        return TestResult.no_tests_found(field_set.address, output_setting=test_subsystem.output)
 
     coverage_config: GoCoverageConfig | None = None
     if test_subsystem.use_coverage:

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -682,7 +682,7 @@ def test_no_tests(rule_runner: RuleRunner) -> None:
     result = rule_runner.request(
         TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
     )
-    assert result.skipped
+    assert result.exit_code is None
 
 
 def test_compilation_error(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -559,13 +559,13 @@ def assert_streaming_output(
     assert result.message() == expected_message
 
 
-def test_streaming_output_skip() -> None:
+def test_streaming_output_no_tests() -> None:
     assert_streaming_output(
         exit_code=None,
         stdout="",
         stderr="",
         expected_level=LogLevel.DEBUG,
-        expected_message="skipped.",
+        expected_message="no tests found.",
     )
 
 


### PR DESCRIPTION
Gets rid of the confusing, implicit "skipped" state, in favor of checking the necessary field values
directly for None before using them.

Context:

The Go backend performs its own test discovery. It uses None values on the `exit_code` 
and/or `result_metadata` fields to communicate back to the test goal that:

A) Test discovery discovered no tests (exit_code=None, result_metadata=None)
B) Test discovery failed due to compilation error (exit_code=1, result_metadata=None)

Elsewhere, the test goal interprets either field being None as the TestResult being in an
implied "skipped" state.

This lead to a bug (#17657) where a result in state B) was seen as "skipped", and therefore 
did not affect the final pants run exit code, leading to an exit code of 0 in a run that had 
compilation errors, which is a potential CI disaster.

This bug was a result of confusion due to the implicit "skipped" state collapsing the meaning
of None on two different underlying fields into a single concept, that was than misapplied.

This change gets rid of the "skipped" concept entirely. It was misnamed from the start - it does not
represent tests that are skipped but packages that had no tests in them. 

Instead, we test each of the two fields for None-ness before using them, and document when 
each can be None.

PS Note that this issue doesn't occur in the JVM backend, where compilation errors fail the entire run eagerly.
TODO: Should the Go backend do the same thing, and propagate compilation errors immediately?