### PR TITLE
Don't invalidate watched files if non-perms metadata changed

### DIFF
--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -197,17 +197,15 @@ impl InvalidationWatcher {
     canonical_build_root: &Path,
     ev: Event,
   ) {
-    if matches!(ev.kind, EventKind::Modify(ModifyKind::Metadata(_)))
-      && !matches!(
-        ev.kind,
-        EventKind::Modify(ModifyKind::Metadata(MetadataKind::Permissions))
-      )
+    if matches!(ev.kind, EventKind::Modify(ModifyKind::Metadata(mk)) if mk != MetadataKind::Permissions)
     {
-      // If only the metadata (AccessTime, WriteTime, Perms, Link Count, etc...) was changed
-      // (other than permissions, which include the executable bit) it doesn't change anything Pants
-      // particularly cares about. One could argue if the permissions/ownership changed Pants would
-      // care, but until the name/data changes (which would be a separate event) the substance of
-      // the file in Pants' eyes is the same.
+      // (Other than permissions, which include the executable bit) if only the metadata
+      // (AccessTime, WriteTime, Perms, Link Count, etc...) was changed, it doesn't change anything
+      // Pants (other than permissions, which include the executable bit)particularly cares about.
+      //
+      // One could argue if the permissions/ownership changed Pants would care, but until the
+      // name/data changes (which would be a separate event) the substance of the file in Pants'
+      // eyes is the same.
       return;
     }
 

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -203,7 +203,7 @@ impl InvalidationWatcher {
       // (AccessTime, WriteTime, Perms, Link Count, etc...) was changed, it doesn't change anything
       // Pants particularly cares about.
       //
-      // One could argue if the permissions/ownership changed Pants would care, but until the
+      // One could argue if the ownership changed Pants would care, but until the
       // name/data changes (which would be a separate event) the substance of the file in Pants'
       // eyes is the same.
       return;

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -201,7 +201,7 @@ impl InvalidationWatcher {
     {
       // (Other than permissions, which include the executable bit) if only the metadata
       // (AccessTime, WriteTime, Perms, Link Count, etc...) was changed, it doesn't change anything
-      // Pants (other than permissions, which include the executable bit)particularly cares about.
+      // Pants particularly cares about.
       //
       // One could argue if the permissions/ownership changed Pants would care, but until the
       // name/data changes (which would be a separate event) the substance of the file in Pants'


### PR DESCRIPTION
This was the underlying root cause of https://github.com/pantsbuild/pants/issues/17754. Although Pants' dogfooding here is mostly to blame, notably a link count changing caused the file watcher to invalidate the file, which I'd argue isn't something Pants cares about.