### PR TITLE
Always stop on `StopIteration` in `rule_runner.run_rule_with_mocks`

### DIFF
--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -680,8 +680,7 @@ def run_rule_with_mocks(
             else:
                 return res  # type: ignore[return-value]
         except StopIteration as e:
-            if e.args:
-                return e.value  # type: ignore[no-any-return]
+            return e.value  # type: ignore[no-any-return]
 
 
 @contextmanager


### PR DESCRIPTION
All `StopIteration` exceptions are, well, stopping. Whether the value is falsy or not shouldn't play a part.

This change was introduced in https://github.com/pantsbuild/pants/pull/8639, I suspect the intent was "if we the generator returns a value then `e.args` will be truthy". However the generator can return Falsy values.

@kaos found this one for me :smile: 