### PR TITLE
go: improve options passed to assembler invocations

### DIFF
--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
+from typing import Iterable
 
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess, GoSdkToolIDRequest, GoSdkToolIDResult
@@ -24,7 +25,9 @@ class GenerateAssemblySymabisRequest:
 
     compilation_input: Digest
     s_files: tuple[str, ...]
+    import_path: str
     dir_path: str
+    extra_assembler_flags: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -48,7 +51,6 @@ class AssembleGoAssemblyFilesRequest:
     input_digest: Digest
     s_files: tuple[str, ...]
     dir_path: str
-    asm_header_path: str | None
     import_path: str
     extra_assembler_flags: tuple[str, ...]
 
@@ -64,6 +66,37 @@ class FallibleAssembleGoAssemblyFilesResult:
     exit_code: int = 0
     stdout: str | None = None
     stderr: str | None = None
+
+
+# Adapted from https://github.com/golang/go/blob/cb07765045aed5104a3df31507564ac99e6ddce8/src/cmd/go/internal/work/gc.go#L358-L410
+#
+# Note: Architecture-specific flags have not been adapted nor the flags added when compiling Go SDK packages
+# themselves.
+def _asm_args(
+    import_path: str, dir_path: str, goroot: GoRoot, extra_flags: Iterable[str]
+) -> tuple[str, ...]:
+    # On Go 1.19+, the import path must be supplied via the `-p` option to `go tool asm`.
+    # See https://go.dev/doc/go1.19#assembler and
+    # https://github.com/bazelbuild/rules_go/commit/cde7d7bc27a34547c014369790ddaa95b932d08d (Bazel rules_go).
+    maybe_package_import_path_args = (
+        ["-p", import_path] if goroot.is_compatible_version("1.19") else []
+    )
+
+    return (
+        *maybe_package_import_path_args,
+        "-trimpath",
+        "__PANTS_SANDBOX_ROOT__",
+        "-I",
+        f"__PANTS_SANDBOX_ROOT__/{dir_path}",
+        # Add -I pkg/GOOS_GOARCH so #include "textflag.h" works in .s files.
+        "-I",
+        os.path.join(goroot.path, "pkg", "include"),
+        "-D",
+        f"GOOS_{goroot.goos}",
+        "-D",
+        f"GOARCH_{goroot.goarch}",
+        *extra_flags,
+    )
 
 
 @rule
