### PR TITLE
Add support for `fmt` cue files.

### DIFF
--- a/src/python/pants/backend/cue/goals/fix.py
+++ b/src/python/pants/backend/cue/goals/fix.py
@@ -2,72 +2,36 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any
-
+from pants.backend.cue.rules import _run_cue
 from pants.backend.cue.subsystem import Cue
-from pants.backend.cue.target_types import CuePackageSourcesField
-from pants.core.goals.lint import LintResult, LintTargetsRequest
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.backend.cue.target_types import CueFieldSet
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import FieldSet
+from pants.engine.rules import collect_rules, rule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize
 
 
-@dataclass(frozen=True)
-class CueFieldSet(FieldSet):
-    required_fields = (CuePackageSourcesField,)
-
-    sources: CuePackageSourcesField
-
-
-class CueLintRequest(LintTargetsRequest):
+class CueFmtRequest(FmtTargetsRequest):
     field_set_type = CueFieldSet
     tool_subsystem = Cue
     partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
-def generate_argv(*args: str, sources: SourceFiles, cue: Cue) -> tuple[str, ...]:
-    return args + cue.args + sources.snapshot.files
-
-
-@rule(desc="Lint CUE files", level=LogLevel.DEBUG)
-async def run_cue_vet(
-    request: CueLintRequest.Batch[CueFieldSet, Any],
-    cue: Cue,
-    platform: Platform,
-) -> LintResult:
-    downloaded_cue, sources = await MultiGet(
-        Get(DownloadedExternalTool, ExternalToolRequest, cue.get_request(platform)),
-        Get(
-            SourceFiles,
-            SourceFilesRequest(
-                sources_fields=[field_set.sources for field_set in request.elements]
-            ),
-        ),
+@rule(desc="Format with cue", level=LogLevel.DEBUG)
+async def run_cue_fmt(request: CueFmtRequest.Batch, cue: Cue, platform: Platform) -> FmtResult:
+    process_result = await _run_cue(
+        "fmt",
+        cue=cue,
+        snapshot=request.snapshot,
+        platform=platform,
+        output_files=request.snapshot.files,
     )
-    input_digest = await Get(Digest, MergeDigests((downloaded_cue.digest, sources.snapshot.digest)))
-    process_result = await Get(
-        FallibleProcessResult,
-        Process(
-            argv=[downloaded_cue.exe, *generate_argv("vet", sources=sources, cue=cue)],
-            input_digest=input_digest,
-            description=f"Run `cue vet` on {pluralize(len(sources.snapshot.files), 'file')}.",
-            level=LogLevel.DEBUG,
-        ),
-    )
-
-    return LintResult.create(request, process_result)
+    return await FmtResult.create(request, process_result)
 
 
 def rules():
     return [
         *collect_rules(),
-        *CueLintRequest.rules(),
+        *CueFmtRequest.rules(),
     ]

--- a/src/python/pants/backend/cue/goals/lint.py
+++ b/src/python/pants/backend/cue/goals/lint.py
@@ -1,0 +1,42 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from typing import Any
+
+from pants.backend.cue.rules import _run_cue
+from pants.backend.cue.subsystem import Cue
+from pants.backend.cue.target_types import CueFieldSet
+from pants.core.goals.lint import LintResult, LintTargetsRequest
+from pants.core.util_rules.partitions import PartitionerType
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.platform import Platform
+from pants.engine.rules import Get, collect_rules, rule
+from pants.util.logging import LogLevel
+
+
+class CueLintRequest(LintTargetsRequest):
+    field_set_type = CueFieldSet
+    tool_subsystem = Cue
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
+
+
+@rule(desc="Lint with cue", level=LogLevel.DEBUG)
+async def run_cue_vet(
+    request: CueLintRequest.Batch[CueFieldSet, Any],
+    cue: Cue,
+    platform: Platform,
+) -> LintResult:
+    sources = await Get(
+        SourceFiles,
+        SourceFilesRequest(sources_fields=[field_set.sources for field_set in request.elements]),
+    )
+    process_result = await _run_cue("vet", cue=cue, snapshot=sources.snapshot, platform=platform)
+    return LintResult.create(request, process_result)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *CueLintRequest.rules(),
+    ]

