### PR TITLE
chdir in `rule_runner.run_interactive_process` (Cherry-pick of #17722)

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -60,7 +60,7 @@ from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.source import source_root
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.collections import assert_single_element
-from pants.util.contextutil import temporary_dir, temporary_file
+from pants.util.contextutil import pushd, temporary_dir, temporary_file
 from pants.util.dirutil import (
     recursive_dirname,
     safe_file_dump,
@@ -522,16 +522,17 @@ class RuleRunner:
         )
 
     def run_interactive_process(self, request: InteractiveProcess) -> InteractiveProcessResult:
-        return native_engine.session_run_interactive_process(
-            self.scheduler.py_session,
-            request,
-            ProcessConfigFromEnvironment(
-                platform=Platform.create_for_localhost().value,
-                docker_image=None,
-                remote_execution=False,
-                remote_execution_extra_platform_properties=[],
-            ),
-        )
+        with pushd(self.build_root):
+            return native_engine.session_run_interactive_process(
+                self.scheduler.py_session,
+                request,
+                ProcessConfigFromEnvironment(
+                    platform=Platform.create_for_localhost().value,
+                    docker_image=None,
+                    remote_execution=False,
+                    remote_execution_extra_platform_properties=[],
+                ),
+            )
 
     def do_not_use_mock(self, output_type: Type, input_types: Iterable[type]) -> MockGet:
         """Returns a `MockGet` whose behavior is to run the actual rule using this `RuleRunner`"""


### PR DESCRIPTION
This change makes it so `rule_runner.run_interactive_process(InteractiveProcess(..., run_in_workspace=True, ...))` has the code running in the build root, as would be the case for normal non-test code (whereas today it runs in the test sandbox, which is certainly not what is expected).
