### PR TITLE
Support freezing command line args and env vars into pex binaries.

### DIFF
--- a/docs/markdown/Python/python-goals/python-package-goal.md
+++ b/docs/markdown/Python/python-goals/python-package-goal.md
@@ -149,8 +149,8 @@ python_requirement(name="gunicorn", requirements=["gunicorn==20.1.0"])
 pex_binary(
   name="myservice_bin",
   script="gunicorn",
-  inject_args=["myproduct.myservice.wsgi:app", "--name=myservice"],
-  inject_env={"MY_ENV_VAR=1"},
+  args=["myproduct.myservice.wsgi:app", "--name=myservice"],
+  env={"MY_ENV_VAR=1"},
   dependencies=[":gunicorn"],
 )
 ```

--- a/docs/markdown/Python/python-goals/python-package-goal.md
+++ b/docs/markdown/Python/python-goals/python-package-goal.md
@@ -139,6 +139,22 @@ You must explicitly add the dependencies you'd like to the `dependencies` field.
 
 This does not work with file arguments; you must use the target address, like `./pants package helloworld:black_bin`.
 
+### Injecting command-line arguments and environment variables
+
+You can use the `inject_args` and `inject_env` fields to "freeze" command-line arguments and environment variables into the PEX file. This can save you from having to create shim files around generic binaries. For example:
+
+```python myproduct/myservice/BUILD
+python_requirement(name="gunicorn", requirements=["gunicorn==20.1.0"])
+
+pex_binary(
+  name="myservice_bin",
+  script="gunicorn",
+  inject_args=["myproduct.myservice.wsgi:app", "--name=myservice"],
+  inject_env={"MY_ENV_VAR=1"},
+  dependencies=[":gunicorn"],
+)
+```
+
 > 🚧 PEX files may be platform-specific
 > 
 > If your code's requirements include distributions that include native code, then the resulting PEX file will only run on the platform it was built on. 

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -17,6 +17,8 @@ from pants.backend.python.target_types import (
     PexIncludeSourcesField,
     PexIncludeToolsField,
     PexInheritPathField,
+    PexInjectArgsField,
+    PexInjectEnvField,
     PexLayout,
     PexLayoutField,
     PexPlatformsField,
@@ -46,6 +48,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.docutil import doc_url
+from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -60,6 +63,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
     entry_point: PexEntryPointField
     script: PexScriptField
+    inject_args: PexInjectArgsField
+    inject_env: PexInjectEnvField
 
     output_path: OutputPathField
     emit_warnings: PexEmitWarningsField
@@ -150,6 +155,8 @@ async def package_pex_binary(
             addresses=[field_set.address],
             internal_only=False,
             main=resolved_entry_point.val or field_set.script.value,
+            inject_args=field_set.inject_args.value or [],
+            inject_env=field_set.inject_env.value or FrozenDict[str, str](),
             platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
             complete_platforms=complete_platforms,
             output_filename=output_filename,

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -6,10 +6,12 @@ from dataclasses import dataclass
 from typing import Tuple
 
 from pants.backend.python.target_types import (
+    PexArgsField,
     PexBinaryDefaults,
     PexCompletePlatformsField,
     PexEmitWarningsField,
     PexEntryPointField,
+    PexEnvField,
     PexExecutionMode,
     PexExecutionModeField,
     PexIgnoreErrorsField,
@@ -17,8 +19,6 @@ from pants.backend.python.target_types import (
     PexIncludeSourcesField,
     PexIncludeToolsField,
     PexInheritPathField,
-    PexInjectArgsField,
-    PexInjectEnvField,
     PexLayout,
     PexLayoutField,
     PexPlatformsField,
@@ -63,8 +63,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
     entry_point: PexEntryPointField
     script: PexScriptField
-    inject_args: PexInjectArgsField
-    inject_env: PexInjectEnvField
+    args: PexArgsField
+    env: PexEnvField
 
     output_path: OutputPathField
     emit_warnings: PexEmitWarningsField
@@ -155,8 +155,8 @@ async def package_pex_binary(
             addresses=[field_set.address],
             internal_only=False,
             main=resolved_entry_point.val or field_set.script.value,
-            inject_args=field_set.inject_args.value or [],
-            inject_env=field_set.inject_env.value or FrozenDict[str, str](),
+            inject_args=field_set.args.value or [],
+            inject_env=field_set.env.value or FrozenDict[str, str](),
             platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
             complete_platforms=complete_platforms,
             output_filename=output_filename,

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -110,12 +110,22 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
 def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
     rule_runner.write_files(
         {
-            "src/py/project/app.py": "print('hello')",
+            "src/py/project/app.py": dedent(
+                """\
+                import os
+                import sys
+                print(f"FOO={os.environ.get('FOO')}")
+                print(f"BAR={os.environ.get('BAR')}")
+                print(f"ARGV={sys.argv[1:]}")
+                """
+            ),
             "src/py/project/BUILD": dedent(
                 f"""\
                 python_sources(name="lib")
                 pex_binary(
                     entry_point="app.py",
+                    inject_args=['123', 'abc'],
+                    inject_env={{'FOO': 'xxx', 'BAR': 'yyy'}},
                     layout="{layout.value}",
                 )
                 """
@@ -136,7 +146,14 @@ def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
         if PexLayout.ZIPAPP is layout
         else os.path.join(expected_pex_relpath, "__main__.py"),
     )
-    assert b"hello\n" == subprocess.run([executable], check=True, stdout=subprocess.PIPE).stdout
+    stdout = dedent(
+        """\
+        FOO=xxx
+        BAR=yyy
+        ARGV=['123', 'abc']
+        """
+    ).encode()
+    assert stdout == subprocess.run([executable], check=True, stdout=subprocess.PIPE).stdout
 
 
 @pytest.fixture

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -124,8 +124,8 @@ def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
                 python_sources(name="lib")
                 pex_binary(
                     entry_point="app.py",
-                    inject_args=['123', 'abc'],
-                    inject_env={{'FOO': 'xxx', 'BAR': 'yyy'}},
+                    args=['123', 'abc'],
+                    env={{'FOO': 'xxx', 'BAR': 'yyy'}},
                     layout="{layout.value}",
                 )
                 """

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -377,8 +377,8 @@ class PexScriptField(Field):
         return ConsoleScript(value)
 
 
-class PexInjectArgsField(StringSequenceField):
-    alias = "inject_args"
+class PexArgsField(StringSequenceField):
+    alias = "args"
     help = softwrap(
         """
         Freeze these command-line args into the PEX. Allows you to run generic entry points
@@ -387,8 +387,8 @@ class PexInjectArgsField(StringSequenceField):
     )
 
 
-class PexInjectEnvField(DictStringToStringField):
-    alias = "inject_env"
+class PexEnvField(DictStringToStringField):
+    alias = "env"
     help = softwrap(
         """
         Freeze these environment variables into the PEX. Allows you to run generic entry points
@@ -680,8 +680,8 @@ class PexBinary(Target):
         *_PEX_BINARY_COMMON_FIELDS,
         PexEntryPointField,
         PexScriptField,
-        PexInjectArgsField,
-        PexInjectEnvField,
+        PexArgsField,
+        PexEnvField,
         OutputPathField,
     )
     help = softwrap(

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -42,6 +42,7 @@ from pants.engine.target import (
     AsyncFieldMixin,
     BoolField,
     Dependencies,
+    DictStringToStringField,
     DictStringToStringSequenceField,
     Field,
     IntField,
@@ -376,6 +377,26 @@ class PexScriptField(Field):
         return ConsoleScript(value)
 
 
+class PexInjectArgsField(StringSequenceField):
+    alias = "inject_args"
+    help = softwrap(
+        """
+        Freeze these command-line args into the PEX. Allows you to run generic entry points
+        on specific arguments without creating a shim file.
+        """
+    )
+
+
+class PexInjectEnvField(DictStringToStringField):
+    alias = "inject_env"
+    help = softwrap(
+        """
+        Freeze these environment variables into the PEX. Allows you to run generic entry points
+        on a specific environment without creating a shim file.
+        """
+    )
+
+
 class PexPlatformsField(StringSequenceField):
     alias = "platforms"
     help = softwrap(
@@ -659,6 +680,8 @@ class PexBinary(Target):
         *_PEX_BINARY_COMMON_FIELDS,
         PexEntryPointField,
         PexScriptField,
+        PexInjectArgsField,
+        PexInjectEnvField,
         OutputPathField,
     )
     help = softwrap(

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -138,6 +138,8 @@ class PexRequest(EngineAwareParameter):
     sources: Digest | None
     additional_inputs: Digest
     main: MainSpecification | None
+    inject_args: tuple[str, ...]
+    inject_env: FrozenDict[str, str]
     additional_args: tuple[str, ...]
     pex_path: tuple[Pex, ...]
     description: str | None = dataclasses.field(compare=False)
@@ -156,6 +158,8 @@ class PexRequest(EngineAwareParameter):
         sources: Digest | None = None,
         additional_inputs: Digest | None = None,
         main: MainSpecification | None = None,
+        inject_args: Iterable[str] = (),
+        inject_env: Mapping[str, str] = FrozenDict(),
         additional_args: Iterable[str] = (),
         pex_path: Iterable[Pex] = (),
         description: str | None = None,
@@ -189,6 +193,8 @@ class PexRequest(EngineAwareParameter):
             directly in the Pex, but should be present in the environment when building the Pex.
         :param main: The main for the built Pex, equivalent to Pex's `-e` or '-c' flag. If
             left off, the Pex will open up as a REPL.
+        :param inject_args: Command line arguments to freeze in to the PEX.
+        :param inject_env: Environment variables to freeze in to the PEX.
         :param additional_args: Any additional Pex flags.
         :param pex_path: Pex files to add to the PEX_PATH.
         :param description: A human-readable description to render in the dynamic UI when building
@@ -207,6 +213,8 @@ class PexRequest(EngineAwareParameter):
         self.sources = sources
         self.additional_inputs = additional_inputs or EMPTY_DIGEST
         self.main = main
+        self.inject_args = tuple(inject_args)
+        self.inject_env = FrozenDict(inject_env)
         self.additional_args = tuple(additional_args)
         self.pex_path = tuple(pex_path)
         self.description = description
@@ -516,6 +524,11 @@ async def build_pex(
 
     if request.main is not None:
         argv.extend(request.main.iter_pex_args())
+
+    for injected_arg in request.inject_args:
+        argv.extend(["--inject-args", str(injected_arg)])
+    for k, v in request.inject_env.items():
+        argv.extend(["--inject-env", f"{k}={v}"])
 
     # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path
     #  requirements, which could lead to problems. Support shading python binaries.

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -527,7 +527,7 @@ async def build_pex(
 
     for injected_arg in request.inject_args:
         argv.extend(["--inject-args", str(injected_arg)])
-    for k, v in request.inject_env.items():
+    for k, v in sorted(request.inject_env.items()):
         argv.extend(["--inject-env", f"{k}={v}"])
 
     # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path


### PR DESCRIPTION
This capability already existed in Pex, this PR plumbs it through in Pants.

This will allow, e.g., running a single gunicorn PEX with different args for different services, without needing a shim file.