### PR TITLE
go: rename option to --go-test-coverage-packages

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -255,7 +255,7 @@ async def run_go_tests(
             build_opts,
             coverage_config=GoCoverageConfig(
                 cover_mode=go_test_subsystem.coverage_mode,
-                import_path_include_patterns=go_test_subsystem.coverage_include_patterns,
+                import_path_include_patterns=go_test_subsystem.coverage_packages,
             ),
         )
 

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -92,11 +92,11 @@ class GoTestSubsystem(Subsystem):
         ),
     )
 
-    coverage_include_patterns = StrListOption(
+    coverage_packages = StrListOption(
         default=[],
         help=softwrap(
             """
-            A list of import path patterns for determining which import paths will be instrumented for code
+            A list of "import path patterns" for determining which import paths will be instrumented for code
             coverage.
 
             From `go help packages`:
@@ -118,6 +118,9 @@ class GoTestSubsystem(Subsystem):
             is not a vendored package: cmd/vendor would be a command named vendor,
             and the pattern cmd/... matches it.
             See golang.org/s/go15vendor for more about vendoring.
+
+            This option is similar to the `go test -coverpkg` option, but without support currently
+            for reserved import path patterns like `std` and `all`.
             """
         ),
     )

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -212,7 +212,7 @@ def test_coverage_of_multiple_packages(rule_runner: RuleRunner) -> None:
         [
             "--go-test-args=-v -bench=.",
             "--test-use-coverage",
-            "--go-test-coverage-include-patterns=foo/adder",
+            "--go-test-coverage-packages=foo/adder",
         ],
         env_inherit={"PATH"},
     )


### PR DESCRIPTION
Rename the `--go-test-coverage-include-patterns` option to `--go-test-coverage-packages` to better align the name with the Go toolchain's name `-coverpkg`. We can rename the option now without deprecation since there has not been a stable release yet of 2.16.

This renaming will eventually allow adding exclusion patterns (prefixed with `!`) to this option which would be a conflicting UX if "include patterns" still remained in the name.