### PR TITLE
upgrade to Rust v1.66.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 
@@ -148,7 +148,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 
@@ -153,7 +153,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 
@@ -314,7 +314,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 
@@ -381,7 +381,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 
@@ -445,7 +445,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.65.0-*
+        path: '~/.rustup/toolchains/1.66.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.66.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -862,7 +862,7 @@ impl Store {
       )
       .await?;
 
-      let ingested_file_sizes = ingested_digests.iter().map(|(digest, _)| digest.size_bytes);
+      let ingested_file_sizes = ingested_digests.keys().map(|digest| digest.size_bytes);
       let uploaded_file_sizes = digests_to_upload.iter().map(|digest| digest.size_bytes);
 
       Ok(UploadSummary {

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -469,7 +469,7 @@ impl<'a> CapturedWorkdir for CommandRunner<'a> {
 
     let working_dir = req
       .working_directory
-      .map(|relpath| Path::new(&sandbox_path_in_container).join(&relpath))
+      .map(|relpath| Path::new(&sandbox_path_in_container).join(relpath))
       .unwrap_or_else(|| Path::new(&sandbox_path_in_container).to_path_buf())
       .into_os_string()
       .into_string()

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -886,7 +886,7 @@ pub fn setup_run_sh_script(
     } else {
       workdir_path.to_owned()
     };
-    let quoted_cwd = bash::escape(&cwd);
+    let quoted_cwd = bash::escape(cwd);
     str::from_utf8(&quoted_cwd)
       .map_err(|e| format!("{:?}", e))?
       .to_string()
@@ -909,7 +909,7 @@ cd {}
     .create_new(true)
     .write(true)
     .mode(USER_EXECUTABLE_MODE) // Executable for user, read-only for others.
-    .open(&full_file_path)
+    .open(full_file_path)
     .map_err(|e| format!("{:?}", e))?
     .write_all(full_script.as_bytes())
     .map_err(|e| format!("{:?}", e))

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -1470,7 +1470,7 @@ pub fn extract_output_files(
   // method.
   if treat_tree_digest_as_final_directory_hack {
     match &action_result.output_directories[..] {
-      &[ref directory] => {
+      [directory] => {
         match require_digest(directory.tree_digest.as_ref()) {
           Ok(digest) => {
             return future::ready::<Result<_, StoreError>>(Ok(

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -627,8 +627,8 @@ impl<R: Rule> Builder<R> {
       #[allow(clippy::type_complexity)]
       let dependencies_by_key: Vec<Vec<(DependencyKey<R::TypeId>, NodeIndex<u32>)>> =
         Self::edges_by_dependency_key(&graph, node_id, false)
-          .into_iter()
-          .map(|(_, edge_refs)| {
+          .into_values()
+          .map(|edge_refs| {
             edge_refs
               .iter()
               .map(|edge_ref| (edge_ref.weight().0.clone(), edge_ref.target()))

--- a/src/rust/engine/src/externs/stdio.rs
+++ b/src/rust/engine/src/externs/stdio.rs
@@ -27,7 +27,7 @@ impl PyStdioRead {
 
   fn readinto(&self, obj: &PyAny, py: Python) -> PyResult<usize> {
     let py_buffer = PyBuffer::get(obj)?;
-    let mut buffer = vec![0; py_buffer.len_bytes() as usize];
+    let mut buffer = vec![0; py_buffer.len_bytes()];
     let read = py
       .allow_threads(|| stdio::get_destination().read_stdin(&mut buffer))
       .map_err(|e| PyException::new_err(e.to_string()))?;

--- a/src/rust/engine/testutil/mock/src/cas_service.rs
+++ b/src/rust/engine/testutil/mock/src/cas_service.rs
@@ -196,7 +196,7 @@ impl StubCASResponder {
     match maybe_bytes {
       Some(bytes) => Ok(
         bytes
-          .chunks(self.chunk_size_bytes as usize)
+          .chunks(self.chunk_size_bytes)
           .map(|b| ReadResponse {
             data: bytes.slice_ref(b),
           })

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -77,7 +77,7 @@ impl SpanId {
 
 impl std::fmt::Display for SpanId {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{:016.x}", self.0)
+    write!(f, "{:016x}", self.0)
   }
 }
 


### PR DESCRIPTION
Upgrade to Rust v1.66.0.  [Announcement](https://blog.rust-lang.org/2022/12/15/Rust-1.66.0.html)
