### PR TITLE
Set up release tag mapping workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,13 +23,6 @@ jobs:
     - name: Create Release -> Commit Mapping
       run: 'tag="${{ steps.determine-tag.outputs.release-tag }}"
 
-
-        # Tricky syntax, but correct. The literal suffix `^{commit}` gets
-
-        # the sha of the commit object that is the tag''s target (as opposed
-
-        # to the sha of the tag object itself).
-
         commit="$(git rev-parse ${tag}^{commit})"
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+# GENERATED, DO NOT EDIT!
+# To change, edit `build-support/bin/generate_github_workflows.py` and run:
+#   ./pants run build-support/bin/generate_github_workflows.py
+
+
+jobs:
+  publish-tag-to-commit-mapping:
+    if: github.repository_owner == 'pantsbuild'
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        TAG: ${{ github.event.inputs.tag }}
+      id: determine-tag
+      name: Determine Release Tag
+      run: "if [[ -n \"$TAG\" ]]; then\n    tag=\"$TAG\"\nelse\n    tag=\"${GITHUB_REF#refs/tags/}\"\
+        \nfi\nif [[ \"${tag}\" =~ ^release_.+$ ]]; then\n    echo \"release-tag=${tag}\"\
+        \ >> $GITHUB_OUTPUT\nelse\n    echo \"::error::Release tag '${tag}' must match\
+        \ 'release_.+'.\"\n    exit 1\nfi\n"
+    - name: Checkout Pants at Release Tag
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ steps.determine-tag.outputs.release-tag }}
+    - name: Create Release -> Commit Mapping
+      run: 'tag="${{ steps.determine-tag.outputs.release-tag }}"
+
+
+        # Tricky syntax, but correct. The literal suffix `^{commit}` gets
+
+        # the sha of the commit object that is the tag''s target (as opposed
+
+        # to the sha of the tag object itself).
+
+        commit="$(git rev-parse ${tag}^{commit})"
+
+
+        echo "Recording tag ${tag} is of commit ${commit}"
+
+        mkdir -p dist/deploy/tags/pantsbuild.pants
+
+        echo "${commit}" > "dist/deploy/tags/pantsbuild.pants/${tag}"
+
+        '
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+      name: Deploy to S3
+      run: ./build-support/bin/deploy_to_s3.py
+name: Record Release Commit
+'on':
+  push:
+    tags:
+    - release_*
+  workflow_dispatch:
+    inputs:
+      tag:
+        required: true
+        type: string

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -835,21 +835,21 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 {
                     "name": "Create Release -> Commit Mapping",
                     # N.B.: The "literal suffix" mentioned below will only be the actual correct
-                    # literal syntax on rendering of the comment out in GHA - confusing. That
-                    # literal suffix syntax is `^{commit}`.
+                    # literal syntax on rendering of the yaml document - confusing. That literal
+                    # suffix syntax is `^{commit}`.
                     "run": dedent(
                         f"""\
-                            tag="{gha_expr("steps.determine-tag.outputs.release-tag")}"
+                        tag="{gha_expr("steps.determine-tag.outputs.release-tag")}"
 
-                            # Tricky syntax, but correct. The literal suffix `^{{commit}}` gets
-                            # the sha of the commit object that is the tag's target (as opposed
-                            # to the sha of the tag object itself).
-                            commit="$(git rev-parse ${{tag}}^{{commit}})"
+                        # Tricky syntax, but correct. The literal suffix `^{{commit}}` gets
+                        # the sha of the commit object that is the tag's target (as opposed
+                        # to the sha of the tag object itself).
+                        commit="$(git rev-parse ${{tag}}^{{commit}})"
 
-                            echo "Recording tag ${{tag}} is of commit ${{commit}}"
-                            mkdir -p dist/deploy/tags/pantsbuild.pants
-                            echo "${{commit}}" > "dist/deploy/tags/pantsbuild.pants/${{tag}}"
-                            """
+                        echo "Recording tag ${{tag}} is of commit ${{commit}}"
+                        mkdir -p dist/deploy/tags/pantsbuild.pants
+                        echo "${{commit}}" > "dist/deploy/tags/pantsbuild.pants/${{tag}}"
+                        """
                     ),
                 },
                 deploy_to_s3(

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -834,16 +834,14 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 },
                 {
                     "name": "Create Release -> Commit Mapping",
-                    # N.B.: The "literal suffix" mentioned below will only be the actual correct
-                    # literal syntax on rendering of the yaml document - confusing. That literal
-                    # suffix syntax is `^{commit}`.
+                    # The `git rev-parse` subshell below is used to obtain the tagged commit sha.
+                    # The syntax it uses is tricky, but correct. The literal suffix `^{commit}` gets
+                    # the sha of the commit object that is the tag's target (as opposed to the sha
+                    # of the tag object itself). Due to Python f-strings, the nearness of shell
+                    # ${VAR} syntax to it and the ${{ github }} syntax ... this is a confusing read.
                     "run": dedent(
                         f"""\
                         tag="{gha_expr("steps.determine-tag.outputs.release-tag")}"
-
-                        # Tricky syntax, but correct. The literal suffix `^{{commit}}` gets
-                        # the sha of the commit object that is the tag's target (as opposed
-                        # to the sha of the tag object itself).
                         commit="$(git rev-parse ${{tag}}^{{commit}})"
 
                         echo "Recording tag ${{tag}} is of commit ${{commit}}"

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -240,11 +240,11 @@ def install_go() -> Step:
     }
 
 
-def deploy_to_s3() -> Step:
+def deploy_to_s3(when: str = "github.event_name == 'push'") -> Step:
     return {
         "name": "Deploy to S3",
         "run": "./build-support/bin/deploy_to_s3.py",
-        "if": "github.event_name == 'push'",
+        "if": when,
         "env": {
             "AWS_SECRET_ACCESS_KEY": f"{gha_expr('secrets.AWS_SECRET_ACCESS_KEY')}",
             "AWS_ACCESS_KEY_ID": f"{gha_expr('secrets.AWS_ACCESS_KEY_ID')}",
@@ -799,6 +799,69 @@ def cache_comparison_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
     return jobs, cc_inputs
 
 
+def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
+    inputs, env = workflow_dispatch_inputs([WorkflowInput("TAG", "string")])
+
+    jobs = {
+        "publish-tag-to-commit-mapping": {
+            "runs-on": "ubuntu-latest",
+            "if": IS_PANTS_OWNER,
+            "steps": [
+                {
+                    "name": "Determine Release Tag",
+                    "id": "determine-tag",
+                    "env": env,
+                    "run": dedent(
+                        """\
+                        if [[ -n "$TAG" ]]; then
+                            tag="$TAG"
+                        else
+                            tag="${GITHUB_REF#refs/tags/}"
+                        fi
+                        if [[ "${tag}" =~ ^release_.+$ ]]; then
+                            echo "release-tag=${tag}" >> $GITHUB_OUTPUT
+                        else
+                            echo "::error::Release tag '${tag}' must match 'release_.+'."
+                            exit 1
+                        fi
+                        """
+                    ),
+                },
+                {
+                    "name": "Checkout Pants at Release Tag",
+                    "uses": "actions/checkout@v3",
+                    "with": {"ref": f"{gha_expr('steps.determine-tag.outputs.release-tag')}"},
+                },
+                {
+                    "name": "Create Release -> Commit Mapping",
+                    # N.B.: The "literal suffix" mentioned below will only be the actual correct
+                    # literal syntax on rendering of the comment out in GHA - confusing. That
+                    # literal suffix syntax is `^{commit}`.
+                    "run": dedent(
+                        f"""\
+                            tag="{gha_expr("steps.determine-tag.outputs.release-tag")}"
+
+                            # Tricky syntax, but correct. The literal suffix `^{{commit}}` gets
+                            # the sha of the commit object that is the tag's target (as opposed
+                            # to the sha of the tag object itself).
+                            commit="$(git rev-parse ${{tag}}^{{commit}})"
+
+                            echo "Recording tag ${{tag}} is of commit ${{commit}}"
+                            mkdir -p dist/deploy/tags/pantsbuild.pants
+                            echo "${{commit}}" > "dist/deploy/tags/pantsbuild.pants/${{tag}}"
+                            """
+                    ),
+                },
+                deploy_to_s3(
+                    when="github.event_name == 'push' || github.event_name == 'workflow_dispatch'"
+                ),
+            ],
+        }
+    }
+
+    return jobs, inputs
+
+
 # ----------------------------------------------------------------------
 # Main file
 # ----------------------------------------------------------------------
@@ -975,12 +1038,26 @@ def generate() -> dict[Path, str]:
         Dumper=NoAliasDumper,
     )
 
+    release_jobs, release_inputs = release_jobs_and_inputs()
+    release_yaml = yaml.dump(
+        {
+            "name": "Record Release Commit",
+            "on": {
+                "push": {"tags": ["release_*"]},
+                "workflow_dispatch": {"inputs": release_inputs},
+            },
+            "jobs": release_jobs,
+        },
+        Dumper=NoAliasDumper,
+    )
+
     return {
         Path(".github/workflows/audit.yaml"): f"{HEADER}\n\n{audit_yaml}",
         Path(".github/workflows/cache_comparison.yaml"): f"{HEADER}\n\n{cache_comparison_yaml}",
         Path(".github/workflows/cancel.yaml"): f"{HEADER}\n\n{cancel_yaml}",
         Path(".github/workflows/test.yaml"): f"{HEADER}\n\n{test_yaml}",
         Path(".github/workflows/test-cron.yaml"): f"{HEADER}\n\n{test_cron_yaml}",
+        Path(".github/workflows/release.yaml"): f"{HEADER}\n\n{release_yaml}",
     }
 
 


### PR DESCRIPTION
This will establish an
`https://binaries.pantsbuild.org/tags/pantsbuild.pants/release_*` file
for each `release_*` tag pushed. The file will contain the tagged
commit's sha for use by `scie-pants` in setting up the proper
`--find-links` repo for the purposes of installing that Pants version.

After manually running this workflow for a few old release tags, an
automated backfill (seperate script forthcoming) will be run.

See commentary in https://github.com/pantsbuild/scie-pants/pull/1