### PR TITLE
DRYs up JVM subsystem registration code

### DIFF
--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -14,30 +14,16 @@ from pants.backend.java.target_types import (
 )
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import archive
-from pants.jvm import classpath, jdk_rules, resources, run
-from pants.jvm import util_rules as jvm_util_rules
-from pants.jvm.dependency_inference import symbol_mapper
-from pants.jvm.goals import lockfile
-from pants.jvm.jar_tool import jar_tool
-from pants.jvm.package import deploy_jar
-from pants.jvm.package.war import rules as war_rules
-from pants.jvm.resolve import coursier_fetch, jvm_tool
-from pants.jvm.shading.rules import rules as shading_rules
-from pants.jvm.strip_jar import strip_jar
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
-from pants.jvm.target_types import build_file_aliases as jvm_build_file_aliases
-from pants.jvm.test import junit
+from pants.jvm import common_rules
 
 
 def target_types():
     return [
-        DeployJarTarget,
         JavaSourceTarget,
         JavaSourcesGeneratorTarget,
         JunitTestTarget,
         JunitTestsGeneratorTarget,
-        JvmArtifactTarget,
-        JvmWarTarget,
+        *common_rules.target_types(),
     ]
 
 
@@ -45,29 +31,15 @@ def rules():
     return [
         *javac.rules(),
         *check.rules(),
-        *classpath.rules(),
-        *junit.rules(),
-        *strip_jar.rules(),
-        *shading_rules(),
-        *deploy_jar.rules(),
-        *jar_tool.rules(),
-        *lockfile.rules(),
-        *coursier_fetch.rules(),
         *java_parser.rules(),
-        *resources.rules(),
-        *symbol_mapper.rules(),
         *dependency_inference_rules.rules(),
         *tailor.rules(),
-        *jvm_util_rules.rules(),
-        *jdk_rules.rules(),
-        *target_types_rules(),
-        *jvm_tool.rules(),
-        *run.rules(),
-        *war_rules(),
         *java_bsp_rules.rules(),
         *archive.rules(),
+        *target_types_rules(),
+        *common_rules.rules(),
     ]
 
 
 def build_file_aliases():
-    return jvm_build_file_aliases()
+    return common_rules.build_file_aliases()

--- a/src/python/pants/backend/experimental/java/register.py
+++ b/src/python/pants/backend/experimental/java/register.py
@@ -14,7 +14,7 @@ from pants.backend.java.target_types import (
 )
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import archive
-from pants.jvm import common_rules
+from pants.jvm import jvm_common
 
 
 def target_types():
@@ -23,7 +23,7 @@ def target_types():
         JavaSourcesGeneratorTarget,
         JunitTestTarget,
         JunitTestsGeneratorTarget,
-        *common_rules.target_types(),
+        *jvm_common.target_types(),
     ]
 
 
@@ -37,9 +37,9 @@ def rules():
         *java_bsp_rules.rules(),
         *archive.rules(),
         *target_types_rules(),
-        *common_rules.rules(),
+        *jvm_common.rules(),
     ]
 
 
 def build_file_aliases():
