### PR TITLE
go: use preexisting constant for testmain filename

### DIFF
--- a/src/python/pants/backend/go/util_rules/tests_analysis.py
+++ b/src/python/pants/backend/go/util_rules/tests_analysis.py
@@ -64,7 +64,7 @@ async def generate_testmain(request: GenerateTestMainRequest) -> GeneratedTestMa
             env=env,
             description=f"Analyze Go test sources for {request.address}",
             level=LogLevel.DEBUG,
-            output_files=("_testmain.go",),
+            output_files=(GeneratedTestMain.TEST_MAIN_FILE,),
         ),
     )
 


### PR DESCRIPTION
Missed a spot when switching over to a constant for the name of the generated "testmain" file.