### PR TITLE
go: add fields for analyzing Go standard library packages

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -36,7 +36,7 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoMod,
     OwningGoModRequest,
 )
-from pants.backend.go.util_rules.import_analysis import GoStdLibImports, GoStdLibImportsRequest
+from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
 from pants.backend.go.util_rules.third_party_pkg import (
     AllThirdPartyPackages,
     AllThirdPartyPackagesRequest,
@@ -230,8 +230,8 @@ async def infer_go_dependencies(
             FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr, build_opts=build_opts)
         ),
         Get(
-            GoStdLibImports,
-            GoStdLibImportsRequest(with_race_detector=build_opts.with_race_detector),
+            GoStdLibPackages,
+            GoStdLibPackagesRequest(with_race_detector=build_opts.with_race_detector),
         ),
     )
 
@@ -317,8 +317,8 @@ async def infer_go_third_party_package_dependencies(
             ),
         ),
         Get(
-            GoStdLibImports,
-            GoStdLibImportsRequest(with_race_detector=build_opts.with_race_detector),
+            GoStdLibPackages,
+            GoStdLibPackagesRequest(with_race_detector=build_opts.with_race_detector),
         ),
     )
 

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -10,6 +10,7 @@ from typing import ClassVar
 import ijson.backends.python as ijson
 
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
+from pants.backend.go.util_rules.cgo import CGoCompilerFlags
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
@@ -21,38 +22,85 @@ from pants.util.logging import LogLevel
 logger = logging.getLogger(__name__)
 
 
-class GoStdLibImports(FrozenDict[str, str]):
-    """A mapping of standard library import paths to the `.a` static file paths for that import
-    path.
+@dataclass(frozen=True)
+class GoStdLibPackage:
+    name: str
+    import_path: str
+    pkg_source_path: str
+    pkg_target: str  # Note: This will be removed once PRs land to support building the Go SDK.
+    imports: tuple[str, ...]
 
-    For example, "net/smtp": "/absolute_path_to_goroot/pkg/darwin_arm64/net/smtp.a".
-    """
+    # Analysis for when Pants is able to compile the SDK directly.
+    go_files: tuple[str, ...]
+    cgo_files: tuple[str, ...]
+    c_files: tuple[str, ...]
+    cxx_files: tuple[str, ...]
+    m_files: tuple[str, ...]
+    h_files: tuple[str, ...]
+    f_files: tuple[str, ...]
+    s_files: tuple[str, ...]
+    syso_files: tuple[str, ...]
+    cgo_flags: CGoCompilerFlags
+
+
+class GoStdLibPackages(FrozenDict[str, GoStdLibPackage]):
+    """A mapping of standard library import paths to an analysis of the package at that import
+    path."""
 
 
 @dataclass(frozen=True)
-class GoStdLibImportsRequest:
+class GoStdLibPackagesRequest:
     with_race_detector: bool
+    cgo_enabled: bool = True
 
 
-@rule(desc="Determine Go std lib's imports", level=LogLevel.DEBUG)
-async def determine_go_std_lib_imports(request: GoStdLibImportsRequest) -> GoStdLibImports:
+@rule(desc="Analyze Go standard library packages.", level=LogLevel.DEBUG)
+async def analyze_go_stdlib_packages(request: GoStdLibPackagesRequest) -> GoStdLibPackages:
     maybe_race_arg = ["-race"] if request.with_race_detector else []
     list_result = await Get(
         ProcessResult,
         GoSdkProcess(
             # "-find" skips determining dependencies and imports for each package.
-            command=("list", "-find", *maybe_race_arg, "-json", "std"),
+            command=("list", *maybe_race_arg, "-json", "std"),
+            env={"CGO_ENABLED": "1" if request.cgo_enabled else "0"},
             description="Ask Go for its available import paths",
         ),
     )
-    result = {}
-    for package_descriptor in ijson.items(list_result.stdout, "", multiple_values=True):
-        import_path = package_descriptor.get("ImportPath")
-        target = package_descriptor.get("Target")
-        if not import_path or not target:
+    stdlib_packages = {}
+    for pkg_json in ijson.items(list_result.stdout, "", multiple_values=True):
+        import_path = pkg_json.get("ImportPath")
+        pkg_source_path = pkg_json.get("Dir")
+        pkg_target = pkg_json.get("Target")
+
+        if not import_path or not pkg_source_path or not pkg_target:
             continue
