### PR TITLE
Remove the ToolCustomLockfile/ToolDefaultLockfile classes.

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -13,9 +13,9 @@ from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
     LoadedLockfileRequest,
+    Lockfile,
+    LockfileContent,
     PexRequirements,
-    ToolCustomLockfile,
-    ToolDefaultLockfile,
 )
 from pants.core.goals.generate_lockfiles import DEFAULT_TOOL_LOCKFILE, NO_TOOL_LOCKFILE
 from pants.core.util_rules.lockfile_metadata import calculate_invalidation_digest
@@ -152,10 +152,10 @@ class PythonToolRequirementsBase(Subsystem):
 
         hex_digest = calculate_invalidation_digest(requirements)
 
-        lockfile: ToolDefaultLockfile | ToolCustomLockfile
+        lockfile: LockfileContent | Lockfile
         if self.lockfile == DEFAULT_TOOL_LOCKFILE:
             assert self.default_lockfile_resource is not None
-            lockfile = ToolDefaultLockfile(
+            lockfile = LockfileContent(
                 file_content=FileContent(
                     f"{self.options_scope}_default.lock",
                     importlib.resources.read_binary(*self.default_lockfile_resource),
@@ -164,7 +164,7 @@ class PythonToolRequirementsBase(Subsystem):
                 resolve_name=self.options_scope,
             )
         else:
-            lockfile = ToolCustomLockfile(
+            lockfile = Lockfile(
                 file_path=self.lockfile,
                 file_path_description_of_origin=f"the option `[{self.options_scope}].lockfile`",
                 lockfile_hex_digest=hex_digest,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -32,8 +32,8 @@ from pants.backend.python.util_rules.partition import (
 from pants.backend.python.util_rules.pex import PexRequest
 from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
+    Lockfile,
     PexRequirements,
-    ToolCustomLockfile,
 )
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -216,7 +216,7 @@ class MyPy(PythonToolBase):
         if self.extra_type_stubs_lockfile == NO_TOOL_LOCKFILE:
             requirements = PexRequirements(self.extra_type_stubs)
         else:
-            tool_lockfile = ToolCustomLockfile(
+            tool_lockfile = Lockfile(
                 file_path=self.extra_type_stubs_lockfile,
                 file_path_description_of_origin=(
                     f"the option `[{self.options_scope}].extra_type_stubs_lockfile`"

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -62,16 +62,6 @@ class LockfileContent:
 
 
 @dataclass(frozen=True)
-class ToolDefaultLockfile(LockfileContent):
-    pass
-
-
-@dataclass(frozen=True)
-class ToolCustomLockfile(Lockfile):
-    pass
-
-
-@dataclass(frozen=True)
 class LoadedLockfile:
     """A lockfile after loading and header stripping.
 


### PR DESCRIPTION
They are no longer needed. We can use vanilla Lockfile/LockfileContent.