### PR TITLE
go: support the `go test` profiling options

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -540,6 +540,7 @@ async def run_go_tests(
 
     output_files = []
     maybe_profile_args = []
+    output_test_runner = False
 
     if test_subsystem.use_coverage:
         maybe_profile_args.append("-test.coverprofile=cover.out")
@@ -548,18 +549,22 @@ async def run_go_tests(
     if go_test_subsystem.block_profile:
         maybe_profile_args.append("-test.blockprofile=block.out")
         output_files.append("block.out")
+        output_test_runner = True
 
     if go_test_subsystem.cpu_profile:
         maybe_profile_args.append("-test.cpuprofile=cpu.out")
         output_files.append("cpu.out")
+        output_test_runner = True
 
     if go_test_subsystem.mem_profile:
         maybe_profile_args.append("-test.memprofile=mem.out")
         output_files.append("mem.out")
+        output_test_runner = True
 
     if go_test_subsystem.mutex_profile:
         maybe_profile_args.append("-test.mutexprofile=mutex.out")
         output_files.append("mutex.out")
+        output_test_runner = True
 
     if go_test_subsystem.trace:
         maybe_profile_args.append("-test.trace=trace.out")
@@ -596,7 +601,12 @@ async def run_go_tests(
     output_files = [x for x in output_files if x != "cover.out"]
     extra_output: Snapshot | None = None
     if output_files:
-        extra_output = await Get(Snapshot, Digest, result.output_digest)
+        output_digest = result.output_digest
+        if output_test_runner:
+            output_digest = await Get(
+                Digest, MergeDigests([output_digest, test_binary.test_binary_digest])
+            )
+        extra_output = await Get(Snapshot, Digest, output_digest)
 
     return TestResult.from_fallible_process_result(
         process_result=result,

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -540,7 +540,7 @@ async def run_go_tests(
 
     output_files = []
     maybe_profile_args = []
-    output_test_runner = False
+    output_test_binary = go_test_subsystem.output_test_binary
 
     if test_subsystem.use_coverage:
         maybe_profile_args.append("-test.coverprofile=cover.out")
@@ -549,22 +549,22 @@ async def run_go_tests(
     if go_test_subsystem.block_profile:
         maybe_profile_args.append("-test.blockprofile=block.out")
         output_files.append("block.out")
-        output_test_runner = True
+        output_test_binary = True
 
     if go_test_subsystem.cpu_profile:
         maybe_profile_args.append("-test.cpuprofile=cpu.out")
         output_files.append("cpu.out")
-        output_test_runner = True
+        output_test_binary = True
 
     if go_test_subsystem.mem_profile:
         maybe_profile_args.append("-test.memprofile=mem.out")
         output_files.append("mem.out")
-        output_test_runner = True
+        output_test_binary = True
 
     if go_test_subsystem.mutex_profile:
         maybe_profile_args.append("-test.mutexprofile=mutex.out")
         output_files.append("mutex.out")
-        output_test_runner = True
+        output_test_binary = True
 
     if go_test_subsystem.trace:
         maybe_profile_args.append("-test.trace=trace.out")
@@ -600,9 +600,9 @@ async def run_go_tests(
 
     output_files = [x for x in output_files if x != "cover.out"]
     extra_output: Snapshot | None = None
-    if output_files:
+    if output_files or output_test_binary:
         output_digest = result.output_digest
-        if output_test_runner:
+        if output_test_binary:
             output_digest = await Get(
                 Digest, MergeDigests([output_digest, test_binary.test_binary_digest])
             )

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -604,6 +604,7 @@ async def run_go_tests(
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,
         extra_output=extra_output,
+        log_extra_output=True,
     )
 
 

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -48,7 +48,7 @@ from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
-from pants.engine.internals.native_engine import EMPTY_DIGEST
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Snapshot
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
@@ -594,15 +594,16 @@ async def run_go_tests(
         )
 
     output_files = [x for x in output_files if x != "cover.out"]
+    extra_output: Snapshot | None = None
     if output_files:
-        # TODO: What is the best way to arrange for these files to be output?
-        pass
+        extra_output = await Get(Snapshot, Digest, result.output_digest)
 
     return TestResult.from_fallible_process_result(
         process_result=result,
         address=field_set.address,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,
+        extra_output=extra_output,
     )
 
 

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -806,3 +806,13 @@ def test_profile_options_write_results(rule_runner: RuleRunner) -> None:
     )
     assert result.exit_code == 0
     assert "PASS: TestAdd" in result.stdout
+
+    extra_output = result.extra_output
+    assert extra_output is not None
+    assert sorted(extra_output.files) == [
+        "block.out",
+        "cpu.out",
+        "mem.out",
+        "mutex.out",
+        "trace.out",
+    ]

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -814,5 +814,6 @@ def test_profile_options_write_results(rule_runner: RuleRunner) -> None:
         "cpu.out",
         "mem.out",
         "mutex.out",
+        "test_runner",
         "trace.out",
     ]

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -789,15 +789,17 @@ def test_profile_options_write_results(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-    rule_runner.set_options([
-        "--go-test-args=-v -bench=.",
-        "--go-test-block-profile",
-        "--go-test-cpu-profile",
-        "--go-test-mem-profile",
-        "--go-test-mutex-profile",
-        "--go-test-trace",
-
-    ], env_inherit={"PATH"})
+    rule_runner.set_options(
+        [
+            "--go-test-args=-v -bench=.",
+            "--go-test-block-profile",
+            "--go-test-cpu-profile",
+            "--go-test-mem-profile",
+            "--go-test-mutex-profile",
+            "--go-test-trace",
+        ],
+        env_inherit={"PATH"},
+    )
     tgt = rule_runner.get_target(Address("foo"))
     result = rule_runner.request(
         TestResult, [GoTestRequest.Batch("", (GoTestFieldSet.create(tgt),), None)]

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -168,6 +168,78 @@ class GoTestSubsystem(Subsystem):
         ),
     )
 
+    _profile_output_dir = StrOption(
+        default=str(PurePath("{distdir}", "go", "profiles", "{target_spec}")),
+        advanced=True,
+        help=softwrap(
+            """
+            Path to write the Go test profiling reports to. Must be relative to the build root.
+
+            Replacements:
+
+            - `{distdir}` is replaced with the Pants `distdir`.
+
+            - `{target_spec}` is replaced with the address of the applicable `go_package` target with `/`
+            characters replaced with dots (`.`).
+
+            - `{import_path}` is replaced with the applicable package's import path. Subdirectories will be made
+            for any path components separated by `/` characters.
+            """
+        ),
+    )
+
+    block_profile = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Capture a goroutine blocking profile from the execution of the test runner. Writes the profile to
+            the file `block.out` in the directory set by the `[go-test].profile_output_dir` option.
+            """
+        ),
+    )
+
+    cpu_profile = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Capture a CPU profile from the execution of the test runner. Writes the profile to the file `cpu.out`
+            in the directory set by the `[go-test].profile_output_dir` option.
+            """
+        ),
+    )
+
+    mem_profile = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Capture an allocation profile from the execution of the test runner after tests have passed.
+            Writes the profile to the file `mem.out` in the directory set by the `[go-test].profile_output_dir`
+            option.
+            """
+        ),
+    )
+
+    mutex_profile = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Capture a mutex contention profile from the execution of the test runner when all tests are
+            complete. Writes the profile to the file `mem.out` in the directory set by the
+            `[go-test].profile_output_dir` option.
+            """
+        ),
+    )
+
+    trace = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Capture an execution trace from the execution of the test runner. Writes the trace to the file
+            `trace.out` in the directory set by the `[go-test].profile_output_dir` option.
+            """
+        ),
+    )
+
     def coverage_output_dir(self, distdir: DistDir, address: Address, import_path: str) -> PurePath:
         target_spec = address.spec_path.replace(os.sep, ".")
         import_path_escaped = import_path.replace("/", "_")
@@ -177,5 +249,14 @@ class GoTestSubsystem(Subsystem):
                 target_spec=target_spec,
                 import_path=import_path,
                 import_path_escaped=import_path_escaped,
+            )
+        )
+
+    def profile_output_dir(self, distdir: DistDir, address: Address, import_path: str) -> PurePath:
+        return PurePath(
+            self._coverage_output_dir.format(
+                distdir=distdir.relpath,
+                target_spec=address.spec_path.replace(os.sep, "."),
+                import_path=import_path,
             )
         )

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -173,7 +173,9 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             """
             Capture a goroutine blocking profile from the execution of the test runner. The profile will be written
-            to the file `block.out` in the test extra output directory.
+            to the file `block.out` in the test extra output directory. The test binary will also be written to
+            the test extra output directory.
+
             """
         ),
     )
@@ -183,7 +185,8 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             """
             Capture a CPU profile from the execution of the test runner. The profile will be written to the
-            file `cpu.out` in the test extra output directory.
+            file `cpu.out` in the test extra output directory. The test binary will also be written to the
+            test extra output directory.
             """
         ),
     )
@@ -194,6 +197,7 @@ class GoTestSubsystem(Subsystem):
             """
             Capture an allocation profile from the execution of the test runner after tests have passed.
             The profile will be written to the file `mem.out` in the test extra output directory.
+            The test binary will also be written to the test extra output directory.
             """
         ),
     )
@@ -204,6 +208,7 @@ class GoTestSubsystem(Subsystem):
             """
             Capture a mutex contention profile from the execution of the test runner when all tests are
             complete. The profile will be written to the file `mem.out` in the test extra output directory.
+            The test binary will also be written to the test extra output directory.
             """
         ),
     )
@@ -216,6 +221,18 @@ class GoTestSubsystem(Subsystem):
             file `trace.out` in the test extra output directory.
             """
         ),
