### PR TITLE
Do not load the BUILD file prelude (macros) in the bootstrap scheduler.

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -40,6 +40,7 @@ from pants.engine.target import (
     RegisteredTargetTypes,
 )
 from pants.engine.unions import UnionMembership
+from pants.init.bootstrap_scheduler import BootstrapStatus
 from pants.option.global_options import GlobalOptions
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap
@@ -53,11 +54,16 @@ class BuildFileOptions:
 
 
 @rule
-def extract_build_file_options(global_options: GlobalOptions) -> BuildFileOptions:
+def extract_build_file_options(
+    global_options: GlobalOptions,
+    bootstrap_status: BootstrapStatus,
+) -> BuildFileOptions:
     return BuildFileOptions(
         patterns=global_options.build_patterns,
         ignores=global_options.build_ignore,
-        prelude_globs=global_options.build_file_prelude_globs,
+        prelude_globs=(
+            () if bootstrap_status.in_progress else global_options.build_file_prelude_globs
+        ),
     )
 
 

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -23,6 +23,7 @@ from pants.engine.internals.build_files import (
 )
 from pants.engine.internals.defaults import ParametrizeDefault
 from pants.engine.internals.dep_rules import MaybeBuildFileDependencyRulesImplementation
+from pants.engine.internals.mapper import AddressFamily
 from pants.engine.internals.parametrize import Parametrize
 from pants.engine.internals.parser import BuildFilePreludeSymbols, Parser
 from pants.engine.internals.scheduler import ExecutionError
@@ -491,3 +492,32 @@ def test_build_files_share_globals() -> None:
     assert symbols.symbols["hello"].__globals__ is symbols.symbols["world"].__globals__
     assert "world" in symbols.symbols["hello"].__globals__
     assert "hello" in symbols.symbols["world"].__globals__
+
+
+def test_macro_undefined_symbol_bootstrap() -> None:
+    # Tests that an undefined symbol in a macro is ignored while bootstrapping. Ignoring undeclared
+    # symbols during parsing is insufficient, because we would need to re-evaluate the preludes after
+    # adding each additional undefined symbol to scope.
+    rule_runner = RuleRunner(
+        rules=[QueryRule(AddressFamily, [AddressFamilyDir])],
+        is_bootstrap=True,
+    )
+    rule_runner.write_files(
+        {
+            "prelude.py": dedent(
+                """
+                def uses_undefined():
+                    return this_is_undefined()
+                """
+            ),
+            "BUILD": dedent(
+                """
+                uses_undefined()
+                """
+            ),
+        }
+    )
+
+    # Parse the root BUILD file.
+    address_family = rule_runner.request(AddressFamily, [AddressFamilyDir("")])
+    assert not address_family.name_to_target_adaptors

--- a/src/python/pants/init/bootstrap_scheduler.py
+++ b/src/python/pants/init/bootstrap_scheduler.py
@@ -11,3 +11,14 @@ class BootstrapScheduler:
     """A Scheduler that has been configured with only the rules for bootstrapping."""
 
     scheduler: Scheduler
+
+
+@dataclass(frozen=True)
+class BootstrapStatus:
+    """A singleton value that `@rules` can use to determine whether bootstrap is underway.
+
+    Bootstrap runs occur before plugins are loaded, and so when they parse BUILD files, they may
+    need to ignore unrecognized symbols (which might be provided by plugins which are loaded later).
+    """
+
+    in_progress: bool

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -40,6 +40,7 @@ from pants.engine.streaming_workunit_handler import rules as streaming_workunit_
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.init import specs_calculator
+from pants.init.bootstrap_scheduler import BootstrapStatus
 from pants.option.global_options import (
     DEFAULT_EXECUTION_OPTIONS,
     DynamicRemoteOptions,
@@ -189,7 +190,7 @@ class EngineInitializer:
         build_configuration: BuildConfiguration,
         dynamic_remote_options: DynamicRemoteOptions,
         executor: PyExecutor | None = None,
-        ignore_unrecognized_build_file_symbols: bool = False,
+        is_bootstrap: bool = False,
     ) -> GraphScheduler:
         build_root = get_buildroot()
         executor = executor or GlobalOptions.create_py_executor(bootstrap_options)
@@ -209,7 +210,7 @@ class EngineInitializer:
             include_trace_on_error=bootstrap_options.print_stacktrace,
             engine_visualize_to=bootstrap_options.engine_visualize_to,
             watch_filesystem=bootstrap_options.watch_filesystem,
-            ignore_unrecognized_build_file_symbols=ignore_unrecognized_build_file_symbols,
+            is_bootstrap=is_bootstrap,
         )
 
     @staticmethod
@@ -228,7 +229,7 @@ class EngineInitializer:
         include_trace_on_error: bool = True,
         engine_visualize_to: str | None = None,
         watch_filesystem: bool = True,
-        ignore_unrecognized_build_file_symbols: bool = False,
+        is_bootstrap: bool = False,
     ) -> GraphScheduler:
         build_root_path = build_root or get_buildroot()
 
@@ -245,8 +246,12 @@ class EngineInitializer:
                 registered_target_types=registered_target_types,
                 union_membership=union_membership,
                 object_aliases=build_configuration.registered_aliases,
-                ignore_unrecognized_symbols=ignore_unrecognized_build_file_symbols,
+                ignore_unrecognized_symbols=is_bootstrap,
             )
+
+        @rule
+        def bootstrap_status() -> BootstrapStatus:
+            return BootstrapStatus(is_bootstrap)
 
         @rule
         def build_configuration_singleton() -> BuildConfiguration:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -77,7 +77,7 @@ def create_bootstrap_scheduler(
             bc_builder.create(),
             DynamicRemoteOptions.disabled(),
             executor,
-            ignore_unrecognized_build_file_symbols=True,
+            is_bootstrap=True,
         ).scheduler
     )
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -234,6 +234,7 @@ class RuleRunner:
         extra_session_values: dict[Any, Any] | None = None,
         max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
         inherent_environment: EnvironmentName | None = EnvironmentName(None),
+        is_bootstrap: bool = False,
     ) -> None:
 
         bootstrap_args = [*bootstrap_args]
@@ -323,6 +324,7 @@ class RuleRunner:
                 ),
                 ca_certs_path=ca_certs_path,
                 engine_visualize_to=None,
+                is_bootstrap=is_bootstrap,
             ).scheduler
         )
 


### PR DESCRIPTION
#16661 introduced ignoring of undefined symbols during bootstrap, to allow us to partially parse `BUILD` files to extract `environment` targets. But defining additional symbols after a function (in particular: a macro) has been evaluated will not cause those symbols to be in scope, and so a `NameError` for an undefined symbol used by a macro was triggered in an infinite loop.

Instead, we can completely skip loading of macros during bootstrap, with the caveat that macros cannot be used to define `environment` targets. We additionally re-raise a `NameError` if we detect that attempting to ignore it has failed.

Fixes #17852.