### PR TITLE
Update and reorganize resource hub (#17922)

### DIFF
--- a/docs/markdown/Introduction/media.md
+++ b/docs/markdown/Introduction/media.md
@@ -4,32 +4,168 @@ slug: "media"
 excerpt: "Learn more about Pants and related topics from these talks, posts and podcasts featuring Pants contributors and users."
 hidden: false
 createdAt: "2021-04-18T17:27:18.361Z"
-updatedAt: "2022-09-08T22:02:38.457Z"
+updatedAt: "2023-01-04T22:02:38.457Z"
 ---
-## Posts & Articles
 
-### Coinbase Blog
+## Case Studies
+
+### Tweag
+
+January 3, 2023
+"From adopting Pants, to generalizing our CI to multiple Python versions" <https://blog.pantsbuild.org/tweag-case-study/>
+
+> Describes why and how the maintainers of Bazel's Haskell rules chose to use Pants for a client's Python monorepo. Also covers some gotchas for newcomers.
+
+### Oxbotica
+
+November 4, 2022
+"Introducing Pants to Oxbotica"
+<https://blog.pantsbuild.org/introducing-pants-to-oxbotica/>
+
+> Self-driving vehicle company's successful journey to adopting Pants locally and in CI.
+
+
+### Coinbase
 
 September 1, 2022  
-[**Case Study**] "Building a Python ecosystem for efficient and reliable development"  
+"Part 1: Building a Python ecosystem for efficient and reliable development"  
 <https://blog.coinbase.com/building-a-python-ecosystem-for-efficient-and-reliable-development-d986c97a94a0>
 
-> Part 1 of 2. Describes how the company developed an efficient, reliable Python ecosystem using Pants, and solved the challenge of managing Python applications at a large scale at Coinbase.
+> Describes how the company developed an efficient, reliable Python ecosystem using Pants, and solved the challenge of managing Python applications at a large scale at Coinbase.
+
+
+October 27, 2022
+"Part 2: Building a Python ecosystem for efficient and reliable development"  
+<https://www.coinbase.com/blog/part-2-building-a-python-ecosystem-for-efficient-and-reliable-development>
+
+> Explains the technical details of the continuous integration/continuous delivery (CI/CD) infrastructure and dependency management of the company's Python ecosystem.
 
 ### IBM Developer Blog
 
 August 24, 2022  
-[**Case Study**] "Incrementally migrating a Python monorepo from Bazel to Pants"  
+"Incrementally migrating a Python monorepo from Bazel to Pants"  
 <https://developer.ibm.com/blogs/case-study-incrementally-migrating-a-python-monorepo-from-bazel-to-pants/>  
 
 > Watson Orders is an IBM Silicon Valley based technology development group targeting the development of world-class conversational AI. This posts walks through the process of migrating off Bazel, where they maintained 19,000 lines of BUILD file metadata, to Pants where that was slashed to 2,400 lines thanks to [dependency inference](doc:/how-does-pants-work#dependency-inference). CI build time for PRs dropped from 10-12 minutes with Bazel to under 4 minutes with Pants.
 
 ### Astranis Space Technologies
 
-August 12, 2022 
-[**Case Study**] "Astranis Case Study: Wrangling Python In a Monorepo"
-<https://blog.pantsbuild.org/astranis-case-study-wrangling-python-in-a-monorepo/>
+August 12, 2022  
+"Astranis Case Study: Wrangling Python In a Monorepo"
+<https://blog.pantsbuild.org/astranis-case-study-wrangling-python-in-a-monorepo/>  
+
 > <i>"...We found it incredibly easy to hook in our existing remote caching systems to Pants, and added other nice features like running tailor in a check-only mode to highlight any inconsistencies in our repo. As a side benefit, Pants has helped us gain better insight into our repository by being able to easily scan for and report the transitive dependencies of modules. Having that insight has helped us plan out how to minimize the coupling of our modules..."</i>
+
+### Twitter Engineering
+
+December 31, 2021  
+"Advancing Jupyter Notebooks at Twitter - Part 1"  
+<https://blog.twitter.com/engineering/en_us/topics/infrastructure/2021/advancing-jupyter-notebooks-at-twitter---part-1--a-first-class-d>  
+
+> About the intersection of Twitter data science, monorepos, Pants, Pex, and the [pants-jupyter-plugin](https://github.com/pantsbuild/pants-jupyter-plugin).
+
+### iManage
+
+October 2, 2021  
+"Putting Pants On: One Thing We Did Right After 5 Years with Django"  
+<https://g-cassie.github.io/2021/10/02/django-pants.html>
+
+
+## Tutorials
+
+### Doctrine.fr Engineering blog
+
+Nov 25, 2022  
+"Industrialized Python code with Pylint plugins in Pants"  
+<https://medium.com/doctrine/industrialized-python-code-with-pylint-plugins-in-pants-321d9cbad07a>
+
+> What if you needed to put strict code convention rules through a linter and apply them with the help of Pants?
+
+### Suresh Joshi
+
+April 4, 2022  
+"It's Pants Plugins All the Way Down"  
+<https://sureshjoshi.com/development/pants-plugin-code-quality>  
+
+> A follow-up to "Your first Pants plugin" detailing how to manage code quality via plugins, continuous integration checks, and pre-commit hooks.
+
+January 25, 2022  
+"Your first Pants plugin"  
+<https://sureshjoshi.com/development/first-pants-plugin>  
+
+> A newcomer's walk-through of the code and experience of writing one's first Pants plugin.
+
+### Gordon Cassie
+
+October 30, 2021  
+"Getting Started With Pants and Django"  
+<https://g-cassie.github.io/2021/10/30/django-pants-tutorial-pt1.html>
+
+
+## Podcasts
+
+### The Real Python Podcast
+
+Episode 137: Start Using a Build System & Continuous Integration in Python
+December 16, 2022
+
+> What advantages can a build system provide for a Python developer? What new skills are required when working with a team of developers? Pants core maintainer and co-author Benjy Weinberger discusses Pants and getting started with continuous integration (CI).
+
+### Happy Path Programming Podcast
+
+Episode 72: Pants Makes Developers Happier and More Productive, with Benjy Weinberger
+December 16, 2022
+<https://anchor.fm/happypathprogramming/episodes/72-Pants-Makes-Developers-Happier--More-Productive-with-Benjy-Weinberger-e1sc1uj>
+
+
+### Humans of Devops
+
+Season 3, Episode 69: The Curse of Knowledge  
+March 7, 2022  
+<https://audioboom.com/posts/8043212-the-curse-of-knowledge-with-eric-arellano-and-nick-grisafi>  
+
+> Pants core maintainer Eric Arellano and Pants contributor Nick Grisafi discuss what Pants team has learned from philosophical concepts such as The Curse of Knowledge, Beginners Mind, and The Power of the Outsider.
+
+### Podcast.\_\_init\_\_
+
+Episode 352: Simplify And Scale Your Software Development Cycles By Putting On Pants (Build Tool)  
+February 14, 2022  
+<https://www.pythonpodcast.com/pants-software-development-lifecycle-tool-episode-352/>  
+
+> Pants core maintainers Stu Hood, Eric Arellano, and Andreas Stenius guest.
+
+### Software Engineering Daily
+
+Build Tools with Benjy Weinberger  
+January 17, 2022  
+<https://softwareengineeringdaily.com/2022/01/17/build-tools-with-benjy-weinberger/>
+
+### Semaphore Uncut
+
+Episode 33: Monorepo and Building at Scale  
+April 13, 2021  
+<https://semaphoreci.com/blog/monorepo-building-at-scale>  
+
+> Pants core maintainer Benjy Weinberger guests.
+
+### Angelneers
+
+Episode 28: Shifting Build Execution Paradigm  
+February 12, 2021  
+<https://angelneers.com/podcast/28-shifting-build-execution-paradigm/>  
+
+> Pants core maintainer Benjy Weinberger guests.
+
+### Podcast.\_\_init\_\_
+
+Episode 290: Pants Has Got Your Python Monorepo Covered  
+November 23, 2020  
+<https://www.pythonpodcast.com/pants-monorepo-build-tool-episode-290/>  
+
+> Pants core maintainers Stu Hood and Eric Arellano guest.
+
+
+## Posts & Articles
 
 ### Dev.to
 
@@ -39,20 +175,6 @@ July 25, 2022
 
 > How the cache solutions offered by CI providers work, why they are often of limited benefit, and how Pants supports a much more effective caching paradigm. 
 
-### Suresh Joshi
-
-April 4, 2022  
-[**Tutorial**] "It's Pants Plugins All the Way Down"  
-<https://sureshjoshi.com/development/pants-plugin-code-quality>  
-
-> A follow-up to "Your first Pants plugin" detailing how to manage code quality via plugins, continuous integration checks, and pre-commit hooks.
-
-January 25, 2022  
-[**Tutorial**] "Your first Pants plugin"  
-<https://sureshjoshi.com/development/first-pants-plugin>  
-
-> A newcomer's walk-through of the code and experience of writing one's first Pants plugin.
-
 ### Software Development Times
 
 January 18, 2022  
@@ -60,24 +182,6 @@ January 18, 2022
 <https://sdtimes.com/softwaredev/the-monorepo-approach-to-code-management/> 
 
 > <i>"If you’re responsible for your organization’s codebase architecture, then at some point you have to make some emphatic choices about how to manage growth in a scalable way..."</i>
-
-### Twitter Engineering
-
-December 31, 2021  
-[**Case Study**] "Advancing Jupyter Notebooks at Twitter - Part 1"  
-<https://blog.twitter.com/engineering/en_us/topics/infrastructure/2021/advancing-jupyter-notebooks-at-twitter---part-1--a-first-class-d>  
-
-> About the intersection of Twitter data science, monorepos, Pants, Pex, and the [pants-jupyter-plugin](https://github.com/pantsbuild/pants-jupyter-plugin).
-
-### Gordon Cassie
-
-October 30, 2021  
-[**Tutorial**] "Getting Started With Pants and Django (Part 1)"  
-<https://g-cassie.github.io/2021/10/30/django-pants-tutorial-pt1.html>
-
-October 2, 2021  
-[**Case Study**] "Putting Pants On: One Thing We Did Right After 5 Years with Django"  
-<https://g-cassie.github.io/2021/10/02/django-pants.html>
 
 ### Semaphore Blog
 
@@ -185,53 +289,6 @@ May 13, 2020
 <https://www.youtube.com/watch?v=mLyW6oAExW0>  
 <https://speakerdeck.com/benjyw/how-the-pants-build-system-leverages-python-3-features>
 
-## Podcasts
-
-### Humans of Devops
-
-Season 3, Episode 69: The Curse of Knowledge  
-March 7, 2022  
-<https://audioboom.com/posts/8043212-the-curse-of-knowledge-with-eric-arellano-and-nick-grisafi>  
-
-> Pants core maintainer Eric Arellano and Pants contributor Nick Grisafi discuss what Pants team has learned from philosophical concepts such as The Curse of Knowledge, Beginners Mind, and The Power of the Outsider.
-
-### Podcast.\_\_init\_\_
-
-Episode 352: Simplify And Scale Your Software Development Cycles By Putting On Pants (Build Tool)  
-February 14, 2022  
-<https://www.pythonpodcast.com/pants-software-development-lifecycle-tool-episode-352/>  
-
-> Pants core maintainers Stu Hood, Eric Arellano, and Andreas Stenius guest.
-
-### Software Engineering Daily
-
-Build Tools with Benjy Weinberger  
-January 17, 2022  
-<https://softwareengineeringdaily.com/2022/01/17/build-tools-with-benjy-weinberger/>
-
-### Semaphore Uncut
-
-Episode 33: Monorepo and Building at Scale  
-April 13, 2021  
-<https://semaphoreci.com/blog/monorepo-building-at-scale>  
-
-> Pants core maintainer Benjy Weinberger guests.
-
-### Angelneers
-
-Episode 28: Shifting Build Execution Paradigm  
-February 12, 2021  
-<https://angelneers.com/podcast/28-shifting-build-execution-paradigm/>  
-
-> Pants core maintainer Benjy Weinberger guests.
-
-### Podcast.\_\_init\_\_
-
-Episode 290: Pants Has Got Your Python Monorepo Covered  
-November 23, 2020  
-<https://www.pythonpodcast.com/pants-monorepo-build-tool-episode-290/>  
-
-> Pants core maintainers Stu Hood and Eric Arellano guest.
 
 ## YouTube
 


### PR DESCRIPTION
* Add recent case studies, tutorial, and podcasts
* Create dedicated section for case studies
* Create dedicated section for tutorials
* Bump up the podcasts section to higher position on page

We've been getting a lot of feedback lately via slack #welcome channel that the podcasts are influential in motivating newcomers to explore Pants. This change is intended to increase exposure to all three of these clusters of resources.