### PR TITLE
Make JVM sources runnable

### DIFF
--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -22,6 +22,7 @@ from pants.jvm.target_types import (
     JunitTestTimeoutField,
     JvmDependenciesField,
     JvmJdkField,
+    JvmMainClassNameField,
     JvmProvidesTypesField,
     JvmResolveField,
     JvmRunnableSourceFieldSet,
@@ -112,6 +113,7 @@ class JavaSourceTarget(Target):
         JvmDependenciesField,
         JavaSourceField,
         JvmResolveField,
+        JvmMainClassNameField,
         JvmProvidesTypesField,
         JvmJdkField,
     )
@@ -137,6 +139,7 @@ class JavaSourcesGeneratorTarget(TargetFilesGenerator):
         JvmDependenciesField,
         JvmResolveField,
         JvmJdkField,
+        JvmMainClassNameField,
         JvmProvidesTypesField,
     )
     help = "Generate a `java_source` target for each file in the `sources` field."

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -24,6 +24,7 @@ from pants.jvm.target_types import (
     JvmJdkField,
     JvmProvidesTypesField,
     JvmResolveField,
+    JvmRunnableSourceFieldSet,
 )
 
 
@@ -36,7 +37,7 @@ class JavaGeneratorSourcesField(MultipleSourcesField):
 
 
 @dataclass(frozen=True)
-class JavaFieldSet(FieldSet):
+class JavaFieldSet(JvmRunnableSourceFieldSet):
     required_fields = (JavaSourceField,)
 
     sources: JavaSourceField
@@ -145,4 +146,6 @@ def rules():
     return [
         *collect_rules(),
         *jvm_target_types.rules(),
+        *JavaFieldSet.rules(),
+        *JavaFieldSet.run_request_rules(),
     ]

--- a/src/python/pants/backend/java/target_types.py
+++ b/src/python/pants/backend/java/target_types.py
@@ -146,6 +146,5 @@ def rules():
     return [
         *collect_rules(),
         *jvm_target_types.rules(),
-        *JavaFieldSet.rules(),
-        *JavaFieldSet.run_request_rules(),
+        *JavaFieldSet.jvm_rules(),
     ]

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
@@ -234,7 +233,5 @@ class KotlincPluginTarget(Target):
 
 def rules():
     return [
-        *KotlinFieldSet.rules(),
-        *KotlinFieldSet.run_request_rules(),
-        *collect_rules(),
+        *KotlinFieldSet.jvm_rules(),
     ]

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -26,6 +26,7 @@ from pants.jvm.target_types import (
     JvmJdkField,
     JvmProvidesTypesField,
     JvmResolveField,
+    JvmRunnableSourceFieldSet,
 )
 from pants.util.strutil import softwrap
 
@@ -56,7 +57,7 @@ class KotlincConsumedPluginIdsField(StringSequenceField):
 
 
 @dataclass(frozen=True)
-class KotlinFieldSet(FieldSet):
+class KotlinFieldSet(JvmRunnableSourceFieldSet):
     required_fields = (KotlinSourceField,)
 
     sources: KotlinSourceField
@@ -232,4 +233,8 @@ class KotlincPluginTarget(Target):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *KotlinFieldSet.rules(),
+        *KotlinFieldSet.run_request_rules(),
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -23,6 +23,7 @@ from pants.jvm.target_types import (
     JunitTestSourceField,
     JunitTestTimeoutField,
     JvmJdkField,
+    JvmMainClassNameField,
     JvmProvidesTypesField,
     JvmResolveField,
     JvmRunnableSourceFieldSet,
@@ -88,6 +89,7 @@ class KotlinSourceTarget(Target):
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
+        JvmMainClassNameField,
     )
     help = "A single Kotlin source file containing application or library code."
 
@@ -113,6 +115,7 @@ class KotlinSourcesGeneratorTarget(TargetFilesGenerator):
         JvmResolveField,
         JvmJdkField,
         JvmProvidesTypesField,
+        JvmMainClassNameField,
     )
     help = "Generate a `kotlin_source` target for each file in the `sources` field."
 

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -39,6 +39,7 @@ from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.strip_jar.strip_jar import StripJarRequest
 from pants.jvm.subsystems import JvmSubsystem
