### PR TITLE
Unconditionally register export-codegen goal in pants.core

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/register.py
+++ b/src/python/pants/backend/codegen/protobuf/python/register.py
@@ -6,7 +6,6 @@
 See https://www.pantsbuild.org/docs/protobuf.
 """
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference
 from pants.backend.codegen.protobuf import tailor as protobuf_tailor
 from pants.backend.codegen.protobuf.python import (
@@ -32,7 +31,6 @@ def rules():
         *python_protobuf_module_mapper.rules(),
         *protobuf_dependency_inference.rules(),
         *protobuf_tailor.rules(),
-        *export_codegen_goal.rules(),
         *protobuf_target_rules(),
         *module_mapper.rules(),
         *stripped_source_files.rules(),

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf.protoc import Protoc
 from pants.backend.codegen.protobuf.scala import dependency_inference
 from pants.backend.codegen.protobuf.scala.subsystem import PluginArtifactSpec, ScalaPBSubsystem
@@ -330,7 +329,6 @@ def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        *export_codegen_goal.rules(),
         *dependency_inference.rules(),
         UnionRule(GenerateSourcesRequest, GenerateScalaFromProtobufRequest),
         UnionRule(GenerateToolLockfileSentinel, ScalapbcToolLockfileSentinel),

--- a/src/python/pants/backend/codegen/thrift/apache/python/register.py
+++ b/src/python/pants/backend/codegen/thrift/apache/python/register.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.thrift.apache.python import (
     additional_fields,
     python_thrift_module_mapper,
@@ -30,5 +29,4 @@ def rules():
         *python_thrift_module_mapper.rules(),
         *module_mapper.rules(),
         *stripped_source_files.rules(),
-        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/backend/docker/register.py
+++ b/src/python/pants/backend/docker/register.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.docker.goals.tailor import rules as tailor_rules
 from pants.backend.docker.rules import rules as docker_rules
 from pants.backend.docker.target_types import DockerImageTarget
@@ -11,7 +10,6 @@ from pants.backend.docker.target_types import rules as target_types_rules
 def rules():
     return (
         *docker_rules(),
-        *export_codegen_goal.rules(),
         *tailor_rules(),
         *target_types_rules(),
     )

--- a/src/python/pants/backend/experimental/codegen/avro/java/register.py
+++ b/src/python/pants/backend/experimental/codegen/avro/java/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.avro.java.rules import rules as avro_java_rules
 from pants.backend.codegen.avro.rules import rules as avro_rules
 from pants.backend.codegen.avro.target_types import AvroSourcesGeneratorTarget, AvroSourceTarget
@@ -19,7 +18,6 @@ def rules():
     return [
         *avro_rules(),
         *avro_java_rules(),
-        *export_codegen_goal.rules(),
         # Re-export rules necessary to avoid rule graph errors.
         *config_files.rules(),
         *classpath.rules(),

--- a/src/python/pants/backend/experimental/codegen/protobuf/go/register.py
+++ b/src/python/pants/backend/experimental/codegen/protobuf/go/register.py
@@ -1,6 +1,5 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference, tailor
 from pants.backend.codegen.protobuf import target_types as protobuf_target_types
 from pants.backend.codegen.protobuf.go import rules as go_protobuf_rules
@@ -20,5 +19,4 @@ def rules():
         *protobuf_target_types.rules(),
         *protobuf_dependency_inference.rules(),
         *tailor.rules(),
-        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/backend/experimental/codegen/protobuf/java/register.py
+++ b/src/python/pants/backend/experimental/codegen/protobuf/java/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference
 from pants.backend.codegen.protobuf import tailor as protobuf_tailor
 from pants.backend.codegen.protobuf import target_types as protobuf_target_types
@@ -21,5 +20,4 @@ def rules():
         *protobuf_target_types.rules(),
         *protobuf_dependency_inference.rules(),
         *protobuf_tailor.rules(),
-        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/backend/experimental/codegen/protobuf/scala/register.py
+++ b/src/python/pants/backend/experimental/codegen/protobuf/scala/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.protobuf import protobuf_dependency_inference
 from pants.backend.codegen.protobuf import target_types as protobuf_target_types
 from pants.backend.codegen.protobuf.scala import rules as scala_protobuf_rules
@@ -29,7 +28,6 @@ def rules():
         *scala_protobuf_rules.rules(),
         *protobuf_target_types.rules(),
         *protobuf_dependency_inference.rules(),
-        *export_codegen_goal.rules(),
         # Re-export rules necessary to avoid rule graph errors.
         *config_files.rules(),
         *classpath.rules(),

--- a/src/python/pants/backend/experimental/codegen/thrift/apache/java/register.py
+++ b/src/python/pants/backend/experimental/codegen/thrift/apache/java/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.thrift.apache.java.rules import rules as apache_thrift_java_rules
 from pants.backend.codegen.thrift.apache.rules import rules as apache_thrift_rules
 from pants.backend.codegen.thrift.rules import rules as thrift_rules
@@ -19,5 +18,4 @@ def rules():
         *thrift_rules(),
         *apache_thrift_rules(),
         *apache_thrift_java_rules(),
-        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/backend/experimental/codegen/thrift/scrooge/java/register.py
+++ b/src/python/pants/backend/experimental/codegen/thrift/scrooge/java/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.thrift.rules import rules as thrift_rules
 from pants.backend.codegen.thrift.scrooge.java.rules import rules as scrooge_java_rules
 from pants.backend.codegen.thrift.scrooge.rules import rules as scrooge_rules
@@ -29,7 +28,6 @@ def rules():
         *thrift_rules(),
         *scrooge_rules(),
         *scrooge_java_rules(),
-        *export_codegen_goal.rules(),
         # Re-export rules necessary to avoid rule graph errors.
         *config_files.rules(),
         *classpath.rules(),

--- a/src/python/pants/backend/experimental/codegen/thrift/scrooge/scala/register.py
+++ b/src/python/pants/backend/experimental/codegen/thrift/scrooge/scala/register.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.codegen.thrift.rules import rules as thrift_rules
 from pants.backend.codegen.thrift.scrooge.rules import rules as scrooge_rules
 from pants.backend.codegen.thrift.scrooge.scala.rules import rules as scrooge_scala_rules
@@ -29,7 +28,6 @@ def rules():
         *thrift_rules(),
         *scrooge_rules(),
         *scrooge_scala_rules(),
-        *export_codegen_goal.rules(),
         # Re-export rules necessary to avoid rule graph errors.
         *config_files.rules(),
         *classpath.rules(),

--- a/src/python/pants/backend/experimental/openapi/codegen/java/register.py
+++ b/src/python/pants/backend/experimental/openapi/codegen/java/register.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.experimental.java.register import rules as java_rules
 from pants.backend.openapi.codegen.java.rules import rules as java_codegen_rules
 
@@ -13,4 +12,4 @@ def target_types():
 
 
 def rules():
-    return [*java_rules(), *java_codegen_rules(), *export_codegen_goal.rules()]
+    return [*java_rules(), *java_codegen_rules()]

--- a/src/python/pants/backend/experimental/python/register.py
+++ b/src/python/pants/backend/experimental/python/register.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.python.goals import debug_goals, publish
 from pants.backend.python.subsystems import setuptools_scm, twine
 from pants.backend.python.target_types import VCSVersion
@@ -14,7 +13,6 @@ def rules():
         *publish.rules(),
         *vcs_versioning.rules(),
         *setuptools_scm.rules(),
-        *export_codegen_goal.rules(),
         *twine.rules(),
         *debug_goals.rules(),
     )

--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.codegen import export_codegen_goal
 from pants.backend.shell import dependency_inference, shunit2_test_runner
 from pants.backend.shell.goals import tailor, test
 from pants.backend.shell.subsystems import shunit2
@@ -39,5 +38,4 @@ def rules():
         *tailor.rules(),
         *target_types_rules(),
         *test.rules(),
-        *export_codegen_goal.rules(),
     ]

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -5,6 +5,7 @@
 
 These are always activated and cannot be disabled.
 """
+from pants.backend.codegen import export_codegen_goal
 from pants.bsp.rules import rules as bsp_rules
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals import (
@@ -63,6 +64,7 @@ def rules():
         *check.rules(),
         *deploy.rules(),
         *export.rules(),
+        *export_codegen_goal.rules(),
         *fmt.rules(),
         *fix.rules(),
         *generate_lockfiles.rules(),


### PR DESCRIPTION
This follows up on https://github.com/pantsbuild/pants/pull/17773#issuecomment-1347361993 to move the `export-codegen` goal to be always registered, by `pants.core`. This is far less fiddly than having to have individual registration by each backend that uses it.