### PR TITLE
Remove potential for panics from spawn APIs

### DIFF
--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -474,7 +474,15 @@ impl PosixFS {
     let vfs = self.clone();
     self
       .executor
-      .spawn_blocking(move || vfs.scandir_sync(&dir_relative_to_root))
+      .spawn_blocking(
+        move || vfs.scandir_sync(&dir_relative_to_root),
+        |e| {
+          Err(io::Error::new(
+            io::ErrorKind::Other,
+            format!("Synchronous scandir failed: {e}"),
+          ))
+        },
+      )
       .await
   }
 

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -1312,13 +1312,16 @@ impl Store {
       store
         .local
         .executor()
-        .spawn_blocking(move || {
-          if is_root {
-            fs::safe_create_dir_all(&destination2)
-          } else {
-            fs::safe_create_dir(&destination2)
-          }
-        })
+        .spawn_blocking(
+          move || {
+            if is_root {
+              fs::safe_create_dir_all(&destination2)
+            } else {
+              fs::safe_create_dir(&destination2)
+            }
+          },
+          |e| Err(format!("Directory creation task failed: {e}")),
+        )
         .map_err(|e| {
           format!(
             "Failed to create directory {}: {}",

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -402,7 +402,7 @@ impl<N: Node> Graph<N> {
       nodes: HashMap::default(),
       pg: DiGraph::new(),
     }));
-    let _join = executor.spawn(Self::cycle_check_task(Arc::downgrade(&inner)));
+    let _join = executor.native_spawn(Self::cycle_check_task(Arc::downgrade(&inner)));
 
     Graph {
       inner,

--- a/src/rust/engine/logging/src/lib.rs
+++ b/src/rust/engine/logging/src/lib.rs
@@ -26,20 +26,16 @@
 #![allow(clippy::mutex_atomic)]
 
 ///
-/// Macro to allow debug logging to a file which bypasses the standard logging systems.
-/// This is useful for one-off debugging, and is code that several developers have found they're
-/// writing a lot as one-offs when working in the rust code (particularly when working on logging),
-/// so this is a useful macro to exist for one-off use.
-///
-/// This should not be used for actual production logging; use the log crate's macros
-/// (info!, debug!, trace!) for that.
+/// Macro to allow fatal logging to a file which bypasses the standard logging systems.
+/// This is useful for code paths which must not interact with stdio or the logging system, and
+/// can also be useful for one-off debugging of stdio, logging, or pantsd issues.
 ///
 #[macro_export]
-macro_rules! debug_log {
-    ($path:expr, $($arg:tt)+) => {
+macro_rules! fatal_log {
+    ($($arg:tt)+) => {
       {
         use ::std::io::Write;
-        let mut f = ::std::fs::OpenOptions::new().create(true).append(true).open($path).unwrap();
+        let mut f = ::std::fs::OpenOptions::new().create(true).append(true).open("fatal.log").unwrap();
         writeln!(f, $($arg)+).unwrap()
       }
     };

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -234,7 +234,7 @@ impl Log for PantsLogger {
           Err(e) => {
             // If we've failed to write to stdio, but also to our log file, our only recourse is to
             // try to write to a different file.
-            debug_log!("fatal.log", "Failed to write to log file {:?}: {}", file, e);
+            fatal_log!("Failed to write to log file {:?}: {}", file, e);
           }
         }
       }

--- a/src/rust/engine/process_execution/src/bounded.rs
+++ b/src/rust/engine/process_execution/src/bounded.rs
@@ -204,7 +204,7 @@ impl AsyncSemaphore {
     // Spawn a task which will periodically balance Tasks.
     let _balancer_task = {
       let state = Arc::downgrade(&state);
-      executor.spawn(async move {
+      executor.native_spawn(async move {
         loop {
           sleep(preemptible_duration / 4).await;
           if let Some(state) = state.upgrade() {

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -167,7 +167,7 @@ impl Drop for RunningOperation {
     if let Some(operation_name) = self.name.take() {
       debug!("Canceling remote operation {operation_name}");
       let mut operations_client = self.operations_client.as_ref().clone();
-      let _ = self.executor.spawn(async move {
+      let _ = self.executor.native_spawn(async move {
         operations_client
           .cancel_operation(CancelOperationRequest {
             name: operation_name,

--- a/src/rust/engine/sharded_lmdb/src/lib.rs
+++ b/src/rust/engine/sharded_lmdb/src/lib.rs
@@ -306,24 +306,27 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_blocking(move || {
-        let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
-        let (env, db, _lease_database) = store.get(&fingerprint);
-        let del_res = env.begin_rw_txn().and_then(|mut txn| {
-          txn.del(db, &effective_key, None)?;
-          txn.commit()
-        });
+      .spawn_blocking(
+        move || {
+          let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
+          let (env, db, _lease_database) = store.get(&fingerprint);
+          let del_res = env.begin_rw_txn().and_then(|mut txn| {
+            txn.del(db, &effective_key, None)?;
+            txn.commit()
+          });
 
-        match del_res {
-          Ok(()) => Ok(true),
-          Err(lmdb::Error::NotFound) => Ok(false),
-          Err(err) => Err(format!(
-            "Error removing versioned key {:?}: {}",
-            effective_key.to_hex(),
-            err
-          )),
-        }
-      })
+          match del_res {
+            Ok(()) => Ok(true),
+            Err(lmdb::Error::NotFound) => Ok(false),
+            Err(err) => Err(format!(
+              "Error removing versioned key {:?}: {}",
+              effective_key.to_hex(),
+              err
+            )),
+          }
+        },
+        |e| Err(format!("`remove` task failed: {e}")),
+      )
       .await
   }
 
@@ -347,52 +350,56 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_blocking(move || {
-        // Group the items by the Environment that they will be applied to.
-        let mut items_by_env = HashMap::new();
-        let mut exists = HashSet::new();
+      .spawn_blocking(
+        move || {
+          // Group the items by the Environment that they will be applied to.
+          let mut items_by_env = HashMap::new();
+          let mut exists = HashSet::new();
 
-        for fingerprint in &fingerprints {
-          let effective_key = VersionedFingerprint::new(*fingerprint, ShardedLmdb::SCHEMA_VERSION);
-          let (env_id, _, env, db, _) = store.get_raw(&fingerprint.0);
+          for fingerprint in &fingerprints {
+            let effective_key =
+              VersionedFingerprint::new(*fingerprint, ShardedLmdb::SCHEMA_VERSION);
+            let (env_id, _, env, db, _) = store.get_raw(&fingerprint.0);
 
-          let (_, _, batch) = items_by_env
-            .entry(*env_id)
-            .or_insert_with(|| (env.clone(), *db, vec![]));
-          batch.push(effective_key);
-        }
+            let (_, _, batch) = items_by_env
+              .entry(*env_id)
+              .or_insert_with(|| (env.clone(), *db, vec![]));
+            batch.push(effective_key);
+          }
 
-        // Open and commit a Transaction per Environment. Since we never have more than one
-        // Transaction open at a time, we don't have to worry about ordering.
-        for (_, (env, db, batch)) in items_by_env {
-          env
-            .begin_ro_txn()
-            .and_then(|txn| {
-              for effective_key in &batch {
-                let get_res = txn.get(db, &effective_key);
-                match get_res {
-                  Ok(_) => {
-                    exists.insert(effective_key.get_fingerprint());
-                  }
-                  Err(lmdb::Error::NotFound) => (),
-                  Err(err) => return Err(err),
-                };
-              }
-              txn.commit()
-            })
-            .map_err(|e| {
-              format!(
-                "Error checking existence of fingerprints {:?}: {}",
-                batch
-                  .iter()
-                  .map(|key| key.get_fingerprint())
-                  .collect::<Vec<_>>(),
-                e
-              )
-            })?;
-        }
-        Ok(exists)
-      })
+          // Open and commit a Transaction per Environment. Since we never have more than one
+          // Transaction open at a time, we don't have to worry about ordering.
+          for (_, (env, db, batch)) in items_by_env {
+            env
+              .begin_ro_txn()
+              .and_then(|txn| {
+                for effective_key in &batch {
+                  let get_res = txn.get(db, &effective_key);
+                  match get_res {
+                    Ok(_) => {
+                      exists.insert(effective_key.get_fingerprint());
+                    }
+                    Err(lmdb::Error::NotFound) => (),
+                    Err(err) => return Err(err),
+                  };
+                }
+                txn.commit()
+              })
+              .map_err(|e| {
+                format!(
+                  "Error checking existence of fingerprints {:?}: {}",
+                  batch
+                    .iter()
+                    .map(|key| key.get_fingerprint())
+                    .collect::<Vec<_>>(),
+                  e
+                )
+              })?;
+          }
+          Ok(exists)
+        },
+        |e| Err(format!("`exists_batch` task failed: {e}")),
+      )
       .await
   }
 
@@ -426,60 +433,63 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_blocking(move || {
-        // Group the items by the Environment that they will be applied to.
-        let mut items_by_env = HashMap::new();
-        let mut fingerprints = Vec::new();
-        for (maybe_fingerprint, bytes) in items {
-          let fingerprint = maybe_fingerprint.unwrap_or_else(|| Digest::of_bytes(&bytes).hash);
-          let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
-          let (env_id, _, env, db, lease_database) = store.get_raw(&fingerprint.0);
+      .spawn_blocking(
+        move || {
+          // Group the items by the Environment that they will be applied to.
+          let mut items_by_env = HashMap::new();
+          let mut fingerprints = Vec::new();
+          for (maybe_fingerprint, bytes) in items {
+            let fingerprint = maybe_fingerprint.unwrap_or_else(|| Digest::of_bytes(&bytes).hash);
+            let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
+            let (env_id, _, env, db, lease_database) = store.get_raw(&fingerprint.0);
 
-          let (_, _, _, batch) = items_by_env
-            .entry(*env_id)
-            .or_insert_with(|| (env.clone(), *db, *lease_database, vec![]));
-          batch.push((effective_key, bytes));
-          fingerprints.push(fingerprint);
-        }
+            let (_, _, _, batch) = items_by_env
+              .entry(*env_id)
+              .or_insert_with(|| (env.clone(), *db, *lease_database, vec![]));
+            batch.push((effective_key, bytes));
+            fingerprints.push(fingerprint);
+          }
 
-        // Open and commit a Transaction per Environment. Since we never have more than one
-        // Transaction open at a time, we don't have to worry about ordering.
-        for (_, (env, db, lease_database, batch)) in items_by_env {
-          env
-            .begin_rw_txn()
-            .and_then(|mut txn| {
-              for (effective_key, bytes) in &batch {
-                let put_res = txn.put(db, &effective_key, &bytes, WriteFlags::NO_OVERWRITE);
-                match put_res {
-                  Ok(()) => (),
-                  Err(lmdb::Error::KeyExist) => continue,
-                  Err(err) => return Err(err),
+          // Open and commit a Transaction per Environment. Since we never have more than one
+          // Transaction open at a time, we don't have to worry about ordering.
+          for (_, (env, db, lease_database, batch)) in items_by_env {
+            env
+              .begin_rw_txn()
+              .and_then(|mut txn| {
+                for (effective_key, bytes) in &batch {
+                  let put_res = txn.put(db, &effective_key, &bytes, WriteFlags::NO_OVERWRITE);
+                  match put_res {
+                    Ok(()) => (),
+                    Err(lmdb::Error::KeyExist) => continue,
+                    Err(err) => return Err(err),
+                  }
+                  if initial_lease {
+                    store.lease_inner(
+                      lease_database,
+                      effective_key,
+                      store.lease_until_secs_since_epoch(),
+                      &mut txn,
+                    )?;
+                  }
                 }
-                if initial_lease {
-                  store.lease_inner(
-                    lease_database,
-                    effective_key,
-                    store.lease_until_secs_since_epoch(),
-                    &mut txn,
-                  )?;
-                }
-              }
-              txn.commit()
-            })
-            .map_err(|e| {
-              format!(
-                "Error storing fingerprints {:?}: {}",
-                batch
-                  .iter()
-                  .map(|(key, _)| key.to_hex())
-                  .collect::<Vec<_>>(),
-                e
-              )
-            })?;
-        }
+                txn.commit()
+              })
+              .map_err(|e| {
+                format!(
+                  "Error storing fingerprints {:?}: {}",
+                  batch
+                    .iter()
+                    .map(|(key, _)| key.to_hex())
+                    .collect::<Vec<_>>(),
+                  e
+                )
+              })?;
+          }
 
-        Ok(fingerprints)
-      })
+          Ok(fingerprints)
+        },
+        |e| Err(format!("`store_bytes_batch` task failed: {e}")),
+      )
       .await
   }
 
@@ -504,116 +514,127 @@ impl ShardedLmdb {
     let store = self.clone();
     self
       .executor
-      .spawn_blocking(move || {
-        let mut attempts = 0;
-        loop {
-          // First pass: compute the Digest.
-          let digest = {
-            let mut read = data_provider().map_err(|e| format!("Failed to read: {}", e))?;
-            let mut hasher = WriterHasher::new(io::sink());
-            let _ = io::copy(&mut read, &mut hasher)
-              .map_err(|e| format!("Failed to read from {:?}: {}", read, e))?;
-            hasher.finish().0
-          };
-
-          let effective_key = VersionedFingerprint::new(digest.hash, ShardedLmdb::SCHEMA_VERSION);
-          let (env, db, lease_database) = store.get(&digest.hash);
-          let put_res: Result<(), StoreError> = env
-            .begin_rw_txn()
-            .map_err(StoreError::Lmdb)
-            .and_then(|mut txn| {
-              // Second pass: copy into the reserved memory.
-              let mut writer = txn
-                .reserve(
-                  db,
-                  &effective_key,
-                  digest.size_bytes,
-                  WriteFlags::NO_OVERWRITE,
-                )?
-                .writer();
+      .spawn_blocking(
+        move || {
+          let mut attempts = 0;
+          loop {
+            // First pass: compute the Digest.
+            let digest = {
               let mut read = data_provider().map_err(|e| format!("Failed to read: {}", e))?;
-              let should_retry = if data_is_immutable {
-                // Trust that the data hasn't changed, and only validate its length.
-                let copied = io::copy(&mut read, &mut writer).map_err(|e| {
-                  format!(
-                    "Failed to copy from {:?} or store in {:?}: {:?}",
-                    read, env, e
-                  )
-                })?;
+              let mut hasher = WriterHasher::new(io::sink());
+              let _ = io::copy(&mut read, &mut hasher)
+                .map_err(|e| format!("Failed to read from {:?}: {}", read, e))?;
+              hasher.finish().0
+            };
 
-                // Should retry if the file got shorter between reads.
-                copied as usize != digest.size_bytes
-              } else {
-                // Confirm that the data hasn't changed.
-                let mut hasher = WriterHasher::new(writer);
-                let _ = io::copy(&mut read, &mut hasher).map_err(|e| {
-                  format!(
-                    "Failed to copy from {:?} or store in {:?}: {:?}",
-                    read, env, e
-                  )
-                })?;
+            let effective_key = VersionedFingerprint::new(digest.hash, ShardedLmdb::SCHEMA_VERSION);
+            let (env, db, lease_database) = store.get(&digest.hash);
+            let put_res: Result<(), StoreError> = env
+              .begin_rw_txn()
+              .map_err(StoreError::Lmdb)
+              .and_then(|mut txn| {
+                // Second pass: copy into the reserved memory.
+                let mut writer = txn
+                  .reserve(
+                    db,
+                    &effective_key,
+                    digest.size_bytes,
+                    WriteFlags::NO_OVERWRITE,
+                  )?
+                  .writer();
+                let mut read = data_provider().map_err(|e| format!("Failed to read: {}", e))?;
+                let should_retry = if data_is_immutable {
+                  // Trust that the data hasn't changed, and only validate its length.
+                  let copied = io::copy(&mut read, &mut writer).map_err(|e| {
+                    format!(
+                      "Failed to copy from {:?} or store in {:?}: {:?}",
+                      read, env, e
+                    )
+                  })?;
 
-                // Should retry if the Digest changed between reads.
-                digest != hasher.finish().0
-              };
+                  // Should retry if the file got shorter between reads.
+                  copied as usize != digest.size_bytes
+                } else {
+                  // Confirm that the data hasn't changed.
+                  let mut hasher = WriterHasher::new(writer);
+                  let _ = io::copy(&mut read, &mut hasher).map_err(|e| {
+                    format!(
+                      "Failed to copy from {:?} or store in {:?}: {:?}",
+                      read, env, e
+                    )
+                  })?;
 
-              if should_retry {
-                let msg = format!("Input {:?} changed while reading.", read);
-                log::debug!("{}", msg);
-                return Err(StoreError::Retry(msg));
+                  // Should retry if the Digest changed between reads.
+                  digest != hasher.finish().0
+                };
+
+                if should_retry {
+                  let msg = format!("Input {:?} changed while reading.", read);
+                  log::debug!("{}", msg);
+                  return Err(StoreError::Retry(msg));
+                }
+
+                if initial_lease {
+                  store.lease_inner(
+                    lease_database,
+                    &effective_key,
+                    store.lease_until_secs_since_epoch(),
+                    &mut txn,
+                  )?;
+                }
+                txn.commit()?;
+                Ok(())
+              });
+
+            match put_res {
+              Ok(()) => return Ok(digest),
+              Err(StoreError::Retry(msg)) => {
+                // Input changed during reading: maybe retry.
+                if attempts > 10 {
+                  return Err(msg);
+                } else {
+                  attempts += 1;
+                  continue;
+                }
               }
-
-              if initial_lease {
-                store.lease_inner(
-                  lease_database,
-                  &effective_key,
-                  store.lease_until_secs_since_epoch(),
-                  &mut txn,
-                )?;
+              Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(digest),
+              Err(StoreError::Lmdb(err)) => {
+                return Err(format!("Error storing {:?}: {}", digest, err))
               }
-              txn.commit()?;
-              Ok(())
-            });
-
-          match put_res {
-            Ok(()) => return Ok(digest),
-            Err(StoreError::Retry(msg)) => {
-              // Input changed during reading: maybe retry.
-              if attempts > 10 {
-                return Err(msg);
-              } else {
-                attempts += 1;
-                continue;
+              Err(StoreError::Io(err)) => {
+                return Err(format!("Error storing {:?}: {}", digest, err))
               }
-            }
-            Err(StoreError::Lmdb(lmdb::Error::KeyExist)) => return Ok(digest),
-            Err(StoreError::Lmdb(err)) => {
-              return Err(format!("Error storing {:?}: {}", digest, err))
-            }
-            Err(StoreError::Io(err)) => return Err(format!("Error storing {:?}: {}", digest, err)),
-          };
-        }
-      })
+            };
+          }
+        },
+        |e| Err(format!("`store` task failed: {e}")),
+      )
       .await
   }
 
-  pub async fn lease(&self, fingerprint: Fingerprint) -> Result<(), lmdb::Error> {
+  pub async fn lease(&self, fingerprint: Fingerprint) -> Result<(), String> {
     let store = self.clone();
     self
       .executor
-      .spawn_blocking(move || {
-        let until_secs_since_epoch: u64 = store.lease_until_secs_since_epoch();
-        let (env, _, lease_database) = store.get(&fingerprint);
-        env.begin_rw_txn().and_then(|mut txn| {
-          store.lease_inner(
-            lease_database,
-            &VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION),
-            until_secs_since_epoch,
-            &mut txn,
-          )?;
-          txn.commit()
-        })
-      })
+      .spawn_blocking(
+        move || {
+          let until_secs_since_epoch: u64 = store.lease_until_secs_since_epoch();
+          let (env, _, lease_database) = store.get(&fingerprint);
+          env
+            .begin_rw_txn()
+            .and_then(|mut txn| {
+              store.lease_inner(
+                lease_database,
+                &VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION),
+                until_secs_since_epoch,
+                &mut txn,
+              )?;
+              txn.commit()
+            })
+            .map_err(|e| format!("Error leasing {fingerprint:?}: {e}"))
+        },
+        |e| Err(format!("`lease` task failed: {e}")),
+      )
       .await
   }
 
@@ -651,21 +672,24 @@ impl ShardedLmdb {
     let effective_key = VersionedFingerprint::new(fingerprint, ShardedLmdb::SCHEMA_VERSION);
     self
       .executor
-      .spawn_blocking(move || {
-        let (env, db, _) = store.get(&fingerprint);
-        let ro_txn = env
-          .begin_ro_txn()
-          .map_err(|err| format!("Failed to begin read transaction: {}", err))?;
-        match ro_txn.get(db, &effective_key) {
-          Ok(bytes) => f(bytes).map(Some),
-          Err(lmdb::Error::NotFound) => Ok(None),
-          Err(err) => Err(format!(
-            "Error loading versioned key {:?}: {}",
-            effective_key.to_hex(),
-            err,
-          )),
-        }
-      })
+      .spawn_blocking(
+        move || {
+          let (env, db, _) = store.get(&fingerprint);
+          let ro_txn = env
+            .begin_ro_txn()
+            .map_err(|err| format!("Failed to begin read transaction: {}", err))?;
+          match ro_txn.get(db, &effective_key) {
+            Ok(bytes) => f(bytes).map(Some),
+            Err(lmdb::Error::NotFound) => Ok(None),
+            Err(err) => Err(format!(
+              "Error loading versioned key {:?}: {}",
+              effective_key.to_hex(),
+              err,
+            )),
+          }
+        },
+        |e| Err(format!("`load_bytes_with` task failed: {e}")),
+      )
       .await
   }
 

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -882,6 +882,6 @@ impl NodeContext for Context {
   where
     F: Future<Output = ()> + Send + 'static,
   {
-    let _join = self.core.executor.spawn(future);
+    let _join = self.core.executor.native_spawn(future);
   }
 }

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -42,6 +42,8 @@ use terminal_size::terminal_size_using_fd;
 use prodash::progress::Step;
 use prodash::render::line;
 use prodash::{Root, TreeOptions};
+
+use logging::fatal_log;
 use task_executor::Executor;
 use workunit_store::{format_workunit_duration_ms, SpanId, WorkunitStore};
 
@@ -226,7 +228,7 @@ impl Instance {
       // TODO: There is a shutdown race here, where if the UI is torn down before exclusive access is
       // dropped, we might drop stderr on the floor. That likely causes:
       //   https://github.com/pantsbuild/pants/issues/13276
-      let _stderr_task = executor.spawn_blocking({
+      let _stderr_task = executor.native_spawn_blocking({
         let mut tree = tree.clone();
         move || {
           while let Ok(stderr) = stderr_receiver.recv() {
@@ -406,7 +408,10 @@ impl Instance {
         prodash
           .executor
           .clone()
-          .spawn_blocking(move || prodash.handle.shutdown_and_wait())
+          .spawn_blocking(
+            move || prodash.handle.shutdown_and_wait(),
+            |e| fatal_log!("Failed to teardown UI: {e}"),
+          )
           .boxed()
       }
     }

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -311,13 +311,16 @@ impl InvalidationWatcher {
 
     let watcher = self.clone();
     executor
-      .spawn_blocking(move || {
-        let mut inner = watcher.0.lock();
-        inner
-          .watcher
-          .watch(&path, RecursiveMode::NonRecursive)
-          .map_err(|e| maybe_enrich_notify_error(&path, e))
-      })
+      .spawn_blocking(
+        move || {
+          let mut inner = watcher.0.lock();
+          inner
+            .watcher
+            .watch(&path, RecursiveMode::NonRecursive)
+            .map_err(|e| maybe_enrich_notify_error(&path, e))
+        },
+        |e| Err(format!("Watch attempt failed: {e}")),
+      )
       .await
   }
 }


### PR DESCRIPTION
To resolve #16105, we will likely want to replace the global static `Executor` with `Executor`s that are created per-`Scheduler`. That would introduce shutdown race conditions which given our current `unwrap`'ing in `task_executor` could lead to panics.

This change adjusts `task_executor`'s `spawn` APIs to avoid panicing by converting task errors into the expected error/result type at each callsite.