### PR TITLE
Get rid of _ToolLockfileMixin.

### DIFF
--- a/docs/markdown/Python/python/python-third-party-dependencies.md
+++ b/docs/markdown/Python/python/python-third-party-dependencies.md
@@ -348,6 +348,8 @@ lockfile = "3rdparty/pytest_lockfile.txt"
 
 You can also run `./pants generate-lockfiles --resolve=tool`, e.g. `--resolve=flake8`, to only generate that tool's lockfile rather than generating all lockfiles.
 
+Some tools, such as Flake8 and Bandit, need to run on an interpreter compatible with the code they operate on. In this case the tool may not have its own `interpreter_constraints` option, and its lockfile must be compatible with your code's interpreter constraints.
+
 To disable lockfiles entirely for a tool, set `[tool].lockfile = "<none>"` for that tool. Although we do not recommend this!
 
 ### Manually generating lockfiles

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -79,7 +79,6 @@ class Pylint(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.lint.pylint", "pylint.lock")
     default_lockfile_path = "src/python/pants/backend/python/lint/pylint/pylint.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    uses_requirements_from_source_plugins = True
 
     skip = SkipOption("lint")
     args = ArgsListOption(example="--ignore=foo.py,bar.py --disable=C0330,W0311")

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -49,7 +49,6 @@ class PythonToolRequirementsBase(Subsystem):
     register_lockfile: ClassVar[bool] = False
     default_lockfile_resource: ClassVar[tuple[str, str] | None] = None
     default_lockfile_url: ClassVar[str | None] = None
-    uses_requirements_from_source_plugins: ClassVar[bool] = False
 
     version = StrOption(
         advanced=True,
@@ -163,8 +162,6 @@ class PythonToolRequirementsBase(Subsystem):
                 ),
                 lockfile_hex_digest=hex_digest,
                 resolve_name=self.options_scope,
-                uses_project_interpreter_constraints=(not self.register_interpreter_constraints),
-                uses_source_plugins=self.uses_requirements_from_source_plugins,
             )
         else:
             lockfile = ToolCustomLockfile(
@@ -172,8 +169,6 @@ class PythonToolRequirementsBase(Subsystem):
                 file_path_description_of_origin=f"the option `[{self.options_scope}].lockfile`",
                 lockfile_hex_digest=hex_digest,
                 resolve_name=self.options_scope,
-                uses_project_interpreter_constraints=(not self.register_interpreter_constraints),
-                uses_source_plugins=self.uses_requirements_from_source_plugins,
             )
         return EntireLockfile(lockfile, complete_req_strings=tuple(requirements))
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -105,7 +105,6 @@ class MyPy(PythonToolBase):
     default_lockfile_resource = ("pants.backend.python.typecheck.mypy", "mypy.lock")
     default_lockfile_path = "src/python/pants/backend/python/typecheck/mypy/mypy.lock"
     default_lockfile_url = git_url(default_lockfile_path)
-    uses_requirements_from_source_plugins = True
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--python-version 3.7 --disallow-any-expr")
@@ -224,8 +223,6 @@ class MyPy(PythonToolBase):
                 ),
                 lockfile_hex_digest=calculate_invalidation_digest(self.extra_type_stubs),
                 resolve_name=MyPyExtraTypeStubsLockfileSentinel.resolve_name,
-                uses_project_interpreter_constraints=True,
-                uses_source_plugins=False,
             )
             requirements = EntireLockfile(tool_lockfile, complete_req_strings=self.extra_type_stubs)
         return PexRequest(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -58,18 +58,12 @@ class LockfileContent:
 
 
 @dataclass(frozen=True)
-class _ToolLockfileMixin:
-    uses_source_plugins: bool
-    uses_project_interpreter_constraints: bool
-
-
-@dataclass(frozen=True)
-class ToolDefaultLockfile(LockfileContent, _ToolLockfileMixin):
+class ToolDefaultLockfile(LockfileContent):
     pass
 
 
 @dataclass(frozen=True)
-class ToolCustomLockfile(Lockfile, _ToolLockfileMixin):
+class ToolCustomLockfile(Lockfile):
     pass
 
 
@@ -563,12 +557,11 @@ def _invalid_tool_lockfile_error(
         yield softwrap(
             f"""
             - You have set different requirements than those used to generate the lockfile.
-            You can fix this by updating `[{tool_name}].version`
+            You can fix this by updating `[{tool_name}].version`,
+            `[{tool_name}].extra_requirements`, and/or
+            `[{tool_name}].source_plugins` (if applicable), or by using a new custom lockfile.
             """
-        )
-        if lockfile.uses_source_plugins:
-            yield f", `[{tool_name}].source_plugins`,"
-        yield f" and/or `[{tool_name}].extra_requirements`, or by using a new custom lockfile.\n"
+        ) + "\n"
         if isinstance(metadata, PythonLockfileMetadataV2):
             not_in_user_reqs = metadata.requirements - user_requirements
             not_in_lock = user_requirements - metadata.requirements
@@ -593,19 +586,8 @@ def _invalid_tool_lockfile_error(
             f"""
             - You have set interpreter constraints (`{user_interpreter_constraints}`) that
             are not compatible with those used to generate the lockfile
-            (`{metadata.valid_for_interpreter_constraints}`).
-            """
-        )
-        yield softwrap(
-            f"""
-            You can fix this by not setting `[{tool_name}].interpreter_constraints`,
-            or by using a new custom lockfile.
-            """
-        ) if not lockfile.uses_project_interpreter_constraints else softwrap(
-            f"""
-            `{tool_name}` determines its interpreter constraints based on your code's own
-            constraints. To fix this error, you can either change your code's constraints
-            (see {doc_url('python-interpreter-compatibility')}) or generate a new
+            (`{metadata.valid_for_interpreter_constraints}`). You can fix this by adjusting
+            `[{tool_name}].interpreter_constraints` (if applicable), or by generating a new
             custom lockfile.
             """
         )

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -484,7 +484,7 @@ def validate_metadata(
     msg = "".join(msg_iter).strip()
     if python_setup.invalid_lockfile_behavior == InvalidLockfileBehavior.error:
         raise InvalidLockfileError(msg)
-    logger.warning("%s", msg)
+    logger.warning(msg)
 
 
 def _common_failure_reasons(
@@ -560,6 +560,7 @@ def _invalid_tool_lockfile_error(
             You can fix this by updating `[{tool_name}].version`,
             `[{tool_name}].extra_requirements`, and/or
             `[{tool_name}].source_plugins` (if applicable), or by using a new custom lockfile.
+            See {doc_url('python-third-party-dependencies')} for details.
             """
         ) + "\n"
         if isinstance(metadata, PythonLockfileMetadataV2):
@@ -588,7 +589,7 @@ def _invalid_tool_lockfile_error(
             are not compatible with those used to generate the lockfile
             (`{metadata.valid_for_interpreter_constraints}`). You can fix this by adjusting
             `[{tool_name}].interpreter_constraints` (if applicable), or by generating a new
-            custom lockfile.
+            custom lockfile. See {doc_url('python-third-party-dependencies')} for details.
             """
         )
         yield "\n\n"


### PR DESCRIPTION
Its fields were only used to generate more elaborate error messages. However we can finesse those messages without that information.

This is a step on the road to greater unification of tool and user lockfiles. Very slightly more generic error messages seems like the right tradeoff.