### PR TITLE
Make mypy cache per-repo

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -222,7 +222,8 @@ async def mypy_typecheck_partition(
     py_version = config_file.python_version_to_autoset(
         partition.interpreter_constraints, python_setup.interpreter_versions_universe
     )
-    named_cache_dir = f".cache/mypy_cache/{sha256(build_root.path.encode()).hexdigest()}"
+    named_cache_dir = ".cache/mypy_cache"
+    mypy_cache_dir = f"{named_cache_dir}/{sha256(build_root.path.encode()).hexdigest()}"
     run_cache_dir = ".tmp_cache/mypy_cache"
     argv = await _generate_argv(
         mypy,
@@ -271,14 +272,14 @@ async def mypy_typecheck_partition(
                             # Lastly, we expect that since this is run through Pants which attempts
                             # to partition MyPy runs by python version (which the DB is independent
                             # for different versions) and uses a one-process-at-a-time daemon by default,
-                            # multuple MyPy processes operating on a single db cache should be rare.
+                            # multiple MyPy processes operating on a single db cache should be rare.
 
                             {mkdir.path} -p {run_cache_dir}/{py_version} > /dev/null 2>&1 || true
-                            {cp.path} {named_cache_dir}/{py_version}/cache.db {run_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
+                            {cp.path} {mypy_cache_dir}/{py_version}/cache.db {run_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
                             {' '.join((shell_quote(arg) for arg in argv))}
                             EXIT_CODE=$?
-                            {mkdir.path} -p {named_cache_dir}/{py_version} > /dev/null 2>&1 || true
-                            {mv.path} {run_cache_dir}/{py_version}/cache.db {named_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
+                            {mkdir.path} -p {mypy_cache_dir}/{py_version} > /dev/null 2>&1 || true
+                            {mv.path} {run_cache_dir}/{py_version}/cache.db {mypy_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
                             exit $EXIT_CODE
                         """
                     ).encode(),


### PR DESCRIPTION
This was the original intent, but somehow didn't quite make it.

Fixes https://github.com/pantsbuild/pants/issues/17526

After:
```
$ ls ~/.cache/pants/named_caches/mypy_cache/
11ee7f53f1ca7a8d3d82683ada394db4d1e4712707d512ec5c3e011a4a6ffdd9
```