+from pants.jvm.target_types import NO_MAIN_CLASS
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -188,7 +189,7 @@ async def compile_scala_source(
                 # NB: We set a non-existent main-class so that using `-d` produces a `jar` manifest
                 # with stable content.
                 "-Xmain-class",
-                "no.main.class",
+                NO_MAIN_CLASS,
                 "-d",
                 output_file,
                 *sorted(

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -32,6 +32,7 @@ from pants.jvm.target_types import (
     JunitTestSourceField,
     JunitTestTimeoutField,
     JvmJdkField,
+    JvmMainClassNameField,
     JvmProvidesTypesField,
     JvmResolveField,
     JvmRunnableSourceFieldSet,
@@ -259,6 +260,7 @@ class ScalaSourceTarget(Target):
         JvmResolveField,
         JvmProvidesTypesField,
         JvmJdkField,
+        JvmMainClassNameField,
     )
     help = "A single Scala source file containing application or library code."
 
@@ -306,6 +308,7 @@ class ScalaSourcesGeneratorTarget(TargetFilesGenerator):
         ScalaConsumedPluginNamesField,
         JvmResolveField,
         JvmJdkField,
+        JvmMainClassNameField,
         JvmProvidesTypesField,
     )
     settings_request_cls = ScalaSettingsRequest

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -360,7 +360,6 @@ def rules():
     return (
         *collect_rules(),
         *jvm_target_types.rules(),
-        *ScalaFieldSet.rules(),
-        *ScalaFieldSet.run_request_rules(),
+        *ScalaFieldSet.jvm_rules(),
         UnionRule(TargetFilesGeneratorSettingsRequest, ScalaSettingsRequest),
     )

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -34,6 +34,7 @@ from pants.jvm.target_types import (
     JvmJdkField,
     JvmProvidesTypesField,
     JvmResolveField,
+    JvmRunnableSourceFieldSet,
 )
 from pants.util.strutil import softwrap
 
@@ -82,7 +83,7 @@ class ScalaConsumedPluginNamesField(StringSequenceField):
 
 
 @dataclass(frozen=True)
-class ScalaFieldSet(FieldSet):
+class ScalaFieldSet(JvmRunnableSourceFieldSet):
     required_fields = (ScalaSourceField,)
 
     sources: ScalaSourceField
@@ -359,5 +360,7 @@ def rules():
     return (
         *collect_rules(),
         *jvm_target_types.rules(),
+        *ScalaFieldSet.rules(),
+        *ScalaFieldSet.run_request_rules(),
         UnionRule(TargetFilesGeneratorSettingsRequest, ScalaSettingsRequest),
     )

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -9,7 +9,17 @@ from abc import ABCMeta
 from dataclasses import dataclass
 from enum import Enum
 from itertools import filterfalse, tee
-from typing import Callable, ClassVar, Iterable, Mapping, NamedTuple, Optional, Tuple, TypeVar
+from typing import (
+    Callable,
+    ClassVar,
+    Iterable,
+    Mapping,
+    NamedTuple,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import final
 
@@ -27,6 +37,7 @@ from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import (
     Effect,
     Get,
+    Rule,
     _uncacheable_rule,
     collect_rules,
     goal_rule,
@@ -91,7 +102,7 @@ class RunFieldSet(FieldSet, metaclass=ABCMeta):
 
     @final
     @classmethod
-    def rules(cls) -> Iterable:
+    def rules(cls) -> Iterable[Union[Rule, UnionRule]]:
         yield UnionRule(RunFieldSet, cls)
         if not cls.supports_debug_adapter:
             yield from _unsupported_debug_adapter_rules(cls)

--- a/src/python/pants/jvm/jvm_common.py
+++ b/src/python/pants/jvm/jvm_common.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.jvm import classpath, jdk_rules, resources, run
+from pants.jvm import classpath, jdk_rules, resources, run, run_deploy_jar
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.dependency_inference import symbol_mapper
 from pants.jvm.goals import lockfile
@@ -39,6 +39,7 @@ def rules():
         *jdk_rules.rules(),
         *jvm_tool.rules(),
         *run.rules(),
+        *run_deploy_jar.rules(),
         *war_rules(),
     ]
 

--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -50,6 +50,7 @@ class DeployJarFieldSet(PackageFieldSet, RunFieldSet):
         JvmMainClassNameField,
         JvmJdkField,
         Dependencies,
+        OutputPathField,
     )
     run_in_sandbox_behavior = RunInSandboxBehavior.RUN_REQUEST_HERMETIC
 

--- a/src/python/pants/jvm/run.py
+++ b/src/python/pants/jvm/run.py
@@ -7,7 +7,6 @@ import logging
 import re
 from typing import Iterable, Optional, Tuple
 
-from pants.core.goals.package import BuiltPackage
 from pants.core.goals.run import RunRequest
 from pants.core.util_rules.system_binaries import UnzipBinary
 from pants.core.util_rules.system_binaries import rules as system_binaries_rules
@@ -20,42 +19,10 @@ from pants.jvm.classpath import Classpath
 from pants.jvm.classpath import rules as classpath_rules
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.jdk_rules import rules as jdk_rules
-from pants.jvm.package.deploy_jar import DeployJarFieldSet
-from pants.jvm.package.deploy_jar import rules as deploy_jar_rules
 from pants.jvm.target_types import NO_MAIN_CLASS, GenericJvmRunRequest
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
-
-
-@rule(level=LogLevel.DEBUG)
-async def create_deploy_jar_run_request(
-    field_set: DeployJarFieldSet,
-) -> RunRequest:
-
-    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(field_set.jdk_version))
-
-    main_class = field_set.main_class.value
-    assert main_class is not None
-
-    package = await Get(BuiltPackage, DeployJarFieldSet, field_set)
-    assert len(package.artifacts) == 1
-    jar_path = package.artifacts[0].relpath
-    assert jar_path is not None
-
-    proc = await Get(
-        Process,
-        JvmProcess(
-            jdk=jdk,
-            classpath_entries=[f"{{chroot}}/{jar_path}"],
-            argv=(main_class,),
-            input_digest=package.digest,
-            description=f"Run {main_class}.main(String[])",
-            use_nailgun=False,
-        ),
-    )
-
-    return _post_process_jvm_process(proc, jdk)
 
 
 @rule_helper
