### PR TITLE
Pyright should grab non-transitive dependencies and make them available in the sandbox (Cherry-pick of #17235)

### DIFF
--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -3,24 +3,43 @@
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.javascript.subsystems.nodejs import NpxProcess
-from pants.backend.python.target_types import PythonSourceField
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import (
+    InterpreterConstraintsField,
+    PythonResolveField,
+    PythonSourceField,
+)
 from pants.backend.python.typecheck.pyright.skip_field import SkipPyrightField
 from pants.backend.python.typecheck.pyright.subsystem import Pyright
+from pants.backend.python.util_rules import pex_from_targets
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.backend.python.util_rules.partition import (
+    _partition_by_interpreter_constraints_and_resolve,
+)
+from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex
+from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
+from pants.backend.python.util_rules.python_sources import (
+    PythonSourceFiles,
+    PythonSourceFilesRequest,
+)
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.collection import Collection
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import Get, Rule, collect_rules, rule
-from pants.engine.target import FieldSet, Target
+from pants.engine.target import CoarsenedTargets, CoarsenedTargetsRequest, FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import pluralize
-
-logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -28,6 +47,8 @@ class PyrightFieldSet(FieldSet):
     required_fields = (PythonSourceField,)
 
     sources: PythonSourceField
+    resolve: PythonResolveField
+    interpreter_constraints: InterpreterConstraintsField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:
@@ -39,35 +60,158 @@ class PyrightRequest(CheckRequest):
     tool_name = Pyright.options_scope
 
 
-@rule(desc="Typecheck using Pyright", level=LogLevel.DEBUG)
-async def pyright_typecheck(request: PyrightRequest, pyright: Pyright) -> CheckResults:
-    if pyright.skip:
-        return CheckResults([], checker_name=request.tool_name)
+@dataclass(frozen=True)
+class PyrightPartition:
+    field_sets: FrozenOrderedSet[PyrightFieldSet]
+    root_targets: CoarsenedTargets
+    resolve_description: str | None
+    interpreter_constraints: InterpreterConstraints
 
-    source_files = await Get(
-        SourceFiles, SourceFilesRequest([field_set.sources for field_set in request.field_sets])
+    def description(self) -> str:
+        ics = str(sorted(str(c) for c in self.interpreter_constraints))
+        return f"{self.resolve_description}, {ics}" if self.resolve_description else ics
+
+
+class PyrightPartitions(Collection[PyrightPartition]):
+    pass
+
+
+@rule(
+    desc="Pyright typecheck each partition based on its interpreter_constraints",
+    level=LogLevel.DEBUG,
+)
+async def pyright_typecheck_partition(
+    partition: PyrightPartition,
+    pyright: Pyright,
+    pex_environment: PexEnvironment,
+) -> CheckResult:
+
+    root_sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(fs.sources for fs in partition.field_sets),
     )
 
+    # Grab the inferred and supporting files for the root source files to be typechecked
+    coarsened_sources = await Get(
+        PythonSourceFiles, PythonSourceFilesRequest(partition.root_targets.closure())
+    )
+
+    # See `requirements_venv_pex` for how this will get wrapped in a `VenvPex`.
+    requirements_pex = await Get(
+        Pex,
+        RequirementsPexRequest(
+            (fs.address for fs in partition.field_sets),
+            hardcoded_interpreter_constraints=partition.interpreter_constraints,
+        ),
+    )
+
+    requirements_venv_pex = await Get(
+        VenvPex,
+        PexRequest(
+            output_filename="requirements_venv.pex",
+            internal_only=True,
+            pex_path=[requirements_pex],
+            interpreter_constraints=partition.interpreter_constraints,
+        ),
+    )
+
+    # venv workaround as per: https://github.com/microsoft/pyright/issues/4051
+    dummy_config_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    "pyrightconfig.json",
+                    f'{{ "venv": "{requirements_venv_pex.venv_rel_dir}" }}'.encode(),
+                )
+            ]
+        ),
+    )
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests(
+            [
+                coarsened_sources.source_files.snapshot.digest,
+                requirements_venv_pex.digest,
+                dummy_config_digest,
+            ]
+        ),
+    )
+
+    complete_pex_env = pex_environment.in_workspace()
     process = await Get(
         Process,
         NpxProcess(
             npm_package=pyright.default_version,
             args=(
+                f"--venv-path={complete_pex_env.pex_root}",  # Used with `venv` in config
                 *pyright.args,  # User-added arguments
-                *source_files.snapshot.files,
+                *root_sources.snapshot.files,
             ),
-            input_digest=source_files.snapshot.digest,
-            description=f"Run Pyright on {pluralize(len(source_files.snapshot.files), 'file')}.",
+            input_digest=input_digest,
+            description=f"Run Pyright on {pluralize(len(root_sources.snapshot.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
     )
     result = await Get(FallibleProcessResult, Process, process)
-    check_result = CheckResult.from_fallible_process_result(
+    return CheckResult.from_fallible_process_result(
         result,
+        partition_description=partition.description(),
     )
 
+
+@rule(
+    desc="Determine if it is necessary to partition Pyright's input (interpreter_constraints and resolves)",
+    level=LogLevel.DEBUG,
+)
+async def pyright_determine_partitions(
+    request: PyrightRequest,
+    pyright: Pyright,
+    python_setup: PythonSetup,
+) -> PyrightPartitions:
+
+    resolve_and_interpreter_constraints_to_field_sets = (
+        _partition_by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
+    )
+
+    coarsened_targets = await Get(
+        CoarsenedTargets,
+        CoarsenedTargetsRequest(field_set.address for field_set in request.field_sets),
+    )
+    coarsened_targets_by_address = coarsened_targets.by_address()
+
+    return PyrightPartitions(
+        PyrightPartition(
+            FrozenOrderedSet(field_sets),
+            CoarsenedTargets(
+                OrderedSet(
+                    coarsened_targets_by_address[field_set.address] for field_set in field_sets
+                )
+            ),
+            resolve if len(python_setup.resolves) > 1 else None,
+            interpreter_constraints or pyright.interpreter_constraints,
+        )
+        for (resolve, interpreter_constraints), field_sets in sorted(
+            resolve_and_interpreter_constraints_to_field_sets.items()
+        )
+    )
+
+
+@rule(desc="Typecheck using Pyright", level=LogLevel.DEBUG)
+async def pyright_typecheck(
+    request: PyrightRequest,
+    pyright: Pyright,
+) -> CheckResults:
+    if pyright.skip:
+        return CheckResults([], checker_name=request.tool_name)
+
+    partitions = await Get(PyrightPartitions, PyrightRequest, request)
+    partitioned_results = await MultiGet(
+        Get(CheckResult, PyrightPartition, partition) for partition in partitions
+    )
     return CheckResults(
-        [check_result],
+        partitioned_results,
         checker_name=request.tool_name,
     )
 
@@ -75,5 +219,6 @@ async def pyright_typecheck(request: PyrightRequest, pyright: Pyright) -> CheckR
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
+        *pex_from_targets.rules(),
         UnionRule(CheckRequest, PyrightRequest),
     )

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -9,14 +9,25 @@ import pytest
 
 from pants.backend.javascript.subsystems.nodejs import rules as nodejs_rules
 from pants.backend.python import target_types_rules
-from pants.backend.python.target_types import PythonSourcesGeneratorTarget, PythonSourceTarget
-from pants.backend.python.typecheck.pyright.rules import PyrightFieldSet, PyrightRequest
+from pants.backend.python.target_types import (
+    PythonRequirementTarget,
+    PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
+)
+from pants.backend.python.typecheck.pyright.rules import (
+    PyrightFieldSet,
+    PyrightPartition,
+    PyrightPartitions,
+    PyrightRequest,
+)
 from pants.backend.python.typecheck.pyright.rules import rules as pyright_rules
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.check import CheckResult, CheckResults
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
+from pants.testutil.python_interpreter_selection import skip_unless_all_pythons_present
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -28,8 +39,9 @@ def rule_runner() -> RuleRunner:
             *pyright_rules(),
             *target_types_rules.rules(),
             QueryRule(CheckResults, (PyrightRequest,)),
+            QueryRule(PyrightPartitions, (PyrightRequest,)),
         ],
