### PR TITLE
Renames `output_files` and `output_directories` fields for `experimental_shell_command`

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -288,9 +288,12 @@ class ShellCommandOutputFilesField(StringSequenceField):
 
 class ShellCommandOutputDirectoriesField(StringSequenceField):
     alias = "output_directories"
+    required = False
+    default = ()
     help = softwrap(
         """
-        Specify full directories of output from the shell command to capture.
+        Specify full directories (including recursive descendants) of output to capture from the
+        shell command.
 
         For files, use `output_files`. At least one of `output_files` and
         `output_directories` must be specified.

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -268,6 +268,34 @@ class ShellCommandOutputsField(StringSequenceField):
         Use a trailing slash on directory names, i.e. `my_dir/`.
         """
     )
+    removal_hint = "To fix, use `output_files` and `output_directories` instead."
+    removal_version = "2.17.0.dev0"
+
+
+class ShellCommandOutputFilesField(StringSequenceField):
+    alias = "output_files"
+    required = False
+    default = ()
+    help = softwrap(
+        """
+        Specify the shell command's output files to capture.
+
+        For directories, use `output_directories`. At least one of `output_files` and
+        `output_directories` must be specified.
+        """
+    )
+
+
+class ShellCommandOutputDirectoriesField(StringSequenceField):
+    alias = "output_directories"
+    help = softwrap(
+        """
+        Specify full directories of output from the shell command to capture.
+
+        For files, use `output_files`. At least one of `output_files` and
+        `output_directories` must be specified.
+        """
+    )
 
 
 class ShellCommandDependenciesField(ShellDependenciesField):
@@ -343,6 +371,8 @@ class ShellCommandTarget(Target):
         ShellCommandCommandField,
         ShellCommandLogOutputField,
         ShellCommandOutputsField,
+        ShellCommandOutputFilesField,
+        ShellCommandOutputDirectoriesField,
         ShellCommandSourcesField,
         ShellCommandTimeoutField,
         ShellCommandToolsField,
@@ -359,7 +389,8 @@ class ShellCommandTarget(Target):
                 command="./my-script.sh --flag",
                 tools=["tar", "curl", "cat", "bash", "env"],
                 dependencies=[":scripts"],
-                outputs=["results/", "logs/my-script.log"],
+                output_files=["logs/my-script.log"],
+                output_directories=["results"],
             )
 
             shell_sources(name="scripts")

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -150,7 +150,9 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
     )
 
 