-        result[import_path] = target
-    return GoStdLibImports(result)
+
+        stdlib_packages[import_path] = GoStdLibPackage(
+            name=pkg_json.get("Name"),
+            import_path=import_path,
+            pkg_source_path=pkg_source_path,
+            pkg_target=pkg_target,
+            imports=tuple(pkg_json.get("Imports", ())),
+            go_files=tuple(pkg_json.get("GoFiles", ())),
+            cgo_files=tuple(pkg_json.get("CgoFiles", ())),
+            c_files=tuple(pkg_json.get("CFiles", ())),
+            cxx_files=tuple(pkg_json.get("CXXFiles", ())),
+            m_files=tuple(pkg_json.get("MFiles", ())),
+            h_files=tuple(pkg_json.get("HFiles", ())),
+            f_files=tuple(pkg_json.get("FFiles", ())),
+            s_files=tuple(pkg_json.get("SFiles", ())),
+            syso_files=tuple(pkg_json.get("SysoFiles", ())),
+            cgo_flags=CGoCompilerFlags(
+                cflags=tuple(pkg_json.get("CgoCFLAGS", [])),
+                cppflags=tuple(pkg_json.get("CgoCPPFLAGS", [])),
+                cxxflags=tuple(pkg_json.get("CgoCXXFLAGS", [])),
+                fflags=tuple(pkg_json.get("CgoFFLAGS", [])),
+                ldflags=tuple(pkg_json.get("CgoLDFLAGS", [])),
+                pkg_config=tuple(pkg_json.get("CgoPkgConfig", [])),
+            ),
+        )
+
+    return GoStdLibPackages(stdlib_packages)
 
 
 @dataclass(frozen=True)
@@ -87,13 +135,13 @@ async def generate_import_config(request: ImportConfigRequest) -> ImportConfig:
         ),
     ]
     if request.include_stdlib:
-        std_lib_imports = await Get(
-            GoStdLibImports,
-            GoStdLibImportsRequest(with_race_detector=request.build_opts.with_race_detector),
+        std_lib_packages = await Get(
+            GoStdLibPackages,
+            GoStdLibPackagesRequest(with_race_detector=request.build_opts.with_race_detector),
         )
         lines.extend(
-            f"packagefile {import_path}={static_file_path}"
-            for import_path, static_file_path in std_lib_imports.items()
+            f"packagefile {import_path}={pkg.pkg_target}"
+            for import_path, pkg in std_lib_packages.items()
         )
     content = "\n".join(lines).encode("utf-8")
     result = await Get(Digest, CreateDigest([FileContent(ImportConfig.CONFIG_PATH, content)]))

--- a/src/python/pants/backend/go/util_rules/import_analysis_test.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis_test.py
@@ -11,8 +11,8 @@ import pytest
 from pants.backend.go.util_rules import import_analysis, sdk
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.import_analysis import (
-    GoStdLibImports,
-    GoStdLibImportsRequest,
+    GoStdLibPackages,
+    GoStdLibPackagesRequest,
     ImportConfig,
     ImportConfigRequest,
 )
@@ -28,7 +28,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *sdk.rules(),
             *import_analysis.rules(),
-            QueryRule(GoStdLibImports, (GoStdLibImportsRequest,)),
+            QueryRule(GoStdLibPackages, (GoStdLibPackagesRequest,)),
             QueryRule(ImportConfig, (ImportConfigRequest,)),
         ],
     )
@@ -39,7 +39,7 @@ def rule_runner() -> RuleRunner:
 @pytest.mark.parametrize("with_race_detector", (False, True))
 def test_stdlib_package_resolution(rule_runner: RuleRunner, with_race_detector: bool) -> None:
     std_lib_imports = rule_runner.request(
-        GoStdLibImports, [GoStdLibImportsRequest(with_race_detector=with_race_detector)]
+        GoStdLibPackages, [GoStdLibPackagesRequest(with_race_detector=with_race_detector)]
     )
     assert "fmt" in std_lib_imports
 


### PR DESCRIPTION
Add support for analyzing the packages within the Go standard library. The analysis fields will be consumed in a subsequent PR which supports compiling the Go SDK.

Also renames the dataclass to `GoStdLibPackage`.

This is part of fixing https://github.com/pantsbuild/pants/issues/17950 and was extracted from https://github.com/pantsbuild/pants/pull/17914.