### PR TITLE
Remove boilerplate for run and test plugins

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-run-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-run-goal.md
@@ -72,7 +72,7 @@ from pants.engine.unions import UnionRule
 def rules():
     return [
       	*collect_rules(),
-        UnionRule(RunFieldSet, BashRunFieldSet),
+        *BashRunFieldSet.rules(),
     ]
 ```
 
@@ -156,7 +156,32 @@ def rules():
 
 Now, when you run `./pants run path/to/binary.sh`, Pants should run the program.
 
-4. Add tests (optional)
+4. Define `@rule`s for debugging
+------------------------------------
+
+`./pants run` exposes `--debug-adapter` options for debugging code. To hook into this behavior, opt-in in your `RunRequest` subclass and define an additional rule:
+
+```python
+from pants.core.goals.run import RunDebugAdapterRequest
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
+
+@dataclass(frozen=True)
+class BashRunFieldSet(RunFieldSet):
+    ...  # Fields from earlier
+    supports_debug_adapter = True  # Supports --debug-adapter
+
+
+@rule
+async def run_bash_binary_debug_adapter(
+    field_set: BashRunFieldSet,
+    debug_adapter: DebugAdapterSubsystem,
+) -> RunDebugAdapterRequest:
+    ...
+```
+
+Your rule should be configured to wait for client connection before continuing.
+
+5. Add tests (optional)
 -----------------------
 
 Refer to [Testing rules](doc:rules-api-testing). TODO

--- a/src/python/pants/backend/docker/goals/run_image.py
+++ b/src/python/pants/backend/docker/goals/run_image.py
@@ -11,11 +11,10 @@ from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import DockerImageRegistriesField, DockerImageSourceField
 from pants.backend.docker.util_rules.docker_binary import DockerBinary
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import WrappedTarget, WrappedTargetRequest
-from pants.engine.unions import UnionRule
 
 
 @dataclass(frozen=True)
@@ -60,17 +59,8 @@ async def docker_image_run_request(
     )
 
 
-@rule
-async def docker_image_run_debug_adapter_request(
-    field_set: DockerRunFieldSet,
-) -> RunDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging a Docker image using a debug adapter has not yet been implemented."
-    )
-
-
 def rules():
     return [
         *collect_rules(),
-        UnionRule(RunFieldSet, DockerRunFieldSet),
+        *DockerRunFieldSet.rules(),
     ]

--- a/src/python/pants/backend/go/goals/run_binary.py
+++ b/src/python/pants/backend/go/goals/run_binary.py
@@ -5,10 +5,9 @@ import os.path
 
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.goals.run import RunRequest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
 
 
 @rule
@@ -19,14 +18,8 @@ async def create_go_binary_run_request(field_set: GoBinaryFieldSet) -> RunReques
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact_relpath),))
 
 
-@rule
-async def go_binary_run_debug_adapter_request(
-    field_set: GoBinaryFieldSet,
-) -> RunDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging a Go binary using a debug adapter has not yet been implemented."
-    )
-
-
 def rules():
-    return [*collect_rules(), UnionRule(RunFieldSet, GoBinaryFieldSet)]
+    return [
+        *collect_rules(),
+        *GoBinaryFieldSet.rules(),
+    ]

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -40,15 +40,7 @@ from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.backend.go.util_rules.tests_analysis import GeneratedTestMain, GenerateTestMainRequest
-from pants.core.goals.test import (
-    TestDebugAdapterRequest,
-    TestDebugRequest,
-    TestExtraEnv,
-    TestFieldSet,
-    TestRequest,
-    TestResult,
-    TestSubsystem,
-)
+from pants.core.goals.test import TestExtraEnv, TestFieldSet, TestRequest, TestResult, TestSubsystem
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
@@ -57,7 +49,6 @@ from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -476,21 +467,8 @@ async def run_go_tests(
     )
 
 
-@rule
-async def generate_go_tests_debug_request(_: GoTestRequest.Batch) -> TestDebugRequest:
-    raise NotImplementedError("This is a stub.")
-
-
-@rule
-async def generate_go_tests_debug_adapter_request(
-    _: GoTestRequest.Batch,
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError("This is a stub.")
-
-
 def rules():
     return [
         *collect_rules(),
-        UnionRule(TestFieldSet, GoTestFieldSet),
         *GoTestRequest.rules(),
     ]

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -24,14 +24,7 @@ from pants.backend.helm.util_rules import tool
 from pants.backend.helm.util_rules.chart import HelmChart, HelmChartRequest
 from pants.backend.helm.util_rules.sources import HelmChartRoot, HelmChartRootRequest
 from pants.backend.helm.util_rules.tool import HelmProcess
-from pants.core.goals.test import (
-    TestDebugAdapterRequest,
-    TestDebugRequest,
-    TestFieldSet,
-    TestRequest,
-    TestResult,
-    TestSubsystem,
-)
+from pants.core.goals.test import TestFieldSet, TestRequest, TestResult, TestSubsystem
 from pants.core.target_types import ResourceSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
@@ -45,7 +38,6 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -166,24 +158,11 @@ async def run_helm_unittest(
     )
 
 
-@rule
-async def generate_helm_unittest_debug_request(_: HelmUnitTestRequest.Batch) -> TestDebugRequest:
-    raise NotImplementedError("Can not debug Helm unit tests")
-
-
-@rule
-async def generate_helm_unittest_debug_adapter_request(
-    _: HelmUnitTestRequest.Batch,
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError("Can not debug Helm unit tests")
-
-
 def rules():
     return [
         *collect_rules(),
         *subsystem_rules(),
         *dependency_rules(),
         *tool.rules(),
-        UnionRule(TestFieldSet, HelmUnitTestFieldSet),
         *HelmUnitTestRequest.rules(),
     ]

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -34,7 +34,6 @@ from pants.core.goals.test import (
     TestDebugAdapterRequest,
     TestDebugRequest,
     TestExtraEnv,
-    TestFieldSet,
     TestRequest,
     TestResult,
     TestSubsystem,
@@ -430,6 +429,8 @@ class PyTestRequest(TestRequest):
     tool_subsystem = PyTest
     field_set_type = PythonTestFieldSet
     partitioner_type = PartitionerType.CUSTOM
+    supports_debug = True
+    supports_debug_adapter = True
 
 
 @rule(desc="Partition Pytest", level=LogLevel.DEBUG)
@@ -595,7 +596,6 @@ def rules():
     return [
         *collect_rules(),
         *pytest.rules(),
-        UnionRule(TestFieldSet, PythonTestFieldSet),
         UnionRule(PytestPluginSetupRequest, RuntimePackagesPluginRequest),
         *PyTestRequest.rules(),
     ]

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -4,23 +4,15 @@
 import os
 
 from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
-from pants.backend.python.subsystems.debugpy import DebugPy
-from pants.backend.python.target_types import PexBinaryDefaults, PexLayout
-from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.backend.python.target_types import PexLayout
 from pants.core.goals.package import BuiltPackage
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
-from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
+from pants.core.goals.run import RunRequest
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_pex_binary_run_request(
-    field_set: PexBinaryFieldSet,
-    pex_binary_defaults: PexBinaryDefaults,
-    pex_env: PexEnvironment,
-) -> RunRequest:
+async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequest:
     built_pex = await Get(BuiltPackage, PexBinaryFieldSet, field_set)
     relpath = built_pex.artifacts[0].relpath
     assert relpath is not None
@@ -33,18 +25,13 @@ async def create_pex_binary_run_request(
     )
 
 
-@rule
-async def run_pex_debug_adapter_binary(
-    field_set: PexBinaryFieldSet,
-    debugpy: DebugPy,
-    debug_adapter: DebugAdapterSubsystem,
-) -> RunDebugAdapterRequest:
-    # NB: Technically we could run this using `debugpy`, however it is unclear how the user
-    # would be able to debug the code, as the client and server will disagree on the code's path.
-    raise NotImplementedError(
-        "Debugging a `pex_binary` using a debug adapter has not yet been implemented."
-    )
+# NB: Technically we could implement RunDebugAdapterRequest by using `debugpy`.
+# However it is unclear how the user would be able to debug the code,
+# as the client and server will disagree on the code's path.
 
 
 def rules():
-    return [*collect_rules(), UnionRule(RunFieldSet, PexBinaryFieldSet)]
+    return [
+        *collect_rules(),
+        *PexBinaryFieldSet.rules(),
+    ]

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -22,12 +22,12 @@ from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
 class PythonSourceFieldSet(RunFieldSet):
+    supports_debug_adapter = True
     required_fields = (PythonSourceField, PythonRunGoalUseSandboxField)
 
     source: PythonSourceField
@@ -91,5 +91,5 @@ async def create_python_source_debug_adapter_request(
 def rules():
     return [
         *collect_rules(),
-        UnionRule(RunFieldSet, PythonSourceFieldSet),
+        *PythonSourceFieldSet.rules(),
     ]

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -24,7 +24,7 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -57,7 +57,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class PyOxidizerFieldSet(PackageFieldSet):
+class PyOxidizerFieldSet(PackageFieldSet, RunFieldSet):
     required_fields = (PyOxidizerDependenciesField,)
 
     binary_name: PyOxidizerBinaryNameField
@@ -238,18 +238,9 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
     return RunRequest(digest=binary.digest, args=(os.path.join("{chroot}", artifact.relpath),))
 
 
-@rule
-async def run_pyoxidizer_debug_adapter_binary(
-    field_set: PyOxidizerFieldSet,
-) -> RunDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging a PyOxidizer binary using a debug adapter has not yet been implemented."
-    )
-
-
 def rules():
     return (
         *collect_rules(),
         UnionRule(PackageFieldSet, PyOxidizerFieldSet),
-        UnionRule(RunFieldSet, PyOxidizerFieldSet),
+        *PyOxidizerFieldSet.rules(),
     )

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -14,7 +14,6 @@ from pants.backend.scala.target_types import (
 )
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import (
-    TestDebugAdapterRequest,
     TestDebugRequest,
     TestExtraEnv,
     TestFieldSet,
@@ -65,6 +64,7 @@ class ScalatestTestFieldSet(TestFieldSet):
 class ScalatestTestRequest(TestRequest):
     tool_subsystem = Scalatest
     field_set_type = ScalatestTestFieldSet
+    supports_debug = True
 
 
 class ScalatestToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
@@ -205,13 +205,6 @@ async def setup_scalatest_debug_request(
 
 
 @rule
-async def setup_scalatest_debug_adapter_request(
-    _: ScalatestTestRequest.Batch,
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError("Debugging Scala using a debug adapter has not yet been implemented.")
-
-
-@rule
 def generate_scalatest_lockfile_request(
     _: ScalatestToolLockfileSentinel, scalatest: Scalatest
 ) -> GenerateJvmLockfileFromTool:
@@ -222,7 +215,6 @@ def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(TestFieldSet, ScalatestTestFieldSet),
         UnionRule(GenerateToolLockfileSentinel, ScalatestToolLockfileSentinel),
         *ScalatestTestRequest.rules(),
     ]

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -14,20 +14,11 @@ from pants.backend.shell.target_types import (
 )
 from pants.backend.shell.util_rules import shell_command
 from pants.backend.shell.util_rules.shell_command import ShellCommandProcessFromTargetRequest
-from pants.core.goals.test import (
-    TestDebugAdapterRequest,
-    TestDebugRequest,
-    TestExtraEnv,
-    TestFieldSet,
-    TestRequest,
-    TestResult,
-    TestSubsystem,
-)
+from pants.core.goals.test import TestExtraEnv, TestFieldSet, TestRequest, TestResult, TestSubsystem
 from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
-from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -86,22 +77,9 @@ async def test_shell_command(
     )
 
 
-@rule
-async def generate_shell_tests_debug_request(_: ShellTestRequest.Batch) -> TestDebugRequest:
-    raise NotImplementedError("This is a stub.")
-
-
-@rule
-async def generate_shell_tests_debug_adapter_request(
-    _: ShellTestRequest.Batch,
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError("This is a stub.")
-
-
 def rules():
     return (
         *collect_rules(),
         *shell_command.rules(),
         *ShellTestRequest.rules(),
-        UnionRule(TestFieldSet, TestShellCommandFieldSet),
     )

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -20,7 +20,6 @@ from pants.core.goals.test import (
     BuildPackageDependenciesRequest,
     BuiltPackageDependencies,
     RuntimePackageDependenciesField,
-    TestDebugAdapterRequest,
     TestDebugRequest,
     TestExtraEnv,
     TestFieldSet,
@@ -48,7 +47,6 @@ from pants.engine.process import (
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import SourcesField, Target, TransitiveTargets, TransitiveTargetsRequest
-from pants.engine.unions import UnionRule
 from pants.option.global_options import GlobalOptions
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
@@ -72,6 +70,7 @@ class Shunit2FieldSet(TestFieldSet):
 class Shunit2TestRequest(TestRequest):
     tool_subsystem = Shunit2
     field_set_type = Shunit2FieldSet
+    supports_debug = False
 
 
 @dataclass(frozen=True)
@@ -268,16 +267,8 @@ async def setup_shunit2_debug_test(
     )
 
 
-@rule
-async def setup_shunit2_debug_adapter_test(
-    _: Shunit2TestRequest.Batch[Shunit2FieldSet, Any]
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError("Debugging Shell using a debug adapter has not yet been implemented.")
-
-
 def rules():
     return [
         *collect_rules(),
-        UnionRule(TestFieldSet, Shunit2FieldSet),
         *Shunit2TestRequest.rules(),
     ]

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -28,7 +28,7 @@ from pants.backend.shell.target_types import (
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
 from pants.base.deprecated import warn_or_error
 from pants.core.goals.package import BuiltPackage, PackageFieldSet
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.goals.run import RunFieldSet, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -401,18 +401,9 @@ async def run_shell_command_request(shell_command: RunShellCommand) -> RunReques
     )
 
 
-@rule
-async def run_shell_debug_adapter_binary(
-    field_set: RunShellCommand,
-) -> RunDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging a shell command using a debug adapter has not yet been implemented."
-    )
-
-
 def rules():
     return [
         *collect_rules(),
         UnionRule(GenerateSourcesRequest, GenerateFilesFromShellCommandRequest),
-        UnionRule(RunFieldSet, RunShellCommand),
+        *RunShellCommand.rules(),
     ]

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -8,7 +8,9 @@ import logging
 from abc import ABCMeta
 from dataclasses import dataclass
 from itertools import filterfalse, tee
-from typing import Callable, Iterable, Mapping, NamedTuple, Optional, Tuple, TypeVar
+from typing import Callable, ClassVar, Iterable, Mapping, NamedTuple, Optional, Tuple, TypeVar
+
+from typing_extensions import final
 
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.environments import _warn_on_non_local_environments
@@ -21,7 +23,7 @@ from pants.engine.internals.specs_rules import (
     TooManyTargetsException,
 )
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
-from pants.engine.rules import Effect, Get, collect_rules, goal_rule, rule_helper
+from pants.engine.rules import Effect, Get, collect_rules, goal_rule, rule, rule_helper
 from pants.engine.target import (
     BoolField,
     FieldSet,
@@ -31,10 +33,11 @@ from pants.engine.target import (
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
 )
-from pants.engine.unions import UnionMembership, union
+from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.global_options import GlobalOptions
 from pants.option.option_types import ArgsListOption, BoolOption
 from pants.util.frozendict import FrozenDict
+from pants.util.memo import memoized
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import softwrap
 
@@ -46,6 +49,15 @@ _T = TypeVar("_T")
 @union(in_scope_types=[EnvironmentName])
 class RunFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary from a target to run a program/script."""
+
+    supports_debug_adapter: ClassVar[bool] = False
+
+    @final
+    @classmethod
+    def rules(cls) -> Iterable:
+        yield UnionRule(RunFieldSet, cls)
+        if not cls.supports_debug_adapter:
+            yield from _unsupported_debug_adapter_rules(cls)
 
 
 class RestartableField(BoolField):
@@ -246,6 +258,19 @@ async def run(
     )
 
     return Run(result.exit_code)
+
+
+@memoized
+def _unsupported_debug_adapter_rules(cls: type[RunFieldSet]) -> Iterable:
+    """Returns a rule that implements DebugAdapterRequest by raising an error."""
+
+    @rule(_param_type_overrides={"request": cls})
+    async def get_run_debug_adapter_request(request: RunFieldSet) -> RunDebugAdapterRequest:
+        raise NotImplementedError(
+            "Running this target type with a debug adapter is not yet supported."
+        )
+
+    return collect_rules(locals())
 
 
 def rules():

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -63,6 +63,7 @@ from pants.option.option_types import BoolOption, EnumOption, IntOption, StrList
 from pants.util.collections import partition_sequentially
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
+from pants.util.memo import memoized
 from pants.util.meta import classproperty
 from pants.util.strutil import softwrap
 
@@ -267,7 +268,6 @@ class TestDebugAdapterRequest(TestDebugRequest):
     """
 
 
-@union(in_scope_types=[EnvironmentName])
 @dataclass(frozen=True)
 class TestFieldSet(FieldSet, metaclass=ABCMeta):
     """The fields necessary to run tests on a target."""
@@ -303,6 +303,9 @@ class TestRequest:
     tool_subsystem: ClassVar[type[SkippableSubsystem]]
     field_set_type: ClassVar[type[TestFieldSet]]
     partitioner_type: ClassVar[PartitionerType] = PartitionerType.DEFAULT_ONE_PARTITION_PER_INPUT
+
+    supports_debug: ClassVar[bool] = False
+    supports_debug_adapter: ClassVar[bool] = False
 
     __test__ = False
 
@@ -361,6 +364,12 @@ class TestRequest:
         yield UnionRule(TestRequest, cls)
         yield UnionRule(TestRequest.PartitionRequest, cls.PartitionRequest)
         yield UnionRule(TestRequest.Batch, cls.Batch)
+
+        if not cls.supports_debug:
+            yield from _unsupported_debug_rules(cls)
+
+        if not cls.supports_debug_adapter:
+            yield from _unsupported_debug_adapter_rules(cls)
 
 
 class CoverageData(ABC):
@@ -470,7 +479,7 @@ class TestSubsystem(GoalSubsystem):
 
     @classmethod
     def activated(cls, union_membership: UnionMembership) -> bool:
-        return TestFieldSet in union_membership
+        return TestRequest in union_membership
 
     class EnvironmentAware:
         extra_env_vars = StrListOption(
@@ -955,6 +964,30 @@ async def get_filtered_environment(test_env_aware: TestSubsystem.EnvironmentAwar
     return TestExtraEnv(
         await Get(EnvironmentVars, EnvironmentVarsRequest(test_env_aware.extra_env_vars))
     )
+
+
+@memoized
+def _unsupported_debug_rules(cls: type[TestRequest]) -> Iterable:
+    """Returns a rule that implements TestDebugRequest by raising an error."""
+
+    @rule(_param_type_overrides={"request": cls.Batch})
+    async def get_test_debug_request(request: TestRequest.Batch) -> TestDebugRequest:
+        raise NotImplementedError("Testing this target with --debug is not yet supported.")
+
+    return collect_rules(locals())
+
+
+@memoized
+def _unsupported_debug_adapter_rules(cls: type[TestRequest]) -> Iterable:
+    """Returns a rule that implements TestDebugAdapterRequest by raising an error."""
+
+    @rule(_param_type_overrides={"request": cls.Batch})
+    async def get_test_debug_adapter_request(request: TestRequest.Batch) -> TestDebugAdapterRequest:
+        raise NotImplementedError(
+            "Testing this target type with a debug adapter is not yet supported."
+        )
+
+    return collect_rules(locals())
 
 
 # -------------------------------------------------------------------------------------------

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -5,10 +5,9 @@ import logging
 from typing import Iterable
 
 from pants.core.goals.package import BuiltPackage
-from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.goals.run import RunRequest
 from pants.engine.process import Process
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.unions import UnionRule
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.package.deploy_jar import DeployJarFieldSet
 from pants.util.logging import LogLevel
@@ -73,14 +72,8 @@ async def create_deploy_jar_run_request(
     )
 
 
-@rule
-async def run_deploy_jar_debug_adapter_binary(
-    field_set: DeployJarFieldSet,
-) -> RunDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging a deploy JAR using a debug adapter has not yet been implemented."
-    )
-
-
 def rules():
-    return [*collect_rules(), UnionRule(RunFieldSet, DeployJarFieldSet)]
+    return [
+        *collect_rules(),
+        *DeployJarFieldSet.rules(),
+    ]

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -10,7 +10,6 @@ from typing import Any
 from pants.backend.java.subsystems.junit import JUnit
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.test import (
-    TestDebugAdapterRequest,
     TestDebugRequest,
     TestExtraEnv,
     TestExtraEnvVarsField,
@@ -67,6 +66,7 @@ class JunitTestFieldSet(TestFieldSet):
 class JunitTestRequest(TestRequest):
     tool_subsystem = JUnit
     field_set_type = JunitTestFieldSet
+    supports_debug = True
 
 
 class JunitToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
@@ -204,15 +204,6 @@ async def setup_junit_debug_request(
 
 
 @rule
-async def setup_junit_debug_adapter_request(
-    _: JunitTestRequest.Batch[JunitTestFieldSet, Any],
-) -> TestDebugAdapterRequest:
-    raise NotImplementedError(
-        "Debugging JUnit tests using a debug adapter has not yet been implemented."
-    )
-
-
-@rule
 def generate_junit_lockfile_request(
     _: JunitToolLockfileSentinel, junit: JUnit
 ) -> GenerateJvmLockfileFromTool:
@@ -223,7 +214,6 @@ def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(TestFieldSet, JunitTestFieldSet),
         UnionRule(GenerateToolLockfileSentinel, JunitToolLockfileSentinel),
         *JunitTestRequest.rules(),
     ]


### PR DESCRIPTION
This change provides default rules for `run` and `test` plugins for the `--debug` and `--debug-adapter` flags so that clients don't have to define them unless they opt-in. It also provides us a single exception raised if a feature isn't supported (some of the plugins raised a string "this is a stub", which isn't very user-friendly).

While I was in the neighborhood, I fixed some holdover code from when test plugins registered using `TestFieldSet` as the union.

I don't love adding a `rules()` to a `FieldSet` subclass because some plugin subclasses inherit from multiple field sets. That can be solved with some `super()` magic, but the alternative is to break the `run` API and add a new request type solely for this. Right now this 100% backwards compatible (a feat) so I'm open to comments.