### PR TITLE
go: remove notion of separate `__obj__` directory

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -6,7 +6,6 @@ import dataclasses
 import hashlib
 import os.path
 from dataclasses import dataclass
-from pathlib import PurePath
 from typing import Iterable
 
 from pants.backend.go.util_rules import cgo, coverage
@@ -37,7 +36,6 @@ from pants.engine.fs import (
     Digest,
     DigestContents,
     DigestSubset,
-    Directory,
     FileContent,
     MergeDigests,
     PathGlobs,
@@ -553,10 +551,7 @@ async def build_go_package(
     # about the Go code that can be used by assembly files.
     asm_header_path: str | None = None
     if s_files:
-        obj_dir_path = PurePath(".", request.dir_path, "__obj__")
-        asm_header_path = str(obj_dir_path / "go_asm.h")
-        obj_dir_digest = await Get(Digest, CreateDigest([Directory(str(obj_dir_path))]))
-        input_digest = await Get(Digest, MergeDigests([input_digest, obj_dir_digest]))
+        asm_header_path = os.path.join(request.dir_path, "go_asm.h")
         compile_args.extend(["-asmhdr", asm_header_path])
 
     if embedcfg.digest != EMPTY_DIGEST:

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -299,11 +299,8 @@ async def make_cgo_compile_wrapper_script(
                     path="wrapper",
                     content=textwrap.dedent(
                         """\
-                export sandbox_root="$(/bin/pwd)"
-                ln -s "${sandbox_root}" __pants_sandbox_root__
-                declare -a args
-                args=("$@")
-                args=("${args[@]//__PANTS_SANDBOX_ROOT__/${sandbox_root}}")
+                sandbox_root="$(/bin/pwd)"
+                args=("${@//__PANTS_SANDBOX_ROOT__/$sandbox_root}")
                 exec "${args[@]}"
                 """
                     ).encode(),


### PR DESCRIPTION
Remove the notion of a separate `__obj__` directory (`obj_dir_path` in the code) for compiling object files (e.g., Cgo and assembly) and just generate and capture object files in the same directory as the sources they are built from.

The issue is that the user can configure references to the source directory in `-I` and other compiler/assembler options using the `${SRCDIR}` syntax. With a separate object directory, the rules would need additional code to either copy files around or duplicate `-I` and other options  to account for both the original sources directory and the objects directory if code wanted to be agnostic to the location of files that it expected to be in the package directory.

The idea for an objects tmp directory originally came from the `go` toolchain. `go` copies source files into the objects directory to avoid the duplication problem mentioned above. It makes sense for the Go toolchain to do this because the original sources are the user's actual source repository. Writing temporary object files into the original repository would make for a bad user experience.

Pants, on the other hand, uses an execution sandbox and does not have the same issue about modifying the original repository during a build. Thus, it makes sense in Pants to avoid copying files and just put object files next to the sources in the execution sandbox they are built from. This means the Cgo rules can avoid having to parse and duplicate options in which `${SRCDIR}` is used.

This is a partial fix for https://github.com/pantsbuild/pants/issues/17592. It fixes errors due to the mishandling of `${SRCDIR}` by the Cgo rules in not duplicating options that had `${SRCDIR}` in them to account for both the original sources directory and the objects directory.