@@ -235,8 +202,6 @@ def _post_process_jvm_process(proc: Process, jdk: JdkEnvironment) -> RunRequest:
 def rules():
     return [
         *collect_rules(),
-        *DeployJarFieldSet.rules(),
-        *deploy_jar_rules(),
         *system_binaries_rules(),
         *jdk_rules(),
         *classpath_rules(),

--- a/src/python/pants/jvm/run.py
+++ b/src/python/pants/jvm/run.py
@@ -1,17 +1,20 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import logging
-from typing import Iterable
+import re
+from typing import Iterable, Optional, Tuple
 
 from pants.core.goals.package import BuiltPackage
 from pants.core.goals.run import RunRequest
 from pants.core.util_rules.system_binaries import UnzipBinary
 from pants.core.util_rules.system_binaries import rules as system_binaries_rules
 from pants.engine.addresses import Addresses
-from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.native_engine import Digest, MergeDigests, Snapshot
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule, rule_helper
 from pants.engine.target import CoarsenedTargets
 from pants.jvm.classpath import Classpath
 from pants.jvm.classpath import rules as classpath_rules
@@ -55,6 +58,104 @@ async def create_deploy_jar_run_request(
     return _post_process_jvm_process(proc, jdk)
 
 
+@rule_helper
+async def _find_main(
+    unzip: UnzipBinary, jdk: JdkEnvironment, input_digest: Digest, jarfile: str
+) -> str:
+    # Find the `main` method, first by inspecting the manifest, and then by inspecting the index
+    # of the included classes.
+
+    main_from_manifest = await _find_main_by_manifest(unzip, input_digest, jarfile)
+
+    if main_from_manifest:
+        return main_from_manifest
+
+    mains_from_javap = await _find_main_by_javap(unzip, jdk, input_digest, jarfile)
+
+    if len(mains_from_javap) == 0:
+        raise Exception(
+            f"Could not find a `public static void main(String[])` method in `{jarfile}`"
+        )
+    if len(mains_from_javap) > 1:
+        raise Exception(f"Found multiple classes that provide `main` methods in `{jarfile}`.")
+
+    return mains_from_javap[0]
+
+
+@rule_helper
+async def _find_main_by_manifest(
+    unzip: UnzipBinary, input_digest: Digest, jarfile: str
+) -> Optional[str]:
+    # jvm only allows `-cp` or `-jar` to be specified, and `-jar` takes precedence. So, even for a
+    # JAR with a valid `Main-Class` in the manifest, we need to peek inside the manifest and
+    # extract `main` ourself.
+    manifest = await Get(
+        ProcessResult,
+        Process(
+            description="Get manifest destails from classpath",
+            argv=(unzip.path, "-p", jarfile, "META-INF/MANIFEST.MF"),
+            input_digest=input_digest,
+        ),
+    )
+
+    main_class_lines = [
+        r.strip()
+        for _, is_main, r in (
+            i.partition("Main-Class:") for i in manifest.stdout.decode().splitlines()
+        )
+        if is_main
+    ]
+
+    return main_class_lines[0] if main_class_lines else None
+
+
+@rule_helper
+async def _find_main_by_javap(
+    unzip: UnzipBinary, jdk: JdkEnvironment, input_digest: Digest, jarfile: str
+) -> Tuple[str, ...]:
+    # Finds the `main` class by inspecting all of the classes inside the specified JAR
+    # to find one with a JVM main method.
+
+    first_jar_contents = await Get(
+        ProcessResult,
+        Process(
+            description=f"Get class files from `{jarfile}` to find `main`",
+            argv=(unzip.path, jarfile, "*.class", "-d", "zip_output"),
+            input_digest=input_digest,
+            output_directories=("zip_output",),
+        ),
+    )
+
+    outputs = await Get(Snapshot, Digest, first_jar_contents.output_digest)
+
+    class_index = await Get(
+        ProcessResult,
+        JvmProcess(
+            jdk=jdk,
+            classpath_entries=[f"{jdk.java_home}/lib/tools.jar"],
+            argv=[
+                "com.sun.tools.javap.Main",
+                *("-cp", jarfile),
+                *outputs.files,
+            ],
+            input_digest=first_jar_contents.output_digest,
+            description=f"Index class files in `{jarfile}` to find `main`",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    output = class_index.stdout.decode()
+    p = re.compile(r"^public class (.*?) .*?{(.*?)}$", flags=re.MULTILINE | re.DOTALL)
+    classes: list[tuple[str, str]] = re.findall(p, output)
+    mains = tuple(
+        classname
+        for classname, definition in classes
+        if "public static void main(java.lang.String[])" in definition
+    )
+
+    return mains
+
+
 @rule(level=LogLevel.DEBUG)
 async def create_jvm_artifact_run_request(
     field_set: JvmArtifactFieldSet,
@@ -70,29 +171,8 @@ async def create_jvm_artifact_run_request(
 
     input_digest = await Get(Digest, MergeDigests(classpath.digests()))
 
-    # Assume that the first entry is the artifact specified in `Addresses`?
-
-    # jvm only allows `-cp` or `-jar` to be specified, and `-jar` takes precedence. So, we need
-    # peek inside the JAR for the thing we want to run, and extract its `Main-Class` line from the
-    # manifest.
-    manifest = await Get(
-        ProcessResult,
-        Process(
-            description="Get manifest destails from classpath",
-            argv=(unzip.path, "-p", classpath_entries[0], "META-INF/MANIFEST.MF"),
-            input_digest=input_digest,
-        ),
-    )
-
-    main_class_line = [
-        r.strip()
-        for _, is_main, r in (
-            i.partition("Main-Class:") for i in manifest.stdout.decode().splitlines()
-        )
-        if is_main
-    ]
-    assert main_class_line
-    main_class = main_class_line[0]
+    # Assume that the first entry in `classpath_entries` is the artifact specified in `Addresses`?
+    main_class = await _find_main(unzip, jdk, input_digest, classpath_entries[0])
 
     proc = await Get(
         Process,

--- a/src/python/pants/jvm/run.py
+++ b/src/python/pants/jvm/run.py
@@ -182,7 +182,9 @@ async def create_run_request(
     input_digest = await Get(Digest, MergeDigests(classpath.digests()))
 
     # Assume that the first entry in `classpath_entries` is the artifact specified in `Addresses`?
-    main_class = await _find_main(unzip, jdk, input_digest, classpath_entries[0])
+    main_class = field_set.main_class.value
+    if main_class is None:
+        main_class = await _find_main(unzip, jdk, input_digest, classpath_entries[0])
 
     proc = await Get(
         Process,

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -1,0 +1,61 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+
+from pants.core.goals.package import BuiltPackage
+from pants.core.goals.run import RunRequest
+from pants.core.util_rules.system_binaries import rules as system_binaries_rules
+from pants.engine.process import Process
+from pants.engine.rules import Get, collect_rules, rule
+from pants.jvm.classpath import rules as classpath_rules
+from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
+from pants.jvm.jdk_rules import rules as jdk_rules
+from pants.jvm.package.deploy_jar import DeployJarFieldSet
+from pants.jvm.package.deploy_jar import rules as deploy_jar_rules
+from pants.jvm.run import _post_process_jvm_process
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@rule(level=LogLevel.DEBUG)
+async def create_deploy_jar_run_request(
+    field_set: DeployJarFieldSet,
+) -> RunRequest:
+
+    jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(field_set.jdk_version))
+
+    main_class = field_set.main_class.value
+    assert main_class is not None
+
+    package = await Get(BuiltPackage, DeployJarFieldSet, field_set)
+    assert len(package.artifacts) == 1
+    jar_path = package.artifacts[0].relpath
+    assert jar_path is not None
+
+    proc = await Get(
+        Process,
+        JvmProcess(
+            jdk=jdk,
+            classpath_entries=[f"{{chroot}}/{jar_path}"],
+            argv=(main_class,),
+            input_digest=package.digest,
+            description=f"Run {main_class}.main(String[])",
+            use_nailgun=False,
+        ),
+    )
+
+    return _post_process_jvm_process(proc, jdk)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *DeployJarFieldSet.rules(),
+        *deploy_jar_rules(),
+        *system_binaries_rules(),
+        *jdk_rules(),
+        *classpath_rules(),
+    ]

--- a/src/python/pants/jvm/run_integration_test.py
+++ b/src/python/pants/jvm/run_integration_test.py
@@ -53,7 +53,7 @@ def antlr_jvm_lockfile(
     return antlr_jvm_lockfile_def.load(request)
 
 
-def test_java() -> None:
+def test_java_by_deploy_jar() -> None:
     sources = {
         "src/org/pantsbuild/test/Hello.java": dedent(
             """\
@@ -92,7 +92,41 @@ def test_java() -> None:
         assert result.stdout.strip() == "Hello, World!"
 
 
-def test_scala(scala_stdlib_jvm_lockfile: JVMLockfileFixture) -> None:
+def test_java_direct() -> None:
+    sources = {
+        "src/org/pantsbuild/test/Hello.java": dedent(
+            """\
+            package org.pantsbuild.test;
+
+            public class Hello {{
+                public static void main(String[] args) {{
+                    System.out.println("Hello, World!");
+                }}
+            }}
+            """
+        ),
+        "src/org/pantsbuild/test/BUILD": dedent(
+            """\
+            java_sources()
+            """
+        ),
+        "lockfile": EMPTY_RESOLVE,
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=pants.backend.experimental.java",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "--pants-ignore=__pycache__",
+            f'--jvm-resolves={{"empty": "{tmpdir}/lockfile"}}',
+            "--jvm-default-resolve=empty",
+            "run",
+            f"{tmpdir}/src/org/pantsbuild/test/Hello.java",
+        ]
+        result = run_pants(args)
+        assert result.stdout.strip() == "Hello, World!"
+
+
+def test_scala_by_deploy_jar(scala_stdlib_jvm_lockfile: JVMLockfileFixture) -> None:
     sources = {
         "src/org/pantsbuild/test/Hello.scala": dedent(
             """\
@@ -131,6 +165,45 @@ def test_scala(scala_stdlib_jvm_lockfile: JVMLockfileFixture) -> None:
             "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
             "run",
             f"{tmpdir}/src/org/pantsbuild/test:test_deploy_jar",
+        ]
+        result = run_pants(args)
+        assert result.stdout.strip() == "Hello, World!"
+
+
+def test_scala_direct(scala_stdlib_jvm_lockfile: JVMLockfileFixture) -> None:
+    sources = {
+        "src/org/pantsbuild/test/Hello.scala": dedent(
+            """\
+            package org.pantsbuild.test;
+
+            object Hello {{
+                def main(args: Array[String]): Unit = {{
+                    println("Hello, World!")
+                }}
+            }}
+
+            """
+        ),
+        "src/org/pantsbuild/test/BUILD": dedent(
+            """\
+            scala_sources()
+            """
+        ),
+        "BUILD": scala_stdlib_jvm_lockfile.requirements_as_jvm_artifact_targets(),
+        "lockfile": scala_stdlib_jvm_lockfile.serialized_lockfile.replace("{", "{{").replace(
+            "}", "}}"
+        ),
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=pants.backend.experimental.scala",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "--pants-ignore=__pycache__",
+            f'--jvm-resolves={{"jvm-default": "{tmpdir}/lockfile"}}',
+            "--jvm-default-resolve=jvm-default",
+            "--scala-version-for-resolve={'jvm-default': '2.13.8'}",
+            "run",
+            f"{tmpdir}/src/org/pantsbuild/test/Hello.scala",
         ]
         result = run_pants(args)
         assert result.stdout.strip() == "Hello, World!"

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -97,10 +97,26 @@ class PrefixedJvmResolveField(JvmResolveField):
 NO_MAIN_CLASS = "org.pantsbuild.meta.no.main.class"
 
 
+class JvmMainClassNameField(StringField):
+    alias = "main"
+    required = False
+    default = None
+    help = softwrap(
+        """
+        `.`-separated name of the JVM class containing the `main()` method to be called when
+        executing this target. If not supplied, this will be calculated automatically, either by
+        inspecting the existing manifest (for 3rd-party JARs), or by inspecting the classes inside
+        the JAR, looking for a valid `main` method.  If a value cannot be calculated automatically,
+        you must supply a value for `run` to succeed.
+        """
+    )
+
+
 @dataclass(frozen=True)
 class JvmRunnableSourceFieldSet(RunFieldSet):
     run_in_sandbox_behavior = RunInSandboxBehavior.RUN_REQUEST_HERMETIC
     jdk_version: JvmJdkField
+    main_class: JvmMainClassNameField
 
     @classmethod
     def jvm_rules(cls) -> Iterable[Union[Rule, UnionRule]]:
@@ -312,6 +328,7 @@ class JvmArtifactTarget(Target):
         JvmArtifactResolveField,
         JvmArtifactExcludeDependenciesField,
         JvmJdkField,
+        JvmMainClassNameField,
     )
     help = softwrap(
         """
@@ -355,9 +372,9 @@ class JunitTestExtraEnvVarsField(TestExtraEnvVarsField):
 # -----------------------------------------------------------------------------------------------
 
 
-class JvmMainClassNameField(StringField):
-    alias = "main"
+class JvmRequiredMainClassNameField(JvmMainClassNameField):
     required = True
+    default = None
     help = softwrap(
         """
         `.`-separated name of the JVM class containing the `main()` method to be called when
@@ -665,7 +682,7 @@ class DeployJarTarget(Target):
         RestartableField,
         OutputPathField,
         JvmDependenciesField,
-        JvmMainClassNameField,
+        JvmRequiredMainClassNameField,
         JvmJdkField,
         JvmResolveField,
         DeployJarDuplicatePolicyField,


### PR DESCRIPTION
This adds `./pants run`/`experimental_run_in_sandbox` support for more JVM targets without needing to explicitly declare a `deploy_jar`. It does that by adapting the existing `jvm_artifact` rule, which was already fairly generic thanks to the use of `ClasspathEntryRequest` rules.

The rules will attempt to automatically find a `main` method through either a JAR manifest (as before for `jvm_artifact`) or by directly inspecting the contents of the classpath entry JAR returned from compilation. This also permits explicitly declaring a `main` method in case the other approaches are inconclusive.