### PR TITLE
Do not load the BUILD file prelude (macros) in the bootstrap scheduler. (Cherry-pick of #17939)

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -31,6 +31,7 @@ from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRe
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership
+from pants.init.bootstrap_scheduler import BootstrapStatus
 from pants.option.global_options import GlobalOptions
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import softwrap
@@ -44,11 +45,16 @@ class BuildFileOptions:
 
 
 @rule
-def extract_build_file_options(global_options: GlobalOptions) -> BuildFileOptions:
+def extract_build_file_options(
+    global_options: GlobalOptions,
+    bootstrap_status: BootstrapStatus,
+) -> BuildFileOptions:
     return BuildFileOptions(
         patterns=global_options.build_patterns,
         ignores=global_options.build_ignore,
-        prelude_globs=global_options.build_file_prelude_globs,
+        prelude_globs=(
+            () if bootstrap_status.in_progress else global_options.build_file_prelude_globs
+        ),
     )
 
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -160,11 +160,19 @@ class Parser:
         global_symbols = {**self._symbols, **extra_symbols.symbols}
 
         if self.ignore_unrecognized_symbols:
+            defined_symbols = set()
             while True:
                 try:
                     exec(build_file_content, global_symbols)
                 except NameError as e:
                     bad_symbol = _extract_symbol_from_name_error(e)
+                    if bad_symbol in defined_symbols:
+                        # We have previously attempted to define this symbol, but have received
+                        # another error for it. This can indicate that the symbol is being used
+                        # from code which has already been compiled, such as builtin functions.
+                        raise
+                    defined_symbols.add(bad_symbol)
+
                     global_symbols[bad_symbol] = _unrecognized_symbol_func
                     self._parse_state.reset(rel_path=os.path.dirname(filepath), defaults=defaults)
                     continue

--- a/src/python/pants/init/bootstrap_scheduler.py
+++ b/src/python/pants/init/bootstrap_scheduler.py
@@ -11,3 +11,14 @@ class BootstrapScheduler:
     """A Scheduler that has been configured with only the rules for bootstrapping."""
 
     scheduler: Scheduler
+
+
+@dataclass(frozen=True)
+class BootstrapStatus:
+    """A singleton value that `@rules` can use to determine whether bootstrap is underway.
+
+    Bootstrap runs occur before plugins are loaded, and so when they parse BUILD files, they may
+    need to ignore unrecognized symbols (which might be provided by plugins which are loaded later).
+    """
+
+    in_progress: bool

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -39,6 +39,7 @@ from pants.engine.streaming_workunit_handler import rules as streaming_workunit_
 from pants.engine.target import RegisteredTargetTypes
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.init import specs_calculator
+from pants.init.bootstrap_scheduler import BootstrapStatus
 from pants.option.global_options import (
     DEFAULT_EXECUTION_OPTIONS,
     DynamicRemoteOptions,
@@ -188,7 +189,7 @@ class EngineInitializer:
         build_configuration: BuildConfiguration,
         dynamic_remote_options: DynamicRemoteOptions,
         executor: PyExecutor | None = None,
-        ignore_unrecognized_build_file_symbols: bool = False,
+        is_bootstrap: bool = False,
     ) -> GraphScheduler:
         build_root = get_buildroot()
         executor = executor or GlobalOptions.create_py_executor(bootstrap_options)
@@ -208,7 +209,7 @@ class EngineInitializer:
             include_trace_on_error=bootstrap_options.print_stacktrace,
             engine_visualize_to=bootstrap_options.engine_visualize_to,
             watch_filesystem=bootstrap_options.watch_filesystem,
-            ignore_unrecognized_build_file_symbols=ignore_unrecognized_build_file_symbols,
+            is_bootstrap=is_bootstrap,
         )
 
     @staticmethod
@@ -227,7 +228,7 @@ class EngineInitializer:
         include_trace_on_error: bool = True,
         engine_visualize_to: str | None = None,
         watch_filesystem: bool = True,
-        ignore_unrecognized_build_file_symbols: bool = False,
+        is_bootstrap: bool = False,
     ) -> GraphScheduler:
         build_root_path = build_root or get_buildroot()
 
@@ -243,8 +244,12 @@ class EngineInitializer:
                 build_root=build_root_path,
                 target_type_aliases=registered_target_types.aliases,
                 object_aliases=build_configuration.registered_aliases,
-                ignore_unrecognized_symbols=ignore_unrecognized_build_file_symbols,
+                ignore_unrecognized_symbols=is_bootstrap,
             )
+
+        @rule
+        def bootstrap_status() -> BootstrapStatus:
+            return BootstrapStatus(is_bootstrap)
 
         @rule
         def build_configuration_singleton() -> BuildConfiguration:

--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -77,7 +77,7 @@ def create_bootstrap_scheduler(
             bc_builder.create(),
             DynamicRemoteOptions.disabled(),
             executor,
-            ignore_unrecognized_build_file_symbols=True,
+            is_bootstrap=True,
         ).scheduler
     )
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -213,6 +213,7 @@ class RuleRunner:
         extra_session_values: dict[Any, Any] | None = None,
         max_workunit_verbosity: LogLevel = LogLevel.DEBUG,
         inherent_environment: EnvironmentName | None = EnvironmentName(None),
+        is_bootstrap: bool = False,
     ) -> None:
 
         bootstrap_args = [*bootstrap_args]
@@ -302,6 +303,7 @@ class RuleRunner:
                 ),
                 ca_certs_path=ca_certs_path,
                 engine_visualize_to=None,
+                is_bootstrap=is_bootstrap,
             ).scheduler
         )
 


### PR DESCRIPTION
#16661 introduced ignoring of undefined symbols during bootstrap, to allow us to partially parse `BUILD` files to extract `environment` targets. But defining additional symbols after a function (in particular: a macro) has been evaluated will not cause those symbols to be in scope, and so a `NameError` for an undefined symbol used by a macro was triggered in an infinite loop.

Instead, we can completely skip loading of macros during bootstrap, with the caveat that macros cannot be used to define `environment` targets. We additionally re-raise a `NameError` if we detect that attempting to ignore it has failed.

Fixes #17852.
