### PR TITLE
Explicitly use "python" ijson backend (cherry-pick of #17787)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ module = [
     "gnupg",
     "hdrh",
     "hdrh.histogram",
-    "ijson",
+    "ijson.*",
     "pex.*",
     "psutil",
     "setproctitle",

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -7,7 +7,7 @@ import logging
 from dataclasses import dataclass
 from typing import ClassVar
 
-import ijson
+import ijson.backends.python as ijson
 
 from pants.backend.go.util_rules.sdk import GoSdkProcess
 from pants.engine.fs import CreateDigest, Digest, FileContent

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -10,7 +10,7 @@ import os
 from dataclasses import dataclass
 from typing import Any
 
-import ijson
+import ijson.backends.python as ijson
 
 from pants.backend.go.go_sources.load_go_binary import LoadedGoBinary, LoadedGoBinaryRequest
 from pants.backend.go.subsystems.golang import GolangSubsystem


### PR DESCRIPTION
ijson provides a few backends with varying levels of compatibility and performance; which backend is chosen by ijson is system-dependent. Unfortunately the yajl2 backend does not play nicely with the JSON output by go list and throws an IncompleteJSONError when parsing.

As a workaround, we can explicitly use the pure Python backend which is able to parse Go's output correctly.

Closes #17778