### PR TITLE
go: rename test function to reflect it uses `pytest.mark.parametrize`

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -78,7 +78,7 @@ def rule_runner() -> RuleRunner:
         ("asan", lambda opts: opts.with_asan, asan_supported),
     ),
 )
-def test_race_detector_fields_work_as_expected(
+def test_runtime_check_enable_fields_work_as_expected(
     rule_runner: RuleRunner,
     field_name: str,
     getter: Callable[[GoBuildOptions], bool],


### PR DESCRIPTION
Rename test function to reflect it now uses `pytest.mark.parametrize`, whereas before it just tested the `race` field.