### PR TITLE
Bump to version `0.26.0` of the Toolchain plugin.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -37,7 +37,7 @@ backend_packages.add = [
 ]
 plugins = [
   "hdrhistogram",  # For use with `--stats-log`.
-  "toolchain.pants.plugin==0.25.0",
+  "toolchain.pants.plugin==0.26.0",
 ]
 
 # The invalidation globs cover the PYTHONPATH by default, but we exclude some files that are on the


### PR DESCRIPTION
https://pypi.org/project/toolchain.pants.plugin/0.26.0/