### PR TITLE
Fix caching of PATH lookups in remote execution (Cherry-pick of #18026)

### DIFF
--- a/src/python/pants/engine/internals/platform_rules.py
+++ b/src/python/pants/engine/internals/platform_rules.py
@@ -70,6 +70,7 @@ async def complete_environment_vars(
             ["env", "-0"],
             description=f"Extract environment variables from {description_of_env_source}",
             level=LogLevel.DEBUG,
+            cache_scope=env_tgt.executable_search_path_cache_scope(),
         ),
     )
     result = {}


### PR DESCRIPTION
Use the value of [cache_binary_discovery](https://www.pantsbuild.org/v2.15/docs/reference-remote_environment#codecache_binary_discoverycode) to decide whether to cache `PATH` lookups.