-    return common_rules.build_file_aliases()
+    return jvm_common.build_file_aliases()

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -13,29 +13,17 @@ from pants.backend.kotlin.target_types import (
 from pants.backend.kotlin.target_types import rules as target_types_rules
 from pants.backend.kotlin.test.junit import rules as kotlin_junit_rules
 from pants.core.util_rules import source_files, system_binaries
-from pants.jvm import classpath, jdk_rules, resources, run
-from pants.jvm import util_rules as jvm_util_rules
-from pants.jvm.goals import lockfile
-from pants.jvm.jar_tool import jar_tool
-from pants.jvm.package import deploy_jar, war
-from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.shading.rules import rules as shading_rules
-from pants.jvm.strip_jar import strip_jar
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
-from pants.jvm.target_types import build_file_aliases as jvm_build_file_aliases
-from pants.jvm.test.junit import rules as jvm_junit_rules
+from pants.jvm import common_rules
 
 
 def target_types():
     return [
-        JvmArtifactTarget,
         KotlinSourceTarget,
         KotlinSourcesGeneratorTarget,
         KotlincPluginTarget,
         KotlinJunitTestTarget,
         KotlinJunitTestsGeneratorTarget,
-        DeployJarTarget,
-        JvmWarTarget,
+        *common_rules.target_types(),
     ]
 
 
@@ -45,28 +33,14 @@ def rules():
         *kotlinc_plugins.rules(),
         *check.rules(),
         *tailor.rules(),
-        *classpath.rules(),
-        *lockfile.rules(),
-        *coursier_fetch.rules(),
-        *coursier_setup.rules(),
-        *shading_rules(),
         *dep_inf_rules(),
-        *jvm_util_rules.rules(),
-        *jdk_rules.rules(),
         *target_types_rules(),
-        *jvm_tool.rules(),
-        *resources.rules(),
         *system_binaries.rules(),
         *source_files.rules(),
-        *strip_jar.rules(),
-        *deploy_jar.rules(),
-        *jar_tool.rules(),
-        *run.rules(),
-        *war.rules(),
-        *jvm_junit_rules(),
         *kotlin_junit_rules(),
+        *common_rules.rules(),
     ]
 
 
 def build_file_aliases():
-    return jvm_build_file_aliases()
+    return common_rules.build_file_aliases()

--- a/src/python/pants/backend/experimental/kotlin/register.py
+++ b/src/python/pants/backend/experimental/kotlin/register.py
@@ -13,7 +13,7 @@ from pants.backend.kotlin.target_types import (
 from pants.backend.kotlin.target_types import rules as target_types_rules
 from pants.backend.kotlin.test.junit import rules as kotlin_junit_rules
 from pants.core.util_rules import source_files, system_binaries
-from pants.jvm import common_rules
+from pants.jvm import jvm_common
 
 
 def target_types():
@@ -23,7 +23,7 @@ def target_types():
         KotlincPluginTarget,
         KotlinJunitTestTarget,
         KotlinJunitTestsGeneratorTarget,
-        *common_rules.target_types(),
+        *jvm_common.target_types(),
     ]
 
 
@@ -38,9 +38,9 @@ def rules():
         *system_binaries.rules(),
         *source_files.rules(),
         *kotlin_junit_rules(),
-        *common_rules.rules(),
+        *jvm_common.rules(),
     ]
 
 
 def build_file_aliases():
-    return common_rules.build_file_aliases()
+    return jvm_common.build_file_aliases()

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -16,25 +16,11 @@ from pants.backend.scala.target_types import (
 )
 from pants.backend.scala.target_types import rules as target_types_rules
 from pants.backend.scala.test import scalatest
-from pants.jvm import classpath, jdk_rules, resources, run
-from pants.jvm import util_rules as jvm_util_rules
-from pants.jvm.goals import lockfile
-from pants.jvm.jar_tool import jar_tool
-from pants.jvm.package import deploy_jar
-from pants.jvm.package.war import rules as war_rules
-from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.shading.rules import rules as shading_rules
-from pants.jvm.strip_jar import strip_jar
-from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
-from pants.jvm.target_types import build_file_aliases as jvm_build_file_aliases
-from pants.jvm.test import junit
+from pants.jvm import common_rules
 
 
 def target_types():
     return [
-        DeployJarTarget,
-        JvmArtifactTarget,
-        JvmWarTarget,
         ScalaJunitTestTarget,
         ScalaJunitTestsGeneratorTarget,
         ScalaSourceTarget,
@@ -42,6 +28,7 @@ def target_types():
         ScalacPluginTarget,
         ScalatestTestTarget,
         ScalatestTestsGeneratorTarget,
+        *common_rules.target_types(),
     ]
 
 
@@ -52,27 +39,13 @@ def rules():
         *check.rules(),
         *tailor.rules(),
         *repl.rules(),
-        *classpath.rules(),
-        *junit.rules(),
-        *strip_jar.rules(),
-        *shading_rules(),
-        *deploy_jar.rules(),
-        *jar_tool.rules(),
-        *lockfile.rules(),
-        *coursier_fetch.rules(),
-        *coursier_setup.rules(),
-        *jvm_util_rules.rules(),
-        *jdk_rules.rules(),
         *dep_inf_rules.rules(),
         *target_types_rules(),
