### PR TITLE
Go back to prior manylinux x86_64 image.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -401,7 +401,7 @@ jobs:
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
-      image: registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e
+      image: quay.io/pypa/manylinux2014_x86_64:latest
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -701,7 +701,7 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
     # the code, install rustup and expose Pythons.
     # TODO: Apply rust caching here.
     if platform == Platform.LINUX_X86_64:
-        container = {"image": "registry.hub.docker.com/pantsbuild/wheel_build_x86_64:v1-568cfc69e"}
+        container = {"image": "quay.io/pypa/manylinux2014_x86_64:latest"}
     elif platform == Platform.LINUX_ARM64:
         # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
         # generously given by the Runs on ARM program. Se we have to build in this image.


### PR DESCRIPTION
For some reason the deploy to s3 fails with an aws cli error on the new image, even though it succeeds on aarch64.