### PR TITLE
Splits `experimental_shell_command` rules to allow for use by other targets

### DIFF
--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -13,7 +13,7 @@ from pants.backend.shell.target_types import (
     SkipShellCommandTestsField,
 )
 from pants.backend.shell.util_rules import shell_command
-from pants.backend.shell.util_rules.shell_command import ShellCommandProcessRequest
+from pants.backend.shell.util_rules.shell_command import ShellCommandProcessFromTargetRequest
 from pants.core.goals.test import (
     TestDebugAdapterRequest,
     TestDebugRequest,
@@ -62,8 +62,7 @@ async def test_shell_command(
 
     shell_process = await Get(
         Process,
-        ShellCommandProcessRequest,
-        ShellCommandProcessRequest.from_target(wrapped_tgt.target),
+        ShellCommandProcessFromTargetRequest(wrapped_tgt.target),
     )
 
     shell_process = dataclasses.replace(

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -60,7 +60,11 @@ async def test_shell_command(
         WrappedTargetRequest(field_set.address, description_of_origin="<infallible>"),
     )
 
-    shell_process = await Get(Process, ShellCommandProcessRequest(wrapped_tgt.target))
+    shell_process = await Get(
+        Process,
+        ShellCommandProcessRequest,
+        ShellCommandProcessRequest.from_target(wrapped_tgt.target),
+    )
 
     shell_process = dataclasses.replace(
         shell_process,

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -390,7 +390,7 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
     )
 
     tgt = rule_runner.get_target(Address("src", target_name="boot-script-test"))
-    res = rule_runner.request(Process, [ShellCommandProcessRequest(tgt)])
+    res = rule_runner.request(Process, [ShellCommandProcessRequest.from_target(tgt)])
     assert "bash" in res.argv[0]
     assert res.argv[1:] == (
         "-c",

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -17,6 +17,7 @@ from pants.backend.shell.target_types import (
 from pants.backend.shell.util_rules.shell_command import (
     GenerateFilesFromShellCommandRequest,
     RunShellCommand,
+    ShellCommandProcessFromTargetRequest,
     ShellCommandProcessRequest,
 )
 from pants.backend.shell.util_rules.shell_command import rules as shell_command_rules
@@ -26,6 +27,7 @@ from pants.core.target_types import rules as core_target_type_rules
 from pants.core.util_rules import archive, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
+from pants.engine.environment import EnvironmentName
 from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents
 from pants.engine.process import Process
 from pants.engine.target import (
@@ -47,6 +49,7 @@ def rule_runner() -> RuleRunner:
             *core_target_type_rules(),
             QueryRule(GeneratedSources, [GenerateFilesFromShellCommandRequest]),
             QueryRule(Process, [ShellCommandProcessRequest]),
+            QueryRule(Process, [EnvironmentName, ShellCommandProcessFromTargetRequest]),
             QueryRule(RunRequest, [RunShellCommand]),
             QueryRule(SourceFiles, [SourceFilesRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
@@ -390,7 +393,7 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
     )
 
     tgt = rule_runner.get_target(Address("src", target_name="boot-script-test"))
-    res = rule_runner.request(Process, [ShellCommandProcessRequest.from_target(tgt)])
+    res = rule_runner.request(Process, [ShellCommandProcessFromTargetRequest(tgt)])
     assert "bash" in res.argv[0]
     assert res.argv[1:] == (
         "-c",


### PR DESCRIPTION
This splits `ShellCommandProcessFromTargetRequest` out from `ShellCommandProcessRequest`. `ShellCommandProcessRequest` contains preprocessed values from the `Target`, and is only responsible for assembling the working environment and returning the `Process`; `ShellCommandProcessFromTargetRequest` contains all of the code specific to `experimental_shell_command`'s configuration (preparing inputs and output specifications, for example).

This will make it easier to write variations that have specialised inputs.