### PR TITLE
go: introduce _go_sdk and _go_sdk_package target types for SDK analysis

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -47,6 +47,7 @@ from pants.backend.go.util_rules.build_pkg_target import (
 )
 from pants.backend.go.util_rules.first_party_pkg import FallibleFirstPartyPkgAnalysis
 from pants.backend.go.util_rules.go_mod import OwningGoMod, OwningGoModRequest
+from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.backend.python.util_rules import pex
@@ -352,10 +353,20 @@ async def setup_full_package_build_request(
         )
     analysis = fallible_analysis.analysis
 
+    stdlib_packages = await Get(
+        GoStdLibPackages,
+        GoStdLibPackagesRequest(with_race_detector=request.build_opts.with_race_detector),
+    )
+
     # Obtain build requests for third-party dependencies.
     # TODO: Consider how to merge this code with existing dependency inference code.
     dep_build_request_addrs: list[Address] = []
     for dep_import_path in (*analysis.imports, *analysis.test_imports, *analysis.xtest_imports):
+        # Skip inference for stdlib packages.
+        # TODO: This check is deprecated and will be removed once support for building SDK packages lands.
+        if dep_import_path in stdlib_packages:
+            continue
+
         # Infer dependencies on other Go packages.
         candidate_addresses = package_mapping.mapping.get(dep_import_path)
         if candidate_addresses:

--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -22,11 +22,7 @@ from pants.backend.codegen.protobuf.target_types import rules as protobuf_target
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import test
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,

--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -22,7 +22,12 @@ from pants.backend.codegen.protobuf.target_types import rules as protobuf_target
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import test
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -79,6 +84,8 @@ def rule_runner() -> RuleRunner:
         target_types=[
             GoModTarget,
             GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
             ProtobufSourceTarget,
             ProtobufSourcesGeneratorTarget,
         ],

--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -25,7 +25,6 @@ from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.target_types import (
     GoModTarget,
     GoPackageTarget,
-    GoSdkPackageTarget,
     GoSdkTarget,
 )
 from pants.backend.go.util_rules import (
@@ -85,7 +84,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
             ProtobufSourceTarget,
             ProtobufSourcesGeneratorTarget,
         ],

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -11,6 +11,8 @@ from pants.backend.go.target_types import (
     GoModTarget,
     GoPackageSourcesField,
     GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
     GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
@@ -45,6 +47,8 @@ def target_types():
         GoThirdPartyPackageTarget,
         GoBinaryTarget,
         *wrap_golang.target_types,
+        GoSdkTarget,
+        GoSdkPackageTarget,
     ]
 
 

