### PR TITLE
Inject a path-safe target spec into `experimental_shell_command` etc processes

### DIFF
--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -126,7 +126,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
 
     return ShellCommandProcessRequest(
         description=description,
-        shell_name=shell_command.address.path_safe_spec,
+        shell_name=shell_command.address.spec,
         interactive=interactive,
         working_directory=working_directory,
         command=command,
@@ -351,7 +351,7 @@ async def run_in_sandbox_request(
 
     process_request = ShellCommandProcessRequest(
         description=description,
-        shell_name=shell_command.address.path_safe_spec,
+        shell_name=shell_command.address.spec,
         interactive=False,
         working_directory=working_directory,
         command=" ".join(shlex.quote(arg) for arg in (run_request.args + extra_args)),

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -84,6 +84,7 @@ class GenerateFilesFromRunInSandboxRequest(GenerateSourcesRequest):
 @dataclass(frozen=True)
 class ShellCommandProcessRequest:
     description: str
+    shell_name: str
     interactive: bool
     working_directory: str | None
     command: str
@@ -125,6 +126,7 @@ async def _prepare_process_request_from_target(shell_command: Target) -> ShellCo
 
     return ShellCommandProcessRequest(
         description=description,
+        shell_name=shell_command.address.path_safe_spec,
         interactive=interactive,
         working_directory=working_directory,
         command=command,
@@ -349,6 +351,7 @@ async def run_in_sandbox_request(
 
     process_request = ShellCommandProcessRequest(
         description=description,
+        shell_name=shell_command.address.path_safe_spec,
         interactive=False,
         working_directory=working_directory,
         command=" ".join(shlex.quote(arg) for arg in (run_request.args + extra_args)),
@@ -426,6 +429,7 @@ async def prepare_shell_command_process(
 ) -> Process:
 
     description = shell_command.description
+    shell_name = shell_command.shell_name
     interactive = shell_command.interactive
     working_directory = shell_command.working_directory
     command = shell_command.command
@@ -485,7 +489,7 @@ async def prepare_shell_command_process(
         )
 
     proc = Process(
-        argv=(bash.path, "-c", boot_script + command),
+        argv=(bash.path, "-c", boot_script + command, shell_name),
         description=f"Running {description}",
         env=command_env,
         input_digest=input_digest,

--- a/src/python/pants/backend/shell/util_rules/shell_command_integration_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_integration_test.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+
+
+def test_passthrough_args() -> None:
+    sources = {
+        "src/BUILD": dedent(
+            """\
+            experimental_run_shell_command(
+                name="args-test",
+                command='echo "cmd name (arg 0)=$0, args:$@"',
+            )
+            """
+        ),
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=pants.backend.shell",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "run",
+            f"{tmpdir}/src:args-test",
+            "--",
+        ] + [f"arg{i}" for i in range(1, 4)]
+        result = run_pants(args)
+        assert "arg1 arg2 arg3" in result.stdout.strip()

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -573,10 +573,10 @@ def test_run_shell_command_request(rule_runner: RuleRunner) -> None:
         assert args[0] in request.args[0]
         assert request.args[1:] == args[1:]
 
-    assert_run_args("test", ("bash", "-c", "some cmd string", "src.test"))
+    assert_run_args("test", ("bash", "-c", "some cmd string", "src:test"))
     assert_run_args(
         "cd-test",
-        ("bash", "-c", "cd 'src/with space'\"'\"'n quote'; some cmd string", "src.cd-test"),
+        ("bash", "-c", "cd 'src/with space'\"'\"'n quote'; some cmd string", "src:cd-test"),
     )
 
 
@@ -611,7 +611,7 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
             'export PATH="$PWD/.bin";'
             "./command.script"
         )
-        + " src.boot-script-test"
+        + " src:boot-script-test"
     )
 
     tools = sorted({"python3_8", "mkdir", "ln"})
@@ -649,7 +649,7 @@ def test_shell_command_boot_script_in_build_root(rule_runner: RuleRunner) -> Non
             'export PATH="$PWD/.bin";'
             "./command.script"
         )
-        + " .boot-script-test"
+        + " //:boot-script-test"
     )
 
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -573,8 +573,11 @@ def test_run_shell_command_request(rule_runner: RuleRunner) -> None:
         assert args[0] in request.args[0]
         assert request.args[1:] == args[1:]
 
-    assert_run_args("test", ("bash", "-c", "some cmd string"))
-    assert_run_args("cd-test", ("bash", "-c", "cd 'src/with space'\"'\"'n quote'; some cmd string"))
+    assert_run_args("test", ("bash", "-c", "some cmd string", "src.test"))
+    assert_run_args(
+        "cd-test",
+        ("bash", "-c", "cd 'src/with space'\"'\"'n quote'; some cmd string", "src.cd-test"),
+    )
 
 
 def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
@@ -608,6 +611,7 @@ def test_shell_command_boot_script(rule_runner: RuleRunner) -> None:
             'export PATH="$PWD/.bin";'
             "./command.script"
         )
+        + " src.boot-script-test"
     )
 
     tools = sorted({"python3_8", "mkdir", "ln"})
@@ -645,6 +649,7 @@ def test_shell_command_boot_script_in_build_root(rule_runner: RuleRunner) -> Non
             'export PATH="$PWD/.bin";'
             "./command.script"
         )
+        + " .boot-script-test"
     )
 
 


### PR DESCRIPTION
This fixes #17981 specifically by making sure that user-supplied passthru args are handled sanely, and indirectly makes `experimental_shell_command` give a better error message if the `command` inherently fails (e.g. if a `tools` is underspecified) by showing the address of the erroring target.

```
$ cat ersc_errors/BUILD
experimental_run_shell_command(
    name="errors",
    command="source please_fail",
)
$ ./pants_from_sources run ersc_errors:errors
ersc_errors:errors: please_fail: No such file or directory
```