### PR TITLE
Document how to update the pants script.

### DIFF
--- a/docs/markdown/Docker/tagging-docker-images.md
+++ b/docs/markdown/Docker/tagging-docker-images.md
@@ -21,7 +21,7 @@ docker_image(
 )
 ```
 
-When publising this image, it will be pushed to these registries by default.
+When publishing this image, it will be pushed to these registries by default.
 
 In order to provide registry specific configuration, add them to the Pants configuration under
 `[docker.registries.<alias>]` and refer to them by their alias from the `docker_image` targets,

--- a/docs/markdown/Getting Started/getting-started/installation.md
+++ b/docs/markdown/Getting Started/getting-started/installation.md
@@ -34,3 +34,12 @@ If you had difficulty installing Pants, see our [getting help](doc:getting-help)
 > 
 > The `./pants` script will automatically install and use the Pants version specified in `pants.toml`, so upgrading Pants is as simple as editing `pants_version` in that file.
 
+
+Updating the `pants` launch script
+----------------------------------
+
+To update to the latest `pants` launch script in an existing repo, run:
+
+```
+curl -L -O https://static.pantsbuild.org/setup/pants && chmod +x ./pants
+```


### PR DESCRIPTION
This is important because the init-pants action sends users to this page for instructions on how to update the script, but there were no such instructions there...

Also fixes a random typo in an unrelated doc page.