### PR TITLE
go: add `compiler_flags` field for adding arbitrary extra compiler flags

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -19,6 +19,7 @@ from pants.engine.target import (
     InvalidTargetException,
     MultipleSourcesField,
     StringField,
+    StringSequenceField,
     Target,
     TargetGenerator,
     TriBoolField,
@@ -127,6 +128,26 @@ class GoTestAddressSanitizerEnabledField(GoRaceDetectorEnabledField):
 
         See https://github.com/google/sanitizers/wiki/AddressSanitizer for additional information about
         the C/C++ address sanitizer.
+        """
+    )
+
+
+class GoCompilerFlagsField(StringSequenceField):
+    alias = "compiler_flags"
+    help = softwrap(
+        """
+        Extra flags to pass to the Go compiler (i.e., `go tool compile`) when compiling Go code.
+
+        This field can be specified on several different target types:
+        - On `go_mod` targets, the specified compiler flags are used when compiling any package involving the module
+        including both first-party (i.e., `go_package` targets) and third-party dependencies.
+        - On `go_binary` targets, the compiler flags are used when compiling for all packages comprising that
+        the binary including third-party dependencies. These compiler flags will be added after any compiler flags
+        added by any `compile_flags` field on the applicable `go_mod` target.
+        - On `go_package` targets, the compiler flags are used only for compiling that specific package and not
+        for any other package. These compiler flags will be added after any compiler flags
+        added by any `compile_flags` field set on the applicable `go_mod` target or any applicable `go_binary`
+        target.
         """
     )
 
@@ -245,6 +266,7 @@ class GoModTarget(TargetGenerator):
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
+        GoCompilerFlagsField,
     )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = ()
@@ -325,6 +347,7 @@ class GoPackageTarget(Target):
         GoTestRaceDetectorEnabledField,
         GoTestMemorySanitizerEnabledField,
         GoTestAddressSanitizerEnabledField,
+        GoCompilerFlagsField,
         SkipGoTestsField,
     )
     help = softwrap(
@@ -372,6 +395,7 @@ class GoBinaryTarget(Target):
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
+        GoCompilerFlagsField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -139,15 +139,19 @@ class GoCompilerFlagsField(StringSequenceField):
         Extra flags to pass to the Go compiler (i.e., `go tool compile`) when compiling Go code.
 
         This field can be specified on several different target types:
-        - On `go_mod` targets, the specified compiler flags are used when compiling any package involving the module
+
+        - On `go_mod` targets, the compiler flags are used when compiling any package involving the module
         including both first-party (i.e., `go_package` targets) and third-party dependencies.
-        - On `go_binary` targets, the compiler flags are used when compiling for all packages comprising that
-        the binary including third-party dependencies. These compiler flags will be added after any compiler flags
-        added by any `compile_flags` field on the applicable `go_mod` target.
+
+        - On `go_binary` targets, the compiler flags are used when compiling any packages comprising that binary
+        including third-party dependencies. These compiler flags will be added after any compiler flags
+        added by any `compiler_flags` field set on the applicable `go_mod` target.
+
         - On `go_package` targets, the compiler flags are used only for compiling that specific package and not
-        for any other package. These compiler flags will be added after any compiler flags
-        added by any `compile_flags` field set on the applicable `go_mod` target or any applicable `go_binary`
-        target.
+        for any other package. These compiler flags will be added after any compiler flags added by any
+        `compiler_flags` field set on the applicable `go_mod` target or applicable `go_binary` target.
+
+        Run `go doc cmd/compile` to see the flags supported by `go tool compile`.
         """
     )
 

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -79,7 +79,7 @@ class GoBuildOptionsFieldSet(FieldSet):
     race: GoRaceDetectorEnabledField
     msan: GoMemorySanitizerEnabledField
     asan: GoAddressSanitizerEnabledField
-    compile_flags: GoCompilerFlagsField
+    compiler_flags: GoCompilerFlagsField
 
 
 @dataclass(frozen=True)
@@ -315,15 +315,15 @@ async def go_extract_build_options_from_target(
         )
 
     # Extract any extra compiler flags specified on `go_mod` or `go_binary` targets.
-    # Note: A `compile_flags` field specified on a `go_package` target is extracted elsewhere.from
+    # Note: A `compiler_flags` field specified on a `go_package` target is extracted elsewhere.
     compiler_flags: list[str] = []
     if go_mod_target_fields is not None:
         # To avoid duplication of options, only add the module-specific compiler flags if the target for this request
         # is not a `go_mod` target (i.e., because it does not conform to the field set or has a different address).
         if target_fields is None or go_mod_target_fields.address != target_fields.address:
