### PR TITLE
docs: provide a link to Google Cloud Function in the backend docstring

### DIFF
--- a/src/python/pants/backend/google_cloud_function/python/register.py
+++ b/src/python/pants/backend/google_cloud_function/python/register.py
@@ -3,7 +3,7 @@
 
 """Create Google Cloud Functions from Python code.
 
-FIXME See https://www.pantsbuild.org/docs/awslambda-python.
+See https://www.pantsbuild.org/docs/google-cloud-function-python.
 """
 
 from pants.backend.google_cloud_function.python import rules as python_rules


### PR DESCRIPTION
The docs have been updated, the `FIXME` is fixed :)