### PR TITLE
go: add `environment` field to `go_binary`

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -23,6 +23,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.fs import AddPrefix, Digest
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
@@ -38,6 +39,7 @@ class GoBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
     main: GoBinaryMainPackageField
     output_path: OutputPathField
+    environment: EnvironmentField
 
 
 @rule(desc="Package Go binary", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -9,6 +9,7 @@ from typing import Iterable, Optional, Sequence, Tuple
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
 from pants.core.goals.test import TestExtraEnvVarsField, TestTimeoutField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -452,6 +453,7 @@ class GoBinaryTarget(Target):
         GoCompilerFlagsField,
         GoLinkerFlagsField,
         RestartableField,
+        EnvironmentField,
     )
     help = "A Go binary."
 


### PR DESCRIPTION
Add an `environment` field to `go_binary` so that Go binaries can users can at least attempt to build binaries in a non-local environment.

Fixes https://github.com/pantsbuild/pants/issues/18115

Note: There is still [a bug with dependencies for the Go SDK](https://github.com/pantsbuild/pants/issues/18114) differing between the local and non-local environments due to condition compilation changing imports. (For example, the `runtime` package in the Go SDK only imports `runtime/internal/syscall` on Linux but not macOS.) This PR does not attempt to fix the bug, which will be fixed in a subsequent PR.