### PR TITLE
allow each resolve to be exported for multiple python interpreters

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -192,6 +192,8 @@ async def do_export(
             description,
             dest,
             post_processing_cmds=[
+                # export creates an empty directory for us when the digest gets written.
+                # We have to remove that before creating the symlink in its place.
                 PostProcessingCommand(["rmdir", output_path]),
                 PostProcessingCommand(["ln", "-s", venv_abspath, output_path]),
             ],

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -106,12 +106,25 @@ def test_export(py_resolve_format: PythonResolveExportFormat) -> None:
         ).assert_success()
 
     export_prefix = os.path.join("dist", "export", "python", "virtualenvs")
+    assert os.path.isdir(
+        export_prefix
+    ), f"expected export prefix dir '{export_prefix}' does not exist"
     py_minor_version = f"{platform.python_version_tuple()[0]}.{platform.python_version_tuple()[1]}"
     for resolve, ansicolors_version in [("a", "1.1.8"), ("b", "1.0.2")]:
-        export_dir = os.path.join(export_prefix, resolve, platform.python_version())
+        export_resolve_dir = os.path.join(export_prefix, resolve)
+        assert os.path.isdir(
+            export_resolve_dir
+        ), f"expected export resolve dir '{export_resolve_dir}' does not exist"
+
+        export_dir = os.path.join(export_resolve_dir, platform.python_version())
         assert os.path.isdir(export_dir), f"expected export dir '{export_dir}' does not exist"
+        if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
+            assert os.path.islink(
+                export_dir
+            ), f"expected export dir '{export_dir}' is not a symlink"
 
         lib_dir = os.path.join(export_dir, "lib", f"python{py_minor_version}", "site-packages")
+        assert os.path.isdir(lib_dir), f"expected export lib dir '{lib_dir}' does not exist"
         expected_ansicolors_dir = os.path.join(
             lib_dir, f"ansicolors-{ansicolors_version}.dist-info"
         )


### PR DESCRIPTION
I want to export a first party resolve multiple times, for multiple interpreters.
The core export code deleted the reldir before toning the export. The python export code passes the resolve export path as reldir, however, so exporting with a different interpreter version forces all old exports to be deleted, even if the interpreter version differs from the old export.

So, this PR includes the interpreter version in reldir. Thus, the core export goal will delete an interpreter specific export only if it is the same as the version that is currently being exported.

This means people will have to clean out old exports themselves, but they will also be able to have multiple exports of the same resolve each with a different interpreter version.