### PR TITLE
WIP Fix Buf expected configuration files

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/subsystem.py
@@ -56,7 +56,8 @@ class BufSubsystem(TemplatedExternalTool):
         help=lambda cls: softwrap(
             f"""
             If true, Pants will include any relevant root config files during runs
-            (`buf.yaml`, `buf.lock`, `buf.gen.yaml` and `buf.work.yaml`).
+            (`buf.yaml`). If the json format is preferred, the path to the `buf.json`
+            file should be provided in the config option.
 
             Use `[{cls.options_scope}].config` instead if your config is in a non-standard location.
             """
@@ -70,7 +71,7 @@ class BufSubsystem(TemplatedExternalTool):
             specified=self.config,
             specified_option_name=f"{self.options_scope}.config",
             discovery=self.config_discovery,
-            check_existence=["buf.yaml", "buf.lock", "buf.gen.yaml", "buf.work.yaml"],
+            check_existence=("buf.yaml",),
             check_content={},
         )
 


### PR DESCRIPTION
This PR intends to:

1. Remove misleading configuration files. `buf.work.yaml`, `buf.lock`, `buf.gen.lock` do not carry any items related to `lint` command and have other meanings
2. Specific doc for `buf.json` files, which are not automatically discovered by Buf and need their path to be supplied with `--config` argument (`buf.yaml` is still automatically discovered by Buf). So adding `buf.json` to `check_existence` param in `config_request` does not have any effect and could be misleading as well.