### PR TITLE
Minor improvements to `PosixFS`

### DIFF
--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -25,6 +25,7 @@ protos = { path = "../protos" }
 rlimit = "0.8"
 serde = "1.0.136"
 task_executor = { path = "../task_executor" }
+tokio = { version = "1.21", features = ["fs"] }
 workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -50,12 +50,10 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use std::{fmt, fs};
 
-use crate::future::FutureExt;
 use ::ignore::gitignore::{Gitignore, GitignoreBuilder};
 use async_trait::async_trait;
 use bytes::Bytes;
 use deepsize::DeepSizeOf;
-use futures::future::{self, BoxFuture, TryFutureExt};
 use lazy_static::lazy_static;
 use serde::Serialize;
 
@@ -537,36 +535,31 @@ impl PosixFS {
   pub async fn read_link(&self, link: &Link) -> Result<PathBuf, io::Error> {
     let link_parent = link.path.parent().map(Path::to_owned);
     let link_abs = self.root.0.join(link.path.as_path());
-    self
-      .executor
-      .spawn_blocking(move || {
-        link_abs
-          .read_link()
-          .and_then(|path_buf| {
-            if path_buf.is_absolute() {
-              Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("Absolute symlink: {:?}", path_buf),
-              ))
-            } else {
-              link_parent
-                .map(|parent| parent.join(&path_buf))
-                .ok_or_else(|| {
-                  io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("Symlink without a parent?: {:?}", path_buf),
-                  )
-                })
-            }
-          })
-          .map_err(|e| {
-            io::Error::new(
-              e.kind(),
-              format!("Failed to read link {:?}: {}", link_abs, e),
-            )
-          })
-      })
+    tokio::fs::read_link(&link_abs)
       .await
+      .and_then(|path_buf| {
+        if path_buf.is_absolute() {
+          Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("Absolute symlink: {:?}", path_buf),
+          ))
+        } else {
+          link_parent
+            .map(|parent| parent.join(&path_buf))
+            .ok_or_else(|| {
+              io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Symlink without a parent?: {:?}", path_buf),
+              )
+            })
+        }
+      })
+      .map_err(|e| {
+        io::Error::new(
+          e.kind(),
+          format!("Failed to read link {:?}: {}", link_abs, e),
+        )
+      })
   }
 
   ///
@@ -623,6 +616,9 @@ impl PosixFS {
     }
   }
 
+  /// NB: This method is synchronous because it is used to stat all files in a directory as one
+  /// blocking operation as part of `scandir_sync` (as recommended by the `tokio` documentation, to
+  /// avoid many small spawned tasks).
   pub fn stat_sync(&self, relative_path: PathBuf) -> Result<Option<Stat>, io::Error> {
     let abs_path = self.root.0.join(&relative_path);
     let metadata = match self.symlink_behavior {
@@ -738,42 +734,6 @@ impl Vfs<String> for DigestTrie {
 
   fn mk_error(msg: &str) -> String {
     msg.to_owned()
-  }
-}
-
-pub trait PathStatGetter<E> {
-  fn path_stats(&self, paths: Vec<PathBuf>) -> BoxFuture<Result<Vec<Option<PathStat>>, E>>;
-}
-
-impl PathStatGetter<io::Error> for Arc<PosixFS> {
-  fn path_stats(&self, paths: Vec<PathBuf>) -> BoxFuture<Result<Vec<Option<PathStat>>, io::Error>> {
-    async move {
-      future::try_join_all(
-        paths
-          .into_iter()
-          .map(|path| {
-            let fs = self.clone();
-            let fs2 = self.clone();
-            self
-              .executor
-              .spawn_blocking(move || fs2.stat_sync(path))
-              .and_then(move |maybe_stat| {
-                async move {
-                  match maybe_stat {
-                    // Note: This will drop PathStats for symlinks which don't point anywhere.
-                    Some(Stat::Link(link)) => fs.canonicalize_link(link.path.clone(), link).await,
-                    Some(Stat::Dir(dir)) => Ok(Some(PathStat::dir(dir.0.clone(), dir))),
-                    Some(Stat::File(file)) => Ok(Some(PathStat::file(file.path.clone(), file))),
-                    None => Ok(None),
-                  }
-                }
-              })
-          })
-          .collect::<Vec<_>>(),
-      )
-      .await
-    }
-    .boxed()
   }
 }
 


### PR DESCRIPTION
* Use async `read_link` to avoid a spawn
* Document the reason that `stat_sync` is synchronous
* Remove `PathStatGetter` (which had performance pitfalls, but was only used in tests anyway).