### PR TITLE
Revert "Immutably hardlink "large" files in a sandbox (#17520)"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-
 import pytest
 
 

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -103,3 +103,4 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
     fail_result = run_test(fail_target)
     assert fail_result.exit_code == 1
     assert fail_result.stdout == "does not contain 'xyzzy'\n"
+

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -103,4 +103,3 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
     fail_result = run_test(fail_target)
     assert fail_result.exit_code == 1
     assert fail_result.stdout == "does not contain 'xyzzy'\n"
-

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -46,7 +46,7 @@ use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
 use protos::require_digest;
 use serde_derive::Serialize;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use store::{
   Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest, SubsetParams, UploadSummary,
 };
@@ -535,13 +535,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           output_digest_opt.ok_or_else(|| ExitError("not found".into(), ExitCode::NotFound))?;
         Ok(
           store
-            .materialize_directory(
-              destination,
-              output_digest,
-              &BTreeSet::new(),
-              None,
-              Permissions::Writable,
-            )
+            .materialize_directory(destination, output_digest, Permissions::Writable)
             .await?,
         )
       }
@@ -559,13 +553,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         let digest = DirectoryDigest::from_persisted_digest(Digest::new(fingerprint, size_bytes));
         Ok(
           store
-            .materialize_directory(
-              destination,
-              digest,
-              &BTreeSet::new(),
-              None,
-              Permissions::Writable,
-            )
+            .materialize_directory(destination, digest, Permissions::Writable)
             .await?,
         )
       }

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -780,8 +780,12 @@ impl DigestTrie {
     let mut prefix_iter = prefix.iter();
     let mut tree = self;
     while let Some(parent) = prefix_iter.next_back() {
-      let directory =
-        Directory::from_digest_tree(first_path_component_to_name(parent.as_ref())?, tree);
+      let directory = Directory {
+        name: first_path_component_to_name(parent.as_ref())?,
+        digest: tree.compute_root_digest(),
+        tree,
+      };
+
       tree = DigestTrie(vec![Entry::Directory(directory)].into());
     }
 

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1,6 +1,4 @@
-// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
-// Licensed under the Apache License, Version 2.0 (see LICENSE).
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
@@ -11,8 +9,7 @@ use testutil::data::{TestData, TestDirectory};
 
 use bytes::{Bytes, BytesMut};
 use fs::{
-  DigestEntry, DirectoryDigest, FileEntry, Link, PathStat, Permissions, RelativePath,
-  EMPTY_DIRECTORY_DIGEST,
+  DigestEntry, DirectoryDigest, FileEntry, Link, PathStat, Permissions, EMPTY_DIRECTORY_DIGEST,
 };
 use grpc_util::prost::MessageExt;
 use grpc_util::tls;
@@ -22,8 +19,7 @@ use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use workunit_store::WorkunitStore;
 
 use crate::{
-  EntryType, FileContent, ImmutableInputs, Snapshot, Store, StoreError, StoreFileByDigest,
-  UploadSummary, MEGABYTES,
+  EntryType, FileContent, Snapshot, Store, StoreError, StoreFileByDigest, UploadSummary, MEGABYTES,
 };
 
 pub(crate) const STORE_BATCH_API_SIZE_LIMIT: usize = 4 * 1024 * 1024;
@@ -1050,12 +1046,7 @@ async fn materialize_missing_file() {
   let store_dir = TempDir::new().unwrap();
   let store = new_local_store(store_dir.path());
   store
-    .materialize_file(
-      file.clone(),
-      TestData::roland().digest(),
-      Permissions::ReadOnly,
-      false,
-    )
+    .materialize_file(file.clone(), TestData::roland().digest(), 0o644)
     .await
     .expect_err("Want unknown digest error");
 }
@@ -1074,12 +1065,7 @@ async fn materialize_file() {
     .await
     .expect("Error saving bytes");
   store
-    .materialize_file(
-      file.clone(),
-      testdata.digest(),
-      Permissions::ReadOnly,
-      false,
-    )
+    .materialize_file(file.clone(), testdata.digest(), 0o644)
     .await
     .expect("Error materializing file");
   assert_eq!(file_contents(&file), testdata.bytes());
@@ -1096,8 +1082,6 @@ async fn materialize_missing_directory() {
     .materialize_directory(
       materialize_dir.path().to_owned(),
       TestDirectory::recursive().directory_digest(),
-      &BTreeSet::new(),
-      None,
       Permissions::Writable,
     )
     .await
@@ -1130,8 +1114,6 @@ async fn materialize_directory(perms: Permissions, executable_file: bool) {
     .materialize_directory(
       materialize_dir.path().to_owned(),
       recursive_testdir.directory_digest(),
-      &BTreeSet::new(),
-      None,
       perms,
     )
     .await
@@ -1602,8 +1584,6 @@ async fn explicitly_overwrites_already_existing_file() {
     .materialize_directory(
       dir_to_write_to.path().to_owned(),
       contents_dir.directory_digest(),
-      &BTreeSet::new(),
-      None,
       Permissions::Writable,
     )
     .await
@@ -1611,90 +1591,4 @@ async fn explicitly_overwrites_already_existing_file() {
 
   let file_contents = std::fs::read(&file_path).unwrap();
   assert_eq!(file_contents, b"abc123".to_vec());
-}
-
-#[tokio::test]
-async fn big_file_immutable_link() {
-  let materialize_dir = TempDir::new().unwrap();
-  let input_file = materialize_dir.path().join("input_file");
-  let output_file = materialize_dir.path().join("output_file");
-  let output_dir = materialize_dir.path().join("output_dir");
-  let nested_output_file = output_dir.join("file");
-
-  let file_bytes = extra_big_file_bytes();
-  let file_digest = extra_big_file_digest();
-
-  let nested_directory = remexec::Directory {
-    files: vec![remexec::FileNode {
-      name: "file".to_owned(),
-      digest: Some(file_digest.into()),
-      is_executable: true,
-      ..remexec::FileNode::default()
-    }],
-    ..remexec::Directory::default()
-  };
-  let directory = remexec::Directory {
-    files: vec![
-      remexec::FileNode {
-        name: "input_file".to_owned(),
-        digest: Some(file_digest.into()),
-        is_executable: true,
-        ..remexec::FileNode::default()
-      },
-      remexec::FileNode {
-        name: "output_file".to_owned(),
-        digest: Some(file_digest.into()),
-        is_executable: true,
-        ..remexec::FileNode::default()
-      },
-    ],
-    directories: vec![remexec::DirectoryNode {
-      name: "output_dir".to_string(),
-      digest: Some(hashing::Digest::of_bytes(&nested_directory.to_bytes()).into()),
-    }],
-    ..remexec::Directory::default()
-  };
-  let directory_digest =
-    fs::DirectoryDigest::from_persisted_digest(hashing::Digest::of_bytes(&directory.to_bytes()));
-
-  let store_dir = TempDir::new().unwrap();
-  let store = new_local_store(store_dir.path());
-  let immutable_inputs_dir = TempDir::new().unwrap();
-  let immutable_inputs = ImmutableInputs::new(store.clone(), immutable_inputs_dir.path()).unwrap();
-  store
-    .record_directory(&nested_directory, false)
-    .await
-    .expect("Error saving Directory");
-  store
-    .record_directory(&directory, false)
-    .await
-    .expect("Error saving Directory");
-  store
-    .store_file_bytes(file_bytes.clone(), false)
-    .await
-    .expect("Error saving bytes");
-
-  store
-    .materialize_directory(
-      materialize_dir.path().to_owned(),
-      directory_digest,
-      &BTreeSet::from([
-        RelativePath::new("output_file").unwrap(),
-        RelativePath::new("output_dir").unwrap(),
-      ]),
-      Some(&immutable_inputs),
-      Permissions::Writable,
-    )
-    .await
-    .expect("Error materializing file");
-
-  let assert_is_linked = |path: &PathBuf, is_linked: bool| {
-    assert_eq!(file_contents(&path), file_bytes);
-    assert!(is_executable(&path));
-    assert_eq!(path.metadata().unwrap().permissions().readonly(), is_linked);
-  };
-
-  assert_is_linked(&input_file, true);
-  assert_is_linked(&output_file, false);
-  assert_is_linked(&nested_output_file, false);
 }

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 
 use cache::PersistentCache;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
-use store::{ImmutableInputs, Store};
+use store::Store;
 use tempfile::TempDir;
 use testutil::data::TestData;
 use testutil::relative_paths;
@@ -14,7 +14,7 @@ use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
   local::KeepSandboxes, CacheContentBehavior, CommandRunner as CommandRunnerTrait, Context,
-  FallibleProcessResultWithPlatform, NamedCaches, Process, ProcessError,
+  FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Process, ProcessError,
 };
 
 struct RoundtripResults {

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -18,7 +18,7 @@ use log::Level;
 use nails::execution::ExitCode;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
-use store::{ImmutableInputs, Store};
+use store::Store;
 use task_executor::Executor;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
@@ -27,8 +27,8 @@ use crate::local::{
   KeepSandboxes,
 };
 use crate::{
-  Context, FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, ProcessError,
-  ProcessExecutionStrategy,
+  Context, FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Platform, Process,
+  ProcessError, ProcessExecutionStrategy,
 };
 
 pub(crate) const SANDBOX_BASE_PATH_IN_CONTAINER: &str = "/pants-sandbox";

--- a/src/rust/engine/process_execution/src/immutable_inputs.rs
+++ b/src/rust/engine/process_execution/src/immutable_inputs.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -8,16 +8,10 @@ use async_oncecell::OnceCell;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::Digest;
 use parking_lot::Mutex;
+use store::{Store, StoreError};
 use tempfile::TempDir;
 
-use crate::{Store, StoreError};
-
-/// A symlink from a relative src to an absolute dst (outside of the workdir).
-#[derive(Debug)]
-pub struct WorkdirSymlink {
-  pub src: RelativePath,
-  pub dst: PathBuf,
-}
+use crate::WorkdirSymlink;
 
 struct Inner {
   store: Store,
@@ -57,74 +51,7 @@ impl ImmutableInputs {
   }
 
   /// Returns an absolute Path to immutably consume the given Digest from.
-  pub(crate) async fn path_for_file(
-    &self,
-    digest: Digest,
-    is_executable: bool,
-  ) -> Result<PathBuf, StoreError> {
-    let cell = self.0.contents.lock().entry(digest).or_default().clone();
-
-    // We (might) need to initialize the value.
-    //
-    // Because this code executes a side-effect which could be observed elsewhere within this
-    // process (other threads can observe the contents of the temporary directory), we need to
-    // ensure that if this method is cancelled (via async Drop), whether the cell has been
-    // initialized or not stays in sync with whether the side-effect is visible.
-    //
-    // Making the initialization "cancellation safe", involves either:
-    //
-    //   1. Adding a Drop guard to "undo" the side-effect if we're dropped before we fully
-    //      initialize the cell.
-    //       * This is challenging to do correctly in this case, because the `Drop` guard cannot
-    //         be created until after initialization begins, but cannot be cleared until after the
-    //         cell has been initialized (i.e., after `get_or_try_init` returns).
-    //   2. Shielding ourselves from cancellation by `spawn`ing a new Task to guarantee that the
-    //      cell initialization always runs to completion.
-    //       * This would work, but would mean that we would finish initializing cells even when
-    //         work was cancelled. Cancellation usually means that the work is no longer necessary,
-    //         and so that could result in a lot of spurious IO (in e.g. warm cache cases which
-    //         never end up actually needing any inputs).
-    //       * An advanced variant of this approach would be to _pause_ work on materializing a
-    //         Digest when demand for it disappeared, and resume the work if another caller
-    //         requested that Digest.
-    //   3. Using anonymous destination paths, such that multiple attempts to initialize cannot
-    //      collide.
-    //       * This means that although the side-effect is visible, it can never collide.
-    //
-    // We take the final approach here currently (for simplicity's sake), but the advanced variant
-    // of approach 2 might eventually be worthwhile.
-    cell
-      .get_or_try_init(async {
-        let chroot = TempDir::new_in(self.0.workdir.path()).map_err(|e| {
-          format!(
-            "Failed to create a temporary directory for materialization of immutable input \
-          digest {:?}: {}",
-            digest, e
-          )
-        })?;
-
-        let dest = chroot.path().join(digest.hash.to_hex());
-        self
-          .0
-          .store
-          .materialize_file(dest.clone(), digest, Permissions::ReadOnly, is_executable)
-          .await?;
-
-        // Now that we've successfully initialized the destination, forget the TempDir so that it
-        // is not cleaned up.
-        let _ = chroot.into_path();
-
-        Ok(dest)
-      })
-      .await
-      .cloned()
-  }
-
-  /// Returns an absolute Path to immutably consume the given Digest from.
-  pub(crate) async fn path_for_dir(
-    &self,
-    directory_digest: DirectoryDigest,
-  ) -> Result<PathBuf, StoreError> {
+  async fn path(&self, directory_digest: DirectoryDigest) -> Result<PathBuf, StoreError> {
     let digest = directory_digest.as_digest();
     let cell = self.0.contents.lock().entry(digest).or_default().clone();
 
@@ -171,13 +98,7 @@ impl ImmutableInputs {
         self
           .0
           .store
-          .materialize_directory(
-            dest.clone(),
-            directory_digest,
-            &BTreeSet::new(),
-            Some(self),
-            Permissions::ReadOnly,
-          )
+          .materialize_directory(dest.clone(), directory_digest, Permissions::ReadOnly)
           .await?;
 
         // Now that we've successfully initialized the destination, forget the TempDir so that it
@@ -193,14 +114,14 @@ impl ImmutableInputs {
   ///
   /// Returns symlinks to create for the given set of immutable cache paths.
   ///
-  pub async fn local_paths(
+  pub(crate) async fn local_paths(
     &self,
     immutable_inputs: &BTreeMap<RelativePath, DirectoryDigest>,
   ) -> Result<Vec<WorkdirSymlink>, StoreError> {
     let dsts = futures::future::try_join_all(
       immutable_inputs
         .values()
-        .map(|d| self.path_for_dir(d.clone()))
+        .map(|d| self.path(d.clone()))
         .collect::<Vec<_>>(),
     )
     .await?;

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -64,6 +64,8 @@ pub mod docker;
 #[cfg(test)]
 mod docker_tests;
 
+pub mod immutable_inputs;
+
 pub mod local;
 #[cfg(test)]
 mod local_tests;
@@ -83,6 +85,7 @@ mod remote_cache_tests;
 extern crate uname;
 
 pub use crate::children::ManagedChild;
+pub use crate::immutable_inputs::ImmutableInputs;
 pub use crate::named_caches::{CacheName, NamedCaches};
 pub use crate::remote_cache::RemoteCacheWarningsBehavior;
 
@@ -249,6 +252,13 @@ impl TryFrom<String> for ProcessCacheScope {
 
 fn serialize_level<S: serde::Serializer>(level: &log::Level, s: S) -> Result<S::Ok, S::Error> {
   s.serialize_str(&level.to_string())
+}
+
+/// A symlink from a relative src to an absolute dst (outside of the workdir).
+#[derive(Debug)]
+pub struct WorkdirSymlink {
+  pub src: RelativePath,
+  pub dst: PathBuf,
 }
 
 /// Input Digests for a process execution.

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -27,9 +27,7 @@ use futures::{try_join, FutureExt, TryFutureExt};
 use log::{debug, info};
 use nails::execution::ExitCode;
 use shell_quote::bash;
-use store::{
-  ImmutableInputs, OneOffStoreFileByDigest, Snapshot, Store, StoreError, WorkdirSymlink,
-};
+use store::{OneOffStoreFileByDigest, Snapshot, Store, StoreError};
 use task_executor::Executor;
 use tempfile::TempDir;
 use tokio::process::{Child, Command};
@@ -39,8 +37,8 @@ use tokio_util::codec::{BytesCodec, FramedRead};
 use workunit_store::{in_workunit, Level, Metric, RunningWorkunit};
 
 use crate::{
-  Context, FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, ProcessError,
-  ProcessResultMetadata, ProcessResultSource,
+  Context, FallibleProcessResultWithPlatform, ImmutableInputs, NamedCaches, Platform, Process,
+  ProcessError, ProcessResultMetadata, ProcessResultSource, WorkdirSymlink,
 };
 
 pub const USER_EXECUTABLE_MODE: u32 = 0o100755;
@@ -714,15 +712,11 @@ pub async fn prepare_workdir(
   // non-determinism when paths overlap: see the method doc.
   let store2 = store.clone();
   let workdir_path_2 = workdir_path.clone();
-  let mut mutable_paths = req.output_files.clone();
-  mutable_paths.extend(req.output_directories.clone());
   in_workunit!("setup_sandbox", Level::Debug, |_workunit| async move {
     store2
       .materialize_directory(
         workdir_path_2,
         materialized_input_digest,
-        &mutable_paths,
-        Some(immutable_inputs),
         Permissions::Writable,
       )
       .await

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -11,7 +11,7 @@ use spectral::{assert_that, string::StrAssertions};
 use tempfile::TempDir;
 
 use fs::EMPTY_DIRECTORY_DIGEST;
-use store::{ImmutableInputs, Store};
+use store::Store;
 use testutil::data::{TestData, TestDirectory};
 use testutil::path::{find_bash, which};
 use testutil::{owned_string_vec, relative_paths};
@@ -19,8 +19,8 @@ use workunit_store::{RunningWorkunit, WorkunitStore};
 
 use crate::{
   local, local::KeepSandboxes, CacheName, CommandRunner as CommandRunnerTrait, Context,
-  FallibleProcessResultWithPlatform, InputDigests, NamedCaches, Platform, Process, ProcessError,
-  RelativePath,
+  FallibleProcessResultWithPlatform, ImmutableInputs, InputDigests, NamedCaches, Platform, Process,
+  ProcessError, RelativePath,
 };
 
 #[derive(PartialEq, Debug)]

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -10,15 +10,15 @@ use futures::future::{FutureExt, TryFutureExt};
 use futures::stream::{BoxStream, StreamExt};
 use log::{debug, trace};
 use nails::execution::{self, child_channel, ChildInput, Command};
-use store::{ImmutableInputs, Store};
+use store::Store;
 use task_executor::Executor;
 use tokio::net::TcpStream;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{prepare_workdir, CapturedWorkdir, ChildOutput};
 use crate::{
-  Context, FallibleProcessResultWithPlatform, InputDigests, NamedCaches, Platform, Process,
-  ProcessError,
+  Context, FallibleProcessResultWithPlatform, ImmutableInputs, InputDigests, NamedCaches, Platform,
+  Process, ProcessError,
 };
 
 #[cfg(test)]

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -20,12 +20,12 @@ use tempfile::TempDir;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use hashing::Fingerprint;
-use store::{ImmutableInputs, Store};
+use store::Store;
 use task_executor::Executor;
 use workunit_store::{in_workunit, Level};
 
 use crate::local::prepare_workdir;
-use crate::{NamedCaches, Process, ProcessError};
+use crate::{ImmutableInputs, NamedCaches, Process, ProcessError};
 
 lazy_static! {
   static ref NAILGUN_PORT_REGEX: Regex = Regex::new(r".*\s+port\s+(\d+)\.$").unwrap();

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::path::PathBuf;
 
-use store::{ImmutableInputs, Store};
+use store::Store;
 use task_executor::Executor;
 use tempfile::TempDir;
 use testutil::owned_string_vec;
 use workunit_store::WorkunitStore;
 
 use crate::nailgun::NailgunPool;
-use crate::{NamedCaches, Process};
+use crate::{ImmutableInputs, NamedCaches, Process};
 
 fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let _ = WorkunitStore::setup_for_tests();

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 use deepsize::DeepSizeOf;
 use serde::Serialize;
 
+use crate::WorkdirSymlink;
 use fs::{default_cache_path, safe_create_dir_all_ioerror, RelativePath};
-use store::WorkdirSymlink;
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize)]
 pub struct CacheName(String);

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -36,14 +36,14 @@ use std::time::Duration;
 use fs::{DirectoryDigest, Permissions, RelativePath};
 use hashing::{Digest, Fingerprint};
 use process_execution::{
-  local::KeepSandboxes, CacheContentBehavior, Context, InputDigests, NamedCaches, Platform,
-  ProcessCacheScope, ProcessExecutionStrategy,
+  local::KeepSandboxes, CacheContentBehavior, Context, ImmutableInputs, InputDigests, NamedCaches,
+  Platform, ProcessCacheScope, ProcessExecutionStrategy,
 };
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2::{Action, Command};
 use protos::gen::buildbarn::cas::UncachedActionResult;
 use protos::require_digest;
-use store::{ImmutableInputs, Store};
+use store::Store;
 use structopt::StructOpt;
 use workunit_store::{in_workunit, Level, WorkunitStore};
 
@@ -362,13 +362,7 @@ async fn main() {
 
   if let Some(output) = args.materialize_output_to {
     store
-      .materialize_directory(
-        output,
-        result.output_directory,
-        &BTreeSet::new(),
-        None,
-        Permissions::Writable,
-      )
+      .materialize_directory(output, result.output_directory, Permissions::Writable)
       .await
       .unwrap();
   }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -30,12 +30,12 @@ use process_execution::docker::{DOCKER, IMAGE_PULL_CACHE};
 use process_execution::switched::SwitchedCommandRunner;
 use process_execution::{
   self, bounded, docker, local, nailgun, remote, remote_cache, CacheContentBehavior, CommandRunner,
-  NamedCaches, ProcessExecutionStrategy, RemoteCacheWarningsBehavior,
+  ImmutableInputs, NamedCaches, ProcessExecutionStrategy, RemoteCacheWarningsBehavior,
 };
 use protos::gen::build::bazel::remote::execution::v2::ServerCapabilities;
 use regex::Regex;
 use rule_graph::RuleGraph;
-use store::{self, ImmutableInputs, Store};
+use store::{self, Store};
 use task_executor::Executor;
 use watch::{Invalidatable, InvalidationWatcher};
 use workunit_store::{Metric, RunId, RunningWorkunit};
@@ -144,7 +144,6 @@ impl Core {
   fn make_store(
     executor: &Executor,
     local_store_options: &LocalStoreOptions,
-    local_execution_root_dir: &Path,
     enable_remote: bool,
     remoting_opts: &RemotingOptions,
     remote_store_address: &Option<String>,
@@ -154,7 +153,6 @@ impl Core {
     let local_only = Store::local_only_with_options(
       executor.clone(),
       local_store_options.store_dir.clone(),
-      local_execution_root_dir,
       local_store_options.into(),
     )?;
     if enable_remote {
@@ -500,7 +498,6 @@ impl Core {
     let full_store = Self::make_store(
       &executor,
       &local_store_options,
-      &local_execution_root_dir,
       need_remote_store,
       &remoting_opts,
       &remoting_opts.store_address,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -8,7 +8,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::hash_map::HashMap;
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::convert::TryInto;
 use std::fs::File;
 use std::hash::Hasher;
@@ -1644,8 +1644,6 @@ fn write_digest(
         .materialize_directory(
           destination.clone(),
           lifted_digest,
-          &BTreeSet::new(),
-          None,
           fs::Permissions::Writable,
         )
         .await


### PR DESCRIPTION
This reverts commit https://github.com/pantsbuild/pants/commit/f8df1173069d33b265a44d613533509fcb033276.

It appears that f8df1173 breaks several integration tests (including `pyoxidizer/rules_integration_tests`) in CI