### PR TITLE
Add error boundary support for rules

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -391,7 +391,7 @@ class PyGeneratorResponseGet(Generic[_Output]):
     output_type: type[_Output]
     input_types: Sequence[type]
     inputs: Sequence[Any]
-    _safe: bool
+    _error_boundary: bool
 
     @overload
     def __init__(
@@ -399,11 +399,11 @@ class PyGeneratorResponseGet(Generic[_Output]):
         output_type: type[_Output],
         input_arg0: dict[Any, type],
         *,
-        _safe: bool = False,
+        _error_boundary: bool = False,
     ) -> None: ...
     @overload
     def __init__(
-        self, output_type: type[_Output], input_arg0: _Input, *, _safe: bool = False
+        self, output_type: type[_Output], input_arg0: _Input, *, _error_boundary: bool = False
     ) -> None: ...
     @overload
     def __init__(
@@ -412,7 +412,7 @@ class PyGeneratorResponseGet(Generic[_Output]):
         input_arg0: type[_Input],
         input_arg1: _Input,
         *,
-        _safe: bool = False,
+        _error_boundary: bool = False,
     ) -> None: ...
     @overload
     def __init__(
@@ -421,7 +421,7 @@ class PyGeneratorResponseGet(Generic[_Output]):
         input_arg0: type[_Input] | _Input,
         input_arg1: _Input | None = None,
         *,
-        _safe: bool = False,
+        _error_boundary: bool = False,
     ) -> None: ...
 
 class PyGeneratorResponseGetMulti:

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -391,21 +391,28 @@ class PyGeneratorResponseGet(Generic[_Output]):
     output_type: type[_Output]
     input_types: Sequence[type]
     inputs: Sequence[Any]
+    _safe: bool
 
     @overload
     def __init__(
         self,
         output_type: type[_Output],
         input_arg0: dict[Any, type],
+        *,
+        _safe: bool = False,
     ) -> None: ...
     @overload
-    def __init__(self, output_type: type[_Output], input_arg0: _Input) -> None: ...
+    def __init__(
+        self, output_type: type[_Output], input_arg0: _Input, *, _safe: bool = False
+    ) -> None: ...
     @overload
     def __init__(
         self,
         output_type: type[_Output],
         input_arg0: type[_Input],
         input_arg1: _Input,
+        *,
+        _safe: bool = False,
     ) -> None: ...
     @overload
     def __init__(
@@ -413,6 +420,8 @@ class PyGeneratorResponseGet(Generic[_Output]):
         output_type: type[_Output],
         input_arg0: type[_Input] | _Input,
         input_arg1: _Input | None = None,
+        *,
+        _safe: bool = False,
     ) -> None: ...
 
 class PyGeneratorResponseGetMulti:

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -339,8 +339,9 @@ def test_unhashable_types_failure() -> None:
 
 @rule(desc="Safe get in this rule")
 async def safe_rule() -> C:
-    res = await Get(A, {}, safe=True)
-    print(f"\n\n==>> SAFE RULE res: {res} <<==\n\n")
+    res = await Get(A, {}, _safe=True)
+    assert isinstance(res, Exception)
+    assert str(res) == "An exception!"
     return C()
 
 

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -330,3 +330,21 @@ def test_unhashable_types_failure() -> None:
     # Fail if the `input` in a `Get` is not hashable.
     with pytest.raises(ExecutionError, match="unhashable type: 'list'"):
         rule_runner.request(C, [])
+
+
+# -----------------------------------------------------------------------------------------------
+# Test safe Get
+# -----------------------------------------------------------------------------------------------
+
+
+@rule(desc="Safe get in this rule")
+async def safe_rule() -> C:
+    res = await Get(A, {}, safe=True)
+    print(f"\n\n==>> SAFE RULE res: {res} <<==\n\n")
+    return C()
+
+
+def test_safe_get() -> None:
+    rule_runner = RuleRunner(rules=[safe_rule, nested_raise, QueryRule(C, [])])
+    res = rule_runner.request(C, [])
+    assert isinstance(res, C)

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -327,7 +327,7 @@ impl PyGeneratorResponseGet {
     product: &PyAny,
     input_arg0: &PyAny,
     input_arg1: Option<&PyAny>,
-    safe: Option<&PyBool>,
+    _safe: Option<&PyBool>,
   ) -> PyResult<Self> {
     let product = product.cast_as::<PyType>().map_err(|_| {
       let actual_type = product.get_type();
@@ -397,7 +397,7 @@ impl PyGeneratorResponseGet {
       )
     };
 
-    let safe_arg = match safe {
+    let safe = match _safe {
       Some(value) => value.is_true(),
       None => false,
     };
@@ -406,7 +406,7 @@ impl PyGeneratorResponseGet {
       output,
       input_types,
       inputs,
-      safe: safe_arg,
+      safe,
     }))))
   }
 
