### PR TITLE
Use GITHUB_PATH to modify paths between CI steps.

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -305,14 +305,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}
@@ -376,14 +376,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}
@@ -447,14 +447,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -247,12 +247,17 @@ jobs:
       run: 'curl --proto ''=https'' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s --
         -v -y --default-toolchain none
 
-        echo "PATH=${PATH}:${HOME}/.cargo/bin" >> $GITHUB_ENV
+        echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
 
         '
     - name: Expose Pythons
-      run: echo "PATH=${PATH}:/opt/python/cp37-cp37m/bin:/opt/python/cp38-cp38/bin:/opt/python/cp39-cp39/bin"
-        >> $GITHUB_ENV
+      run: 'echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+
+        echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+
+        echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+
+        '
     - if: github.event_name != 'pull_request'
       name: Setup toolchain auth
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
@@ -638,14 +643,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}
@@ -711,14 +716,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}
@@ -784,14 +789,14 @@ jobs:
         go-version: 1.17.1
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
-      run: 'mkdir -p "$HOME/.thrift"
+      run: 'mkdir -p "${HOME}/.thrift"
 
         curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift
-        -o "$HOME/.thrift/thrift"
+        -o "${HOME}/.thrift/thrift"
 
-        chmod +x "$HOME/.thrift/thrift"
+        chmod +x "${HOME}/.thrift/thrift"
 
-        echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+        echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
     - name: Set up Python ${{ matrix.python-version }}

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -216,7 +216,7 @@ def install_rustup() -> Step:
         "run": dedent(
             """\
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -v -y --default-toolchain none
-            echo "PATH=${PATH}:${HOME}/.cargo/bin" >> $GITHUB_ENV
+            echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
             """
         ),
     }
@@ -293,10 +293,10 @@ def download_apache_thrift() -> Step:
         "if": "runner.os == 'Linux'",
         "run": dedent(
             """\
-            mkdir -p "$HOME/.thrift"
-            curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "$HOME/.thrift/thrift"
-            chmod +x "$HOME/.thrift/thrift"
-            echo "PATH=${PATH}:${HOME}/.thrift" >> $GITHUB_ENV
+            mkdir -p "${HOME}/.thrift"
+            curl --fail -L https://binaries.pantsbuild.org/bin/thrift/linux/x86_64/0.15.0/thrift -o "${HOME}/.thrift/thrift"
+            chmod +x "${HOME}/.thrift/thrift"
+            echo "${HOME}/.thrift" >> $GITHUB_PATH
             """
         ),
     }
@@ -618,11 +618,12 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
             install_rustup(),
             {
                 "name": "Expose Pythons",
-                "run": (
-                    'echo "PATH=${PATH}:'
-                    "/opt/python/cp37-cp37m/bin:"
-                    "/opt/python/cp38-cp38/bin:"
-                    '/opt/python/cp39-cp39/bin" >> $GITHUB_ENV'
+                "run": dedent(
+                    """\
+                    echo "/opt/python/cp37-cp37m/bin" >> $GITHUB_PATH
+                    echo "/opt/python/cp38-cp38/bin" >> $GITHUB_PATH
+                    echo "/opt/python/cp39-cp39/bin" >> $GITHUB_PATH
+                    """
                 ),
             },
         ]


### PR DESCRIPTION
Previously we used GITHUB_ENV, and interpolated the existing $PATH.

However in the containerized manylinux wheel builds, due to improper escaping, this interpolated the host $PATH into the container's $PATH.

This did not seem to cause harm in practice on the x86_64 manylinux wheel build, presumably because the host paths happened to still be suitable in the container. However this was exposed while working on setting up the aarch64 manylinux wheel build, where the host and container paths are not at all compatible.

GITHUB_PATH is the blessed way of prepending to the container path anyway, and means we don't have to think about proper escaping of the interpolated $PATH.