### PR TITLE
go: support code coverage over multiple packages during single test

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -320,9 +320,7 @@ async def run_go_tests(
         # Scan the tree of BuildGoPackageRequest's and lift any packages with coverage enabled to be direct
         # dependencies of the generated main package. This facilitates registration of the code coverage
         # setup functions.
-        print(f"main_direct_deps={main_direct_deps}")
         coverage_transitive_deps = _lift_build_requests_with_coverage(main_direct_deps)
-        print(f"coverage_transitive_deps={coverage_transitive_deps}")
         coverage_transitive_deps.sort(key=lambda build_req: build_req.import_path)
         main_direct_deps.extend(coverage_transitive_deps)
 

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -285,7 +285,7 @@ async def run_go_tests(
         )
     test_pkg_build_request = maybe_test_pkg_build_request.request
 
-    # Determine the direct dependencies of the generated main package. The test package itself it always a
+    # Determine the direct dependencies of the generated main package. The test package itself is always a
     # dependency. Add the xtests package as well if any xtests exist.
     main_direct_deps = [test_pkg_build_request]
     if testmain.has_xtests:

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import dataclasses
 import os
+from collections import deque
 from dataclasses import dataclass
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 
 from pants.backend.go.subsystems.gotest import GoTestSubsystem
 from pants.backend.go.target_types import (
@@ -166,6 +168,23 @@ def transform_test_args(args: Sequence[str], timeout_field_value: int | None) ->
     return tuple(result)
 
 
+def _lift_build_requests_with_coverage(
+    roots: Iterable[BuildGoPackageRequest],
+) -> list[BuildGoPackageRequest]:
+    result: list[BuildGoPackageRequest] = []
+
+    queue: deque[BuildGoPackageRequest] = deque()
+    queue.extend(roots)
+
+    while queue:
+        build_request = queue.popleft()
+        if build_request.with_coverage:
+            result.append(build_request)
+        queue.extend(build_request.direct_dependencies)
+
+    return result
+
+
 @rule(desc="Test with Go", level=LogLevel.DEBUG)
 async def run_go_tests(
     batch: GoTestRequest.Batch[GoTestFieldSet, Any],
@@ -238,9 +257,16 @@ async def run_go_tests(
     if not testmain.has_tests and not testmain.has_xtests:
         return TestResult.no_tests_found(field_set.address, output_setting=test_subsystem.output)
 
-    coverage_config: GoCoverageConfig | None = None
+    with_coverage = False
     if test_subsystem.use_coverage:
-        coverage_config = GoCoverageConfig(cover_mode=go_test_subsystem.coverage_mode)
+        with_coverage = True
+        build_opts = dataclasses.replace(
+            build_opts,
+            coverage_config=GoCoverageConfig(
+                cover_mode=go_test_subsystem.coverage_mode,
+                import_path_include_patterns=go_test_subsystem.coverage_include_patterns,
+            ),
+        )
 
     # Construct the build request for the package under test.
     maybe_test_pkg_build_request = await Get(
@@ -248,7 +274,7 @@ async def run_go_tests(
         BuildGoPackageTargetRequest(
             field_set.address,
             for_tests=True,
-            coverage_config=coverage_config,
+            with_coverage=with_coverage,
             build_opts=build_opts,
         ),
     )
@@ -259,10 +285,9 @@ async def run_go_tests(
         )
     test_pkg_build_request = maybe_test_pkg_build_request.request
 
-    # TODO: Eventually support adding coverage to non-test packages. Those other packages will need to be
-    # added to `main_direct_deps` and to the coverage setup in the testmain.
+    # Determine the direct dependencies of the generated main package. The test package itself it always a
+    # dependency. Add the xtests package as well if any xtests exist.
     main_direct_deps = [test_pkg_build_request]
-
     if testmain.has_xtests:
         # Build a synthetic package for xtests where the import path is the same as the package under test
         # but with "_test" appended.
@@ -271,7 +296,7 @@ async def run_go_tests(
             BuildGoPackageTargetRequest(
                 field_set.address,
                 for_xtests=True,
-                coverage_config=coverage_config,
+                with_coverage=with_coverage,
                 build_opts=build_opts,
             ),
         )
@@ -291,7 +316,16 @@ async def run_go_tests(
     # register them with the coverage runtime.
     coverage_setup_digest = EMPTY_DIGEST
     coverage_setup_files = []
-    if coverage_config is not None:
+    if with_coverage:
+        # Scan the tree of BuildGoPackageRequest's and lift any packages with coverage enabled to be direct
+        # dependencies of the generated main package. This facilitates registration of the code coverage
+        # setup functions.
+        print(f"main_direct_deps={main_direct_deps}")
+        coverage_transitive_deps = _lift_build_requests_with_coverage(main_direct_deps)
+        print(f"coverage_transitive_deps={coverage_transitive_deps}")
+        coverage_transitive_deps.sort(key=lambda build_req: build_req.import_path)
+        main_direct_deps.extend(coverage_transitive_deps)
+
         # Build the `main_direct_deps` when in coverage mode to obtain the "coverage variables" for those packages.
         built_main_direct_deps = await MultiGet(
             Get(BuiltGoPackage, BuildGoPackageRequest, build_req) for build_req in main_direct_deps

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -13,7 +13,14 @@ from pants.backend.go.target_types import (
 )
 from pants.backend.go.util_rules.coverage import GoCoverMode
 from pants.core.util_rules.distdir import DistDir
-from pants.option.option_types import ArgsListOption, BoolOption, EnumOption, SkipOption, StrOption
+from pants.option.option_types import (
+    ArgsListOption,
+    BoolOption,
+    EnumOption,
+    SkipOption,
+    StrListOption,
+    StrOption,
+)
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -68,6 +75,36 @@ class GoTestSubsystem(Subsystem):
             """
             If true, then convert coverage reports to HTML format and write a `coverage.html` file next to the
             raw coverage data.
+            """
+        ),
+    )
+
+    coverage_include_patterns = StrListOption(
+        default=[],
+        help=softwrap(
+            """
+            A list of import path patterns for determining which import paths will be instrumented for code
+            coverage.
+
+            From `go help packages`:
+
+            An import path is a pattern if it includes one or more "..." wildcards,
+            each of which can match any string, including the empty string and
+            strings containing slashes. Such a pattern expands to all package
+            directories found in the GOPATH trees with names matching the
+            patterns.
+
+            To make common patterns more convenient, there are two special cases.
+            First, /... at the end of the pattern can match an empty string,
+            so that net/... matches both net and packages in its subdirectories, like net/http.
+            Second, any slash-separated pattern element containing a wildcard never
+            participates in a match of the "vendor" element in the path of a vendored
+            package, so that ./... does not match packages in subdirectories of
+            ./vendor or ./mycode/vendor, but ./vendor/... and ./mycode/vendor/... do.
+            Note, however, that a directory named vendor that itself contains code
+            is not a vendored package: cmd/vendor would be a command named vendor,
+            and the pattern cmd/... matches it.
+            See golang.org/s/go15vendor for more about vendoring.
             """
         ),
     )

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -38,7 +38,7 @@ class GoBuildOptions:
     # Coverage configuration.
     # If this is set and a package's import path matches `import_path_include_patterns`, then the package
     # will be instrumented for code coverage. (A caller can also force code coverage instrumentation by setting
-    # `with_coverage` to True on `BuildGoPackageTargetRequest`.
+    # `with_coverage` to `True` on `BuildGoPackageTargetRequest`.)
     coverage_config: GoCoverageConfig | None = None
 
     # Controls whether cgo support is enabled.

--- a/src/python/pants/backend/go/util_rules/build_opts.py
+++ b/src/python/pants/backend/go/util_rules/build_opts.py
@@ -20,6 +20,7 @@ from pants.backend.go.target_types import (
     GoTestRaceDetectorEnabledField,
 )
 from pants.backend.go.util_rules import go_mod, goroot
+from pants.backend.go.util_rules.coverage import GoCoverageConfig
 from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.build_graph.address import Address
@@ -34,6 +35,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class GoBuildOptions:
+    # Coverage configuration.
+    # If this is set and a package's import path matches `import_path_include_patterns`, then the package
+    # will be instrumented for code coverage. (A caller can also force code coverage instrumentation by setting
+    # `with_coverage` to True on `BuildGoPackageTargetRequest`.
+    coverage_config: GoCoverageConfig | None = None
+
     # Controls whether cgo support is enabled.
     cgo_enabled: bool = True
 

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -22,7 +22,6 @@ from pants.backend.go.util_rules.build_pkg import (
     FallibleBuildGoPackageRequest,
 )
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
-from pants.backend.go.util_rules.coverage import GoCoverageConfig
 from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.first_party_pkg import (
     FallibleFirstPartyPkgAnalysis,
@@ -38,6 +37,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoMod,
     OwningGoModRequest,
 )
+from pants.backend.go.util_rules.pkg_pattern import match_simple_pattern
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
@@ -73,7 +73,9 @@ class BuildGoPackageTargetRequest(EngineAwareParameter):
     is_main: bool = False
     for_tests: bool = False
     for_xtests: bool = False
-    coverage_config: GoCoverageConfig | None = None
+
+    # If True, then force coverage instead of applying import path patterns from `build_opts.coverage_config`.
+    with_coverage: bool = False
 
     def debug_hint(self) -> str:
         return str(self.address)
@@ -369,6 +371,12 @@ async def setup_build_go_package_target_request(
             )
         pkg_direct_dependencies.append(maybe_base_pkg_dep.request)
 
+    with_coverage = request.with_coverage
+    coverage_config = request.build_opts.coverage_config
+    if coverage_config:
+        for pattern in coverage_config.import_path_include_patterns:
+            with_coverage = with_coverage or match_simple_pattern(pattern)(import_path)
+
     result = BuildGoPackageRequest(
         digest=digest,
         import_path="main" if request.is_main else import_path,
@@ -388,7 +396,7 @@ async def setup_build_go_package_target_request(
         direct_dependencies=tuple(pkg_direct_dependencies),
         for_tests=request.for_tests,
         embed_config=embed_config,
-        coverage_config=request.coverage_config,
+        with_coverage=with_coverage,
         pkg_specific_compiler_flags=tuple(pkg_specific_compiler_flags),
     )
     return FallibleBuildGoPackageRequest(result, import_path)

--- a/src/python/pants/backend/go/util_rules/coverage.py
+++ b/src/python/pants/backend/go/util_rules/coverage.py
@@ -37,7 +37,11 @@ class GoCoverMode(enum.Enum):
 
 @dataclass(frozen=True)
 class GoCoverageConfig:
+    # How to count the code usage.
     cover_mode: GoCoverMode
+
+    # Import path patterns for packages which should be instrumented for code coverage.
+    import_path_include_patterns: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -38,6 +38,7 @@ from pants.core.util_rules import source_files
 from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Digest
 from pants.engine.rules import QueryRule
+from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -125,3 +126,96 @@ def test_basic_coverage(rule_runner: RuleRunner) -> None:
     digest_contents = rule_runner.request(DigestContents, (html_report.result_snapshot.digest,))
     assert len(digest_contents) == 1
     assert digest_contents[0].path == "coverage.html"
+
+
+def test_coverage_of_multiple_packages(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": "go_mod(name='mod')\ngo_package()",
+            "foo/go.mod": "module foo",
+            # `foo/adder` is a separate package so the test can attempt to include it into coverage of the
+            # `foo` package.
+            "foo/adder/BUILD": "go_package()",
+            "foo/adder/add.go": textwrap.dedent(
+                """\
+            package adder
+            func Add(x, y int) int {
+              return x + y
+            }
+            """
+            ),
+            "foo/add.go": textwrap.dedent(
+                """\
+                package foo
+                import "foo/adder"
+                func add(x, y int) int {
+                  return adder.Add(x, y)
+                }
+                """
+            ),
+            "foo/add_test.go": textwrap.dedent(
+                """\
+            package foo
+            import "testing"
+            func TestAdd(t *testing.T) {
+              if add(2, 3) != 5 {
+                t.Fail()
+              }
+            }
+            """
+            ),
+        }
+    )
+
+    def run_test(tgt: Target) -> str:
+        result = rule_runner.request(
+            TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]
+        )
+        assert result.exit_code == 0
+        assert "PASS: TestAdd" in result.stdout
+        coverage_data = result.coverage_data
+        assert coverage_data is not None
+        assert isinstance(coverage_data, GoCoverageData)
+        assert coverage_data.import_path == "foo"
+        coverage_reports = rule_runner.request(
+            CoverageReports, [GoCoverageDataCollection([coverage_data])]
+        )
+        assert len(coverage_reports.reports) == 2
+        reports: list[CoverageReport] = list(coverage_reports.reports)
+
+        go_report = reports[0]
+        assert isinstance(go_report, FilesystemCoverageReport)
+        digest_contents = rule_runner.request(DigestContents, (go_report.result_snapshot.digest,))
+        assert len(digest_contents) == 1
+        assert digest_contents[0].path == "cover.out"
+
+        raw_go_report = digest_contents[0].content.decode()
+
+        html_report = reports[1]
+        assert isinstance(html_report, FilesystemCoverageReport)
+        digest_contents = rule_runner.request(DigestContents, (html_report.result_snapshot.digest,))
+        assert len(digest_contents) == 1
+        assert digest_contents[0].path == "coverage.html"
+
+        return raw_go_report
+
+    # Test that the `foo/adder` package is missing when it is **not** configured to be covered via
+    # via the `--go-test-coverage-include-patterns` option.
+    tgt = rule_runner.get_target(Address("foo"))
+    cover_report = run_test(tgt)
+    assert "foo/add.go" in cover_report
+    assert "foo/adder/add.go" not in cover_report
+
+    # Then set `--go-test-coverage-include-patterns` to include the `foo/adder` package in coverage.
+    # It should now show up in the raw coverage report.
+    rule_runner.set_options(
+        [
+            "--go-test-args=-v -bench=.",
+            "--test-use-coverage",
+            "--go-test-coverage-include-patterns=foo/adder",
+        ],
+        env_inherit={"PATH"},
+    )
+    multi_cover_report = run_test(tgt)
+    assert "foo/add.go" in multi_cover_report
+    assert "foo/adder/add.go" in multi_cover_report

--- a/src/python/pants/backend/go/util_rules/pkg_pattern.py
+++ b/src/python/pants/backend/go/util_rules/pkg_pattern.py
@@ -1,0 +1,99 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+# Adapted from Go toolchain:
+# https://github.com/golang/go/blob/6a70292d1cb3464e5b2c2c03341e5148730a1889/src/cmd/internal/pkgpattern/pkgpattern.go
+#
+# // Copyright 2022 The Go Authors. All rights reserved.
+# // Use of this source code is governed by a BSD-style
+# // license that can be found in the LICENSE file.
+
+
+def match_pattern(pattern: str) -> Callable[[str], bool]:
+    """MatchPattern(pattern)(name) reports whether name matches pattern. Pattern is a limited glob
+    pattern in which '...' means 'any string' and there is no other special syntax. Unfortunately,
+    there are two special cases. Quoting "go help packages":
+
+    First, /... at the end of the pattern can match an empty string, so that net/... matches both
+    net and packages in its subdirectories, like net/http. Second, any slash-separated pattern
+    element containing a wildcard never participates in a match of the "vendor" element in the path
+    of a vendored package, so that ./... does not match packages in subdirectories of ./vendor or
+    ./mycode/vendor, but ./vendor/... and ./mycode/vendor/... do. Note, however, that a directory
+    named vendor that itself contains code is not a vendored package: cmd/vendor would be a command
+    named vendor, and the pattern cmd/... matches it.
+    """
+    return _match_pattern_internal(pattern, True)
+
+
+def match_simple_pattern(pattern: str) -> Callable[[str], bool]:
+    """MatchSimplePattern returns a function that can be used to check whether a given name matches
+    a pattern, where pattern is a limited glob pattern in which '...' means 'any string', with no
+    other special syntax.
+
+    There is one special case for MatchPatternSimple: according to the rules in "go help packages":
+    a /... at the end of the pattern can match an empty string, so that net/... matches both net and
+    packages in its subdirectories, like net/http.
+    """
+    return _match_pattern_internal(pattern, False)
+
+
+def _match_pattern_internal(pattern: str, vendor_exclude: bool) -> Callable[[str], bool]:
+    # Convert pattern to regular expression.
+    # The strategy for the trailing /... is to nest it in an explicit ? expression.
+    # The strategy for the vendor exclusion is to change the unmatchable
+    # vendor strings to a disallowed code point (vendorChar) and to use
+    # "(anything but that codepoint)*" as the implementation of the ... wildcard.
+    # This is a bit complicated but the obvious alternative,
+    # namely a hand-written search like in most shell glob matchers,
+    # is too easy to make accidentally exponential.
+    # Using package regexp guarantees linear-time matching.
+
+    vendor_char = chr(0)  # "\x00"
+
+    if vendor_exclude and vendor_char in pattern:
+        return lambda _name: False
+
+    r: str = re.escape(pattern)
+    wild = ".*"
+    if vendor_exclude:
+        wild = rf"[^{vendor_char}]*"
+        r = _replace_vendor(r, vendor_char)
+
+        suffix = rf"/{vendor_char}/\.\.\."
+        if r.endswith(suffix):
+            r = r[0 : -len(suffix)] + rf"(/vendor|/{vendor_char}/\.\.\.)"
+        elif r == rf"{vendor_char}/\.\.\.":
+            r = rf"(/vendor|/{vendor_char}/\.\.\.)"
+
+    suffix = r"/\.\.\."
+    if r.endswith(suffix):
+        r = r[0 : -len(suffix)] + r"(/\.\.\.)?"
+    r = r.replace(r"\.\.\.", wild)
+
+    reg = re.compile(rf"^{r}$")
+
+    def f(name: str) -> bool:
+        if vendor_exclude:
+            if vendor_char in name:
+                return False
+            name = _replace_vendor(name, vendor_char)
+        return bool(reg.match(name))
+
+    return f
+
+
+# replaceVendor returns the result of replacing
+# non-trailing vendor path elements in x with repl.
+def _replace_vendor(x: str, repl: str) -> str:
+    if "vendor" not in x:
+        return x
+
+    elems = x.split("/")
+    for i, elem in enumerate(elems[0:-1]):
+        if elem == "vendor":
+            elems[i] = repl
+    return "/".join(elems)

--- a/src/python/pants/backend/go/util_rules/pkg_pattern_test.py
+++ b/src/python/pants/backend/go/util_rules/pkg_pattern_test.py
@@ -1,0 +1,137 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from typing import Callable
+
+from pants.backend.go.util_rules.pkg_pattern import match_pattern, match_simple_pattern
+
+# Adapted from Go toolchain:
+# https://github.com/golang/go/blob/6a70292d1cb3464e5b2c2c03341e5148730a1889/src/cmd/internal/pkgpattern/pat_test.go
+#
+# // Copyright 2022 The Go Authors. All rights reserved.
+# // Use of this source code is governed by a BSD-style
+# // license that can be found in the LICENSE file.
+
+_MATCH_PATTERN_TESTS = """
+pattern ...
+match foo
+
+pattern net
+match net
+not net/http
+
+pattern net/http
+match net/http
+not net
+
+pattern net...
+match net net/http netchan
+not not/http not/net/http
+
+# Special cases. Quoting docs:
+
+# First, /... at the end of the pattern can match an empty string,
+# so that net/... matches both net and packages in its subdirectories, like net/http.
+pattern net/...
+match net net/http
+not not/http not/net/http netchan
+
+# Second, any slash-separated pattern element containing a wildcard never
+# participates in a match of the "vendor" element in the path of a vendored
+# package, so that ./... does not match packages in subdirectories of
+# ./vendor or ./mycode/vendor, but ./vendor/... and ./mycode/vendor/... do.
+# Note, however, that a directory named vendor that itself contains code
+# is not a vendored package: cmd/vendor would be a command named vendor,
+# and the pattern cmd/... matches it.
+pattern ./...
+match ./vendor ./mycode/vendor
+not ./vendor/foo ./mycode/vendor/foo
+
+pattern ./vendor/...
+match ./vendor/foo ./vendor/foo/vendor
+not ./vendor/foo/vendor/bar
+
+pattern mycode/vendor/...
+match mycode/vendor mycode/vendor/foo mycode/vendor/foo/vendor
+not mycode/vendor/foo/vendor/bar
+
+pattern x/vendor/y
+match x/vendor/y
+not x/vendor
+
+pattern x/vendor/y/...
+match x/vendor/y x/vendor/y/z x/vendor/y/vendor x/vendor/y/z/vendor
+not x/vendor/y/vendor/z
+
+pattern .../vendor/...
+match x/vendor/y x/vendor/y/z x/vendor/y/vendor x/vendor/y/z/vendor
+"""
+
+
+def test_match_pattern() -> None:
+    _run_test(
+        "match_pattern", _MATCH_PATTERN_TESTS, lambda pattern, name: match_pattern(pattern)(name)
+    )
+
+
+_MATCH_SIMPLE_PATTERN_TESTS = """
+pattern ...
+match foo
+
+pattern .../bar/.../baz
+match foo/bar/abc/baz
+
+pattern net
+match net
+not net/http
+
+pattern net/http
+match net/http
+not net
+
+pattern net...
+match net net/http netchan
+not not/http not/net/http
+
+# Special cases. Quoting docs:
+
+# First, /... at the end of the pattern can match an empty string,
+# so that net/... matches both net and packages in its subdirectories, like net/http.
+pattern net/...
+match net net/http
+not not/http not/net/http netchan
+"""
+
+
+def test_simple_match_pattern() -> None:
+    _run_test(
+        "match_simple_pattern",
+        _MATCH_SIMPLE_PATTERN_TESTS,
+        lambda pattern, name: match_simple_pattern(pattern)(name),
+    )
+
+
+def _run_test(name: str, tests: str, fn: Callable[[str, str], bool]) -> None:
+    patterns: list[str] = []
+    for line in tests.splitlines():
+        i = line.find("#")
+        if i >= 0:
+            line = line[:i]
+
+        f = line.split()
+        if len(f) == 0:
+            continue
+
+        if f[0] == "pattern":
+            patterns = f[1:]
+        elif f[0] in ("match", "not"):
+            want = f[0] == "match"
+            for pattern in patterns:
+                for test_example in f[1:]:
+                    result = fn(pattern, test_example)
+                    assert (
+                        result == want
+                    ), f"{name}({pattern})({test_example}): result={result}, want={want}"
+        else:
+            raise ValueError(f"Unknown directive {f[0]}")


### PR DESCRIPTION
Pants currently only supports gathering code coverage from the package under test. The `go` toolchain, however, supports a `-coverpkg` option for opting in to instrumenting other packages in addition to the package under test.

This PR teaches Pants how to instrument other packages for code coverage besides the package under test. The new `--go-test-coverage-include-patterns` option is a list of "import path patterns" with the same syntax as used by the `-coverpkg` option. See `go help packages` for the details on format.

Fixes https://github.com/pantsbuild/pants/issues/17260.