### PR TITLE
Split out different entry point fields, and revert `PexBinaryFieldSet`

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -56,10 +56,7 @@ logger = logging.getLogger(__name__)
 class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     run_in_sandbox_behavior = RunInSandboxBehavior.RUN_REQUEST_HERMETIC
 
-    required_fields = (
-        PexEntryPointField,
-        PexScriptField,
-    )
+    required_fields = (PexEntryPointField,)
 
     entry_point: PexEntryPointField
     script: PexScriptField

--- a/src/python/pants/backend/python/goals/run_python_requirement.py
+++ b/src/python/pants/backend/python/goals/run_python_requirement.py
@@ -19,8 +19,8 @@ from pants.backend.python.dependency_inference.module_mapper import (
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     EntryPoint,
-    PexEntryPointField,
     PythonRequirementDependenciesField,
+    PythonRequirementEntryPointField,
     PythonRequirementModulesField,
     PythonRequirementResolveField,
     PythonRequirementsField,
@@ -59,14 +59,14 @@ class PythonRequirementFieldSet(RunFieldSet):
         PythonRequirementModulesField,
         PythonRequirementTypeStubModulesField,
         PythonRequirementResolveField,
-        PexEntryPointField,
+        PythonRequirementEntryPointField,
     )
 
     requirements: PythonRequirementsField
     dependencies: PythonRequirementDependenciesField
     modules: PythonRequirementModulesField
     resolve: PythonRequirementResolveField
-    entry_point: PexEntryPointField
+    entry_point: PythonRequirementEntryPointField
 
 
 @memoized

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -292,7 +292,7 @@ class ConsoleScript(MainSpecification):
         return self.name
 
 
-class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
+class EntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
     alias = "entry_point"
     default = None
     help = softwrap(
@@ -333,6 +333,11 @@ class PexEntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
         return {"includes": [full_glob]}
 
 
+class PexEntryPointField(EntryPointField):
+    # Specialist subclass for use with `PexBinary` targets.
+    pass
+
+
 # See `target_types_rules.py` for the `ResolvePexEntryPointRequest -> ResolvedPexEntryPoint` rule.
 @dataclass(frozen=True)
 class ResolvedPexEntryPoint:
@@ -344,7 +349,7 @@ class ResolvedPexEntryPoint:
 class ResolvePexEntryPointRequest:
     """Determine the `entry_point` for a `pex_binary` after applying all syntactic sugar."""
 
-    entry_point_field: PexEntryPointField
+    entry_point_field: EntryPointField
 
 
 class PexScriptField(Field):
@@ -1257,6 +1262,11 @@ class PythonRequirementResolveField(PythonResolveField):
     )
 
 
+class PythonRequirementEntryPointField(EntryPointField):
+    # Specialist subclass for matching `PythonRequirementTarget` when running.
+    pass
+
+
 class PythonRequirementTarget(Target):
     alias = "python_requirement"
     core_fields = (
@@ -1266,7 +1276,7 @@ class PythonRequirementTarget(Target):
         PythonRequirementModulesField,
         PythonRequirementTypeStubModulesField,
         PythonRequirementResolveField,
-        PexEntryPointField,
+        PythonRequirementEntryPointField,
     )
     help = softwrap(
         f"""


### PR DESCRIPTION
Addresses concerns raised in #17864.