### PR TITLE
go: track whether a package to build is in stdlib

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -157,6 +157,8 @@ async def setup_build_go_package_target_request(
         return codegen_result
 
     embed_config: EmbedConfig | None = None
+    is_stdlib = False
+
     if target.has_field(GoPackageSourcesField):
         _maybe_first_party_pkg_analysis, _maybe_first_party_pkg_digest = await MultiGet(
             Get(
@@ -411,6 +413,7 @@ async def setup_build_go_package_target_request(
         with_coverage=with_coverage,
         pkg_specific_compiler_flags=tuple(pkg_specific_compiler_flags),
         pkg_specific_assembler_flags=tuple(pkg_specific_assembler_flags),
+        is_stdlib=is_stdlib,
     )
     return FallibleBuildGoPackageRequest(result, import_path)
 


### PR DESCRIPTION
Add `is_stdlib` field to `BuildGoPackageRequest` to track whether a package is in the standard library. Add compile options based in part on that status.