### PR TITLE
Make pants work when the uid doesn't map to a user.

### DIFF
--- a/src/python/pants/goal/run_tracker.py
+++ b/src/python/pants/goal/run_tracker.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import getpass
 import logging
 import platform
 import socket
@@ -21,6 +20,7 @@ from pants.option.errors import ConfigValidationError
 from pants.option.options import Options
 from pants.option.options_fingerprinter import CoercingOptionEncoder
 from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
+from pants.util.osutil import getuser
 from pants.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -128,7 +128,7 @@ class RunTracker:
                 "id": self.run_id,
                 "timestamp": run_start_time,
                 "datetime": datetime,
-                "user": getpass.getuser(),
+                "user": getuser(),
                 "machine": socket.gethostname(),
                 "buildroot": get_buildroot(),
                 "path": get_buildroot(),
@@ -158,7 +158,7 @@ class RunTracker:
             # Note that if repo_id is the empty string then these three fields will be empty.
             "repo_id": maybe_hash_with_repo_id_prefix(""),
             "machine_id": maybe_hash_with_repo_id_prefix(str(uuid.getnode())),
-            "user_id": maybe_hash_with_repo_id_prefix(getpass.getuser()),
+            "user_id": maybe_hash_with_repo_id_prefix(getuser()),
             # Note that we conserve the order in which the goals were specified on the cmd line.
             "standard_goals": [goal for goal in self.goals if goal in self.STANDARD_GOALS],
             # Lets us know of any custom goals were used, without knowing their names.

--- a/src/python/pants/goal/run_tracker_test.py
+++ b/src/python/pants/goal/run_tracker_test.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import datetime
-import getpass
 import re
 import time
 from pathlib import Path
@@ -15,6 +14,7 @@ from pants.base.exiter import PANTS_FAILED_EXIT_CODE, PANTS_SUCCEEDED_EXIT_CODE,
 from pants.goal.run_tracker import RunTracker
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.contextutil import environment_as
+from pants.util.osutil import getuser
 from pants.version import VERSION
 
 
@@ -61,7 +61,7 @@ def test_run_information(exit_code: ExitCode, expected: str, tmp_path: Path, **k
         assert "Jan" in run_information["datetime"]
         assert "2020" in run_information["datetime"]
         assert run_information["timestamp"] == 1578657601.0
-        assert run_information["user"] == getpass.getuser()
+        assert run_information["user"] == getuser()
         assert run_information["version"] == VERSION
         assert re.match(f"pants.*{spec}", run_information["cmd_line"])
         assert run_information["specs_from_command_line"] == [spec]

--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import getpass
 import logging
 import os
 import re
@@ -17,6 +16,7 @@ from typing_extensions import Protocol
 from pants.base.build_environment import get_buildroot
 from pants.option.errors import ConfigError, ConfigValidationError, InterpolationMissingOptionError
 from pants.option.ranked_value import Value
+from pants.util.osutil import getuser
 
 logger = logging.getLogger(__name__)
 
@@ -122,8 +122,10 @@ class Config:
 
         all_seed_values: dict[str, Any] = {
             "buildroot": buildroot,
+            # Note that expanduser will return the root dir when running with a uid
+            # not associated with a user.
             "homedir": os.path.expanduser("~"),
-            "user": getpass.getuser(),
+            "user": getuser(),
         }
         if env:
             all_seed_values["env"] = SimpleNamespace(**env)

--- a/src/python/pants/util/osutil.py
+++ b/src/python/pants/util/osutil.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import errno
+import getpass
 import logging
 import os
 import platform
@@ -97,6 +98,15 @@ def get_normalized_arch_name() -> str:
 
 def is_macos_big_sur() -> bool:
     return hasattr(platform, "mac_ver") and platform.mac_ver()[0].startswith("11.")
+
+
+def getuser() -> str:
+    try:
+        return getpass.getuser()
+    except KeyError:
+        # Work when running with a uid not associated with a user,
+        # e.g., in a docker container with a host uid.
+        return str(os.getuid())
 
 
 def _values(aliases: dict[str, set[str]]) -> set[str]:


### PR DESCRIPTION
E.g., when running in a docker container with the uid set to a host uid that doesn't map to a user in the container.