+    )
+
+    output_test_binary = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Write the test binary to the test extra output directory.
+
+            This is similar to the `go test -c` option.
+            """
+        ),
+        advanced=True,
     )
 
     def coverage_output_dir(self, distdir: DistDir, address: Address, import_path: str) -> PurePath:

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -168,32 +168,12 @@ class GoTestSubsystem(Subsystem):
         ),
     )
 
-    _profile_output_dir = StrOption(
-        default=str(PurePath("{distdir}", "go", "profiles", "{target_spec}")),
-        advanced=True,
-        help=softwrap(
-            """
-            Path to write the Go test profiling reports to. Must be relative to the build root.
-
-            Replacements:
-
-            - `{distdir}` is replaced with the Pants `distdir`.
-
-            - `{target_spec}` is replaced with the address of the applicable `go_package` target with `/`
-            characters replaced with dots (`.`).
-
-            - `{import_path}` is replaced with the applicable package's import path. Subdirectories will be made
-            for any path components separated by `/` characters.
-            """
-        ),
-    )
-
     block_profile = BoolOption(
         default=False,
         help=softwrap(
             """
-            Capture a goroutine blocking profile from the execution of the test runner. Writes the profile to
-            the file `block.out` in the directory set by the `[go-test].profile_output_dir` option.
+            Capture a goroutine blocking profile from the execution of the test runner. The profile will be written
+            to the file `block.out` in the test extra output directory.
             """
         ),
     )
@@ -202,8 +182,8 @@ class GoTestSubsystem(Subsystem):
         default=False,
         help=softwrap(
             """
