### PR TITLE
Move group_by_dir to src/python/pants/util/dirutil.py

### DIFF
--- a/docs/markdown/Tutorials/integrate-new-goal-with-the-repository.md
+++ b/docs/markdown/Tutorials/integrate-new-goal-with-the-repository.md
@@ -206,8 +206,8 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
+from pants.util.dirutil import group_by_dir
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
@@ -597,12 +597,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from project_version.target_types import ProjectVersionTarget
 
 

--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
@@ -19,7 +19,6 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
-from pants.core.goals.tailor import group_by_dir
 from pants.core.goals.test import TestExtraEnv
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.collection import DeduplicatedCollection
@@ -34,6 +33,7 @@ from pants.engine.target import Targets, TransitiveTargets, TransitiveTargetsReq
 from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata
+from pants.util.dirutil import group_by_dir
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 

--- a/src/python/pants/backend/cc/goals/tailor.py
+++ b/src/python/pants/backend/cc/goals/tailor.py
@@ -12,13 +12,13 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/codegen/avro/tailor.py
+++ b/src/python/pants/backend/codegen/avro/tailor.py
@@ -12,12 +12,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -52,7 +52,6 @@ from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.backend.python.util_rules import pex
 from pants.build_graph.address import Address
-from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
@@ -89,6 +88,7 @@ from pants.source.source_root import (
     SourceRootsRequest,
     SourceRootsResult,
 )
+from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap

--- a/src/python/pants/backend/codegen/protobuf/tailor.py
+++ b/src/python/pants/backend/codegen/protobuf/tailor.py
@@ -12,12 +12,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/codegen/soap/tailor.py
+++ b/src/python/pants/backend/codegen/soap/tailor.py
@@ -12,12 +12,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/codegen/thrift/tailor.py
+++ b/src/python/pants/backend/codegen/thrift/tailor.py
@@ -12,12 +12,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -22,7 +22,6 @@ from pants.backend.go.util_rules.first_party_pkg import (
 )
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.build_graph.address import Address
-from pants.core.goals.tailor import group_by_dir
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
     CreateDigest,
@@ -46,6 +45,7 @@ from pants.engine.rules import collect_rules, goal_rule, rule, rule_helper
 from pants.engine.target import Targets
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
+from pants.util.dirutil import group_by_dir
 from pants.util.strutil import softwrap
 
 # Adapted from Go toolchain.

--- a/src/python/pants/backend/go/goals/tailor.py
+++ b/src/python/pants/backend/go/goals/tailor.py
@@ -24,12 +24,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import DigestContents, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.engine.target import UnexpandedTargets
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -22,7 +22,6 @@ from pants.backend.go.util_rules.embedcfg import EmbedConfig
 from pants.backend.go.util_rules.pkg_analyzer import PackageAnalyzerSetup
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.build_graph.address import Address
-from pants.core.goals.tailor import group_by_dir
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import (
     EMPTY_DIGEST,
@@ -39,6 +38,7 @@ from pants.engine.fs import (
 )
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
+from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet

--- a/src/python/pants/backend/java/goals/tailor.py
+++ b/src/python/pants/backend/java/goals/tailor.py
@@ -18,7 +18,6 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
@@ -26,6 +25,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -12,13 +12,13 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/kotlin/goals/tailor.py
+++ b/src/python/pants/backend/kotlin/goals/tailor.py
@@ -18,7 +18,6 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
@@ -26,6 +25,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/openapi/goals/tailor.py
+++ b/src/python/pants/backend/openapi/goals/tailor.py
@@ -19,13 +19,13 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.native_engine import Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -32,7 +32,6 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import DigestContents, FileContent, PathGlobs, Paths
 from pants.engine.internals.selectors import Get, MultiGet
@@ -41,6 +40,7 @@ from pants.engine.target import Target, UnexpandedTargets
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
 from pants.source.source_root import SourceRootsRequest, SourceRootsResult
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/backend/scala/goals/tailor.py
+++ b/src/python/pants/backend/scala/goals/tailor.py
@@ -20,7 +20,6 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
@@ -28,6 +27,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/scala/lint/scalafmt/rules.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules.py
@@ -12,7 +12,6 @@ from pants.backend.scala.lint.scalafmt.subsystem import ScalafmtSubsystem
 from pants.backend.scala.target_types import ScalaSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.goals.tailor import group_by_dir
 from pants.core.util_rules.partitions import Partition
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
@@ -24,6 +23,7 @@ from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
+from pants.util.dirutil import group_by_dir
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize

--- a/src/python/pants/backend/shell/goals/tailor.py
+++ b/src/python/pants/backend/shell/goals/tailor.py
@@ -18,7 +18,6 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
@@ -26,6 +25,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.source.filespec import FilespecMatcher
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/swift/goals/tailor.py
+++ b/src/python/pants/backend/swift/goals/tailor.py
@@ -12,13 +12,13 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -17,7 +17,6 @@ from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
-from pants.core.goals.tailor import group_by_dir
 from pants.engine.fs import CreateDigest, Digest, FileContent
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
@@ -31,6 +30,7 @@ from pants.engine.target import (
     Targets,
 )
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -12,12 +12,12 @@ from pants.core.goals.tailor import (
     PutativeTarget,
     PutativeTargets,
     PutativeTargetsRequest,
-    group_by_dir,
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 
 

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -395,15 +395,6 @@ class TailorGoal(Goal):
     environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
-def group_by_dir(paths: Iterable[str]) -> dict[str, set[str]]:
-    """For a list of file paths, returns a dict of directory path -> files in that dir."""
-    ret = defaultdict(set)
-    for path in paths:
-        dirname, filename = os.path.split(path)
-        ret[dirname].add(filename)
-    return ret
-
-
 def group_by_build_file(
     build_file_name: str, ptgts: Iterable[PutativeTarget]
 ) -> dict[str, list[PutativeTarget]]:

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -23,7 +23,6 @@ from pants.core.goals.tailor import (
     TailorSubsystem,
     UniquelyNamedPutativeTargets,
     default_sources_for_target_type,
-    group_by_dir,
     make_content_str,
 )
 from pants.core.util_rules import source_files
@@ -36,6 +35,7 @@ from pants.source.filespec import FilespecMatcher
 from pants.testutil.option_util import create_goal_subsystem
 from pants.testutil.pytest_util import no_exception
 from pants.testutil.rule_runner import RuleRunner
+from pants.util.dirutil import group_by_dir
 from pants.util.strutil import softwrap
 
 

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -14,7 +14,7 @@ import uuid
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Callable, DefaultDict, Iterator, Sequence, overload
+from typing import Any, Callable, DefaultDict, Iterable, Iterator, Sequence, overload
 
 from typing_extensions import Literal
 
@@ -438,3 +438,12 @@ def rm_rf(name: str) -> None:
         elif e.errno != errno.ENOENT:
             # Pass on 'No such file or directory', otherwise re-raise OSError to surface perm issues etc.
             raise
+
+
+def group_by_dir(paths: Iterable[str]) -> dict[str, set[str]]:
+    """For a list of file paths, returns a dict of directory path -> files in that dir."""
+    ret = defaultdict(set)
+    for path in paths:
+        dirname, filename = os.path.split(path)
+        ret[dirname].add(filename)
+    return ret


### PR DESCRIPTION
Per a suggestion from @thejcannon on #17821, move `group_by_dir` from `pants.core.goals.tailor` to `pants.util.dirutil`.