### PR TITLE
Bring back hardlinking big files

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -81,8 +81,7 @@ const GIGABYTES: usize = 1024 * MEGABYTES;
 // NB: These numbers were chosen after micro-benchmarking the code on one machine at the time of
 // writing. They were chosen using a rough equation from the microbenchmarks that are optimized
 // for somewhere between 2 and 3 uses of the corresponding entry to "break even".
-// Number set impossibly high to disable the linking feature -- see #17754 for tracking.
-const IMMUTABLE_FILE_SIZE_LIMIT: usize = usize::MAX - 1; // was: 512 * KILOBYTES;
+const IMMUTABLE_FILE_SIZE_LIMIT: usize = 512 * KILOBYTES;
 
 mod local;
 #[cfg(test)]


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/17874 should've fixed the "issue". https://github.com/pantsbuild/pants/pull/17875 is also an attempt to really drive the issue away.

Fixes https://github.com/pantsbuild/pants/issues/17754