### PR TITLE
Choose distinct debug adapter ports in different tests.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -175,6 +175,7 @@ extra_requirements.add = [
   "pygments",
 ]
 lockfile = "3rdparty/python/pytest.lock"
+execution_slot_var = "TEST_EXECUTION_SLOT"
 
 [test]
 extra_env_vars = [

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -108,6 +108,9 @@ def _configure_pytest_runner(
     args = [
         "--backend-packages=pants.backend.python",
         f"--source-root-patterns={SOURCE_ROOT}",
+        # NB: Each test file that tests the debug adapter should pick a unique port
+        #  so that different test files can run concurrently without port collisions.
+        "--debug-adapter-port=22335",
         *(extra_args or ()),
     ]
     rule_runner.set_options(args, env=env, env_inherit={"PATH", "PYENV_ROOT", "HOME"})

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -40,7 +40,6 @@ from pants.core.goals.test import (
     build_runtime_package_dependencies,
     get_filtered_environment,
 )
-from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules import config_files, distdir
 from pants.core.util_rules.partitions import Partitions
 from pants.engine.addresses import Address
@@ -49,6 +48,7 @@ from pants.engine.process import InteractiveProcessResult
 from pants.engine.rules import Get, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.testutil.debug_adapter_util import debugadapter_port_for_testing
 from pants.testutil.python_interpreter_selection import (
     all_major_minor_python_versions,
     skip_unless_python27_and_python3_present,
@@ -109,7 +109,7 @@ def _configure_pytest_runner(
     args = [
         "--backend-packages=pants.backend.python",
         f"--source-root-patterns={SOURCE_ROOT}",
-        f"--debug-adapter-port={DebugAdapterSubsystem.port_for_testing()}",
+        f"--debug-adapter-port={debugadapter_port_for_testing()}",
         *(extra_args or ()),
     ]
     rule_runner.set_options(args, env=env, env_inherit={"PATH", "PYENV_ROOT", "HOME"})

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -40,6 +40,7 @@ from pants.core.goals.test import (
     build_runtime_package_dependencies,
     get_filtered_environment,
 )
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules import config_files, distdir
 from pants.core.util_rules.partitions import Partitions
 from pants.engine.addresses import Address
@@ -108,9 +109,7 @@ def _configure_pytest_runner(
     args = [
         "--backend-packages=pants.backend.python",
         f"--source-root-patterns={SOURCE_ROOT}",
-        # NB: Each test file that tests the debug adapter should pick a unique port
-        #  so that different test files can run concurrently without port collisions.
-        "--debug-adapter-port=22335",
+        f"--debug-adapter-port={DebugAdapterSubsystem.port_for_testing()}",
         *(extra_args or ()),
     ]
     rule_runner.set_options(args, env=env, env_inherit={"PATH", "PYENV_ROOT", "HOME"})

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -186,6 +186,9 @@ def test_run_sample_script(
         "--backend-packages=pants.backend.python",
         "--backend-packages=pants.backend.codegen.protobuf.python",
         "--source-root-patterns=['src_root1', 'src_root2']",
+        # NB: Each test file that tests the debug adapter should pick a unique port
+        #  so that different test files can run concurrently without port collisions.
+        "--debug-adapter-port=22334",
         *(
             (
                 "--python-default-run-goal-use-sandbox"

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -34,10 +34,10 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules import local_dists, pex_from_targets
 from pants.build_graph.address import Address
 from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
-from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
+from pants.testutil.debug_adapter_util import debugadapter_port_for_testing
 from pants.testutil.pants_integration_test import run_pants
 from pants.testutil.rule_runner import RuleRunner, mock_console
 
@@ -187,7 +187,7 @@ def test_run_sample_script(
         "--backend-packages=pants.backend.python",
         "--backend-packages=pants.backend.codegen.protobuf.python",
         "--source-root-patterns=['src_root1', 'src_root2']",
-        f"--debug-adapter-port={DebugAdapterSubsystem.port_for_testing()}",
+        f"--debug-adapter-port={debugadapter_port_for_testing()}",
         *(
             (
                 "--python-default-run-goal-use-sandbox"

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -34,6 +34,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules import local_dists, pex_from_targets
 from pants.build_graph.address import Address
 from pants.core.goals.run import RunDebugAdapterRequest, RunRequest
+from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
@@ -186,9 +187,7 @@ def test_run_sample_script(
         "--backend-packages=pants.backend.python",
         "--backend-packages=pants.backend.codegen.protobuf.python",
         "--source-root-patterns=['src_root1', 'src_root2']",
-        # NB: Each test file that tests the debug adapter should pick a unique port
-        #  so that different test files can run concurrently without port collisions.
-        "--debug-adapter-port=22334",
+        f"--debug-adapter-port={DebugAdapterSubsystem.port_for_testing()}",
         *(
             (
                 "--python-default-run-goal-use-sandbox"

--- a/src/python/pants/core/subsystems/debug_adapter.py
+++ b/src/python/pants/core/subsystems/debug_adapter.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 from pants.option.option_types import IntOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
@@ -23,3 +25,13 @@ class DebugAdapterSubsystem(Subsystem):
         default=5678,
         help="The port to use when launching the server.",
     )
+
+    @staticmethod
+    def port_for_testing() -> int:
+        """Return a custom port we can use in Pants's own tests to avoid collisions.
+
+        Assumes that the env var TEST_EXECUTION_SLOT has been set. If not, all tests will use the
+        same port, and collisions may occur.
+        """
+        execution_slot = os.environ.get("TEST_EXECUTION_SLOT", "0")
+        return 22000 + int(execution_slot)

--- a/src/python/pants/core/subsystems/debug_adapter.py
+++ b/src/python/pants/core/subsystems/debug_adapter.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import os
-
 from pants.option.option_types import IntOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
@@ -25,13 +23,3 @@ class DebugAdapterSubsystem(Subsystem):
         default=5678,
         help="The port to use when launching the server.",
     )
-
-    @staticmethod
-    def port_for_testing() -> int:
-        """Return a custom port we can use in Pants's own tests to avoid collisions.
-
-        Assumes that the env var TEST_EXECUTION_SLOT has been set. If not, all tests will use the
-        same port, and collisions may occur.
-        """
-        execution_slot = os.environ.get("TEST_EXECUTION_SLOT", "0")
-        return 22000 + int(execution_slot)

--- a/src/python/pants/testutil/debug_adapter_util.py
+++ b/src/python/pants/testutil/debug_adapter_util.py
@@ -1,0 +1,16 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+
+
+def debugadapter_port_for_testing() -> int:
+    """Return a unique-per-concurrent-process debug adapter port.
+
+    Use this in Pants's (and plugins') own tests to avoid collisions.
+
+    Assumes that the env var TEST_EXECUTION_SLOT has been set. If not, all tests
+    will use the same port, and collisions may occur.
+    """
+    execution_slot = os.environ.get("TEST_EXECUTION_SLOT", "0")
+    return 22000 + int(execution_slot)


### PR DESCRIPTION
Prevents a port collision error if the two test files happen to run concurrently.

Prior to this change I was sometimes getting this error in one or both tests:

`Can't listen for client connections: [Errno 48] Address already in use`