-def _parse_outputs_from_command(shell_command, description):
+def _parse_outputs_from_command(
+    shell_command: Target, description: str
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
     outputs = shell_command.get(ShellCommandOutputsField).value or ()
     output_files = shell_command.get(ShellCommandOutputFilesField).value or ()
     output_directories = shell_command.get(ShellCommandOutputDirectoriesField).value or ()

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -15,6 +15,8 @@ from pants.backend.shell.target_types import (
     ShellCommandCommandField,
     ShellCommandExtraEnvVarsField,
     ShellCommandLogOutputField,
+    ShellCommandOutputDirectoriesField,
+    ShellCommandOutputFilesField,
     ShellCommandOutputsField,
     ShellCommandRunWorkdirField,
     ShellCommandSourcesField,
@@ -90,6 +92,8 @@ class ShellCommandProcessFromTargetRequest:
 
 @rule_helper
 async def _prepare_process_request_from_target(shell_command: Target) -> ShellCommandProcessRequest:
+    description = f"the `{shell_command.alias}` at `{shell_command.address}`"
+
     interactive = shell_command.has_field(ShellCommandRunWorkdirField)
     if interactive:
         working_directory = shell_command[ShellCommandRunWorkdirField].value or ""
@@ -98,9 +102,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
 
     command = shell_command[ShellCommandCommandField].value
     if not command:
-        raise ValueError(
-            f"Missing `command` line in `{shell_command.alias}` target {shell_command.address}."
-        )
+        raise ValueError(f"Missing `command` line in `{description}.")
 
     # Prepare `input_digest`: Currently uses transitive targets per old behaviour, but
     # this will probably change soon, per #17345.
@@ -132,12 +134,10 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
         Digest, MergeDigests([sources.snapshot.digest, *(pkg.digest for pkg in packages)])
     )
 
-    outputs = shell_command.get(ShellCommandOutputsField).value or ()
-    output_files = tuple(f for f in outputs if not f.endswith("/"))
-    output_directories = tuple(d for d in outputs if d.endswith("/"))
+    output_files, output_directories = _parse_outputs_from_command(shell_command, description)
 
     return ShellCommandProcessRequest(
-        description=f"the `{shell_command.alias}` at `{shell_command.address}`",
+        description=description,
         interactive=interactive,
         working_directory=working_directory,
         command=command,
@@ -148,6 +148,22 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
         output_directories=output_directories,
         extra_env_vars=shell_command.get(ShellCommandExtraEnvVarsField).value or (),
     )
+
+
+def _parse_outputs_from_command(shell_command, description):
+    outputs = shell_command.get(ShellCommandOutputsField).value or ()
+    output_files = shell_command.get(ShellCommandOutputFilesField).value or ()
+    output_directories = shell_command.get(ShellCommandOutputDirectoriesField).value or ()
+    if outputs and (output_files or output_directories):
+        raise ValueError(
+            "Both new-style `output_files` or `output_directories` and old-style `outputs` were "
+            f"specified in {description}. To fix, move all values from `outputs` to "
+            "`output_files` or `output_directories`."
+        )
+    elif outputs:
+        output_files = tuple(f for f in outputs if not f.endswith("/"))
+        output_directories = tuple(d for d in outputs if d.endswith("/"))
+    return output_files, output_directories
 
 
 @rule

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -102,7 +102,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
 
     command = shell_command[ShellCommandCommandField].value
     if not command:
-        raise ValueError(f"Missing `command` line in `{description}.")
+        raise ValueError(f"Missing `command` line in {description}.")
 
     # Prepare `input_digest`: Currently uses transitive targets per old behaviour, but
     # this will probably change soon, per #17345.

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -108,7 +108,7 @@ def test_sources_and_files(rule_runner: RuleRunner) -> None:
                     "tee",
                   ],
                   output_files=["message.txt"],
-                  output_directories=["res/"],
+                  output_directories=["res"],
                   command="./script.sh",
                 )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -107,7 +107,8 @@ def test_sources_and_files(rule_runner: RuleRunner) -> None:
                     "mkdir",
                     "tee",
                   ],
-                  outputs=["message.txt", "res/"],
+                  output_files=["message.txt"],
+                  output_directories=["res/"],
                   command="./script.sh",
                 )
 
@@ -151,7 +152,7 @@ def test_quotes_command(rule_runner: RuleRunner) -> None:
                   name="quotes",
                   tools=["echo", "tee"],
                   command='echo "foo bar" | tee out.log',
-                  outputs=["out.log"],
+                  output_files=["out.log"],
                 )
                 """
             ),
@@ -173,7 +174,7 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
                 experimental_shell_command(
                   name="msg",
                   tools=["echo"],
-                  outputs=["msg"],
+                  output_files=["msg"],
                   command="echo 'shell_command:a' > msg",
                 )
                 """
@@ -183,7 +184,7 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
                 experimental_shell_command(
                   name="msg",
                   tools=["cp", "echo"],
-                  outputs=["msg"],
+                  output_files=["msg"],
                   command="cp ../a/msg . ; echo 'shell_command:b' >> msg",
                   dependencies=["src/a:msg"],
                 )
@@ -270,7 +271,7 @@ def test_shell_command_masquerade_as_a_files_target(rule_runner: RuleRunner) -> 
                   name="content-gen",
                   command="echo contents > contents.txt",
                   tools=["echo"],
-                  outputs=["contents.txt"]
+                  output_files=["contents.txt"]
                 )
                 """
             ),
@@ -312,7 +313,7 @@ def test_package_dependencies(caplog, rule_runner: RuleRunner) -> None:
                   name="msg-gen",
                   command="echo message > msg.txt",
                   tools=["echo"],
-                  outputs=["msg.txt"],
+                  output_files=["msg.txt"],
                 )
 
                 archive(


### PR DESCRIPTION
Replaces the `outputs` field, which has a usability issue demonstrated in #17345.

Extraculated from #17743.