### PR TITLE
fix type in `check` help output

### DIFF
--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -171,7 +171,7 @@ class CheckSubsystem(GoalSubsystem):
     def activated(cls, union_membership: UnionMembership) -> bool:
         return CheckRequest in union_membership
 
-    only = OnlyOption("checkers", "mypy", "javac")
+    only = OnlyOption("checker", "mypy", "javac")
 
 
 class Check(Goal):


### PR DESCRIPTION
Current output of `./pants help-advanced check` includes:

```
 --check-only="['<str>', '<str>', ...]"
  PANTS_CHECK_ONLY
  only
      default: []
      current value: []
      Only run these checkerss and skip all others.
```

The [code
here](https://github.com/pantsbuild/pants/blob/63ade26eda1397cff9b731149bace925a63cbb64/src/python/pants/core/goals/multi_tool_goal_helper.py#L34) adds an 's', so it appears that the source string should be singular.