@@ -513,14 +513,14 @@ pub struct Get {
   pub output: TypeId,
   pub input_types: SmallVec<[TypeId; 2]>,
   pub inputs: SmallVec<[Key; 2]>,
-  pub safe: bool,  
+  pub safe: bool,
 }
 
 impl fmt::Display for Get {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
     write!(f, "Get({}", self.output)?;
     if self.safe {
-      write!(f, " [SAFE]")?;
+      write!(f, " <SAFE>")?;
     }
     match self.input_types.len() {
       0 => write!(f, ")"),
@@ -540,7 +540,6 @@ impl fmt::Display for Get {
   }
 }
 
-#[derive(Debug)]
 pub enum GeneratorResponse {
   Break(Value, TypeId),
   Get(Get),

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -327,7 +327,7 @@ impl PyGeneratorResponseGet {
     product: &PyAny,
     input_arg0: &PyAny,
     input_arg1: Option<&PyAny>,
-    _safe: Option<&PyBool>,
+    _error_boundary: Option<&PyBool>,
   ) -> PyResult<Self> {
     let product = product.cast_as::<PyType>().map_err(|_| {
       let actual_type = product.get_type();
@@ -397,7 +397,7 @@ impl PyGeneratorResponseGet {
       )
     };
 
-    let safe = match _safe {
+    let safe = match _error_boundary {
       Some(value) => value.is_true(),
       None => false,
     };
@@ -469,7 +469,7 @@ impl PyGeneratorResponseGet {
   }
 
   #[getter]
-  fn safe<'p>(&'p self, py: Python<'p>) -> PyResult<&'p PyBool> {
+  fn _error_boundary<'p>(&'p self, py: Python<'p>) -> PyResult<&'p PyBool> {
     Ok(PyBool::new(
       py,
       self

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1118,7 +1118,12 @@ impl Task {
                 ))
               }
             })?;
-          select.run_node(context).await
+          let res = select.run_node(context).await;
+          if get.safe && let Err(Failure::Throw { val, .. }) = res {
+            val
+          } else {
+            res
+          }
         }
       })
       .collect::<Vec<_>>();

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1119,8 +1119,11 @@ impl Task {
               }
             })?;
           let res = select.run_node(context).await;
-          if get.safe && let Err(Failure::Throw { val, .. }) = res {
-            val
+          if get.safe {
+            match res {
+              Err(Failure::Throw { val, .. }) => Ok(val),
+              _ => res,
+            }
           } else {
             res
           }


### PR DESCRIPTION
The idea: to allow `@rule`s to declare "error boundaries", by introducing a new `_error_boundary: bool = False` param to `Get()`s and `Effect()`s. :) (using underscore prefix on `_error_boundary` to indicate this as a private feature, at least for now ;) )

Example:
```python


@rule 
async def i_want_this_to_be_unfallible(...) -> CertainResult:
  try:
    not_so_sure = await Get(Data, UnreliableSource(), _error_boundary=True)
    ...
  except Exception as e:
    return CertainResult(error=f"Oh no! ERROR: {e}")
  ...
  return CertainResult(result="Yay!")
```

<details><summary>Outdated example</summary>

```python
@rule 
async def i_want_this_to_be_unfallible(...) -> CertainResult:
  not_so_sure = await Get(Data, UnreliableSource(), _safe=True)
  if isinstance(not_so_sure, Exception):
    return CertainResult(error=f"Oh no! ERROR: {not_so_sure}")
  ...
  return CertainResult(result="Yay!")
```
</details>

This allows rules to not have to worry about wrapping return values as "optional foo" etc, which can be very invasive especially when the optional but is buried deep in the rule graph, all intermediate types must also support, *and handle*, the optional result values every where.


~I'm still not sure how to adjust the type hints to accommodate the new result type of a "safe" `Get`, ought to be `_Output | Exception` to force consumers to address the possibility of the error in the result value.~ 
Edit: no need, throwing errors at the error boundary instead side-steps the typing issue altogether.

An alternative approach, presented by @thejcannon, could be to support a `Result` enum like of type where one leg is a the value and the other the error. Not sure what that would look like (in UX nor in implementation).