-            Capture a CPU profile from the execution of the test runner. Writes the profile to the file `cpu.out`
-            in the directory set by the `[go-test].profile_output_dir` option.
+            Capture a CPU profile from the execution of the test runner. The profile will be written to the
+            file `cpu.out` in the test extra output directory.
             """
         ),
     )
@@ -213,8 +193,7 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             """
             Capture an allocation profile from the execution of the test runner after tests have passed.
-            Writes the profile to the file `mem.out` in the directory set by the `[go-test].profile_output_dir`
-            option.
+            The profile will be written to the file `mem.out` in the test extra output directory.
             """
         ),
     )
@@ -224,8 +203,7 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             """
             Capture a mutex contention profile from the execution of the test runner when all tests are
-            complete. Writes the profile to the file `mem.out` in the directory set by the
-            `[go-test].profile_output_dir` option.
+            complete. The profile will be written to the file `mem.out` in the test extra output directory.
             """
         ),
     )
@@ -234,8 +212,8 @@ class GoTestSubsystem(Subsystem):
         default=False,
         help=softwrap(
             """
-            Capture an execution trace from the execution of the test runner. Writes the trace to the file
-            `trace.out` in the directory set by the `[go-test].profile_output_dir` option.
+            Capture an execution trace from the execution of the test runner. The trace will be written to the
+            file `trace.out` in the test extra output directory.
             """
         ),
     )
@@ -249,14 +227,5 @@ class GoTestSubsystem(Subsystem):
                 target_spec=target_spec,
                 import_path=import_path,
                 import_path_escaped=import_path_escaped,
-            )
-        )
-
-    def profile_output_dir(self, distdir: DistDir, address: Address, import_path: str) -> PurePath:
-        return PurePath(
-            self._coverage_output_dir.format(
-                distdir=distdir.relpath,
-                target_spec=address.spec_path.replace(os.sep, "."),
-                import_path=import_path,
             )
         )

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -207,7 +207,7 @@ class GoTestSubsystem(Subsystem):
         help=softwrap(
             """
             Capture a mutex contention profile from the execution of the test runner when all tests are
