### PR TITLE
add pytorch-lightning to module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -148,6 +148,7 @@ DEFAULT_MODULE_MAPPING = {
     "python-pptx": ("pptx",),
     "python-socketio": ("socketio",),
     "python-statsd": ("statsd",),
+    "pytorch-lightning": ("pytorch_lightning"),
     "pyyaml": ("yaml",),
     "pymongo": ("bson", "gridfs", "pymongo"),
     "pymupdf": ("fitz",),


### PR DESCRIPTION
add "pytorch-lightning" (https://pypi.org/project/pytorch-lightning/) to the default module mapping.