### PR TITLE
go: add basic parsing of vendor/modules.txt files

### DIFF
--- a/src/python/pants/backend/go/go_sources/BUILD
+++ b/src/python/pants/backend/go/go_sources/BUILD
@@ -7,5 +7,6 @@ python_sources(
         "src/python/pants/backend/go/go_sources/asm_check",
         "src/python/pants/backend/go/go_sources/embedcfg",
         "src/python/pants/backend/go/go_sources/generate_testmain",
+        "src/python/pants/backend/go/go_sources/parse_vendor_modules",
     ],
 )

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/BUILD
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/BUILD
@@ -1,0 +1,5 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_source(name="init", source="__init__.py")
+resources(sources=["*.go"], dependencies=[":init"])

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
@@ -1,10 +1,16 @@
 /* Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
  * Licensed under the Apache License, Version 2.0 (see LICENSE).
- *
- * Parts adapted from Go SDK and Bazel rules_go, both under BSD-compatible licenses.
  */
 
 package main
+
+/*
+ * Adapted from https://github.com/golang/go/blob/d45df06663c88984b75052fd0631974916b1bddb/src/cmd/go/internal/modload/vendor.go
+ * Original License:
+ *  // Copyright 2020 The Go Authors. All rights reserved.
+ *  // Use of this source code is governed by a BSD-style
+ *  // license that can be found in the LICENSE file.
+ */
 
 import (
 	"encoding/json"

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
@@ -1,0 +1,150 @@
+/* Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+ * Licensed under the Apache License, Version 2.0 (see LICENSE).
+ *
+ * Parts adapted from Go SDK and Bazel rules_go, both under BSD-compatible licenses.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type Version struct {
+	Path    string `json:"path"`
+	Version string `json:"version"`
+}
+
+type Module struct {
+	ModVersion         Version  `json:"mod_version"`
+	PackageImportPaths []string `json:"package_import_paths,omitempty"`
+	Explicit           bool     `json:"explicit"`
+	GoVersion          string   `json:"go_version"`
+	Replacement        Version  `json:"replacement"`
+}
+
+// CutPrefix returns s without the provided leading prefix string
+// and reports whether it found the prefix.
+// If s doesn't start with prefix, CutPrefix returns s, false.
+// If prefix is the empty string, CutPrefix returns s, true.
+func CutPrefix(s, prefix string) (after string, found bool) {
+	if !strings.HasPrefix(s, prefix) {
+		return s, false
+	}
+	return s[len(prefix):], true
+}
+
+func parseVendoredModuleList(path string) ([]Module, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var modules []Module
+	var mod Module
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "# ") {
+			f := strings.Fields(line)
+
+			if len(f) < 3 {
+				continue
+			}
+			if IsValid(f[2]) {
+				// A module, but we don't yet know whether it is in the build list or
+				// only included to indicate a replacement.
+				if mod.ModVersion.Path != "" {
+					modules = append(modules, mod)
+				}
+				mod = Module{ModVersion: Version{Path: f[1], Version: f[2]}}
+				f = f[3:]
+			} else if f[2] == "=>" {
+				// A wildcard replacement found in the main module's go.mod file.
+				if mod.ModVersion.Path != "" {
+					modules = append(modules, mod)
+				}
+				mod = Module{ModVersion: Version{Path: f[1]}}
+				f = f[2:]
+			} else {
+				// Not a version or a wildcard replacement.
+				// We don't know how to interpret this module line, so ignore it.
+				mod = Module{}
+				continue
+			}
+
+			if len(f) >= 2 && f[0] == "=>" {
+				if len(f) == 2 {
+					// File replacement.
+					mod.Replacement = Version{Path: f[1]}
+				} else if len(f) == 3 && IsValid(f[2]) {
+					// Path and version replacement.
+					mod.Replacement = Version{Path: f[1], Version: f[2]}
+				} else {
+					// We don't understand this replacement. Ignore it.
+				}
+			}
+			continue
+		}
+
+		// Not a module line. Must be a package within a module or a metadata
+		// directive, either of which requires a preceding module line.
+		if mod.ModVersion.Path == "" {
+			continue
+		}
+
+		if annonations, ok := CutPrefix(line, "## "); ok {
+			// Metadata. Take the union of annotations across multiple lines, if present.
+			for _, entry := range strings.Split(annonations, ";") {
+				entry = strings.TrimSpace(entry)
+				if entry == "explicit" {
+					mod.Explicit = true
+				}
+				if goVersion, ok := CutPrefix(entry, "go "); ok {
+					mod.GoVersion = goVersion
+				}
+				// All other tokens are reserved for future use.
+			}
+			continue
+		}
+
+		// TODO: Actually port CheckImportPath impl over from `go` sources.
+		if f := strings.Fields(line); len(f) == 1 /* && module.CheckImportPath(f[0]) == nil */ {
+			// A package within the current module.
+			mod.PackageImportPaths = append(mod.PackageImportPaths, f[0])
+		}
+	}
+
+	if mod.ModVersion.Path != "" {
+		modules = append(modules, mod)
+	}
+
+	return modules, nil
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, "ERROR: Not enough arguments.\n")
+		os.Exit(1)
+	}
+
+	modules, err := parseVendoredModuleList(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to parse `%s`: %s\n", os.Args[1], err)
+		os.Exit(1)
+	}
+
+	outputBytes, err := json.Marshal(modules)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to encode parswd modules: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = os.Stdout.Write(outputBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: Failed to write JSON: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/parse.go
@@ -59,7 +59,7 @@ func parseVendoredModuleList(path string) ([]Module, error) {
 			if len(f) < 3 {
 				continue
 			}
-			if IsValid(f[2]) {
+			if IsValidSemver(f[2]) {
 				// A module, but we don't yet know whether it is in the build list or
 				// only included to indicate a replacement.
 				if mod.ModVersion.Path != "" {
@@ -85,7 +85,7 @@ func parseVendoredModuleList(path string) ([]Module, error) {
 				if len(f) == 2 {
 					// File replacement.
 					mod.Replacement = Version{Path: f[1]}
-				} else if len(f) == 3 && IsValid(f[2]) {
+				} else if len(f) == 3 && IsValidSemver(f[2]) {
 					// Path and version replacement.
 					mod.Replacement = Version{Path: f[1], Version: f[2]}
 				} else {

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
@@ -27,10 +27,6 @@
 
 package main
 
-import (
-	"sort"
-)
-
 // parsed returns the parsed form of a semantic version string.
 type parsed struct {
 	major      string
@@ -42,138 +38,9 @@ type parsed struct {
 }
 
 // IsValid reports whether v is a valid semantic version string.
-func IsValid(v string) bool {
+func IsValidSemver(v string) bool {
 	_, ok := parse(v)
 	return ok
-}
-
-// Canonical returns the canonical formatting of the semantic version v.
-// It fills in any missing .MINOR or .PATCH and discards build metadata.
-// Two semantic versions compare equal only if their canonical formattings
-// are identical strings.
-// The canonical invalid semantic version is the empty string.
-func Canonical(v string) string {
-	p, ok := parse(v)
-	if !ok {
-		return ""
-	}
-	if p.build != "" {
-		return v[:len(v)-len(p.build)]
-	}
-	if p.short != "" {
-		return v + p.short
-	}
-	return v
-}
-
-// Major returns the major version prefix of the semantic version v.
-// For example, Major("v2.1.0") == "v2".
-// If v is an invalid semantic version string, Major returns the empty string.
-func Major(v string) string {
-	pv, ok := parse(v)
-	if !ok {
-		return ""
-	}
-	return v[:1+len(pv.major)]
-}
-
-// MajorMinor returns the major.minor version prefix of the semantic version v.
-// For example, MajorMinor("v2.1.0") == "v2.1".
-// If v is an invalid semantic version string, MajorMinor returns the empty string.
-func MajorMinor(v string) string {
-	pv, ok := parse(v)
-	if !ok {
-		return ""
-	}
-	i := 1 + len(pv.major)
-	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
-		return v[:j]
-	}
-	return v[:i] + "." + pv.minor
-}
-
-// Prerelease returns the prerelease suffix of the semantic version v.
-// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
-// If v is an invalid semantic version string, Prerelease returns the empty string.
-func Prerelease(v string) string {
-	pv, ok := parse(v)
-	if !ok {
-		return ""
-	}
-	return pv.prerelease
-}
-
-// Build returns the build suffix of the semantic version v.
-// For example, Build("v2.1.0+meta") == "+meta".
-// If v is an invalid semantic version string, Build returns the empty string.
-func Build(v string) string {
-	pv, ok := parse(v)
-	if !ok {
-		return ""
-	}
-	return pv.build
-}
-
-// Compare returns an integer comparing two versions according to
-// semantic version precedence.
-// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
-//
-// An invalid semantic version string is considered less than a valid one.
-// All invalid semantic version strings compare equal to each other.
-func Compare(v, w string) int {
-	pv, ok1 := parse(v)
-	pw, ok2 := parse(w)
-	if !ok1 && !ok2 {
-		return 0
-	}
-	if !ok1 {
-		return -1
-	}
-	if !ok2 {
-		return +1
-	}
-	if c := compareInt(pv.major, pw.major); c != 0 {
-		return c
-	}
-	if c := compareInt(pv.minor, pw.minor); c != 0 {
-		return c
-	}
-	if c := compareInt(pv.patch, pw.patch); c != 0 {
-		return c
-	}
-	return comparePrerelease(pv.prerelease, pw.prerelease)
-}
-
-// Max canonicalizes its arguments and then returns the version string
-// that compares greater.
-//
-// Deprecated: use Compare instead. In most cases, returning a canonicalized
-// version is not expected or desired.
-func Max(v, w string) string {
-	v = Canonical(v)
-	w = Canonical(w)
-	if Compare(v, w) > 0 {
-		return v
-	}
-	return w
-}
-
-// ByVersion implements sort.Interface for sorting semantic version strings.
-type ByVersion []string
-
-func (vs ByVersion) Len() int      { return len(vs) }
-func (vs ByVersion) Swap(i, j int) { vs[i], vs[j] = vs[j], vs[i] }
-func (vs ByVersion) Less(i, j int) bool {
-	cmp := Compare(vs[i], vs[j])
-	if cmp != 0 {
-		return cmp < 0
-	}
-	return vs[i] < vs[j]
-}
-
-// Sort sorts a list of semantic version strings using ByVersion.
-func Sort(list []string) {
-	sort.Sort(ByVersion(list))
 }
 
 func parse(v string) (p parsed, ok bool) {

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//
+// Copied from https://github.com/golang/go/blob/d45df06663c88984b75052fd0631974916b1bddb/src/cmd/vendor/golang.org/x/mod/semver/semver.go
+//
+
 // Package semver implements comparison of semantic version strings.
 // In this package, semantic version strings must begin with a leading "v",
 // as in "v1.0.0".
@@ -20,6 +24,7 @@
 // with two exceptions. First, it requires the "v" prefix. Second, it recognizes
 // vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
 // as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+
 package main
 
 import (

--- a/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
+++ b/src/python/pants/backend/go/go_sources/parse_vendor_modules/semver.go
@@ -1,0 +1,403 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semver implements comparison of semantic version strings.
+// In this package, semantic version strings must begin with a leading "v",
+// as in "v1.0.0".
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with two exceptions. First, it requires the "v" prefix. Second, it recognizes
+// vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+package main
+
+import (
+	"sort"
+)
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+}
+
+// IsValid reports whether v is a valid semantic version string.
+func IsValid(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Canonical returns the canonical formatting of the semantic version v.
+// It fills in any missing .MINOR or .PATCH and discards build metadata.
+// Two semantic versions compare equal only if their canonical formattings
+// are identical strings.
+// The canonical invalid semantic version is the empty string.
+func Canonical(v string) string {
+	p, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	if p.build != "" {
+		return v[:len(v)-len(p.build)]
+	}
+	if p.short != "" {
+		return v + p.short
+	}
+	return v
+}
+
+// Major returns the major version prefix of the semantic version v.
+// For example, Major("v2.1.0") == "v2".
+// If v is an invalid semantic version string, Major returns the empty string.
+func Major(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return v[:1+len(pv.major)]
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+// Prerelease returns the prerelease suffix of the semantic version v.
+// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
+// If v is an invalid semantic version string, Prerelease returns the empty string.
+func Prerelease(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.prerelease
+}
+
+// Build returns the build suffix of the semantic version v.
+// For example, Build("v2.1.0+meta") == "+meta".
+// If v is an invalid semantic version string, Build returns the empty string.
+func Build(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.build
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// Max canonicalizes its arguments and then returns the version string
+// that compares greater.
+//
+// Deprecated: use Compare instead. In most cases, returning a canonicalized
+// version is not expected or desired.
+func Max(v, w string) string {
+	v = Canonical(v)
+	w = Canonical(w)
+	if Compare(v, w) > 0 {
+		return v
+	}
+	return w
+}
+
+// ByVersion implements sort.Interface for sorting semantic version strings.
+type ByVersion []string
+
+func (vs ByVersion) Len() int      { return len(vs) }
+func (vs ByVersion) Swap(i, j int) { vs[i], vs[j] = vs[j], vs[i] }
+func (vs ByVersion) Less(i, j int) bool {
+	cmp := Compare(vs[i], vs[j])
+	if cmp != 0 {
+		return cmp < 0
+	}
+	return vs[i] < vs[j]
+}
+
+// Sort sorts a list of semantic version strings using ByVersion.
+func Sort(list []string) {
+	sort.Sort(ByVersion(list))
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			return
+		}
+	}
+	if v != "" {
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}

--- a/src/python/pants/backend/go/util_rules/vendor.py
+++ b/src/python/pants/backend/go/util_rules/vendor.py
@@ -1,0 +1,104 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.go.go_sources import load_go_binary
+from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.selectors import Get
+from pants.engine.process import Process, ProcessResult
+from pants.engine.rules import Rule, collect_rules, rule
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ParseVendorModulesMetadataRequest(EngineAwareParameter):
+    digest: Digest
+    path: str
+
+    def debug_hint(self) -> str | None:
+        return str(self.path)
+
+
+@dataclass(frozen=True)
+class VendoredModuleMetadata:
+    """Metadata from vendor/modules.txt for one module."""
+
+    module_import_path: str
+    module_version: str
+    package_import_paths: frozenset[str]
+    explicit: bool
+    go_version: str | None
+
+    @classmethod
+    def from_json_dict(cls, data):
+        return cls(
+            module_import_path=data["mod_version"]["path"],
+            module_version=data["mod_version"]["version"],
+            package_import_paths=frozenset(data.get("package_import_paths", [])),
+            explicit=data["explicit"],
+            go_version=data.get("go_version"),
+        )
+
+
+@dataclass(frozen=True)
+class ParseVendorModulesMetadataResult:
+    modules: tuple[VendoredModuleMetadata, ...]
+
+
+@dataclass(frozen=True)
+class VendorModulesParserSetup:
+    digest: Digest
+    path: str
+
+
+@rule
+async def setup_vendor_modules_txt_parser() -> VendorModulesParserSetup:
+    output_name = "__go_parse_vendor__"
+    binary = await Get(
+        LoadedGoBinary,
+        LoadedGoBinaryRequest("parse_vendor_modules", ("parse.go", "semver.go"), output_name),
+    )
+    return VendorModulesParserSetup(
+        digest=binary.digest,
+        path=f"./{output_name}",
+    )
+
+
+@rule
+async def parse_vendor_modules_metadata(
+    request: ParseVendorModulesMetadataRequest,
+    parser: VendorModulesParserSetup,
+) -> ParseVendorModulesMetadataResult:
+    input_digest = await Get(Digest, MergeDigests([request.digest, parser.digest]))
+    result = await Get(
+        ProcessResult,
+        Process(
+            argv=(parser.path, request.path),
+            input_digest=input_digest,
+            description=f"Parse vendor modules list: `{request.path}`",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    raw_modules = json.loads(result.stdout)
+    modules = [VendoredModuleMetadata.from_json_dict(m) for m in raw_modules]
+
+    return ParseVendorModulesMetadataResult(
+        modules=tuple(modules),
+    )
+
+
+def rules() -> Iterable[Rule]:
+    return (
+        *collect_rules(),
+        *load_go_binary.rules(),
+    )

--- a/src/python/pants/backend/go/util_rules/vendor_test.py
+++ b/src/python/pants/backend/go/util_rules/vendor_test.py
@@ -1,0 +1,149 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    first_party_pkg,
+    link,
+    sdk,
+    third_party_pkg,
+    vendor,
+)
+from pants.backend.go.util_rules.vendor import (
+    ParseVendorModulesMetadataRequest,
+    ParseVendorModulesMetadataResult,
+    VendoredModuleMetadata,
+)
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *vendor.rules(),
+            *first_party_pkg.rules(),
+            *sdk.rules(),
+            *third_party_pkg.rules(),
+            *target_type_rules.rules(),
+            *build_pkg.rules(),
+            *link.rules(),
+            *assembly.rules(),
+            QueryRule(ParseVendorModulesMetadataResult, (ParseVendorModulesMetadataRequest,)),
+        ]
+    )
+    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+def test_read_vendor_manifest(rule_runner: RuleRunner) -> None:
+    snapshot = rule_runner.make_snapshot(
+        {
+            "module.txt": dedent(
+                """\
+            # golang.org/x/crypto v0.3.1-0.20221117191849-2c476679df9a
+            ## explicit; go 1.17
+            golang.org/x/crypto/chacha20
+            golang.org/x/crypto/chacha20poly1305
+            golang.org/x/crypto/cryptobyte
+            golang.org/x/crypto/cryptobyte/asn1
+            golang.org/x/crypto/hkdf
+            golang.org/x/crypto/internal/alias
+            golang.org/x/crypto/internal/poly1305
+            # golang.org/x/net v0.2.1-0.20221117215542-ecf7fda6a59e
+            ## explicit; go 1.17
+            golang.org/x/net/dns/dnsmessage
+            golang.org/x/net/http/httpguts
+            golang.org/x/net/http/httpproxy
+            golang.org/x/net/http2/hpack
+            golang.org/x/net/idna
+            golang.org/x/net/lif
+            golang.org/x/net/nettest
+            golang.org/x/net/route
+            # golang.org/x/sys v0.2.1-0.20221110211117-d684c6f88669
+            ## explicit; go 1.17
+            golang.org/x/sys/cpu
+            # golang.org/x/text v0.4.1-0.20221110184632-c8236a6712b1
+            ## explicit; go 1.17
+            golang.org/x/text/secure/bidirule
+            golang.org/x/text/transform
+            golang.org/x/text/unicode/bidi
+            golang.org/x/text/unicode/norm
+            """
+            )
+        }
+    )
+    result = rule_runner.request(
+        ParseVendorModulesMetadataResult,
+        [ParseVendorModulesMetadataRequest(digest=snapshot.digest, path="module.txt")],
+    )
+    assert result.modules == (
+        VendoredModuleMetadata(
+            module_import_path="golang.org/x/crypto",
+            module_version="v0.3.1-0.20221117191849-2c476679df9a",
+            package_import_paths=frozenset(
+                [
+                    "golang.org/x/crypto/chacha20",
+                    "golang.org/x/crypto/chacha20poly1305",
+                    "golang.org/x/crypto/cryptobyte",
+                    "golang.org/x/crypto/cryptobyte/asn1",
+                    "golang.org/x/crypto/hkdf",
+                    "golang.org/x/crypto/internal/alias",
+                    "golang.org/x/crypto/internal/poly1305",
+                ]
+            ),
+            explicit=True,
+            go_version="1.17",
+        ),
+        VendoredModuleMetadata(
+            module_import_path="golang.org/x/net",
+            module_version="v0.2.1-0.20221117215542-ecf7fda6a59e",
+            package_import_paths=frozenset(
+                [
+                    "golang.org/x/net/dns/dnsmessage",
+                    "golang.org/x/net/http/httpguts",
+                    "golang.org/x/net/http/httpproxy",
+                    "golang.org/x/net/http2/hpack",
+                    "golang.org/x/net/idna",
+                    "golang.org/x/net/lif",
+                    "golang.org/x/net/nettest",
+                    "golang.org/x/net/route",
+                ]
+            ),
+            explicit=True,
+            go_version="1.17",
+        ),
+        VendoredModuleMetadata(
+            module_import_path="golang.org/x/sys",
+            module_version="v0.2.1-0.20221110211117-d684c6f88669",
+            package_import_paths=frozenset(
+                [
+                    "golang.org/x/sys/cpu",
+                ]
+            ),
+            explicit=True,
+            go_version="1.17",
+        ),
+        VendoredModuleMetadata(
+            module_import_path="golang.org/x/text",
+            module_version="v0.4.1-0.20221110184632-c8236a6712b1",
+            package_import_paths=frozenset(
+                [
+                    "golang.org/x/text/secure/bidirule",
+                    "golang.org/x/text/transform",
+                    "golang.org/x/text/unicode/bidi",
+                    "golang.org/x/text/unicode/norm",
+                ]
+            ),
+            explicit=True,
+            go_version="1.17",
+        ),
+    )


### PR DESCRIPTION
Add rules to parse `vendor/modules.txt` files. This flle is used by `go` to understand what packages are provided in a vendor tree. 

The code is adapted from https://github.com/golang/go/blob/master/src/cmd/go/internal/modload/vendor.go which unfortunately is not available as a public API.

This will be used for eventual vendored module support.