@@ -92,8 +125,12 @@ async def generate_go_assembly_symabisfile(
             command=(
                 "tool",
                 "asm",
-                "-I",
-                os.path.join(goroot.path, "pkg", "include"),
+                *_asm_args(
+                    import_path=request.import_path,
+                    dir_path=request.dir_path,
+                    goroot=goroot,
+                    extra_flags=request.extra_assembler_flags,
+                ),
                 "-gensymabis",
                 "-o",
                 symabis_path,
@@ -125,18 +162,7 @@ async def assemble_go_assembly_files(
     request: AssembleGoAssemblyFilesRequest,
     goroot: GoRoot,
 ) -> FallibleAssembleGoAssemblyFilesResult:
-    # On Go 1.19+, the import path must be supplied via the `-p` option to `go tool asm`.
-    # See https://go.dev/doc/go1.19#assembler and
-    # https://github.com/bazelbuild/rules_go/commit/cde7d7bc27a34547c014369790ddaa95b932d08d (Bazel rules_go).
-    maybe_package_import_path_args = (
-        ["-p", request.import_path] if goroot.is_compatible_version("1.19") else []
-    )
-
     asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
-
-    maybe_asm_header_path_args = (
-        ["-I", str(PurePath(request.asm_header_path).parent)] if request.asm_header_path else []
-    )
 
     def obj_output_path(s_file: str) -> str:
         return str(request.dir_path / PurePath(s_file).with_suffix(".o"))
@@ -149,11 +175,12 @@ async def assemble_go_assembly_files(
                 command=(
                     "tool",
                     "asm",
-                    "-I",
-                    os.path.join(goroot.path, "pkg", "include"),
-                    *maybe_asm_header_path_args,
-                    *maybe_package_import_path_args,
-                    *request.extra_assembler_flags,
+                    *_asm_args(
+                        import_path=request.import_path,
+                        dir_path=request.dir_path,
+                        goroot=goroot,
+                        extra_flags=request.extra_assembler_flags,
+                    ),
                     "-o",
                     obj_output_path(s_file),
                     str(os.path.normpath(PurePath(".", request.dir_path, s_file))),

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -322,3 +322,81 @@ def test_build_package_using_api_metdata(rule_runner: RuleRunner) -> None:
     result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
     assert result.returncode == 0
     assert result.stdout == b"52\n"  # should be 10 + the 42 "magic" value
+
+
+def test_build_package_with_copied_header(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "go.mod": dedent(
+                """\
+                module example.com/assembly
+                go 1.17
+                """
+            ),
+            "constant_linux.h": dedent(
+                """
+                #define MAGIC_VALUE 42
+                """
+            ),
+            "constant_darwin.h": dedent(
+                """
+                #define MAGIC_VALUE 42
+                """
+            ),
+            "main.go": dedent(
+                """\
+                package main
+
+                import "fmt"
+
+                func main() {
+                    fmt.Println(add_magic(10))
+                }
+                """
+            ),
+            "add_amd64.go": "package main\nfunc add_magic(x int64) int64",
+            "add_arm64.go": "package main\nfunc add_magic(x int64) int64",
+            "add_amd64.s": dedent(
+                """\
+                #include "textflag.h"  // for NOSPLIT
+                #include "constant_GOOS.h"  // for MAGIC_VALUE
+                TEXT ·add_magic(SB),NOSPLIT,$0
+                    MOVQ  x+0(FP), BX
+                    MOVQ  $MAGIC_VALUE, BP
+
+                    ADDQ  BP, BX
+                    MOVQ  BX, ret+8(FP)
+                    RET
+                """
+            ),
+            "add_arm64.s": dedent(
+                """\
+                #include "textflag.h"  // for NOSPLIT
+                #include "constant_GOOS.h"  // for MAGIC_VALUE
+                TEXT ·add_magic(SB),NOSPLIT,$0
+                    MOVD  x+0(FP), R0
+                    MOVD  $MAGIC_VALUE, R1
+
+                    ADD   R1, R0, R0
+                    MOVD  R0, ret+8(FP)
+                    RET
+                """
+            ),
+            "BUILD": dedent(
+                """\
+                go_mod(name="mod")
+                go_package(name="pkg", sources=["*.go", "*.s", "*.h"])
+                go_binary(name="bin")
+                """
+            ),
+        }
+    )
+
+    binary_tgt = rule_runner.get_target(Address("", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
+    assert len(built_package.artifacts) == 1
+    assert built_package.artifacts[0].relpath == "bin"
+
+    result = subprocess.run([os.path.join(rule_runner.build_root, "bin")], stdout=subprocess.PIPE)
+    assert result.returncode == 0
+    assert result.stdout == b"52\n"  # should be 10 + the 42 "magic" value

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -212,6 +212,7 @@ async def setup_build_go_package_target_request(
         cgo_files = _first_party_pkg_analysis.cgo_files
         cgo_flags = _first_party_pkg_analysis.cgo_flags
         c_files = _first_party_pkg_analysis.c_files
+        h_files = _first_party_pkg_analysis.h_files
         cxx_files = _first_party_pkg_analysis.cxx_files
         objc_files = _first_party_pkg_analysis.m_files
         fortran_files = _first_party_pkg_analysis.f_files
@@ -234,6 +235,7 @@ async def setup_build_go_package_target_request(
                 pkg_config=(),
             )
             c_files = ()
+            h_files = ()
             cxx_files = ()
             objc_files = ()
             fortran_files = ()
@@ -271,6 +273,7 @@ async def setup_build_go_package_target_request(
         cgo_files = _third_party_pkg_info.cgo_files
         cgo_flags = _third_party_pkg_info.cgo_flags
         c_files = _third_party_pkg_info.c_files
+        h_files = _third_party_pkg_info.h_files
         cxx_files = _third_party_pkg_info.cxx_files
         objc_files = _third_party_pkg_info.m_files
         fortran_files = _third_party_pkg_info.f_files
@@ -395,6 +398,7 @@ async def setup_build_go_package_target_request(
         cgo_files=cgo_files,
         cgo_flags=cgo_flags,
         c_files=c_files,
+        header_files=h_files,
         cxx_files=cxx_files,
         objc_files=objc_files,
         fortran_files=fortran_files,


### PR DESCRIPTION
Make some improvements to invoking the Go assembler in order to conform to what `go build` does:

- Add `-I` option for the source directory.
- Add `-D` options to define macros based on GOOS and GOARCH.
- Copy header files to architecture-independent names. For example, `defs_linux_amd64.h` becomes `defs_GOOS_GOARCH.h`.
- Pass assembler options to gensymabis stage as well.

Fixes https://github.com/pantsbuild/pants/issues/17478.
