### PR TITLE
Add overloads to `RuleRunner.write_files` to make it more caller-friendly

### DIFF
--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -325,8 +325,8 @@ def test_embeds_supported(rule_runner: RuleRunner) -> None:
                 go 1.17
                 """
             ),
-            **resources,  # type: ignore[arg-type]
-            **go_sources,  # type: ignore[arg-type]
+            **resources,
+            **go_sources,
         }
     )
     maybe_analysis = rule_runner.request(

--- a/src/python/pants/backend/helm/util_rules/renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/renderer_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pathlib import PurePath
 from textwrap import dedent
 
 import pytest
@@ -55,7 +54,7 @@ def _read_file_from_digest(rule_runner: RuleRunner, *, digest: Digest, filename:
     return config_file_contents[0].content.decode("utf-8")
 
 
-def _common_workspace_files() -> dict[str | PurePath, str | bytes]:
+def _common_workspace_files() -> dict[str, str]:
     return {
         "src/mychart/BUILD": "helm_chart()",
         "src/mychart/Chart.yaml": HELM_CHART_FILE,

--- a/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pylint/rules_integration_test.py
@@ -497,7 +497,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         **create_folder("resolveB_1", "b", "3.9"),
         **create_folder("resolveB_2", "b", "3.9"),
     }
-    rule_runner.write_files(files)  # type: ignore[arg-type]
+    rule_runner.write_files(files)
     rule_runner.set_options(
         ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -810,7 +810,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         **create_folder("resolveB_1", "b", "3.9"),
         **create_folder("resolveB_2", "b", "3.9"),
     }
-    rule_runner.write_files(files)  # type: ignore[arg-type]
+    rule_runner.write_files(files)
     rule_runner.set_options(
         ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -49,7 +49,7 @@ def rule_runner() -> RuleRunner:
 
 def test_warn_if_python_version_configured(rule_runner: RuleRunner, caplog) -> None:
     config = {"mypy.ini": "[mypy]\npython_version = 3.6"}
-    rule_runner.write_files(config)  # type: ignore[arg-type]
+    rule_runner.write_files(config)
     config_digest = rule_runner.make_snapshot(config).digest
 
     def maybe_assert_configured(*, has_config: bool, args: list[str], warning: str = "") -> None:

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -177,7 +177,7 @@ def test_partition_targets(rule_runner: RuleRunner) -> None:
         **create_folder("resolveB_1", "b", "3.9"),
         **create_folder("resolveB_2", "b", "3.9"),
     }
-    rule_runner.write_files(files)  # type: ignore[arg-type]
+    rule_runner.write_files(files)
     rule_runner.set_options(
         ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
         env_inherit={"PATH", "PYENV_ROOT", "HOME"},

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -802,16 +802,18 @@ def test_lockfile_requirements_selection(
         ),
     }
     if mode == ResolveMode.resolve_all_constraints:
-        mode_files = {"constraints.txt": "setuptools==54.1.2"}
+        mode_files.update({"constraints.txt": "setuptools==54.1.2"})
     elif mode == ResolveMode.poetry_or_manual:
-        mode_files = {"3rdparty/python/default.lock": setuptools_poetry_lockfile}
+        mode_files.update({"3rdparty/python/default.lock": setuptools_poetry_lockfile})
     else:
         assert mode == ResolveMode.pex
 
         requirements = rule_runner.request(Setuptools, []).pex_requirements()
         assert isinstance(requirements, EntireLockfile)
         assert isinstance(requirements.lockfile, LockfileContent)
-        mode_files = {"3rdparty/python/default.lock": requirements.lockfile.file_content.content}
+        mode_files.update(
+            {"3rdparty/python/default.lock": requirements.lockfile.file_content.content}
+        )
 
     rule_runner.write_files(mode_files)
 

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path, PurePath
 from textwrap import dedent
-from typing import Iterable, List, Mapping, cast
+from typing import Iterable, List, cast
 from unittest.mock import Mock
 
 import pytest
@@ -94,7 +94,7 @@ def rule_runner() -> RuleRunner:
 def test_choose_compatible_resolve(rule_runner: RuleRunner) -> None:
     def create_target_files(
         directory: str, *, req_resolve: str, source_resolve: str, test_resolve: str
-    ) -> dict[str | PurePath, str | bytes]:
+    ) -> dict[str, str]:
         return {
             f"{directory}/BUILD": dedent(
                 f"""\
@@ -792,7 +792,15 @@ def test_lockfile_requirements_selection(
     internal_only: bool,
     run_against_entire_lockfile: bool,
 ) -> None:
-    mode_files: Mapping[str | PurePath, str | bytes]
+    mode_files: dict[str, str | bytes] = {
+        "a.py": "",
+        "BUILD": dedent(
+            """
+                python_sources(name="lib", dependencies=[":setuptools"])
+                python_requirement(name="setuptools", requirements=["setuptools"])
+                """
+        ),
+    }
     if mode == ResolveMode.resolve_all_constraints:
         mode_files = {"constraints.txt": "setuptools==54.1.2"}
     elif mode == ResolveMode.poetry_or_manual:
@@ -805,18 +813,7 @@ def test_lockfile_requirements_selection(
         assert isinstance(requirements.lockfile, LockfileContent)
         mode_files = {"3rdparty/python/default.lock": requirements.lockfile.file_content.content}
 
-    rule_runner.write_files(
-        {
-            **mode_files,
-            "a.py": "",
-            "BUILD": dedent(
-                """
-                python_sources(name="lib", dependencies=[":setuptools"])
-                python_requirement(name="setuptools", requirements=["setuptools"])
-                """
-            ),
-        }
-    )
+    rule_runner.write_files(mode_files)
 
     if mode == ResolveMode.resolve_all_constraints:
         options = [

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -68,7 +68,7 @@ def make_target(
         "BUILD": f"terraform_module(name='{target_name}')\n",
     }
     files.update({source_file.path: source_file.content.decode() for source_file in source_files})
-    rule_runner.write_files(files)  # type: ignore[arg-type]
+    rule_runner.write_files(files)
     return rule_runner.get_target(Address("", target_name=target_name))
 
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -26,6 +26,7 @@ from typing import (
     Type,
     TypeVar,
     cast,
+    overload,
 )
 
 from pants.base.build_root import BuildRoot
@@ -462,7 +463,17 @@ class RuleRunner:
         self._invalidate_for(str(relpath))
         return path
 
-    def write_files(self, files: Mapping[str | PurePath, str | bytes]) -> tuple[str, ...]:
+    @overload
+    def write_files(self, files: Mapping[str, str | bytes]) -> tuple[str, ...]:
+        ...
+
+    @overload
+    def write_files(self, files: Mapping[PurePath, str | bytes]) -> tuple[str, ...]:
+        ...
+
+    def write_files(
+        self, files: Mapping[PurePath, str | bytes] | Mapping[str, str | bytes]
+    ) -> tuple[str, ...]:
         """Write the files to the build root.
 
         :API: public


### PR DESCRIPTION
Dicts and Mappings arent covariant on the key, this works around that.