### PR TITLE
Disable lazy fetch in pantsbuild CI

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -69,10 +69,10 @@ build_ignore.add = [
 
 unmatched_build_file_globs = "error"
 
-# TODO: May cause tests which experience missing digests to hang. If you experience an
-# issue, please change this to `fetch` and then report an issue on:
+# TODO: We would like to be able to use `validate` or `defer` here, but further hardening of
+# network codepaths is needed. See:
 #   https://github.com/pantsbuild/pants/issues/16096.
-cache_content_behavior = "validate"
+cache_content_behavior = "fetch"
 
 [anonymous-telemetry]
 enabled = true


### PR DESCRIPTION
Pantsbuild CI experiences #16667 fairly frequently (where a long running job hits an authentication error), and until we have resolved that issue, we don't want to continue subjecting contributors to flaky failures.