### PR TITLE
Make the python dep inference script extensible.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -91,6 +91,7 @@ root_patterns = [
   "test/*",
   "tests/*",
   "3rdparty/*",
+  "src/python/pants/backend/python/dependency_inference/scripts",
   "/build-support/bin",
   "/build-support/flake8",
   "/build-support/migration-support",

--- a/src/python/pants/backend/python/dependency_inference/BUILD
+++ b/src/python/pants/backend/python/dependency_inference/BUILD
@@ -1,7 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources()
+python_sources(dependencies=["src/python/pants/backend/python/dependency_inference/scripts"])
 
 python_tests(
     name="tests",

--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -1,8 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 import json
 from dataclasses import dataclass
+from typing import Iterable
 
+from pants.backend.python.dependency_inference.subsystem import PythonInferSubsystem
 from pants.backend.python.target_types import PythonSourceField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
@@ -11,7 +14,8 @@ from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
+from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
@@ -47,23 +51,91 @@ class ParsedPythonDependencies:
 class ParsePythonDependenciesRequest:
     source: PythonSourceField
     interpreter_constraints: InterpreterConstraints
-    string_imports: bool
-    string_imports_min_dots: int
-    assets: bool
-    assets_min_slashes: int
+
+
+@union(in_scope_types=[])
+class PythonDependencyVisitorRequest:
+    pass
+
+
+@dataclass(frozen=True)
+class PythonDependencyVisitor:
+    digest: Digest
+    classname: str
+    env: FrozenDict[str, str]
 
 
 @dataclass(frozen=True)
 class ParserScript:
     digest: Digest
+    env: FrozenDict[str, str]
+
+
+@rule_helper
+async def _get_script_digest(relpaths: Iterable[str]) -> Digest:
+    scripts = [read_resource(__name__, f"scripts/{relpath}") for relpath in relpaths]
+    assert all(script is not None for script in scripts)
+    digest = await Get(
+        Digest,
+        CreateDigest([FileContent(relpath, script) for relpath, script in zip(relpaths, scripts)]),
+    )
+    return digest
 
 
 @rule
-async def parser_script() -> ParserScript:
-    script = read_resource(__name__, "scripts/dependency_parser.py")
-    assert script is not None
-    return ParserScript(
-        await Get(Digest, CreateDigest([FileContent("__parse_python_dependencies.py", script)]))
+async def get_parser_script(union_membership: UnionMembership) -> ParserScript:
+    dep_visitor_request_types = union_membership[PythonDependencyVisitorRequest]
+    dep_visitors = await MultiGet(
+        Get(PythonDependencyVisitor, PythonDependencyVisitorRequest, dvrt())
+        for dvrt in dep_visitor_request_types
+    )
+    utils = await _get_script_digest(
+        [
+            "_pants_dep_parser/__init__.py",
+            "_pants_dep_parser/dependency_visitor_base.py",
+            "_pants_dep_parser/main.py",
+        ]
+    )
+    digest = await Get(Digest, MergeDigests([utils, *(dv.digest for dv in dep_visitors)]))
+    env = {
+        "VISITOR_CLASSNAMES": "|".join(dv.classname for dv in dep_visitors),
+        "PYTHONPATH": ".",
+    }
+    for dv in dep_visitors:
+        for k, v in dv.env.items():
+            if k in env:
+                existing_v = env[k]
+                raise ValueError(
+                    f"Environment variable {k} was set to value {existing_v} by a "
+                    f"PythonDependencyVisitor implementation, cannot reset it to {v}."
+                )
+            env[k] = v
+    return ParserScript(digest, FrozenDict(env))
+
+
+@dataclass(frozen=True)
+class GeneralPythonDependencyVisitorRequest(PythonDependencyVisitorRequest):
+    # Union member for the general dep parser that applies to all .py files.
+    pass
+
+
+@rule
+async def general_parser_script(
+    python_infer_subsystem: PythonInferSubsystem,
+    request: GeneralPythonDependencyVisitorRequest,
+) -> PythonDependencyVisitor:
+    script_digest = await _get_script_digest(["_pants_dep_parser/general_dependency_visitor.py"])
+    return PythonDependencyVisitor(
+        digest=script_digest,
+        classname="_pants_dep_parser.general_dependency_visitor.GeneralDependencyVisitor",
+        env=FrozenDict(
+            {
+                "STRING_IMPORTS": "y" if python_infer_subsystem.string_imports else "n",
+                "STRING_IMPORTS_MIN_DOTS": str(python_infer_subsystem.string_imports_min_dots),
+                "ASSETS": "y" if python_infer_subsystem.assets else "n",
+                "ASSETS_MIN_SLASHES": str(python_infer_subsystem.assets_min_slashes),
+            }
+        ),
     )
 
 
@@ -89,21 +161,16 @@ async def parse_python_dependencies(
         Process(
             argv=[
                 python_interpreter.path,
-                "./__parse_python_dependencies.py",
+                "./_pants_dep_parser/main.py",
                 file,
             ],
             input_digest=input_digest,
             description=f"Determine Python dependencies for {request.source.address}",
-            env={
-                "STRING_IMPORTS": "y" if request.string_imports else "n",
-                "STRING_IMPORTS_MIN_DOTS": str(request.string_imports_min_dots),
-                "ASSETS": "y" if request.assets else "n",
-                "ASSETS_MIN_SLASHES": str(request.assets_min_slashes),
-            },
+            env=parser_script.env,
             level=LogLevel.DEBUG,
         ),
     )
-    # See above for where we explicitly encoded as utf8. Even though utf8 is the
+    # See in script for where we explicitly encoded as utf8. Even though utf8 is the
     # default for decode(), we make that explicit here for emphasis.
     process_output = process_result.stdout.decode("utf8") or "{}"
     output = json.loads(process_output)
@@ -117,4 +184,7 @@ async def parse_python_dependencies(
 
 
 def rules():
-    return collect_rules()
+    return [
+        UnionRule(PythonDependencyVisitorRequest, GeneralPythonDependencyVisitorRequest),
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -63,7 +63,7 @@ class PythonDependencyVisitorRequest:
 class PythonDependencyVisitor:
     """Wraps a subclass of _pants_dep_parser.DependencyVisitorBase."""
 
-    digest: Digest  # The content of the subclass
+    digest: Digest  # The file contents for the visitor
     classname: str  # The full classname, e.g., _my_custom_dep_parser.MyCustomVisitor
     env: FrozenDict[str, str]  # Set these env vars when invoking the visitor
 

--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
@@ -56,7 +56,15 @@ def assert_deps_parsed(
     assets: bool = True,
     assets_min_slashes: int = 1,
 ) -> None:
-    rule_runner.set_options([], env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    rule_runner.set_options(
+        [
+            f"--python-infer-string-imports={string_imports}",
+            f"--python-infer-string-imports-min-dots={string_imports_min_dots}",
+            f"--python-infer-assets={assets}",
+            f"--python-infer-assets-min-slashes={assets_min_slashes}",
+        ],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
     rule_runner.write_files(
         {
             "BUILD": f"python_source(name='t', source={repr(filename)})",
@@ -70,10 +78,6 @@ def assert_deps_parsed(
             ParsePythonDependenciesRequest(
                 tgt[PythonSourceField],
                 InterpreterConstraints([constraints]),
-                string_imports=string_imports,
-                string_imports_min_dots=string_imports_min_dots,
-                assets=assets,
-                assets_min_slashes=assets_min_slashes,
             )
         ],
     )

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -333,7 +333,6 @@ async def _handle_unowned_imports(
 @rule_helper
 async def _exec_parse_deps(
     field_set: PythonImportDependenciesInferenceFieldSet,
-    python_infer_subsystem: PythonInferSubsystem,
     python_setup: PythonSetup,
 ) -> ParsedPythonDependencies:
     interpreter_constraints = InterpreterConstraints.create_from_compatibility_fields(
@@ -344,10 +343,6 @@ async def _exec_parse_deps(
         ParsePythonDependenciesRequest(
             field_set.source,
             interpreter_constraints,
-            string_imports=python_infer_subsystem.string_imports,
-            string_imports_min_dots=python_infer_subsystem.string_imports_min_dots,
-            assets=python_infer_subsystem.assets,
-            assets_min_slashes=python_infer_subsystem.assets_min_slashes,
         ),
     )
     return resp
@@ -439,9 +434,7 @@ async def infer_python_dependencies_via_source(
     if not python_infer_subsystem.imports and not python_infer_subsystem.assets:
         return InferredDependencies([])
 
-    parsed_dependencies = await _exec_parse_deps(
-        request.field_set, python_infer_subsystem, python_setup
-    )
+    parsed_dependencies = await _exec_parse_deps(request.field_set, python_setup)
 
     resolve = request.field_set.resolve.normalized_value(python_setup)
 

--- a/src/python/pants/backend/python/dependency_inference/scripts/BUILD
+++ b/src/python/pants/backend/python/dependency_inference/scripts/BUILD
@@ -1,13 +1,13 @@
-# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-resource(
-    name="dependency_parser",
-    source="dependency_parser.py",
+# Scripts are consumed at runtime as resources.
+resources(
+    sources=["**/*.py"],
 )
 
-# Also expose script as a python source so it gets formatted/linted/checked.
-python_source(
-    name="dependency_parser_source",
-    source="dependency_parser.py",
+# Also expose the scripts as python sources so they get formatted/linted/checked.
+python_sources(
+    name="py_sources",
+    sources=["**/*.py"],
 )

--- a/src/python/pants/backend/python/dependency_inference/scripts/BUILD
+++ b/src/python/pants/backend/python/dependency_inference/scripts/BUILD
@@ -1,4 +1,4 @@
-# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # Scripts are consumed at runtime as resources.

--- a/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/dependency_visitor_base.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/dependency_visitor_base.py
@@ -23,6 +23,8 @@ class FoundDependencies:
 
 
 class DependencyVisitorBase(ast.NodeVisitor):
+    """Base class for code that extracts dependencies from the AST."""
+
     @staticmethod
     def maybe_str(node):
         if sys.version_info[0:2] < (3, 8):

--- a/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/dependency_visitor_base.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/dependency_visitor_base.py
@@ -1,0 +1,64 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# -*- coding: utf-8 -*-
+
+# NB: This must be compatible with Python 2.7 and 3.5+.
+
+from __future__ import print_function, unicode_literals
+
+import ast
+import itertools
+import sys
+
+
+class FoundDependencies:
+    def __init__(self):
+        # Each of these maps module_name to first lineno of occurance
+        # N.B. use `setdefault` when adding imports
+        # (See `ParsedPythonImportInfo` in parse_python_imports.py for the delineation of
+        #   weak/strong)
+        self.strong_imports = {}
+        self.weak_imports = {}
+        self.assets = set()
+
+
+class DependencyVisitorBase(ast.NodeVisitor):
+    @staticmethod
+    def maybe_str(node):
+        if sys.version_info[0:2] < (3, 8):
+            return node.s if isinstance(node, ast.Str) else None
+        else:
+            return node.value if isinstance(node, ast.Constant) else None
+
+    def __init__(self, found_dependencies, package_parts, contents):
+        self._found_dependencies = found_dependencies
+        self._package_parts = package_parts
+        self._contents_lines = contents.decode(errors="ignore").splitlines()
+
+        # While this is set to True, otherwise-strong imports will be treated as weak.
+        self.weaken_strong_imports = False
+
+    def add_strong_import(self, name, lineno):
+        if not self._is_pragma_ignored(lineno - 1):
+            imports = (
+                self._found_dependencies.weak_imports
+                if self.weaken_strong_imports
+                else self._found_dependencies.strong_imports
+            )
+            imports.setdefault(name, lineno)
+
+    def add_weak_import(self, name, lineno):
+        if not self._is_pragma_ignored(lineno - 1):
+            self._found_dependencies.weak_imports.setdefault(name, lineno)
+
+    def add_asset(self, name, lineno):
+        if not self._is_pragma_ignored(lineno - 1):
+            self._found_dependencies.assets.add(name)
+
+    def _is_pragma_ignored(self, line_index):
+        """Return if the line at `line_index` (0-based) is pragma ignored."""
+        line_iter = itertools.dropwhile(
+            lambda line: line.endswith("\\"),
+            itertools.islice(self._contents_lines, line_index, None),
+        )
+        return "# pants: no-infer-dep" in next(line_iter)

--- a/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/general_dependency_visitor.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/general_dependency_visitor.py
@@ -3,41 +3,21 @@
 # -*- coding: utf-8 -*-
 
 # NB: This must be compatible with Python 2.7 and 3.5+.
-# NB: If you're needing to debug this, an easy way is to just invoke it on a file.
-#   E.g. `STRING_IMPORTS=y ... python3 src/python/pants/backend/python/dependency_inference/scripts/dependency_parser_py FILENAME`
-
 from __future__ import print_function, unicode_literals
 
 import ast
 import itertools
-import json
 import os
 import re
-import sys
 import tokenize
-from io import open
+
+from _pants_dep_parser.dependency_visitor_base import DependencyVisitorBase
 
 
-def _maybe_str(node):
-    if sys.version_info[0:2] < (3, 8):
-        return node.s if isinstance(node, ast.Str) else None
-    else:
-        return node.value if isinstance(node, ast.Constant) else None
+class GeneralDependencyVisitor(DependencyVisitorBase):
+    def __init__(self, *args, **kwargs):
+        super(GeneralDependencyVisitor, self).__init__(*args, **kwargs)
 
-
-class AstVisitor(ast.NodeVisitor):
-    def __init__(self, package_parts, contents):
-        self._package_parts = package_parts
-        self._contents_lines = contents.decode(errors="ignore").splitlines()
-
-        # Each of these maps module_name to first lineno of occurance
-        # N.B. use `setdefault` when adding imports
-        # (See `ParsedPythonImportInfo` in ../parse_python_imports.py for the delineation of
-        #   weak/strong)
-        self.strong_imports = {}
-        self.weak_imports = {}
-        self.assets = set()
-        self._weaken_strong_imports = False
         if os.environ.get("STRING_IMPORTS", "n") == "y":
             # This regex is used to infer imports from strings, e.g .
             #  `importlib.import_module("example.subdir.Foo")`.
@@ -66,24 +46,7 @@ class AstVisitor(ast.NodeVisitor):
         if self._string_import_regex and self._string_import_regex.match(s):
             self.add_weak_import(s, node.lineno)
         if self._asset_regex and self._asset_regex.match(s):
-            self.assets.add(s)
-
-    def add_strong_import(self, name, lineno):
-        if not self._is_pragma_ignored(lineno - 1):
-            imports = self.weak_imports if self._weaken_strong_imports else self.strong_imports
-            imports.setdefault(name, lineno)
-
-    def add_weak_import(self, name, lineno):
-        if not self._is_pragma_ignored(lineno - 1):
-            self.weak_imports.setdefault(name, lineno)
-
-    def _is_pragma_ignored(self, line_index):
-        """Return if the line at `line_index` (0-based) is pragma ignored."""
-        line_iter = itertools.dropwhile(
-            lambda line: line.endswith("\\"),
-            itertools.islice(self._contents_lines, line_index, None),
-        )
-        return "# pants: no-infer-dep" in next(line_iter)
+            self.add_asset(s, node.lineno)
 
     def _visit_import_stmt(self, node, import_prefix):
         # N.B. We only add imports whose line doesn't contain "# pants: no-infer-dep"
@@ -137,13 +100,13 @@ class AstVisitor(ast.NodeVisitor):
                 continue
 
             if any(isinstance(expr, ast.Name) and expr.id == "ImportError" for expr in exprs):
-                self._weaken_strong_imports = True
+                self.weaken_strong_imports = True
                 break
 
         for stmt in node.body:
             self.visit(stmt)
 
-        self._weaken_strong_imports = False
+        self.weaken_strong_imports = False
 
         for handler in node.handlers:
             self.visit(handler)
@@ -161,7 +124,7 @@ class AstVisitor(ast.NodeVisitor):
         # to explicitly mark namespace packages.  Note that we don't handle more complex
         # uses, such as those that set `level`.
         if isinstance(node.func, ast.Name) and node.func.id == "__import__" and len(node.args) == 1:
-            name = _maybe_str(node.args[0])
+            name = self.maybe_str(node.args[0])
             if name is not None:
                 self.add_strong_import(name, node.args[0].lineno)
                 return
@@ -180,45 +143,3 @@ class AstVisitor(ast.NodeVisitor):
     def visit_Constant(self, node):
         if isinstance(node.value, str):
             self.maybe_add_string_dependency(node, node.value)
-
-
-def main(filename):
-    with open(filename, "rb") as f:
-        content = f.read()
-    try:
-        tree = ast.parse(content, filename=filename)
-    except SyntaxError:
-        return
-
-    package_parts = os.path.dirname(filename).split(os.path.sep)
-    visitor = AstVisitor(package_parts, content)
-    visitor.visit(tree)
-
-    # We have to be careful to set the encoding explicitly and write raw bytes ourselves.
-    # See below for where we explicitly decode.
-    buffer = sys.stdout if sys.version_info[0:2] == (2, 7) else sys.stdout.buffer
-
-    # N.B. Start with weak and `update` with definitive so definite "wins"
-    imports_result = {
-        module_name: {"lineno": lineno, "weak": True}
-        for module_name, lineno in visitor.weak_imports.items()
-    }
-    imports_result.update(
-        {
-            module_name: {"lineno": lineno, "weak": False}
-            for module_name, lineno in visitor.strong_imports.items()
-        }
-    )
-
-    buffer.write(
-        json.dumps(
-            {
-                "imports": imports_result,
-                "assets": sorted(visitor.assets),
-            }
-        ).encode("utf8")
-    )
-
-
-if __name__ == "__main__":
-    main(sys.argv[1])

--- a/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/main.py
+++ b/src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/main.py
@@ -1,0 +1,77 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# -*- coding: utf-8 -*-
+
+# NB: This must be compatible with Python 2.7 and 3.5+.
+# NB: If you're needing to debug this, an easy way is to just invoke it on a file.
+#   E.g.
+#   $ export ROOT=src/python/pants/backend/python/dependency_inference/scripts/
+#   $ PYTHONPATH=$ROOT STRING_IMPORTS=y python $ROOT/_pants_dep_parser/main.py FILE
+#   Or
+#   $ ./pants --no-python-infer-imports run \
+#     src/python/pants/backend/python/dependency_inference/scripts/_pants_dep_parser/main.py \
+#     -- src/python/pants/base/specs.py
+
+from __future__ import print_function, unicode_literals
+
+import ast
+import importlib
+import json
+import os
+import sys
+from io import open
+
+from _pants_dep_parser.dependency_visitor_base import FoundDependencies
+
+
+def main(filename):
+    with open(filename, "rb") as f:
+        content = f.read()
+    try:
+        tree = ast.parse(content, filename=filename)
+    except SyntaxError:
+        return
+
+    package_parts = os.path.dirname(filename).split(os.path.sep)
+    visitor_classnames = os.environ.get(
+        "VISITOR_CLASSNAMES",
+        "_pants_dep_parser.general_dependency_visitor.GeneralDependencyVisitor",
+    ).split("|")
+    visitors = []
+    found_dependencies = FoundDependencies()
+    for visitor_classname in visitor_classnames:
+        module_name, _, class_name = visitor_classname.rpartition(".")
+        module = importlib.import_module(module_name)
+        visitor_cls = getattr(module, class_name)
+        visitors.append(visitor_cls(found_dependencies, package_parts, content))
+    for visitor in visitors:
+        visitor.visit(tree)
+
+    # We have to be careful to set the encoding explicitly and write raw bytes ourselves.
+    # See below for where we explicitly decode.
+    buffer = sys.stdout if sys.version_info[0:2] == (2, 7) else sys.stdout.buffer
+
+    # N.B. Start with weak and `update` with definitive so definite "wins"
+    imports_result = {
+        module_name: {"lineno": lineno, "weak": True}
+        for module_name, lineno in found_dependencies.weak_imports.items()
+    }
+    imports_result.update(
+        {
+            module_name: {"lineno": lineno, "weak": False}
+            for module_name, lineno in found_dependencies.strong_imports.items()
+        }
+    )
+
+    buffer.write(
+        json.dumps(
+            {
+                "imports": imports_result,
+                "assets": sorted(found_dependencies.assets),
+            }
+        ).encode("utf8")
+    )
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/src/python/pants/backend/python/goals/debug_goals.py
+++ b/src/python/pants/backend/python/goals/debug_goals.py
@@ -26,7 +26,6 @@ from pants.backend.python.dependency_inference.rules import (
     _find_other_owners_for_unowned_imports,
     import_rules,
 )
-from pants.backend.python.dependency_inference.subsystem import PythonInferSubsystem
 from pants.backend.python.goals.run_python_source import PythonSourceFieldSet
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.build_graph.address import Address
@@ -82,12 +81,11 @@ class PythonSourceAnalysis:
 @rule
 async def dump_python_source_analysis_single(
     fs: PythonImportDependenciesInferenceFieldSet,
-    python_infer_subsystem: PythonInferSubsystem,
     python_setup: PythonSetup,
 ) -> PythonSourceAnalysis:
     """Infer the dependencies for a single python fieldset, keeping all the intermediate results."""
 
-    parsed_dependencies = await _exec_parse_deps(fs, python_infer_subsystem, python_setup)
+    parsed_dependencies = await _exec_parse_deps(fs, python_setup)
 
     resolve = fs.resolve.normalized_value(python_setup)
 


### PR DESCRIPTION
This is so we can implement custom dep parsing logic in plugins, without the performance overhead of running multiple processes per input file.

* Breaks the script up into:
     - A base visitor class for reuse 
     - A general-purpose visitor that implements the current, generally-applicable logic
     - A main that executes multiple visitors, as specified by an env var
* Introduces a union for visitor types
* Logic for providing a visitor, and accompanying env var settings, based on union membership

For the existing general-purpose visitor, this meant reading the settings directly from the subsystem, instead of passing them through the request object, which is fine (and could have been implemented that way all along TBH).

