### PR TITLE
Don't strip the input of a `DictOption` file config

### DIFF
--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -1503,6 +1503,20 @@ class OptionsTest(unittest.TestCase):
             options = self._parse(flags=f"fromfile --{'dictvalue'}=@{fp.name}")
             assert val == options.for_scope("fromfile")["dictvalue"]
 
+    def test_fromfile_yaml_trailing_newlines_matter(self) -> None:
+        with temporary_file(suffix=".yaml", binary_mode=False) as fp:
+            fp.write(
+                dedent(
+                    """\
+                        a: |+
+                          multiline
+                    """
+                )
+            )
+            fp.close()
+            options = self._parse(flags=f"fromfile --{'dictvalue'}=@{fp.name}")
+            assert {"a": "multiline\n"} == options.for_scope("fromfile")["dictvalue"]
+
     def test_fromfile_error(self) -> None:
         options = self._parse(flags="fromfile --string=@/does/not/exist")
         with pytest.raises(FromfileError):

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -571,7 +571,7 @@ class Parser:
                             elif fromfile.endswith(".yml") or fromfile.endswith(".yaml"):
                                 return yaml.safe_load(s)
                             else:
-                                return s
+                                return s.strip()
                     except (OSError, ValueError, yaml.YAMLError) as e:
                         raise FromfileError(
                             f"Failed to read {dest} in {self._scope_str()} from file {fromfile}: {e!r}"

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -565,7 +565,7 @@ class Parser:
                     fromfile = val_or_str[1:]
                     try:
                         with open(fromfile) as fp:
-                            s = fp.read().strip()
+                            s = fp.read()
                             if fromfile.endswith(".json"):
                                 return json.loads(s)
                             elif fromfile.endswith(".yml") or fromfile.endswith(".yaml"):


### PR DESCRIPTION
YAML, in particular, is trailing-newline aware, as evidenced by the new test (fails before change). Let's just let the underlying  libraries handle leading/trailing space :wink: 