### PR TITLE
go: use target spec for coverage output directories plus support import path

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -465,6 +465,7 @@ async def run_go_tests(
             import_path=import_path,
             sources_digest=pkg_digest.digest,
             sources_dir_path=pkg_analysis.dir_path,
+            pkg_target_address=field_set.address,
         )
 
     return TestResult.from_fallible_process_result(

--- a/src/python/pants/backend/go/util_rules/coverage.py
+++ b/src/python/pants/backend/go/util_rules/coverage.py
@@ -12,6 +12,7 @@ import chevron
 
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.build_graph.address import Address
 from pants.core.goals.test import CoverageData
 from pants.engine.fs import CreateDigest, DigestSubset, FileContent, PathGlobs
 from pants.engine.internals.native_engine import Digest, MergeDigests
@@ -27,6 +28,7 @@ class GoCoverageData(CoverageData):
     import_path: str
     sources_digest: Digest
     sources_dir_path: str
+    pkg_target_address: Address
 
 
 class GoCoverMode(enum.Enum):

--- a/src/python/pants/backend/go/util_rules/coverage_output.py
+++ b/src/python/pants/backend/go/util_rules/coverage_output.py
@@ -48,7 +48,9 @@ async def go_render_coverage_report(
     go_test_subsystem: GoTestSubsystem,
 ) -> RenderGoCoverageReportResult:
     output_dir = go_test_subsystem.coverage_output_dir(
-        distdir=distdir_value, import_path=request.raw_report.import_path
+        distdir=distdir_value,
+        address=request.raw_report.pkg_target_address,
+        import_path=request.raw_report.import_path,
     )
     snapshot, digest_contents = await MultiGet(
         Get(Snapshot, Digest, request.raw_report.coverage_digest),


### PR DESCRIPTION
Add two new replacements for `--go-test-coverage-output-dir` values:

- `{target_spec}` which is the address of the applicable `go_package` escaped just like `go_binary` does (`/` -> `.`).

- `{import_path}` which is the import path of the applicable `go_package` target. Subdirectories implied by path-like components in the import path will be created.

The previous behavior was to the use the import path escaped with `/` to underscores which does not fit other Pants conventions (e.g., default `output_path` behavior) and just looked silly to me.

Fixes https://github.com/pantsbuild/pants/issues/17446.