### PR TITLE
Build Linux wheels in custom images.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -330,7 +330,7 @@ jobs:
     timeout-minutes: 60
   build_wheels_linux_arm64:
     container:
-      image: quay.io/pypa/manylinux2014_aarch64:latest
+      image: registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v1-568cfc69e
       options: --user 1000:1000
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
@@ -401,7 +401,7 @@ jobs:
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
-      image: quay.io/pypa/manylinux2014_x86_64:latest
+      image: registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -701,9 +701,7 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
     # the code, install rustup and expose Pythons.
     # TODO: Apply rust caching here.
     if platform == Platform.LINUX_X86_64:
-        container = {
-            "image": "registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e"
-        }
+        container = {"image": "registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e"}
     elif platform == Platform.LINUX_ARM64:
         # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
         # generously given by the Runs on ARM program. Se we have to build in this image.

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -701,12 +701,14 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
     # the code, install rustup and expose Pythons.
     # TODO: Apply rust caching here.
     if platform == Platform.LINUX_X86_64:
-        container = {"image": "quay.io/pypa/manylinux2014_x86_64:latest"}
+        container = {
+            "image": "registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e"
+        }
     elif platform == Platform.LINUX_ARM64:
         # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
         # generously given by the Runs on ARM program. Se we have to build in this image.
         container = {
-            "image": "quay.io/pypa/manylinux2014_aarch64:latest",
+            "image": "registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v1-568cfc69e",
             # The uid/gid for the gha user and group we set up on the self-hosted runner.
             # Necessary to avoid https://github.com/actions/runner/issues/434.
             # Alternatively we could run absolutely everything in a container,

--- a/pants.toml
+++ b/pants.toml
@@ -294,3 +294,6 @@ master = "src/python/pants/notes/master.rst"
 "2.14.x" = "src/python/pants/notes/2.14.x.md"
 "2.15.x" = "src/python/pants/notes/2.15.x.md"
 "2.16.x" = "src/python/pants/notes/2.16.x.md"
+
+
+# Just to force a wheel build

--- a/pants.toml
+++ b/pants.toml
@@ -294,6 +294,3 @@ master = "src/python/pants/notes/master.rst"
 "2.14.x" = "src/python/pants/notes/2.14.x.md"
 "2.15.x" = "src/python/pants/notes/2.15.x.md"
 "2.16.x" = "src/python/pants/notes/2.16.x.md"
-
-
-# Just to force a wheel build


### PR DESCRIPTION
These are the standard manylinux images, with the aws cli installed.
    
We need the aws cli to publish the wheels to S3, and our on-the-fly installation doesn't work for aarch64 because we don't run as root in the image.
