### PR TITLE
Unify validation of tool and user lockfile metadata.

### DIFF
--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -76,7 +76,6 @@ class PythonLockfileMetadata(LockfileMetadata):
     def is_valid_for(
         self,
         *,
-        is_tool: bool,
         expected_invalidation_digest: str | None,
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
@@ -122,7 +121,6 @@ class PythonLockfileMetadataV1(PythonLockfileMetadata):
     def is_valid_for(
         self,
         *,
-        is_tool: bool,
         expected_invalidation_digest: str | None,
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
@@ -192,7 +190,6 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
     def is_valid_for(
         self,
         *,
-        is_tool: bool,
         expected_invalidation_digest: str | None,  # Not used by V2.
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
@@ -204,13 +201,7 @@ class PythonLockfileMetadataV2(PythonLockfileMetadata):
         no_binary: Iterable[str],
     ) -> LockfileMetadataValidation:
         failure_reasons = set()
-
-        invalid_reqs = (
-            self.requirements != set(user_requirements)
-            if is_tool
-            else not set(user_requirements).issubset(self.requirements)
-        )
-        if invalid_reqs:
+        if not set(user_requirements).issubset(self.requirements):
             failure_reasons.add(InvalidPythonLockfileReason.REQUIREMENTS_MISMATCH)
 
         if not self.valid_for_interpreter_constraints.contains(
@@ -273,7 +264,6 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
     def is_valid_for(
         self,
         *,
-        is_tool: bool,
         expected_invalidation_digest: str | None,  # Validation digests are not used by V2.
         user_interpreter_constraints: InterpreterConstraints,
         interpreter_universe: Iterable[str],
@@ -286,7 +276,6 @@ class PythonLockfileMetadataV3(PythonLockfileMetadataV2):
         failure_reasons = (
             super()
             .is_valid_for(
-                is_tool=is_tool,
                 expected_invalidation_digest=expected_invalidation_digest,
                 user_interpreter_constraints=user_interpreter_constraints,
                 interpreter_universe=interpreter_universe,

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -470,7 +470,6 @@ def validate_metadata(
     # TODO(#12314): Improve the exception if invalid strings
     user_requirements = {PipRequirement.parse(i) for i in consumed_req_strings}
     validation = metadata.is_valid_for(
-        is_tool=isinstance(lockfile, (ToolCustomLockfile, ToolDefaultLockfile)),
         expected_invalidation_digest=lockfile.lockfile_hex_digest,
         user_interpreter_constraints=interpreter_constraints,
         interpreter_universe=python_setup.interpreter_versions_universe,


### PR DESCRIPTION
The only distinction was that user requirements only had to be a subset of the requirements the lockfile was generated for, while tool requirements had to be identical. But that distinction is not significant - a tool will run fine if it is just a subset of a larger lockfile, so there is no need to be extra strict in this case.

This not only allows us to reduce complexity, but may also be useful. For example, it paves the way to using a user lockfile that includes pytest as the lockfile for running pytest, thus avoiding having to update pytest versions in two places.