### PR TITLE
go: pass module sources through to linker if `${SRCDIR}` is referenced

### DIFF
--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -90,6 +90,12 @@ class GolangSubsystem(Subsystem):
             help="Name of the tool to use to compile fortran code included via CGo in a Go package.",
         )
 
+        external_linker_binary_name = StrOption(
+            default="gcc",
+            advanced=True,
+            help='Name of the tool to use as the "external linker" when invoking `go tool link`.',
+        )
+
         cgo_c_flags = StrListOption(
             default=lambda _: list(_DEFAULT_COMPILER_FLAGS),
             advanced=True,

--- a/src/python/pants/backend/go/util_rules/link.py
+++ b/src/python/pants/backend/go/util_rules/link.py
@@ -2,11 +2,17 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import textwrap
 from dataclasses import dataclass
 
+from pants.backend.go.subsystems.golang import GolangSubsystem
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
+from pants.backend.go.util_rules.cgo_binaries import CGoBinaryPathRequest
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
-from pants.engine.fs import Digest
+from pants.core.util_rules.system_binaries import BashBinary, BinaryPath, BinaryPathTest
+from pants.engine.fs import CreateDigest, Digest, Directory, FileContent
+from pants.engine.internals.native_engine import MergeDigests
+from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
 
@@ -30,19 +36,77 @@ class LinkedGoBinary:
     digest: Digest
 
 
+@dataclass(frozen=True)
+class LinkerSetup:
+    digest: Digest
+    extld_wrapper_path: str
+
+
 @rule
-async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
-    link_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("link"))
+async def setup_go_linker(
+    bash: BashBinary, golang_subsystem: GolangSubsystem.EnvironmentAware
+) -> LinkerSetup:
+    extld_binary = await Get(
+        BinaryPath,
+        CGoBinaryPathRequest(
+            binary_name=golang_subsystem.external_linker_binary_name,
+            binary_path_test=BinaryPathTest(["--version"]),
+        ),
+    )
+
+    extld_wrapper_path = "__pants_extld_wrapper__"
+    digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    path=extld_wrapper_path,
+                    content=textwrap.dedent(
+                        f"""\
+                        #!{bash.path}
+                        args=("${{@//__PANTS_SANDBOX_ROOT__/$__PANTS_SANDBOX_ROOT__}}")
+                        exec {extld_binary.path} "${{args[@]}}"
+                        """
+                    ).encode(),
+                    is_executable=True,
+                ),
+            ]
+        ),
+    )
+    return LinkerSetup(digest, extld_wrapper_path)
+
+
+@rule
+async def link_go_binary(
+    request: LinkGoBinaryRequest,
+    linker_setup: LinkerSetup,
+) -> LinkedGoBinary:
+    link_tmp_dir = "link-tmp"
+    link_tmp_dir_digest = await Get(Digest, CreateDigest([Directory(link_tmp_dir)]))
+
+    link_tool_id, input_digest = await MultiGet(
+        Get(GoSdkToolIDResult, GoSdkToolIDRequest("link")),
+        Get(Digest, MergeDigests([request.input_digest, link_tmp_dir_digest, linker_setup.digest])),
+    )
+
     maybe_race_arg = ["-race"] if request.build_opts.with_race_detector else []
     maybe_msan_arg = ["-msan"] if request.build_opts.with_msan else []
     maybe_asan_arg = ["-asan"] if request.build_opts.with_asan else []
     result = await Get(
         ProcessResult,
         GoSdkProcess(
-            input_digest=request.input_digest,
+            input_digest=input_digest,
             command=(
                 "tool",
                 "link",
+                # Put the linker's temporary directory into the input root.
+                "-tmpdir",
+                f"__PANTS_SANDBOX_ROOT__/{link_tmp_dir}",
+                # Force `go tool link` to use a wrapper script as the "external linker" so that the script can
+                # replace any instances of `__PANTS_SANDBOX_ROOT__` in the linker arguments. This also allows
+                # Pants to know which external linker is in use and invalidate this `Process` as needed.
+                "-extld",
+                f"__PANTS_SANDBOX_ROOT__/{linker_setup.extld_wrapper_path}",
                 *maybe_race_arg,
                 *maybe_msan_arg,
                 *maybe_asan_arg,
@@ -59,6 +123,7 @@ async def link_go_binary(request: LinkGoBinaryRequest) -> LinkedGoBinary:
             },
             description=f"Link Go binary: {request.output_filename}",
             output_files=(request.output_filename,),
+            replace_sandbox_root_in_args=True,
         ),
     )
 

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -87,6 +87,7 @@ async def go_sdk_invoke_setup(goroot: GoRoot) -> GoSdkRunSetup:
               cd "${GoSdkRunSetup.CHDIR_ENV}"
             fi
             if [ -n "${GoSdkRunSetup.SANDBOX_ROOT_ENV}" ]; then
+              export __PANTS_SANDBOX_ROOT__="$sandbox_root"
               args=("${{@//__PANTS_SANDBOX_ROOT__/$sandbox_root}}")
               set -- "${{args[@]}}"
             fi


### PR DESCRIPTION
Some Go modules, e.g. https://github.com/confluentinc/confluent-kafka-go, try to link a static archive emedded in the module into the package archive using Cgo. If so, mark this package so that the module sources are included in the output digest for the build of this package.

The need for this inclusion is assumed if the Cgo rules observe the `${SRCDIR}` in any linker option. The SRCDIR string will be replaced with the string `__PANTS_SANDBOX_ROOT__` which will then be replaced during linking with the actual sandbox path.

This is accomplished by overriding the "external linker" binary used by `go tool link`. As an additional benefit, this also allows Pants to directly control which external linker binary is actually used so the link `Process` can be properly invalidated if the external linker changes.

Fixes https://github.com/pantsbuild/pants/issues/17592. With this, a simple client binary using https://github.com/confluentinc/confluent-kafka-go links and can be executed.