### PR TITLE
internals: improve error message when imports are found in a build file or a macro

### DIFF
--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -290,7 +290,7 @@ def error_on_imports(build_file_content: str, filepath: str) -> None:
             f"Import used in {filepath} at line {lineno}. Import statements are banned in "
             "BUILD files and macros (that act like a normal BUILD file) because they can easily "
             "break Pants caching and lead to stale results. "
-            f"\n\nInstead, consider writing a plugin ({doc_url('plugins-overview')}."
+            f"\n\nInstead, consider writing a plugin ({doc_url('plugins-overview')})."
         )
 
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -288,9 +288,9 @@ def error_on_imports(build_file_content: str, filepath: str) -> None:
             continue
         raise ParseError(
             f"Import used in {filepath} at line {lineno}. Import statements are banned in "
-            "BUILD files because they can easily break Pants caching and lead to stale results. "
-            f"\n\nInstead, consider writing a macro ({doc_url('macros')}) or "
-            f"writing a plugin ({doc_url('plugins-overview')}."
+            "BUILD files and macros (that act like a normal BUILD file) because they can easily "
+            "break Pants caching and lead to stale results. "
+            f"\n\nInstead, consider writing a plugin ({doc_url('plugins-overview')}."
         )
 
 


### PR DESCRIPTION
Work towards #17932 

The idea is that if a user is adding `import`s in a `BUILD` file, then we should likely suggest writing a macro. If they import in a macro, then we suggest writing a plugin (they've tried both BUILD files and macros at this stage, presumably).