### PR TITLE
go: add `assembler_flags` field for adding arbitrary extra assembler flags

### DIFF
--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -132,6 +132,32 @@ class GoTestAddressSanitizerEnabledField(GoRaceDetectorEnabledField):
     )
 
 
+class GoAssemblerFlagsField(StringSequenceField):
+    alias = "assembler_flags"
+    help = softwrap(
+        """
+        Extra flags to pass to the Go assembler (i.e., `go tool asm`) when assembling Go-format assembly code.
+
+        Note: These flags will not be added to gcc/clang-format assembly that is assembled in packages using Cgo.
+
+        This field can be specified on several different target types:
+
+        - On `go_mod` targets, the assembler flags are used when building any package involving the module
+        including both first-party (i.e., `go_package` targets) and third-party dependencies.
+
+        - On `go_binary` targets, the assembler flags are used when building any packages comprising that binary
+        including third-party dependencies. These assembler flags will be added after any assembler flags
+        added by any `assembler_flags` field set on the applicable `go_mod` target.
+
+        - On `go_package` targets, the assembler flags are used only for building that specific package and not
+        for any other package. These assembler flags will be added after any assembler flags added by any
+        `assembler_flags` field set on the applicable `go_mod` target or applicable `go_binary` target.
+
+        Run `go doc cmd/asm` to see the flags supported by `go tool asm`.
+        """
+    )
+
+
 class GoCompilerFlagsField(StringSequenceField):
     alias = "compiler_flags"
     help = softwrap(
@@ -290,6 +316,7 @@ class GoModTarget(TargetGenerator):
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
+        GoAssemblerFlagsField,
         GoCompilerFlagsField,
         GoLinkerFlagsField,
     )
@@ -372,6 +399,7 @@ class GoPackageTarget(Target):
         GoTestRaceDetectorEnabledField,
         GoTestMemorySanitizerEnabledField,
         GoTestAddressSanitizerEnabledField,
+        GoAssemblerFlagsField,
         GoCompilerFlagsField,
         SkipGoTestsField,
     )
@@ -420,6 +448,7 @@ class GoBinaryTarget(Target):
         GoRaceDetectorEnabledField,
         GoMemorySanitizerEnabledField,
         GoAddressSanitizerEnabledField,
+        GoAssemblerFlagsField,
         GoCompilerFlagsField,
         GoLinkerFlagsField,
         RestartableField,

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -50,6 +50,7 @@ class AssembleGoAssemblyFilesRequest:
     dir_path: str
     asm_header_path: str | None
     import_path: str
+    extra_assembler_flags: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -160,6 +161,7 @@ async def assemble_go_assembly_files(
                     os.path.join(goroot.path, "pkg", "include"),
                     *maybe_asm_header_path_args,
                     *maybe_package_import_path_args,
+                    *request.extra_assembler_flags,
                     "-o",
                     obj_output_path(s_file),
                     str(os.path.normpath(PurePath(".", request.dir_path, s_file))),

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -73,6 +73,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         fortran_files: tuple[str, ...] = (),
         prebuilt_object_files: tuple[str, ...] = (),
         pkg_specific_compiler_flags: tuple[str, ...] = (),
+        pkg_specific_assembler_flags: tuple[str, ...] = (),
     ) -> None:
         """Build a package and its dependencies as `__pkg__.a` files.
 
@@ -105,6 +106,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
         self.fortran_files = fortran_files
         self.prebuilt_object_files = prebuilt_object_files
         self.pkg_specific_compiler_flags = pkg_specific_compiler_flags
+        self.pkg_specific_assembler_flags = pkg_specific_assembler_flags
         self._hashcode = hash(
             (
                 self.import_path,
@@ -127,6 +129,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
                 self.fortran_files,
                 self.prebuilt_object_files,
                 self.pkg_specific_compiler_flags,
+                self.pkg_specific_assembler_flags,
             )
         )
 
@@ -154,7 +157,8 @@ class BuildGoPackageRequest(EngineAwareParameter):
             f"objc_files={self.objc_files}, "
             f"fortran_files={self.fortran_files}, "
             f"prebuilt_object_files={self.prebuilt_object_files}, "
-            f"pkg_specific_compiler_flags={self.pkg_specific_compiler_flags}"
+            f"pkg_specific_compiler_flags={self.pkg_specific_compiler_flags}, "
+            f"pkg_specific_assembler_flags={self.pkg_specific_assembler_flags}"
             ")"
         )
 
@@ -185,6 +189,7 @@ class BuildGoPackageRequest(EngineAwareParameter):
             and self.fortran_files == other.fortran_files
             and self.prebuilt_object_files == other.prebuilt_object_files
             and self.pkg_specific_compiler_flags == other.pkg_specific_compiler_flags
+            and self.pkg_specific_assembler_flags == other.pkg_specific_assembler_flags
             # TODO: Use a recursive memoized __eq__ if this ever shows up in profiles.
             and self.direct_dependencies == other.direct_dependencies
         )
@@ -628,6 +633,9 @@ async def build_go_package(
                 dir_path=request.dir_path,
                 asm_header_path=asm_header_path,
                 import_path=request.import_path,
+                extra_assembler_flags=tuple(
+                    *request.build_opts.assembler_flags, *request.pkg_specific_assembler_flags
+                ),
             ),
         )
         assembly_result = assembly_fallible_result.result

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -10,6 +10,7 @@ from typing import ClassVar, Type, cast
 from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
 from pants.backend.go.target_type_rules import GoImportPathMappingRequest
 from pants.backend.go.target_types import (
+    GoAssemblerFlagsField,
     GoCompilerFlagsField,
     GoImportPathField,
     GoPackageSourcesField,
@@ -287,6 +288,12 @@ async def setup_build_go_package_target_request(
         if compiler_flags_field and compiler_flags_field.value:
             pkg_specific_compiler_flags = compiler_flags_field.value
 
+    pkg_specific_assembler_flags: tuple[str, ...] = ()
+    if target.has_field(GoAssemblerFlagsField):
+        assembler_flags_field = target.get(GoAssemblerFlagsField)
+        if assembler_flags_field and assembler_flags_field.value:
+            pkg_specific_assembler_flags = assembler_flags_field.value
+
     all_direct_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
 
     first_party_dep_import_path_targets = []
@@ -398,6 +405,7 @@ async def setup_build_go_package_target_request(
         embed_config=embed_config,
         with_coverage=with_coverage,
         pkg_specific_compiler_flags=tuple(pkg_specific_compiler_flags),
+        pkg_specific_assembler_flags=tuple(pkg_specific_assembler_flags),
     )
     return FallibleBuildGoPackageRequest(result, import_path)
 


### PR DESCRIPTION
Add `assembler_flags` field for adding arbitrary extra assembler flags when assembling Go-format assembly files.

Note: These flags will not be added to gcc/clang-format assembly that is assembled packages using Cgo.

This field can be specified on several different target types:

- On `go_mod` targets, the assembler flags are used when building any package involving the module including both first-party (i.e., `go_package` targets) and third-party dependencies.

- On `go_binary` targets, the assembler flags are used when building any packages comprising that binary including third-party dependencies. These assembler flags will be added after any assembler flags added by any `assembler_flags` field set on the applicable `go_mod` target.

- On `go_package` targets, the assembler flags are used only for building that specific package and not for any other package. These assembler flags will be added after any assembler flags added by any `assembler_flags` field set on the applicable `go_mod` target or applicable `go_binary` target.

Run `go doc cmd/asm` to see the flags supported by `go tool asm`.

Fixes https://github.com/pantsbuild/pants/issues/17441.