### PR TITLE
[Visibility] `**/..` globs can match root level files

### DIFF
--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -92,18 +92,19 @@ class PathGlob:
     def _translate_pattern_to_regexp(pattern: str, snap_to_path: bool) -> str:
         # Escape regexp characters, then restore any `*`s.
         glob = re.escape(pattern).replace(r"\*", "*")
-        # Translate recursive `**` globs to regexp, a `/` prefix is optional.
-        glob = glob.replace("/**", "(/.<<$>>)?")
-        glob = glob.replace("**", ".<<$>>")
+        # Translate recursive `**` globs to regexp, any adjacent `/` is optional.
+        glob = glob.replace("/**", r"(/.<<$>>)?")
+        glob = glob.replace("**/", r"/?\b")
+        glob = glob.replace("**", r".<<$>>")
         # Translate `*` to match any path segment.
-        glob = glob.replace("*", "[^/]<<$>>")
+        glob = glob.replace("*", r"[^/]<<$>>")
         # Restore `*`s that was "escaped" during translation.
-        glob = glob.replace("<<$>>", "*")
+        glob = glob.replace("<<$>>", r"*")
         # Snap to closest `/`
         if snap_to_path and glob and glob[0].isalnum():
             glob = r"/?\b" + glob
 
-        return glob + "$"
+        return glob + r"$"
 
     def _match_path(self, path: str, base: str) -> str | None:
         if self.anchor_mode is PathGlobAnchorMode.INVOKED_PATH:

--- a/src/python/pants/backend/visibility/glob_test.py
+++ b/src/python/pants/backend/visibility/glob_test.py
@@ -143,6 +143,16 @@ from pants.engine.internals.target_adaptor import TargetAdaptor
                 uplvl=0,
             ),
         ),
+        (
+            "base",
+            "**/path",
+            PathGlob(
+                raw="**/path",
+                anchor_mode=PathGlobAnchorMode.FLOATING,
+                glob=re.compile(r"/?\bpath$"),
+                uplvl=0,
+            ),
+        ),
     ],
 )
 def test_pathglob_parse(base: str, pattern_text: str | tuple[str, str], expected: PathGlob) -> None:


### PR DESCRIPTION
The intent was for `foo.py` to be equivalent to `**/foo.py`, but the extra `/` in the glob wasn't optional when matched against a path.

Reported by @thejcannon 