### PR TITLE
upgrade Rust to v1.67.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -134,7 +134,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -249,7 +249,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -139,7 +139,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -256,7 +256,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -488,7 +488,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 
@@ -557,7 +557,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.66.1-*
+        path: '~/.rustup/toolchains/1.67.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.66.1"
+channel = "1.67.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/async_value/src/tests.rs
+++ b/src/rust/engine/async_value/src/tests.rs
@@ -4,7 +4,6 @@ use crate::AsyncValue;
 
 use std::time::Duration;
 
-use tokio;
 use tokio::time::sleep;
 
 #[tokio::test]

--- a/src/rust/engine/cache/src/lib.rs
+++ b/src/rust/engine/cache/src/lib.rs
@@ -65,7 +65,7 @@ impl PersistentCache {
       lease_time,
       shard_count,
     )
-    .map_err(|err| format!("Could not initialize store for cache: {:?}", err))?;
+    .map_err(|err| format!("Could not initialize store for cache: {err:?}"))?;
 
     Ok(Self { store })
   }

--- a/src/rust/engine/client/src/client.rs
+++ b/src/rust/engine/client/src/client.rs
@@ -34,7 +34,7 @@ pub async fn execute_command(
     "PANTSD_RUNTRACKER_CLIENT_START_TIME".to_owned(),
     start
       .duration_since(SystemTime::UNIX_EPOCH)
-      .map_err(|e| format!("Failed to determine current time: {err}", err = e))?
+      .map_err(|e| format!("Failed to determine current time: {e}"))?
       .as_secs_f64()
       .to_string(),
   ));
