### PR TITLE
Streamline local dist handling when running python sources.

### DIFF
--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import dataclasses
 import os
 import textwrap
 from typing import Optional
@@ -14,14 +13,9 @@ from pants.backend.python.target_types import (
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
-from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
-from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
-from pants.backend.python.util_rules.pex_from_targets import (
-    InterpreterConstraintsRequest,
-    PexFromTargetsRequest,
-)
+from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
@@ -48,8 +42,7 @@ async def _create_python_source_run_request(
     console_script: Optional[ConsoleScript] = None,
 ) -> RunRequest:
     addresses = [address]
-    interpreter_constraints, entry_point, transitive_targets = await MultiGet(
-        Get(InterpreterConstraints, InterpreterConstraintsRequest(addresses)),
+    entry_point, transitive_targets = await MultiGet(
         Get(
             ResolvedPexEntryPoint,
             ResolvePexEntryPointRequest(entry_point_field),
@@ -69,6 +62,7 @@ async def _create_python_source_run_request(
                 output_filename=f"{pex_filename}.pex",
                 internal_only=True,
                 include_source_files=False,
+                include_local_dists=True,
                 # `PEX_EXTRA_SYS_PATH` should contain this entry_point's module.
                 main=console_script or entry_point.val,
                 additional_args=(
@@ -85,19 +79,6 @@ async def _create_python_source_run_request(
         ),
     )
 
-    local_dists = await Get(
-        LocalDistsPex,
-        LocalDistsPexRequest(
-            addresses,
-            internal_only=True,
-            interpreter_constraints=interpreter_constraints,
-            sources=sources,
-        ),
-    )
-    pex_request = dataclasses.replace(
-        pex_request, pex_path=(*pex_request.pex_path, local_dists.pex)
-    )
-
     complete_pex_environment = pex_env.in_workspace()
     venv_pex = await Get(VenvPex, VenvPexRequest(pex_request, complete_pex_environment))
     input_digests = [
@@ -108,7 +89,7 @@ async def _create_python_source_run_request(
         # complexity of figuring out here which sources were codegenned, we copy everything.
         # The inline source roots precede the chrooted ones in PEX_EXTRA_SYS_PATH, so the inline
         # sources will take precedence and their copies in the chroot will be ignored.
-        local_dists.remaining_sources.source_files.snapshot.digest,
+        sources.source_files.snapshot.digest,
     ]
     merged_digest = await Get(Digest, MergeDigests(input_digests))
 


### PR DESCRIPTION
Use PexFromTargetsRequest's built-in ability to handle local dists, instead of doing it separately.