-            complete. The profile will be written to the file `mem.out` in the test extra output directory.
+            complete. The profile will be written to the file `mutex.out` in the test extra output directory.
             The test binary will also be written to the test extra output directory.
             """
         ),

--- a/src/python/pants/backend/go/subsystems/gotest.py
+++ b/src/python/pants/backend/go/subsystems/gotest.py
@@ -229,7 +229,7 @@ class GoTestSubsystem(Subsystem):
             """
             Write the test binary to the test extra output directory.
 
-            This is similar to the `go test -c` option.
+            This is similar to the `go test -c` option, but will still run the underlying test.
             """
         ),
         advanced=True,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -861,7 +861,9 @@ async def run_tests(
                 path_prefix=path_prefix,
             )
             if result.log_extra_output:
-                logger.info(f"Wrote extra output from test `{result.addresses[0]}` to `{path_prefix}`.")
+                logger.info(
+                    f"Wrote extra output from test `{result.addresses[0]}` to `{path_prefix}`."
+                )
 
     if test_subsystem.report:
         report_dir = test_subsystem.report_dir(distdir)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -93,6 +93,8 @@ class TestResult(EngineAwareReturnType):
     xml_results: Snapshot | None = None
     # Any extra output (such as from plugins) that the test runner was configured to output.
     extra_output: Snapshot | None = None
+    # True if the core test rules should log that extra output was written.
+    log_extra_output: bool = False
 
     # Prevent this class from being detected by pytest as a test class.
     __test__ = False
@@ -137,6 +139,7 @@ class TestResult(EngineAwareReturnType):
         coverage_data: CoverageData | None = None,
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
+        log_extra_output: bool = False,
     ) -> TestResult:
         return TestResult(
             exit_code=process_result.exit_code,
@@ -150,6 +153,7 @@ class TestResult(EngineAwareReturnType):
             coverage_data=coverage_data,
             xml_results=xml_results,
             extra_output=extra_output,
+            log_extra_output=log_extra_output,
         )
 
     @staticmethod
@@ -161,6 +165,7 @@ class TestResult(EngineAwareReturnType):
         coverage_data: CoverageData | None = None,
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
+        log_extra_output: bool = False,
     ) -> TestResult:
         return TestResult(
             exit_code=process_result.exit_code,
@@ -174,6 +179,7 @@ class TestResult(EngineAwareReturnType):
             coverage_data=coverage_data,
             xml_results=xml_results,
             extra_output=extra_output,
+            log_extra_output=log_extra_output,
             partition_description=batch.partition_metadata.description,
         )
 
@@ -849,10 +855,13 @@ async def run_tests(
         console.print_stderr(_format_test_summary(result, run_id, console))
 
         if result.extra_output and result.extra_output.files:
+            path_prefix = str(distdir.relpath / "test" / result.path_safe_description)
             workspace.write_digest(
                 result.extra_output.digest,
-                path_prefix=str(distdir.relpath / "test" / result.path_safe_description),
+                path_prefix=path_prefix,
             )
+            if result.log_extra_output:
+                logger.info(f"Wrote extra output from test `{result.addresses[0]}` to `{path_prefix}`.")
 
     if test_subsystem.report:
         report_dir = test_subsystem.report_dir(distdir)


### PR DESCRIPTION
Support the `go test` profiling options which take various profiles of a test run (e.g., CPU, memory, etc.). The profiles are output via the `extra_output` field on `TestResult`. Also includes the ability to export the compiled test binary (which is needed for analysis of some of the profiles).

Closes https://github.com/pantsbuild/pants/issues/16610.