### PR TITLE
go: fix path lookup for copied header files

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -402,7 +402,7 @@ async def _maybe_copy_headers_to_platform_independent_names(
     for header_file in header_files:
         header_file_path = PurePath(dir_path, header_file)
 
-        entry = digest_entries_by_path.get(str(header_file))
+        entry = digest_entries_by_path.get(str(header_file_path))
         if not entry:
             continue
 


### PR DESCRIPTION
Lookup the full path and not the base name.