### PR TITLE
A stub page for dep validation docs.

### DIFF
--- a/docs/markdown/Using Pants/validating-dependencies.md
+++ b/docs/markdown/Using Pants/validating-dependencies.md
@@ -1,0 +1,10 @@
+---
+title: "Validating dependencies"
+slug: "validating-dependencies"
+excerpt: "Validating your code's dependencies."
+hidden: true
+createdAt: "2022-12-12T09:10:16.427Z"
+updatedAt: "2022-12-12T03:00:53.427Z"
+---
+
+Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API.


### PR DESCRIPTION
To be fleshed out in a separate PR.

Page is currently non-public, we will change that, and link to it, once it has content.