### PR TITLE
Default `use_pantsd` to `False` in `run_pants`

### DIFF
--- a/src/python/pants/explorer/server/integration_test.py
+++ b/src/python/pants/explorer/server/integration_test.py
@@ -46,7 +46,6 @@ def test_explorer_graphql_query(query: dict, expected_result: dict) -> None:
                 "--port=7908",
             ],
             workdir=workdir,
-            use_pantsd=False,
         )
         assert handle.process.stderr is not None
         os.set_blocking(handle.process.stderr.fileno(), False)

--- a/src/python/pants/goal/anonymous_telemetry_integration_test.py
+++ b/src/python/pants/goal/anonymous_telemetry_integration_test.py
@@ -41,7 +41,6 @@ def test_no_warn_if_explicitly_on() -> None:
     result = run_pants(
         ["roots"],
         config={"anonymous-telemetry": {"enabled": True, "repo_id": 36 * "a"}},
-        use_pantsd=False,
     )
     result.assert_success()
     assert _no_explicit_setting_msg not in result.stderr

--- a/src/python/pants/testutil/pants_integration_test.py
+++ b/src/python/pants/testutil/pants_integration_test.py
@@ -199,7 +199,7 @@ def run_pants(
     command: Command,
     *,
     hermetic: bool = True,
-    use_pantsd: bool = True,
+    use_pantsd: bool = False,
     config: Mapping | None = None,
     extra_env: Mapping[str, str] | None = None,
     stdin_data: bytes | str | None = None,

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -49,7 +49,6 @@ def test_warns_on_remote_cache_errors() -> None:
                 "check",
                 "testprojects/src/jvm/org/pantsbuild/example/lib/ExampleLib.java",
             ],
-            use_pantsd=False,
         )
         pants_run.assert_success()
         return pants_run.stderr
@@ -78,7 +77,6 @@ def test_warns_on_remote_cache_errors() -> None:
             "--no-local-cache",
             "generate-lockfiles",
         ],
-        use_pantsd=False,
     )
     pants_run.assert_success()
 


### PR DESCRIPTION
`run_pants` runs pants in a temporary workdir, meaning that the daemon won't be utilized for subsequent runs, which pretty much means using the daemon (if not explictly asked) is kinda useless.

Other invocations still default to `True`, as callers might be re-using workdirs.

(As a side note, this also led to https://github.com/pantsbuild/pants/issues/17754. See https://github.com/pantsbuild/pants/issues/17754#issuecomment-1364180901)