### PR TITLE
Fix wheel reversioning for Linux aarch64.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -967,12 +967,12 @@ def check_roles() -> None:
 
 
 def reversion_prebuilt_wheels() -> None:
-    # First, rewrite to manylinux. See https://www.python.org/dev/peps/pep-0599/. We build on
-    # Centos7, so use manylinux2014.
-    source_platform = "linux_x86_64"
-    dest_platform = "manylinux2014_x86_64"
+    # First, rewrite to manylinux. See https://www.python.org/dev/peps/pep-0599/. We use
+    # manylinux2014 images.
+    source_platform = "linux_"
+    dest_platform = "manylinux2014_"
     unstable_wheel_dir = CONSTANTS.deploy_pants_wheel_dir / CONSTANTS.pants_unstable_version
-    for whl in unstable_wheel_dir.glob(f"*{source_platform}.whl"):
+    for whl in unstable_wheel_dir.glob(f"*{source_platform}*.whl"):
         whl.rename(str(whl).replace(source_platform, dest_platform))
 
     # Now, reversion to use the STABLE_VERSION.

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -763,6 +763,9 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
 
 
 def build_wheels_jobs() -> Jobs:
+    # N.B.: When altering the number of total wheels built (currently 10), please edit the expected
+    # total in the _release_helper script. Currently here:
+    # https://github.com/pantsbuild/pants/blob/8c83e4db33d5fe577918ce073f6d89957cb6eef1/build-support/bin/_release_helper.py#L1182-L1192
     return {
         **build_wheels_job(Platform.LINUX_X86_64, ALL_PYTHON_VERSIONS),
         **build_wheels_job(Platform.LINUX_ARM64, ALL_PYTHON_VERSIONS),


### PR DESCRIPTION
Also add a sync-comment to avoid non-local release breaks when adding
or removing wheels.

Fixes #18023