### PR TITLE
docs: generate a JSON schema file to be used in IDEs when editing pants.toml

### DIFF
--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -19,7 +19,10 @@ python_tests(
     overrides={
         "reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]},
         "generate_json_schema_test.py": {
-            "dependencies": ["build-support/bin/json_schema_testdata:json_schema_samples"]
+            "dependencies": [
+                "build-support/bin/json_schema_testdata:json_schema_samples",
+                "3rdparty/python#types-setuptools",
+            ]
         },
     },
 )

--- a/build-support/bin/BUILD
+++ b/build-support/bin/BUILD
@@ -16,7 +16,12 @@ python_sources(
 
 python_tests(
     name="py_tests",
-    overrides={"reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]}},
+    overrides={
+        "reversion_test.py": {"timeout": 90, "dependencies": ["3rdparty/python#pex"]},
+        "generate_json_schema_test.py": {
+            "dependencies": ["build-support/bin/json_schema_testdata:json_schema_samples"]
+        },
+    },
 )
 
 pex_binary(

--- a/build-support/bin/check_json_schema.py
+++ b/build-support/bin/check_json_schema.py
@@ -21,11 +21,23 @@ def main() -> None:
     with open(args.schema) as fh:
         json_data = json.load(fh)
 
-    # certain options' default values may be a result of variable expansion
-    assert getpass.getuser() not in raw_data
-
     # there should be some options
     assert json_data["properties"]["GLOBAL"]["properties"]["pants_version"]
+
+    # certain options' default values may be a result of variable expansion
+    username = getpass.getuser()
+    if username in raw_data:
+        raise ValueError(f"{username} is in the schema file.")
+
+    for section_name, section_data in json_data["properties"].items():
+        for option_name, option_data in section_data["properties"].items():
+            # every property description should contain some text before the URL
+            if option_data["description"].startswith("\nhttp"):
+                raise ValueError(f"{option_name} has an incomplete description.")
+
+            # every option's description should contain a URL
+            if "https://www.pantsbuild.org/v" not in option_data["description"]:
+                raise ValueError(f"{option_name} should have a URL in description.")
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/build-support/bin/check_json_schema.py
+++ b/build-support/bin/check_json_schema.py
@@ -1,0 +1,46 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Check a generated a JSON schema file before uploading it to the JSON schema store
+(https://www.schemastore.org/json/).
+
+Live run:
+
+    $ ./pants run build-support/bin/generate_json_schema.py -- --all-help-file=all-help.json
+    $ ./pants run build-support/bin/check_json_schema.py -- --schema="pantsbuild-$(./pants version).json"
+"""
+import argparse
+import getpass
+import json
+
+
+def main() -> None:
+    args = get_args()
+    with open(args.schema) as fh:
+        raw_data = fh.read()
+
+    with open(args.schema) as fh:
+        json_data = json.load(fh)
+
+    # certain options' default values may be a result of variable expansion
+    assert getpass.getuser() not in raw_data
+
+    # there should be some options
+    assert json_data["properties"]["GLOBAL"]["properties"]["pants_version"]
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Checks JSON schema file.")
+    parser.add_argument(
+        "--schema",
+        help="Input schema file with the contents produced by the schema generation script.",
+        required=True,
+    )
+    return parser
+
+
+def get_args():
+    return create_parser().parse_args()
+
+
+if __name__ == "__main__":
+    main()

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -80,11 +80,13 @@ def main() -> None:
 
     schema: Dict[str, Any] = dict()
     schema["$schema"] = "http://json-schema.org/draft-04/schema#"
-    schema["description"] = "https://www.pantsbuild.org/"
+    schema["description"] = "Pants configuration file schema: https://www.pantsbuild.org/"
     schema["properties"] = ruleset
+    # custom plugins may have own configuration sections
+    schema["additionalProperties"] = True
 
     with open(GENERATED_JSON_SCHEMA_FILENAME, "w") as fh:
-        fh.write(json.dumps(schema, indent=4))
+        fh.write(json.dumps(schema, indent=4, sort_keys=True))
 
 
 def create_parser() -> argparse.ArgumentParser:

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -22,7 +22,7 @@ from pants.version import VERSION
 
 GENERATED_JSON_SCHEMA_FILENAME = f"pantsbuild-{VERSION}.json"
 DOCS_URL = "https://www.pantsbuild.org"
-VERSION_MAJOR_MINOR = f"v{Version(VERSION).major}.{Version(VERSION).minor}"
+VERSION_MAJOR_MINOR = f"{Version(VERSION).major}.{Version(VERSION).minor}"
 
 PYTHON_TO_JSON_TYPE_MAPPING = {
     "str": "string",
@@ -58,7 +58,7 @@ def get_description(option: dict, section: str) -> str:
     option_help: str = option["help"].split("\n")[0]
     option_name: str = option["config_key"]
     simplified_option_help = simplify_option_description(option_help)
-    url = f"{DOCS_URL}/{VERSION_MAJOR_MINOR}/docs/reference-{section.lower()}#{option_name}"
+    url = f"{DOCS_URL}/v{VERSION_MAJOR_MINOR}/docs/reference-{section.lower()}#{option_name}"
     return f"{simplified_option_help}\n{url}"
 
 

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -4,8 +4,10 @@
 (https://www.schemastore.org/json/). The schema file is used by IDEs (PyCharm, VSCode, etc) to
 provide intellisense when editing Pants configuration files in TOML format.
 
-Live run:     $ ./pants help-all > all-help.json     $ ./pants run build-
-support/bin/generate_json_schema.py -- --all-help-file=all-help.json
+Live run:
+
+    $ ./pants help-all > all-help.json
+    $ ./pants run build-support/bin/generate_json_schema.py -- --all-help-file=all-help.json
 """
 import argparse
 import itertools

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -50,12 +50,12 @@ def simplify_option_description(description: str) -> str:
 
     There is an assumption that there are no newlines.
     """
-    return re.split(r"(?<=[^A-Z].[.?]) +(?=[A-Z])", description)[0].rpartition(".")[0]
+    return re.split(r"(?<=[^A-Z].[.?]) +(?=[A-Z])", description)[0].rstrip(".")
 
 
 def get_description(option: dict, section: str) -> str:
     """Get a shortened description with a URL to the online docs of the given option."""
-    option_help: str = option["help"].split("\n")[0]
+    option_help: str = option["help"].lstrip("\n").split("\n")[0]
     option_name: str = option["config_key"]
     simplified_option_help = simplify_option_description(option_help)
     url = f"{DOCS_URL}/v{VERSION_MAJOR_MINOR}/docs/reference-{section.lower()}#{option_name}"
@@ -93,6 +93,9 @@ def build_scope_properties(ruleset: dict, options: Iterable[dict], scope: str) -
             properties[option["config_key"]]["enum"] = option["choices"]
         else:
             typ = PYTHON_TO_JSON_TYPE_MAPPING.get(option["typ"])
+            # TODO(alte): do we want to maintain a mapping between special options?
+            #  `process_total_child_memory_usage` ("typ": "memory_size") -> "int"
+            #  `engine_visualize_to` ("typ": "dir_option") -> "str"
             if typ:
                 # options may allow providing value inline or loading from a filepath string
                 if option.get("fromfile"):

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -49,7 +49,10 @@ def build_scope_properties(ruleset: dict, options: Iterable[dict], scope: str) -
         else:
             typ = PYTHON_TO_JSON_TYPE_MAPPING.get(option["typ"])
             if typ:
-                properties[option["config_key"]]["type"] = typ
+                # options may allow providing value inline or loading from a filepath string
+                properties[option["config_key"]]["type"] = (
+                    [typ, "string"] if option["fromfile"] else typ
+                )
 
     return ruleset
 

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -2,7 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 """Generates a JSON schema file to be uploaded to the JSON schema store
 (https://www.schemastore.org/json/). The schema file is used by IDEs (PyCharm, VSCode, etc) to
-provide intellisense when editing Pants configuration files in TOML format.
+provide intellisense when editing Pants configuration files in TOML format. It can also be used to
+validate your pants.toml configuration file programmatically.
 
 Live run:
 
@@ -16,7 +17,9 @@ from typing import Any, Dict, Iterable
 
 from pants.version import VERSION
 
-python_to_json_type_mapping = {
+GENERATED_JSON_SCHEMA_FILENAME = f"pantsbuild-{VERSION}.json"
+
+PYTHON_TO_JSON_TYPE_MAPPING = {
     "str": "string",
     "bool": "boolean",
     "list": "array",
@@ -26,24 +29,13 @@ python_to_json_type_mapping = {
 }
 
 
-def create_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Generates JSON schema file to be used in IDEs for Pants configuration files in TOML format."
-    )
-    parser.add_argument(
-        "--all-help-file",
-        help="Input file with the contents produced by the `./pants help-all` command.",
-        required=True,
-    )
-    return parser
-
-
-def build_scope_properties(ruleset: dict, options: Iterable, scope: str) -> dict:
+def build_scope_properties(ruleset: dict, options: Iterable[dict], scope: str) -> dict:
     """Build properties object for a single scope.
 
     There are custom types (e.g. `file_option` or `LogLevel`) for which one cannot safely infer a
     type, so no type is added to the ruleset. If there are choices, there is no need to provide
-    "type". Otherwise, a provided `typ` field is used.
+    "type" for the schema (assuming all choices share the same type). Otherwise, a provided `typ`
+    field is used.
     """
     for option in options:
         properties = ruleset[scope]["properties"]
@@ -55,7 +47,7 @@ def build_scope_properties(ruleset: dict, options: Iterable, scope: str) -> dict
         if option["choices"]:
             properties[option["config_key"]]["enum"] = option["choices"]
         else:
-            typ = python_to_json_type_mapping.get(option["typ"])
+            typ = PYTHON_TO_JSON_TYPE_MAPPING.get(option["typ"])
             if typ:
                 properties[option["config_key"]]["type"] = typ
 
@@ -63,17 +55,16 @@ def build_scope_properties(ruleset: dict, options: Iterable, scope: str) -> dict
 
 
 def main() -> None:
-    args = create_parser().parse_args()
-    output_schema_filename = f"pantsbuild-{VERSION}.json"
-
+    args = get_args()
     with open(args.all_help_file) as fh:
         all_help = json.load(fh)["scope_to_help_info"]
 
-    # set GLOBAL scope
+    # set GLOBAL scope that is declared under an empty string
     all_help["GLOBAL"] = all_help[""]
     del all_help[""]
 
-    # build ruleset for all scopes
+    # build ruleset for all scopes (where "scope" is a [section]
+    # in the pants.toml configuration file such as "pytest" or "mypy")
     ruleset = {}
     for scope, options in all_help.items():
         ruleset[scope] = {
@@ -92,8 +83,24 @@ def main() -> None:
     schema["description"] = "https://www.pantsbuild.org/"
     schema["properties"] = ruleset
 
-    with open(output_schema_filename, "w") as fh:
+    with open(GENERATED_JSON_SCHEMA_FILENAME, "w") as fh:
         fh.write(json.dumps(schema, indent=4))
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generates JSON schema file to be used in IDEs for Pants configuration files in TOML format."
+    )
+    parser.add_argument(
+        "--all-help-file",
+        help="Input file with the contents produced by the `./pants help-all` command.",
+        required=True,
+    )
+    return parser
+
+
+def get_args():
+    return create_parser().parse_args()
 
 
 if __name__ == "__main__":

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -1,0 +1,98 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Generates a JSON schema file to be uploaded to the JSON schema store
+(https://www.schemastore.org/json/). The schema file is used by IDEs (PyCharm, VSCode, etc) to
+provide intellisense when editing Pants configuration files in TOML format.
+
+Live run:     $ ./pants help-all > all-help.json     $ ./pants run build-
+support/bin/generate_json_schema.py -- --all-help-file=all-help.json
+"""
+import argparse
+import itertools
+import json
+from typing import Any, Dict, Iterable
+
+from pants.version import VERSION
+
+python_to_json_type_mapping = {
+    "str": "string",
+    "bool": "boolean",
+    "list": "array",
+    "int": "number",
+    "float": "number",
+    "dict": "object",
+}
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generates JSON schema file to be used in IDEs for Pants configuration files in TOML format."
+    )
+    parser.add_argument(
+        "--all-help-file",
+        help="Input file with the contents produced by the `./pants help-all` command.",
+        required=True,
+    )
+    return parser
+
+
+def build_scope_properties(ruleset: dict, options: Iterable, scope: str) -> dict:
+    """Build properties object for a single scope.
+
+    There are custom types (e.g. `file_option` or `LogLevel`) for which one cannot safely infer a
+    type, so no type is added to the ruleset. If there are choices, there is no need to provide
+    "type". Otherwise, a provided `typ` field is used.
+    """
+    for option in options:
+        properties = ruleset[scope]["properties"]
+
+        properties[option["config_key"]] = {
+            "description": option["help"],
+            "default": option["default"],
+        }
+        if option["choices"]:
+            properties[option["config_key"]]["enum"] = option["choices"]
+        else:
+            typ = python_to_json_type_mapping.get(option["typ"])
+            if typ:
+                properties[option["config_key"]]["type"] = typ
+
+    return ruleset
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+    output_schema_filename = f"pantsbuild-{VERSION}.json"
+
+    with open(args.all_help_file) as fh:
+        all_help = json.load(fh)["scope_to_help_info"]
+
+    # set GLOBAL scope
+    all_help["GLOBAL"] = all_help[""]
+    del all_help[""]
+
+    # build ruleset for all scopes
+    ruleset = {}
+    for scope, options in all_help.items():
+        ruleset[scope] = {
+            "description": all_help[scope]["description"],
+            "type": "object",
+            "properties": {},
+        }
+        ruleset = build_scope_properties(
+            ruleset=ruleset,
+            options=itertools.chain(options["basic"], options["advanced"]),
+            scope=scope,
+        )
+
+    schema: Dict[str, Any] = dict()
+    schema["$schema"] = "http://json-schema.org/draft-04/schema#"
+    schema["description"] = "https://www.pantsbuild.org/"
+    schema["properties"] = ruleset
+
+    with open(output_schema_filename, "w") as fh:
+        fh.write(json.dumps(schema, indent=4))
+
+
+if __name__ == "__main__":
+    main()

--- a/build-support/bin/generate_json_schema_test.py
+++ b/build-support/bin/generate_json_schema_test.py
@@ -8,9 +8,12 @@ from generate_json_schema import GENERATED_JSON_SCHEMA_FILENAME, main
 
 def test_main():
     """Test generating a JSON schema using a simplified output of the `./pants help-all` command."""
-    cliargs = Mock()
-    cliargs.all_help_file = "build-support/bin/json_schema_testdata/all_help_sample_output.json"
-    with patch("generate_json_schema.get_args", lambda *args, **kwargs: cliargs):
+    with patch(
+        "generate_json_schema.get_args",
+        lambda *args, **kwargs: Mock(
+            all_help_file="build-support/bin/json_schema_testdata/all_help_sample_output.json"
+        ),
+    ):
         main()
 
     with open(GENERATED_JSON_SCHEMA_FILENAME) as fh:

--- a/build-support/bin/generate_json_schema_test.py
+++ b/build-support/bin/generate_json_schema_test.py
@@ -4,7 +4,12 @@ import json
 from unittest.mock import Mock, patch
 
 import pytest
-from generate_json_schema import GENERATED_JSON_SCHEMA_FILENAME, main, simplify_option_description
+from generate_json_schema import (
+    GENERATED_JSON_SCHEMA_FILENAME,
+    VERSION_MAJOR_MINOR,
+    main,
+    simplify_option_description,
+)
 
 
 @pytest.mark.parametrize(
@@ -65,7 +70,7 @@ def test_main():
 
     # an option description should be a single sentence with a URL to the option docs section
     assert schema["properties"]["GLOBAL"]["properties"]["level"]["description"] == (
-        "Set the logging level\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#level"
+        f"Set the logging level\nhttps://www.pantsbuild.org/v{VERSION_MAJOR_MINOR}/docs/reference-global#level"
     )
 
     # options should be part of the enum

--- a/build-support/bin/generate_json_schema_test.py
+++ b/build-support/bin/generate_json_schema_test.py
@@ -15,6 +15,10 @@ from generate_json_schema import (
 @pytest.mark.parametrize(
     "description,output",
     [
+        (
+            "Sentence starts here and ends without a full stop",
+            "Sentence starts here and ends without a full stop",
+        ),
         ("Sentence starts here and ends here.", "Sentence starts here and ends here"),
         (
             "We run `./pants goal` and stop here, then continue.",
@@ -35,6 +39,14 @@ from generate_json_schema import (
         (
             "Sentence starts here and ends here.\n\nA new sentence goes on in a new paragraph.",
             "Sentence starts here and ends here.\n\nA new sentence goes on in a new paragraph",
+        ),
+        (
+            "Path to a .pypirc config. (https://packaging.python.org/specifications/pypirc/). Set this.",
+            "Path to a .pypirc config. (https://packaging.python.org/specifications/pypirc/)",
+        ),
+        (
+            "Use this (4-space indentation). ('AOSP' is the Android Open Source Project.)",
+            "Use this (4-space indentation). ('AOSP' is the Android Open Source Project.)",
         ),
     ],
 )

--- a/build-support/bin/generate_json_schema_test.py
+++ b/build-support/bin/generate_json_schema_test.py
@@ -65,7 +65,7 @@ def test_main():
 
     # an option description should be a single sentence with a URL to the option docs section
     assert schema["properties"]["GLOBAL"]["properties"]["level"]["description"] == (
-        "Set the logging level\nhttps://www.pantsbuild.org/v2.14/docs/reference-GLOBAL#level"
+        "Set the logging level\nhttps://www.pantsbuild.org/v2.14/docs/reference-global#level"
     )
 
     # options should be part of the enum

--- a/build-support/bin/generate_json_schema_test.py
+++ b/build-support/bin/generate_json_schema_test.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from unittest.mock import Mock, patch
+
+from generate_json_schema import GENERATED_JSON_SCHEMA_FILENAME, main
+
+
+def test_main():
+    """Test generating a JSON schema using a simplified output of the `./pants help-all` command."""
+    cliargs = Mock()
+    cliargs.all_help_file = "build-support/bin/json_schema_testdata/all_help_sample_output.json"
+    with patch("generate_json_schema.get_args", lambda *args, **kwargs: cliargs):
+        main()
+
+    with open(GENERATED_JSON_SCHEMA_FILENAME) as fh:
+        schema = json.load(fh)
+
+    assert all((schema["$schema"], schema["description"]))
+    collected_properties = schema["properties"]["GLOBAL"]["properties"].keys()
+    assert all(
+        [
+            key in collected_properties
+            for key in ["log_show_rust_3rdparty", "ignore_warnings", "level"]
+        ]
+    )
+    assert "process_cleanup" not in collected_properties  # deprecated fields shouldn't be included

--- a/build-support/bin/json_schema_testdata/BUILD
+++ b/build-support/bin/json_schema_testdata/BUILD
@@ -1,0 +1,6 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+resources(
+    name="json_schema_samples",
+    sources=["all_help_sample_output.json"],
+)

--- a/build-support/bin/json_schema_testdata/all_help_sample_output.json
+++ b/build-support/bin/json_schema_testdata/all_help_sample_output.json
@@ -14,6 +14,7 @@
             "--[no-]log-show-rust-3rdparty"
           ],
           "env_var": "PANTS_LOG_SHOW_RUST_3RDPARTY",
+          "fromfile": false,
           "help": "Whether to show/hide logging done by 3rdparty Rust crates used by the Pants engine.",
           "removal_hint": null,
           "removal_version": null,
@@ -54,6 +55,7 @@
             "--ignore-warnings=\"['<str>', '<str>', ...]\""
           ],
           "env_var": "PANTS_IGNORE_WARNINGS",
+          "fromfile": false,
           "help": "Ignore logs and warnings matching these strings.\n\nNormally, Pants will look for literal matches from the start of the log/warning message, but you can prefix the ignore with `$regex$` for Pants to instead treat your string as a regex pattern. For example:\n\n    ignore_warnings = [\n        \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n        '$regex$:No files\\s*'\n    ]",
           "removal_hint": null,
           "removal_version": null,
@@ -101,6 +103,7 @@
             "--level=<LogLevel>"
           ],
           "env_var": "PANTS_LEVEL",
+          "fromfile": false,
           "help": "Set the logging level.",
           "removal_hint": null,
           "removal_version": null,
@@ -143,6 +146,7 @@
             "--[no-]process-cleanup"
           ],
           "env_var": "PANTS_PROCESS_CLEANUP",
+          "fromfile": false,
           "help": "If false, Pants will not clean up local directories used as chroots for running processes. Pants will log their location so that you can inspect the chroot, and run the `__run.sh` script to recreate the process using the same argv and environment variables used by Pants. This option is useful for debugging.",
           "removal_hint": "Use the `keep_sandboxes` option instead.",
           "removal_version": "3.0.0.dev0",

--- a/build-support/bin/json_schema_testdata/all_help_sample_output.json
+++ b/build-support/bin/json_schema_testdata/all_help_sample_output.json
@@ -147,7 +147,7 @@
           ],
           "env_var": "PANTS_PROCESS_CLEANUP",
           "fromfile": false,
-          "help": "If false, Pants will not clean up local directories used as chroots for running processes. Pants will log their location so that you can inspect the chroot, and run the `__run.sh` script to recreate the process using the same argv and environment variables used by Pants. This option is useful for debugging.",
+          "help": "\nIf false, Pants will not clean up local directories used as chroots for running processes. Pants will log their location so that you can inspect the chroot, and run the `__run.sh` script to recreate the process using the same argv and environment variables used by Pants. This option is useful for debugging.",
           "removal_hint": "Use the `keep_sandboxes` option instead.",
           "removal_version": "3.0.0.dev0",
           "scoped_cmd_line_args": [

--- a/build-support/bin/json_schema_testdata/all_help_sample_output.json
+++ b/build-support/bin/json_schema_testdata/all_help_sample_output.json
@@ -1,0 +1,182 @@
+{
+  "scope_to_help_info": {
+    "": {
+      "advanced": [
+        {
+          "choices": null,
+          "comma_separated_choices": null,
+          "comma_separated_display_args": "--[no-]log-show-rust-3rdparty",
+          "config_key": "log_show_rust_3rdparty",
+          "default": false,
+          "deprecated_message": null,
+          "deprecation_active": false,
+          "display_args": [
+            "--[no-]log-show-rust-3rdparty"
+          ],
+          "env_var": "PANTS_LOG_SHOW_RUST_3RDPARTY",
+          "help": "Whether to show/hide logging done by 3rdparty Rust crates used by the Pants engine.",
+          "removal_hint": null,
+          "removal_version": null,
+          "scoped_cmd_line_args": [
+            "--log-show-rust-3rdparty",
+            "--no-log-show-rust-3rdparty"
+          ],
+          "target_field_name": null,
+          "typ": "bool",
+          "unscoped_cmd_line_args": [
+            "--log-show-rust-3rdparty",
+            "--no-log-show-rust-3rdparty"
+          ],
+          "value_history": {
+            "ranked_values": [
+              {
+                "details": null,
+                "rank": "NONE",
+                "value": null
+              },
+              {
+                "details": null,
+                "rank": "HARDCODED",
+                "value": false
+              }
+            ]
+          }
+        },
+        {
+          "choices": null,
+          "comma_separated_choices": null,
+          "comma_separated_display_args": "--ignore-warnings=\"['<str>', '<str>', ...]\"",
+          "config_key": "ignore_warnings",
+          "default": [],
+          "deprecated_message": null,
+          "deprecation_active": false,
+          "display_args": [
+            "--ignore-warnings=\"['<str>', '<str>', ...]\""
+          ],
+          "env_var": "PANTS_IGNORE_WARNINGS",
+          "help": "Ignore logs and warnings matching these strings.\n\nNormally, Pants will look for literal matches from the start of the log/warning message, but you can prefix the ignore with `$regex$` for Pants to instead treat your string as a regex pattern. For example:\n\n    ignore_warnings = [\n        \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n        '$regex$:No files\\s*'\n    ]",
+          "removal_hint": null,
+          "removal_version": null,
+          "scoped_cmd_line_args": [
+            "--ignore-warnings"
+          ],
+          "target_field_name": null,
+          "typ": "list",
+          "unscoped_cmd_line_args": [
+            "--ignore-warnings"
+          ],
+          "value_history": {
+            "ranked_values": [
+              {
+                "details": "",
+                "rank": "NONE",
+                "value": []
+              },
+              {
+                "details": "",
+                "rank": "HARDCODED",
+                "value": []
+              }
+            ]
+          }
+        }
+      ],
+      "basic": [
+        {
+          "choices": [
+            "trace",
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
+          "comma_separated_choices": "trace, debug, info, warn, error",
+          "comma_separated_display_args": "-l=<LogLevel>, --level=<LogLevel>",
+          "config_key": "level",
+          "default": "info",
+          "deprecated_message": null,
+          "deprecation_active": false,
+          "display_args": [
+            "-l=<LogLevel>",
+            "--level=<LogLevel>"
+          ],
+          "env_var": "PANTS_LEVEL",
+          "help": "Set the logging level.",
+          "removal_hint": null,
+          "removal_version": null,
+          "scoped_cmd_line_args": [
+            "-l",
+            "--level"
+          ],
+          "target_field_name": null,
+          "typ": "LogLevel",
+          "unscoped_cmd_line_args": [
+            "-l",
+            "--level"
+          ],
+          "value_history": {
+            "ranked_values": [
+              {
+                "details": null,
+                "rank": "NONE",
+                "value": null
+              },
+              {
+                "details": null,
+                "rank": "HARDCODED",
+                "value": "info"
+              }
+            ]
+          }
+        }
+      ],
+      "deprecated": [
+        {
+          "choices": null,
+          "comma_separated_choices": null,
+          "comma_separated_display_args": "--[no-]process-cleanup",
+          "config_key": "process_cleanup",
+          "default": true,
+          "deprecated_message": "Deprecated, is scheduled to be removed in version: 3.0.0.dev0.",
+          "deprecation_active": true,
+          "display_args": [
+            "--[no-]process-cleanup"
+          ],
+          "env_var": "PANTS_PROCESS_CLEANUP",
+          "help": "If false, Pants will not clean up local directories used as chroots for running processes. Pants will log their location so that you can inspect the chroot, and run the `__run.sh` script to recreate the process using the same argv and environment variables used by Pants. This option is useful for debugging.",
+          "removal_hint": "Use the `keep_sandboxes` option instead.",
+          "removal_version": "3.0.0.dev0",
+          "scoped_cmd_line_args": [
+            "--process-cleanup",
+            "--no-process-cleanup"
+          ],
+          "target_field_name": null,
+          "typ": "bool",
+          "unscoped_cmd_line_args": [
+            "--process-cleanup",
+            "--no-process-cleanup"
+          ],
+          "value_history": {
+            "ranked_values": [
+              {
+                "details": null,
+                "rank": "NONE",
+                "value": null
+              },
+              {
+                "details": null,
+                "rank": "HARDCODED",
+                "value": true
+              }
+            ]
+          }
+        }
+      ],
+      "deprecated_scope": null,
+      "description": "Options to control the overall behavior of Pants.",
+      "is_goal": false,
+      "provider": "pants.core",
+      "scope": ""
+    }
+  }
+}


### PR DESCRIPTION
Work towards #17895 

Limitations:

* types of items in array are not defined as `all-help` output doesn't provide the item types (I don't feel comfortable parsing `"comma_separated_display_args": "--ignore-warnings=\"['<str>', '<str>', ...]\"",`)

<details>
  <summary>JSON schema example</summary>
  
```
        {
          "choices": null,
          "comma_separated_choices": null,
          "comma_separated_display_args": "--ignore-warnings=\"['<str>', '<str>', ...]\"",
          "config_key": "ignore_warnings",
          "default": [],
          "deprecated_message": null,
          "deprecation_active": false,
          "display_args": [
            "--ignore-warnings=\"['<str>', '<str>', ...]\""
          ],
          "env_var": "PANTS_IGNORE_WARNINGS",
          "help": "Ignore logs and warnings matching these strings.\n\nNormally, Pants will look for literal matches from the start of the log/warning message, but you can prefix the ignore with `$regex$` for Pants to instead treat your string as a regex pattern. For example:\n\n    ignore_warnings = [\n        \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n        '$regex$:No files\\s*'\n    ]",
          "removal_hint": null,
          "removal_version": null,
          "scoped_cmd_line_args": [
            "--ignore-warnings"
          ],
          "target_field_name": null,
          "typ": "list",
          "unscoped_cmd_line_args": [
            "--ignore-warnings"
          ],
          "value_history": {
            "ranked_values": [
              {
                "details": "",
                "rank": "NONE",
                "value": []
              },
              {
                "details": "",
                "rank": "HARDCODED",
                "value": []
              }
            ]
          }
        },
```

</details>

* The special Pants only `.add` syntax as in:

```
extra_requirements.add = [
  "mypy-typing-asserts",
  "strawberry-graphql>=0.95.1,<0.96",
]
```

is considered a violation: `{"add":["mypy-typing-asserts","strawberry-graphql>=0.95.1,<0.96"]} is not of type "array"`

This is likely possible to solve by providing a union of types `[object(key: array) OR array]` (where only allowed keys are "add" and "remove"), but didn't feel that's critical for the first iteration.

The arrays can be:
* a string (that follows a particular syntax):

```
[pytest]
extra_requirements = "+['pytest-vcr']"
```

* an array:
```
[pytest]
extra_requirements = ["pytest-vcr"]
```

* an object (with keys being only `add` or `remove`):

```
[pytest]
extra_requirements.add = ["pytest-vcr"]
```