--- a/src/python/pants/backend/go/dependency_inference_test.py
+++ b/src/python/pants/backend/go/dependency_inference_test.py
@@ -9,7 +9,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, (GoTestRequest.Batch,)),
             QueryRule(ProcessResult, (GoSdkProcess,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget, GoSdkTarget],
     )
     rule_runner.set_options(["--go-test-args=-v"], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/check_test.py
+++ b/src/python/pants/backend/go/goals/check_test.py
@@ -10,12 +10,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import check
 from pants.backend.go.goals.check import GoCheckFieldSet, GoCheckRequest
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -49,7 +44,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(CheckResults, [GoCheckRequest]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/check_test.py
+++ b/src/python/pants/backend/go/goals/check_test.py
@@ -10,7 +10,12 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import check
 from pants.backend.go.goals.check import GoCheckFieldSet, GoCheckRequest
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -44,7 +49,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(CheckResults, [GoCheckRequest]),
         ],
-        target_types=[GoModTarget, GoPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -11,7 +11,12 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import generate
 from pants.backend.go.goals.generate import GoGenerateGoal, OverwriteMergeDigests, _expand_env
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -50,7 +55,7 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(DigestContents, (OverwriteMergeDigests,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
         preserve_tmpdirs=True,
     )
     rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -11,12 +11,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import generate
 from pants.backend.go.goals.generate import GoGenerateGoal, OverwriteMergeDigests, _expand_env
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -55,7 +50,7 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(DigestContents, (OverwriteMergeDigests,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
         preserve_tmpdirs=True,
     )
     rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -12,7 +12,13 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -48,7 +54,13 @@ def rule_runner() -> RuleRunner:
             *sdk.rules(),
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
         ],
-        target_types=[GoBinaryTarget, GoModTarget, GoPackageTarget],
+        target_types=[
+            GoBinaryTarget,
+            GoModTarget,
+            GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -12,13 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import (
-    GoBinaryTarget,
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -59,7 +53,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -12,13 +12,7 @@ from pants.backend.go.goals.tailor import (
     has_package_main,
 )
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
-from pants.backend.go.target_types import (
-    GoBinaryTarget,
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -57,7 +51,6 @@ def rule_runner() -> RuleRunner:
             GoBinaryTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -12,7 +12,13 @@ from pants.backend.go.goals.tailor import (
     has_package_main,
 )
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -46,7 +52,13 @@ def rule_runner() -> RuleRunner:
             *link.rules(),
             QueryRule(PutativeTargets, [PutativeGoTargetsRequest, AllOwnedSources]),
         ],
-        target_types=[GoModTarget, GoBinaryTarget, GoPackageTarget],
+        target_types=[
+            GoModTarget,
+            GoBinaryTarget,
+            GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -11,7 +11,12 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
 from pants.backend.go.goals.test import transform_test_args
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -52,7 +57,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, [GoTestRequest.Batch]),
             QueryRule(ProcessResult, [GoSdkProcess]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget, FileTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -11,12 +11,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
 from pants.backend.go.goals.test import transform_test_args
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -57,7 +52,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, [GoTestRequest.Batch]),
             QueryRule(ProcessResult, [GoSdkProcess]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, FileTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -13,7 +13,12 @@ from pants.backend.go.lint.golangci_lint import skip_field
 from pants.backend.go.lint.golangci_lint.rules import GolangciLintFieldSet, GolangciLintRequest
 from pants.backend.go.lint.golangci_lint.rules import rules as golangci_lint_rules
 from pants.backend.go.lint.golangci_lint.subsystem import GolangciLint
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -35,7 +40,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
         rules=[
             *assembly.rules(),
             *build_pkg.rules(),

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -13,12 +13,7 @@ from pants.backend.go.lint.golangci_lint import skip_field
 from pants.backend.go.lint.golangci_lint.rules import GolangciLintFieldSet, GolangciLintRequest
 from pants.backend.go.lint.golangci_lint.rules import rules as golangci_lint_rules
 from pants.backend.go.lint.golangci_lint.subsystem import GolangciLint
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -40,7 +35,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
         rules=[
             *assembly.rules(),
             *build_pkg.rules(),

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -13,12 +13,7 @@ from pants.backend.go.lint.vet import skip_field
 from pants.backend.go.lint.vet.rules import GoVetFieldSet, GoVetRequest
 from pants.backend.go.lint.vet.rules import rules as go_vet_rules
 from pants.backend.go.lint.vet.subsystem import GoVetSubsystem
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -41,7 +36,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
         rules=[
             *skip_field.rules(),
             *go_vet_rules(),

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -13,7 +13,12 @@ from pants.backend.go.lint.vet import skip_field
 from pants.backend.go.lint.vet.rules import GoVetFieldSet, GoVetRequest
 from pants.backend.go.lint.vet.rules import rules as go_vet_rules
 from pants.backend.go.lint.vet.subsystem import GoVetSubsystem
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -36,7 +41,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget],
         rules=[
             *skip_field.rules(),
             *go_vet_rules(),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -19,6 +19,9 @@ from pants.backend.go.target_types import (
     GoModSourcesField,
     GoModTarget,
     GoPackageSourcesField,
+    GoSdkImportPathField,
+    GoSdkPackageTarget,
+    GoSdkTarget,
     GoThirdPartyPackageDependenciesField,
     GoThirdPartyPackageTarget,
 )
@@ -36,7 +39,11 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoMod,
     OwningGoModRequest,
 )
-from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackage,
+    GoStdLibPackages,
+    GoStdLibPackagesRequest,
+)
 from pants.backend.go.util_rules.third_party_pkg import (
     AllThirdPartyPackages,
     AllThirdPartyPackagesRequest,
@@ -50,6 +57,12 @@ from pants.core.target_types import (
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest, Snapshot
+from pants.engine.internals.synthetic_targets import (
+    SyntheticAddressMap,
+    SyntheticAddressMaps,
+    SyntheticTargetsRequest,
+)
+from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
@@ -91,7 +104,8 @@ async def go_map_import_paths_by_module(
     candidate_go_source_targets = [
         tgt
         for tgt in all_targets
-        if tgt.has_field(GoImportPathField) or tgt.has_field(GoPackageSourcesField)
+        if (tgt.has_field(GoImportPathField) or tgt.has_field(GoPackageSourcesField))
+        and not tgt.has_field(GoSdkImportPathField)
     ]
 
     owning_go_mod_targets = await MultiGet(
@@ -225,7 +239,7 @@ async def infer_go_dependencies(
     )
 
     addr = request.field_set.address
-    maybe_pkg_analysis, std_lib_imports = await MultiGet(
+    maybe_pkg_analysis, stdlib_packages = await MultiGet(
         Get(
             FallibleFirstPartyPkgAnalysis, FirstPartyPkgAnalysisRequest(addr, build_opts=build_opts)
         ),
@@ -249,7 +263,9 @@ async def infer_go_dependencies(
         *pkg_analysis.test_imports,
         *pkg_analysis.xtest_imports,
     ):
-        if import_path in std_lib_imports:
+        # Skip inference for stdlib packages.
+        # TODO: This check is deprecated and will be removed once support for building SDK packages lands.
+        if import_path in stdlib_packages:
             continue
         # Avoid a dependency cycle caused by external test imports of this package (i.e., "xtest").
         if import_path == pkg_analysis.import_path:
@@ -305,7 +321,7 @@ async def infer_go_third_party_package_dependencies(
         Get(GoBuildOptions, GoBuildOptionsFromTargetRequest(go_mod_address)),
     )
 
-    pkg_info, std_lib_imports = await MultiGet(
+    pkg_info, stdlib_packages = await MultiGet(
         Get(
             ThirdPartyPkgAnalysis,
             ThirdPartyPkgAnalysisRequest(
@@ -324,9 +340,10 @@ async def infer_go_third_party_package_dependencies(
 
     inferred_dependencies: list[Address] = []
     for import_path in pkg_info.imports:
-        if import_path in std_lib_imports:
+        # Skip inference for stdlib packages.
+        # TODO: This check is deprecated and will be removed once support for building SDK packages lands.
+        if import_path in stdlib_packages:
             continue
-
         candidate_packages = package_mapping.mapping.get(import_path, ())
         if candidate_packages:
             if candidate_packages.infer_all:
@@ -414,6 +431,74 @@ async def generate_targets_from_go_mod(
     return GeneratedTargets(request.generator, result)
 
 
+# -----------------------------------------------------------------------------------------------
+# `go_sdk` and `go_sdk_package` target types
+# -----------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GoSdkSyntheticTargetsRequest(SyntheticTargetsRequest):
+    path: str = SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS
+
+
+@rule
+async def generate_go_sdk_synthetic_targets(
+    request: GoSdkSyntheticTargetsRequest,
+) -> SyntheticAddressMaps:
+    return SyntheticAddressMaps(
+        [
+            SyntheticAddressMap.create(
+                "BUILD._go_sdk", [TargetAdaptor(GoSdkTarget.alias, name="default_go_sdk")]
+            )
+        ]
+    )
+
+
+class GenerateTargetsFromGoSdkRequest(GenerateTargetsRequest):
+    generate_from = GoSdkTarget
+
+
+@rule(desc="Generate `_go_sdk_package` targets from `_go_sdk` target", level=LogLevel.DEBUG)
+async def generate_targets_from_go_sdk(
+    request: GenerateTargetsFromGoSdkRequest,
+    union_membership: UnionMembership,
+) -> GeneratedTargets:
+    generator_addr = request.generator.address
+
+    stdlib_packages, stdlib_packages_race = await MultiGet(
+        Get(
+            GoStdLibPackages,
+            GoStdLibPackagesRequest(with_race_detector=False),
+        ),
+        Get(
+            GoStdLibPackages,
+            GoStdLibPackagesRequest(with_race_detector=True),
+        ),
+    )
+
+    def create_tgt(pkg: GoStdLibPackage) -> GoSdkPackageTarget:
+        dep_import_paths = sorted(
+            {*pkg.imports, *stdlib_packages_race[pkg.import_path].imports} - {"C", "unsafe"}
+        )
+        return GoSdkPackageTarget(
+            {
+                **request.template,
+                GoSdkImportPathField.alias: pkg.import_path,
+                Dependencies.alias: [
+                    generator_addr.create_generated(dep_import_path).spec
+                    for dep_import_path in dep_import_paths
+                ],
+            },
+            # E.g. `//:default_go_sdk#net/http`.
+            generator_addr.create_generated(pkg.import_path),
+            union_membership,
+            residence_dir=generator_addr.spec_path,
+        )
+
+    result = tuple(create_tgt(pkg_info) for pkg_info in stdlib_packages.values())
+    return GeneratedTargets(request.generator, result)
+
+
 def rules():
     return (
         *collect_rules(),
@@ -423,5 +508,7 @@ def rules():
         UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),
         UnionRule(InferDependenciesRequest, InferGoThirdPartyPackageDependenciesRequest),
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoModRequest),
+        UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoSdkRequest),
         UnionRule(GoModuleImportPathsMappingsHook, FirstPartyGoModuleImportPathsMappingsHook),
+        UnionRule(SyntheticTargetsRequest, GoSdkSyntheticTargetsRequest),
     )

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -15,6 +15,7 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappingsHook,
 )
 from pants.backend.go.target_types import (
+    DEFAULT_GO_SDK_ADDR,
     GoImportPathField,
     GoModSourcesField,
     GoModTarget,
@@ -57,11 +58,7 @@ from pants.core.target_types import (
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest, Snapshot
-from pants.engine.internals.synthetic_targets import (
-    SyntheticAddressMap,
-    SyntheticAddressMaps,
-    SyntheticTargetsRequest,
-)
+from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
 from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -445,12 +442,14 @@ class GoSdkSyntheticTargetsRequest(SyntheticTargetsRequest):
 async def generate_go_sdk_synthetic_targets(
     request: GoSdkSyntheticTargetsRequest,
 ) -> SyntheticAddressMaps:
-    return SyntheticAddressMaps(
+    return SyntheticAddressMaps.for_targets_request(
+        request,
         [
-            SyntheticAddressMap.create(
-                "BUILD._go_sdk", [TargetAdaptor(GoSdkTarget.alias, name="default_go_sdk")]
+            (
+                "BUILD._go_sdk",
+                [TargetAdaptor(GoSdkTarget.alias, name=DEFAULT_GO_SDK_ADDR.target_name)],
             )
-        ]
+        ],
     )
 
 

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -15,7 +15,6 @@ from pants.backend.go.target_types import (
     GoModTarget,
     GoPackageSourcesField,
     GoPackageTarget,
-    GoSdkPackageTarget,
     GoSdkTarget,
     GoThirdPartyPackageTarget,
 )
@@ -79,7 +78,6 @@ def rule_runner() -> RuleRunner:
             GoPackageTarget,
             GoBinaryTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
             GenericTarget,
         ],
     )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from pants.backend.go import target_type_rules
 from pants.backend.go.target_types import (
+    DEFAULT_GO_SDK_ADDR,
     GoBinaryMainPackageField,
     GoBinaryTarget,
     GoImportPathField,
@@ -325,9 +326,7 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
 
 
 def test_go_sdk_target_exists(rule_runner: RuleRunner) -> None:
-    _ = rule_runner.get_target(Address("", target_name="default_go_sdk"))
-    fmt_pkg_tgt = rule_runner.get_target(
-        Address("", target_name="default_go_sdk", generated_name="fmt")
-    )
+    _ = rule_runner.get_target(DEFAULT_GO_SDK_ADDR)
+    fmt_pkg_tgt = rule_runner.get_target(DEFAULT_GO_SDK_ADDR.create_generated("fmt"))
     addrs = rule_runner.request(Addresses, [DependenciesRequest(fmt_pkg_tgt[Dependencies])])
     assert len(addrs) > 0, "no dependencies were inferred for `fmt` _go_sdk_package target type"

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -475,3 +475,35 @@ class GoOwningGoModAddressField(StringField):
         for that single `go_mod` target.
         """
     )
+
+
+# -----------------------------------------------------------------------------------------------
+# `go_sdk` and `go_sdk_package` target types
+# -----------------------------------------------------------------------------------------------
+
+
+class GoSdkPackageDependenciesField(Dependencies):
+    pass
+
+
+class GoSdkImportPathField(GoImportPathField):
+    pass
+
+
+class GoSdkPackageTarget(Target):
+    alias = "_go_sdk_package"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        GoSdkImportPathField,
+        GoSdkPackageDependenciesField,
+    )
+    help = "Internal-only target: Represents a Go SDK package."
+
+
+class GoSdkTarget(TargetGenerator):
+    alias = "_go_sdk"
+    generated_target_cls = GoSdkPackageTarget
+    core_fields = (*COMMON_TARGET_FIELDS,)
+    help = "Internal-only: Go SDK generator target"
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = ()

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -482,6 +482,9 @@ class GoOwningGoModAddressField(StringField):
 # -----------------------------------------------------------------------------------------------
 
 
+DEFAULT_GO_SDK_ADDR = Address("", target_name="default_go_sdk")
+
+
 class GoSdkPackageDependenciesField(Dependencies):
     pass
 

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -14,7 +14,13 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -54,7 +60,13 @@ def rule_runner() -> RuleRunner:
             QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
             QueryRule(FallibleBuiltGoPackage, (BuildGoPackageRequest,)),
         ],
-        target_types=[GoBinaryTarget, GoModTarget, GoPackageTarget],
+        target_types=[
+            GoBinaryTarget,
+            GoModTarget,
+            GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -14,13 +14,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import (
-    GoBinaryTarget,
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -65,7 +59,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -13,13 +13,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import (
-    GoBinaryTarget,
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_opts,
@@ -78,7 +72,6 @@ def rule_runner() -> RuleRunner:
             GoPackageTarget,
             GoBinaryTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -13,7 +13,13 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_opts,
@@ -67,7 +73,13 @@ def rule_runner() -> RuleRunner:
             QueryRule(GoRoot, ()),
             QueryRule(BuildGoPackageRequest, [BuildGoPackageTargetRequest]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget],
+        target_types=[
+            GoModTarget,
+            GoPackageTarget,
+            GoBinaryTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -20,7 +20,6 @@ from pants.backend.go.target_types import (
     GoModTarget,
     GoOwningGoModAddressField,
     GoPackageTarget,
-    GoSdkPackageTarget,
     GoSdkTarget,
 )
 from pants.backend.go.util_rules import (
@@ -186,7 +185,6 @@ def rule_runner() -> RuleRunner:
             GoPackageTarget,
             FilesGeneratorTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -16,7 +16,13 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappings,
     GoModuleImportPathsMappingsHook,
 )
-from pants.backend.go.target_types import GoModTarget, GoOwningGoModAddressField, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoOwningGoModAddressField,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -175,7 +181,13 @@ def rule_runner() -> RuleRunner:
             FileTarget.register_plugin_field(GoOwningGoModAddressField),
             FilesGeneratorTarget.register_plugin_field(GoOwningGoModAddressField),
         ],
-        target_types=[GoModTarget, GoPackageTarget, FilesGeneratorTarget],
+        target_types=[
+            GoModTarget,
+            GoPackageTarget,
+            FilesGeneratorTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -14,13 +14,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import (
-    GoBinaryTarget,
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -79,7 +73,6 @@ def rule_runner() -> RuleRunner:
             GoPackageTarget,
             GoBinaryTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
             ResourceTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -14,7 +14,13 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -68,7 +74,14 @@ def rule_runner() -> RuleRunner:
             QueryRule(CGoCompileResult, [CGoCompileRequest]),
             QueryRule(ProcessResult, (Process,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget, ResourceTarget],
+        target_types=[
+            GoModTarget,
+            GoPackageTarget,
+            GoBinaryTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+            ResourceTarget,
+        ],
     )
     rule_runner.set_options(
         [

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -9,7 +9,12 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -65,7 +70,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(CoverageReports, (GoCoverageDataCollection,)),
             QueryRule(DigestContents, (Digest,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget, FileTarget],
     )
     rule_runner.set_options(
         ["--go-test-args=-v -bench=.", "--test-use-coverage"], env_inherit={"PATH"}

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -9,12 +9,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -70,7 +65,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(CoverageReports, (GoCoverageDataCollection,)),
             QueryRule(DigestContents, (Digest,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, GoSdkPackageTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, FileTarget],
     )
     rule_runner.set_options(
         ["--go-test-args=-v -bench=.", "--test-use-coverage"], env_inherit={"PATH"}

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -17,7 +17,12 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -56,7 +61,13 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(TestResult, [GoTestRequest.Batch]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, ResourceTarget],
+        target_types=[
+            GoModTarget,
+            GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+            ResourceTarget,
+        ],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -17,12 +17,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -65,7 +60,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
             ResourceTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -9,12 +9,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -61,7 +56,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoSdkTarget,
-            GoSdkPackageTarget,
             ResourcesGeneratorTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -9,7 +9,12 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget
+from pants.backend.go.target_types import (
+    GoModTarget,
+    GoPackageTarget,
+    GoSdkPackageTarget,
+    GoSdkTarget,
+)
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -52,7 +57,13 @@ def rule_runner() -> RuleRunner:
             QueryRule(FallibleFirstPartyPkgDigest, [FirstPartyPkgDigestRequest]),
             QueryRule(FirstPartyPkgImportPath, [FirstPartyPkgImportPathRequest]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, ResourcesGeneratorTarget],
+        target_types=[
+            GoModTarget,
+            GoPackageTarget,
+            GoSdkTarget,
+            GoSdkPackageTarget,
+            ResourcesGeneratorTarget,
+        ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -4,18 +4,29 @@
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import ClassVar
 
 import ijson.backends.python as ijson
 
+from pants.backend.go.dependency_inference import (
+    GoImportPathsMappingAddressSet,
+    GoModuleImportPathsMapping,
+    GoModuleImportPathsMappings,
+    GoModuleImportPathsMappingsHook,
+)
+from pants.backend.go.util_rules import go_mod
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
+from pants.backend.go.util_rules.go_mod import AllGoModTargets
 from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.build_graph.address import Address
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -148,5 +159,63 @@ async def generate_import_config(request: ImportConfigRequest) -> ImportConfig:
     return ImportConfig(result)
 
 
+class GoSdkImportPathsMappingsHook(GoModuleImportPathsMappingsHook):
+    pass
+
+
+@rule(desc="Analyze and map Go import paths for the Go SDK.", level=LogLevel.DEBUG)
+async def go_map_import_paths_by_module(
+    _request: GoSdkImportPathsMappingsHook,
+    all_go_mod_targets: AllGoModTargets,
+) -> GoModuleImportPathsMappings:
+    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
+        lambda: defaultdict(set)
+    )
+
+    stdlib_packages = await Get(
+        GoStdLibPackages,
+        GoStdLibPackagesRequest(with_race_detector=False),
+    )
+
+    sdk_addr = Address("", target_name="default_go_sdk")
+
+    # Replicate the Go SDK imports path to all Go modules.
+    # TODO: This will need to change eventually for multiple Go SDK support.
+    for import_path in stdlib_packages.keys():
+        for go_mod_tgt in all_go_mod_targets:
+            import_paths_by_module[go_mod_tgt.address][import_path].add(
+                sdk_addr.create_generated(import_path)
+            )
+
+    return GoModuleImportPathsMappings(
+        FrozenDict(
+            {
+                go_mod_addr: GoModuleImportPathsMapping(
+                    mapping=FrozenDict(
+                        {
+                            import_path: GoImportPathsMappingAddressSet(
+                                addresses=tuple(sorted(addresses)), infer_all=False
+                            )
+                            for import_path, addresses in import_path_mapping.items()
+                        }
+                    ),
+                    address_to_import_path=FrozenDict(
+                        {
+                            address: import_path
+                            for import_path, addresses in import_path_mapping.items()
+                            for address in addresses
+                        }
+                    ),
+                )
+                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
+            }
+        )
+    )
+
+
 def rules():
-    return collect_rules()
+    return (
+        *collect_rules(),
+        *go_mod.rules(),
+        UnionRule(GoModuleImportPathsMappingsHook, GoSdkImportPathsMappingsHook),
+    )

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -16,6 +16,7 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappings,
     GoModuleImportPathsMappingsHook,
 )
+from pants.backend.go.target_types import DEFAULT_GO_SDK_ADDR
 from pants.backend.go.util_rules import go_mod
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
@@ -177,14 +178,12 @@ async def go_map_import_paths_by_module(
         GoStdLibPackagesRequest(with_race_detector=False),
     )
 
-    sdk_addr = Address("", target_name="default_go_sdk")
-
     # Replicate the Go SDK imports path to all Go modules.
     # TODO: This will need to change eventually for multiple Go SDK support.
     for import_path in stdlib_packages.keys():
         for go_mod_tgt in all_go_mod_targets:
             import_paths_by_module[go_mod_tgt.address][import_path].add(
-                sdk_addr.create_generated(import_path)
+                DEFAULT_GO_SDK_ADDR.create_generated(import_path)
             )
 
     return GoModuleImportPathsMappings(


### PR DESCRIPTION
Introduce the `_go_sdk` and `_go_sdk_package` target types to allow the build graph to represent the structure of a Go SDK.

- The `_go_sdk` target type is used to create a synthetic target `//:default_go_sdk` to represent the Go SDK found using the `[golang].go_search_paths` option. This target type is a target generator and generates a `_go_sdk_package` target for each SDK package.
  * This target type could be made visible to users in the future if we decide to support multiple Go SDKs in a repository, but for now it is an implementation detail to provide a place to use target generation when analyzing the Go SDK. 
- The `_go_sdk_package` target type is used as the target type for each target representing a SDK package.

This is part of fixing https://github.com/pantsbuild/pants/issues/17950 and was extracted from https://github.com/pantsbuild/pants/pull/17914.