### PR TITLE
go: add `linker_flags` field to `go_mod` and `go_binary` target types

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -156,6 +156,26 @@ class GoCompilerFlagsField(StringSequenceField):
     )
 
 
+class GoLinkerFlagsField(StringSequenceField):
+    alias = "linker_flags"
+    help = softwrap(
+        """
+        Extra flags to pass to the Go linker (i.e., `go tool link`) when linking Go binaries.
+
+        This field can be specified on several different target types:
+
+        - On `go_mod` targets, the linker flags are used when linking any binary involving the module
+        including both `go_binary` targets and test binaries for `go_package` targets within the module.
+
+        - On `go_binary` targets, the linker flags are used when linking that binary. These linker flags
+        will be added after any linker flags added by any `linker_flags` field set on the applicable
+        `go_mod` target.
+
+        Run `go doc cmd/link` to see the flags supported by `go tool link`.
+        """
+    )
+
+
 # -----------------------------------------------------------------------------------------------
 # `go_third_party_package` target
 # -----------------------------------------------------------------------------------------------
@@ -271,6 +291,7 @@ class GoModTarget(TargetGenerator):
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
         GoCompilerFlagsField,
+        GoLinkerFlagsField,
     )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = ()
@@ -400,6 +421,7 @@ class GoBinaryTarget(Target):
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
         GoCompilerFlagsField,
+        GoLinkerFlagsField,
         RestartableField,
     )
     help = "A Go binary."

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -51,6 +51,7 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
                 "-o",
                 request.output_filename,
                 "-buildmode=exe",  # seen in `go build -x` output
+                *request.build_opts.linker_flags,
                 *request.archives,
             ),
             env={


### PR DESCRIPTION
Add a `linker_flags` field to `go_mod` and `go_binary` target types to allow setting arbitrary extra linker arguments to be passed to `go tool link`.

Fixes https://github.com/pantsbuild/pants/issues/17440.