### PR TITLE
docs: fix markdown inline code typo in a docstring

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -130,7 +130,7 @@ class CoverageSubsystem(PythonToolBase):
         help=softwrap(
             """
             A list of Python modules or filesystem paths to use in the coverage report, e.g.
-            `['helloworld_test', 'helloworld/util/dirutil'].
+            `['helloworld_test', 'helloworld/util/dirutil']`.
 
             Both modules and directory paths are recursive: any submodules or child paths,
             respectively, will be included.


### PR DESCRIPTION
Noticed this when reviewing the JSON schema option descriptions seeing the code not being rendered properly.