### PR TITLE
Start phasing out `frozen_after_init`

### DIFF
--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
@@ -13,11 +13,9 @@ from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, 
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import LockfileContext
 from pants.util.docutil import bin_name
-from pants.util.meta import frozen_after_init
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class JVMLockfileFixtureDefinition:
     lockfile_rel_path: Path
     requirements: tuple[Coordinate, ...]
@@ -25,10 +23,6 @@ class JVMLockfileFixtureDefinition:
     def __init__(
         self, lockfile_rel_path: Path | str, requirements: Iterable[Coordinate | str]
     ) -> None:
-        self.lockfile_rel_path = (
-            lockfile_rel_path if isinstance(lockfile_rel_path, Path) else Path(lockfile_rel_path)
-        )
-
         coordinates: list[Coordinate] = []
         for requirement in requirements:
             if isinstance(requirement, Coordinate):
@@ -40,7 +34,13 @@ class JVMLockfileFixtureDefinition:
                 raise TypeError(
                     f"Unsupported type `{type(requirement)}` for JVM coordinate. Expected `Coordinate` or `str`."
                 )
-        self.requirements = tuple(coordinates)
+
+        object.__setattr__(
+            self,
+            "lockfile_rel_path",
+            lockfile_rel_path if isinstance(lockfile_rel_path, Path) else Path(lockfile_rel_path),
+        )
+        object.__setattr__(self, "requirements", tuple(coordinates))
 
     @classmethod
     def from_json_dict(cls, kwargs) -> JVMLockfileFixtureDefinition:

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -11,6 +11,7 @@ python_sources(
 )
 
 python_test_utils(name="test_utils")
