### PR TITLE
Add export-codegen goal to more backends

### DIFF
--- a/src/python/pants/backend/codegen/thrift/apache/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/register.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.thrift.apache.python import (
     additional_fields,
     python_thrift_module_mapper,
@@ -29,4 +30,5 @@ def rules():
         *python_thrift_module_mapper.rules(),
         *module_mapper.rules(),
         *stripped_source_files.rules(),
+        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/backend/experimental/openapi/codegen/java/register.py
+++ b/src/python/pants/backend/experimental/openapi/codegen/java/register.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pants.backend.codegen import export_codegen_goal
 from pants.backend.experimental.java.register import rules as java_rules
 from pants.backend.openapi.codegen.java.rules import rules as java_codegen_rules
 
@@ -12,4 +13,4 @@ def target_types():
 
 
 def rules():
-    return [*java_rules(), *java_codegen_rules()]
+    return [*java_rules(), *java_codegen_rules(), *export_codegen_goal.rules()]

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,6 +6,7 @@
 See https://www.pantsbuild.org/docs/python-backend.
 """
 
+from pants.backend.codegen import export_codegen_goal
 from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.goals import (
@@ -79,6 +80,7 @@ def rules():
         *local_dists.rules(),
         *export.rules(),
         *lockfile.rules(),
+        *export_codegen_goal.rules(),
         # Macros.
         *pipenv_requirements.rules(),
         *poetry_requirements.rules(),

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -6,7 +6,6 @@
 See https://www.pantsbuild.org/docs/python-backend.
 """
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.python import target_types_rules
 from pants.backend.python.dependency_inference import rules as dependency_inference_rules
 from pants.backend.python.goals import (

--- a/src/python/pants/backend/python/register.py
+++ b/src/python/pants/backend/python/register.py
@@ -80,7 +80,6 @@ def rules():
         *local_dists.rules(),
         *export.rules(),
         *lockfile.rules(),
-        *export_codegen_goal.rules(),
         # Macros.
         *pipenv_requirements.rules(),
         *poetry_requirements.rules(),

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.backend.codegen import export_codegen_goal
 from pants.backend.shell import dependency_inference, shunit2_test_runner
 from pants.backend.shell.goals import tailor, test
 from pants.backend.shell.subsystems import shunit2
@@ -38,4 +39,5 @@ def rules():
         *tailor.rules(),
         *target_types_rules(),
         *test.rules(),
+        *export_codegen_goal.rules(),
     ]


### PR DESCRIPTION
Several backends create `GenerateSourcesRequest` but do not create the `export-codegen` goal. If these backends are activated alone, that goal will not be registered and thus not work, despite some of their targets supporting it. I imagine this will rarely be relevant, as the backends will mostly used with others that _do_ register the goal.

This PR fixes the ones I can find by `./pants GenerateSourcesRequest --help-advanced` (specifically, comparing that list to the files that mention `export_codegen_goal.rules()`, and adding that as necessary). This includes the shell backend as raised in https://pantsbuild.slack.com/archives/C046T6T9U/p1670630617169509