### PR TITLE
go: check for out of range indices in asm check helper

### DIFF
--- a/src/python/pants/backend/go/go_sources/asm_check/asm_check.go
+++ b/src/python/pants/backend/go/go_sources/asm_check/asm_check.go
@@ -26,15 +26,17 @@ func maybeGolangAssembly(filename string) (bool, error) {
 }
 
 func main() {
-	for _, arg := range os.Args {
-		found, err := maybeGolangAssembly(arg)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
-			os.Exit(1)
-		}
+	if len(os.Args) >= 2 {
+		for _, arg := range os.Args[1:] {
+			found, err := maybeGolangAssembly(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+				os.Exit(1)
+			}
 
-		if found {
-			fmt.Printf("%s\n", arg)
+			if found {
+				fmt.Printf("%s\n", arg)
+			}
 		}
 	}
 }


### PR DESCRIPTION
I was seeing some segfaults with the assembly checker helper. Add an index check to ensure we don't access out of bounds indices.