### PR TITLE
Upgrade to Rust 1.66.1

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -134,7 +134,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -249,7 +249,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -139,7 +139,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -256,7 +256,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -492,7 +492,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -563,7 +563,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 
@@ -631,7 +631,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.0-*
+        path: '~/.rustup/toolchains/1.66.1-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.66.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
To avoid this CVE: https://blog.rust-lang.org/2023/01/10/cve-2022-46176.html