### PR TITLE
[python-infer]: allow ignoring unowned imports

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -206,10 +206,10 @@ def _collect_imports_info(
     )
 
 
-def _filter_unowned_imports(
+def _remove_ignored_imports(
     unowned_imports: frozenset[str], ignored_paths: tuple[str, ...]
 ) -> frozenset[str]:
-    """Filter unowned imports given a list of paths to ignore.
+    """Remove unowned imports given a list of paths to ignore.
 
     E.g. having
     ```
@@ -470,8 +470,8 @@ async def infer_python_dependencies_via_source(
         ResolvedParsedPythonDependenciesRequest(request.field_set, parsed_dependencies, resolve),
     )
     import_deps, unowned_imports = _collect_imports_info(resolved_dependencies.resolve_results)
-    unowned_imports = _filter_unowned_imports(
-        unowned_imports, python_infer_subsystem.ignore_unowned_imports
+    unowned_imports = _remove_ignored_imports(
+        unowned_imports, python_infer_subsystem.ignored_unowned_imports
     )
 
     asset_deps, unowned_assets = _collect_imports_info(resolved_dependencies.assets)

--- a/src/python/pants/backend/python/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/python/dependency_inference/subsystem.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pants.option.option_types import BoolOption, EnumOption, IntOption
+from pants.option.option_types import BoolOption, EnumOption, IntOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import bin_name
 from pants.util.strutil import softwrap
@@ -164,5 +164,29 @@ class PythonInferSubsystem(Subsystem):
             symbols (because of repeated first-party module paths or overlapping
             requirements.txt) and you want to resolve the ambiguity locally in each project.
             """
+        ),
+    )
+
+    ignore_unowned_imports = StrListOption(
+        default=[],
+        help=softwrap(
+            """Unowned imports that should be ignored.
+
+            If there are any unowned import statements and adding the `# pants: no-infer-dep`
+            to the lines of the import is impractical, you can instead provide a list of imports
+            that Pants should ignore. You can declare a specific import or a path to a package
+            if you would like any of the package imports to be ignored.
+
+            For example, you could ignore all the following imports of the code
+
+                ```
+                import src.generated.app
+                from src.generated.app import load
+                from src.generated.app import start
+                from src.generated.client import connect
+                ```
+
+            by setting `ignore-unowned-imports=["src.generated.app", "src.generated.client.connect"]`.
+        """
         ),
     )

--- a/src/python/pants/backend/python/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/python/dependency_inference/subsystem.py
@@ -167,7 +167,7 @@ class PythonInferSubsystem(Subsystem):
         ),
     )
 
-    ignore_unowned_imports = StrListOption(
+    ignored_unowned_imports = StrListOption(
         default=[],
         help=softwrap(
             """Unowned imports that should be ignored.
@@ -186,7 +186,7 @@ class PythonInferSubsystem(Subsystem):
                 from src.generated.client import connect
                 ```
 
-            by setting `ignore-unowned-imports=["src.generated.app", "src.generated.client.connect"]`.
+            by setting `ignored-unowned-imports=["src.generated.app", "src.generated.client.connect"]`.
         """
         ),
     )


### PR DESCRIPTION
This PR adds a new option to the `[python-infer]` section.

This is to let users provide unowned imports that should be ignored.

If there are any unowned import statements and adding the `# pants: no-infer-dep`
to the lines of the import is impractical, you can instead provide a list of imports
that Pants should ignore. You can declare a specific import or a path to a package
if you would like any of the package imports to be ignored.

For example, you could ignore all the following imports of the code

    import src.generated.app
    from src.generated.app import load
    from src.generated.app import start
    from src.generated.client import connect

by setting `ignored-unowned-imports=["src.generated.app", "src.generated.client.connect"]`.

---

By default, this has no impact on existing users of Pants as there are no imports to be ignored, so behavior will stay the same. Only if a user has provided a list of imports that will be ignored, then it will impact the dependency reference and what's reported as unowned imports.

---

This should be helpful for the following use cases:
* when there is a single problematic import that is known to cause problems with inference but it's being imported in a hundred of places and adding `# pants: no-infer-dep` is not feasible; before this PR, the current implementation forces the users who don't know (or don't need to care) about Pants to add some comments, potentially extending any existing comments they may have set on the import statements to satisfy other tools (e.g. `pylint`)
* when there are lots of import statements that consume generated Python code (a package or a module); e.g. a file is not under version control (and is Git ignored), is generated locally in the dev environment and in CI (using ad hoc tooling, not Pants) and Pants is not able to see it during dependency inference. Again, having dozens of `# pants: no-infer-dep` comments is less appealing when one can set it just once in the configuration file.

