### PR TITLE
Fix wheel reversioning

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -986,7 +986,7 @@ def reversion_prebuilt_wheels() -> None:
             whl_file=str(whl),
             dest_dir=str(stable_wheel_dir),
             target_version=CONSTANTS.pants_stable_version,
-            extra_globs=["pants/VERSION"],
+            extra_globs=["pants/_version/VERSION"],
         )
 
 


### PR DESCRIPTION
Fixes #17664. Note version moved in https://github.com/pantsbuild/pants/pull/17582

Tested by modifying the release helper to call `reversion_prebuilt_wheels()` in `build_pex` and comparing behavior before/after. Before: it had the unstable version, After: it has the stable version.