### PR TITLE
Ensure JDK is propagated into `experimental_run_in_sandbox` exection environment

### DIFF
--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -90,6 +90,7 @@ class ShellCommandProcessRequest:
     timeout: int | None
     tools: tuple[str, ...]
     input_digest: Digest
+    immutable_input_digests: FrozenDict[str, Digest] | None
     append_only_caches: FrozenDict[str, str] | None
     output_files: tuple[str, ...]
     output_directories: tuple[str, ...]
@@ -135,6 +136,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
         fetch_env_vars=shell_command.get(ShellCommandExtraEnvVarsField).value or (),
         append_only_caches=None,
         supplied_env_var_values=None,
+        immutable_input_digests=None,
     )
 
 
@@ -353,6 +355,7 @@ async def run_in_sandbox_request(
         timeout=None,
         tools=(),
         input_digest=input_digest,
+        immutable_input_digests=FrozenDict(run_request.immutable_input_digests or {}),
         append_only_caches=FrozenDict(run_request.append_only_caches or {}),
         output_files=output_files,
         output_directories=output_directories,
@@ -433,6 +436,7 @@ async def prepare_shell_command_process(
     fetch_env_vars = shell_command.fetch_env_vars
     supplied_env_vars = shell_command.supplied_env_var_values or FrozenDict()
     append_only_caches = shell_command.append_only_caches or FrozenDict()
+    immutable_input_digests = shell_command.immutable_input_digests
 
     if interactive:
         command_env = {
@@ -490,6 +494,7 @@ async def prepare_shell_command_process(
         timeout_seconds=timeout,
         working_directory=working_directory,
         append_only_caches=append_only_caches,
+        immutable_input_digests=immutable_input_digests,
     )
 
     if not interactive:


### PR DESCRIPTION
Using JVM targets as runnables was not working, because we didn't propagate the JDK immutable input into the execution environment. Now we do.