### PR TITLE
Test DebugAdapter requests, and fix issues (Cherry-pick of #17678)

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -3,6 +3,8 @@
 
 python_sources()
 
+python_test_utils(name="test_utils")
+
 python_tests(
     name="tests",
     overrides={
@@ -19,7 +21,7 @@ python_tests(
         },
         "pytest_runner_integration_test.py": {
             "tags": ["platform_specific_behavior"],
-            "timeout": 480,
+            "timeout": 600,
         },
         "repl_integration_test.py": {
             "tags": ["platform_specific_behavior"],

--- a/src/python/pants/backend/python/goals/conftest.py
+++ b/src/python/pants/backend/python/goals/conftest.py
@@ -1,0 +1,18 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import pytest
+
+from pants.backend.python.subsystems.debugpy import DebugPy
+
+
+@pytest.fixture(autouse=True)
+def debugpy_dont_wait_for_client(monkeypatch):
+    old_debugpy_get_args = DebugPy.get_args
+
+    def get_debugpy_args_but_dont_wait_for_client(*args, **kwargs):
+        result = list(old_debugpy_get_args(*args, **kwargs))
+        result.remove("--wait-for-client")
+        return tuple(result)
+
+    monkeypatch.setattr(DebugPy, "get_args", get_debugpy_args_but_dont_wait_for_client)

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -19,7 +19,6 @@ from pants.backend.python.subsystems import pytest
 from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.subsystems.pytest import PyTest, PythonTestFieldSet
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import MainSpecification
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists import LocalDistsPex, LocalDistsPexRequest
 from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex, VenvPexProcess
@@ -76,6 +75,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import GlobalOptions
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger()
@@ -184,7 +184,7 @@ class TestSetupRequest:
     field_sets: Tuple[PythonTestFieldSet, ...]
     metadata: TestMetadata
     is_debug: bool
-    main: Optional[MainSpecification] = None  # Defaults to pytest.main
+    extra_env: FrozenDict[str, str] = FrozenDict()
     prepend_argv: Tuple[str, ...] = ()
     additional_pexes: Tuple[Pex, ...] = ()
 
@@ -284,7 +284,7 @@ async def setup_pytest_for_target(
         PexRequest(
             output_filename="pytest_runner.pex",
             interpreter_constraints=interpreter_constraints,
-            main=request.main or pytest.main,
+            main=pytest.main,
             internal_only=True,
             pex_path=[pytest_pex, requirements_pex, local_dists.pex, *request.additional_pexes],
         ),
@@ -362,6 +362,7 @@ async def setup_pytest_for_target(
     extra_env = {
         "PYTEST_ADDOPTS": " ".join(add_opts),
         "PEX_EXTRA_SYS_PATH": ":".join(prepared_sources.source_roots),
+        **request.extra_env,
         **test_extra_env.env,
         # NOTE: field_set_extra_env intentionally after `test_extra_env` to allow overriding within
         # `python_tests`.
@@ -398,10 +399,12 @@ async def setup_pytest_for_target(
         VenvPexProcess(
             pytest_runner_pex,
             argv=(
-                *(("-c", pytest.config) if pytest.config else ()),
-                *(("-n", "{pants_concurrency}") if xdist_concurrency else ()),
                 *request.prepend_argv,
                 *pytest.args,
+                *(("-c", pytest.config) if pytest.config else ()),
+                *(("-n", "{pants_concurrency}") if xdist_concurrency else ()),
+                # N.B.: Now that we're using command-line options instead of the PYTEST_ADDOPTS
+                # environment variable, it's critical that `pytest_args` comes after `pytest.args`.
                 *coverage_args,
                 *field_set_source_files.files,
             ),
@@ -533,9 +536,17 @@ async def debugpy_python_test(
     batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata],
     debugpy: DebugPy,
     debug_adapter: DebugAdapterSubsystem,
-    pytest: PyTest,
+    python_setup: PythonSetup,
 ) -> TestDebugAdapterRequest:
-    debugpy_pex = await Get(Pex, PexRequest, debugpy.to_pex_request())
+    debugpy_pex = await Get(
+        Pex,
+        PexRequest,
+        debugpy.to_pex_request(
+            interpreter_constraints=InterpreterConstraints.create_from_compatibility_fields(
+                [field_set.interpreter_constraints for field_set in batch.elements], python_setup
+            )
+        ),
+    )
 
     setup = await Get(
         TestSetup,
@@ -543,8 +554,8 @@ async def debugpy_python_test(
             batch.elements,
             batch.partition_metadata,
             is_debug=True,
-            main=debugpy.main,
-            prepend_argv=debugpy.get_args(debug_adapter, pytest.main),
+            prepend_argv=debugpy.get_args(debug_adapter),
+            extra_env=FrozenDict(PEX_MODULE="debugpy"),
             additional_pexes=(debugpy_pex,),
         ),
     )

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -128,6 +128,7 @@ def run_pytest(
     *,
     extra_args: list[str] | None = None,
     env: dict[str, str] | None = None,
+    test_debug_adapter: bool = True,
 ) -> TestResult:
     _configure_pytest_runner(rule_runner, extra_args=extra_args, env=env)
     batch = _get_pytest_batch(rule_runner, test_targets)
@@ -137,6 +138,19 @@ def run_pytest(
         with mock_console(rule_runner.options_bootstrapper):
             debug_result = rule_runner.run_interactive_process(debug_request.process)
             assert test_result.exit_code == debug_result.exit_code
+
+    if test_debug_adapter:
+        debug_adapter_request = rule_runner.request(TestDebugAdapterRequest, [batch])
+        if debug_adapter_request.process is not None:
+            with mock_console(rule_runner.options_bootstrapper) as mocked_console:
+                _, stdioreader = mocked_console
+                debug_adapter_result = rule_runner.run_interactive_process(
+                    debug_adapter_request.process
+                )
+                assert (
+                    test_result.exit_code == debug_adapter_result.exit_code
+                ), f"{stdioreader.get_stdout()}\n{stdioreader.get_stderr()}"
+
     return test_result
 
 
@@ -289,14 +303,14 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     py2_tgt = rule_runner.get_target(
         Address(PACKAGE, target_name="py2", relative_file_path="tests.py")
     )
-    result = run_pytest(rule_runner, [py2_tgt], extra_args=extra_args)
+    result = run_pytest(rule_runner, [py2_tgt], extra_args=extra_args, test_debug_adapter=False)
     assert result.exit_code == 2
     assert "SyntaxError: invalid syntax" in result.stdout
 
     py3_tgt = rule_runner.get_target(
         Address(PACKAGE, target_name="py3", relative_file_path="tests.py")
     )
-    result = run_pytest(rule_runner, [py3_tgt], extra_args=extra_args)
+    result = run_pytest(rule_runner, [py3_tgt], extra_args=extra_args, test_debug_adapter=False)
     assert result.exit_code == 0
     assert f"{PACKAGE}/tests.py ." in result.stdout
 
@@ -732,7 +746,6 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
         "./pytest_runner.pex_pex_shim.sh",
         "--listen",
         "127.0.0.1:5678",
-        "--wait-for-client",
         "-c",
         unittest.mock.ANY,
         "tests/python/pants_test/test_foo.py",

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -192,7 +192,6 @@ async def _create_python_source_run_dap_request(
     extra_env["PANTS_CHROOT"] = _in_chroot("").rstrip("/")
     args = [
         regular_run_request.args[0],  # python executable
-        _in_chroot(debugpy_pex.name),
         _in_chroot("__debugpy_launcher.py"),
         *debugpy.get_args(debug_adapter),
     ]

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -150,6 +150,8 @@ async def _create_python_source_run_dap_request(
                             import os
                             CHROOT = os.environ["PANTS_CHROOT"]
 
+                            del os.environ["PEX_INTERPRETER"]
+
                             # See https://github.com/pantsbuild/pants/issues/17540
                             # For `run --debug-adapter`, the client might send a `pathMappings`
                             # (this is likely as VS Code likes to configure that by default) with

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -10,10 +10,13 @@ from pants.backend.python.goals.run_helper import (
 from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
+    InterpreterConstraintsField,
     PexEntryPointField,
     PythonRunGoalUseSandboxField,
     PythonSourceField,
 )
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.pex import Pex, PexRequest
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
@@ -28,22 +31,24 @@ class PythonSourceFieldSet(RunFieldSet):
     required_fields = (PythonSourceField, PythonRunGoalUseSandboxField)
 
     source: PythonSourceField
-    run_goal_use_sandbox: PythonRunGoalUseSandboxField
+    interpreter_constraints: InterpreterConstraintsField
+    _run_goal_use_sandbox: PythonRunGoalUseSandboxField
+
+    def should_use_sandbox(self, python_setup: PythonSetup) -> bool:
+        if self._run_goal_use_sandbox.value is None:
+            return python_setup.default_run_goal_use_sandbox
+        return self._run_goal_use_sandbox.value
 
 
 @rule(level=LogLevel.DEBUG)
 async def create_python_source_run_request(
-    field_set: PythonSourceFieldSet, pex_env: PexEnvironment, python: PythonSetup
+    field_set: PythonSourceFieldSet, pex_env: PexEnvironment, python_setup: PythonSetup
 ) -> RunRequest:
-    run_goal_use_sandbox = field_set.run_goal_use_sandbox.value
-    if run_goal_use_sandbox is None:
-        run_goal_use_sandbox = python.default_run_goal_use_sandbox
-
     return await _create_python_source_run_request(
         field_set.address,
         entry_point_field=PexEntryPointField(field_set.source.value, field_set.address),
         pex_env=pex_env,
-        run_in_sandbox=run_goal_use_sandbox,
+        run_in_sandbox=field_set.should_use_sandbox(python_setup),
     )
 
 
@@ -52,11 +57,32 @@ async def create_python_source_debug_adapter_request(
     field_set: PythonSourceFieldSet,
     debugpy: DebugPy,
     debug_adapter: DebugAdapterSubsystem,
+    pex_env: PexEnvironment,
+    python_setup: PythonSetup,
 ) -> RunDebugAdapterRequest:
-    run_request = await Get(RunRequest, PythonSourceFieldSet, field_set)
+    debugpy_pex = await Get(
+        # NB: We fold the debugpy PEX into the normally constructed VenvPex so that debugpy is in the
+        # venv, but isn't the main entrypoint. Then we use PEX_* env vars to dynamically have debugpy
+        # be invoked in that VenvPex. Hence, a vanilla Pex.
+        Pex,
+        PexRequest,
+        debugpy.to_pex_request(
+            interpreter_constraints=InterpreterConstraints.create_from_compatibility_fields(
+                [field_set.interpreter_constraints], python_setup
+            )
+        ),
+    )
+
+    run_request = await _create_python_source_run_request(
+        field_set.address,
+        entry_point_field=PexEntryPointField(field_set.source.value, field_set.address),
+        pex_env=pex_env,
+        pex_path=[debugpy_pex],
+        run_in_sandbox=field_set.should_use_sandbox(python_setup),
+    )
+
     return await _create_python_source_run_dap_request(
         run_request,
-        entry_point_field=PexEntryPointField(field_set.source.value, field_set.address),
         debugpy=debugpy,
         debug_adapter=debug_adapter,
     )

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -57,7 +57,7 @@ def rule_runner() -> RuleRunner:
             *protobuf_additional_fields.rules(),
             *protobuf_module_mapper_rules(),
             QueryRule(RunRequest, (PythonSourceFieldSet,)),
-            QueryRule(RunDebugAdapterRequest, (RunDebugAdapterRequest,)),
+            QueryRule(RunDebugAdapterRequest, (PythonSourceFieldSet,)),
         ],
         target_types=[
             ProtobufSourcesGeneratorTarget,
@@ -69,7 +69,11 @@ def rule_runner() -> RuleRunner:
     )
 
 
-def run_run_request(rule_runner: RuleRunner, target: Target) -> Tuple[int, str, str]:
+def run_run_request(
+    rule_runner: RuleRunner,
+    target: Target,
+    test_debug_adapter: bool = True,
+) -> Tuple[int, str, str]:
     run_request = rule_runner.request(RunRequest, [PythonSourceFieldSet.create(target)])
     run_process = InteractiveProcess(
         argv=run_request.args,
@@ -83,6 +87,24 @@ def run_run_request(rule_runner: RuleRunner, target: Target) -> Tuple[int, str, 
         result = rule_runner.run_interactive_process(run_process)
         stdout = mocked_console[1].get_stdout()
         stderr = mocked_console[1].get_stderr()
+
+    if test_debug_adapter:
+        debug_adapter_request = rule_runner.request(
+            RunDebugAdapterRequest, [PythonSourceFieldSet.create(target)]
+        )
+        debug_adapter_process = InteractiveProcess(
+            argv=debug_adapter_request.args,
+            env=debug_adapter_request.extra_env,
+            input_digest=debug_adapter_request.digest,
+            run_in_workspace=True,
+            immutable_input_digests=debug_adapter_request.immutable_input_digests,
+            append_only_caches=debug_adapter_request.append_only_caches,
+        )
+        with mock_console(rule_runner.options_bootstrapper) as mocked_console:
+            debug_adapter_result = rule_runner.run_interactive_process(debug_adapter_process)
+            assert debug_adapter_result.exit_code == result.exit_code, mocked_console[
+                1
+            ].get_stderr()
 
     return result.exit_code, stdout, stderr
 
@@ -217,7 +239,7 @@ def test_no_strip_pex_env_issues_12057(rule_runner: RuleRunner) -> None:
     ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     target = rule_runner.get_target(Address("src", relative_file_path="app.py"))
-    exit_code, _, stderr = run_run_request(rule_runner, target)
+    exit_code, _, stderr = run_run_request(rule_runner, target, test_debug_adapter=False)
     assert exit_code == 42, stderr
 
 
@@ -248,7 +270,7 @@ def test_no_leak_pex_root_issues_12055(rule_runner: RuleRunner) -> None:
     ]
     rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     target = rule_runner.get_target(Address("src", relative_file_path="app.py"))
-    exit_code, stdout, _ = run_run_request(rule_runner, target)
+    exit_code, stdout, _ = run_run_request(rule_runner, target, test_debug_adapter=False)
     assert exit_code == 0
     assert os.path.join(named_caches_dir, "pex_root") == stdout.strip()
 

--- a/src/python/pants/backend/python/subsystems/debugpy.lock
+++ b/src/python/pants/backend/python/subsystems/debugpy.lock
@@ -4,14 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
-//     "CPython<3.11,>=3.7"
+//     "CPython>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "debugpy==1.6.0",
-//     "importlib_metadata==1.4.0"
-//   ]
+//     "debugpy==1.6.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -80,80 +83,21 @@
           "project_name": "debugpy",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "1.6"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "bdd9b7c397c273bcc9a11d6629a38487cd07154fa255a467bf704cd2c258e359",
-              "url": "https://files.pythonhosted.org/packages/d7/31/74dcb59a601b95fce3b0334e8fc9db758f78e43075f22aeb3677dfb19f4c/importlib_metadata-1.4.0-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "f17c015735e1a88296994c0697ecea7e11db24290941983b08c9feb30921e6d8",
-              "url": "https://files.pythonhosted.org/packages/8c/0e/10e247f40c89ba72b7f2a2104ccf1b65de18f79562ffe11bfb837b711acf/importlib_metadata-1.4.0.tar.gz"
-            }
-          ],
-          "project_name": "importlib-metadata",
-          "requires_dists": [
-            "configparser>=3.5; python_version < \"3\"",
-            "contextlib2; python_version < \"3\"",
-            "importlib-resources; python_version < \"3.7\" and extra == \"testing\"",
-            "packaging; extra == \"testing\"",
-            "pathlib2; python_version < \"3\"",
-            "rst.linker; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
-            "zipp>=0.5"
-          ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
-              "url": "https://files.pythonhosted.org/packages/f0/36/639d6742bcc3ffdce8b85c31d79fcfae7bb04b95f0e5c4c6f8b206a038cc/zipp-3.8.1-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-              "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz"
-            }
-          ],
-          "project_name": "zipp",
-          "requires_dists": [
-            "func-timeout; extra == \"testing\"",
-            "jaraco.itertools; extra == \"testing\"",
-            "jaraco.packaging>=9; extra == \"docs\"",
-            "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest-checkdocs>=2.4; extra == \"testing\"",
-            "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
-            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest>=6; extra == \"testing\"",
-            "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "3.8.1"
+          "version": "1.6.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.99",
+  "pex_version": "2.1.116",
+  "pip_version": "20.3.4-patched",
   "prefer_older_binary": false,
   "requirements": [
-    "debugpy==1.6.0",
-    "importlib_metadata==1.4.0"
+    "debugpy==1.6.0"
   ],
   "requires_python": [
-    "<3.11,>=3.7"
+    ">=3.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -9,7 +9,7 @@ from pants.backend.python.goals.lockfile import (
     GeneratePythonToolLockfileSentinel,
 )
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.backend.python.target_types import ConsoleScript, EntryPoint, MainSpecification
+from pants.backend.python.target_types import EntryPoint
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules, rule
@@ -27,7 +27,7 @@ class DebugPy(PythonToolBase):
     default_main = EntryPoint("debugpy")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.7,<3.11"]
+    default_interpreter_constraints = ["CPython>=3.7"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
@@ -36,49 +36,17 @@ class DebugPy(PythonToolBase):
 
     args = ArgsListOption(example="--log-to-stderr")
 
-    @property
-    def all_requirements(self) -> tuple[str, ...]:
-        """All the raw requirement strings to install the tool.
-
-        This may not include transitive dependencies: these are top-level requirements.
-        """
-        # NB: Locking with importlib_metadata is only necessary while debugpy supports Py 3.7, as
-        # `importlib.metadata` was added in Py 3.8 and would allow us to resolve the console_script
-        # using just the stdlib.
-        #
-        # Lastly, importlib_metadata, has so-far maintained a backwards-compatible API for
-        # `entry_points`, so we lock using the lowest version but can be reasonably confident our
-        # code will still work if executed in an environment with a user requirement on a newer
-        # importlib_metadata.
-        return (self.version, "importlib_metadata==1.4.0", *self.extra_requirements)
-
-    @staticmethod
-    def _get_main_spec_args(main: MainSpecification) -> tuple[str, ...]:
-        if isinstance(main, EntryPoint):
-            if main.function:
-                return ("-c", f"import {main.module};{main.module}.{main.function}();")
-            return ("-m", main.module)
-
-        assert isinstance(main, ConsoleScript)
-        return (
-            "-c",
-            (
-                "import importlib_metadata;"
-                + "eps = importlib_metadata.entry_points()['console_scripts'];"
-                + f"ep = next(ep for ep in eps if ep.name == '{main.name}');"
-                + "ep.load()()"
-            ),
-        )
-
-    def get_args(
-        self, debug_adapter: DebugAdapterSubsystem, main: MainSpecification
-    ) -> tuple[str, ...]:
+    # NB: The debugpy arguments assume that:
+    #   1. debugpy is being invoked in a venv (likely we're in a VenvPex)
+    #   2. debugpy is in the same venv as the user code
+    def get_args(self, debug_adapter: DebugAdapterSubsystem) -> tuple[str, ...]:
         return (
             "--listen",
             f"{debug_adapter.host}:{debug_adapter.port}",
             "--wait-for-client",
             *self.args,
-            *self._get_main_spec_args(main),
+            "-c",
+            "__import__('runpy').run_path(__import__('os').environ['VIRTUAL_ENV'] + '/pex', run_name='__main__')",
         )
 
 


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/17672 and fixes https://github.com/pantsbuild/pants/issues/17692

Added new test-code which tests the `DebugAdapterRequest` by running it without `--wait-for-client`. This wouldn't catch issues like https://github.com/pantsbuild/pants/issues/17540 which require a client, but would catches issues like https://github.com/pantsbuild/pants/issues/17672 and https://github.com/pantsbuild/pants/issues/17692.

Fixes:
- Bad debugpy ICs
- Untracked issue where the process would always return 0
- The config wouldn't be used if provided
- Removes the reliance on `importlib_metadata` to load the entrypoint, instead re-enters the already executing pex in-process
