### PR TITLE
Make export cleanup a subset of `dist/export`, not the whole thing

### DIFF
--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -148,7 +148,9 @@ async def export(
         Get(Digest, AddPrefix(result.digest, result.reldir)) for result in flattened_results
     )
     output_dir = os.path.join(str(dist_dir.relpath), "export")
-    safe_rmtree(output_dir)
+    for result in flattened_results:
+        digest_root = os.path.join(build_root.path, output_dir, result.reldir)
+        safe_rmtree(digest_root)
     merged_digest = await Get(Digest, MergeDigests(prefixed_digests))
     dist_digest = await Get(Digest, AddPrefix(merged_digest, output_dir))
     workspace.write_digest(dist_digest)


### PR DESCRIPTION
This is prep work for re-submitting (or re-opening) #17711. This makes `./pants export --resolve=...` match my expectations (see https://github.com/pantsbuild/pants/pull/17711#issuecomment-1336795750):

> I thought it only deleted the export for a particular resolve. I was wrong, or I was remembering from when I tested a long time ago. https://github.com/pantsbuild/pants/pull/15068 made it delete the entire `dist/export` directory before each export. So you have to know a priori exactly which virtualenvs you will need. You can't add them ad-hoc like I thought.

With this PR, it only removes the exported venvs for the requested resolves, not any previously exported venvs. This way you can request one tool or resolve at a time, without clobbering your previous exports.