### PR TITLE
Restore support for :all: in only_binary/no_binary.

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -8,7 +8,8 @@ import logging
 import os
 from typing import Iterable, List, Optional, TypeVar, cast
 
-from pants.backend.python.pip_requirement import PipRequirement
+from packaging.utils import canonicalize_name
+
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.option.option_types import (
     BoolOption,
@@ -257,7 +258,8 @@ class PythonSetup(Subsystem):
             You can use the key `{RESOLVE_OPTION_KEY__DEFAULT}` to set a default value for all
             resolves.
 
-            For each resolve's value, you can use the value `:all:` to disable all binary packages.
+            For each resolve, you can also use the value `:all:` to disable all binary packages:
+            `{{'data-science': [':all:']}}`.
 
             Note that some packages are tricky to compile and may fail to install when this option
             is used on them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-no-binary
@@ -280,7 +282,8 @@ class PythonSetup(Subsystem):
             You can use the key `{RESOLVE_OPTION_KEY__DEFAULT}` to set a default value for all
             resolves.
 
-            For each resolve's value, you can use the value `:all:` to disable all source packages.
+            For each resolve you can use the value `:all:` to disable all source packages:
+            `{{'data-science': [':all:']}}`.
 
             Packages without binary distributions will fail to install when this option is used on
             them. See https://pip.pypa.io/en/stable/cli/pip_install/#install-only-binary for
@@ -564,17 +567,9 @@ class PythonSetup(Subsystem):
     @memoized_method
     def resolves_to_no_binary(
         self, all_python_tool_resolve_names: tuple[str, ...]
-    ) -> dict[str, list[PipRequirement]]:
+    ) -> dict[str, list[str]]:
         return {
-            resolve: [
-                PipRequirement.parse(
-                    v,
-                    description_of_origin=(
-                        f"the option `[python].resolves_to_no_binary` for the resolve {resolve}"
-                    ),
-                )
-                for v in vals
-            ]
+            resolve: [canonicalize_name(v) for v in vals]
             for resolve, vals in self._resolves_to_option_helper(
                 self._resolves_to_no_binary,
                 "resolves_to_no_binary",
@@ -585,17 +580,9 @@ class PythonSetup(Subsystem):
     @memoized_method
     def resolves_to_only_binary(
         self, all_python_tool_resolve_names: tuple[str, ...]
-    ) -> dict[str, list[PipRequirement]]:
+    ) -> dict[str, list[str]]:
         return {
-            resolve: [
-                PipRequirement.parse(
-                    v,
-                    description_of_origin=(
-                        f"the option `[python].resolves_to_only_binary` for the resolve {resolve}"
-                    ),
-                )
-                for v in vals
-            ]
+            resolve: sorted([canonicalize_name(v) for v in vals])
             for resolve, vals in self._resolves_to_option_helper(
                 self._resolves_to_only_binary,
                 "resolves_to_only_binary",

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -44,8 +44,8 @@ class PythonLockfileMetadata(LockfileMetadata):
         requirements: set[PipRequirement],
         manylinux: str | None,
         requirement_constraints: set[PipRequirement],
-        only_binary: set[PipRequirement],
-        no_binary: set[PipRequirement],
+        only_binary: set[str],
+        no_binary: set[str],
     ) -> PythonLockfileMetadata:
         """Call the most recent version of the `LockfileMetadata` class to construct a concrete
         instance.
@@ -83,8 +83,8 @@ class PythonLockfileMetadata(LockfileMetadata):
         user_requirements: Iterable[PipRequirement],
         manylinux: str | None,
         requirement_constraints: Iterable[PipRequirement],
-        only_binary: Iterable[PipRequirement],
-        no_binary: Iterable[PipRequirement],
+        only_binary: Iterable[str],
+        no_binary: Iterable[str],
     ) -> LockfileMetadataValidation:
         """Returns Truthy if this `PythonLockfileMetadata` can be used in the current execution
         context."""
@@ -130,8 +130,8 @@ class PythonLockfileMetadataV1(PythonLockfileMetadata):
         user_requirements: Iterable[PipRequirement],
         manylinux: str | None,
         requirement_constraints: Iterable[PipRequirement],
-        only_binary: Iterable[PipRequirement],
-        no_binary: Iterable[PipRequirement],
+        only_binary: Iterable[str],
+        no_binary: Iterable[str],
     ) -> LockfileMetadataValidation:
         failure_reasons: set[InvalidPythonLockfileReason] = set()
 
@@ -200,8 +200,8 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
         # Everything below is not used by V2.
         manylinux: str | None,
         requirement_constraints: Iterable[PipRequirement],
-        only_binary: Iterable[PipRequirement],
-        no_binary: Iterable[PipRequirement],
+        only_binary: Iterable[str],
+        no_binary: Iterable[str],
     ) -> LockfileMetadataValidation:
         failure_reasons = set()
 
@@ -228,8 +228,8 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
 
     manylinux: str | None
     requirement_constraints: set[PipRequirement]
-    only_binary: set[PipRequirement]
-    no_binary: set[PipRequirement]
+    only_binary: set[str]
+    no_binary: set[str]
 
     @classmethod
     def _from_json_dict(
@@ -248,20 +248,8 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
                 PipRequirement.parse(i, description_of_origin=lockfile_description) for i in l
             },
         )
-        only_binary = metadata(
-            "only_binary",
-            Set[PipRequirement],
-            lambda l: {
-                PipRequirement.parse(i, description_of_origin=lockfile_description) for i in l
-            },
-        )
-        no_binary = metadata(
-            "no_binary",
-            Set[PipRequirement],
-            lambda l: {
-                PipRequirement.parse(i, description_of_origin=lockfile_description) for i in l
-            },
-        )
+        only_binary = metadata("only_binary", Set[str], lambda l: set(l))
+        no_binary = metadata("no_binary", Set[str], lambda l: set(l))
 
         return PythonLockfileMetadataV3(
             valid_for_interpreter_constraints=v2_metadata.valid_for_interpreter_constraints,
@@ -278,8 +266,8 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
         return {
             "manylinux": instance.manylinux,
             "requirement_constraints": sorted(str(i) for i in instance.requirement_constraints),
-            "only_binary": sorted(str(i) for i in instance.only_binary),
-            "no_binary": sorted(str(i) for i in instance.no_binary),
+            "only_binary": sorted(instance.only_binary),
+            "no_binary": sorted(instance.no_binary),
         }
 
     def is_valid_for(
@@ -292,8 +280,8 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
         user_requirements: Iterable[PipRequirement],
         manylinux: str | None,
         requirement_constraints: Iterable[PipRequirement],
-        only_binary: Iterable[PipRequirement],
-        no_binary: Iterable[PipRequirement],
+        only_binary: Iterable[str],
+        no_binary: Iterable[str],
     ) -> LockfileMetadataValidation:
         failure_reasons = (
             super()

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata_test.py
@@ -34,8 +34,8 @@ def test_metadata_header_round_trip() -> None:
         requirements=reqset("ansicolors==0.1.0"),
         manylinux="manylinux2014",
         requirement_constraints={PipRequirement.parse("constraint")},
-        only_binary={PipRequirement.parse("bdist")},
-        no_binary={PipRequirement.parse("sdist")},
+        only_binary={"bdist"},
+        no_binary={"sdist"},
     )
     serialized_lockfile = input_metadata.add_header_to_lockfile(
         b"req1==1.0", regenerate_command="./pants lock", delimeter="#"
@@ -89,8 +89,8 @@ dave==3.1.4 \\
         requirements=reqset("ansicolors==0.1.0"),
         manylinux=None,
         requirement_constraints={PipRequirement.parse("constraint")},
-        only_binary={PipRequirement.parse("bdist")},
-        no_binary={PipRequirement.parse("sdist")},
+        only_binary={"bdist"},
+        no_binary={"sdist"},
     )
     result = metadata.add_header_to_lockfile(
         input_lockfile, regenerate_command="./pants lock", delimeter="#"
@@ -280,8 +280,8 @@ def test_is_valid_for_v3_metadata(is_tool: bool) -> None:
         # Everything below is new to v3+.
         manylinux=None,
         requirement_constraints={PipRequirement.parse("c1")},
-        only_binary={PipRequirement.parse("bdist")},
-        no_binary={PipRequirement.parse("sdist")},
+        only_binary={"bdist"},
+        no_binary={"sdist"},
     ).is_valid_for(
         is_tool=is_tool,
         expected_invalidation_digest="",
@@ -290,8 +290,8 @@ def test_is_valid_for_v3_metadata(is_tool: bool) -> None:
         user_requirements=reqset(),
         manylinux="manylinux2014",
         requirement_constraints={PipRequirement.parse("c2")},
-        only_binary={PipRequirement.parse("not-bdist")},
-        no_binary={PipRequirement.parse("not-sdist")},
+        only_binary={"not-bdist"},
+        no_binary={"not-sdist"},
     )
     assert result.failure_reasons == {
         InvalidPythonLockfileReason.CONSTRAINTS_FILE_MISMATCH,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -302,8 +302,8 @@ class ResolvePexConfig:
     find_links: tuple[str, ...]
     manylinux: str | None
     constraints_file: ResolvePexConstraintsFile | None
-    only_binary: FrozenOrderedSet[PipRequirement]
-    no_binary: FrozenOrderedSet[PipRequirement]
+    only_binary: FrozenOrderedSet[str]
+    no_binary: FrozenOrderedSet[str]
     path_mappings: tuple[str, ...]
 
     def pex_args(self) -> Iterator[str]:

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -33,8 +33,8 @@ METADATA = PythonLockfileMetadataV3(
     {PipRequirement.parse("ansicolors"), PipRequirement.parse("requests")},
     manylinux=None,
     requirement_constraints={PipRequirement.parse("abc")},
-    only_binary={PipRequirement.parse("bdist")},
-    no_binary={PipRequirement.parse("sdist")},
+    only_binary={"bdist"},
+    no_binary={"sdist"},
 )
 
 
@@ -147,12 +147,8 @@ def test_validate_tool_lockfiles(
                     {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
                 ),
             ),
-            no_binary=FrozenOrderedSet(
-                [PipRequirement.parse("not-sdist" if invalid_no_binary else "sdist")]
-            ),
-            only_binary=FrozenOrderedSet(
-                [PipRequirement.parse("not-bdist" if invalid_only_binary else "bdist")]
-            ),
+            no_binary=FrozenOrderedSet(["not-sdist" if invalid_no_binary else "sdist"]),
+            only_binary=FrozenOrderedSet(["not-bdist" if invalid_only_binary else "bdist"]),
             path_mappings=(),
         ),
     )
@@ -268,12 +264,8 @@ def test_validate_user_lockfiles(
                     {PipRequirement.parse("xyz" if invalid_constraints_file else "abc")}
                 ),
             ),
-            no_binary=FrozenOrderedSet(
-                [PipRequirement.parse("not-sdist" if invalid_no_binary else "sdist")]
-            ),
-            only_binary=FrozenOrderedSet(
-                [PipRequirement.parse("not-bdist" if invalid_only_binary else "bdist")]
-            ),
+            no_binary=FrozenOrderedSet(["not-sdist" if invalid_no_binary else "sdist"]),
+            only_binary=FrozenOrderedSet(["not-bdist" if invalid_only_binary else "bdist"]),
             path_mappings=(),
         ),
     )


### PR DESCRIPTION
We document that the user can pass `:all:` in `resolves_to_no_binary`/`resolves_to_only_binary`, but #16559 inadvertently broke this. 

That change also had understandably incorrect logic in it: `pkgutil.Requirement`'s `__eq__` method, strangely, does *not* match the PEP 503 name canonicalization that PyPI/pip apply.

This change manually reverts the relevant parts of that change, so that values are passed around as strings again, instead of `PipRequirement` instances (which was overkill anyway, since they are intended to just be project names, not arbitrary requirement strings with version constraints). 

Instead, to solve the issue that #16559 was intended to solve, we canonicalize the option values on input.