### PR TITLE
go: set missing `Goal.environment_behavior` on a debug goal

### DIFF
--- a/src/python/pants/backend/go/goals/debug_goals.py
+++ b/src/python/pants/backend/go/goals/debug_goals.py
@@ -110,6 +110,7 @@ class DumpGoImportPathsForModuleSubsystem(GoalSubsystem):
 
 class DumpGoImportPathsForModule(Goal):
     subsystem_cls = DumpGoImportPathsForModuleSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY  # TODO(#17129) — Migrate this.
 
 
 @goal_rule


### PR DESCRIPTION
Set `environment_behavior` for the `go-dump-import-path-mapping` debug goal.