### PR TITLE
docker: Allow overriding FROM args when determining upstream image dependencies

### DIFF
--- a/src/python/pants/backend/docker/util_rules/dependencies_test.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies_test.py
@@ -164,7 +164,10 @@ def test_does_not_infer_dependency_when_docker_build_arg_overwrites(
     )
 
     tgt = rule_runner.get_target(Address("src/downstream", target_name="image"))
-    rule_runner.set_options(["--docker-build-args=BASE_IMAGE=alpine:3.17.0"])
+    rule_runner.set_options(
+        ["--docker-build-args=BASE_IMAGE=alpine:3.17.0"],
+        env_inherit={"PATH", "PYENV_ROOT", "HOME"},
+    )
     inferred = rule_runner.request(
         InferredDependencies,
         [InferDockerDependencies(tgt[DockerImageDependenciesField])],

--- a/src/python/pants/backend/docker/util_rules/dependencies_test.py
+++ b/src/python/pants/backend/docker/util_rules/dependencies_test.py
@@ -8,7 +8,7 @@ import pytest
 from pants.backend.docker.goals import package_image
 from pants.backend.docker.subsystems import dockerfile_parser
 from pants.backend.docker.target_types import DockerImageDependenciesField, DockerImageTarget
-from pants.backend.docker.util_rules import dockerfile
+from pants.backend.docker.util_rules import docker_build_args, dockerfile
 from pants.backend.docker.util_rules.dependencies import (
     InferDockerDependencies,
     infer_docker_dependencies,
@@ -32,6 +32,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *dockerfile.rules(),
             *dockerfile_parser.rules(),
+            *docker_build_args.rules(),
             package.find_all_packageable_targets,
             *package_image.rules(),
             *package_pex_binary.rules(),
@@ -135,3 +136,37 @@ def test_infer_docker_dependencies(files, rule_runner: RuleRunner) -> None:
             Address("project/hello/main/go", target_name="go_bin"),
         ]
     )
+
+
+def test_does_not_infer_dependency_when_docker_build_arg_overwrites(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/upstream/BUILD": dedent(
+                """\
+                docker_image(
+                  name="image",
+                  repository="upstream/{name}",
+                  image_tags=["1.0"],
+                  instructions=["FROM alpine:3.16.1"],
+                )
+                """
+            ),
+            "src/downstream/BUILD": "docker_image(name='image')",
+            "src/downstream/Dockerfile": dedent(
+                """\
+                ARG BASE_IMAGE=src/upstream:image
+                FROM $BASE_IMAGE
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("src/downstream", target_name="image"))
+    rule_runner.set_options(["--docker-build-args=BASE_IMAGE=alpine:3.17.0"])
+    inferred = rule_runner.request(
+        InferredDependencies,
+        [InferDockerDependencies(tgt[DockerImageDependenciesField])],
+    )
+    assert inferred == InferredDependencies([])

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -331,11 +331,12 @@ async def create_docker_build_context(request: DockerBuildContextRequest) -> Doc
     if request.build_upstream_images:
         # Update build arg values for FROM image build args.
 
-        # Get the FROM image build args with defined values in the Dockerfile.
-        dockerfile_build_args = {
-            k: v for k, v in dockerfile_info.from_image_build_args.to_dict().items() if v
+        # Get the FROM image build args with defined values in the Dockerfile & build args.
+        merged_from_build_args = {
+            k: build_args.to_dict().get(k, v)
+            for k, v in dockerfile_info.from_image_build_args.to_dict().items()
         }
-
+        dockerfile_build_args = {k: v for k, v in merged_from_build_args.items() if v}
         # Parse the build args values into Address instances.
         from_image_addresses = await Get(
             Addresses,


### PR DESCRIPTION
This solution allows `docker_build_args` to override the 
```dockerfile
ARG VAR=<address>
FROM $VAR
```
inference by assuming a supplied docker build arg option is preferred to the "default value" in the Dockerfile when inferring dependencies and assembling docker build context.


Fixes #18004.