-        *jvm_tool.rules(),
-        *resources.rules(),
-        *run.rules(),
         *scala_lockfile_rules(),
         *bsp_rules(),
-        *war_rules(),
+        *common_rules.rules(),
     ]
 
 
 def build_file_aliases():
-    return jvm_build_file_aliases()
+    return common_rules.build_file_aliases()

--- a/src/python/pants/backend/experimental/scala/register.py
+++ b/src/python/pants/backend/experimental/scala/register.py
@@ -16,7 +16,7 @@ from pants.backend.scala.target_types import (
 )
 from pants.backend.scala.target_types import rules as target_types_rules
 from pants.backend.scala.test import scalatest
-from pants.jvm import common_rules
+from pants.jvm import jvm_common
 
 
 def target_types():
@@ -28,7 +28,7 @@ def target_types():
         ScalacPluginTarget,
         ScalatestTestTarget,
         ScalatestTestsGeneratorTarget,
-        *common_rules.target_types(),
+        *jvm_common.target_types(),
     ]
 
 
@@ -43,9 +43,9 @@ def rules():
         *target_types_rules(),
         *scala_lockfile_rules(),
         *bsp_rules(),
-        *common_rules.rules(),
+        *jvm_common.rules(),
     ]
 
 
 def build_file_aliases():
-    return common_rules.build_file_aliases()
+    return jvm_common.build_file_aliases()

--- a/src/python/pants/jvm/common_rules.py
+++ b/src/python/pants/jvm/common_rules.py
@@ -1,0 +1,48 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.jvm import classpath, jdk_rules, resources, run, run_deploy_jar
+from pants.jvm import util_rules as jvm_util_rules
+from pants.jvm.dependency_inference import symbol_mapper
+from pants.jvm.goals import lockfile
+from pants.jvm.jar_tool import jar_tool
+from pants.jvm.package import deploy_jar
+from pants.jvm.package.war import rules as war_rules
+from pants.jvm.resolve import coursier_fetch, jvm_tool
+from pants.jvm.shading.rules import rules as shading_rules
+from pants.jvm.strip_jar import strip_jar
+from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget, JvmWarTarget
+from pants.jvm.target_types import build_file_aliases as jvm_build_file_aliases
+from pants.jvm.test import junit
+
+
+def target_types():
+    return [
+        DeployJarTarget,
+        JvmArtifactTarget,
+        JvmWarTarget,
+    ]
+
+
+def rules():
+    return [
+        *classpath.rules(),
+        *junit.rules(),
+        *strip_jar.rules(),
+        *shading_rules(),
+        *deploy_jar.rules(),
+        *jar_tool.rules(),
+        *lockfile.rules(),
+        *coursier_fetch.rules(),
+        *resources.rules(),
+        *symbol_mapper.rules(),
+        *jvm_util_rules.rules(),
+        *jdk_rules.rules(),
+        *jvm_tool.rules(),
+        *run.rules(),
+        *run_deploy_jar.rules(),
+        *war_rules(),
+    ]
+
+
+def build_file_aliases():
+    return jvm_build_file_aliases()

--- a/src/python/pants/jvm/jvm_common.py
+++ b/src/python/pants/jvm/jvm_common.py
@@ -1,6 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.jvm import classpath, jdk_rules, resources, run, run_deploy_jar
+from pants.jvm import classpath, jdk_rules, resources, run
 from pants.jvm import util_rules as jvm_util_rules
 from pants.jvm.dependency_inference import symbol_mapper
 from pants.jvm.goals import lockfile
@@ -39,7 +39,6 @@ def rules():
         *jdk_rules.rules(),
         *jvm_tool.rules(),
         *run.rules(),
-        *run_deploy_jar.rules(),
         *war_rules(),
     ]
 


### PR DESCRIPTION
This pulls out some repetitive rule registration from the Java, Scala, and Kotlin subsystems. They all depend on common JVM infrastructure that is split across a lot of files. This PR pulls those files out into common definitions that can be easily included in each registration module.