### PR TITLE
CI: install Go for now into wheel building jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -372,6 +372,10 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.1
     - env:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
@@ -440,6 +444,10 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.1
     - env: {}
       name: Build wheels
       run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
@@ -506,6 +514,10 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.1
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
@@ -573,6 +585,10 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.1
     - env:
         ARCHFLAGS: -arch arm64
       name: Build wheels
@@ -637,6 +653,10 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.17.1
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -754,6 +754,7 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
             "steps": initial_steps
             + [
                 setup_toolchain_auth(),
+                install_go(),
                 *helper.build_wheels(python_versions),
                 helper.upload_log_artifacts(name="wheels"),
                 deploy_to_s3(),


### PR DESCRIPTION
Add Go to wheel building jobs to work around issue where Pants is looking for `go`. Example errors here: https://github.com/pantsbuild/pants/actions/runs/3905384605/jobs/6672312872

After landing https://github.com/pantsbuild/pants/pull/17973, Pants now generates a synthetic target to represent the Go SDK. That target type is a target generator and eagerly calls `go` to find out what targets to generate for the Go SDK.

The wheel building jobs were missing Go, so boom.