### PR TITLE
More precise running workunit for processes executing remotely (Cherry-pick of #17719)

### DIFF
--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -22,9 +22,9 @@ use protos::gen::google::rpc::{PreconditionFailure, Status as StatusProto};
 use protos::require_digest;
 use rand::{thread_rng, Rng};
 use remexec::{
-  capabilities_client::CapabilitiesClient, execution_client::ExecutionClient, Action, Command,
-  ExecuteRequest, ExecuteResponse, ExecutedActionMetadata, ServerCapabilities,
-  WaitExecutionRequest,
+  capabilities_client::CapabilitiesClient, execution_client::ExecutionClient,
+  execution_stage::Value as ExecutionStageValue, Action, Command, ExecuteRequest, ExecuteResponse,
+  ExecutedActionMetadata, ServerCapabilities, WaitExecutionRequest,
 };
 use tonic::metadata::BinaryMetadataValue;
 use tonic::{Code, Request, Status};
@@ -122,20 +122,34 @@ enum StreamOutcome {
   StreamClosed,
 }
 
+enum OperationStreamItem {
+  Running(ExecutionStageValue),
+  Outcome(StreamOutcome),
+}
+
 /// A single remote Operation, with a `Drop` implementation to cancel the work if our client goes
 /// away.
 struct RunningOperation {
   name: Option<String>,
   operations_client: Arc<OperationsClient<LayeredService>>,
   executor: Executor,
+  process_level: Level,
+  process_description: String,
 }
 
 impl RunningOperation {
-  fn new(operations_client: Arc<OperationsClient<LayeredService>>, executor: Executor) -> Self {
+  fn new(
+    operations_client: Arc<OperationsClient<LayeredService>>,
+    executor: Executor,
+    process_level: Level,
+    process_description: String,
+  ) -> Self {
     Self {
       name: None,
       operations_client,
       executor,
+      process_level,
+      process_description,
     }
   }
 
@@ -242,18 +256,87 @@ impl CommandRunner {
       .await
   }
 
-  // Monitors the operation stream returned by the REv2 Execute and WaitExecution methods.
-  // Outputs progress reported by the server and returns the next actionable operation
-  // or gRPC status back to the main loop (plus the operation name so the main loop can
-  // reconnect).
+  async fn wait_on_operation_stream_item<S>(
+    stream: &mut S,
+    context: &Context,
+    running_operation: &mut RunningOperation,
+    start_time_opt: &mut Option<Instant>,
+  ) -> OperationStreamItem
+  where
+    S: Stream<Item = Result<Operation, Status>> + Unpin,
+  {
+    let item = stream.next().await;
+
+    if let Some(start_time) = start_time_opt.take() {
+      let timing: Result<u64, _> = Instant::now()
+        .duration_since(start_time)
+        .as_micros()
+        .try_into();
+      if let Ok(obs) = timing {
+        context.workunit_store.record_observation(
+          ObservationMetric::RemoteExecutionRPCFirstResponseTimeMicros,
+          obs,
+        );
+      }
+    }
+
+    match item {
+      Some(Ok(operation)) => {
+        trace!(
+          "wait_on_operation_stream (build_id={}): got operation: {:?}",
+          &context.build_id,
+          &operation
+        );
+
+        // Extract the operation name.
+        // Note: protobuf can return empty string for an empty field so convert empty strings
+        // to None.
+        running_operation.name = Some(operation.name.clone()).filter(|s| !s.trim().is_empty());
+
+        if operation.done {
+          // Continue monitoring if the operation is not complete.
+          OperationStreamItem::Outcome(StreamOutcome::Complete(OperationOrStatus::Operation(
+            operation,
+          )))
+        } else {
+          // Otherwise, return to the main loop with the operation as the result.
+          OperationStreamItem::Running(
+            Self::maybe_extract_execution_stage(&operation).unwrap_or(ExecutionStageValue::Unknown),
+          )
+        }
+      }
+
+      Some(Err(err)) => {
+        debug!("wait_on_operation_stream: got error: {:?}", err);
+        let status_proto = StatusProto {
+          code: err.code() as i32,
+          message: err.message().to_string(),
+          ..StatusProto::default()
+        };
+        OperationStreamItem::Outcome(StreamOutcome::Complete(OperationOrStatus::Status(
+          status_proto,
+        )))
+      }
+
+      None => {
+        // Stream disconnected unexpectedly.
+        debug!("wait_on_operation_stream: unexpected disconnect from RE server");
+        OperationStreamItem::Outcome(StreamOutcome::StreamClosed)
+      }
+    }
+  }
+
+  /// Monitors the operation stream returned by the REv2 Execute and WaitExecution methods.
+  /// Outputs progress reported by the server and returns the next actionable operation
+  /// or gRPC status back to the main loop (plus the operation name so the main loop can
+  /// reconnect).
   async fn wait_on_operation_stream<S>(
-    &self,
     mut stream: S,
     context: &Context,
     running_operation: &mut RunningOperation,
   ) -> StreamOutcome
   where
-    S: Stream<Item = Result<Operation, Status>> + Unpin,
+    S: Stream<Item = Result<Operation, Status>> + Unpin + Send,
   {
     let mut start_time_opt = Some(Instant::now());
 
@@ -262,61 +345,73 @@ impl CommandRunner {
       &context.build_id
     );
 
+    // If the server returns an `ExecutionStage` other than `Unknown`, then we assume that it
+    // implements reporting when the operation actually begins `Executing` (as opposed to being
+    // `Queued`, etc), and will wait to create a workunit until we see the `Executing` stage.
+    //
+    // We start by consuming the prefix of the stream before we receive an `Executing` or `Unknown` stage.
     loop {
-      let item = stream.next().await;
-
-      if let Some(start_time) = start_time_opt.take() {
-        let timing: Result<u64, _> = Instant::now()
-          .duration_since(start_time)
-          .as_micros()
-          .try_into();
-        if let Ok(obs) = timing {
-          context.workunit_store.record_observation(
-            ObservationMetric::RemoteExecutionRPCFirstResponseTimeMicros,
-            obs,
-          );
+      match Self::wait_on_operation_stream_item(
+        &mut stream,
+        context,
+        running_operation,
+        &mut start_time_opt,
+      )
+      .await
+      {
+        OperationStreamItem::Running(
+          ExecutionStageValue::Unknown | ExecutionStageValue::Executing,
+        ) => {
+          // Either the server doesn't know how to report the stage, or the operation has
+          // actually begun executing serverside: proceed to the suffix.
+          break;
         }
-      }
-
-      match item {
-        Some(Ok(operation)) => {
-          trace!(
-            "wait_on_operation_stream (build_id={}): got operation: {:?}",
-            &context.build_id,
-            &operation
-          );
-
-          // Extract the operation name.
-          // Note: protobuf can return empty string for an empty field so convert empty strings
-          // to None.
-          running_operation.name = Some(operation.name.clone()).filter(|s| !s.trim().is_empty());
-
-          // Continue monitoring if the operation is not complete.
-          if !operation.done {
-            continue;
-          }
-
-          // Otherwise, return to the main loop with the operation as the result.
-          return StreamOutcome::Complete(OperationOrStatus::Operation(operation));
+        OperationStreamItem::Running(_) => {
+          // The operation has not reached an ExecutionStage that we recognize as
+          // "executing" (likely: it is queued, doing a cache lookup, etc): keep waiting.
+          continue;
         }
-
-        Some(Err(err)) => {
-          debug!("wait_on_operation_stream: got error: {:?}", err);
-          let status_proto = StatusProto {
-            code: err.code() as i32,
-            message: err.message().to_string(),
-            ..StatusProto::default()
-          };
-          return StreamOutcome::Complete(OperationOrStatus::Status(status_proto));
-        }
-
-        None => {
-          // Stream disconnected unexpectedly.
-          debug!("wait_on_operation_stream: unexpected disconnect from RE server");
-          return StreamOutcome::StreamClosed;
-        }
+        OperationStreamItem::Outcome(outcome) => return outcome,
       }
     }
+
+    // Start a workunit to represent the execution of the work, and consume the rest of the stream.
+    in_workunit!(
+      "run_remote_process",
+      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
+      // renders at the Process's level.
+      running_operation.process_level,
+      desc = Some(running_operation.process_description.clone()),
+      |_workunit| async move {
+        loop {
+          match Self::wait_on_operation_stream_item(
+            &mut stream,
+            context,
+            running_operation,
+            &mut start_time_opt,
+          )
+          .await
+          {
+            OperationStreamItem::Running(
+              ExecutionStageValue::Queued | ExecutionStageValue::CacheCheck,
+            ) => {
+              // The server must have cancelled and requeued the work: although this isn't an error
+              // per-se, it is much easier for us to re-open the stream than to treat this as a
+              // nested loop. In particular:
+              // 1. we can't break/continue out of a workunit
+              // 2. the stream needs to move into the workunit, and can't move back out
+              break StreamOutcome::StreamClosed;
+            }
+            OperationStreamItem::Running(_) => {
+              // The operation is still running.
+              continue;
+            }
+            OperationStreamItem::Outcome(outcome) => break outcome,
+          }
+        }
+      }
+    )
+    .await
   }
 
   // Store the remote timings into the workunit store.
@@ -473,6 +568,20 @@ impl CommandRunner {
     ExecutionError::MissingRemoteDigests(missing_digests)
   }
 
+  /// If set, extract `ExecuteOperationMetadata` from the `Operation`.
+  fn maybe_extract_execution_stage(operation: &Operation) -> Option<ExecutionStageValue> {
+    let metadata = operation.metadata.as_ref()?;
+
+    let eom = remexec::ExecuteOperationMetadata::decode(&metadata.value[..])
+      .map(Some)
+      .unwrap_or_else(|e| {
+        log::warn!("Invalid ExecuteOperationMetadata from server: {e:?}");
+        None
+      })?;
+
+    ExecutionStageValue::from_i32(eom.stage)
+  }
+
   // pub(crate) for testing
   pub(crate) async fn extract_execute_response(
     &self,
@@ -627,8 +736,13 @@ impl CommandRunner {
     const MAX_BACKOFF_DURATION: Duration = Duration::from_secs(10);
 
     let start_time = Instant::now();
-    let mut running_operation =
-      RunningOperation::new(self.operations_client.clone(), self.executor.clone());
+
+    let mut running_operation = RunningOperation::new(
+      self.operations_client.clone(),
+      self.executor.clone(),
+      process.level,
+      process.description.clone(),
+    );
     let mut num_retries = 0;
 
     loop {
@@ -681,9 +795,8 @@ impl CommandRunner {
           // Monitor the operation stream until there is an actionable operation
           // or status to interpret.
           let operation_stream = operation_stream_response.into_inner();
-          let stream_outcome = self
-            .wait_on_operation_stream(operation_stream, context, &mut running_operation)
-            .await;
+          let stream_outcome =
+            Self::wait_on_operation_stream(operation_stream, context, &mut running_operation).await;
 
           match stream_outcome {
             StreamOutcome::Complete(status) => {
@@ -856,10 +969,9 @@ impl crate::CommandRunner for CommandRunner {
     let context2 = context.clone();
     in_workunit!(
       "run_execute_request",
-      // NB: See engine::nodes::NodeKey::workunit_level for more information on why this workunit
-      // renders at the Process's level.
-      request.level,
-      desc = Some(request.description.clone()),
+      // NB: The process has not actually started running until the server has notified us that it
+      // has: see `wait_on_operation_stream`.
+      Level::Debug,
       user_metadata = vec![(
         "action_digest".to_owned(),
         UserMetadataItem::String(format!("{action_digest:?}")),

--- a/src/rust/engine/process_execution/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_tests.rs
@@ -12,7 +12,7 @@ use mock::execution_server::{ExpectedAPICall, MockOperation};
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use protos::gen::google::longrunning::Operation;
-use remexec::ExecutedActionMetadata;
+use remexec::{execution_stage::Value as ExecutionStageValue, ExecutedActionMetadata};
 use spectral::prelude::*;
 use spectral::{assert_that, string::StrAssertions};
 use store::{SnapshotOps, Store, StoreError};
@@ -20,7 +20,7 @@ use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory, TestTree};
 use testutil::{owned_string_vec, relative_paths};
 use tokio::time::{sleep, timeout};
-use workunit_store::{RunId, WorkunitStore};
+use workunit_store::{Level, RunId, RunningWorkunit, WorkunitStore};
 
 use crate::remote::{CommandRunner, EntireExecuteRequest, ExecutionError, OperationOrStatus};
 use crate::{
@@ -1052,6 +1052,95 @@ async fn successful_after_reconnect_from_retryable_error() {
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, *EMPTY_DIRECTORY_DIGEST);
   assert_cancellation_requests(&mock_server, vec![]);
+}
+
+#[tokio::test]
+async fn creates_executing_workunit() {
+  let (workunit_store, mut workunit) = WorkunitStore::setup_for_tests();
+  let executor = task_executor::Executor::new();
+  let store_dir = TempDir::new().unwrap();
+  let store = Store::local_only(executor, store_dir).unwrap();
+
+  let execute_request = echo_foo_request();
+  let op_name = "gimme-foo".to_string();
+
+  let queue_time = Duration::from_millis(100);
+  let executing_time = Duration::from_millis(100);
+
+  let mock_server = {
+    let EntireExecuteRequest {
+      execute_request, ..
+    } = crate::remote::make_execute_request(
+      &execute_request.clone().try_into().unwrap(),
+      None,
+      None,
+      &store,
+      None,
+    )
+    .await
+    .unwrap();
+
+    mock::execution_server::TestServer::new(
+      mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
+        execute_request,
+        stream_responses: Ok(vec![
+          make_delayed_incomplete_operation_with_stage(
+            &op_name,
+            queue_time,
+            ExecutionStageValue::Queued,
+          ),
+          make_delayed_incomplete_operation_with_stage(
+            &op_name,
+            Duration::from_millis(0),
+            ExecutionStageValue::Executing,
+          ),
+          make_delayed_incomplete_operation_with_stage(
+            &op_name,
+            executing_time,
+            ExecutionStageValue::Completed,
+          ),
+          make_successful_operation(
+            &op_name,
+            StdoutType::Raw("foo".to_owned()),
+            StderrType::Raw("".to_owned()),
+            0,
+          ),
+        ]),
+      }]),
+      None,
+    )
+  };
+
+  let result =
+    run_command_remote_in_workunit(mock_server.address(), execute_request, &mut workunit)
+      .await
+      .unwrap();
+
+  assert_eq!(result.original.exit_code, 0);
+
+  // Confirm that a workunit was created, and that it took:
+  // 1. at least the queue_time less than its parent
+  // 2. more than the executing_time
+  let (_, completed_workunits) = workunit_store.latest_workunits(Level::Trace);
+  let parent_duration: Duration = completed_workunits
+    .iter()
+    .find(|wu| wu.name == "run_execute_request")
+    .unwrap()
+    .time_span()
+    .unwrap()
+    .duration
+    .into();
+  let child_duration: Duration = completed_workunits
+    .iter()
+    .find(|wu| wu.name == "run_remote_process")
+    .unwrap()
+    .time_span()
+    .unwrap()
+    .duration
+    .into();
+
+  assert!(parent_duration - queue_time >= child_duration);
+  assert!(child_duration >= executing_time);
 }
 
 #[tokio::test]
@@ -2392,17 +2481,37 @@ pub fn echo_foo_request() -> Process {
 }
 
 fn make_incomplete_operation(operation_name: &str) -> MockOperation {
-  let op = Operation {
+  MockOperation::new(Operation {
     name: operation_name.to_string(),
     done: false,
     ..Default::default()
-  };
-  MockOperation::new(op)
+  })
 }
 
 fn make_delayed_incomplete_operation(operation_name: &str, delay: Duration) -> MockOperation {
   let mut op = make_incomplete_operation(operation_name);
   op.duration = Some(delay);
+  op
+}
+
+fn make_delayed_incomplete_operation_with_stage(
+  operation_name: &str,
+  delay: Duration,
+  stage: ExecutionStageValue,
+) -> MockOperation {
+  let mut op = make_delayed_incomplete_operation(operation_name, delay);
+  match &mut op.op {
+    Ok(Some(op)) => {
+      op.metadata = Some(make_any_proto(
+        &remexec::ExecuteOperationMetadata {
+          stage: stage as i32,
+          ..Default::default()
+        },
+        "protos::gen::",
+      ));
+    }
+    x => panic!("Unexpected MockOperation content: {x:?}"),
+  }
   op
 }
 
@@ -2618,6 +2727,14 @@ async fn run_command_remote(
   request: Process,
 ) -> Result<RemoteTestResult, ProcessError> {
   let (_, mut workunit) = WorkunitStore::setup_for_tests();
+  run_command_remote_in_workunit(execution_address, request, &mut workunit).await
+}
+
+async fn run_command_remote_in_workunit(
+  execution_address: String,
+  request: Process,
+  workunit: &mut RunningWorkunit,
+) -> Result<RemoteTestResult, ProcessError> {
   let cas = mock::StubCAS::builder()
     .file(&TestData::roland())
     .directory(&TestDirectory::containing_roland())
@@ -2625,7 +2742,7 @@ async fn run_command_remote(
     .build();
   let (command_runner, store) = create_command_runner(execution_address, &cas);
   let original = command_runner
-    .run(Context::default(), &mut workunit, request)
+    .run(Context::default(), workunit, request)
     .await?;
 
   let stdout_bytes = store

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -262,6 +262,14 @@ pub struct Workunit {
 }
 
 impl Workunit {
+  // If the workunit has completed, its TimeSpan.
+  pub fn time_span(&self) -> Option<TimeSpan> {
+    match self.state {
+      WorkunitState::Started { .. } => None,
+      WorkunitState::Completed { time_span } => Some(time_span),
+    }
+  }
+
   fn log_workunit_state(&self, canceled: bool) {
     let metadata = match self.metadata.as_ref() {
       Some(metadata) if log::log_enabled!(self.level) => metadata,


### PR DESCRIPTION
The `run_execute_request` workunit includes the "scheduling" time inside the remote execution server, during which the process might be queued because other workers are busy. But some servers (including `buildgrid`) support sending `Operation` API updates which indicate that a process has moved from queued to actually running.

To avoid including the queueing time in the Pants UI (and blaming processes as "long running" even though they are just queued), this change begins to consume the `ExecuteOperationMetadata` on streaming `Operations` to wait to begin reporting the process as running until either:
1. We see an `ExecutionStage::Unknown` (indicating that the server probably doesn't support sending fine-grained operations)
2. We see an `ExecutionStage::Executing`

The impact is that an overloaded execution server which reports `ExecuteOperationMetadata` will not begin reporting processes as running until they have actually begun executing.
