### PR TITLE
A banner stating that v1 is unmaintained, and linking to v2 docs.

### DIFF
--- a/src/docs/docsite.css
+++ b/src/docs/docsite.css
@@ -155,6 +155,19 @@ nav.pagetoc ul li.toc-h4 {
   padding-left: 3.0em;
 }
 
+.deprecated {
+  padding: 0.3rem 0;
+  margin: 0;
+  font-size: larger;
+  background-color: lightcoral;
+  text-align: center;
+}
+
+.deprecated a:hover {
+  background-color: lightcoral;
+  color: blue;
+}
+
 div.ci-status {
   position: absolute;
   top: 0;

--- a/src/docs/docsite.html.mustache
+++ b/src/docs/docsite.html.mustache
@@ -35,7 +35,7 @@
           <img src="{{topdots}}pants-logo.ico" alt="[pantsbuild logo]">
         </a>
         <a class="navbar-brand" href="{{topdots}}index.html">
-          Pants
+          Pants v1
         </a>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
@@ -54,6 +54,7 @@
         </ul>
       </div><!--/.nav-collapse -->
     </div>
+    <div class="deprecated">Pants v1 is no longer maintained. See <a href="https://www.pantsbuild.org/">here</a> for the Pants v2 documentation.</div>
   </nav>
 </div>
 


### PR DESCRIPTION
A previous attempt to get this working modified the generated HTML files in https://github.com/pantsbuild/pantsbuild.github.io, but those get overwritten
when running the v1 docs publishing step in this repo.
I had forgotten how all this works...

This will generate the correct files, which will be pushed to that repo when we
run the publishing step.