### PR TITLE
Visibility rules: error if more than one declaration per BUILD file.

### DIFF
--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -62,7 +62,7 @@ class AddressMap:
                 dependencies_rules,
             )
         except Exception as e:
-            raise MappingError(f"Failed to parse ./{filepath}:\n{e}")
+            raise MappingError(f"Failed to parse ./{filepath}:\n{type(e).__name__}: {e}")
         return cls.create(filepath, target_adaptors)
 
     @classmethod


### PR DESCRIPTION
@AlexTereshenkov discovered that there was undesirable behaviour if you provide more than one of the `__dependencies_rules__`/`__dependents_rules__` in a BUILD file.

This PR adds a check that throws an error in case there is more than one each of these per BUILD file.