-            compiler_flags.extend(go_mod_target_fields.compile_flags.value or [])
+            compiler_flags.extend(go_mod_target_fields.compiler_flags.value or [])
     if target_fields is not None:
-        compiler_flags.extend(target_fields.compile_flags.value or [])
+        compiler_flags.extend(target_fields.compiler_flags.value or [])
 
     return GoBuildOptions(
         cgo_enabled=cgo_enabled,

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -11,6 +11,7 @@ from pants.backend.go.subsystems.gotest import GoTestSubsystem
 from pants.backend.go.target_types import (
     GoAddressSanitizerEnabledField,
     GoCgoEnabledField,
+    GoCompilerFlagsField,
     GoMemorySanitizerEnabledField,
     GoRaceDetectorEnabledField,
     GoTestAddressSanitizerEnabledField,
@@ -44,6 +45,11 @@ class GoBuildOptions:
     # Enable interoperation with the C/C++ address sanitizer.
     with_asan: bool = False
 
+    # Extra flags to pass to the Go compiler (i.e., `go tool compile`).
+    # Note: These flags come from `go_mod` and `go_binary` targets. Package-specific compiler flags
+    # may still come from `go_package` targets.
+    compiler_flags: tuple[str, ...] = ()
+
     def __post_init__(self):
         assert not (self.with_race_detector and self.with_msan)
         assert not (self.with_race_detector and self.with_asan)
@@ -61,17 +67,28 @@ class GoBuildOptionsFromTargetRequest(EngineAwareParameter):
 
 @dataclass(frozen=True)
 class GoBuildOptionsFieldSet(FieldSet):
-    required_fields = (GoCgoEnabledField, GoRaceDetectorEnabledField, GoMemorySanitizerEnabledField)
+    required_fields = (
+        GoCgoEnabledField,
+        GoRaceDetectorEnabledField,
+        GoMemorySanitizerEnabledField,
+        GoAddressSanitizerEnabledField,
+        GoCompilerFlagsField,
+    )
 
     cgo_enabled: GoCgoEnabledField
     race: GoRaceDetectorEnabledField
     msan: GoMemorySanitizerEnabledField
     asan: GoAddressSanitizerEnabledField
+    compile_flags: GoCompilerFlagsField
 
 
 @dataclass(frozen=True)
 class GoTestBuildOptionsFieldSet(FieldSet):
-    required_fields = (GoTestRaceDetectorEnabledField, GoTestMemorySanitizerEnabledField)
+    required_fields = (
+        GoTestRaceDetectorEnabledField,
+        GoTestMemorySanitizerEnabledField,
+        GoTestAddressSanitizerEnabledField,
+    )
 
     test_race: GoTestRaceDetectorEnabledField
     test_msan: GoTestMemorySanitizerEnabledField
@@ -297,11 +314,23 @@ async def go_extract_build_options_from_target(
             f"The C/C++ address sanitizer is enabled because {asan_reason}."
         )
 
+    # Extract any extra compiler flags specified on `go_mod` or `go_binary` targets.
+    # Note: A `compile_flags` field specified on a `go_package` target is extracted elsewhere.from
+    compiler_flags: list[str] = []
+    if go_mod_target_fields is not None:
+        # To avoid duplication of options, only add the module-specific compiler flags if the target for this request
+        # is not a `go_mod` target (i.e., because it does not conform to the field set or has a different address).
+        if target_fields is None or go_mod_target_fields.address != target_fields.address:
+            compiler_flags.extend(go_mod_target_fields.compile_flags.value or [])
+    if target_fields is not None:
+        compiler_flags.extend(target_fields.compile_flags.value or [])
+
     return GoBuildOptions(
         cgo_enabled=cgo_enabled,
         with_race_detector=with_race_detector,
         with_msan=with_msan,
         with_asan=with_asan,
+        compiler_flags=tuple(compiler_flags),
     )
 
 


### PR DESCRIPTION
Add `compiler_flags` field for adding arbitrary extra compiler flags when compiling Go files.

Design:
- When `compiler_flags` is specified on a `go_mod` target, the flags are added for all compilation involving that Go module (including third-party dependencies).
- When `compiler_flags` is specified on a `go_binary` target, the flags are added for all compilation involved in building that Go binary (including third-party dependencies). These flags are added in addition to any flags specified via setting `compiler_flags` on the applicable `go_mod` target.
- When `compiler_flags` is specified on a `go_package` target, the flags are added only for the compilation of that specific package. These flags are added in addition to any flags specified via setting `compiler_flags` on the applicable `go_mod` and/or `go_binary` targets.

Fixes https://github.com/pantsbuild/pants/issues/17439