### PR TITLE
go: use module sources digest for each of its packages

### DIFF
--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -430,20 +430,8 @@ async def analyze_go_third_party_package(
                 "the third-party module."
             )
 
-    package_digest = await Get(
-        Digest,
-        DigestSubset(
-            request.module_sources_digest,
-            PathGlobs(
-                [os.path.join(request.package_path, "*")],
-                glob_match_error_behavior=GlobMatchErrorBehavior.error,
-                description_of_origin=f"the analysis of Go package {import_path}",
-            ),
-        ),
-    )
-
     analysis = ThirdPartyPkgAnalysis(
-        digest=package_digest,
+        digest=request.module_sources_digest,
         import_path=import_path,
         name=request.pkg_json["Name"],
         dir_path=request.package_path,
@@ -485,7 +473,8 @@ async def analyze_go_third_party_package(
             Get(Digest, CreateDigest([FileContent("patterns.json", patterns_json)])),
         )
         input_digest = await Get(
-            Digest, MergeDigests((package_digest, patterns_json_digest, embedder.digest))
+            Digest,
+            MergeDigests((request.module_sources_digest, patterns_json_digest, embedder.digest)),
         )
         embed_result = await Get(
             FallibleProcessResult,

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -170,9 +170,10 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner) -> None:
         assert pkg_info.go_files == go_files
         assert not pkg_info.s_files
         snapshot = rule_runner.request(Snapshot, [pkg_info.digest])
-        assert set(snapshot.files) == {
+        expected_files = {
             os.path.join(dir_path, file_name) for file_name in (*go_files, *extra_files)
         }
+        assert expected_files.issubset(snapshot.files)
         assert pkg_info.minimum_go_version == minimum_go_version
 
     assert_pkg_info(


### PR DESCRIPTION
## Problem

As reported in https://github.com/pantsbuild/pants/issues/17592, third-party Go modules are allowed to assume that all files packaged with the module will be visible during compilation. In that particular issue, the [Confluent Kafka client library](https://github.com/confluentinc/confluent-kafka-go) uses Cgo and expected a subdirectory with files used during C compilation will be visible to the package using Cgo.

Pants, however, subsets the modules sources digest to just the files in the exact subdirectory for each of the module's packages. This means that the [subdirectory files](https://github.com/confluentinc/confluent-kafka-go/tree/master/kafka/librdkafka_vendor) were not visible when compiling [the package in confluent-kafka-go in the immediate parent directory](https://github.com/confluentinc/confluent-kafka-go/tree/master/kafka/).

## Solution

Since Pants cannot predict how a third party package will use the files in the modules sources, Pants cannot reasonably subset the modules source digest. Solve the issue by not subsetting the module sources digest to produce a package-specific digest.


This is a partial fix for https://github.com/pantsbuild/pants/issues/17592.