### PR TITLE
go: compile Go SDK when building internal binaries

### DIFF
--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -44,6 +44,8 @@ class NaiveBuildGoPackageRequestForStdlibPackageRequest:
     import_path: str
 
 
+# This rule is necessary because the rules in this file are used to build internal binaries including the
+# package analyzer.
 @rule
 async def naive_build_go_package_request_for_stdlib(
     request: NaiveBuildGoPackageRequestForStdlibPackageRequest,

--- a/src/python/pants/backend/go/go_sources/load_go_binary.py
+++ b/src/python/pants/backend/go/go_sources/load_go_binary.py
@@ -3,14 +3,23 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
+from typing import Iterable
 
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
 from pants.backend.go.util_rules.build_pkg import BuildGoPackageRequest, BuiltGoPackage
-from pants.backend.go.util_rules.import_analysis import ImportConfig, ImportConfigRequest
+from pants.backend.go.util_rules.goroot import GoRoot
+from pants.backend.go.util_rules.import_analysis import (
+    GoStdLibPackages,
+    GoStdLibPackagesRequest,
+    ImportConfig,
+    ImportConfigRequest,
+)
 from pants.backend.go.util_rules.link import LinkedGoBinary, LinkGoBinaryRequest
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
+from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.resources import read_resource
 
@@ -30,6 +39,49 @@ class LoadedGoBinaryRequest(EngineAwareParameter):
         return self.output_name
 
 
+@dataclass(frozen=True)
+class NaiveBuildGoPackageRequestForStdlibPackageRequest:
+    import_path: str
+
+
+@rule
+async def naive_build_go_package_request_for_stdlib(
+    request: NaiveBuildGoPackageRequestForStdlibPackageRequest,
+    goroot: GoRoot,
+) -> BuildGoPackageRequest:
+    stdlib_packages = await Get(
+        GoStdLibPackages,
+        GoStdLibPackagesRequest(with_race_detector=False, cgo_enabled=False),
+    )
+
+    pkg_info = stdlib_packages[request.import_path]
+
+    dep_build_requests = await MultiGet(
+        Get(
+            BuildGoPackageRequest,
+            NaiveBuildGoPackageRequestForStdlibPackageRequest(
+                import_path=dep_import_path,
+            ),
+        )
+        for dep_import_path in pkg_info.imports
+        if dep_import_path not in ("C", "unsafe", "builtin")
+    )
+
+    return BuildGoPackageRequest(
+        import_path=request.import_path,
+        pkg_name=pkg_info.name,
+        dir_path=pkg_info.pkg_source_path,
+        digest=EMPTY_DIGEST,
+        go_files=pkg_info.go_files,
+        s_files=pkg_info.s_files,
+        prebuilt_object_files=pkg_info.syso_files,
+        direct_dependencies=tuple(dep_build_requests),
+        minimum_go_version=goroot.version,
+        build_opts=GoBuildOptions(cgo_enabled=False),
+        is_stdlib=True,
+    )
+
+
 def setup_files(dir_name: str, file_names: tuple[str, ...]) -> tuple[FileContent, ...]:
     def get_file(file_name: str) -> bytes:
         content = read_resource(f"pants.backend.go.go_sources.{dir_name}", file_name)
@@ -40,15 +92,37 @@ def setup_files(dir_name: str, file_names: tuple[str, ...]) -> tuple[FileContent
     return tuple(FileContent(f, get_file(f)) for f in file_names)
 
 
+_IMPORTS_REGEX = re.compile(r"^import\s+\((.*?)\)", re.MULTILINE | re.DOTALL)
+
+
+def _extract_imports(files: Iterable[FileContent]) -> set[str]:
+    """Extract Go imports naively from given content."""
+    imports: set[str] = set()
+    for f in files:
+        m = _IMPORTS_REGEX.search(f.content.decode())
+        if m:
+            f_imports = [x.strip('"') for x in m.group(1).split()]
+            imports.update(f_imports)
+    return imports
+
+
 # TODO(13879): Maybe see if can consolidate compilation of wrapper binaries to common rules with Scala/Java?
 @rule
-async def setup_go_binary(request: LoadedGoBinaryRequest) -> LoadedGoBinary:
+async def setup_go_binary(request: LoadedGoBinaryRequest, goroot: GoRoot) -> LoadedGoBinary:
     file_contents = setup_files(request.dir_name, request.file_names)
-    build_opts = GoBuildOptions()
+    imports = _extract_imports(file_contents)
+    imports.add("runtime")  # implicit linker dependency for all Go binaries
 
-    source_digest, import_config = await MultiGet(
-        Get(Digest, CreateDigest(file_contents)),
-        Get(ImportConfig, ImportConfigRequest, ImportConfigRequest.stdlib_only(build_opts)),
+    build_opts = GoBuildOptions(cgo_enabled=False)
+
+    source_digest = await Get(Digest, CreateDigest(file_contents))
+
+    dep_build_requests = await MultiGet(
+        Get(
+            BuildGoPackageRequest,
+            NaiveBuildGoPackageRequestForStdlibPackageRequest(dep_import_path),
+        )
+        for dep_import_path in sorted(imports)
     )
 
     built_pkg = await Get(
@@ -56,15 +130,23 @@ async def setup_go_binary(request: LoadedGoBinaryRequest) -> LoadedGoBinary:
         BuildGoPackageRequest(
             import_path="main",
             pkg_name="main",
-            dir_path="",
+            dir_path=".",
             build_opts=build_opts,
             digest=source_digest,
             go_files=tuple(fc.path for fc in file_contents),
             s_files=(),
-            direct_dependencies=(),
-            minimum_go_version=None,
+            direct_dependencies=dep_build_requests,
+            minimum_go_version=goroot.version,
         ),
     )
+
+    import_config = await Get(
+        ImportConfig,
+        ImportConfigRequest(
+            built_pkg.import_paths_to_pkg_a_files, build_opts=build_opts, include_stdlib=False
+        ),
+    )
+
     main_pkg_a_file_path = built_pkg.import_paths_to_pkg_a_files["main"]
     input_digest = await Get(Digest, MergeDigests([built_pkg.digest, import_config.digest]))
 
@@ -76,7 +158,7 @@ async def setup_go_binary(request: LoadedGoBinaryRequest) -> LoadedGoBinary:
             build_opts=build_opts,
             import_config_path=import_config.CONFIG_PATH,
             output_filename=request.output_name,
-            description="Link Go package analyzer",
+            description=f"Link internal Go binary `{request.output_name}`",
         ),
     )
     return LoadedGoBinary(binary.digest)

--- a/src/python/pants/backend/go/goals/BUILD
+++ b/src/python/pants/backend/go/goals/BUILD
@@ -4,5 +4,5 @@
 python_sources()
 python_tests(
     name="tests",
-    overrides={"test_test.py": {"timeout": 120}},
+    overrides={"test_test.py": {"timeout": 320}},
 )

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -265,12 +265,10 @@ async def prepare_go_test_binary(
         GenerateTestMainRequest(
             digest=pkg_digest.digest,
             test_paths=FrozenOrderedSet(
-                os.path.join(".", pkg_analysis.dir_path, name)
-                for name in pkg_analysis.test_go_files
+                os.path.join(pkg_analysis.dir_path, name) for name in pkg_analysis.test_go_files
             ),
             xtest_paths=FrozenOrderedSet(
-                os.path.join(".", pkg_analysis.dir_path, name)
-                for name in pkg_analysis.xtest_go_files
+                os.path.join(pkg_analysis.dir_path, name) for name in pkg_analysis.xtest_go_files
             ),
             import_path=import_path,
             register_cover=with_coverage,

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -68,6 +68,14 @@ class FallibleAssembleGoAssemblyFilesResult:
     stderr: str | None = None
 
 
+def _is_runtime_package_import_path(import_path: str) -> bool:
+    """Returns True if the import path is from one of the Go runtime packages in stdlib which needs
+    special handling."""
+    if import_path in ("runtime", "reflect", "syscall", "internal/bytealg"):
+        return True
+    return import_path.startswith("runtime/internal")
+
+
 # Adapted from https://github.com/golang/go/blob/cb07765045aed5104a3df31507564ac99e6ddce8/src/cmd/go/internal/work/gc.go#L358-L410
 #
 # Note: Architecture-specific flags have not been adapted nor the flags added when compiling Go SDK packages
@@ -82,6 +90,10 @@ def _asm_args(
         ["-p", import_path] if goroot.is_compatible_version("1.19") else []
     )
 
+    maybe_compiling_runtime_in_stdlib_args: list[str] = []
+    if _is_runtime_package_import_path(import_path):
+        maybe_compiling_runtime_in_stdlib_args = ["-compiling-runtime"]
+
     return (
         *maybe_package_import_path_args,
         "-trimpath",
@@ -95,6 +107,7 @@ def _asm_args(
         f"GOOS_{goroot.goos}",
         "-D",
         f"GOARCH_{goroot.goarch}",
+        *maybe_compiling_runtime_in_stdlib_args,
         *extra_flags,
     )
 
@@ -110,7 +123,10 @@ async def generate_go_assembly_symabisfile(
     #   that we don't need the actual definitions that would appear in go_asm.h.
     #
     # See https://go-review.googlesource.com/c/go/+/146999/8/src/cmd/go/internal/work/gc.go
-    symabis_path = os.path.join(request.dir_path, "symabis")
+    if os.path.isabs(request.dir_path):
+        symabis_path = "symabis"
+    else:
+        symabis_path = os.path.join(request.dir_path, "symabis")
     go_asm_h_digest, asm_tool_id = await MultiGet(
         Get(Digest, CreateDigest([FileContent("go_asm.h", b"")])),
         Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
@@ -135,7 +151,7 @@ async def generate_go_assembly_symabisfile(
                 "-o",
                 symabis_path,
                 "--",
-                *(str(PurePath(".", request.dir_path, s_file)) for s_file in request.s_files),
+                *(str(PurePath(request.dir_path, s_file)) for s_file in request.s_files),
             ),
             env={
                 "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,
@@ -166,7 +182,10 @@ async def assemble_go_assembly_files(
     asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
 
     def obj_output_path(s_file: str) -> str:
-        return str(request.dir_path / PurePath(s_file).with_suffix(".o"))
+        if os.path.isabs(request.dir_path):
+            return str(PurePath(s_file).with_suffix(".o"))
+        else:
+            return str(request.dir_path / PurePath(s_file).with_suffix(".o"))
 
     assembly_results = await MultiGet(
         Get(
@@ -184,7 +203,7 @@ async def assemble_go_assembly_files(
                     ),
                     "-o",
                     obj_output_path(s_file),
-                    str(os.path.normpath(PurePath(".", request.dir_path, s_file))),
+                    str(os.path.normpath(PurePath(request.dir_path, s_file))),
                 ),
                 env={
                     "__PANTS_GO_ASM_TOOL_ID": asm_tool_id.tool_id,

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -207,7 +207,7 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert invalid_direct_result.exit_code == 1
     assert (
         invalid_direct_result.stdout
-        == "./dep/f.go:1:1: syntax error: package statement must be first\n"
+        == "dep/f.go:1:1: syntax error: package statement must be first\n"
     )
 
     invalid_dep_result = rule_runner.request(FallibleBuiltGoPackage, [main])
@@ -215,5 +215,5 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert invalid_dep_result.exit_code == 1
     assert (
         invalid_dep_result.stdout
-        == "./dep/f.go:1:1: syntax error: package statement must be first\n"
+        == "dep/f.go:1:1: syntax error: package statement must be first\n"
     )

--- a/src/python/pants/backend/go/util_rules/build_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_test.py
@@ -214,6 +214,5 @@ def test_build_invalid_pkg(rule_runner: RuleRunner) -> None:
     assert invalid_dep_result.output is None
     assert invalid_dep_result.exit_code == 1
     assert (
-        invalid_dep_result.stdout
-        == "dep/f.go:1:1: syntax error: package statement must be first\n"
+        invalid_dep_result.stdout == "dep/f.go:1:1: syntax error: package statement must be first\n"
     )


### PR DESCRIPTION
Build the Go SDK (instead of linking to prebuilt package archives) when building internal binaries like the package and test analyzers. Also includes path-related fixes in the `build_pkg` and `assembly` utility rules for getting those binaries to build.

This is part of fixing https://github.com/pantsbuild/pants/issues/17950 and was extracted from https://github.com/pantsbuild/pants/pull/17914.