### PR TITLE
Ensure we set the region when deploying to S3.

### DIFF
--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -80,6 +80,7 @@ def deploy(scope: str | None = None) -> None:
 
     local_path = "dist/deploy"
     s3_dest = "s3://binaries.pantsbuild.org"
+    s3_dest_region = "us-east-1"
     if scope:
         local_path = f"{local_path}/{scope}"
         s3_dest = f"{s3_dest}/{scope}"
@@ -87,6 +88,8 @@ def deploy(scope: str | None = None) -> None:
     _run(
         [
             "aws",
+            "--region",
+            s3_dest_region,
             "s3",
             "sync",
             # This instructs the sync command to ignore timestamps, which we must do to allow


### PR DESCRIPTION
The AWS CLI requires a region, either explicitly on the command line, via the AWS_DEFAULT_REGION env var, or a default profile.

The publish-tag-to-commit-mapping CI job was failing, apparently due to lack of a region (as established by SSHing to the CI runner and reproducing the problem).

It is not yet clear why publishing to S3 works in the wheel publish jobs, which should have the same issue.