--- a/src/python/pants/backend/cue/goals/lint_test.py
+++ b/src/python/pants/backend/cue/goals/lint_test.py
@@ -1,0 +1,115 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from collections import namedtuple
+from textwrap import dedent
+from typing import Any, Iterable
+
+import pytest
+
+from pants.backend.cue.goals.lint import CueLintRequest, rules
+from pants.backend.cue.target_types import CueFieldSet, CuePackageTarget
+from pants.core.goals.lint import LintResult, Partitions
+from pants.core.util_rules import external_tool, source_files
+from pants.engine.addresses import AddressInput
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *rules(),
+            *external_tool.rules(),
+            *source_files.rules(),
+            QueryRule(Partitions, [CueLintRequest.PartitionRequest]),
+            QueryRule(LintResult, [CueLintRequest.Batch]),
+        ],
+        target_types=[CuePackageTarget],
+    )
+
+
+def run_cue(
+    rule_runner: RuleRunner, addresses: Iterable[str], *, extra_args: list[str] | None = None
+) -> tuple[LintResult, ...]:
+    targets = [
+        rule_runner.get_target(
+            AddressInput.parse(address, description_of_origin="cue tests").file_to_address()
+        )
+        for address in addresses
+    ]
+    rule_runner.set_options(
+        extra_args or (),
+        # env_inherit={"PATH"},
+    )
+    partitions = rule_runner.request(
+        Partitions[CueFieldSet, Any],
+        [CueLintRequest.PartitionRequest(tuple(CueFieldSet.create(tgt) for tgt in targets))],
+    )
+    assert len(partitions) == 1
+    results = []
+    for partition in partitions:
+        result = rule_runner.request(
+            LintResult,
+            [CueLintRequest.Batch("cue", partition.elements, partition.metadata)],
+        )
+        results.append(result)
+    return tuple(results)
+
+
+ExpectedResult = namedtuple("ExpectedResult", "exit_code, stdout, stderr", defaults=("", ""))
+
+
+def assert_results(results: tuple[LintResult, ...], *expected_results: ExpectedResult) -> None:
+    assert len(results) == len(expected_results)
+    for result, expected in zip(results, expected_results):
+        assert result.exit_code == expected.exit_code
+        assert result.stdout == expected.stdout
+        assert result.stderr == expected.stderr
+
+
+def test_simple_cue_vet(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": "cue_package()",
+            "src/example.cue": dedent(
+                """\
+                package example
+
+                config: "value"
+                """
+            ),
+        }
+    )
+    assert_results(
+        run_cue(rule_runner, ["src/example.cue"]),
+        ExpectedResult(0),
+    )
+
+
+def test_simple_cue_vet_issue(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": "cue_package()",
+            "src/example.cue": dedent(
+                """\
+                package example
+
+                config: "value"
+                config: 42
+                """
+            ),
+        }
+    )
+    assert_results(
+        run_cue(rule_runner, ["src/example.cue"]),
+        ExpectedResult(
+            1,
+            stderr=(
+                'config: conflicting values "value" and 42 (mismatched types string and int):\n'
+                "    ./src/example.cue:3:9\n"
+                "    ./src/example.cue:4:9\n"
+            ),
+        ),
+    )

--- a/src/python/pants/backend/cue/rules.py
+++ b/src/python/pants/backend/cue/rules.py
@@ -1,7 +1,37 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.cue.goals import fix
+from __future__ import annotations
+
+from pants.backend.cue.subsystem import Cue
+from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
+from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.engine.platform import Platform
+from pants.engine.process import FallibleProcessResult, Process
+from pants.engine.rules import Get, rule_helper
+from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
 
 
-def rules():
-    return [*fix.rules()]
+def generate_argv(*args: str, files: tuple[str, ...], cue: Cue) -> tuple[str, ...]:
+    return args + cue.args + files
+
+
+@rule_helper
+async def _run_cue(
+    *args: str, cue: Cue, snapshot: Snapshot, platform: Platform, **kwargs
+) -> FallibleProcessResult:
+    downloaded_cue = await Get(
+        DownloadedExternalTool, ExternalToolRequest, cue.get_request(platform)
+    )
+    input_digest = await Get(Digest, MergeDigests((downloaded_cue.digest, snapshot.digest)))
+    process_result = await Get(
+        FallibleProcessResult,
+        Process(
+            argv=[downloaded_cue.exe, *generate_argv(*args, files=snapshot.files, cue=cue)],
+            input_digest=input_digest,
+            description=f"Run `cue {args[0]}` on {pluralize(len(snapshot.files), 'file')}.",
+            level=LogLevel.DEBUG,
+            **kwargs,
+        ),
+    )
+    return process_result

--- a/src/python/pants/backend/cue/target_types.py
+++ b/src/python/pants/backend/cue/target_types.py
@@ -2,8 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    FieldSet,
     MultipleSourcesField,
     Target,
     generate_multiple_sources_field_help_message,
@@ -34,3 +37,10 @@ class CuePackageTarget(Target):
         CUE docs: https://cuelang.org/docs/concepts/packages/
         """
     )
+
+
+@dataclass(frozen=True)
+class CueFieldSet(FieldSet):
+    required_fields = (CuePackageSourcesField,)
+
+    sources: CuePackageSourcesField

--- a/src/python/pants/backend/experimental/cue/register.py
+++ b/src/python/pants/backend/experimental/cue/register.py
@@ -1,15 +1,16 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.cue.rules import rules as cue_rules
+from pants.backend.cue.goals import fix, lint
 from pants.backend.cue.target_types import CuePackageTarget
 
 
 def target_types():
-    return [
-        CuePackageTarget,
-    ]
+    return (CuePackageTarget,)
 
 
 def rules():
-    return cue_rules()
+    return (
+        *fix.rules(),
+        *lint.rules(),
+    )


### PR DESCRIPTION
Add `cue fmt` support.

This includes some refactoring as I had placed the cue lint implementation in `fix.py` was a bit off, moving the `lint` implementation to `goals/lint.py` instead.