### PR TITLE
[internal] Expanding `cc` dependency inference to support `include_directories`

### DIFF
--- a/src/python/pants/backend/cc/dependency_inference/rules.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules.py
@@ -128,7 +128,7 @@ async def map_cc_files(cc_targets: AllCCTargets, cc_infer: CCInferSubsystem) -> 
         mapping_not_stripped, tuple(cc_infer.include_directories)
     )
 
-    m = CCFilesMapping(
+    return CCFilesMapping(
         mapping=FrozenDict(sorted(stripped_files_to_addresses.items())),
         ambiguous_files=FrozenDict(
             (k, tuple(sorted(v))) for k, v in sorted(stripped_files_with_multiple_owners.items())
@@ -136,9 +136,6 @@ async def map_cc_files(cc_targets: AllCCTargets, cc_infer: CCInferSubsystem) -> 
         mapping_not_stripped=FrozenDict(mapping_not_stripped),
         mapping_relative_to_include_dirs=FrozenDict(mapping_relative_to_include_dirs),
     )
-
-    print(m)
-    return m
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/cc/dependency_inference/rules.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules.py
@@ -6,7 +6,7 @@ import re
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import DefaultDict
+from typing import DefaultDict, Iterable
 
 from pants.backend.cc.subsystems.cc_infer import CCInferSubsystem
 from pants.backend.cc.target_types import CCDependenciesField, CCSourceField
@@ -16,7 +16,7 @@ from pants.core.util_rules.stripped_source_files import StrippedFileName, Stripp
 from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
     DependenciesRequest,
@@ -65,10 +65,44 @@ class CCFilesMapping:
     mapping: FrozenDict[str, Address]
     ambiguous_files: FrozenDict[str, tuple[Address, ...]]
     mapping_not_stripped: FrozenDict[str, Address]
+    mapping_relative_to_include_dirs: FrozenDict[str, Address]
+
+
+def _map_relative_to_include_directories(
+    cc_file_mapping: dict[str, Address], include_directories: Iterable[str]
+) -> dict[str, Address]:
+    """Returns a mapping of CC files (made relative to a potential set of include_directories) to
+    their owning file address.
+
+    This is used to infer dependencies when an #include statement is relative to an include_directory, but does
+    not explicitly state that relative include_directory.
+
+    For example, a project with a file at `root/include/mylib/foo.h` may be referenced via `#include "mylib/foo.h"`,
+    with pre-defined build settings to reference the `root/include` automatically.
+
+    This is a common pattern in C/C++ libraries, where the public headers are all in a single directory (e.g. `include/`)
+    and the library is compiled with `-Iinclude` to automatically reference the public headers. Private headers are
+    typically in a separate directory alongside source files (e.g. `src/`).
+
+    TODO: Would a more "correct" implementation be to grab SourceRoots and use those to determine the relative path? Currently,
+    this implementation progresses up the file's parent chain until it finds a directory that matches an include_directory, and then
+    uses that as the relative path.
+    """
+
+    mapping: dict[str, Address] = {}
+    for not_stripped_file in cc_file_mapping.keys():
+        path = PurePath(not_stripped_file)
+        path_parents = list(path.parents)
+        for parent in path_parents:
+            if parent.name in include_directories:
+                relative_path = path.relative_to(parent)
+                mapping[str(relative_path)] = cc_file_mapping[not_stripped_file]
+
+    return mapping
 
 
 @rule(desc="Creating map of CC file names to CC targets", level=LogLevel.DEBUG)
-async def map_cc_files(cc_targets: AllCCTargets) -> CCFilesMapping:
+async def map_cc_files(cc_targets: AllCCTargets, cc_infer: CCInferSubsystem) -> CCFilesMapping:
     stripped_file_per_target = await MultiGet(
         Get(StrippedFileName, StrippedFileNameRequest(tgt[CCSourceField].file_path))
         for tgt in cc_targets
@@ -90,13 +124,21 @@ async def map_cc_files(cc_targets: AllCCTargets) -> CCFilesMapping:
 
     mapping_not_stripped = {tgt[CCSourceField].file_path: tgt.address for tgt in cc_targets}
 
-    return CCFilesMapping(
+    mapping_relative_to_include_dirs = _map_relative_to_include_directories(
+        mapping_not_stripped, tuple(cc_infer.include_directories)
+    )
+
+    m = CCFilesMapping(
         mapping=FrozenDict(sorted(stripped_files_to_addresses.items())),
         ambiguous_files=FrozenDict(
             (k, tuple(sorted(v))) for k, v in sorted(stripped_files_with_multiple_owners.items())
         ),
         mapping_not_stripped=FrozenDict(mapping_not_stripped),
+        mapping_relative_to_include_dirs=FrozenDict(mapping_relative_to_include_dirs),
     )
+
+    print(m)
+    return m
 
 
 @dataclass(frozen=True)
@@ -158,8 +200,10 @@ async def infer_cc_source_dependencies(
         if cc_infer.include_from_source_roots:
             unambiguous = cc_files_mapping.mapping.get(include.path)
             ambiguous = cc_files_mapping.ambiguous_files.get(include.path)
+
             if unambiguous:
                 result.add(unambiguous)
+
             elif ambiguous:
                 explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
                     ambiguous,
@@ -176,10 +220,18 @@ async def infer_cc_source_dependencies(
                 if maybe_disambiguated:
                     result.add(maybe_disambiguated)
 
+            else:
+                # Finally, try searching relative to provided include_directories (from the source root).
+                maybe_relative_to_include_dir = (
+                    cc_files_mapping.mapping_relative_to_include_dirs.get(include.path)
+                )
+                if maybe_relative_to_include_dir:
+                    result.add(maybe_relative_to_include_dir)
+
     return InferredDependencies(sorted(result))
 
 
-def rules():
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *stripped_source_files.rules(),

--- a/src/python/pants/backend/cc/dependency_inference/rules_integration_test.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules_integration_test.py
@@ -68,7 +68,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_dependency_inference(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.set_options(["--source-root-patterns=['src/native']"])
+    rule_runner.set_options(["--source-root-patterns=['src/native', 'mylib']"])
     rule_runner.write_files(
         {
             "src/native/BUILD": "cc_sources()",
@@ -112,6 +112,22 @@ def test_dependency_inference(rule_runner: RuleRunner, caplog) -> None:
                 )
                 """
             ),
+            # Test handling of imports that are nested in a public "include" (or similar) directory.
+            # This is a common project and library structure, so if possible, we should handle it gracefully.
+            "mylib/include/mylib/BUILD": "cc_sources()",
+            "mylib/include/mylib/public1.h": "int foo1() { return 1; }",
+            "mylib/include/mylib/public2.h": "int foo2() { return 2; }",
+            "mylib/src/BUILD": "cc_sources()",
+            "mylib/src/private1.h": "int bar1() { return 1; }",
+            "mylib/src/private2.h": "int bar2() { return 2; }",
+            "mylib/src/main.c": dedent(
+                """\
+                #include "mylib/public1.h"
+                #include "mylib/public2.h"
+                #include "private1.h"
+                #include "private2.h"
+                """
+            ),
         }
     )
 
@@ -142,3 +158,15 @@ def test_dependency_inference(rule_runner: RuleRunner, caplog) -> None:
     assert "The target src/native/ambiguous/main.c:main includes `ambiguous/dep.h`" in caplog.text
     assert "['src/native/ambiguous/dep.h:dep1', 'src/native/ambiguous/dep.h:dep2']" in caplog.text
     assert "disambiguated.h" not in caplog.text
+
+    caplog.clear()
+    assert run_dep_inference(
+        Address("mylib/src", relative_file_path="main.c")
+    ) == InferredDependencies(
+        [
+            Address("mylib/include/mylib", relative_file_path="public1.h"),
+            Address("mylib/include/mylib", relative_file_path="public2.h"),
+            Address("mylib/src", relative_file_path="private1.h"),
+            Address("mylib/src", relative_file_path="private2.h"),
+        ]
+    )

--- a/src/python/pants/backend/cc/dependency_inference/rules_integration_test.py
+++ b/src/python/pants/backend/cc/dependency_inference/rules_integration_test.py
@@ -68,7 +68,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_dependency_inference(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.set_options(["--source-root-patterns=['src/native', 'mylib']"])
+    rule_runner.set_options(["--source-root-patterns=['src/native', '/mylib', 'mylib/include']"])
     rule_runner.write_files(
         {
             "src/native/BUILD": "cc_sources()",

--- a/src/python/pants/backend/cc/subsystems/cc_infer.py
+++ b/src/python/pants/backend/cc/subsystems/cc_infer.py
@@ -1,8 +1,9 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.option_types import BoolOption
+from pants.option.option_types import BoolOption, StrListOption
 from pants.option.subsystem import Subsystem
+from pants.util.strutil import softwrap
 
 
 class CCInferSubsystem(Subsystem):
@@ -19,4 +20,24 @@ class CCInferSubsystem(Subsystem):
     include_from_source_roots = BoolOption(
         default=True,
         help="Infer a target's dependencies by trying to include relative to source roots.",
+    )
+
+    # TODO: Should this be more generalized?
+    include_directories = StrListOption(
+        default=["include", "includes", "inc"],
+        help=softwrap(
+            """
+            Infer a target's dependencies by searching relative to an include_directory.
+
+            An example where this may be useful is if you have a a file at `root/include/mylib/foo.h`
+            which may be referenced via `#include "mylib/foo.h"`. This option will allow you to
+            correctly infer dependencies by searching for `mylib/foo.h` relative to the `root/{include}`
+            directory.
+
+            The inferred files take part in compilation, and the inferred directory is added to compilation
+            arguments prefixed by the '-I' flag.
+
+            This option is only used if `--include-from-source-roots` is set to True.
+            """
+        ),
     )

--- a/src/python/pants/backend/cc/subsystems/cc_infer.py
+++ b/src/python/pants/backend/cc/subsystems/cc_infer.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.option_types import BoolOption, StrListOption
+from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -19,25 +19,18 @@ class CCInferSubsystem(Subsystem):
     # change depending on how we want to model in-repo includes.
     include_from_source_roots = BoolOption(
         default=True,
-        help="Infer a target's dependencies by trying to include relative to source roots.",
-    )
-
-    # TODO: Should this be more generalized?
-    include_directories = StrListOption(
-        default=["include", "includes", "inc"],
         help=softwrap(
             """
-            Infer a target's dependencies by searching relative to an include_directory.
+            Infer a target's dependencies by trying to include relative to source roots.
 
             An example where this may be useful is if you have a a file at `root/include/mylib/foo.h`
             which may be referenced via `#include "mylib/foo.h"`. This option will allow you to
-            correctly infer dependencies by searching for `mylib/foo.h` relative to the `root/{include}`
-            directory.
+            correctly infer dependencies if you have a source root at `root/{include}` and searching for
+            `mylib/foo.h` relative to the that source root.
 
-            The inferred files take part in compilation, and the inferred directory is added to compilation
-            arguments prefixed by the '-I' flag.
-
-            This option is only used if `--include-from-source-roots` is set to True.
-            """
+            The inferred files take part in compilation, and the source root is added to the compilation
+            include search path (https://clang.llvm.org/docs/ClangCommandLineReference.html#include-path-management)
+            with command line arguments prefixed by the '-I' flag.
+            """,
         ),
     )


### PR DESCRIPTION
First of many smaller PRs extracted from https://github.com/pantsbuild/pants/pull/16424.

# EDIT (Dec 9)

After discussions in this PR, most of the contents were reverted - with the new idea being that `mylib/include` should be a source root - which will effectively act as an include_directory for `cc`. 

New LevelDB example is:

```bash
⏺ oss/leveldb % ./pants_from_sources --source-root-patterns="['/', '/include']" filedeps --transitive db/c.cc                                                                                                                                                                                              

db/BUILD
db/c.cc
include/leveldb/BUILD
include/leveldb/c.h
include/leveldb/cache.h
include/leveldb/comparator.h
include/leveldb/db.h
include/leveldb/env.h
include/leveldb/export.h
include/leveldb/filter_policy.h
include/leveldb/iterator.h
include/leveldb/options.h
include/leveldb/slice.h
include/leveldb/status.h
include/leveldb/write_batch.h
```

Leaving content below for posterity

---

This PR expands `cc` dependency inference to support relative paths that may not be specified in an `#include` statement. Using the integration_test addition as an example - a file sits in `mylib/include/mylib/public1.h` but is referenced via `mylib/public1.h`. 

This is a pretty common library structure to split public headers from implementation, so it seems reasonable to automatically infer on it. An alternative option is to specify `mylib/include` as a source root, or to explicitly specify the public headers. 

```python
"mylib/include/mylib/BUILD": "cc_sources()",
"mylib/include/mylib/public1.h": "int foo1() { return 1; }",
"mylib/include/mylib/public2.h": "int foo2() { return 2; }",
"mylib/src/BUILD": "cc_sources()",
"mylib/src/private1.h": "int bar1() { return 1; }",
"mylib/src/private2.h": "int bar2() { return 2; }",
"mylib/src/main.c": dedent(
    """\
    #include "mylib/public1.h"
    #include "mylib/public2.h"
    #include "private1.h"
    #include "private2.h"
    """
),
```

For a non-SJ-created example, refer to [LevelDB](https://github.com/google/leveldb):

### Before PR
```bash
oss/leveldb % ./pants_from_sources filedeps --transitive db/c.cc

db/BUILD
db/c.cc
```

Works for them because of this in their CMakeLists.txt
```
include_directories(
  "${PROJECT_BINARY_DIR}/include"
  "."
)
```

### After PR
```bash
oss/leveldb % ./pants_from_sources filedeps --transitive db/c.cc

db/BUILD
db/c.cc
include/leveldb/BUILD
include/leveldb/c.h
include/leveldb/cache.h
include/leveldb/comparator.h
include/leveldb/db.h
include/leveldb/env.h
include/leveldb/export.h
include/leveldb/filter_policy.h
include/leveldb/iterator.h
include/leveldb/options.h
include/leveldb/slice.h
include/leveldb/status.h
include/leveldb/write_batch.h
```

[ci skip-rust]
[ci skip-build-wheels]