### PR TITLE
Fix validation of release PEXes. (Cherry-pick of #17785)

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -863,15 +863,12 @@ def build_pex(fetch: bool) -> None:
         dest = stable_dest
     green(f"Built {dest}")
 
-    with temporary_dir() as tmpdir:
-        validated_pex_path = Path(tmpdir, "pants.pex")
-        shutil.copyfile(dest, validated_pex_path)
-        validated_pex_path.chmod(0o777)
-        Path(tmpdir, "BUILD_ROOT").touch()
-        # We also need to filter out Pants options like `PANTS_CONFIG_FILES` and disable certain internal backends.
-        env = {k: v for k, v in env.items() if not k.startswith("PANTS_")}
-        env.update(DISABLED_BACKENDS_CONFIG)
-        subprocess.run([validated_pex_path, "--version"], env=env, check=True, cwd=dest.parent)
+    # We filter out Pants options like `PANTS_CONFIG_FILES` and disable certain internal backends.
+    env = {k: v for k, v in env.items() if not k.startswith("PANTS_")}
+    env.update(DISABLED_BACKENDS_CONFIG)
+    # NB: Set `--concurrent` so that if this script is running under `pantsd`, the validation
+    # won't kill it.
+    subprocess.run([dest, "--concurrent", "--version"], env=env, check=True)
     green(f"Validated {dest}")
 
 


### PR DESCRIPTION
When the release script subprocesses Pants, it needs to use `--concurrent` in order to avoid killing itself.
