### PR TITLE
Unify the messages for lockfile validation errors.

### DIFF
--- a/docs/markdown/Writing Plugins/target-api/target-api-concepts.md
+++ b/docs/markdown/Writing Plugins/target-api/target-api-concepts.md
@@ -132,7 +132,7 @@ This subclass mechanism is key to how the Target API behaves:
 Synthetic Targets API
 ---------------------
 
-Normally targets are declared in BUILD files to provide meta data about the project's sources and artifacts etc. Occassionally there may be instances of project meta data that is not served well by being declared explicitly in a BUILD file, for instance if the meta data itself is inferred from other sources of information. For these cases, there is a Target API for declaring synthetic targets, that is targets that are not declared in a BUILD file on disk but instead come from a Plugin's rule.
+Normally targets are declared in BUILD files to provide metadata about the project's sources and artifacts etc. Occassionally there may be instances of project metadata that is not served well by being declared explicitly in a BUILD file, for instance if the metadata itself is inferred from other sources of information. For these cases, there is a Target API for declaring synthetic targets, that is targets that are not declared in a BUILD file on disk but instead come from a Plugin's rule.
 
 ### Example
 


### PR DESCRIPTION
Now the same error message applies whether the lockfile is a user or tool lockfile. 
This is a step on the road to unifying the two concepts.

Note that these error messages also further clarify the distinction between how a 
lockfile was generated vs how it is used:

Today only a lockfile generated from tool requirements can be used to later satisfy 
that tool's requirements, so the concept of a "tool lockfile" is well-defined. 
But in the future we'll want to, e.g., allow you to use your python-default lockfile 
to provide pytest, so you don't have to configure pytest requirements in two places. 
So this is a lockfile generated from user inputs being used to satisfy tool requirements. 
In this world the concept of "tool lockfile" is no longer clear.

This PR also includes a tiny docs tweak that didn't justify its own PR.