### PR TITLE
use Go 1.19.x in CI

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -459,7 +459,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"
@@ -531,7 +531,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"
@@ -603,7 +603,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -441,7 +441,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - env: {}
       name: Build wheels
       run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
@@ -509,7 +509,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
@@ -578,7 +578,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - env:
         ARCHFLAGS: -arch arm64
       name: Build wheels
@@ -813,7 +813,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"
@@ -887,7 +887,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"
@@ -961,7 +961,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.17.1
+        go-version: 1.19.5
     - if: runner.os == 'Linux'
       name: Download Apache `thrift` binary (Linux)
       run: 'mkdir -p "${HOME}/.thrift"

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -238,7 +238,7 @@ def install_go() -> Step:
     return {
         "name": "Install Go",
         "uses": "actions/setup-go@v3",
-        "with": {"go-version": "1.17.1"},
+        "with": {"go-version": "1.19.5"},
     }
 
 


### PR DESCRIPTION
Use the latest Go version in CI, specifically 1.19.5.

This is motivated by staying current but also to avoid a weird runtime error seen in another PR: https://github.com/pantsbuild/pants/actions/runs/4020543751/jobs/6908852674#step:11:869