-        target_types=[PythonSourcesGeneratorTarget, PythonSourceTarget],
+        target_types=[PythonRequirementTarget, PythonSourcesGeneratorTarget, PythonSourceTarget],
     )
 
 
@@ -102,3 +114,119 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/bad.py:4" in result[0].stdout
     assert "Found 2 source files" in result[0].stdout
     assert result[0].report == EMPTY_DIGEST
+
+
+def test_skip(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({f"{PACKAGE}/f.py": BAD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
+    result = run_pyright(rule_runner, [tgt], extra_args=["--pyright-skip"])
+    assert not result
+
+
+def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": (
+                "python_requirement(name='more-itertools', requirements=['more-itertools==8.4.0'])"
+            ),
+            f"{PACKAGE}/f.py": dedent(
+                """\
+                from more_itertools import flatten
+
+                assert flatten(42) == [4, 2]
+                """
+            ),
+            f"{PACKAGE}/BUILD": "python_sources()",
+        }
+    )
+    tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
+    result = run_pyright(rule_runner, [tgt])
+    assert len(result) == 1
+    assert result[0].exit_code == 1
+    assert f"{PACKAGE}/f.py:3" in result[0].stdout
+
+
+@skip_unless_all_pythons_present("3.8", "3.9")
+def test_partition_targets(rule_runner: RuleRunner) -> None:
+    def create_folder(folder: str, resolve: str, interpreter: str) -> dict[str, str]:
+        return {
+            f"{folder}/dep.py": "",
+            f"{folder}/root.py": "",
+            f"{folder}/BUILD": dedent(
+                f"""\
+                python_source(
+                    name='dep',
+                    source='dep.py',
+                    resolve='{resolve}',
+                    interpreter_constraints=['=={interpreter}.*'],
+                )
+                python_source(
+                    name='root',
+                    source='root.py',
+                    resolve='{resolve}',
+                    interpreter_constraints=['=={interpreter}.*'],
+                    dependencies=[':dep'],
+                )
+                """
+            ),
+        }
+
+    files = {
+        **create_folder("resolveA_py38", "a", "3.8"),
+        **create_folder("resolveA_py39", "a", "3.9"),
+        **create_folder("resolveB_1", "b", "3.9"),
+        **create_folder("resolveB_2", "b", "3.9"),
+    }
+    rule_runner.write_files(files)
+    rule_runner.set_options(
+        ["--python-resolves={'a': '', 'b': ''}", "--python-enable-resolves"],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
+
+    resolve_a_py38_dep = rule_runner.get_target(Address("resolveA_py38", target_name="dep"))
+    resolve_a_py38_root = rule_runner.get_target(Address("resolveA_py38", target_name="root"))
+    resolve_a_py39_dep = rule_runner.get_target(Address("resolveA_py39", target_name="dep"))
+    resolve_a_py39_root = rule_runner.get_target(Address("resolveA_py39", target_name="root"))
+    resolve_b_dep1 = rule_runner.get_target(Address("resolveB_1", target_name="dep"))
+    resolve_b_root1 = rule_runner.get_target(Address("resolveB_1", target_name="root"))
+    resolve_b_dep2 = rule_runner.get_target(Address("resolveB_2", target_name="dep"))
+    resolve_b_root2 = rule_runner.get_target(Address("resolveB_2", target_name="root"))
+    request = PyrightRequest(
+        PyrightFieldSet.create(t)
+        for t in (
+            resolve_a_py38_root,
+            resolve_a_py39_root,
+            resolve_b_root1,
+            resolve_b_root2,
+        )
+    )
+
+    partitions = rule_runner.request(PyrightPartitions, [request])
+    assert len(partitions) == 3
+
+    def assert_partition(
+        partition: PyrightPartition,
+        roots: list[Target],
+        deps: list[Target],
+        interpreter: str,
+        resolve: str,
+    ) -> None:
+        root_addresses = {t.address for t in roots}
+        assert {fs.address for fs in partition.field_sets} == root_addresses
+        assert {t.address for t in partition.root_targets.closure()} == {
+            *root_addresses,
+            *(t.address for t in deps),
+        }
+        ics = [f"CPython=={interpreter}.*"]
+        assert partition.interpreter_constraints == InterpreterConstraints(ics)
+        assert partition.description() == f"{resolve}, {ics}"
+
+    assert_partition(partitions[0], [resolve_a_py38_root], [resolve_a_py38_dep], "3.8", "a")
+    assert_partition(partitions[1], [resolve_a_py39_root], [resolve_a_py39_dep], "3.9", "a")
+    assert_partition(
+        partitions[2],
+        [resolve_b_root1, resolve_b_root2],
+        [resolve_b_dep1, resolve_b_dep2],
+        "3.9",
+        "b",
+    )

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -3,7 +3,8 @@
 
 from __future__ import annotations
 
-from pants.option.option_types import ArgsListOption, SkipOption
+from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -22,3 +23,17 @@ class Pyright(Subsystem):
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")
+
+    _interpreter_constraints = StrListOption(
+        advanced=True,
+        default=["CPython>=3.7,<4"],
+        help="Python interpreter constraints for Pyright (which is, itself, a NodeJS tool).",
+    )
+
+    @property
+    def interpreter_constraints(self) -> InterpreterConstraints:
+        """The interpreter constraints to use when installing and running the tool.
+
+        This assumes you have set the class property `register_interpreter_constraints = True`.
+        """
+        return InterpreterConstraints(self._interpreter_constraints)


### PR DESCRIPTION
The first PR for pyright was a naive "files in, pyright them" (#17163). This PR adds support for pulling in related dependencies (including 3rd party) and handling multiple `interpreter_constraints`. 

Out-of-scope:
- `pyright` [configuration file](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#pyright-configuration) support (other than "dummy" which allows using a venv)

(See #17225)

[ci skip-rust]
[ci skip-build-wheels]
