### PR TITLE
An enum of Python export formats.

### DIFF
--- a/docs/markdown/Using Pants/setting-up-an-ide.md
+++ b/docs/markdown/Using Pants/setting-up-an-ide.md
@@ -41,13 +41,13 @@ Assuming you are using the ["resolves" feature for Python lockfiles](doc:python-
 To use the `export` goal to create a virtualenv:
 
 ```
-❯ ./pants export --symlink-python-virtualenv --resolve=python-default
+❯ ./pants export --py-resolve-format=symlinked_immutable_virtualenv --resolve=python-default
 Wrote symlink to immutable virtualenv for python-default (using Python 3.9.13) to dist/export/python/virtualenvs/python-default
 ```
 
 You can specify the `--resolve` flag [multiple times](doc:options#list-values) to export multiple virtualenvs at once.
 
-The `--symlink-python-virtualenv` option symlinks to an immutable, internal virtualenv that does not have `pip` installed in it. This method is faster, but you must be careful not to attempt to modify the virtualenv. If you omit this flag, Pants will create a standalone, mutable virtualenv that includes `pip`, and that you can modify, but this method is slower.
+The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an immutable, internal virtualenv that does not have `pip` installed in it. This method is faster, but you must be careful not to attempt to modify the virtualenv. If you omit this flag, Pants will create a standalone, mutable virtualenv that includes `pip`, and that you can modify, but this method is slower.
 
 ### Tool virtualenvs
 

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -11,6 +11,7 @@ from typing import List, Mapping, MutableMapping
 
 import pytest
 
+from pants.backend.python.goals.export import PythonResolveExportFormat
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
 SOURCES = {
@@ -54,7 +55,7 @@ EXPORTED_TOOLS: List[_ToolConfig] = [
 ]
 
 
-def build_config(tmpdir: str, symlink_python_virtualenv: bool) -> Mapping:
+def build_config(tmpdir: str, py_resolve_format: PythonResolveExportFormat) -> Mapping:
     cfg: MutableMapping = {
         "GLOBAL": {
             "backend_packages": ["pants.backend.python"],
@@ -67,7 +68,7 @@ def build_config(tmpdir: str, symlink_python_virtualenv: bool) -> Mapping:
                 "b": f"{tmpdir}/3rdparty/b.lock",
             },
         },
-        "export": {"symlink_python_virtualenv": symlink_python_virtualenv},
+        "export": {"py_resolve_format": py_resolve_format.value},
     }
     for tool_config in EXPORTED_TOOLS:
         cfg[tool_config.name] = {
@@ -90,12 +91,18 @@ def build_config(tmpdir: str, symlink_python_virtualenv: bool) -> Mapping:
     return cfg
 
 
-@pytest.mark.parametrize("symlink_python_virtualenv", [False, True])
-def test_export(symlink_python_virtualenv: bool) -> None:
+@pytest.mark.parametrize(
+    "py_resolve_format",
+    [
+        PythonResolveExportFormat.mutable_virtualenv,
+        PythonResolveExportFormat.symlinked_immutable_virtualenv,
+    ],
+)
+def test_export(py_resolve_format: PythonResolveExportFormat) -> None:
     with setup_tmpdir(SOURCES) as tmpdir:
         run_pants(
             ["generate-lockfiles", "export", f"{tmpdir}/::"],
-            config=build_config(tmpdir, symlink_python_virtualenv),
+            config=build_config(tmpdir, py_resolve_format),
         ).assert_success()
 
     export_prefix = os.path.join("dist", "export", "python", "virtualenvs")
@@ -114,7 +121,7 @@ def test_export(symlink_python_virtualenv: bool) -> None:
 
     for tool_config in EXPORTED_TOOLS:
         export_dir = os.path.join(export_prefix, "tools", tool_config.name)
-        if symlink_python_virtualenv:
+        if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
             export_dir = os.path.join(export_dir, platform.python_version())
         assert os.path.isdir(export_dir), f"expected export dir '{export_dir}' does not exist"
 


### PR DESCRIPTION
Currently supports our existing formats: symlinked immutable virtualenv and mutable virtualenv.

This allows us to add more formats in the future, such as emitting a requirements.txt, as requested in #17721.

Replaces the symlink_python_virtualenv option, which is now deprecated.