### PR TITLE
Makes `tools` optional for `experimental_shell_command`

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -290,7 +290,7 @@ class ShellCommandTimeoutField(IntField):
 
 class ShellCommandToolsField(StringSequenceField):
     alias = "tools"
-    required = True
+    default = ()
     help = softwrap(
         """
         Specify required executable tools that might be used.

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -187,8 +187,8 @@ async def run_shell_command(
     if fallible_result.exit_code == 127:
         logger.error(
             f"`{shell_command.alias}` requires the names of any external commands used by this "
-            "shell command to be specified in the `{ShellCommandToolsField.alias}` field. If "
-            "`bash` cannot find a tool, add it to the `{ShellCommandToolsField.alias}` field."
+            f"shell command to be specified in the `{ShellCommandToolsField.alias}` field. If "
+            f"`bash` cannot find a tool, add it to the `{ShellCommandToolsField.alias}` field."
         )
 
     result = await Get(

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -137,7 +137,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
     output_directories = tuple(d for d in outputs if d.endswith("/"))
 
     return ShellCommandProcessRequest(
-        description="the `{alias}` at {address}",
+        description=f"the `{shell_command.alias}` at `{shell_command.address}`",
         interactive=interactive,
         working_directory=working_directory,
         command=command,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -254,7 +254,10 @@ async def prepare_shell_command_process(
         }
     else:
         if not tools:
-            raise ValueError(f"Must provide any `tools` used by the {description}.")
+            raise ValueError(
+                f"Must provide any `tools` used by the {description}. If your command relies only "
+                'on the shell and its internal commands, set `tools=["bash"]`.'
+            )
 
         resolved_tools = await _shell_command_tools(shell_setup, tools, f"execute {description}")
         tools = tuple(tool for tool in sorted(resolved_tools))


### PR DESCRIPTION
This change looks for the `bash` exit code 127, which indicates that a command could not be found. An error log is raised at that point.

As a side effect, we no longer need to nag the user to set `tools`, which makes `experimental_shell_commands` that depend only on `bash` internal commands a bit more concise.

Note that this would _not_ raise a warning if the error is not one that bash would ignore -- e.g. running a command in backticks, without `set -e` enabled.