### PR TITLE
Allow `experimental_shell_command`/`experimental_run_in_sandbox` to specify `output_`s from anywhere under the buildroot

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -277,9 +277,13 @@ class ShellCommandOutputsField(StringSequenceField):
     alias = "outputs"
     help = softwrap(
         """
-        Specify the shell command output files and directories.
+        Specify the shell command output files and directories, relative to the `BUILD` file's
+        directory.
 
         Use a trailing slash on directory names, i.e. `my_dir/`.
+
+        Relative paths (including `..`) may be used, as long as the path does not ascend further
+        than the build root.
         """
     )
     removal_hint = "To fix, use `output_files` and `output_directories` instead."
@@ -292,10 +296,14 @@ class ShellCommandOutputFilesField(StringSequenceField):
     default = ()
     help = softwrap(
         """
-        Specify the shell command's output files to capture.
+        Specify the shell command's output files to capture, relative to the `BUILD` file's
+        directory.
 
         For directories, use `output_directories`. At least one of `output_files` and
         `output_directories` must be specified.
+
+        Relative paths (including `..`) may be used, as long as the path does not ascend further
+        than the build root.
         """
     )
 
@@ -307,10 +315,13 @@ class ShellCommandOutputDirectoriesField(StringSequenceField):
     help = softwrap(
         """
         Specify full directories (including recursive descendants) of output to capture from the
-        shell command.
+        shell command, relative to the `BUILD` file's directory.
 
-        For files, use `output_files`. At least one of `output_files` and
+        For individual files, use `output_files`. At least one of `output_files` and
         `output_directories` must be specified.
+
+        Relative paths (including `..`) may be used, as long as the path does not ascend further
+        than the build root.
         """
     )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -495,9 +495,7 @@ async def prepare_shell_command_process(
 
 def _output_at_build_root(process: Process, bash: BashBinary) -> Process:
 
-    working_directory = process.working_directory
-    if working_directory is None:
-        working_directory = ""
+    working_directory = process.working_directory or ""
 
     output_directories = process.output_directories
     output_files = process.output_files
@@ -505,9 +503,9 @@ def _output_at_build_root(process: Process, bash: BashBinary) -> Process:
         output_directories = tuple(os.path.join(working_directory, d) for d in output_directories)
         output_files = tuple(os.path.join(working_directory, d) for d in output_files)
 
-    cd = f"cd {shlex.quote(working_directory)} &&" if working_directory else ""
+    cd = f"cd {shlex.quote(working_directory)} && " if working_directory else ""
     shlexed_argv = " ".join(shlex.quote(arg) for arg in process.argv)
-    new_argv = (bash.path, "-c", f"{cd} {shlexed_argv}")
+    new_argv = (bash.path, "-c", f"{cd}{shlexed_argv}")
 
     return dataclasses.replace(
         process,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -148,6 +148,10 @@ async def _execution_environment_from_dependencies(shell_command: Target) -> Dig
         shell_command.get(ShellCommandExecutionDependenciesField).value is not None
     )
 
+    any_dependencies_defined = (
+        shell_command.get(ShellCommandOutputDependenciesField).value is not None
+    )
+
     # If we're specifying the `dependencies` as relevant to the execution environment, then include
     # this command as a root for the transitive dependency search for execution dependencies.
     maybe_this_target = (shell_command.address,) if not runtime_dependencies_defined else ()
@@ -159,7 +163,7 @@ async def _execution_environment_from_dependencies(shell_command: Target) -> Dig
             UnparsedAddressInputs,
             shell_command.get(ShellCommandExecutionDependenciesField).to_unparsed_address_inputs(),
         )
-    else:
+    elif any_dependencies_defined:
         runtime_dependencies = Addresses()
         warn_or_error(
             "2.17.0.dev0",
@@ -174,6 +178,8 @@ async def _execution_environment_from_dependencies(shell_command: Target) -> Dig
             ),
             print_warning=True,
         )
+    else:
+        runtime_dependencies = Addresses()
 
     transitive = await Get(
         TransitiveTargets,

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import shlex
 from textwrap import dedent
 
 import pytest
@@ -553,7 +554,8 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
     assert "bash" in res.argv[0]
     assert res.argv[1:] == (
         "-c",
-        (
+        "cd src && /bin/bash -c "
+        + shlex.quote(
             "$mkdir -p .bin;"
             "for tool in $TOOLS; do $ln -sf ${!tool} .bin; done;"
             'export PATH="$PWD/.bin";'

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -553,15 +553,16 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("src", target_name="boot-script-test"))
     res = rule_runner.request(Process, [ShellCommandProcessFromTargetRequest(tgt)])
     assert "bash" in res.argv[0]
-    assert res.argv[1:] == (
-        "-c",
-        "cd src && /bin/bash -c "
-        + shlex.quote(
+    assert res.argv[1] == "-c"
+    assert res.argv[2].startswith("cd src &&")
+    assert "bash -c" in res.argv[2]
+    assert res.argv[2].endswith(
+        shlex.quote(
             "$mkdir -p .bin;"
             "for tool in $TOOLS; do $ln -sf ${!tool} .bin; done;"
             'export PATH="$PWD/.bin";'
             "./command.script"
-        ),
+        )
     )
 
     tools = sorted({"python3_8", "mkdir", "ln"})
@@ -590,15 +591,15 @@ def test_shell_command_boot_script_in_build_root(rule_runner: RuleRunner) -> Non
     tgt = rule_runner.get_target(Address("", target_name="boot-script-test"))
     res = rule_runner.request(Process, [ShellCommandProcessFromTargetRequest(tgt)])
     assert "bash" in res.argv[0]
-    assert res.argv[1:] == (
-        "-c",
-        "/bin/bash -c "
-        + shlex.quote(
+    assert res.argv[1] == "-c"
+    assert "bash -c" in res.argv[2]
+    assert res.argv[2].endswith(
+        shlex.quote(
             "$mkdir -p .bin;"
             "for tool in $TOOLS; do $ln -sf ${!tool} .bin; done;"
             'export PATH="$PWD/.bin";'
             "./command.script"
-        ),
+        )
     )
 
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -630,3 +630,26 @@ def test_run_runnable_in_sandbox(rule_runner: RuleRunner) -> None:
         Address("src", target_name="run_fruitcake"),
         expected_contents={"src/fruitcake.txt": "fruitcake\n"},
     )
+
+
+def test_relative_directories(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                """\
+                experimental_shell_command(
+                  name="quotes",
+                  tools=["echo"],
+                  command='echo foosh > ../foosh.txt',
+                  output_files=["../foosh.txt"],
+                )
+                """
+            ),
+        }
+    )
+
+    assert_shell_command_result(
+        rule_runner,
+        Address("src", target_name="quotes"),
+        expected_contents={"foosh.txt": "foosh\n"},
+    )


### PR DESCRIPTION
Over in #17928, @danxmoran slightly nerdsniped me :)

WIth this change, ad-hoc processes are wrapped by a `bash` process that runs in the buildroot, and immediately `chdir`s into the working directory, rather than using `Process`' native `working_directory` argument. This means that Pants will allow the processes to request output files from anywhere under the buildroot, rather than just under the working directory.

Prework for #17928, addresses one of the use cases in #16807.