@@ -62,7 +62,7 @@ pub async fn execute_command(
     if connection_settings.dynamic_ui {
       if let Ok(path) = nix::unistd::ttyname(*raw_fd) {
         env.push((
-          format!("NAILGUN_TTY_PATH_{fd}", fd = raw_fd),
+          format!("NAILGUN_TTY_PATH_{raw_fd}"),
           path.display().to_string(),
         ));
       }

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -79,8 +79,8 @@ async fn execute(start: SystemTime) -> Result<i32, String> {
   })?;
   env_logger::init_from_env(env_logger::Env::new().filter_or("__PANTS_LEVEL__", level.as_ref()));
 
-  let working_dir = env::current_dir()
-    .map_err(|e| format!("Could not detect current working directory: {err}", err = e))?;
+  let working_dir =
+    env::current_dir().map_err(|e| format!("Could not detect current working directory: {e}"))?;
   let pantsd_settings = find_pantsd(&working_dir, &options_parser)?;
   let env = env::vars().collect::<Vec<(_, _)>>();
   let argv = env::args().collect::<Vec<_>>();
@@ -147,7 +147,7 @@ async fn main() {
   let start = SystemTime::now();
   match execute(start).await {
     Err(err) => {
-      eprintln!("{}", err);
+      eprintln!("{err}");
       // We use this exit code to indicate an error running pants via the nailgun protocol to
       // differentiate from a successful nailgun protocol session.
       std::process::exit(EX_TEMPFAIL);

--- a/src/rust/engine/client/src/pantsd.rs
+++ b/src/rust/engine/client/src/pantsd.rs
@@ -16,7 +16,7 @@ pub(crate) struct Metadata {
 
 impl Metadata {
   pub(crate) fn mount<P: AsRef<Path>>(directory: P) -> Result<Metadata, String> {
-    let info = uname::uname().map_err(|e| format!("{}", e))?;
+    let info = uname::uname().map_err(|e| format!("{e}"))?;
     let host_hash = Sha256::new()
       .chain(&info.sysname)
       .chain(&info.nodename)
@@ -28,7 +28,7 @@ impl Metadata {
     const HOST_FINGERPRINT_LENGTH: usize = 12;
     let mut hex_digest = String::with_capacity(HOST_FINGERPRINT_LENGTH);
     for byte in host_hash {
-      fmt::Write::write_fmt(&mut hex_digest, format_args!("{:02x}", byte)).unwrap();
+      fmt::Write::write_fmt(&mut hex_digest, format_args!("{byte:02x}")).unwrap();
       if hex_digest.len() >= HOST_FINGERPRINT_LENGTH {
         break;
       }
@@ -140,7 +140,7 @@ pub fn probe(working_dir: &Path, metadata_dir: &Path) -> Result<u16, String> {
       // wrapped).
       if std::mem::discriminant(&ProcessStatus::Zombie) == std::mem::discriminant(&process.status())
       {
-        return Err(format!("The pantsd at pid {pid} is a zombie.", pid = pid));
+        return Err(format!("The pantsd at pid {pid} is a zombie."));
       }
       let expected_process_name_prefix = pantsd_metadata.process_name()?;
       let actual_argv0 = {
@@ -158,11 +158,8 @@ pub fn probe(working_dir: &Path, metadata_dir: &Path) -> Result<u16, String> {
         Err(format!(
           "\
           The process with pid {pid} is not pantsd. Expected a process name matching \
-          {expected_name} but is {actual_name}.\
-          ",
-          pid = pid,
-          expected_name = expected_process_name_prefix,
-          actual_name = actual_argv0
+          {expected_process_name_prefix} but is {actual_argv0}.\
+          "
         ))
       }
     }

--- a/src/rust/engine/client/src/pantsd_testing.rs
+++ b/src/rust/engine/client/src/pantsd_testing.rs
@@ -27,13 +27,7 @@ pub(crate) fn launch_pantsd() -> (BuildRoot, TempDir) {
     .stderr(Stdio::inherit());
   let result = cmd
     .output()
-    .map_err(|e| {
-      format!(
-        "Problem running command {command:?}: {err}",
-        command = cmd,
-        err = e
-      )
-    })
+    .map_err(|e| format!("Problem running command {cmd:?}: {e}"))
     .unwrap();
   assert_eq!(Some(0), result.status.code());
   assert_eq!(

--- a/src/rust/engine/concrete_time/src/lib.rs
+++ b/src/rust/engine/concrete_time/src/lib.rs
@@ -133,8 +133,7 @@ impl TimeSpan {
         duration: duration.into(),
       }),
       None => Err(format!(
-        "Got negative {} time: {:?} - {:?}",
-        time_span_description, end, start
+        "Got negative {time_span_description} time: {end:?} - {start:?}"
       )),
     }
   }

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -82,13 +82,13 @@ pub fn digest_from_filepath(str: &str) -> Result<Digest, String> {
   let mut parts = str.split('-');
   let fingerprint_str = parts
     .next()
-    .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?;
+    .ok_or_else(|| format!("Invalid digest: {str} wasn't of form fingerprint-size"))?;
   let fingerprint = Fingerprint::from_hex_string(fingerprint_str)?;
   let size_bytes = parts
     .next()
-    .ok_or_else(|| format!("Invalid digest: {} wasn't of form fingerprint-size", str))?
+    .ok_or_else(|| format!("Invalid digest: {str} wasn't of form fingerprint-size"))?
     .parse::<usize>()
-    .map_err(|err| format!("Invalid digest; size {} not a number: {}", str, err))?;
+    .map_err(|err| format!("Invalid digest; size {str} not a number: {err}"))?;
   Ok(Digest::new(fingerprint, size_bytes))
 }
 
@@ -799,7 +799,7 @@ async fn main() {
     F: Fn() -> SignalKind,
   {
     SignalStream::new(
-      signal(install_fn()).unwrap_or_else(|_| panic!("Failed to install SIG{:?} handler", sig)),
+      signal(install_fn()).unwrap_or_else(|_| panic!("Failed to install SIG{sig:?} handler")),
     )
     .map(move |_| Some(sig))
   }

--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -1198,7 +1198,7 @@ fn first_path_component_to_name(path: &Path) -> Result<Name, String> {
   let name = first_path_component
     .as_os_str()
     .to_str()
-    .ok_or_else(|| format!("{:?} is not representable in UTF8", first_path_component))?;
+    .ok_or_else(|| format!("{first_path_component:?} is not representable in UTF8"))?;
   Ok(Name(Intern::from(name)))
 }
 

--- a/src/rust/engine/fs/src/directory_tests.rs
+++ b/src/rust/engine/fs/src/directory_tests.rs
@@ -13,7 +13,7 @@ fn make_tree(path_stats: Vec<TypedPath>) -> DigestTrie {
   file_digests.extend(
     path_stats
       .iter()
-      .map(|path| (PathBuf::from(path.to_path_buf()), EMPTY_DIGEST)),
+      .map(|path| (path.to_path_buf(), EMPTY_DIGEST)),
   );
 
   DigestTrie::from_unique_paths(path_stats, &file_digests).unwrap()
@@ -278,14 +278,14 @@ fn assert_walk(tree: &DigestTrie, expected_filenames: Vec<String>, expected_dirn
     filenames,
     expected_filenames
       .iter()
-      .map(|s| PathBuf::from(s))
+      .map(PathBuf::from)
       .collect::<Vec<_>>()
   );
   assert_eq!(
     dirnames,
     expected_dirnames
       .iter()
-      .map(|s| PathBuf::from(s))
+      .map(PathBuf::from)
       .collect::<Vec<_>>()
   );
 }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -127,7 +127,7 @@ impl PathGlob {
     for component in Path::new(pattern).components() {
       let part = match component {
         Component::Prefix(..) | Component::RootDir => {
-          return Err(format!("Absolute paths not supported: {:?}", pattern));
+          return Err(format!("Absolute paths not supported: {pattern:?}"));
         }
         Component::CurDir => continue,
         c => c.as_os_str(),
@@ -160,7 +160,7 @@ impl PathGlob {
       .into_iter()
       .map(|part| {
         Pattern::new(&part.to_string_lossy())
-          .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", filespec, e))
+          .map_err(|e| format!("Could not parse {filespec:?} as a glob: {e:?}"))
       })
       .collect::<Result<Vec<_>, _>>()?;
 
@@ -233,8 +233,7 @@ impl PathGlob {
         let mut symbolic_path = symbolic_path_parent;
         symbolic_path.extend(parts.iter().map(Pattern::as_str));
         return Err(format!(
-          "Globs may not traverse outside of the buildroot: {:?}",
-          symbolic_path,
+          "Globs may not traverse outside of the buildroot: {symbolic_path:?}",
         ));
       }
       symbolic_path_parent.push(Path::new(&Component::ParentDir));
@@ -334,7 +333,7 @@ impl FilespecMatcher {
         PathGlob::normalize_pattern(glob).and_then(|components| {
           let normalized_pattern: PathBuf = components.into_iter().collect();
           Pattern::new(normalized_pattern.to_str().unwrap())
-            .map_err(|e| format!("Could not parse {:?} as a glob: {:?}", glob, e))
+            .map_err(|e| format!("Could not parse {glob:?} as a glob: {e:?}"))
         })
       })
       .collect::<Result<Vec<_>, String>>()?;
@@ -569,14 +568,14 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
         let prefix = format!("Unmatched glob{}", if single_glob { "" } else { "s" });
         let origin = match &strict_match_behavior {
           StrictGlobMatching::Warn(description) | StrictGlobMatching::Error(description) => {
-            format!(" from {}: ", description)
+            format!(" from {description}: ")
           }
           _ => ": ".to_string(),
         };
         let unmatched_globs = if single_glob {
           format!("{:?}", non_matching_inputs[0])
         } else {
-          format!("{:?}", non_matching_inputs)
+          format!("{non_matching_inputs:?}")
         };
         let exclude_patterns = exclude.exclude_patterns();
         let excludes_portion = if exclude_patterns.is_empty() {
@@ -586,7 +585,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
           if single_exclude {
             format!(", exclude: {:?}", exclude_patterns[0])
           } else {
-            format!(", excludes: {:?}", exclude_patterns)
+            format!(", excludes: {exclude_patterns:?}")
           }
         };
         let msg = format!(

--- a/src/rust/engine/fs/src/glob_matching_tests.rs
+++ b/src/rust/engine/fs/src/glob_matching_tests.rs
@@ -11,7 +11,7 @@ fn path_globs_create_distinguishes_between_includes_and_excludes() {
 
   let mut glob_inputs: Vec<String> = vec![];
   glob_inputs.extend_from_slice(&include_globs);
-  glob_inputs.extend(parsed_exclude_globs.iter().map(|glob| format!("!{}", glob)));
+  glob_inputs.extend(parsed_exclude_globs.iter().map(|glob| format!("!{glob}")));
 
   let pg = PathGlobs::new(
     glob_inputs,

--- a/src/rust/engine/fs/store/src/immutable_inputs.rs
+++ b/src/rust/engine/fs/store/src/immutable_inputs.rs
@@ -39,12 +39,7 @@ impl ImmutableInputs {
     let workdir = tempfile::Builder::new()
       .prefix("immutable_inputs")
       .tempdir_in(base)
-      .map_err(|e| {
-        format!(
-          "Failed to create temporary directory for immutable inputs: {}",
-          e
-        )
-      })?;
+      .map_err(|e| format!("Failed to create temporary directory for immutable inputs: {e}"))?;
     Ok(Self(Arc::new(Inner {
       store,
       workdir,
@@ -98,8 +93,7 @@ impl ImmutableInputs {
         let chroot = TempDir::new_in(self.0.workdir.path()).map_err(|e| {
           format!(
             "Failed to create a temporary directory for materialization of immutable input \
-          digest {:?}: {}",
-            digest, e
+          digest {digest:?}: {e}"
           )
         })?;
 
@@ -162,8 +156,7 @@ impl ImmutableInputs {
         let chroot = TempDir::new_in(self.0.workdir.path()).map_err(|e| {
           format!(
             "Failed to create a temporary directory for materialization of immutable input \
-            digest {:?}: {}",
-            digest, e
+            digest {digest:?}: {e}"
           )
         })?;
 

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -265,8 +265,7 @@ impl RemoteStore {
           Ok(())
         } else {
           Err(StoreError::Unclassified(format!(
-            "CAS gave wrong digest: expected {:?}, got {:?}",
-            digest, stored_digest
+            "CAS gave wrong digest: expected {digest:?}, got {stored_digest:?}"
           )))
         }
       })
@@ -679,10 +678,7 @@ impl Store {
         // and only verify in debug mode, as it's slightly expensive.
         move |bytes: &[u8]| {
           let directory = remexec::Directory::decode(bytes).map_err(|e| {
-            format!(
-              "LMDB corruption: Directory bytes for {:?} were not valid: {:?}",
-              digest, e
-            )
+            format!("LMDB corruption: Directory bytes for {digest:?} were not valid: {e:?}")
           })?;
           if cfg!(debug_assertions) {
             protos::verify_directory_canonical(digest, &directory)?;
@@ -693,10 +689,7 @@ impl Store {
         // into our local store.
         move |bytes: Bytes| {
           let directory = remexec::Directory::decode(bytes).map_err(|e| {
-            format!(
-              "CAS returned Directory proto for {:?} which was not valid: {:?}",
-              digest, e
-            )
+            format!("CAS returned Directory proto for {digest:?} which was not valid: {e:?}")
           })?;
           protos::verify_directory_canonical(digest, &directory)?;
           Ok(())
@@ -876,10 +869,7 @@ impl Store {
     match maybe_bytes {
       Some(bytes) => Ok(remote.store_bytes(bytes).await?),
       None => Err(StoreError::MissingDigest(
-        format!(
-          "Failed to upload {entry_type:?}: Not found in local store",
-          entry_type = entry_type,
-        ),
+        format!("Failed to upload {entry_type:?}: Not found in local store",),
         digest,
       )),
     }
@@ -896,21 +886,13 @@ impl Store {
         let result = local
           .load_bytes_with(entry_type, digest, move |bytes| {
             buffer.write_all(bytes).map_err(|e| {
-              format!(
-                "Failed to write {entry_type:?} {digest:?} to temporary buffer: {err}",
-                entry_type = entry_type,
-                digest = digest,
-                err = e
-              )
+              format!("Failed to write {entry_type:?} {digest:?} to temporary buffer: {e}")
             })
           })
           .await?;
         match result {
           None => Err(StoreError::MissingDigest(
-            format!(
-              "Failed to upload {entry_type:?}: Not found in local store",
-              entry_type = entry_type,
-            ),
+            format!("Failed to upload {entry_type:?}: Not found in local store",),
             digest,
           )),
           Some(Err(err)) => Err(err.into()),
@@ -1058,7 +1040,7 @@ impl Store {
 
     match remote.store.load_bytes(tree_digest).await? {
       Some(b) => {
-        let tree = Tree::decode(b).map_err(|e| format!("protobuf decode error: {:?}", e))?;
+        let tree = Tree::decode(b).map_err(|e| format!("protobuf decode error: {e:?}"))?;
         let trie = DigestTrie::try_from(tree)?;
         Ok(Some(trie.into()))
       }
@@ -1100,7 +1082,7 @@ impl Store {
         }
         Ok(())
       }
-      Err(err) => Err(format!("Garbage collection failed: {:?}", err)),
+      Err(err) => Err(format!("Garbage collection failed: {err:?}")),
     }
   }
 
@@ -1451,7 +1433,7 @@ impl Store {
         let content = store
           .load_file_bytes_with(digest, Bytes::copy_from_slice)
           .await
-          .map_err(|e| e.enrich(&format!("Couldn't find file contents for {:?}", path)))?;
+          .map_err(|e| e.enrich(&format!("Couldn't find file contents for {path:?}")))?;
         Ok(FileContent {
           path,
           content,

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -110,7 +110,7 @@ impl ByteStore {
       dbs?
         .lease(digest.hash)
         .await
-        .map_err(|err| format!("Error leasing digest {:?}: {}", digest, err))?;
+        .map_err(|err| format!("Error leasing digest {digest:?}: {err}"))?;
     }
     Ok(())
   }
@@ -171,7 +171,7 @@ impl ByteStore {
             used_bytes -= aged_fingerprint.size_bytes;
             txn.commit()
           })
-          .map_err(|err| format!("Error garbage collecting: {}", err))?;
+          .map_err(|err| format!("Error garbage collecting: {err}"))?;
       }
     }
 
@@ -193,16 +193,16 @@ impl ByteStore {
       EntryType::Directory => self.inner.directory_dbs.clone(),
     };
 
-    for &(ref env, ref database, ref lease_database) in &database?.all_lmdbs() {
+    for (env, database, lease_database) in &database?.all_lmdbs() {
       let txn = env
         .begin_ro_txn()
-        .map_err(|err| format!("Error beginning transaction to garbage collect: {}", err))?;
+        .map_err(|err| format!("Error beginning transaction to garbage collect: {err}"))?;
       let mut cursor = txn
         .open_ro_cursor(*database)
-        .map_err(|err| format!("Failed to open lmdb read cursor: {}", err))?;
+        .map_err(|err| format!("Failed to open lmdb read cursor: {err}"))?;
       for key_res in cursor.iter() {
         let (key, bytes) =
-          key_res.map_err(|err| format!("Failed to advance lmdb read cursor: {}", err))?;
+          key_res.map_err(|err| format!("Failed to advance lmdb read cursor: {err}"))?;
         *used_bytes += bytes.len();
 
         // Random access into the lease_database is slower than iterating, but hopefully garbage
@@ -218,7 +218,7 @@ impl ByteStore {
           })
           .unwrap_or_else(|e| match e {
             NotFound => 0,
-            e => panic!("Error reading lease, probable lmdb corruption: {:?}", e),
+            e => panic!("Error reading lease, probable lmdb corruption: {e:?}"),
           });
 
         let leased_until = time::UNIX_EPOCH + Duration::from_secs(lease_until_unix_timestamp);
@@ -436,16 +436,16 @@ impl ByteStore {
       EntryType::Directory => self.inner.directory_dbs.clone(),
     };
     let mut digests = vec![];
-    for &(ref env, ref database, ref _lease_database) in &database?.all_lmdbs() {
+    for (env, database, _lease_database) in &database?.all_lmdbs() {
       let txn = env
         .begin_ro_txn()
-        .map_err(|err| format!("Error beginning transaction to garbage collect: {}", err))?;
+        .map_err(|err| format!("Error beginning transaction to garbage collect: {err}"))?;
       let mut cursor = txn
         .open_ro_cursor(*database)
-        .map_err(|err| format!("Failed to open lmdb read cursor: {}", err))?;
+        .map_err(|err| format!("Failed to open lmdb read cursor: {err}"))?;
       for key_res in cursor.iter() {
         let (key, bytes) =
-          key_res.map_err(|err| format!("Failed to advance lmdb read cursor: {}", err))?;
+          key_res.map_err(|err| format!("Failed to advance lmdb read cursor: {err}"))?;
         let v = VersionedFingerprint::from_bytes_unsafe(key);
         let fingerprint = v.get_fingerprint();
         digests.push(Digest::new(fingerprint, bytes.len()));

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -275,8 +275,7 @@ async fn garbage_collect_remove_one_of_two_files_no_leases() {
   assert_eq!(
     1,
     entries.iter().filter(|maybe| maybe.is_some()).count(),
-    "Want one Some but got: {:?}",
-    entries
+    "Want one Some but got: {entries:?}"
   );
 }
 
@@ -310,14 +309,12 @@ async fn garbage_collect_remove_both_files_no_leases() {
   assert_eq!(
     load_bytes(&store, EntryType::File, digest_1).await,
     Ok(None),
-    "Should have garbage collected {:?}",
-    fingerprint_1
+    "Should have garbage collected {fingerprint_1:?}"
   );
   assert_eq!(
     load_bytes(&store, EntryType::File, digest_2).await,
     Ok(None),
-    "Should have garbage collected {:?}",
-    fingerprint_2
+    "Should have garbage collected {fingerprint_2:?}"
   );
 }
 
@@ -354,8 +351,7 @@ async fn garbage_collect_remove_one_of_two_directories_no_leases() {
   assert_eq!(
     1,
     entries.iter().filter(|maybe| maybe.is_some()).count(),
-    "Want one Some but got: {:?}",
-    entries
+    "Want one Some but got: {entries:?}"
   );
 }
 
@@ -485,8 +481,7 @@ async fn garbage_collect_and_compact() {
   let size = get_directory_size(dir.path());
   assert!(
     size >= 2 * 1024 * 1024,
-    "Expect size to be at least 2MB but was {}",
-    size
+    "Expect size to be at least 2MB but was {size}"
   );
 
   store
@@ -496,8 +491,7 @@ async fn garbage_collect_and_compact() {
   let size = get_directory_size(dir.path());
   assert!(
     size < 2 * 1024 * 1024,
-    "Expect size to be less than 2MB but was {}",
-    size
+    "Expect size to be less than 2MB but was {size}"
   );
 }
 
@@ -609,14 +603,14 @@ pub fn new_store_with_lease_time<P: AsRef<Path>>(dir: P, lease_time: Duration) -
 }
 
 pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::File, digest).await
+  load_bytes(store, EntryType::File, digest).await
 }
 
 pub async fn load_directory_proto_bytes(
   store: &ByteStore,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, EntryType::Directory, digest).await
+  load_bytes(store, EntryType::Directory, digest).await
 }
 
 pub async fn load_bytes(
@@ -625,7 +619,7 @@ pub async fn load_bytes(
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
   store
-    .load_bytes_with(entry_type, digest, |b| Bytes::copy_from_slice(b))
+    .load_bytes_with(entry_type, digest, Bytes::copy_from_slice)
     .await
 }
 

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -132,18 +132,10 @@ impl ByteStore {
     WriteResult: Future<Output = Result<(), StoreError>>,
   {
     let write_buffer = tempfile::tempfile().map_err(|e| {
-      format!(
-        "Failed to create a temporary blob upload buffer for {digest:?}: {err}",
-        digest = digest,
-        err = e
-      )
+      format!("Failed to create a temporary blob upload buffer for {digest:?}: {e}")
     })?;
     let read_buffer = write_buffer.try_clone().map_err(|e| {
-      format!(
-        "Failed to create a read handle for the temporary upload buffer for {digest:?}: {err}",
-        digest = digest,
-        err = e
-      )
+      format!("Failed to create a read handle for the temporary upload buffer for {digest:?}: {e}")
     })?;
     write_to_buffer(write_buffer).await?;
 
@@ -153,11 +145,7 @@ impl ByteStore {
     // the code just above.
     let mmap = Arc::new(unsafe {
       let mapping = memmap::Mmap::map(&read_buffer).map_err(|e| {
-        format!(
-          "Failed to memory map the temporary file buffer for {digest:?}: {err}",
-          digest = digest,
-          err = e
-        )
+        format!("Failed to memory map the temporary file buffer for {digest:?}: {e}")
       })?;
       if let Err(err) = madvise::madvise(
         mapping.as_ptr(),

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -74,8 +74,7 @@ async fn load_file_grpc_error() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {}",
-    error
+    "Bad error message, got: {error}"
   )
 }
 
@@ -92,8 +91,7 @@ async fn load_directory_grpc_error() {
   .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {}",
-    error
+    "Bad error message, got: {error}"
   )
 }
 
@@ -226,8 +224,7 @@ async fn write_file_errors() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {}",
-    error
+    "Bad error message, got: {error}"
   );
 }
 
@@ -252,8 +249,7 @@ async fn write_connection_error() {
     .expect_err("Want error");
   assert!(
     error.contains("Unavailable: \"error trying to connect: dns error"),
-    "Bad error message, got: {}",
-    error
+    "Bad error message, got: {error}"
   );
 }
 
@@ -303,8 +299,7 @@ async fn list_missing_digests_error() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {}",
-    error
+    "Bad error message, got: {error}"
   );
 }
 
@@ -325,14 +320,14 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
 }
 
 pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, digest).await
+  load_bytes(store, digest).await
 }
 
 pub async fn load_directory_proto_bytes(
   store: &ByteStore,
   digest: Digest,
 ) -> Result<Option<Bytes>, String> {
-  load_bytes(&store, digest).await
+  load_bytes(store, digest).await
 }
 
 async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -168,7 +168,7 @@ impl Snapshot {
       let path_stats = posix_fs
         .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
         .await
-        .map_err(|err| format!("Error expanding globs: {}", err))?;
+        .map_err(|err| format!("Error expanding globs: {err}"))?;
       Snapshot::from_path_stats(
         OneOffStoreFileByDigest::new(store, posix_fs, true),
         path_stats,

--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -90,9 +90,8 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
           if content_length > MAX_LENGTH && !log_enabled!(log::Level::Debug) {
             bytes.extend_from_slice(
               format!(
-                "\n... TRUNCATED contents from {}B to {}B \
-                  (Pass -ldebug to see full contents).",
-                content_length, MAX_LENGTH
+                "\n... TRUNCATED contents from {content_length}B to {MAX_LENGTH}B \
+                  (Pass -ldebug to see full contents)."
               )
               .as_bytes(),
             );
@@ -101,7 +100,7 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
         })
         .await
         .unwrap_or_else(|_| "<could not load contents>".to_string());
-      let detail = format!("{}{}", header, contents);
+      let detail = format!("{header}{contents}");
       let res: Result<_, String> = Ok((file.name().to_owned(), detail));
       res
     })
@@ -155,7 +154,7 @@ async fn render_merge_error<T: SnapshotOps + 'static>(
     res
   }
   .await
-  .unwrap_or_else(|err| vec![format!("Failed to load contents for comparison: {}", err)]);
+  .unwrap_or_else(|err| vec![format!("Failed to load contents for comparison: {err}")]);
 
   Ok(format!(
     "Can only merge Directories with no duplicates, but found {} duplicate entries in {}:\
@@ -231,7 +230,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
     let path_stats = input_tree
       .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
       .await
-      .map_err(|err| format!("Error matching globs against {directory_digest:?}: {}", err))?;
+      .map_err(|err| format!("Error matching globs against {directory_digest:?}: {err}"))?;
 
     let mut files = HashMap::new();
     input_tree.walk(SymlinkBehavior::Oblivious, &mut |path, entry| match entry {

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -5,8 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use hashing::{Digest, Fingerprint, EMPTY_DIGEST};
-use task_executor;
-use tempfile;
+
 use testutil::data::TestDirectory;
 use testutil::make_file;
 
@@ -73,7 +72,7 @@ async fn snapshot_recursive_directories() {
 
   let cats = PathBuf::from("cats");
   let roland = cats.join("roland");
-  std::fs::create_dir_all(&dir.path().join(cats)).unwrap();
+  std::fs::create_dir_all(dir.path().join(cats)).unwrap();
   make_file(&dir.path().join(&roland), STR.as_bytes(), 0o600);
 
   let path_stats = expand_all_sorted(posix_fs).await;
@@ -100,7 +99,7 @@ async fn snapshot_from_digest() {
 
   let cats = PathBuf::from("cats");
   let roland = cats.join("roland");
-  std::fs::create_dir_all(&dir.path().join(cats)).unwrap();
+  std::fs::create_dir_all(dir.path().join(cats)).unwrap();
   make_file(&dir.path().join(&roland), STR.as_bytes(), 0o600);
 
   let path_stats = expand_all_sorted(posix_fs).await;
@@ -143,9 +142,9 @@ async fn snapshot_recursive_directories_including_empty() {
   let roland = cats.join("roland");
   let dogs = PathBuf::from("dogs");
   let llamas = PathBuf::from("llamas");
-  std::fs::create_dir_all(&dir.path().join(&cats)).unwrap();
-  std::fs::create_dir_all(&dir.path().join(&dogs)).unwrap();
-  std::fs::create_dir_all(&dir.path().join(&llamas)).unwrap();
+  std::fs::create_dir_all(dir.path().join(&cats)).unwrap();
+  std::fs::create_dir_all(dir.path().join(&dogs)).unwrap();
+  std::fs::create_dir_all(dir.path().join(&llamas)).unwrap();
   make_file(&dir.path().join(&roland), STR.as_bytes(), 0o600);
 
   let sorted_path_stats = expand_all_sorted(posix_fs).await;
@@ -229,9 +228,8 @@ async fn merge_directories_clashing_files() {
     .expect_err("Want error merging");
 
   assert!(
-    format!("{:?}", err).contains("roland"),
-    "Want error message to contain roland but was: {:?}",
-    err
+    format!("{err:?}").contains("roland"),
+    "Want error message to contain roland but was: {err:?}"
   );
 }
 
@@ -375,15 +373,9 @@ async fn snapshot_merge_colliding() {
 
   match merged_res {
     Err(ref msg)
-      if format!("{:?}", msg).contains("found 2 duplicate entries")
-        && format!("{:?}", msg).contains("roland") =>
-    {
-      ()
-    }
-    x => panic!(
-      "Snapshot::merge should have failed with a useful message; got: {:?}",
-      x
-    ),
+      if format!("{msg:?}").contains("found 2 duplicate entries")
+        && format!("{msg:?}").contains("roland") => {}
+    x => panic!("Snapshot::merge should have failed with a useful message; got: {x:?}"),
   }
 }
 

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -65,7 +65,7 @@ pub fn extra_big_file_bytes() -> Bytes {
 
 pub async fn load_file_bytes(store: &Store, digest: Digest) -> Result<Bytes, StoreError> {
   store
-    .load_file_bytes_with(digest, |bytes| Bytes::copy_from_slice(bytes))
+    .load_file_bytes_with(digest, Bytes::copy_from_slice)
     .await
 }
 
@@ -404,12 +404,11 @@ async fn malformed_remote_directory_is_error() {
 async fn non_canonical_remote_directory_is_error() {
   let mut non_canonical_directory = TestDirectory::containing_roland().directory();
   non_canonical_directory.files.push({
-    let file = remexec::FileNode {
+    remexec::FileNode {
       name: "roland".to_string(),
       digest: Some((&TestData::roland().digest()).into()),
       ..Default::default()
-    };
-    file
+    }
   });
   let non_canonical_directory_bytes = non_canonical_directory.to_bytes();
   let directory_digest = Digest::of_bytes(&non_canonical_directory_bytes);
@@ -420,12 +419,12 @@ async fn non_canonical_remote_directory_is_error() {
   let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::builder()
     .unverified_content(
-      non_canonical_directory_fingerprint.clone(),
+      non_canonical_directory_fingerprint,
       non_canonical_directory_bytes,
     )
     .build();
   new_store(dir.path(), &cas.address())
-    .load_directory(directory_digest.clone())
+    .load_directory(directory_digest)
     .await
     .expect_err("Want error");
 
@@ -577,8 +576,7 @@ async fn expand_missing_directory() {
     .expect_err("Want error");
   assert!(
     matches!(error, StoreError::MissingDigest { .. }),
-    "Bad error: {}",
-    error
+    "Bad error: {error}"
   );
 }
 
@@ -599,8 +597,7 @@ async fn expand_directory_missing_subdir() {
     .expect_err("Want error");
   assert!(
     matches!(error, StoreError::MissingDigest { .. }),
-    "Bad error message: {}",
-    error
+    "Bad error message: {error}"
   );
 }
 
@@ -804,8 +801,7 @@ async fn upload_missing_files() {
     .expect_err("Want error");
   assert!(
     matches!(error, StoreError::MissingDigest { .. }),
-    "Bad error: {}",
-    error
+    "Bad error: {error}"
   );
 }
 
@@ -849,8 +845,7 @@ async fn upload_missing_file_in_directory() {
     .expect_err("Want error");
   assert!(
     matches!(error, StoreError::MissingDigest { .. }),
-    "Bad error: {}",
-    error
+    "Bad error: {error}"
   );
 }
 
@@ -951,7 +946,7 @@ async fn instance_name_download() {
 
   assert_eq!(
     store_with_remote
-      .load_file_bytes_with(TestData::roland().digest(), |b| Bytes::copy_from_slice(b))
+      .load_file_bytes_with(TestData::roland().digest(), Bytes::copy_from_slice)
       .await
       .unwrap(),
     TestData::roland().bytes()
@@ -1035,7 +1030,7 @@ async fn auth_download() {
 
   assert_eq!(
     store_with_remote
-      .load_file_bytes_with(TestData::roland().digest(), |b| Bytes::copy_from_slice(b))
+      .load_file_bytes_with(TestData::roland().digest(), Bytes::copy_from_slice)
       .await
       .unwrap(),
     TestData::roland().bytes()
@@ -1168,7 +1163,7 @@ async fn materialize_directory(perms: Permissions, executable_file: bool) {
     is_readonly(&materialize_dir.path().join("cats").join("feed.ext"))
   );
   assert_eq!(readonly, is_readonly(&materialize_dir.path().join("cats")));
-  assert_eq!(readonly, is_readonly(&materialize_dir.path()));
+  assert_eq!(readonly, is_readonly(materialize_dir.path()));
 }
 
 #[tokio::test]
@@ -1256,9 +1251,7 @@ fn assert_same_filecontents(left: Vec<FileContent>, right: Vec<FileContent>) {
   assert_eq!(
     left.len(),
     right.len(),
-    "FileContents did not match, different lengths: left: {:?} right: {:?}",
-    left,
-    right
+    "FileContents did not match, different lengths: left: {left:?} right: {right:?}"
   );
 
   let mut success = true;
@@ -1287,8 +1280,7 @@ fn assert_same_filecontents(left: Vec<FileContent>, right: Vec<FileContent>) {
   }
   assert!(
     success,
-    "FileContents did not match: Left: {:?}, Right: {:?}",
-    left, right
+    "FileContents did not match: Left: {left:?}, Right: {right:?}"
   );
 }
 
@@ -1351,9 +1343,7 @@ fn assert_same_digest_entries(left: Vec<DigestEntry>, right: Vec<DigestEntry>) {
   assert_eq!(
     left.len(),
     right.len(),
-    "DigestEntry vectors did not match, different lengths: left: {:?} right: {:?}",
-    left,
-    right
+    "DigestEntry vectors did not match, different lengths: left: {left:?} right: {right:?}"
   );
 
   let mut success = true;
@@ -1386,21 +1376,19 @@ fn assert_same_digest_entries(left: Vec<DigestEntry>, right: Vec<DigestEntry>) {
         if path_left != path_right {
           success = false;
           eprintln!(
-            "Paths did not match for empty directory at index {}: {:?}, {:?}",
-            index, path_left, path_right
+            "Paths did not match for empty directory at index {index}: {path_left:?}, {path_right:?}"
           );
         }
       }
       (l, r) => {
         success = false;
-        eprintln!("Differing types at index {}: {:?}, {:?}", index, l, r)
+        eprintln!("Differing types at index {index}: {l:?}, {r:?}")
       }
     }
   }
   assert!(
     success,
-    "FileEntry vectors did not match: Left: {:?}, Right: {:?}",
-    left, right
+    "FileEntry vectors did not match: Left: {left:?}, Right: {right:?}"
   );
 }
 
@@ -1598,7 +1586,7 @@ async fn explicitly_overwrites_already_existing_file() {
     .build();
   let store = new_store(tempfile::tempdir().unwrap(), &cas.address());
 
-  let _ = store
+  store
     .materialize_directory(
       dir_to_write_to.path().to_owned(),
       contents_dir.directory_digest(),
@@ -1690,8 +1678,8 @@ async fn big_file_immutable_link() {
     .expect("Error materializing file");
 
   let assert_is_linked = |path: &PathBuf, is_linked: bool| {
-    assert_eq!(file_contents(&path), file_bytes);
-    assert!(is_executable(&path));
+    assert_eq!(file_contents(path), file_bytes);
+    assert!(is_executable(path));
     assert_eq!(path.metadata().unwrap().permissions().readonly(), is_linked);
   };
 

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -461,8 +461,7 @@ impl<N: Node> Entry<N> {
         );
         assert!(
           !result.is_clean(context),
-          "A clean Node should not reach this point: {:?}",
-          result
+          "A clean Node should not reach this point: {result:?}"
         );
         // The Node has already completed but needs to re-run. If the Node is dirty, we are the
         // first caller to request it since it was marked dirty. We attempt to clean it (which
@@ -843,7 +842,7 @@ impl<N: Node> Entry<N> {
   pub(crate) fn format(&self, context: &N::Context) -> String {
     let state = match self.peek(context) {
       Some(ref nr) => {
-        let item = format!("{:?}", nr);
+        let item = format!("{nr:?}");
         if item.len() <= 1024 {
           item
         } else {

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -229,10 +229,7 @@ async fn invalidate_randomly() {
         // Some amount of concurrent invalidation is expected: retry.
         continue;
       }
-      Err(e) => panic!(
-        "Did not expect any errors other than Invalidation. Got: {:?}",
-        e
-      ),
+      Err(e) => panic!("Did not expect any errors other than Invalidation. Got: {e:?}"),
     };
     max_distinct_context_values = cmp::max(
       max_distinct_context_values,
@@ -240,7 +237,7 @@ async fn invalidate_randomly() {
     );
 
     // Poll the channel to see whether the background thread has exited.
-    if let Ok(_) = recv.try_recv() {
+    if recv.try_recv().is_ok() {
       break;
     }
     iterations += 1;
@@ -248,9 +245,7 @@ async fn invalidate_randomly() {
 
   assert!(
     max_distinct_context_values > 1,
-    "In {} iterations, observed a maximum of {} distinct context values.",
-    iterations,
-    max_distinct_context_values
+    "In {iterations} iterations, observed a maximum of {max_distinct_context_values} distinct context values."
   );
 }
 
@@ -279,7 +274,7 @@ async fn poll_cacheable() {
   let request = graph.poll(TNode::new(2), Some(token2), None, &context);
   match timeout(Duration::from_millis(1000), request).await {
     Err(Elapsed { .. }) => (),
-    e => panic!("Should have timed out, instead got: {:?}", e),
+    e => panic!("Should have timed out, instead got: {e:?}"),
   }
 
   // Invalidating something and re-polling should re-compute.
@@ -313,7 +308,7 @@ async fn poll_uncacheable() {
   let request = graph.poll(TNode::new(2), Some(token1), None, &context);
   match timeout(Duration::from_millis(1000), request).await {
     Err(Elapsed { .. }) => (),
-    e => panic!("Should have timed out, instead got: {:?}", e),
+    e => panic!("Should have timed out, instead got: {e:?}"),
   }
 
   // Invalidating something and re-polling should re-compute.
@@ -797,7 +792,7 @@ impl Node for TNode {
 
 impl std::fmt::Display for TNode {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-    write!(f, "{:?}", self)
+    write!(f, "{self:?}")
   }
 }
 
@@ -829,8 +824,7 @@ impl TNode {
     for node_id in node_ids {
       if previous + 1 != node_id {
         return Err(format!(
-          "Node ids in {:?} were not monotonically ordered.",
-          output
+          "Node ids in {output:?} were not monotonically ordered."
         ));
       }
       previous = node_id;
@@ -839,7 +833,7 @@ impl TNode {
     let mut previous: usize = 0;
     for &context_id in &context_ids {
       if previous > context_id {
-        return Err(format!("Context ids in {:?} were not ordered.", output));
+        return Err(format!("Context ids in {output:?} were not ordered."));
       }
       previous = context_id;
     }

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -100,13 +100,13 @@ pub fn create_endpoint(
   headers: &mut BTreeMap<String, String>,
 ) -> Result<Endpoint, String> {
   let uri =
-    tonic::transport::Uri::try_from(addr).map_err(|err| format!("invalid address: {}", err))?;
+    tonic::transport::Uri::try_from(addr).map_err(|err| format!("invalid address: {err}"))?;
   let endpoint = Channel::builder(uri);
 
   let endpoint = if let Some(tls_config) = tls_config_opt {
     endpoint
       .tls_config(ClientTlsConfig::new().rustls_client_config(tls_config.clone()))
-      .map_err(|e| format!("TLS setup error: {}", e))?
+      .map_err(|e| format!("TLS setup error: {e}"))?
   } else {
     endpoint
   };
@@ -116,7 +116,7 @@ pub fn create_endpoint(
       let (_, user_agent) = e.remove_entry();
       endpoint
         .user_agent(user_agent)
-        .map_err(|e| format!("Unable to convert user-agent header: {}", e))?
+        .map_err(|e| format!("Unable to convert user-agent header: {e}"))?
     }
     Entry::Vacant(_) => endpoint,
   };
@@ -129,10 +129,10 @@ pub fn headers_to_http_header_map(headers: &BTreeMap<String, String>) -> Result<
     .iter()
     .map(|(key, value)| {
       let header_name =
-        HeaderName::from_str(key).map_err(|err| format!("Invalid header name {}: {}", key, err))?;
+        HeaderName::from_str(key).map_err(|err| format!("Invalid header name {key}: {err}"))?;
 
       let header_value = HeaderValue::from_str(value)
-        .map_err(|err| format!("Invalid header value {}: {}", value, err))?;
+        .map_err(|err| format!("Invalid header value {value}: {err}"))?;
 
       Ok((header_name, header_value))
     })
@@ -218,16 +218,14 @@ mod tests {
           Some(user_agent_value) => {
             let user_agent = user_agent_value.to_str().map_err(|err| {
               Status::invalid_argument(format!(
-                "Unable to convert user-agent header to string: {}",
-                err
+                "Unable to convert user-agent header to string: {err}"
               ))
             })?;
             if user_agent.contains(EXPECTED_USER_AGENT) {
               Ok(Response::new(gen::Output {}))
             } else {
               Err(Status::invalid_argument(format!(
-                "user-agent header did not contain expected value: actual={}",
-                user_agent
+                "user-agent header did not contain expected value: actual={user_agent}"
               )))
             }
           }

--- a/src/rust/engine/grpc_util/src/retry.rs
+++ b/src/rust/engine/grpc_util/src/retry.rs
@@ -100,8 +100,8 @@ mod tests {
     let client = MockClient::new(vec![
       Err(MockError(true, "first")),
       Err(MockError(true, "second")),
-      Ok(3isize),
-      Ok(4isize),
+      Ok(3_isize),
+      Ok(4_isize),
     ]);
     let result = retry_call(
       client.clone(),
@@ -109,14 +109,14 @@ mod tests {
       |err| err.0,
     )
     .await;
-    assert_eq!(result, Ok(3isize));
+    assert_eq!(result, Ok(3_isize));
     assert_eq!(client.values.lock().len(), 1);
 
     let client = MockClient::new(vec![
       Err(MockError(true, "first")),
       Err(MockError(false, "second")),
-      Ok(3isize),
-      Ok(4isize),
+      Ok(3_isize),
+      Ok(4_isize),
     ]);
     let result = retry_call(
       client.clone(),
@@ -131,7 +131,7 @@ mod tests {
       Err(MockError(true, "first")),
       Err(MockError(true, "second")),
       Err(MockError(true, "third")),
-      Ok(1isize),
+      Ok(1_isize),
     ]);
     let result = retry_call(
       client.clone(),

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -54,8 +54,7 @@ impl TryFrom<Config> for ClientConfig {
             format!(
               "Could not discover root CA cert files to use TLS with remote caching and remote \
             execution. Consider setting `--remote-ca-certs-path` instead to explicitly point to \
-            the correct PEM file.\n\n{}",
-              e
+            the correct PEM file.\n\n{e}"
             )
           })?;
       }
@@ -67,7 +66,7 @@ impl TryFrom<Config> for ClientConfig {
           cert_chain_from_pem_bytes(cert_chain)?,
           der_key_from_pem_bytes(key)?,
         )
-        .map_err(|err| format!("Error creating MTLS config: {:?}", err))?;
+        .map_err(|err| format!("Error creating MTLS config: {err:?}"))?;
     }
 
     if let CertificateCheck::DangerouslyDisabled = config.certificate_check {
@@ -120,12 +119,12 @@ fn cert_chain_from_pem_bytes(cert_chain: Vec<u8>) -> Result<Vec<rustls::Certific
         .map(|cert| Ok(rustls::Certificate(cert)))
         .collect::<Result<Vec<_>, _>>()
     })
-    .map_err(|err| format!("Failed to parse certificates from PEM file {:?}", err))
+    .map_err(|err| format!("Failed to parse certificates from PEM file {err:?}"))
 }
 
 fn der_key_from_pem_bytes(pem_bytes: Vec<u8>) -> Result<rustls::PrivateKey, String> {
   let key = rustls_pemfile::read_one(&mut pem_bytes.as_slice())
-    .map_err(|err| format!("Failed to read PEM file: {:?}", err))?
+    .map_err(|err| format!("Failed to read PEM file: {err:?}"))?
     .ok_or_else(|| "No private key found in PEM file".to_owned())?;
   use rustls_pemfile::Item;
   let key = match key {

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -73,7 +73,7 @@ impl Fingerprint {
   pub fn from_hex_string(hex_string: &str) -> Result<Fingerprint, String> {
     <[u8; FINGERPRINT_SIZE] as hex::FromHex>::from_hex(hex_string)
       .map(Fingerprint)
-      .map_err(|e| format!("{:?}", e))
+      .map_err(|e| format!("{e:?}"))
   }
 
   pub fn as_bytes(&self) -> &[u8; FINGERPRINT_SIZE] {
@@ -84,7 +84,7 @@ impl Fingerprint {
   pub fn to_hex(&self) -> String {
     let mut s = String::new();
     for &byte in &self.0 {
-      fmt::Write::write_fmt(&mut s, format_args!("{:02x}", byte)).unwrap();
+      fmt::Write::write_fmt(&mut s, format_args!("{byte:02x}")).unwrap();
     }
     s
   }
@@ -145,8 +145,8 @@ impl<'de> Deserialize<'de> for Fingerprint {
       {
         Fingerprint::from_hex_string(v).map_err(|err| {
           serde::de::Error::invalid_value(
-            serde::de::Unexpected::Str(&format!("{:?}: {}", v, err)),
-            &format!("A hex representation of a {} byte value", FINGERPRINT_SIZE).as_str(),
+            serde::de::Unexpected::Str(&format!("{v:?}: {err}")),
+            &format!("A hex representation of a {FINGERPRINT_SIZE} byte value").as_str(),
           )
         })
       }

--- a/src/rust/engine/logging/build.rs
+++ b/src/rust/engine/logging/build.rs
@@ -53,7 +53,7 @@ fn main() {
     File::create(PathBuf::from(std::env::var("OUT_DIR").unwrap()).join("packages.rs")).unwrap();
   writeln!(out_file, "pub const PANTS_PACKAGE_NAMES: &[&str] = &[").unwrap();
   for package in packages {
-    writeln!(out_file, "  \"{}\",", package).unwrap();
+    writeln!(out_file, "  \"{package}\",").unwrap();
   }
   writeln!(out_file, "];").unwrap();
 }

--- a/src/rust/engine/logging/src/logger.rs
+++ b/src/rust/engine/logging/src/logger.rs
@@ -64,7 +64,7 @@ impl PantsLogger {
       .iter()
       .map(|(k, v)| {
         let python_level: PythonLogLevel = (*v).try_into().unwrap_or_else(|e| {
-          panic!("Unrecognized log level from python: {}: {}", v, e);
+          panic!("Unrecognized log level from python: {v}: {e}");
         });
         let level: log::LevelFilter = python_level.into();
         (k.clone(), level)
@@ -73,14 +73,14 @@ impl PantsLogger {
 
     let max_python_level: PythonLogLevel = max_level
       .try_into()
-      .map_err(|e| format!("Unrecognised log level from Python: {}: {}", max_level, e))?;
+      .map_err(|e| format!("Unrecognised log level from Python: {max_level}: {e}"))?;
     let global_level: LevelFilter = max_python_level.into();
 
     let log_file = OpenOptions::new()
       .create(true)
       .append(true)
       .open(log_file_path)
-      .map_err(|err| format!("Error opening pantsd logfile: {}", err))?;
+      .map_err(|err| format!("Error opening pantsd logfile: {err}"))?;
 
     PANTS_LOGGER.0.store(Arc::new(Inner {
       per_run_logs: Mutex::default(),
@@ -115,7 +115,7 @@ impl PantsLogger {
           .create(true)
           .append(true)
           .open(path)
-          .map_err(|err| format!("Error opening per-run logfile: {}", err))
+          .map_err(|err| format!("Error opening per-run logfile: {err}"))
           .unwrap();
         *self.0.load().per_run_logs.lock() = Some(file);
       }
@@ -127,7 +127,7 @@ impl PantsLogger {
   /// function, which translates the log message into the Rust log paradigm provided by
   /// the `log` crate.
   pub fn log_from_python(message: &str, python_level: u64, target: &str) -> Result<(), String> {
-    let level: PythonLogLevel = python_level.try_into().map_err(|err| format!("{}", err))?;
+    let level: PythonLogLevel = python_level.try_into().map_err(|err| format!("{err}"))?;
     log!(target: target, level.into(), "{}", message);
     Ok(())
   }
@@ -199,19 +199,19 @@ impl Log for PantsLogger {
 
       let level = record.level();
       let level_marker = match level {
-        _ if !use_color => format!("[{}]", level).normal().clear(),
-        Level::Info => format!("[{}]", level).normal(),
-        Level::Error => format!("[{}]", level).red(),
-        Level::Warn => format!("[{}]", level).yellow(),
-        Level::Debug => format!("[{}]", level).green(),
-        Level::Trace => format!("[{}]", level).magenta(),
+        _ if !use_color => format!("[{level}]").normal().clear(),
+        Level::Info => format!("[{level}]").normal(),
+        Level::Error => format!("[{level}]").red(),
+        Level::Warn => format!("[{level}]").yellow(),
+        Level::Debug => format!("[{level}]").green(),
+        Level::Trace => format!("[{level}]").magenta(),
       };
-      write!(log_string, " {}", level_marker).unwrap();
+      write!(log_string, " {level_marker}").unwrap();
 
       if inner.show_target {
         write!(log_string, " ({})", record.target()).unwrap();
       };
-      writeln!(log_string, " {}", log_msg).unwrap();
+      writeln!(log_string, " {log_msg}").unwrap();
       log_string
     };
     let log_bytes = log_string.as_bytes();

--- a/src/rust/engine/nailgun/src/client.rs
+++ b/src/rust/engine/nailgun/src/client.rs
@@ -25,7 +25,7 @@ fn handle_postconnect_stdio(err: io::Error, msg: &str) -> NailgunClientError {
     // the Python runtime has a special error type and handling for.
     NailgunClientError::BrokenPipe
   } else {
-    NailgunClientError::PostConnect(format!("{}: {}", msg, err))
+    NailgunClientError::PostConnect(format!("{msg}: {err}"))
   }
 }
 
@@ -112,12 +112,12 @@ pub async fn client_execute(
   };
 
   let signal_stream = signal(SignalKind::interrupt()).map_err(|err| {
-    NailgunClientError::PreConnect(format!("Failed to install interrupt handler: {}", err))
+    NailgunClientError::PreConnect(format!("Failed to install interrupt handler: {err}"))
   })?;
   let socket = TcpStream::connect((Ipv4Addr::new(127, 0, 0, 1), port))
     .await
     .map_err(|err| {
-      NailgunClientError::PreConnect(format!("Failed to connect to localhost: {}", err))
+      NailgunClientError::PreConnect(format!("Failed to connect to localhost: {err}"))
     })?;
 
   let mut child = nails::client::handle_connection(config, socket, command, async {
@@ -126,7 +126,7 @@ pub async fn client_execute(
     stdin_read
   })
   .await
-  .map_err(|err| NailgunClientError::PreConnect(format!("Failed to start: {}", err)))?;
+  .map_err(|err| NailgunClientError::PreConnect(format!("Failed to start: {err}")))?;
 
   handle_client_output(
     child.output_stream.take().unwrap(),
@@ -150,7 +150,7 @@ pub async fn client_execute(
             although you will miss out on additional caching."
           .to_owned()
       }
-      _ => format!("Failed during execution: {}", err),
+      _ => format!("Failed during execution: {err}"),
     };
     NailgunClientError::PostConnect(err_str)
   })?;

--- a/src/rust/engine/nailgun/src/server.rs
+++ b/src/rust/engine/nailgun/src/server.rs
@@ -42,10 +42,10 @@ impl Server {
   ) -> Result<Server, String> {
     let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), port_requested))
       .await
-      .map_err(|e| format!("Could not bind to port {}: {:?}", port_requested, e))?;
+      .map_err(|e| format!("Could not bind to port {port_requested}: {e:?}"))?;
     let port_actual = listener
       .local_addr()
-      .map_err(|e| format!("No local address for listener: {:?}", e))?
+      .map_err(|e| format!("No local address for listener: {e:?}"))?
       .port();
 
     // NB: The C client requires noisy_stdin (see the `nails` crate for more info), but neither
@@ -110,7 +110,7 @@ impl Server {
           tcp_stream
         }
         future::Either::Left((Err(e), _)) => {
-          break Err(format!("Server failed to accept connections: {}", e));
+          break Err(format!("Server failed to accept connections: {e}"));
         }
         future::Either::Right((_, _)) => {
           break Ok(());
@@ -352,7 +352,7 @@ impl RawFdNail {
   ///
   fn ttypath_from_env(env: &HashMap<String, String>, fd_number: usize) -> Option<PathBuf> {
     env
-      .get(&format!("NAILGUN_TTY_PATH_{}", fd_number))
+      .get(&format!("NAILGUN_TTY_PATH_{fd_number}"))
       .map(PathBuf::from)
   }
 }

--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -45,9 +45,9 @@ impl Args {
   fn arg_names(id: &OptionId, negate: Negate) -> HashMap<String, bool> {
     let mut arg_names = HashMap::new();
     if let Some(switch) = id.2 {
-      arg_names.insert(format!("-{}", switch), false);
+      arg_names.insert(format!("-{switch}"), false);
       if negate == Negate::True {
-        arg_names.insert(format!("--no-{}", switch), true);
+        arg_names.insert(format!("--no-{switch}"), true);
       }
     }
     arg_names.insert(Self::arg_name(id, Negate::False), false);
@@ -106,12 +106,9 @@ impl OptionsSource for Args {
       let mut components = arg.as_str().splitn(2, '=');
       if let Some(name) = components.next() {
         if arg_names.contains_key(name) {
-          let value = components.next().ok_or_else(|| {
-            format!(
-              "Expected string list option {name} to have a value.",
-              name = name
-            )
-          })?;
+          let value = components
+            .next()
+            .ok_or_else(|| format!("Expected string list option {name} to have a value."))?;
           edits.extend(parse_string_list(value).map_err(|e| e.render(name))?)
         }
       }

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -88,7 +88,7 @@ fn test_float() {
   let assert_float =
     |expected: f64, id: OptionId| assert_eq!(expected, args.get_float(&id).unwrap().unwrap());
 
-  assert_float(4 as f64, option_id!(-'j', "jobs"));
+  assert_float(4_f64, option_id!(-'j', "jobs"));
   assert_float(3.14, option_id!("foo"));
   assert_float(1.137, option_id!("baz", "spam"));
 

--- a/src/rust/engine/options/src/build_root.rs
+++ b/src/rust/engine/options/src/build_root.rs
@@ -14,7 +14,7 @@ impl BuildRoot {
   const SENTINEL_FILES: &'static [&'static str] = &["pants", "BUILDROOT", "BUILD_ROOT"];
 
   pub fn find() -> Result<BuildRoot, String> {
-    let cwd = env::current_dir().map_err(|e| format!("Failed to determine $CWD: {}", e))?;
+    let cwd = env::current_dir().map_err(|e| format!("Failed to determine $CWD: {e}"))?;
     Self::find_from(&cwd)
   }
 

--- a/src/rust/engine/options/src/build_root_tests.rs
+++ b/src/rust/engine/options/src/build_root_tests.rs
@@ -22,7 +22,7 @@ fn test_find_cwd() {
     assert!(BuildRoot::find_from(&buildroot_path).is_err());
 
     let file = buildroot.path().join(name);
-    fs::write(&file, &[]).unwrap();
+    fs::write(&file, []).unwrap();
     sentinel = Some(file);
     assert_eq!(
       &buildroot_path,
@@ -45,7 +45,7 @@ fn test_find_subdir() {
   assert!(BuildRoot::find_from(&subdir).is_err());
 
   let sentinel = &buildroot.path().join("pants");
-  fs::write(&sentinel, &[]).unwrap();
+  fs::write(sentinel, []).unwrap();
   assert_eq!(
     &buildroot_path,
     BuildRoot::find_from(&buildroot_path).unwrap().deref()

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -86,16 +86,14 @@ impl Config {
           items.push(value.to_owned())
         } else {
           return Err(format!(
-            "Expected {} to be an array of strings but given {} containing non string item {}",
-            option_name, value, item
+            "Expected {option_name} to be an array of strings but given {value} containing non string item {item}"
           ));
         }
       }
       Ok(items)
     } else {
       Err(format!(
-        "Expected {} to be an array but given {}.",
-        option_name, value
+        "Expected {option_name} to be an array but given {value}."
       ))
     }
   }
@@ -129,7 +127,7 @@ impl Config {
 
 impl OptionsSource for Config {
   fn display(&self, id: &OptionId) -> String {
-    format!("{}", id)
+    format!("{id}")
   }
 
   fn get_string(&self, id: &OptionId) -> Result<Option<String>, String> {
@@ -137,10 +135,7 @@ impl OptionsSource for Config {
       if let Some(string) = value.as_str() {
         Ok(Some(string.to_owned()))
       } else {
-        Err(format!(
-          "Expected {} to be a string but given {}.",
-          id, value
-        ))
+        Err(format!("Expected {id} to be a string but given {value}."))
       }
     } else {
       Ok(None)
@@ -152,7 +147,7 @@ impl OptionsSource for Config {
       if let Some(bool) = value.as_bool() {
         Ok(Some(bool))
       } else {
-        Err(format!("Expected {} to be a bool but given {}.", id, value))
+        Err(format!("Expected {id} to be a bool but given {value}."))
       }
     } else {
       Ok(None)
@@ -164,10 +159,7 @@ impl OptionsSource for Config {
       if let Some(float) = value.as_float() {
         Ok(Some(float))
       } else {
-        Err(format!(
-          "Expected {} to be a float but given {}.",
-          id, value
-        ))
+        Err(format!("Expected {id} to be a float but given {value}."))
       }
     } else {
       Ok(None)
@@ -188,20 +180,19 @@ impl OptionsSource for Config {
             )
           {
             return Err(format!(
-              "Expected {} to contain an 'add' element, a 'remove' element or both but found: {:?}",
-              option_name, sub_table
+              "Expected {option_name} to contain an 'add' element, a 'remove' element or both but found: {sub_table:?}"
             ));
           }
           if let Some(add) = sub_table.get("add") {
             list_edits.push(ListEdit {
               action: ListEditAction::Add,
-              items: Self::extract_string_list(&format!("{}.add", option_name), add)?,
+              items: Self::extract_string_list(&format!("{option_name}.add"), add)?,
             })
           }
           if let Some(remove) = sub_table.get("remove") {
             list_edits.push(ListEdit {
               action: ListEditAction::Remove,
-              items: Self::extract_string_list(&format!("{}.remove", option_name), remove)?,
+              items: Self::extract_string_list(&format!("{option_name}.remove"), remove)?,
             })
           }
         } else {

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -15,7 +15,7 @@ fn config<I: IntoIterator<Item = &'static str>>(file_contents: I) -> Config {
     .into_iter()
     .enumerate()
     .map(|(idx, file_content)| {
-      let path = dir.path().join(format!("{}.toml", idx));
+      let path = dir.path().join(format!("{idx}.toml"));
       File::create(&path)
         .unwrap()
         .write_all(file_content.as_bytes())

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -29,7 +29,7 @@ impl Env {
       name
     )];
     if id.0 == Scope::Global {
-      names.push(format!("PANTS_{}", name));
+      names.push(format!("PANTS_{name}"));
     }
     if name.starts_with("PANTS_") {
       names.push(name);

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -97,7 +97,7 @@ fn test_float() {
   let assert_float =
     |expected: f64, id: OptionId| assert_eq!(expected, env.get_float(&id).unwrap().unwrap());
 
-  assert_float(4 as f64, option_id!("foo"));
+  assert_float(4_f64, option_id!("foo"));
   assert_float(3.14, option_id!("bar", "baz"));
   assert_float(1.137, option_id!("pants", "eggs"));
 

--- a/src/rust/engine/options/src/id.rs
+++ b/src/rust/engine/options/src/id.rs
@@ -48,8 +48,7 @@ impl OptionId {
       .collect::<Vec<_>>();
     if name_components.is_empty() {
       return Err(format!(
-        "Cannot create an OptionId with an empty name. Given a scope of {:?}.",
-        scope
+        "Cannot create an OptionId with an empty name. Given a scope of {scope:?}."
       ));
     }
     Ok(OptionId(scope, name_components, switch))

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -274,7 +274,7 @@ pub fn render_choice(items: &[&str]) -> Option<String> {
   match items {
     [] => None,
     [this] => Some(this.to_string()),
-    [this, that] => Some(format!("{} or {}", this, that)),
+    [this, that] => Some(format!("{this} or {that}")),
     [these @ .., that] => Some(format!("{} or {}", these.join(", "), that)),
   }
 }

--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -129,9 +129,8 @@ mod err {
         template_ref.contains("{name}"),
         "\
         Expected the template to contain at least one `{{name}}` placeholder, but found none: \
-        {template}.\
-        ",
-        template = template_ref
+        {template_ref}.\
+        "
       );
       ParseError {
         template: template_ref.to_owned(),
@@ -164,7 +163,7 @@ fn format_parse_error(
           "-".repeat(parse_error.location.column - 1)
         )
       } else {
-        format!("{}:{}", line_no, line)
+        format!("{line_no}:{line}")
       }
     })
     .collect::<Vec<_>>()
@@ -199,8 +198,7 @@ pub(crate) fn parse_bool(value: &str) -> Result<bool, ParseError> {
     "true" => Ok(true),
     "false" => Ok(false),
     _ => Err(ParseError::new(format!(
-      "Got '{value}' for {{name}}. Expected 'true' or 'false'.",
-      value = value
+      "Got '{value}' for {{name}}. Expected 'true' or 'false'."
     ))),
   }
 }

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -35,7 +35,7 @@ fn list_edit<I: IntoIterator<Item = &'static str>>(
   }
 }
 
-const EMPTY_STRING_LIST: [&'static str; 0] = [];
+const EMPTY_STRING_LIST: [&str; 0] = [];
 
 #[test]
 fn test_parse_string_list_replace() {

--- a/src/rust/engine/process_execution/src/bounded_tests.rs
+++ b/src/rust/engine/process_execution/src/bounded_tests.rs
@@ -314,7 +314,6 @@ async fn dropped_future_is_removed_from_queue() {
         tx_thread2.send(()).unwrap();
         rx_thread2.await.unwrap();
         drop(waiter_future);
-        ()
       }
       future::Either::Right(_) => {
         panic!("The sleep result should always be ready first!");

--- a/src/rust/engine/process_execution/src/cache.rs
+++ b/src/rust/engine/process_execution/src/cache.rs
@@ -119,7 +119,7 @@ impl crate::CommandRunner for CommandRunner {
                 initial.map(|(initial, _)| {
                   (
                     WorkunitMetadata {
-                      desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+                      desc: initial.desc.as_ref().map(|desc| format!("Hit: {desc}")),
                       ..initial
                     },
                     Level::Debug,
@@ -188,10 +188,10 @@ impl CommandRunner {
     let maybe_cache_value = self.cache.load(action_key).await?;
     let maybe_execute_response = if let Some(bytes) = maybe_cache_value {
       let decoded: PlatformAndResponseBytes = bincode::deserialize(&bytes)
-        .map_err(|err| format!("Could not deserialize platform and response: {}", err))?;
+        .map_err(|err| format!("Could not deserialize platform and response: {err}"))?;
       let platform = decoded.platform;
       let execute_response = ExecuteResponse::decode(&decoded.response_bytes[..])
-        .map_err(|e| format!("Invalid ExecuteResponse: {:?}", e))?;
+        .map_err(|e| format!("Invalid ExecuteResponse: {e:?}"))?;
       Some((execute_response, platform))
     } else {
       return Ok(None);
@@ -266,19 +266,14 @@ impl CommandRunner {
     let mut response_bytes = Vec::with_capacity(execute_response.encoded_len());
     execute_response
       .encode(&mut response_bytes)
-      .map_err(|err| format!("Error serializing execute process result to cache: {}", err))?;
+      .map_err(|err| format!("Error serializing execute process result to cache: {err}"))?;
 
     let bytes_to_store = bincode::serialize(&PlatformAndResponseBytes {
       platform: result.platform,
       response_bytes,
     })
     .map(Bytes::from)
-    .map_err(|err| {
-      format!(
-        "Error serializing platform and execute process result: {}",
-        err
-      )
-    })?;
+    .map_err(|err| format!("Error serializing platform and execute process result: {err}"))?;
 
     self.cache.store(action_key, bytes_to_store).await?;
     Ok(())

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -30,7 +30,7 @@ fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
   let store = Store::local_only(runtime.clone(), store_dir).unwrap();
   let runner = Box::new(crate::local::CommandRunner::new(
     store.clone(),
-    runtime.clone(),
+    runtime,
     base_dir.path().to_owned(),
     NamedCaches::new(named_cache_dir),
     ImmutableInputs::new(store.clone(), base_dir.path()).unwrap(),
@@ -50,7 +50,7 @@ fn create_cached_runner(
   let cache = PersistentCache::new(
     cache_dir.path(),
     max_lmdb_size,
-    runtime.clone(),
+    runtime,
     DEFAULT_LEASE_TIME,
     1,
   )
@@ -96,13 +96,13 @@ async fn run_roundtrip(script_exit_code: i8, workunit: &mut RunningWorkunit) -> 
   let (process, script_path, _script_dir) = create_script(script_exit_code);
 
   let local_result = local
-    .run(Context::default(), workunit, process.clone().into())
+    .run(Context::default(), workunit, process.clone())
     .await;
 
   let (caching, _cache_dir) = create_cached_runner(local, store.clone());
 
   let uncached_result = caching
-    .run(Context::default(), workunit, process.clone().into())
+    .run(Context::default(), workunit, process.clone())
     .await;
 
   assert_eq!(local_result, uncached_result);
@@ -111,9 +111,7 @@ async fn run_roundtrip(script_exit_code: i8, workunit: &mut RunningWorkunit) -> 
   // fail due to a FileNotFound error. So, If the second run succeeds, that implies that the
   // cache was successfully used.
   std::fs::remove_file(&script_path).unwrap();
-  let maybe_cached_result = caching
-    .run(Context::default(), workunit, process.into())
-    .await;
+  let maybe_cached_result = caching.run(Context::default(), workunit, process).await;
 
   RoundtripResults {
     uncached: uncached_result,
@@ -147,7 +145,7 @@ async fn recover_from_missing_store_contents() {
 
   // Run once to cache the process.
   let first_result = caching
-    .run(Context::default(), &mut workunit, process.clone().into())
+    .run(Context::default(), &mut workunit, process.clone())
     .await
     .unwrap();
 
@@ -183,7 +181,7 @@ async fn recover_from_missing_store_contents() {
 
   // Ensure that we don't fail if we re-run.
   let second_result = caching
-    .run(Context::default(), &mut workunit, process.clone().into())
+    .run(Context::default(), &mut workunit, process.clone())
     .await
     .unwrap();
 

--- a/src/rust/engine/process_execution/src/children.rs
+++ b/src/rust/engine/process_execution/src/children.rs
@@ -40,7 +40,7 @@ impl ManagedChild {
         nix::unistd::setsid().map(|_pgid| ()).map_err(|e| {
           std::io::Error::new(
             std::io::ErrorKind::Other,
-            format!("Could not create new pgid: {}", e),
+            format!("Could not create new pgid: {e}"),
           )
         })
       });
@@ -49,7 +49,7 @@ impl ManagedChild {
     // Then spawn.
     let child = command
       .spawn()
-      .map_err(|e| format!("Error executing interactive process: {}", e))?;
+      .map_err(|e| format!("Error executing interactive process: {e}"))?;
     Ok(Self {
       child,
       graceful_shutdown_timeout,
@@ -60,7 +60,7 @@ impl ManagedChild {
   fn get_pgid(&self) -> Result<Pid, String> {
     let pid = self.id().ok_or_else(|| "Process had no PID.".to_owned())?;
     let pgid = getpgid(Some(Pid::from_raw(pid as i32)))
-      .map_err(|e| format!("Could not get process group id of child process: {}", e))?;
+      .map_err(|e| format!("Could not get process group id of child process: {e}"))?;
     Ok(pgid)
   }
 
@@ -69,7 +69,7 @@ impl ManagedChild {
     let pgid = self.get_pgid()?;
     // the negative PGID will signal the entire process group.
     signal::kill(Pid::from_raw(-pgid.as_raw()), signal)
-      .map_err(|e| format!("Failed to interrupt child process group: {}", e))?;
+      .map_err(|e| format!("Failed to interrupt child process group: {e}"))?;
     Ok(())
   }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -182,8 +182,7 @@ impl Platform {
         ref machine,
         ..
       } => Err(format!(
-        "Found unknown system/arch name pair {} {}",
-        sysname, machine
+        "Found unknown system/arch name pair {sysname} {machine}"
       )),
     }
   }
@@ -208,10 +207,7 @@ impl TryFrom<String> for Platform {
       "macos_x86_64" => Ok(Platform::Macos_x86_64),
       "linux_x86_64" => Ok(Platform::Linux_x86_64),
       "linux_arm64" => Ok(Platform::Linux_arm64),
-      other => Err(format!(
-        "Unknown platform {:?} encountered in parsing",
-        other
-      )),
+      other => Err(format!("Unknown platform {other:?} encountered in parsing")),
     }
   }
 }
@@ -242,7 +238,7 @@ impl TryFrom<String> for ProcessCacheScope {
       "per_restart_always" => Ok(ProcessCacheScope::PerRestartAlways),
       "per_restart_successful" => Ok(ProcessCacheScope::PerRestartSuccessful),
       "per_session" => Ok(ProcessCacheScope::PerSession),
-      other => Err(format!("Unknown Process cache scope: {:?}", other)),
+      other => Err(format!("Unknown Process cache scope: {other:?}")),
     }
   }
 }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -93,9 +93,9 @@ async fn env() {
 
   let stdout = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   let got_env: BTreeMap<String, String> = stdout
-    .split("\n")
+    .split('\n')
     .filter(|line| !line.is_empty())
-    .map(|line| line.splitn(2, "="))
+    .map(|line| line.splitn(2, '='))
     .map(|mut parts| {
       (
         parts.next().unwrap().to_string(),
@@ -309,7 +309,7 @@ async fn append_only_cache_created() {
   let name = "geo";
   let dest_base = ".cache";
   let cache_name = CacheName::new(name.to_owned()).unwrap();
-  let cache_dest = RelativePath::new(format!("{}/{}", dest_base, name)).unwrap();
+  let cache_dest = RelativePath::new(format!("{dest_base}/{name}")).unwrap();
   let result = run_command_locally(
     Process::new(owned_string_vec(&["/bin/ls", dest_base]))
       .append_only_caches(vec![(cache_name, cache_dest)].into_iter().collect()),
@@ -317,7 +317,7 @@ async fn append_only_cache_created() {
   .await
   .unwrap();
 
-  assert_eq!(result.stdout_bytes, format!("{}\n", name).as_bytes());
+  assert_eq!(result.stdout_bytes, format!("{name}\n").as_bytes());
   assert_eq!(result.stderr_bytes, "".as_bytes());
   assert_eq!(result.original.exit_code, 0);
   assert_eq!(result.original.output_directory, *EMPTY_DIRECTORY_DIGEST);
@@ -385,9 +385,9 @@ async fn test_chroot_placeholder() {
 
   let stdout = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   let got_env: BTreeMap<String, String> = stdout
-    .split("\n")
+    .split('\n')
     .filter(|line| !line.is_empty())
-    .map(|line| line.splitn(2, "="))
+    .map(|line| line.splitn(2, '='))
     .map(|mut parts| {
       (
         parts.next().unwrap().to_string(),
@@ -798,7 +798,7 @@ async fn run_command_locally_in_dir(
   executor: Option<task_executor::Executor>,
 ) -> Result<LocalTestResult, ProcessError> {
   let store_dir = TempDir::new().unwrap();
-  let executor = executor.unwrap_or_else(|| task_executor::Executor::new());
+  let executor = executor.unwrap_or_else(task_executor::Executor::new);
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
   let (_caches_dir, named_caches, immutable_inputs) =
@@ -811,7 +811,7 @@ async fn run_command_locally_in_dir(
     immutable_inputs,
     cleanup,
   );
-  let original = runner.run(Context::default(), workunit, req.into()).await?;
+  let original = runner.run(Context::default(), workunit, req).await?;
   let stdout_bytes = store
     .load_file_bytes_with(original.stdout_digest, |bytes| bytes.to_vec())
     .await?;

--- a/src/rust/engine/process_execution/src/nailgun/mod.rs
+++ b/src/rust/engine/process_execution/src/nailgun/mod.rs
@@ -53,7 +53,7 @@ fn construct_nailgun_server_request(
     output_files: BTreeSet::new(),
     output_directories: BTreeSet::new(),
     timeout: None,
-    description: format!("nailgun server for {}", nailgun_name),
+    description: format!("nailgun server for {nailgun_name}"),
     level: log::Level::Info,
     execution_slot_variable: None,
     env: client_request.env,
@@ -119,7 +119,7 @@ impl CommandRunner {
   }
 
   fn calculate_nailgun_name(main_class: &str) -> String {
-    format!("nailgun_server_{}", main_class)
+    format!("nailgun_server_{main_class}")
   }
 }
 
@@ -261,7 +261,7 @@ impl CapturedWorkdir for CommandRunner {
             stdin_read
           })
         })
-        .map_err(|e| format!("Error communicating with nailgun server: {}", e))
+        .map_err(|e| format!("Error communicating with nailgun server: {e}"))
         .await?
     };
 
@@ -276,7 +276,7 @@ impl CapturedWorkdir for CommandRunner {
     let exit_code = child
       .wait()
       .map_ok(ChildOutput::Exit)
-      .map_err(|e| format!("Error communicating with nailgun server: {}", e));
+      .map_err(|e| format!("Error communicating with nailgun server: {e}"));
 
     Ok(futures::stream::select(output_stream, exit_code.into_stream()).boxed())
   }

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -537,7 +537,8 @@ async fn clear_workdir(
   future::try_join_all(moves).await?;
 
   // And drop it in the background.
-  let _ = executor.native_spawn_blocking(move || std::mem::drop(garbage_dir));
+  let fut = executor.native_spawn_blocking(move || std::mem::drop(garbage_dir));
+  drop(fut);
 
   Ok(())
 }

--- a/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/src/nailgun/nailgun_pool.rs
@@ -221,7 +221,7 @@ impl NailgunPool {
     let status = process
       .handle
       .try_wait()
-      .map_err(|e| format!("Error getting the process status from nailgun: {}", e))?;
+      .map_err(|e| format!("Error getting the process status from nailgun: {e}"))?;
     match status {
       None => {
         // Process hasn't exited yet.
@@ -315,7 +315,7 @@ fn spawn_and_read_port(
         .next()
         .ok_or_else(|| "There is no line ready in the child's output".to_string())
     })
-    .and_then(|res| res.map_err(|e| format!("Failed to read stdout from nailgun: {}", e)));
+    .and_then(|res| res.map_err(|e| format!("Failed to read stdout from nailgun: {e}")));
 
   // If we failed to read a port line and the child has exited, report that.
   if port_line.is_err() {
@@ -328,8 +328,7 @@ fn spawn_and_read_port(
         .read_to_string(&mut stderr)
         .map_err(|e| e.to_string())?;
       return Err(format!(
-        "Nailgun failed to start: exited with {}, stderr:\n{}",
-        exit_status, stderr
+        "Nailgun failed to start: exited with {exit_status}, stderr:\n{stderr}"
       ));
     }
   }
@@ -338,10 +337,10 @@ fn spawn_and_read_port(
   let port_str = &NAILGUN_PORT_REGEX
     .captures_iter(&port_line)
     .next()
-    .ok_or_else(|| format!("Output for nailgun server was unexpected:\n{:?}", port_line))?[1];
+    .ok_or_else(|| format!("Output for nailgun server was unexpected:\n{port_line:?}"))?[1];
   let port = port_str
     .parse::<Port>()
-    .map_err(|e| format!("Error parsing nailgun port {}: {}", port_str, e))?;
+    .map_err(|e| format!("Error parsing nailgun port {port_str}: {e}"))?;
 
   Ok((child, port))
 }
@@ -360,7 +359,7 @@ impl NailgunProcess {
     let workdir = tempfile::Builder::new()
       .prefix("pants-sandbox-")
       .tempdir_in(workdir_base)
-      .map_err(|err| format!("Error making tempdir for nailgun server: {:?}", err))?;
+      .map_err(|err| format!("Error making tempdir for nailgun server: {err:?}"))?;
 
     // Prepare the workdir, and then list it to identify the base set of names which should be
     // preserved across runs. TODO: This is less efficient than computing the set of names
@@ -518,12 +517,7 @@ async fn clear_workdir(
   let garbage_dir = tempfile::Builder::new()
     .prefix("pants-sandbox-")
     .tempdir_in(workdir.parent().unwrap())
-    .map_err(|err| {
-      format!(
-        "Error making garbage directory for nailgun cleanup: {:?}",
-        err
-      )
-    })?;
+    .map_err(|err| format!("Error making garbage directory for nailgun cleanup: {err:?}"))?;
   let moves = list_workdir(workdir)
     .await?
     .into_iter()
@@ -551,12 +545,12 @@ async fn clear_workdir(
 async fn list_workdir(workdir: &Path) -> Result<HashSet<OsString>, String> {
   let mut dir_entries = tokio::fs::read_dir(workdir)
     .await
-    .map_err(|e| format!("Failed to read nailgun process directory: {}", e))?;
+    .map_err(|e| format!("Failed to read nailgun process directory: {e}"))?;
   let mut names = HashSet::new();
   while let Some(dir_entry) = dir_entries
     .next_entry()
     .await
-    .map_err(|e| format!("Failed to read entry in nailgun process directory: {}", e))?
+    .map_err(|e| format!("Failed to read entry in nailgun process directory: {e}"))?
   {
     names.insert(dir_entry.file_name());
   }

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines.rs
@@ -81,10 +81,7 @@ impl ParsedJVMCommandLines {
       .ok_or_else(|| "No classpath value found!".to_string())
       .and_then(|elem| {
         if ParsedJVMCommandLines::is_flag(elem) {
-          Err(format!(
-            "Classpath value has incorrect formatting {}.",
-            elem
-          ))
+          Err(format!("Classpath value has incorrect formatting {elem}."))
         } else {
           Ok(elem)
         }

--- a/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines_tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/parsed_jvm_command_lines_tests.rs
@@ -97,7 +97,7 @@ impl CLIBuilder {
   }
 
   pub fn render_to_parsed_args(&self) -> ParsedJVMCommandLines {
-    let mut nailgun_args: Vec<String> = self.jdk.iter().map(|e| e.clone()).collect();
+    let mut nailgun_args: Vec<String> = self.jdk.iter().cloned().collect();
     nailgun_args.extend(self.args_before_classpath.clone());
     nailgun_args.extend(self.classpath_flag.clone());
     nailgun_args.extend(self.classpath_value.clone());

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -34,7 +34,7 @@ async fn run(pool: &(NailgunPool, NamedCaches, ImmutableInputs), port: u16) -> P
       Process::new(owned_string_vec(&[
         "/bin/bash",
         "-c",
-        &format!("echo Mock port {}.; sleep 10", port),
+        &format!("echo Mock port {port}.; sleep 10"),
       ])),
       &pool.1,
       &pool.2,

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -21,8 +21,7 @@ impl CacheName {
       Ok(CacheName(name))
     } else {
       Err(format!(
-        "Cache names may only contain lowercase alphanumeric characters or underscores: got {:?}",
-        name
+        "Cache names may only contain lowercase alphanumeric characters or underscores: got {name:?}"
       ))
     }
   }

--- a/src/rust/engine/process_execution/src/remote.rs
+++ b/src/rust/engine/process_execution/src/remote.rs
@@ -167,13 +167,14 @@ impl Drop for RunningOperation {
     if let Some(operation_name) = self.name.take() {
       debug!("Canceling remote operation {operation_name}");
       let mut operations_client = self.operations_client.as_ref().clone();
-      let _ = self.executor.native_spawn(async move {
+      let fut = self.executor.native_spawn(async move {
         operations_client
           .cancel_operation(CancelOperationRequest {
             name: operation_name,
           })
           .await
       });
+      drop(fut);
     }
   }
 }

--- a/src/rust/engine/process_execution/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/src/remote_cache.rs
@@ -365,7 +365,7 @@ impl CommandRunner {
         initial.map(|(initial, _)| {
           (
             WorkunitMetadata {
-              desc: initial.desc.as_ref().map(|desc| format!("Hit: {}", desc)),
+              desc: initial.desc.as_ref().map(|desc| format!("Hit: {desc}")),
               ..initial
             },
             Level::Debug,
@@ -445,10 +445,8 @@ impl CommandRunner {
       CacheErrorType::ReadError => "read from",
       CacheErrorType::WriteError => "write to",
     };
-    let log_msg = format!(
-      "Failed to {} remote cache ({} occurrences so far): {}",
-      failure_desc, err_count, err
-    );
+    let log_msg =
+      format!("Failed to {failure_desc} remote cache ({err_count} occurrences so far): {err}");
     let log_at_warn = match self.warnings_behavior {
       RemoteCacheWarningsBehavior::Ignore => false,
       RemoteCacheWarningsBehavior::FirstOnly => err_count == 1,
@@ -553,7 +551,7 @@ impl crate::CommandRunner for CommandRunner {
       }
       // NB: We must box the future to avoid a stack overflow.
       .boxed());
-      let task_name = format!("remote cache write {:?}", action_digest);
+      let task_name = format!("remote cache write {action_digest:?}");
       context
         .tail_tasks
         .spawn_on(&task_name, self.executor.handle(), write_fut.boxed());
@@ -587,7 +585,7 @@ async fn check_action_cache(
   in_workunit!(
     "check_action_cache",
     Level::Debug,
-    desc = Some(format!("Remote cache lookup for: {}", command_description)),
+    desc = Some(format!("Remote cache lookup for: {command_description}")),
     |workunit| async move {
       workunit.increment_counter(Metric::RemoteCacheRequests, 1);
 

--- a/src/rust/engine/process_execution/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/src/remote_cache_tests.rs
@@ -190,7 +190,7 @@ async fn cache_read_success() {
 
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
   let remote_result = cache_runner
-    .run(Context::default(), &mut workunit, process.into())
+    .run(Context::default(), &mut workunit, process)
     .await
     .unwrap();
   assert_eq!(remote_result.exit_code, 0);
@@ -223,7 +223,7 @@ async fn cache_read_skipped_on_action_cache_errors() {
   );
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
   let remote_result = cache_runner
-    .run(Context::default(), &mut workunit, process.into())
+    .run(Context::default(), &mut workunit, process)
     .await
     .unwrap();
   assert_eq!(remote_result.exit_code, 1);
@@ -260,7 +260,7 @@ async fn cache_read_skipped_on_missing_digest() {
   );
   assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
   let remote_result = cache_runner
-    .run(Context::default(), &mut workunit, process.into())
+    .run(Context::default(), &mut workunit, process)
     .await
     .unwrap();
   assert_eq!(remote_result.exit_code, 1);
@@ -298,7 +298,7 @@ async fn cache_read_eager_fetch() {
 
     assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
     let remote_result = cache_runner
-      .run(Context::default(), workunit, process.into())
+      .run(Context::default(), workunit, process)
       .await
       .unwrap();
 
@@ -355,7 +355,7 @@ async fn cache_read_speculation() {
 
     assert_eq!(local_runner_call_counter.load(Ordering::SeqCst), 0);
     let result = cache_runner
-      .run(Context::default(), workunit, process.into())
+      .run(Context::default(), workunit, process)
       .await
       .unwrap();
 
@@ -481,7 +481,7 @@ async fn cache_write_success() {
 
   let context = Context::default();
   let local_result = cache_runner
-    .run(context.clone(), &mut workunit, process.clone().into())
+    .run(context.clone(), &mut workunit, process.clone())
     .await
     .unwrap();
   context.tail_tasks.wait(Duration::from_secs(2)).await;
@@ -514,7 +514,7 @@ async fn cache_write_not_for_failures() {
   assert!(store_setup.cas.action_cache.action_map.lock().is_empty());
 
   let local_result = cache_runner
-    .run(Context::default(), &mut workunit, process.clone().into())
+    .run(Context::default(), &mut workunit, process.clone())
     .await
     .unwrap();
   assert_eq!(local_result.exit_code, 1);
@@ -543,7 +543,7 @@ async fn cache_write_does_not_block() {
 
   let context = Context::default();
   let local_result = cache_runner
-    .run(context.clone(), &mut workunit, process.clone().into())
+    .run(context.clone(), &mut workunit, process.clone())
     .await
     .unwrap();
   assert_eq!(local_result.exit_code, 0);

--- a/src/rust/engine/process_execution/src/switched.rs
+++ b/src/rust/engine/process_execution/src/switched.rs
@@ -108,7 +108,7 @@ mod tests {
     if let ProcessError::Unclassified(msg) = &err {
       assert_eq!(msg, "left");
     } else {
-      panic!("unexpected value: {:?}", err)
+      panic!("unexpected value: {err:?}")
     }
 
     let req = Process::new(vec!["not-left".to_string()]);
@@ -119,7 +119,7 @@ mod tests {
     if let ProcessError::Unclassified(msg) = &err {
       assert_eq!(msg, "right");
     } else {
-      panic!("unexpected value: {:?}", err)
+      panic!("unexpected value: {err:?}")
     }
   }
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -469,7 +469,7 @@ async fn make_request_from_flat_args(
     .clone()
     .map(|path| {
       RelativePath::new(path)
-        .map_err(|err| format!("working-directory must be a relative path: {:?}", err))
+        .map_err(|err| format!("working-directory must be a relative path: {err:?}"))
     })
     .transpose()?;
 
@@ -481,7 +481,7 @@ async fn make_request_from_flat_args(
     BTreeSet::default(),
   )
   .await
-  .map_err(|e| format!("Could not create input digest for process: {:?}", e))?;
+  .map_err(|e| format!("Could not create input digest for process: {e:?}"))?;
 
   let process = process_execution::Process {
     argv: args.command.argv.clone(),
@@ -522,15 +522,10 @@ async fn extract_request_from_action_digest(
     .load_file_bytes_with(action_digest, |bytes| Action::decode(bytes))
     .await
     .map_err(|e| e.enrich("Could not load action proto from CAS").to_string())?
-    .map_err(|err| {
-      format!(
-        "Error deserializing action proto {:?}: {:?}",
-        action_digest, err
-      )
-    })?;
+    .map_err(|err| format!("Error deserializing action proto {action_digest:?}: {err:?}"))?;
 
-  let command_digest = require_digest(&action.command_digest)
-    .map_err(|err| format!("Bad Command digest: {:?}", err))?;
+  let command_digest =
+    require_digest(&action.command_digest).map_err(|err| format!("Bad Command digest: {err:?}"))?;
   let command = store
     .load_file_bytes_with(command_digest, |bytes| Command::decode(bytes))
     .await
@@ -538,24 +533,19 @@ async fn extract_request_from_action_digest(
       e.enrich("Could not load command proto from CAS")
         .to_string()
     })?
-    .map_err(|err| {
-      format!(
-        "Error deserializing command proto {:?}: {:?}",
-        command_digest, err
-      )
-    })?;
+    .map_err(|err| format!("Error deserializing command proto {command_digest:?}: {err:?}"))?;
   let working_directory = if command.working_directory.is_empty() {
     None
   } else {
     Some(
       RelativePath::new(command.working_directory)
-        .map_err(|err| format!("working-directory must be a relative path: {:?}", err))?,
+        .map_err(|err| format!("working-directory must be a relative path: {err:?}"))?,
     )
   };
 
   let input_digests = InputDigests::with_input_files(DirectoryDigest::from_persisted_digest(
     require_digest(&action.input_root_digest)
-      .map_err(|err| format!("Bad input root digest: {:?}", err))?,
+      .map_err(|err| format!("Bad input root digest: {err:?}"))?,
   ));
 
   // In case the local Store doesn't have the input root Directory,
@@ -632,16 +622,13 @@ async fn extract_request_from_buildbarn_url(
       let action_fingerprint = Fingerprint::from_hex_string(interesting_parts[2])?;
       let action_digest_length: usize = interesting_parts[3]
         .parse()
-        .map_err(|err| format!("Couldn't parse action digest length as a number: {:?}", err))?;
+        .map_err(|err| format!("Couldn't parse action digest length as a number: {err:?}"))?;
       Digest::new(action_fingerprint, action_digest_length)
     }
     "uncached_action_result" => {
       let action_result_fingerprint = Fingerprint::from_hex_string(interesting_parts[2])?;
       let action_result_digest_length: usize = interesting_parts[3].parse().map_err(|err| {
-        format!(
-          "Couldn't parse uncached action digest result length as a number: {:?}",
-          err
-        )
+        format!("Couldn't parse uncached action digest result length as a number: {err:?}")
       })?;
       let action_result_digest =
         Digest::new(action_result_fingerprint, action_result_digest_length);
@@ -652,14 +639,13 @@ async fn extract_request_from_buildbarn_url(
         })
         .await
         .map_err(|e| e.enrich("Could not load action result proto").to_string())?
-        .map_err(|err| format!("Error deserializing action result proto: {:?}", err))?;
+        .map_err(|err| format!("Error deserializing action result proto: {err:?}"))?;
 
       require_digest(&action_result.action_digest)?
     }
     _ => {
       return Err(format!(
-        "Wrong kind in buildbarn URL; wanted action or uncached_action_result, got {}",
-        kind
+        "Wrong kind in buildbarn URL; wanted action or uncached_action_result, got {kind}"
       ));
     }
   };

--- a/src/rust/engine/protos/src/conversions_tests.rs
+++ b/src/rust/engine/protos/src/conversions_tests.rs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::convert::TryInto;
 
-use hashing;
-
 use crate::gen::build::bazel::remote::execution::v2 as remexec;
 
 #[test]
@@ -50,7 +48,6 @@ fn from_bad_bazel_digest() {
   let err = converted.expect_err("Want Err converting bad digest");
   assert!(
     err.starts_with("Bad fingerprint in Digest \"0\":"),
-    "Bad error message: {}",
-    err
+    "Bad error message: {err}"
   );
 }

--- a/src/rust/engine/protos/src/verification.rs
+++ b/src/rust/engine/protos/src/verification.rs
@@ -11,9 +11,9 @@ pub fn verify_directory_canonical(
   directory: &remote_execution::Directory,
 ) -> Result<(), String> {
   verify_nodes(&directory.files, |n| &n.name, |n| n.digest.as_ref())
-    .map_err(|e| format!("Invalid file in {:?}: {}", digest, e))?;
+    .map_err(|e| format!("Invalid file in {digest:?}: {e}"))?;
   verify_nodes(&directory.directories, |n| &n.name, |n| n.digest.as_ref())
-    .map_err(|e| format!("Invalid directory in {:?}: {}", digest, e))?;
+    .map_err(|e| format!("Invalid directory in {digest:?}: {e}"))?;
   let child_names: HashSet<&str> = directory
     .files
     .iter()
@@ -27,8 +27,7 @@ pub fn verify_directory_canonical(
     .collect();
   if child_names.len() != directory.files.len() + directory.directories.len() {
     return Err(format!(
-      "Child paths must be unique, but a child path of {:?} was both a file and a directory: {:?}",
-      digest, directory
+      "Child paths must be unique, but a child path of {digest:?} was both a file and a directory: {directory:?}"
     ));
   }
   Ok(())
@@ -54,8 +53,7 @@ where
       ));
     } else if name.contains('/') {
       return Err(format!(
-        "All children must have one path segment, but found {}",
-        name
+        "All children must have one path segment, but found {name}"
       ));
     }
     if let Some(p) = prev {

--- a/src/rust/engine/protos/src/verification_tests.rs
+++ b/src/rust/engine/protos/src/verification_tests.rs
@@ -80,8 +80,7 @@ fn empty_child_name() {
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
   assert!(
     error.contains("A child name must not be empty"),
-    "Bad error message: {}",
-    error
+    "Bad error message: {error}"
   );
 }
 
@@ -99,7 +98,7 @@ fn multiple_path_segments_in_directory() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(error.contains("pets/cats"), "Bad error message: {}", error);
+  assert!(error.contains("pets/cats"), "Bad error message: {error}");
 }
 
 #[test]
@@ -117,11 +116,7 @@ fn multiple_path_segments_in_file() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(
-    error.contains("cats/roland"),
-    "Bad error message: {}",
-    error
-  );
+  assert!(error.contains("cats/roland"), "Bad error message: {error}");
 }
 
 #[test]
@@ -147,7 +142,7 @@ fn duplicate_path_in_directory() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(error.contains("cats"), "Bad error message: {}", error);
+  assert!(error.contains("cats"), "Bad error message: {error}");
 }
 
 #[test]
@@ -175,7 +170,7 @@ fn duplicate_path_in_file() {
   };
 
   let error = verify_directory_canonical(EMPTY_DIGEST, &directory).expect_err("Want error");
-  assert!(error.contains("roland"), "Bad error message: {}", error);
+  assert!(error.contains("roland"), "Bad error message: {error}");
 }
 
 #[test]

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -34,9 +34,9 @@ enum Node<R: Rule> {
 impl<R: Rule> std::fmt::Display for Node<R> {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match self {
-      Node::Query(q) => write!(f, "{}", q),
-      Node::Rule(r) => write!(f, "{}", r),
-      Node::Param(p) => write!(f, "Param({})", p),
+      Node::Query(q) => write!(f, "{q}"),
+      Node::Rule(r) => write!(f, "{r}"),
+      Node::Param(p) => write!(f, "Param({p})"),
       Node::Reentry(q, in_scope) => write!(f, "Reentry({}, {})", q.product, params_str(in_scope)),
     }
   }
@@ -773,7 +773,7 @@ impl<R: Rule> Builder<R> {
           let subgraph = graph.filter_map(
             |node_id, node| {
               if maybe_in_loop.contains(&node_id) {
-                Some(format!("{:?}: {}", node_id, node))
+                Some(format!("{node_id:?}: {node}"))
               } else {
                 None
               }
@@ -1177,10 +1177,10 @@ impl<R: Rule> Builder<R> {
             let reason = edge_ref
               .weight()
               .deleted_reason()
-              .map(|r| format!("{:?}", r))
-              .or_else(|| node.deleted_reason().map(|r| format!("{:?}", r)));
+              .map(|r| format!("{r:?}"))
+              .or_else(|| node.deleted_reason().map(|r| format!("{r:?}")));
             let reason_suffix = if let Some(reason) = reason {
-              format!("{}: ", reason)
+              format!("{reason}: ")
             } else {
               "".to_owned()
             };
@@ -1354,10 +1354,7 @@ impl<R: Rule> Builder<R> {
       edges_by_dependency_key
         .get_mut(dependency_key)
         .unwrap_or_else(|| {
-          panic!(
-            "{} did not declare a dependency {}, but had an edge for it.",
-            node, dependency_key
-          );
+          panic!("{node} did not declare a dependency {dependency_key}, but had an edge for it.");
         })
         .push(edge_ref);
     }

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -190,7 +190,7 @@ impl<R: Rule> DisplayForGraph for Entry<R> {
   fn fmt_for_graph(&self, display_args: DisplayForGraphArgs) -> String {
     match self {
       Entry::WithDeps(e) => e.fmt_for_graph(display_args),
-      Entry::Param(type_id) => format!("Param({})", type_id),
+      Entry::Param(type_id) => format!("Param({type_id})"),
     }
   }
 }
@@ -207,13 +207,13 @@ impl<R: Rule> DisplayForGraph for EntryWithDeps<R> {
         display_args.line_separator(),
         params_str(params)
       ),
-      &EntryWithDeps::Root(ref root) => format!(
+      EntryWithDeps::Root(root) => format!(
         "Query({}){}for {}",
         root.0.product,
         display_args.line_separator(),
         params_str(&root.0.params)
       ),
-      &EntryWithDeps::Reentry(ref reentry) => format!(
+      EntryWithDeps::Reentry(reentry) => format!(
         "Reentry({}){}for {}",
         reentry.query.product,
         display_args.line_separator(),
@@ -232,7 +232,7 @@ pub fn visualize_entry<R: Rule>(
 ) -> GraphVizEntryWithAttrs {
   let entry_str = entry.fmt_for_graph(display_args);
   let attrs_str = match entry {
-    &Entry::WithDeps(ref e) => {
+    Entry::WithDeps(e) => {
       // Color "singleton" entries (with no params)!
       if e.params().is_empty() {
         Some(Palette::Olive.fmt_for_graph(display_args))
@@ -302,7 +302,7 @@ impl<R: Rule> RuleGraph<R> {
           _ => None,
         }));
       } else {
-        return Err(format!("Unknown entry in RuleGraph: {:?}", entry));
+        return Err(format!("Unknown entry in RuleGraph: {entry:?}"));
       }
     }
 
@@ -397,7 +397,7 @@ impl<R: Rule> RuleGraph<R> {
             suggestions.join("\n  ")
           )
         };
-        Err(format!("No installed QueryRules {}", suggestions_str,))
+        Err(format!("No installed QueryRules {suggestions_str}",))
       }
       _ => {
         let match_strs = subset_matches
@@ -422,7 +422,7 @@ impl<R: Rule> RuleGraph<R> {
     if let Entry::WithDeps(ref e) = entry {
       self.rule_dependency_edges.get(e).cloned()
     } else {
-      panic!("not an inner entry! {:?}", entry)
+      panic!("not an inner entry! {entry:?}")
     }
   }
 

--- a/src/rust/engine/rule_graph/src/tests.rs
+++ b/src/rust/engine/rule_graph/src/tests.rs
@@ -301,7 +301,7 @@ fn in_scope_computed() {
 
   // Valid when the `in_scope` param can be computed or is a singleton.
   let queries = indexset![Query::new("a", vec![])];
-  let graph = RuleGraph::new(rules.clone(), queries).unwrap();
+  let graph = RuleGraph::new(rules, queries).unwrap();
   graph.validate_reachability().unwrap();
   graph.find_root_edges(vec![], "a").unwrap();
 }
@@ -326,7 +326,7 @@ fn in_scope_provided() {
 
   // Valid when the `in_scope` param can be computed or is a singleton.
   let queries = indexset![Query::new("a", vec![])];
-  let graph = RuleGraph::new(rules.clone(), queries).unwrap();
+  let graph = RuleGraph::new(rules, queries).unwrap();
   graph.validate_reachability().unwrap();
   graph.find_root_edges(vec![], "a").unwrap();
 }

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -32,10 +32,8 @@ async fn shard_counts() {
 
     // Confirm that each database gets an even share.
     let mut databases = HashMap::new();
-    for prefix_byte in 0u8..=255u8 {
-      *databases
-        .entry(s.get_raw(&[prefix_byte]).0.clone())
-        .or_insert(0) += 1;
+    for prefix_byte in 0_u8..=255_u8 {
+      *databases.entry(s.get_raw(&[prefix_byte]).0).or_insert(0) += 1;
     }
     assert_eq!(databases.len(), shard_count as usize);
     for (_, count) in databases {
@@ -83,7 +81,7 @@ async fn store_failure() {
   let (s, _tempdir) = new_store(1);
 
   // Produces Readers that never stabilize.
-  let contents = Mutex::new((0..100).map(|b| bytes(b)));
+  let contents = Mutex::new((0..100).map(bytes));
 
   let result = s
     .store(true, false, move || {

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -470,7 +470,7 @@ impl Core {
     let root_ca_certs = if let Some(ref path) = remoting_opts.root_ca_certs_path {
       Some(
         std::fs::read(path)
-          .map_err(|err| format!("Error reading root CA certs file {:?}: {}", path, err))?,
+          .map_err(|err| format!("Error reading root CA certs file {path:?}: {err}"))?,
       )
     } else {
       None
@@ -507,7 +507,7 @@ impl Core {
       &root_ca_certs,
       capabilities_cell_opt.clone(),
     )
-    .map_err(|e| format!("Could not initialize Store: {:?}", e))?;
+    .map_err(|e| format!("Could not initialize Store: {e:?}"))?;
 
     let local_cache = PersistentCache::new(
       &local_store_options.store_dir,
@@ -565,7 +565,7 @@ impl Core {
       });
     let http_client = http_client_builder
       .build()
-      .map_err(|err| format!("Error building HTTP client: {}", err))?;
+      .map_err(|err| format!("Error building HTTP client: {err}"))?;
     let rule_graph = RuleGraph::new(tasks.rules().clone(), tasks.queries().clone())?;
 
     let gitignore_file = if use_gitignore {
@@ -580,7 +580,7 @@ impl Core {
     };
     let ignorer =
       GitignoreStyleExcludes::create_with_gitignore_file(ignore_patterns, gitignore_file)
-        .map_err(|e| format!("Could not parse build ignore patterns: {:?}", e))?;
+        .map_err(|e| format!("Could not parse build ignore patterns: {e:?}"))?;
 
     let watcher = if watch_filesystem {
       let w = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?;
@@ -604,7 +604,7 @@ impl Core {
       http_client,
       local_cache,
       vfs: PosixFS::new(&build_root, ignorer, executor)
-        .map_err(|e| format!("Could not initialize Vfs: {:?}", e))?,
+        .map_err(|e| format!("Could not initialize Vfs: {e:?}"))?,
       build_root,
       watcher,
       local_parallelism: exec_strategy_opts.local_parallelism,

--- a/src/rust/engine/src/downloads.rs
+++ b/src/rust/engine/src/downloads.rs
@@ -109,10 +109,7 @@ struct FileDownload {
 impl FileDownload {
   async fn start(path: &str, file_name: String) -> Result<FileDownload, StreamingError> {
     let file = tokio::fs::File::open(path).await.map_err(|e| {
-      let msg = format!(
-        "Error ({}) opening file at {} for download to {}",
-        e, path, file_name
-      );
+      let msg = format!("Error ({e}) opening file at {path} for download to {file_name}");
       // Fail quickly for non-existent files.
       if e.kind() == io::ErrorKind::NotFound {
         StreamingError::Permanent(msg)
@@ -247,8 +244,7 @@ pub async fn download(
 
   if expected_digest != actual_digest {
     return Err(format!(
-      "Wrong digest for downloaded file: want {:?} got {:?}",
-      expected_digest, actual_digest
+      "Wrong digest for downloaded file: want {expected_digest:?} got {actual_digest:?}"
     ));
   }
 

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -73,7 +73,7 @@ impl PyDigest {
   #[new]
   fn __new__(fingerprint: &str, serialized_bytes_length: usize) -> PyResult<Self> {
     let fingerprint = Fingerprint::from_hex_string(fingerprint)
-      .map_err(|e| PyValueError::new_err(format!("Invalid digest hex: {}", e)))?;
+      .map_err(|e| PyValueError::new_err(format!("Invalid digest hex: {e}")))?;
     Ok(Self(DirectoryDigest::from_persisted_digest(Digest::new(
       fingerprint,
       serialized_bytes_length,
@@ -85,7 +85,7 @@ impl PyDigest {
   }
 
   fn __repr__(&self) -> String {
-    format!("{}", self)
+    format!("{self}")
   }
 
   fn __richcmp__(&self, other: &PyDigest, op: CompareOp, py: Python) -> PyObject {
@@ -116,7 +116,7 @@ impl PyFileDigest {
   #[new]
   fn __new__(fingerprint: &str, serialized_bytes_length: usize) -> PyResult<Self> {
     let fingerprint = Fingerprint::from_hex_string(fingerprint)
-      .map_err(|e| PyValueError::new_err(format!("Invalid file digest hex: {}", e)))?;
+      .map_err(|e| PyValueError::new_err(format!("Invalid file digest hex: {e}")))?;
     Ok(Self(Digest::new(fingerprint, serialized_bytes_length)))
   }
 
@@ -287,7 +287,7 @@ impl PyMergeDigests {
       .iter()
       .map(|d| format!("{}", PyDigest(d.clone())))
       .join(", ");
-    format!("MergeDigests([{}])", digests)
+    format!("MergeDigests([{digests}])")
   }
 
   fn __richcmp__(&self, other: &PyMergeDigests, op: CompareOp, py: Python) -> PyObject {
@@ -489,8 +489,7 @@ fn default_cache_path() -> PyResult<String> {
     .into_string()
     .map_err(|s| {
       PyTypeError::new_err(format!(
-        "Default cache path {:?} could not be converted to a string.",
-        s
+        "Default cache path {s:?} could not be converted to a string."
       ))
     })
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1254,7 +1254,7 @@ fn session_new_run_id(py_session: &PySession) {
 }
 
 #[pyfunction]
-fn session_get_metrics<'py>(py: Python<'py>, py_session: &PySession) -> HashMap<&'static str, u64> {
+fn session_get_metrics(py: Python<'_>, py_session: &PySession) -> HashMap<&'static str, u64> {
   py.allow_threads(|| py_session.0.workunit_store().get_metrics())
 }
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -353,8 +353,7 @@ impl PyLocalStoreOptions {
   ) -> PyO3Result<Self> {
     if shard_count.count_ones() != 1 {
       return Err(PyValueError::new_err(format!(
-        "The local store shard count must be a power of two: got {}",
-        shard_count
+        "The local store shard count must be a power of two: got {shard_count}"
       )));
     }
     Ok(Self(LocalStoreOptions {
@@ -493,7 +492,7 @@ fn py_result_from_root(py: Python, result: Result<Value, Failure>) -> PyResult {
     Err(f) => {
       let (val, python_traceback, engine_traceback) = match f {
         f @ (Failure::Invalidated | Failure::MissingDigest { .. }) => {
-          let msg = format!("{}", f);
+          let msg = format!("{f}");
           let python_traceback = Failure::native_traceback(&msg);
           (
             externs::create_exception(py, msg),
@@ -956,7 +955,7 @@ fn session_poll_workunits(
       let py_session = py_session.extract::<PyRef<PySession>>(py)?;
       let py_level: PythonLogLevel = max_log_verbosity_level
         .try_into()
-        .map_err(|e| PyException::new_err(format!("{}", e)))?;
+        .map_err(|e| PyException::new_err(format!("{e}")))?;
       (py_scheduler.0.core.clone(), py_session.0.clone(), py_level)
     };
     core.executor.enter(|| {
@@ -1129,7 +1128,7 @@ fn tasks_task_begin(
 ) -> PyO3Result<()> {
   let py_level: PythonLogLevel = level
     .try_into()
-    .map_err(|e| PyException::new_err(format!("{}", e)))?;
+    .map_err(|e| PyException::new_err(format!("{e}")))?;
   let func = Function(Key::from_value(func.into())?);
   let output_type = TypeId::new(output_type);
   let arg_types = arg_types.into_iter().map(TypeId::new).collect();
@@ -1417,8 +1416,8 @@ pub(crate) fn generate_panic_string(payload: &(dyn Any + Send)) -> String {
     .cloned()
     .or_else(|| payload.downcast_ref::<&str>().map(|&s| s.to_string()))
   {
-    Some(ref s) => format!("panic at '{}'", s),
-    None => format!("Non-string panic payload at {:p}", payload),
+    Some(ref s) => format!("panic at '{s}'"),
+    None => format!("Non-string panic payload at {payload:p}"),
   }
 }
 
@@ -1674,8 +1673,7 @@ fn stdio_initialize(
       Regex::new(re).map_err(|e| {
         PyException::new_err(
           format!(
-            "Failed to parse warning filter. Please check the global option `--ignore-warnings`.\n\n{}",
-            e,
+            "Failed to parse warning filter. Please check the global option `--ignore-warnings`.\n\n{e}",
           )
         )
       })
@@ -1691,7 +1689,7 @@ fn stdio_initialize(
     regex_filters,
     log_file_path,
   )
-  .map_err(|s| PyException::new_err(format!("Could not initialize logging: {}", s)))?;
+  .map_err(|s| PyException::new_err(format!("Could not initialize logging: {s}")))?;
 
   Ok((
     externs::stdio::PyStdioRead,

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -61,7 +61,7 @@ impl PyFailure {
     match &self.0 {
       Failure::Throw { val, .. } => val.into_py(py),
       f @ (Failure::Invalidated | Failure::MissingDigest { .. }) => {
-        EngineError::new_err(format!("{}", f))
+        EngineError::new_err(format!("{f}"))
       }
     }
   }
@@ -159,7 +159,7 @@ where
 {
   value
     .getattr(field)
-    .map_err(|e| format!("Could not get field `{}`: {:?}", field, e))?
+    .map_err(|e| format!("Could not get field `{field}`: {e:?}"))?
     .extract::<T>()
     .map_err(|e| {
       format!(
@@ -270,10 +270,9 @@ pub fn generator_send(
     (Some(arg), None) => arg.to_object(py),
     (None, Some(err)) => err.into_py(py),
     (None, None) => py.None(),
-    (Some(arg), Some(err)) => panic!(
-      "generator_send got both value and error: arg={:?}, err={:?}",
-      arg, err
-    ),
+    (Some(arg), Some(err)) => {
+      panic!("generator_send got both value and error: arg={arg:?}, err={err:?}")
+    }
   };
   let response = native_engine_generator_send
     .call1((generator.to_object(py), py_arg))
@@ -301,10 +300,7 @@ pub fn generator_send(
       .collect::<Result<Vec<_>, _>>()?;
     Ok(GeneratorResponse::GetMulti(gets))
   } else {
-    panic!(
-      "native_engine_generator_send returned unrecognized type: {:?}",
-      response
-    );
+    panic!("native_engine_generator_send returned unrecognized type: {response:?}");
   }
 }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -158,12 +158,9 @@ impl Select {
     dependency_key: &DependencyKey<TypeId>,
     edges: &rule_graph::RuleEdges<Rule>,
   ) -> Select {
-    let entry = edges.entry_for(dependency_key).unwrap_or_else(|| {
-      panic!(
-        "{:?} did not declare a dependency on {:?}",
-        edges, dependency_key
-      )
-    });
+    let entry = edges
+      .entry_for(dependency_key)
+      .unwrap_or_else(|| panic!("{edges:?} did not declare a dependency on {dependency_key:?}"));
     Select::new(params, dependency_key.product(), entry)
   }
 
@@ -200,8 +197,7 @@ impl Select {
       .edges_for_inner(&self.entry)
       .ok_or_else(|| {
         throw(format!(
-          "Tried to request {} for {} but found no edges",
-          dependency_key, caller_description
+          "Tried to request {dependency_key} for {caller_description} but found no edges"
         ))
       });
     let params = self.params.clone();
@@ -218,7 +214,7 @@ impl Select {
     match self.entry.as_ref() {
       &rule_graph::Entry::WithDeps(wd) => match wd.as_ref() {
         rule_graph::EntryWithDeps::Rule(ref rule) => match rule.rule() {
-          &tasks::Rule::Task(ref task) => {
+          tasks::Rule::Task(task) => {
             context
               .get(Task {
                 params: self.params.clone(),
@@ -228,7 +224,7 @@ impl Select {
               })
               .await
           }
-          &Rule::Intrinsic(ref intrinsic) => {
+          Rule::Intrinsic(intrinsic) => {
             let values = future::try_join_all(
               intrinsic
                 .inputs
@@ -246,7 +242,7 @@ impl Select {
               .await
           }
         },
-        &rule_graph::EntryWithDeps::Reentry(ref reentry) => {
+        rule_graph::EntryWithDeps::Reentry(reentry) => {
           // TODO: Actually using the `RuleEdges` of this entry to compute inputs is not
           // implemented: doing so would involve doing something similar to what we do for
           // intrinsics above, and waiting to compute inputs before executing the query here.
@@ -282,12 +278,12 @@ impl From<Select> for NodeKey {
 }
 
 pub fn lift_directory_digest(digest: &PyAny) -> Result<DirectoryDigest, String> {
-  let py_digest: externs::fs::PyDigest = digest.extract().map_err(|e| format!("{}", e))?;
+  let py_digest: externs::fs::PyDigest = digest.extract().map_err(|e| format!("{e}"))?;
   Ok(py_digest.0)
 }
 
 pub fn lift_file_digest(digest: &PyAny) -> Result<hashing::Digest, String> {
-  let py_file_digest: externs::fs::PyFileDigest = digest.extract().map_err(|e| format!("{}", e))?;
+  let py_file_digest: externs::fs::PyFileDigest = digest.extract().map_err(|e| format!("{e}"))?;
   Ok(py_file_digest.0)
 }
 
@@ -306,7 +302,7 @@ impl ExecuteProcess {
     let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
       let value = (**value).as_ref(py);
       let input_files = lift_directory_digest(externs::getattr(value, "input_digest").unwrap())
-        .map_err(|err| format!("Error parsing input_digest {}", err))?;
+        .map_err(|err| format!("Error parsing input_digest {err}"))?;
       let immutable_inputs =
         externs::getattr_from_str_frozendict::<&PyAny>(value, "immutable_input_digests")
           .into_iter()
@@ -456,7 +452,7 @@ impl ExecuteProcess {
       .await?;
 
     let definition = serde_json::to_string(&request)
-      .map_err(|e| throw(format!("Failed to serialize process: {}", e)))?;
+      .map_err(|e| throw(format!("Failed to serialize process: {e}")))?;
     workunit.update_metadata(|initial| {
       initial.map(|(initial, level)| {
         (
@@ -557,7 +553,7 @@ impl ReadLink {
       .vfs
       .read_link(&node.0)
       .await
-      .map_err(|e| throw(format!("{}", e)))?;
+      .map_err(|e| throw(format!("{e}")))?;
     Ok(LinkDest(link_dest))
   }
 }
@@ -617,7 +613,7 @@ impl Scandir {
       .vfs
       .scandir(self.0)
       .await
-      .map_err(|e| throw(format!("{}", e)))?;
+      .map_err(|e| throw(format!("{e}")))?;
     Ok(Arc::new(directory_listing))
   }
 }
@@ -641,8 +637,7 @@ fn unmatched_globs_additional_context() -> Option<String> {
   Some(format!(
     "\n\nDo the file(s) exist? If so, check if the file(s) are in your `.gitignore` or the global \
     `pants_ignore` option, which may result in Pants not being able to see the file(s) even though \
-    they exist on disk. Refer to {}.",
-    url
+    they exist on disk. Refer to {url}."
   ))
 }
 
@@ -669,7 +664,7 @@ impl Paths {
         SymlinkBehavior::Oblivious,
         unmatched_globs_additional_context(),
       )
-      .map_err(|e| throw(format!("{}", e)))
+      .map_err(|e| throw(format!("{e}")))
       .await
   }
 
@@ -678,13 +673,13 @@ impl Paths {
     let mut dirs = Vec::new();
     for ps in item.iter() {
       match ps {
-        &PathStat::File { ref path, .. } => {
+        PathStat::File { path, .. } => {
           files.push(Snapshot::store_path(py, path)?);
         }
-        &PathStat::Link { ref path, .. } => {
+        PathStat::Link { path, .. } => {
           panic!("Paths shouldn't be symlink-aware {path:?}");
         }
-        &PathStat::Dir { ref path, .. } => {
+        PathStat::Dir { path, .. } => {
           dirs.push(Snapshot::store_path(py, path)?);
         }
       }
@@ -792,22 +787,22 @@ impl Snapshot {
     let path_globs = Snapshot::lift_path_globs(item)?;
     path_globs
       .parse()
-      .map_err(|e| format!("Failed to parse PathGlobs for globs({:?}): {}", item, e))
+      .map_err(|e| format!("Failed to parse PathGlobs for globs({item:?}): {e}"))
   }
 
   pub fn store_directory_digest(py: Python, item: DirectoryDigest) -> Result<Value, String> {
-    let py_digest = Py::new(py, externs::fs::PyDigest(item)).map_err(|e| format!("{}", e))?;
+    let py_digest = Py::new(py, externs::fs::PyDigest(item)).map_err(|e| format!("{e}"))?;
     Ok(Value::new(py_digest.into_py(py)))
   }
 
   pub fn store_file_digest(py: Python, item: hashing::Digest) -> Result<Value, String> {
     let py_file_digest =
-      Py::new(py, externs::fs::PyFileDigest(item)).map_err(|e| format!("{}", e))?;
+      Py::new(py, externs::fs::PyFileDigest(item)).map_err(|e| format!("{e}"))?;
     Ok(Value::new(py_file_digest.into_py(py)))
   }
 
   pub fn store_snapshot(py: Python, item: store::Snapshot) -> Result<Value, String> {
-    let py_snapshot = Py::new(py, externs::fs::PySnapshot(item)).map_err(|e| format!("{}", e))?;
+    let py_snapshot = Py::new(py, externs::fs::PySnapshot(item)).map_err(|e| format!("{e}"))?;
     Ok(Value::new(py_snapshot.into_py(py)))
   }
 
@@ -815,7 +810,7 @@ impl Snapshot {
     if let Some(p) = item.as_os_str().to_str() {
       Ok(externs::store_utf8(py, p))
     } else {
-      Err(format!("Could not decode path `{:?}` as UTF8.", item))
+      Err(format!("Could not decode path `{item:?}` as UTF8."))
     }
   }
 
@@ -931,11 +926,11 @@ impl Snapshot {
         SymlinkBehavior::Oblivious,
         unmatched_globs_additional_context(),
       )
-      .map_err(|e| throw(format!("{}", e)))
+      .map_err(|e| throw(format!("{e}")))
       .await?;
 
     store::Snapshot::from_path_stats(context.clone(), path_stats)
-      .map_err(|e| throw(format!("Snapshot failed: {}", e)))
+      .map_err(|e| throw(format!("Snapshot failed: {e}")))
       .await
   }
 }
@@ -976,7 +971,7 @@ impl DownloadedFile {
       .path_segments()
       .and_then(Iterator::last)
       .map(str::to_owned)
-      .ok_or_else(|| format!("Error getting the file name from the parsed URL: {}", url))?;
+      .ok_or_else(|| format!("Error getting the file name from the parsed URL: {url}"))?;
     let path = RelativePath::new(&file_name).map_err(|e| {
       format!(
         "The file name derived from {} was {} which is not relative: {:?}",
@@ -1021,8 +1016,8 @@ impl DownloadedFile {
         Ok((url_str, py_file_digest.0, auth_headers));
       res
     })?;
-    let url = Url::parse(&url_str)
-      .map_err(|err| throw(format!("Error parsing URL {}: {}", url_str, err)))?;
+    let url =
+      Url::parse(&url_str).map_err(|err| throw(format!("Error parsing URL {url_str}: {err}")))?;
     self
       .load_or_download(context.core, url, auth_headers, expected_digest)
       .await
@@ -1077,7 +1072,7 @@ impl Task {
             .core
             .rule_graph
             .edges_for_inner(&entry)
-            .ok_or_else(|| throw(format!("No edges for task {:?} exist!", entry)))?;
+            .ok_or_else(|| throw(format!("No edges for task {entry:?} exist!")))?;
 
           // Find the entry for the Get.
           let select = edges
@@ -1105,20 +1100,18 @@ impl Task {
             .ok_or_else(|| {
               if get.input_types.iter().any(|t| t.is_union()) {
                 throw(format!(
-                  "Invalid Get. Because an input type for `{}` was annotated with `@union`, \
+                  "Invalid Get. Because an input type for `{get}` was annotated with `@union`, \
                   the value for that type should be a member of that union. Did you \
                   intend to register a `UnionRule`? If not, you may be using the incorrect \
                   explicitly declared type.",
-                  get,
                 ))
               } else {
                 // NB: The Python constructor for `Get()` will have already errored if
                 // `type(input) != input_type`.
                 throw(format!(
-                  "{} was not detected in your @rule body at rule compile time. \
+                  "{get} was not detected in your @rule body at rule compile time. \
                   Was the `Get` constructor called in a separate function, or perhaps \
                   dynamically? If so, it must be inlined into the @rule body.",
-                  get,
                 ))
               }
             })?;
@@ -1296,9 +1289,9 @@ pub enum NodeKey {
 impl NodeKey {
   pub fn fs_subject(&self) -> Option<&Path> {
     match self {
-      &NodeKey::DigestFile(ref s) => Some(s.0.path.as_path()),
-      &NodeKey::ReadLink(ref s) => Some((s.0).path.as_path()),
-      &NodeKey::Scandir(ref s) => Some((s.0).0.as_path()),
+      NodeKey::DigestFile(s) => Some(s.0.path.as_path()),
+      NodeKey::ReadLink(s) => Some((s.0).path.as_path()),
+      NodeKey::Scandir(s) => Some((s.0).0.as_path()),
 
       // Not FS operations:
       // Explicitly listed so that if people add new NodeKeys they need to consider whether their
@@ -1513,14 +1506,14 @@ impl Node for NodeKey {
     // A Task / @rule is only restartable if it has not had a side effect (as determined by the
     // calls to the `task_side_effected` function).
     match self {
-      &NodeKey::Task(ref s) => !s.side_effected.load(Ordering::SeqCst),
+      NodeKey::Task(s) => !s.side_effected.load(Ordering::SeqCst),
       _ => true,
     }
   }
 
   fn cacheable(&self) -> bool {
     match self {
-      &NodeKey::Task(ref s) => s.task.cacheable,
+      NodeKey::Task(s) => s.task.cacheable,
       &NodeKey::SessionValues(_) | &NodeKey::RunId(_) => false,
       _ => true,
     }
@@ -1576,15 +1569,15 @@ impl Node for NodeKey {
 impl Display for NodeKey {
   fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
     match self {
-      &NodeKey::DigestFile(ref s) => write!(f, "DigestFile({})", s.0.path.display()),
-      &NodeKey::DownloadedFile(ref s) => write!(f, "DownloadedFile({})", s.0),
-      &NodeKey::ExecuteProcess(ref s) => {
+      NodeKey::DigestFile(s) => write!(f, "DigestFile({})", s.0.path.display()),
+      NodeKey::DownloadedFile(s) => write!(f, "DownloadedFile({})", s.0),
+      NodeKey::ExecuteProcess(s) => {
         write!(f, "Process({})", s.process.description)
       }
-      &NodeKey::ReadLink(ref s) => write!(f, "ReadLink({})", (s.0).path.display()),
-      &NodeKey::Scandir(ref s) => write!(f, "Scandir({})", (s.0).0.display()),
-      &NodeKey::Select(ref s) => write!(f, "{}", s.product),
-      &NodeKey::Task(ref task) => {
+      NodeKey::ReadLink(s) => write!(f, "ReadLink({})", (s.0).path.display()),
+      NodeKey::Scandir(s) => write!(f, "Scandir({})", (s.0).0.display()),
+      NodeKey::Select(s) => write!(f, "{}", s.product),
+      NodeKey::Task(task) => {
         let params = {
           let gil = Python::acquire_gil();
           let py = gil.python();
@@ -1603,10 +1596,10 @@ impl Display for NodeKey {
           params.join(", ")
         )
       }
-      &NodeKey::Snapshot(ref s) => write!(f, "Snapshot({})", s.path_globs),
+      NodeKey::Snapshot(s) => write!(f, "Snapshot({})", s.path_globs),
       &NodeKey::SessionValues(_) => write!(f, "SessionValues"),
       &NodeKey::RunId(_) => write!(f, "RunId"),
-      &NodeKey::Paths(ref s) => write!(f, "Paths({})", s.path_globs),
+      NodeKey::Paths(s) => write!(f, "Paths({})", s.path_globs),
     }
   }
 }

--- a/src/rust/engine/src/python.rs
+++ b/src/rust/engine/src/python.rs
@@ -105,7 +105,7 @@ where
   T: Iterator,
   T::Item: fmt::Display,
 {
-  let mut items: Vec<_> = items.map(|p| format!("{}", p)).collect();
+  let mut items: Vec<_> = items.map(|p| format!("{p}")).collect();
   match items.len() {
     0 => "()".to_string(),
     1 => items.pop().unwrap(),
@@ -169,14 +169,14 @@ impl fmt::Debug for TypeId {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     Python::with_gil(|py| {
       let name = self.as_py_type(py).name().unwrap();
-      write!(f, "{}", name)
+      write!(f, "{name}")
     })
   }
 }
 
 impl fmt::Display for TypeId {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{:?}", self)
+    write!(f, "{self:?}")
   }
 }
 
@@ -207,7 +207,7 @@ impl Function {
       let line_no: u64 = externs::getattr(obj, "__line_number__").unwrap();
       (module, name, line_no)
     });
-    format!("{}:{}:{}", module, line_no, name)
+    format!("{module}:{line_no}:{name}")
   }
 }
 
@@ -219,7 +219,7 @@ impl fmt::Debug for Function {
 
 impl fmt::Display for Function {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{:?}", self)
+    write!(f, "{self:?}")
   }
 }
 
@@ -253,7 +253,7 @@ impl fmt::Debug for Key {
 
 impl fmt::Display for Key {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{:?}", self)
+    write!(f, "{self:?}")
   }
 }
 
@@ -339,13 +339,13 @@ impl fmt::Debug for Value {
       let obj = (*self.0).as_ref(py);
       externs::val_to_str(obj)
     });
-    write!(f, "{}", repr)
+    write!(f, "{repr}")
   }
 }
 
 impl fmt::Display for Value {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    write!(f, "{:?}", self)
+    write!(f, "{self:?}")
   }
 }
 
@@ -470,8 +470,7 @@ impl Failure {
           py_err.set_cause(py, Some(PyErr::from_value((*val.0).as_ref(py))));
           (
             format!(
-              "{}\nDuring handling of the above exception, another exception occurred:\n\n",
-              python_traceback
+              "{python_traceback}\nDuring handling of the above exception, another exception occurred:\n\n"
             ),
             engine_traceback,
           )
@@ -512,10 +511,7 @@ impl Failure {
   }
 
   pub fn native_traceback(msg: &str) -> String {
-    format!(
-      "Traceback (no traceback):\n  <pants native internals>\nException: {}",
-      msg
-    )
+    format!("Traceback (no traceback):\n  <pants native internals>\nException: {msg}")
   }
 }
 
@@ -547,7 +543,7 @@ impl fmt::Display for Failure {
           let obj = (*val.0).as_ref(py);
           externs::val_to_str(obj)
         });
-        write!(f, "{}", repr)
+        write!(f, "{repr}")
       }
     }
   }

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -223,7 +223,7 @@ impl Scheduler {
     Ok((
       result
         .try_into()
-        .unwrap_or_else(|e| panic!("A Node implementation was ambiguous: {:?}", e)),
+        .unwrap_or_else(|e| panic!("A Node implementation was ambiguous: {e:?}")),
       last_observed,
     ))
   }

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -407,7 +407,7 @@ impl Sessions {
     // non-isolated Sessions.
     let signal_task_handle = {
       let mut signal_stream = signal(SignalKind::interrupt())
-        .map_err(|err| format!("Failed to install interrupt handler: {}", err))?;
+        .map_err(|err| format!("Failed to install interrupt handler: {err}"))?;
       let sessions = sessions.clone();
       executor.native_spawn(async move {
         loop {
@@ -480,7 +480,7 @@ impl Sessions {
         log::info!("Waiting for shutdown of: {:?}", build_ids);
         tokio::time::timeout(timeout, future::join_all(cancellation_latches))
           .await
-          .map_err(|_| format!("Some Sessions did not shutdown within {:?}.", timeout))?;
+          .map_err(|_| format!("Some Sessions did not shutdown within {timeout:?}."))?;
       }
     }
     Ok(())

--- a/src/rust/engine/src/tasks.rs
+++ b/src/rust/engine/src/tasks.rs
@@ -55,10 +55,7 @@ impl DisplayForGraph for Rule {
           "goal_rule".to_string()
         };
 
-        format!(
-          "@{}({}({}) -> {}{})",
-          rule_type, task_name, clause_portion, product, get_portion,
-        )
+        format!("@{rule_type}({task_name}({clause_portion}) -> {product}{get_portion})",)
       }
       Rule::Intrinsic(ref intrinsic) => format!(
         "@rule(<intrinsic>({}) -> {})",

--- a/src/rust/engine/stdio/src/lib.rs
+++ b/src/rust/engine/stdio/src/lib.rs
@@ -181,8 +181,7 @@ impl Destination {
       }) => stderr_use_color,
       _ => {
         return Err(format!(
-          "Cannot start Exclusive access on Destination {:?}",
-          destination
+          "Cannot start Exclusive access on Destination {destination:?}"
         ))
       }
     };
@@ -279,10 +278,8 @@ impl Destination {
     };
 
     // Release the lock, clear the Console, log the error and retry.
-    let error_str = format!(
-      "Failed to write stdout to {:?}, falling back to Logging: {:?}",
-      destination, error_res
-    );
+    let error_str =
+      format!("Failed to write stdout to {destination:?}, falling back to Logging: {error_res:?}");
     std::mem::drop(destination);
     self.console_clear();
     log::warn!("{}", error_str);
@@ -348,10 +345,8 @@ impl Destination {
     };
 
     // Release the lock, clear the Console, log the error and retry.
-    let error_str = format!(
-      "Failed to write stderr to {:?}, falling back to Logging: {:?}",
-      destination, error_res
-    );
+    let error_str =
+      format!("Failed to write stderr to {destination:?}, falling back to Logging: {error_res:?}");
     std::mem::drop(destination);
     self.console_clear();
     log::warn!("{}", error_str);

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -121,7 +121,7 @@ impl Executor {
 
     let runtime = runtime_builder
       .build()
-      .map_err(|e| format!("Failed to start the runtime: {}", e))?;
+      .map_err(|e| format!("Failed to start the runtime: {e}"))?;
 
     // Attempt to swap, then recurse to retry.
     GLOBAL_EXECUTOR.compare_and_swap(global, Some(Arc::new(runtime)));

--- a/src/rust/engine/testutil/mock/src/action_cache_service.rs
+++ b/src/rust/engine/testutil/mock/src/action_cache_service.rs
@@ -95,8 +95,7 @@ impl ActionCache for ActionCacheResponder {
       Some(ar) => ar.clone(),
       None => {
         return Err(Status::not_found(format!(
-          "ActionResult for Action {:?} does not exist",
-          action_digest
+          "ActionResult for Action {action_digest:?} does not exist"
         )));
       }
     };

--- a/src/rust/engine/testutil/mock/src/cas.rs
+++ b/src/rust/engine/testutil/mock/src/cas.rs
@@ -168,7 +168,7 @@ impl StubCASBuilder {
       always_errors: self.cas_always_errors,
       read_request_count: read_request_count.clone(),
       write_message_sizes: write_message_sizes.clone(),
-      required_auth_header: self.required_auth_token.map(|t| format!("Bearer {}", t)),
+      required_auth_header: self.required_auth_token.map(|t| format!("Bearer {t}")),
     };
 
     let action_map = Arc::new(Mutex::new(HashMap::new()));

--- a/src/rust/engine/testutil/mock/src/cas_service.rs
+++ b/src/rust/engine/testutil/mock/src/cas_service.rs
@@ -181,11 +181,11 @@ impl StubCASResponder {
 
   fn read_internal(&self, req: &ReadRequest) -> Result<Vec<ReadResponse>, Status> {
     let parsed_resource_name = parse_read_resource_name(&req.resource_name)
-      .map_err(|err| Status::invalid_argument(format!("Failed to parse resource name: {}", err)))?;
+      .map_err(|err| Status::invalid_argument(format!("Failed to parse resource name: {err}")))?;
 
     let digest = parsed_resource_name.hash;
     let fingerprint = Fingerprint::from_hex_string(digest)
-      .map_err(|e| Status::invalid_argument(format!("Bad digest {}: {}", digest, e)))?;
+      .map_err(|e| Status::invalid_argument(format!("Bad digest {digest}: {e}")))?;
     if self.always_errors {
       return Err(Status::internal(
         "StubCAS is configured to always fail".to_owned(),
@@ -203,8 +203,7 @@ impl StubCASResponder {
           .collect(),
       ),
       None => Err(Status::not_found(format!(
-        "Did not find digest {}",
-        fingerprint
+        "Did not find digest {fingerprint}"
       ))),
     }
   }
@@ -254,8 +253,7 @@ impl ByteStream for StubCASResponder {
         Ok(r) => r,
         Err(e) => {
           return Err(Status::invalid_argument(format!(
-            "Client sent an error: {}",
-            e
+            "Client sent an error: {e}"
           )))
         }
       };

--- a/src/rust/engine/testutil/mock/src/execution_server.rs
+++ b/src/rust/engine/testutil/mock/src/execution_server.rs
@@ -190,11 +190,10 @@ impl Drop for TestServer {
       );
       if std::thread::panicking() {
         eprintln!(
-          "TestServer missing requests, but not panicking because caller is already panicking: {}",
-          message
+          "TestServer missing requests, but not panicking because caller is already panicking: {message}"
         );
       } else {
-        assert_eq!(remaining_expected_responses, 0, "{}", message,);
+        assert_eq!(remaining_expected_responses, 0, "{message}",);
       }
     }
   }
@@ -240,7 +239,7 @@ impl MockResponder {
   fn display_all<D: Debug>(items: &[D]) -> String {
     items
       .iter()
-      .map(|i| format!("{:?}\n", i))
+      .map(|i| format!("{i:?}\n"))
       .collect::<Vec<_>>()
       .concat()
   }
@@ -292,16 +291,14 @@ impl Execution for MockResponder {
           }
         } else {
           return Err(Status::invalid_argument(format!(
-            "Did not expect this request. Expected: {:?}, Got: {:?}",
-            execute_request, request
+            "Did not expect this request. Expected: {execute_request:?}, Got: {request:?}"
           )));
         }
       }
 
       Some(api_call) => {
         return Err(Status::invalid_argument(format!(
-          "Execute endpoint called. Expected: {:?}",
-          api_call
+          "Execute endpoint called. Expected: {api_call:?}"
         )));
       }
 
@@ -344,8 +341,7 @@ impl Execution for MockResponder {
 
       Some(api_call) => {
         return Err(Status::invalid_argument(format!(
-          "WaitExecution endpoint called. Expected: {:?}",
-          api_call,
+          "WaitExecution endpoint called. Expected: {api_call:?}",
         )));
       }
 
@@ -402,8 +398,7 @@ impl Operations for MockResponder {
       }
 
       Some(api_call) => Err(Status::invalid_argument(format!(
-        "GetOperation endpoint called. Expected: {:?}",
-        api_call,
+        "GetOperation endpoint called. Expected: {api_call:?}",
       ))),
 
       None => Err(Status::invalid_argument(
@@ -451,8 +446,7 @@ impl ActionCache for MockResponder {
             Ok(d) => d,
             Err(e) => {
               return Err(Status::invalid_argument(format!(
-                "GetActionResult endpoint called with bad digest: {:?}",
-                e,
+                "GetActionResult endpoint called with bad digest: {e:?}",
               )));
             }
           };
@@ -471,8 +465,7 @@ impl ActionCache for MockResponder {
       }
 
       Some(api_call) => Err(Status::invalid_argument(format!(
-        "GetActionResult endpoint called. Expected: {:?}",
-        api_call,
+        "GetActionResult endpoint called. Expected: {api_call:?}",
       ))),
 
       None => Err(Status::invalid_argument(

--- a/src/rust/engine/testutil/src/file.rs
+++ b/src/rust/engine/testutil/src/file.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 pub fn list_dir(path: &Path) -> Vec<String> {
   let mut v: Vec<_> = std::fs::read_dir(path)
-    .unwrap_or_else(|err| panic!("Listing dir {:?}: {:?}", path, err))
+    .unwrap_or_else(|err| panic!("Listing dir {path:?}: {err:?}"))
     .map(|entry| {
       entry
         .expect("Error reading entry")

--- a/src/rust/engine/ui/src/console_ui.rs
+++ b/src/rust/engine/ui/src/console_ui.rs
@@ -342,7 +342,7 @@ impl Instance {
               None => "(Waiting)".to_string(),
               Some(duration) => format_workunit_duration_ms!((duration).as_millis()).to_string(),
             };
-            format!("{} {}", duration_label, label)
+            format!("{duration_label} {label}")
           });
 
           match maybe_label {

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use crossbeam_channel::{self, RecvTimeoutError};
 use fs::GitignoreStyleExcludes;
-use notify;
+
 use parking_lot::Mutex;
 use task_executor::Executor;
 use testutil::{append_to_existing_file, make_file};

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -298,16 +298,13 @@ impl Workunit {
     let effective_identifier = if identifier.len() > max_len {
       let truncated_identifier: String = identifier.chars().take(max_len).collect();
       let trunc = identifier.len() - max_len;
-      format!(
-        "{}... ({} characters truncated)",
-        truncated_identifier, trunc
-      )
+      format!("{truncated_identifier}... ({trunc} characters truncated)")
     } else {
       identifier.to_string()
     };
 
     let message = if let Some(ref s) = metadata.message {
-      format!(" - {}", s)
+      format!(" - {s}")
     } else {
       "".to_string()
     };

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -142,7 +142,7 @@ fn hex_16_digit_string_actually_uses_input_number() {
     SpanId(0x_ffff_ffff_ffff_ffff).to_string(),
     "ffffffffffffffff"
   );
-  assert_eq!(SpanId(0x_1).to_string(), "0000000000000001");
+  assert_eq!(SpanId(0x0001).to_string(), "0000000000000001");
   assert_eq!(
     SpanId(0x_0123_4567_89ab_cdef).to_string(),
     "0123456789abcdef"
@@ -219,6 +219,6 @@ fn wu(span_id: u64, parent_id: u64) -> AnonymousWorkunit {
 
 fn wu_level(span_id: u64, parent_id: Option<u64>, level: Level) -> AnonymousWorkunit {
   let mut metadata = WorkunitMetadata::default();
-  metadata.desc = Some(format!("{}", span_id));
+  metadata.desc = Some(format!("{span_id}"));
   (level, SpanId(span_id), parent_id.map(SpanId), metadata)
 }


### PR DESCRIPTION
Upgrade Rust to v1.67.0.

Lots of changes due to clippy lints:
- `clippy::uninlined_format_args`: `format!("{}", err)` must now be `format!("{err}")`. These changes were made with `cargp clippy --fix`.
- `clippy::let_underscore_future`: Have to explicitly drop a future and not bind it to `_`.
- `clippy::needless_lifetimes`: One call site fixed.