+python_tests(name="tests")
 
 python_distribution(
     name="pants-packaged",

--- a/src/python/pants/backend/go/util_rules/embedcfg.py
+++ b/src/python/pants/backend/go/util_rules/embedcfg.py
@@ -8,12 +8,10 @@ from dataclasses import dataclass
 from typing import Any, Iterable, Mapping
 
 from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import strip_prefix
 
 
-@dataclass(unsafe_hash=True)
-@frozen_after_init
+@dataclass(frozen=True)
 class EmbedConfig:
     patterns: FrozenDict[str, tuple[str, ...]]
     files: FrozenDict[str, str]
@@ -35,8 +33,8 @@ class EmbedConfig:
         :param files: Maps each virtual, relative file path used as a value in the `patterns`
           dictionary to the actual filesystem path with that file's content.
         """
-        self.patterns = FrozenDict({k: tuple(v) for k, v in patterns.items()})
-        self.files = FrozenDict(files)
+        object.__setattr__(self, "patterns", FrozenDict({k: tuple(v) for k, v in patterns.items()}))
+        object.__setattr__(self, "files", FrozenDict(files))
 
     @classmethod
     def from_json_dict(

--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -18,11 +18,9 @@ from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class GoSdkProcess:
     command: tuple[str, ...]
     description: str
@@ -46,18 +44,22 @@ class GoSdkProcess:
         allow_downloads: bool = False,
         replace_sandbox_root_in_args: bool = False,
     ) -> None:
-        self.command = tuple(command)
-        self.description = description
-        self.env = (
-            FrozenDict(env or {})
-            if allow_downloads
-            else FrozenDict({**(env or {}), "GOPROXY": "off"})
+        object.__setattr__(self, "command", tuple(command))
+        object.__setattr__(self, "description", description)
+        object.__setattr__(
+            self,
+            "env",
+            (
+                FrozenDict(env or {})
+                if allow_downloads
+                else FrozenDict({**(env or {}), "GOPROXY": "off"})
+            ),
         )
-        self.input_digest = input_digest
-        self.working_dir = working_dir
-        self.output_files = tuple(output_files)
-        self.output_directories = tuple(output_directories)
-        self.replace_sandbox_root_in_args = replace_sandbox_root_in_args
+        object.__setattr__(self, "input_digest", input_digest)
+        object.__setattr__(self, "working_dir", working_dir)
+        object.__setattr__(self, "output_files", tuple(output_files))
+        object.__setattr__(self, "output_directories", tuple(output_directories))
+        object.__setattr__(self, "replace_sandbox_root_in_args", replace_sandbox_root_in_args)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -36,7 +36,6 @@ from pants.engine.unions import UnionRule
 from pants.util.docutil import git_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list, pluralize, softwrap
 
 logger = logging.getLogger(__name__)
@@ -126,8 +125,7 @@ class SetupHelmPostRenderer(EngineAwareParameter):
         return self.description_of_origin
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class HelmPostRenderer(EngineAwareReturnType):
     exe: str
     digest: Digest
@@ -146,12 +144,14 @@ class HelmPostRenderer(EngineAwareReturnType):
         immutable_input_digests: Mapping[str, Digest] | None = None,
         append_only_caches: Mapping[str, str] | None = None,
     ) -> None:
-        self.exe = exe
-        self.digest = digest
-        self.description_of_origin = description_of_origin
-        self.env = FrozenDict(env or {})
-        self.append_only_caches = FrozenDict(append_only_caches or {})
-        self.immutable_input_digests = FrozenDict(immutable_input_digests or {})
+        object.__setattr__(self, "exe", exe)
+        object.__setattr__(self, "digest", digest)
+        object.__setattr__(self, "description_of_origin", description_of_origin)
+        object.__setattr__(self, "env", FrozenDict(env or {}))
+        object.__setattr__(self, "append_only_caches", FrozenDict(append_only_caches or {}))
+        object.__setattr__(
+            self, "immutable_input_digests", FrozenDict(immutable_input_digests or {})
+        )
 
     def level(self) -> LogLevel | None:
         return LogLevel.DEBUG

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -42,7 +42,6 @@ from pants.engine.internals.native_engine import FileDigest
 from pants.engine.process import InteractiveProcess, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import pluralize, softwrap
 from pants.util.value_interpolation import InterpolationContext, InterpolationValue
 
@@ -56,8 +55,7 @@ class HelmDeploymentCmd(Enum):
     RENDER = "template"
 
 
-@dataclass(unsafe_hash=True)
-@frozen_after_init
+@dataclass(frozen=True)
 class HelmDeploymentRequest(EngineAwareParameter):
     field_set: HelmDeploymentFieldSet
 
@@ -75,11 +73,11 @@ class HelmDeploymentRequest(EngineAwareParameter):
         extra_argv: Iterable[str] | None = None,
         post_renderer: HelmPostRenderer | None = None,
     ) -> None:
-        self.field_set = field_set
-        self.cmd = cmd
-        self.description = description
-        self.extra_argv = tuple(extra_argv or ())
-        self.post_renderer = post_renderer
+        object.__setattr__(self, "field_set", field_set)
+        object.__setattr__(self, "cmd", cmd)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "extra_argv", tuple(extra_argv or ()))
+        object.__setattr__(self, "post_renderer", post_renderer)
 
     def debug_hint(self) -> str | None:
         return self.field_set.address.spec

--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -48,7 +48,6 @@ from pants.engine.unions import UnionMembership, union
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list, pluralize
 
 logger = logging.getLogger(__name__)
@@ -285,8 +284,7 @@ async def download_external_helm_plugin(request: ExternalHelmPluginRequest) -> H
 # ---------------------------------------------
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class HelmBinary:
     path: str
 
@@ -301,9 +299,9 @@ class HelmBinary:
         local_env: Mapping[str, str],
         immutable_input_digests: Mapping[str, Digest],
     ) -> None:
-        self.path = path
-        self.immutable_input_digests = FrozenDict(immutable_input_digests)
-        self.env = FrozenDict({**helm_env, **local_env})
+        object.__setattr__(self, "path", path)
+        object.__setattr__(self, "immutable_input_digests", FrozenDict(immutable_input_digests))
+        object.__setattr__(self, "env", FrozenDict({**helm_env, **local_env}))
 
     @property
     def config_digest(self) -> Digest:
@@ -318,8 +316,7 @@ class HelmBinary:
         return {_HELM_CACHE_NAME: _HELM_CACHE_DIR}
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class HelmProcess:
     argv: tuple[str, ...]
     input_digest: Digest
@@ -348,17 +345,21 @@ class HelmProcess:
         cache_scope: ProcessCacheScope | None = None,
         timeout_seconds: int | None = None,
     ):
-        self.argv = tuple(argv)
-        self.input_digest = input_digest
-        self.description = description
-        self.level = level
-        self.output_directories = tuple(output_directories or ())
-        self.output_files = tuple(output_files or ())
-        self.extra_env = FrozenDict(extra_env or {})
-        self.extra_immutable_input_digests = FrozenDict(extra_immutable_input_digests or {})
-        self.extra_append_only_caches = FrozenDict(extra_append_only_caches or {})
-        self.cache_scope = cache_scope
-        self.timeout_seconds = timeout_seconds
+        object.__setattr__(self, "argv", tuple(argv))
+        object.__setattr__(self, "input_digest", input_digest)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "level", level)
+        object.__setattr__(self, "output_directories", tuple(output_directories or ()))
+        object.__setattr__(self, "output_files", tuple(output_files or ()))
+        object.__setattr__(self, "extra_env", FrozenDict(extra_env or {}))
+        object.__setattr__(
+            self, "extra_immutable_input_digests", FrozenDict(extra_immutable_input_digests or {})
+        )
+        object.__setattr__(
+            self, "extra_append_only_caches", FrozenDict(extra_append_only_caches or {})
+        )
+        object.__setattr__(self, "cache_scope", cache_scope)
+        object.__setattr__(self, "timeout_seconds", timeout_seconds)
 
 
 @rule(desc="Download and configure Helm", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/helm/utils/yaml.py
+++ b/src/python/pants/backend/helm/utils/yaml.py
@@ -11,11 +11,9 @@ from typing import Any, Callable, Generic, Iterable, Iterator, Mapping, Optional
 
 from pants.engine.collection import Collection
 from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
 
 
 @dataclass(unsafe_hash=True)
-@frozen_after_init
 class YamlPath:
     """Simple implementation of YAML paths using `/` syntax and being the single slash the path to
     the root."""
@@ -24,8 +22,8 @@ class YamlPath:
     _absolute: bool
 
     def __init__(self, elements: Iterable[str], *, absolute: bool) -> None:
-        self._elements = tuple(elements)
-        self._absolute = absolute
+        object.__setattr__(self, "_elements", tuple(elements))
+        object.__setattr__(self, "_absolute", absolute)
 
         if len(self._elements) == 0 and not self._absolute:
             raise ValueError("Relative YAML paths with no elements are not allowed.")
@@ -181,7 +179,7 @@ class _YamlDocumentIndexNode(Generic[T]):
         return {"paths": items_dict}
 
 
-@frozen_after_init
+@dataclass(frozen=True)
 class FrozenYamlIndex(Generic[T]):
     """Represents a frozen collection of items that is indexed by the following keys:
 
@@ -204,7 +202,7 @@ class FrozenYamlIndex(Generic[T]):
                 doc_list[idx] = _YamlDocumentIndexNode(paths=FrozenDict(item_map))
 
             data[file_path] = Collection(doc_list)
-        self._data = FrozenDict(data)
+        object.__setattr__(self, "_data", FrozenDict(data))
 
     def transform_values(self, func: Callable[[T], Optional[R]]) -> FrozenYamlIndex[R]:
         """Transforms the values of the given indexed collection into those that are returned from

--- a/src/python/pants/backend/openapi/util_rules/generator_process.py
+++ b/src/python/pants/backend/openapi/util_rules/generator_process.py
@@ -24,7 +24,6 @@ from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.util_rules import rules as jvm_util_rules
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 
 
 @unique
@@ -32,8 +31,7 @@ class OpenAPIGeneratorType(Enum):
     JAVA = "java"
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class OpenAPIGeneratorProcess:
     argv: tuple[str, ...]
     generator_type: OpenAPIGeneratorType
@@ -64,18 +62,20 @@ class OpenAPIGeneratorProcess:
         extra_jvm_options: Iterable[str] | None = None,
         cache_scope: ProcessCacheScope | None = None,
     ):
-        self.generator_type = generator_type
-        self.argv = tuple(argv)
-        self.input_digest = input_digest
-        self.description = description
-        self.level = level
-        self.output_directories = tuple(output_directories or ())
-        self.output_files = tuple(output_files or ())
-        self.extra_env = FrozenDict(extra_env or {})
-        self.extra_classpath_entries = tuple(extra_classpath_entries or ())
-        self.extra_immutable_input_digests = FrozenDict(extra_immutable_input_digests or {})
-        self.extra_jvm_options = tuple(extra_jvm_options or ())
-        self.cache_scope = cache_scope
+        object.__setattr__(self, "generator_type", generator_type)
+        object.__setattr__(self, "argv", tuple(argv))
+        object.__setattr__(self, "input_digest", input_digest)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "level", level)
+        object.__setattr__(self, "output_directories", tuple(output_directories or ()))
+        object.__setattr__(self, "output_files", tuple(output_files or ()))
+        object.__setattr__(self, "extra_env", FrozenDict(extra_env or {}))
+        object.__setattr__(self, "extra_classpath_entries", tuple(extra_classpath_entries or ()))
+        object.__setattr__(
+            self, "extra_immutable_input_digests", FrozenDict(extra_immutable_input_digests or {})
+        )
+        object.__setattr__(self, "extra_jvm_options", tuple(extra_jvm_options or ()))
+        object.__setattr__(self, "cache_scope", cache_scope)
 
 
 _GENERATOR_CLASS_NAME = "org.openapitools.codegen.OpenAPIGenerator"

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -14,7 +14,6 @@ from pants.engine.target import AllUnexpandedTargets, Dependencies, Dependencies
 from pants.option.option_types import BoolOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 
 
@@ -44,8 +43,7 @@ async def map_addresses_to_dependents(all_targets: AllUnexpandedTargets) -> Addr
     )
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class DependentsRequest:
     addresses: FrozenOrderedSet[Address]
     transitive: bool
@@ -54,9 +52,9 @@ class DependentsRequest:
     def __init__(
         self, addresses: Iterable[Address], *, transitive: bool, include_roots: bool
     ) -> None:
-        self.addresses = FrozenOrderedSet(addresses)
-        self.transitive = transitive
-        self.include_roots = include_roots
+        object.__setattr__(self, "addresses", FrozenOrderedSet(addresses))
+        object.__setattr__(self, "transitive", transitive)
+        object.__setattr__(self, "include_roots", include_roots)
 
 
 class Dependents(DeduplicatedCollection[Address]):

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -91,7 +91,6 @@ from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
-from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
 
@@ -213,8 +212,7 @@ class DistBuildChrootRequest:
     interpreter_constraints: InterpreterConstraints
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class SetupKwargs:
     """The keyword arguments to the `setup()` function in the generated `setup.py`."""
 
@@ -256,7 +254,11 @@ class SetupKwargs:
         # would require that all values are immutable, and we may have lists and dictionaries as
         # values. It's too difficult/clunky to convert those all, then to convert them back out of
         # `FrozenDict`. We don't use JSON because it does not preserve data types like `tuple`.
-        self._pickled_bytes = pickle.dumps({k: v for k, v in sorted(kwargs.items())}, protocol=4)
+        object.__setattr__(
+            self,
+            "_pickled_bytes",
+            pickle.dumps({k: v for k, v in sorted(kwargs.items())}, protocol=4),
+        )
 
     @memoized_property
     def kwargs(self) -> dict[str, Any]:

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -31,7 +31,6 @@ from pants.engine.target import (
 )
 from pants.util.dirutil import fast_relpath_optional
 from pants.util.docutil import doc_url
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
@@ -102,8 +101,7 @@ async def isolate_local_dist_wheels(
     return LocalDistWheels(tuple(wheels), wheels_snapshot.digest, frozenset(provided_files))
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class LocalDistsPexRequest:
     """Request to build the local dists from the dependency closure of a set of addresses."""
 
@@ -122,10 +120,10 @@ class LocalDistsPexRequest:
         interpreter_constraints: InterpreterConstraints = InterpreterConstraints(),
         sources: PythonSourceFiles = PythonSourceFiles.empty(),
     ) -> None:
-        self.addresses = Addresses(addresses)
-        self.internal_only = internal_only
-        self.interpreter_constraints = interpreter_constraints
-        self.sources = sources
+        object.__setattr__(self, "addresses", Addresses(addresses))
+        object.__setattr__(self, "internal_only", internal_only)
+        object.__setattr__(self, "interpreter_constraints", interpreter_constraints)
+        object.__setattr__(self, "sources", sources)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -103,6 +103,8 @@ class PexCliProcess:
         object.__setattr__(self, "concurrency_available", concurrency_available)
         object.__setattr__(self, "cache_scope", cache_scope)
 
+        self.__post_init__()
+
     def __post_init__(self) -> None:
         if "--pex-root-path" in self.extra_args:
             raise ValueError("`--pex-root` flag not allowed. We set its value for you.")

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -29,7 +29,7 @@ from pants.engine.rules import Get, collect_rules, rule
 from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_content
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import classproperty, frozen_after_init
+from pants.util.meta import classproperty
 from pants.util.strutil import create_path_env_var
 
 
@@ -57,8 +57,7 @@ class PexCli(TemplatedExternalTool):
         ]
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class PexCliProcess:
     subcommand: tuple[str, ...]
     extra_args: tuple[str, ...]
@@ -89,19 +88,20 @@ class PexCliProcess:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
     ) -> None:
-        self.subcommand = tuple(subcommand)
-        self.extra_args = tuple(extra_args)
-        self.set_resolve_args = set_resolve_args
-        self.description = description
-        self.additional_input_digest = additional_input_digest
-        self.extra_env = FrozenDict(extra_env) if extra_env else None
-        self.output_files = tuple(output_files) if output_files else None
-        self.output_directories = tuple(output_directories) if output_directories else None
-        self.python = python
-        self.level = level
-        self.concurrency_available = concurrency_available
-        self.cache_scope = cache_scope
-        self.__post_init__()
+        object.__setattr__(self, "subcommand", tuple(subcommand))
+        object.__setattr__(self, "extra_args", tuple(extra_args))
+        object.__setattr__(self, "set_resolve_args", set_resolve_args)
+        object.__setattr__(self, "description", description)
+        object.__setattr__(self, "additional_input_digest", additional_input_digest)
+        object.__setattr__(self, "extra_env", FrozenDict(extra_env) if extra_env else None)
+        object.__setattr__(self, "output_files", tuple(output_files) if output_files else None)
+        object.__setattr__(
+            self, "output_directories", tuple(output_directories) if output_directories else None
+        )
+        object.__setattr__(self, "python", python)
+        object.__setattr__(self, "level", level)
+        object.__setattr__(self, "concurrency_available", concurrency_available)
+        object.__setattr__(self, "cache_scope", cache_scope)
 
     def __post_init__(self) -> None:
         if "--pex-root-path" in self.extra_args:

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -52,14 +52,12 @@ from pants.engine.target import Target, TransitiveTargets, TransitiveTargetsRequ
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.meta import frozen_after_init
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class PexFromTargetsRequest:
     addresses: Addresses
     output_filename: str
@@ -141,25 +139,28 @@ class PexFromTargetsRequest:
         :param description: A human-readable description to render in the dynamic UI when building
             the Pex.
         """
-        self.addresses = Addresses(addresses)
-        self.output_filename = output_filename
-        self.internal_only = internal_only
-        self.layout = layout
-        self.main = main
-        self.inject_args = tuple(inject_args)
-        self.inject_env = FrozenDict(inject_env)
-        self.platforms = platforms
-        self.complete_platforms = complete_platforms
-        self.additional_args = tuple(additional_args)
-        self.additional_lockfile_args = tuple(additional_lockfile_args)
-        self.include_source_files = include_source_files
-        self.include_requirements = include_requirements
-        self.include_local_dists = include_local_dists
-        self.additional_sources = additional_sources
-        self.additional_inputs = additional_inputs
-        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
-        self.description = description
+        object.__setattr__(self, "addresses", Addresses(addresses))
+        object.__setattr__(self, "output_filename", output_filename)
+        object.__setattr__(self, "internal_only", internal_only)
+        object.__setattr__(self, "layout", layout)
+        object.__setattr__(self, "main", main)
+        object.__setattr__(self, "inject_args", tuple(inject_args))
+        object.__setattr__(self, "inject_env", FrozenDict(inject_env))
+        object.__setattr__(self, "platforms", platforms)
+        object.__setattr__(self, "complete_platforms", complete_platforms)
+        object.__setattr__(self, "additional_args", tuple(additional_args))
+        object.__setattr__(self, "additional_lockfile_args", tuple(additional_lockfile_args))
+        object.__setattr__(self, "include_source_files", include_source_files)
+        object.__setattr__(self, "include_requirements", include_requirements)
+        object.__setattr__(self, "include_local_dists", include_local_dists)
+        object.__setattr__(self, "additional_sources", additional_sources)
+        object.__setattr__(self, "additional_inputs", additional_inputs)
+        object.__setattr__(
+            self, "hardcoded_interpreter_constraints", hardcoded_interpreter_constraints
+        )
+        object.__setattr__(self, "description", description)
 
+    def __post_init__(self):
         if self.internal_only and (self.platforms or self.complete_platforms):
             raise AssertionError(
                 softwrap(
@@ -178,8 +179,7 @@ class PexFromTargetsRequest:
         )
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class InterpreterConstraintsRequest:
     addresses: Addresses
     hardcoded_interpreter_constraints: InterpreterConstraints | None
@@ -190,8 +190,10 @@ class InterpreterConstraintsRequest:
         *,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
     ) -> None:
-        self.addresses = Addresses(addresses)
-        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
+        object.__setattr__(self, "addresses", Addresses(addresses))
+        object.__setattr__(
+            self, "hardcoded_interpreter_constraints", hardcoded_interpreter_constraints
+        )
 
 
 @rule
@@ -340,8 +342,7 @@ async def determine_requirement_strings_in_closure(
     )
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class _RepositoryPexRequest:
     addresses: Addresses
     hardcoded_interpreter_constraints: InterpreterConstraints | None
@@ -360,12 +361,14 @@ class _RepositoryPexRequest:
         complete_platforms: CompletePlatforms = CompletePlatforms(),
         additional_lockfile_args: tuple[str, ...] = (),
     ) -> None:
-        self.addresses = Addresses(addresses)
-        self.internal_only = internal_only
-        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
-        self.platforms = platforms
-        self.complete_platforms = complete_platforms
-        self.additional_lockfile_args = additional_lockfile_args
+        object.__setattr__(self, "addresses", Addresses(addresses))
+        object.__setattr__(self, "internal_only", internal_only)
+        object.__setattr__(
+            self, "hardcoded_interpreter_constraints", hardcoded_interpreter_constraints
+        )
+        object.__setattr__(self, "platforms", platforms)
+        object.__setattr__(self, "complete_platforms", complete_platforms)
+        object.__setattr__(self, "additional_lockfile_args", additional_lockfile_args)
 
     def to_interpreter_constraints_request(self) -> InterpreterConstraintsRequest:
         return InterpreterConstraintsRequest(
@@ -668,8 +671,7 @@ async def _setup_constraints_repository_pex(
     return OptionalPexRequest(repository_pex)
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class RequirementsPexRequest:
     """Requests a PEX containing only thirdparty requirements for internal/non-portable use.
 
@@ -686,8 +688,10 @@ class RequirementsPexRequest:
         *,
         hardcoded_interpreter_constraints: InterpreterConstraints | None = None,
     ) -> None:
-        self.addresses = Addresses(addresses)
-        self.hardcoded_interpreter_constraints = hardcoded_interpreter_constraints
+        object.__setattr__(self, "addresses", Addresses(addresses))
+        object.__setattr__(
+            self, "hardcoded_interpreter_constraints", hardcoded_interpreter_constraints
+        )
 
 
 @rule

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -160,6 +160,8 @@ class PexFromTargetsRequest:
         )
         object.__setattr__(self, "description", description)
 
+        self.__post_init__()
+
     def __post_init__(self):
         if self.internal_only and (self.platforms or self.complete_platforms):
             raise AssertionError(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -35,7 +35,6 @@ from pants.engine.fs import (
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.unions import UnionMembership
 from pants.util.docutil import bin_name, doc_url
-from pants.util.meta import frozen_after_init
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
@@ -239,8 +238,7 @@ class EntireLockfile:
     complete_req_strings: tuple[str, ...] | None = None
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
+@dataclass(frozen=True)
 class PexRequirements:
     """A request to resolve a series of requirements (optionally from a "superset" resolve)."""
 
@@ -263,18 +261,22 @@ class PexRequirements:
         :param constraints_strings: Constraints strings to apply during the resolve.
         :param from_superset: An optional superset PEX or lockfile to resolve the req strings from.
         """
-        self.req_strings = FrozenOrderedSet(sorted(req_strings))
-        self.constraints_strings = FrozenOrderedSet(sorted(constraints_strings))
-        if isinstance(from_superset, LoadedLockfile) and not from_superset.is_pex_native:
+        object.__setattr__(self, "req_strings", FrozenOrderedSet(sorted(req_strings)))
+        object.__setattr__(
+            self, "constraints_strings", FrozenOrderedSet(sorted(constraints_strings))
+        )
+        object.__setattr__(self, "from_superset", from_superset)
+
+    def __post_init__(self):
+        if isinstance(self.from_superset, LoadedLockfile) and not self.from_superset.is_pex_native:
             raise ValueError(
                 softwrap(
                     f"""
-                    The lockfile {from_superset.original_lockfile} was not in PEX's
+                    The lockfile {self.from_superset.original_lockfile} was not in PEX's
                     native format, and so cannot be directly used as a superset.
                     """
                 )
             )
-        self.from_superset = from_superset
 
     @classmethod
     def create_from_requirement_fields(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -267,6 +267,8 @@ class PexRequirements:
         )
         object.__setattr__(self, "from_superset", from_superset)
 
+        self.__post_init__()
+
     def __post_init__(self):
         if isinstance(self.from_superset, LoadedLockfile) and not self.from_superset.is_pex_native:
             raise ValueError(

--- a/src/python/pants/conftest.py
+++ b/src/python/pants/conftest.py
@@ -1,6 +1,8 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import dataclasses
+
 import pytest
 
 
@@ -36,3 +38,37 @@ def dedicated_target_fields():
                     raise ValueError(
                         f"{cls.__name__} should have a dedicated field type for the dependencies field."
                     )
+
+
+def _check_frozen_dataclass_attributes() -> None:
+    """Ensures that calls to `object.__setattr__` in a frozen dataclass' `__init__` are valid."""
+
+    actual_dataclass_decorator = dataclasses.dataclass
+
+    def new_dataclass_decorator(*args, **kwargs):
+        if not kwargs.get("frozen", False):
+            return actual_dataclass_decorator(*args, **kwargs)
+
+        def wrapper(cls):
+            dataclass_cls = actual_dataclass_decorator(*args, **kwargs)(cls)
+
+            if dataclass_cls.__init__ is cls.__init__:
+                old__init__ = getattr(dataclass_cls, "__init__")
+
+                def new__init__(self, *args, **kwargs):
+                    old__init__(self, *args, **kwargs)
+                    assert sorted(field.name for field in dataclasses.fields(self)) == sorted(
+                        self.__dict__
+                    )
+
+                setattr(dataclass_cls, "__init__", new__init__)
+
+            return dataclass_cls
+
+        return wrapper
+
+    dataclasses.dataclass = new_dataclass_decorator
+
+
+def pytest_configure() -> None:
+    _check_frozen_dataclass_attributes()

--- a/src/python/pants/conftest_test.py
+++ b/src/python/pants/conftest_test.py
@@ -1,0 +1,26 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from dataclasses import dataclass
+
+import pytest
+
+
+def test_frozen_dataclass_checking() -> None:
+    @dataclass(frozen=True)
+    class MissingInitialization:
+        x: str
+
+        def __init__(self):
+            pass
+
+    with pytest.raises(AssertionError):
+        MissingInitialization()
+
+    @dataclass(frozen=True)
+    class TooMuchInitialized:
+        def __init__(self):
+            object.__setattr__(self, "x", 1)
+
+    with pytest.raises(AssertionError):
+        TooMuchInitialized()


### PR DESCRIPTION
As discussed on Slack, `frozen_after_init` has a few drawbacks:

- We lose the normal "frozen" benefits from dataclass
- You have to remember to use `unsafe_hash`, because...
- Type checkers won't help you identify when assign a variable. You're on your own
- These are mostly used for converters. If/when those get into stdlib `dataclass` we could eliminate a lot of this code.

On the other hand, the standard library already spells out what to do in this situation: https://docs.python.org/3/library/dataclasses.html#frozen-instances. I love doing as the Romans do :wink: 

After we switch internally, we can deprecate the function for a few releases