### PR TITLE
add skip_pyright field to python test targets (Cherry-pick of #17960)

### DIFF
--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -9,12 +9,13 @@ from typing import Iterable
 
 from pants.backend.javascript.subsystems.nodejs import NpxProcess
 from pants.backend.python.target_types import PythonSourceField
+from pants.backend.python.typecheck.pyright.skip_field import SkipPyrightField
 from pants.backend.python.typecheck.pyright.subsystem import Pyright
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, Rule, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -27,6 +28,10 @@ class PyrightFieldSet(FieldSet):
     required_fields = (PythonSourceField,)
 
     sources: PythonSourceField
+
+    @classmethod
+    def opt_out(cls, tgt: Target) -> bool:
+        return tgt.get(SkipPyrightField).value
 
 
 class PyrightRequest(CheckRequest):

--- a/src/python/pants/backend/python/typecheck/pyright/skip_field.py
+++ b/src/python/pants/backend/python/typecheck/pyright/skip_field.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from pants.backend.python.target_types import PythonSourcesGeneratorTarget, PythonSourceTarget
+from pants.backend.python.target_types import (
+    PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
+    PythonTestsGeneratorTarget,
+    PythonTestTarget,
+    PythonTestUtilsGeneratorTarget,
+)
 from pants.engine.rules import Rule
 from pants.engine.target import BoolField
 from pants.engine.unions import UnionRule
@@ -21,4 +27,7 @@ def rules() -> Iterable[Rule | UnionRule]:
     return (
         PythonSourcesGeneratorTarget.register_plugin_field(SkipPyrightField),
         PythonSourceTarget.register_plugin_field(SkipPyrightField),
+        PythonTestsGeneratorTarget.register_plugin_field(SkipPyrightField),
+        PythonTestTarget.register_plugin_field(SkipPyrightField),
+        PythonTestUtilsGeneratorTarget.register_plugin_field(SkipPyrightField),
     )


### PR DESCRIPTION
Unlike with mypy, the skip_pyright field is not present on test targets, meaning that you cannot disable it.
