### PR TITLE
Kill use of MODE=debug for PR wheel builds.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -375,9 +375,7 @@ jobs:
     - env:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+      run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
         ./build-support/bin/release.sh build-wheels
@@ -446,9 +444,7 @@ jobs:
         go-version: 1.17.1
     - env: {}
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+      run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
         ./build-support/bin/release.sh build-wheels
@@ -517,9 +513,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+      run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
         ./build-support/bin/release.sh build-wheels
@@ -588,9 +582,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch arm64
       name: Build wheels
-      run: '[[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
-
-        USE_PY39=true ./build-support/bin/release.sh build-local-pex
+      run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
         USE_PY39=true ./build-support/bin/release.sh build-wheels'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -462,14 +462,11 @@ class Helper:
 
     def build_wheels(self, python_versions: list[str]) -> list[Step]:
         cmd = dedent(
-            # We use MODE=debug on PR builds to speed things up, given that those are
-            # only smoke tests of our release process.
             # Note that the build-local-pex run is just for smoke-testing that pex
             # builds work, and it must come *before* the build-wheels runs, since
             # it cleans out `dist/deploy`, which the build-wheels runs populate for
             # later attention by deploy_to_s3.py.
             """\
-            [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]] && export MODE=debug
             USE_PY39=true ./build-support/bin/release.sh build-local-pex
             """
         )


### PR DESCRIPTION
This had slowed the step down to the point of either timing out pantsd
starts at 60s or else timing out the whole shard at 90 minutes.