### PR TITLE
docker: Allow overriding FROM args when determining upstream images 

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -331,11 +331,12 @@ async def create_docker_build_context(request: DockerBuildContextRequest) -> Doc
     if request.build_upstream_images:
         # Update build arg values for FROM image build args.
 
-        # Get the FROM image build args with defined values in the Dockerfile.
-        dockerfile_build_args = {
-            k: v for k, v in dockerfile_info.from_image_build_args.to_dict().items() if v
+        # Get the FROM image build args with defined values in the Dockerfile & build args.
+        merged_from_build_args = {
+            k: build_args.to_dict().get(k, v)
+            for k, v in dockerfile_info.from_image_build_args.to_dict().items()
         }
-
+        dockerfile_build_args = {k: v for k, v in merged_from_build_args.items() if v}
         # Parse the build args values into Address instances.
         from_image_addresses = await Get(
             Addresses,

--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -256,6 +256,48 @@ def test_from_image_build_arg_dependency(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_from_image_build_arg_dependency_overwritten(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/upstream/BUILD": dedent(
+                """\
+                docker_image(
+                  name="image",
+                  repository="upstream/{name}",
+                  image_tags=["1.0"],
+                  instructions=["FROM alpine:3.16.1"],
+                )
+                """
+            ),
+            "src/downstream/BUILD": "docker_image(name='image')",
+            "src/downstream/Dockerfile": dedent(
+                """\
+                ARG BASE_IMAGE=src/upstream:image
+                FROM $BASE_IMAGE
+                """
+            ),
+        }
+    )
+
+    assert_build_context(
+        rule_runner,
+        Address("src/downstream", target_name="image"),
+        expected_files=["src/downstream/Dockerfile", "src.upstream/image.docker-info.json"],
+        build_upstream_images=True,
+        expected_interpolation_context={
+            "tags": {
+                "baseimage": "3.10-slim",
+                "stage0": "3.10-slim",
+            },
+            "build_args": {
+                "BASE_IMAGE": "python:3.10-slim",
+            },
+        },
+        expected_num_upstream_images=1,
+        pants_args=["--docker-build-args=BASE_IMAGE=python:3.10-slim"],
+    )
+
+
 def test_from_image_build_arg_not_in_repo_issue_15585(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
This solution allows `docker_build_args` to override the 
```dockerfile
ARG VAR=<address>
FROM $VAR
```
inference by assuming a supplied docker build arg option is preferred to the "default value" in the Dockerfile.


Fixes #18004.