### PR TITLE
Improve type inference for `@rule`s

### DIFF
--- a/src/python/pants/base/exceptions.py
+++ b/src/python/pants/base/exceptions.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
     from pants.engine.internals.native_engine import PyFailure
 
 
-class TargetDefinitionException(Exception):
+class PantsException(Exception):
+    """Base exception type for Pants."""
+
+
+class TargetDefinitionException(PantsException):
     """Indicates an invalid target definition.
 
     :API: public
@@ -29,7 +33,7 @@ class TargetDefinitionException(Exception):
         super().__init__(f"Invalid target {target}: {msg}")
 
 
-class BuildConfigurationError(Exception):
+class BuildConfigurationError(PantsException):
     """Indicates an error in a pants installation's configuration."""
 
 
@@ -37,8 +41,12 @@ class BackendConfigurationError(BuildConfigurationError):
     """Indicates a plugin backend with a missing or malformed register module."""
 
 
-class MappingError(Exception):
+class MappingError(PantsException):
     """Indicates an error mapping addressable objects."""
+
+
+class RuleTypeError(PantsException):
+    """Invalid @rule implementation."""
 
 
 class NativeEngineFailure(Exception):


### PR DESCRIPTION
caveat: This does add *a lot* of extra overhead during rule parsing affecting the Pants scheduler startup time (~12s)--which we need to address. Either by caching the rule-parsing step, or refactoring over to Rust, or something else..

This opens up for calling rule helpers more dynamically so we can have rule-logic closer to the classes and not spread out in all the rules, and also `Get`s without having to spell out the input types as long as the type of the input arg is known (which it does more now than before).

I think the latter can help reducing the number of imports we need in all rule files as well.

As an example, imagine this:

```python
    if python_infer_subsystem.local_disambiguation:
        source_root = await Get(
            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
        )
        locality = source_root.path
```

`Address` could have a rule helper instead, so we could do:

```python
    if python_infer_subsystem.local_disambiguation:
        locality = (await request.field_set.address._get_source_root()).path
```

and the rule helper something like (where the return type from `.for_address()` is used to find out it is a `SourceRootRequest`:

```python
    @rule_helper
    async def _get_source_root(self) -> SourceRoot:
        return await Get(
            SourceRoot, SourceRootRequest.for_address(self)
        )
```

Doesn't maybe look like much for this example, but I can see this opens up a lot of flexibility and I think it'll lower the learning curve for new users as well.