### PR TITLE
Added support for discovering and patching `pyright` config files (cherry-pick of #17771)

### DIFF
--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
@@ -37,3 +38,22 @@ class Pyright(Subsystem):
         This assumes you have set the class property `register_interpreter_constraints = True`.
         """
         return InterpreterConstraints(self._interpreter_constraints)
+
+    def config_request(self) -> ConfigFilesRequest:
+        """Pyright will look for a `pyrightconfig.json` or a `pyproject.toml` (with a
+        `[tool.pyright]` section) in the project root.
+
+        `pyrightconfig.json` takes precedence if both are present.
+        Pyright's configuration content is specified here:
+        https://github.com/microsoft/pyright/blob/main/docs/configuration.md.
+
+        In order for Pants to work with Pyright, we modify the config file before
+        putting it in the Pyright digest. Specifically, we append source roots
+        to `extraPaths` and we overwrite `venv` to point to a pex venv.
+        """
+
+        return ConfigFilesRequest(
+            discovery=True,
+            check_existence=["pyrightconfig.json"],
+            check_content={"pyproject.toml": b"[tool.pyright"},
+        )


### PR DESCRIPTION


- Grab the the pyrightconfig.json or pyproject.toml from the project root
- Patching the config with `venv` and `extraPaths` info - before passing them into our Process.
- Pass source roots to `extraPaths`