### PR TITLE
Visibility: empty selector should match no target.

### DIFF
--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -151,7 +151,7 @@ class TargetGlob:
             else ""
         )
         path = f"[{self.path}]" if self.path is not None else ""
-        return f"{self.type_ or ''}{tags}{path}" or "*"
+        return f"{self.type_ or ''}{tags}{path}" or "!*"
 
     @memoized_classmethod
     def create(  # type: ignore[misc]
@@ -241,6 +241,10 @@ class TargetGlob:
             return address.spec_path
 
     def match(self, address: Address, adaptor: TargetAdaptor, base: str) -> bool:
+        if not (self.type_ or self.path or self.tags):
+            # Nothing rules this target in.
+            return False
+
         # target type
         if self.type_ and not fnmatchcase(adaptor.type_alias, self.type_):
             return False
@@ -258,5 +262,6 @@ class TargetGlob:
                 any(fnmatchcase(str(tag), pattern) for tag in target_tags) for pattern in self.tags
             ):
                 return False
-        # Nothing rules this target out
+
+        # Nothing rules this target out.
         return True

--- a/src/python/pants/backend/visibility/glob_test.py
+++ b/src/python/pants/backend/visibility/glob_test.py
@@ -250,8 +250,8 @@ def test_pathglob_match(glob: PathGlob, tests: tuple[tuple[str, str, bool], ...]
 @pytest.mark.parametrize(
     "target_spec, expected",
     [
-        ({}, "*"),
-        ("", "*"),
+        ({}, "!*"),
+        ("", "!*"),
         (dict(type="resources"), "resources"),
         (dict(type="file", path="glob/*/this.ext"), "file[glob/*/this.ext]"),
         (dict(path="glob/*/this.ext"), "[glob/*/this.ext]"),
@@ -270,14 +270,10 @@ def test_target_glob_parse_spec(target_spec: str | Mapping[str, Any], expected: 
     assert expected == str(TargetGlob.parse(target_spec, "base"))
 
 
-def tagged(type_alias: str, name: str | None = None, *tags: str, **kwargs) -> TargetAdaptor:
-    kwargs["tags"] = tags
-    return TargetAdaptor(type_alias, name, **kwargs)
-
-
 @pytest.mark.parametrize(
     "expected, target_spec",
     [
+        (False, ""),
         (True, "*"),
         (True, "file"),
         (True, "(tag-c)"),

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -119,6 +119,22 @@ class VisibilityRuleSet:
     selectors: tuple[TargetGlob, ...]
     rules: tuple[VisibilityRule, ...]
 
+    def __post_init__(self) -> None:
+        if all("!*" == str(selector) for selector in self.selectors):
+            rules = tuple(map(str, self.rules))
+            raise BuildFileVisibilityRulesError(
+                softwrap(
+                    f"""
+                    The rule set will never apply to anything, for the rules: {rules}
+
+                    At least one target selector must have a filtering rule that can match
+                    something, for example:
+
+                        ("python_*", {rules})
+                    """
+                )
+            )
+
     @classmethod
     def parse(cls, build_file: str, arg: Any) -> VisibilityRuleSet:
         """Translate input `arg` from BUILD file call.

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -52,6 +52,20 @@ def parse_ruleset(rules: Any, build_file: str = "test/path/BUILD") -> Visibility
     return VisibilityRuleSet.parse(build_file, rules)
 
 
+def test_dead_ruleset() -> None:
+    err = softwrap(
+        """\
+        The rule set will never apply to anything, for the rules: \\('src/\\*', '!\\*'\\)
+        """
+    )
+    with pytest.raises(BuildFileVisibilityRulesError, match=err):
+        # These rules will never apply.
+        parse_ruleset(("", "src/*", "!*"))
+
+    # Ignore match-none selectors if there are others that do match on something.
+    parse_ruleset((("", "foo"), "src/*", "!*"))
+
+
 @pytest.mark.parametrize(
     "expected, xs",
     [


### PR DESCRIPTION
I think it is a mistake to treat an empty rule selector as matching any target. By treating an empty selector as match-none, we enforce selectors to be explicit about matching anything with a match all wildcard glob such as `"*"`.