### PR TITLE
javascript: npm package-lock.json lockfile `generate-lockfile` support

### DIFF
--- a/src/python/pants/backend/javascript/BUILD
+++ b/src/python/pants/backend/javascript/BUILD
@@ -2,3 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/src/python/pants/backend/javascript/goals/lockfile.py
+++ b/src/python/pants/backend/javascript/goals/lockfile.py
@@ -1,0 +1,97 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import os.path
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.javascript import package_json
+from pants.backend.javascript.package_json import AllPackageJson, PackageJson
+from pants.backend.javascript.subsystems import nodejs
+from pants.backend.javascript.subsystems.nodejs import NodeJSToolProcess
+from pants.core.goals.generate_lockfiles import (
+    GenerateLockfile,
+    GenerateLockfileResult,
+    KnownUserResolveNames,
+    KnownUserResolveNamesRequest,
+    RequestedUserResolveNames,
+    UserGenerateLockfiles,
+)
+from pants.engine.internals.native_engine import AddPrefix, Digest, RemovePrefix
+from pants.engine.internals.selectors import Get
+from pants.engine.process import ProcessResult
+from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.unions import UnionRule
+
+
+@dataclass(frozen=True)
+class GeneratePackageLockJsonFile(GenerateLockfile):
+    pkg_json: PackageJson
+
+
+class KnownPackageJsonUserResolveNamesRequest(KnownUserResolveNamesRequest):
+    pass
+
+
+class RequestedPackageJsonUserResolveNames(RequestedUserResolveNames):
+    pass
+
+
+@rule
+async def determine_package_json_user_resolves(
+    _: KnownPackageJsonUserResolveNamesRequest, pkg_jsons: AllPackageJson
+) -> KnownUserResolveNames:
+    return KnownUserResolveNames(
+        names=tuple(pkg.name for pkg in pkg_jsons),
+        option_name="<generated>",
+        requested_resolve_names_cls=RequestedPackageJsonUserResolveNames,
+    )
+
+
+@rule
+async def setup_user_lockfile_requests(
+    requested: RequestedPackageJsonUserResolveNames, pkg_jsons: AllPackageJson
+) -> UserGenerateLockfiles:
+    return UserGenerateLockfiles(
+        GeneratePackageLockJsonFile(
+            resolve_name=pkg.name,
+            lockfile_dest=f"{pkg.root_dir}{os.path.sep}package-lock.json",
+            pkg_json=pkg,
+            diff=False,
+        )
+        for pkg in pkg_jsons
+        if pkg.name in requested
+    )
+
+
+@rule
+async def generate_lockfile_from_package_jsons(
+    request: GeneratePackageLockJsonFile,
+) -> GenerateLockfileResult:
+    input_digest = await Get(
+        Digest, RemovePrefix(request.pkg_json.digest, request.pkg_json.root_dir)
+    )
+    result = await Get(
+        ProcessResult,
+        NodeJSToolProcess,
+        NodeJSToolProcess.npm(
+            args=("install", "--package-lock-only"),
+            description=f"generate package-lock.json for '{request.resolve_name}'.",
+            input_digest=input_digest,
+            output_files=("package-lock.json",),
+        ),
+    )
+    output_digest = await Get(Digest, AddPrefix(result.output_digest, request.pkg_json.root_dir))
+    return GenerateLockfileResult(output_digest, request.resolve_name, request.lockfile_dest)
+
+
+def rules() -> Iterable[Rule | UnionRule]:
+    return (
+        *collect_rules(),
+        *package_json.rules(),
+        *nodejs.rules(),
+        UnionRule(GenerateLockfile, GeneratePackageLockJsonFile),
+        UnionRule(KnownUserResolveNamesRequest, KnownPackageJsonUserResolveNamesRequest),
+        UnionRule(RequestedUserResolveNames, RequestedPackageJsonUserResolveNames),
+    )

--- a/src/python/pants/backend/javascript/goals/lockfile_test.py
+++ b/src/python/pants/backend/javascript/goals/lockfile_test.py
@@ -1,0 +1,94 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+
+import pytest
+
+from pants.backend.javascript.goals import lockfile
+from pants.backend.javascript.goals.lockfile import (
+    GeneratePackageLockJsonFile,
+    KnownPackageJsonUserResolveNamesRequest,
+)
+from pants.backend.javascript.package_json import (
+    AllPackageJson,
+    PackageJson,
+    PackageJsonSourceField,
+    PackageJsonTarget,
+    ReadPackageJsonRequest,
+)
+from pants.build_graph.address import Address
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult, KnownUserResolveNames
+from pants.engine.fs import DigestContents
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *lockfile.rules(),
+            QueryRule(
+                KnownUserResolveNames, (KnownPackageJsonUserResolveNamesRequest, AllPackageJson)
+            ),
+            QueryRule(AllPackageJson, ()),
+            QueryRule(GenerateLockfileResult, (GeneratePackageLockJsonFile,)),
+            QueryRule(PackageJson, (ReadPackageJsonRequest,)),
+        ],
+        target_types=[PackageJsonTarget],
+    )
+
+
+def given_package_with_name(name: str) -> str:
+    return json.dumps({"name": name, "version": "0.0.1"})
+
+
+def test_resolves_are_package_names(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/foo/BUILD": "package_json()",
+            "src/js/foo/package.json": given_package_with_name("ham"),
+            "src/js/bar/BUILD": "package_json()",
+            "src/js/bar/package.json": given_package_with_name("spam"),
+        }
+    )
+    pkg_jsons = rule_runner.request(AllPackageJson, [])
+    resolves = rule_runner.request(
+        KnownUserResolveNames, (pkg_jsons, KnownPackageJsonUserResolveNamesRequest())
+    )
+    assert set(resolves.names) == {"ham", "spam"}
+
+
+def test_generates_lockfile_for_package_json(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": given_package_with_name("ham"),
+        }
+    )
+    tgt = rule_runner.get_target(Address("src/js"))
+    pkg_json = rule_runner.request(
+        PackageJson, [ReadPackageJsonRequest(tgt[PackageJsonSourceField])]
+    )
+
+    lockfile = rule_runner.request(
+        GenerateLockfileResult,
+        (
+            GeneratePackageLockJsonFile(
+                resolve_name="ham",
+                lockfile_dest="src/js/package-lock.json",
+                pkg_json=pkg_json,
+                diff=False,
+            ),
+        ),
+    )
+
+    digest_contents = rule_runner.request(DigestContents, [lockfile.digest])
+
+    assert json.loads(digest_contents[0].content) == {
+        "name": "ham",
+        "version": "0.0.1",
+        "lockfileVersion": 2,
+        "requires": True,
+        "packages": {"": {"name": "ham", "version": "0.0.1"}},
+    }

--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -3,9 +3,11 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Iterable
 
+from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.target_types import JS_FILE_EXTENSIONS, JSSourcesGeneratorTarget
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -15,7 +17,7 @@ from pants.core.goals.tailor import (
 )
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
-from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule, rule_helper
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -27,21 +29,37 @@ class PutativeJSTargetsRequest(PutativeTargetsRequest):
     pass
 
 
+@dataclass(frozen=True)
+class PutativePackageJsonTargetsRequest(PutativeTargetsRequest):
+    pass
+
+
 def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
     """Returns a dict of target type -> files that belong to targets of that type."""
     sources_files = set(paths)
     return {JSSourcesGeneratorTarget: sources_files}
 
 
-@rule(level=LogLevel.DEBUG, desc="Determine candidate JS targets to create")
-async def find_putative_targets(
-    req: PutativeJSTargetsRequest,
+@rule_helper
+async def _get_unowned_files_for_globs(
+    request: PutativeTargetsRequest,
     all_owned_sources: AllOwnedSources,
+    filename_globs: Iterable[str],
+) -> set[str]:
+    matching_paths = await Get(Paths, PathGlobs, request.path_globs(*filename_globs))
+    return set(matching_paths.files) - set(all_owned_sources)
+
+
+_LOG_DESCRIPTION_TEMPLATE = "Determine candidate {} to create"
+
+
+@rule(level=LogLevel.DEBUG, desc=_LOG_DESCRIPTION_TEMPLATE.format("JS targets"))
+async def find_putative_js_targets(
+    req: PutativeJSTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    all_js_files = await Get(
-        Paths, PathGlobs, req.path_globs(*(f"*{ext}" for ext in JS_FILE_EXTENSIONS))
+    unowned_js_files = await _get_unowned_files_for_globs(
+        req, all_owned_sources, (f"*{ext}" for ext in JS_FILE_EXTENSIONS)
     )
-    unowned_js_files = set(all_js_files.files) - set(all_owned_sources)
     classified_unowned_js_files = classify_source_files(unowned_js_files)
 
     putative_targets = []
@@ -56,8 +74,27 @@ async def find_putative_targets(
     return PutativeTargets(putative_targets)
 
 
+@rule(level=LogLevel.DEBUG, desc=_LOG_DESCRIPTION_TEMPLATE.format("package.json targets"))
+async def find_putative_package_json_targets(
+    req: PutativePackageJsonTargetsRequest, all_owned_sources: AllOwnedSources
+) -> PutativeTargets:
+    unowned_package_json_files = await _get_unowned_files_for_globs(
+        req, all_owned_sources, (f"**{os.path.sep}package.json",)
+    )
+
+    putative_targets = [
+        PutativeTarget.for_target_type(
+            PackageJsonTarget, path=dirname, name=None, triggering_sources=[filename]
+        )
+        for dirname, filename in (os.path.split(file) for file in unowned_package_json_files)
+    ]
+
+    return PutativeTargets(putative_targets)
+
+
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         UnionRule(PutativeTargetsRequest, PutativeJSTargetsRequest),
+        UnionRule(PutativeTargetsRequest, PutativePackageJsonTargetsRequest),
     )

--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -4,7 +4,11 @@
 import pytest
 
 from pants.backend.javascript.goals import tailor
-from pants.backend.javascript.goals.tailor import PutativeJSTargetsRequest
+from pants.backend.javascript.goals.tailor import (
+    PutativeJSTargetsRequest,
+    PutativePackageJsonTargetsRequest,
+)
+from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.target_types import JSSourcesGeneratorTarget
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
 from pants.engine.rules import QueryRule
@@ -17,12 +21,13 @@ def rule_runner() -> RuleRunner:
         rules=[
             *tailor.rules(),
             QueryRule(PutativeTargets, (PutativeJSTargetsRequest, AllOwnedSources)),
+            QueryRule(PutativeTargets, (PutativePackageJsonTargetsRequest, AllOwnedSources)),
         ],
-        target_types=[JSSourcesGeneratorTarget],
+        target_types=[JSSourcesGeneratorTarget, PackageJsonTarget],
     )
 
 
-def test_find_putative_targets(rule_runner: RuleRunner) -> None:
+def test_find_putative_js_targets(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/owned/BUILD": "javascript_sources()\n",
@@ -50,4 +55,31 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
             ]
         )
         == putative_targets
+    )
+
+
+def test_find_putative_package_json_targets(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/owned/BUILD": "package_json()\n",
+            "src/owned/package.json": "",
+            "src/unowned/package.json": "",
+        }
+    )
+    putative_targets = rule_runner.request(
+        PutativeTargets,
+        [
+            PutativePackageJsonTargetsRequest(("src/owned", "src/unowned")),
+            AllOwnedSources(["src/owned/package.json"]),
+        ],
+    )
+    assert putative_targets == PutativeTargets(
+        [
+            PutativeTarget.for_target_type(
+                PackageJsonTarget,
+                "src/unowned",
+                "unowned",
+                ["package.json"],
+            ),
+        ]
     )

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from pants.backend.javascript.lint.prettier.subsystem import Prettier
-from pants.backend.javascript.subsystems.nodejs import NpxProcess
+from pants.backend.javascript.subsystems.nodejs import NodeJSToolProcess
 from pants.backend.javascript.target_types import JSSourceField
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
@@ -60,7 +60,8 @@ async def prettier_fmt(request: PrettierFmtRequest.Batch, prettier: Prettier) ->
 
     result = await Get(
         ProcessResult,
-        NpxProcess(
+        NodeJSToolProcess,
+        NodeJSToolProcess.npx(
             npm_package=prettier.version,
             args=(
                 "--write",

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -1,0 +1,126 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+import os.path
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from pants.backend.project_info import dependencies
+from pants.core.util_rules import stripped_source_files
+from pants.engine import fs
+from pants.engine.collection import Collection
+from pants.engine.fs import DigestContents, PathGlobs
+from pants.engine.internals import graph
+from pants.engine.internals.native_engine import Digest, Snapshot
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.target import (
+    COMMON_TARGET_FIELDS,
+    AllUnexpandedTargets,
+    Dependencies,
+    SingleSourceField,
+    Target,
+    TargetGenerator,
+    Targets,
+)
+from pants.engine.unions import UnionRule
+from pants.option.global_options import UnmatchedBuildFileGlobs
+from pants.util.frozendict import FrozenDict
+
+
+class PackageJsonSourceField(SingleSourceField):
+    default = "package.json"
+    required = False
+
+
+class PackageJsonDependenciesField(Dependencies):
+    pass
+
+
+class PackageJsonTarget(TargetGenerator):
+    alias = "package_json"
+    core_fields = (*COMMON_TARGET_FIELDS, PackageJsonSourceField, PackageJsonDependenciesField)
+    help = "A package.json file."
+
+    copied_fields = COMMON_TARGET_FIELDS
+    moved_fields = ()
+
+
+@dataclass(frozen=True)
+class PackageJson:
+    content: FrozenDict[str, Any]
+    name: str
+    version: str
+    snapshot: Snapshot
+
+    @property
+    def digest(self) -> Digest:
+        return self.snapshot.digest
+
+    @property
+    def file(self) -> str:
+        return self.snapshot.files[0]
+
+    @property
+    def root_dir(self) -> str:
+        return os.path.dirname(self.file)
+
+
+class AllPackageJsonTargets(Targets):
+    pass
+
+
+class AllPackageJson(Collection[PackageJson]):
+    pass
+
+
+@dataclass(frozen=True)
+class ReadPackageJsonRequest:
+    source: PackageJsonSourceField
+
+
+@rule
+async def read_package_json(request: ReadPackageJsonRequest) -> PackageJson:
+    snapshot = await Get(
+        Snapshot, PathGlobs, request.source.path_globs(UnmatchedBuildFileGlobs.error)
+    )
+
+    digest_content = await Get(DigestContents, Digest, snapshot.digest)
+    package_json = json.loads(digest_content[0].content)
+
+    return PackageJson(
+        content=FrozenDict.deep_freeze(package_json),
+        name=package_json["name"],
+        version=package_json["version"],
+        snapshot=snapshot,
+    )
+
+
+@rule
+async def all_package_json_targets(targets: AllUnexpandedTargets) -> AllPackageJsonTargets:
+    return AllPackageJsonTargets(tgt for tgt in targets if tgt.has_field(PackageJsonSourceField))
+
+
+@rule
+async def all_package_json(targets: AllPackageJsonTargets) -> AllPackageJson:
+    return AllPackageJson(
+        await MultiGet(
+            Get(PackageJson, ReadPackageJsonRequest(tgt[PackageJsonSourceField])) for tgt in targets
+        )
+    )
+
+
+def target_types() -> Iterable[type[Target]]:
+    return [PackageJsonTarget]
+
+
+def rules() -> Iterable[Rule | UnionRule]:
+    return [
+        *graph.rules(),
+        *dependencies.rules(),
+        *stripped_source_files.rules(),
+        *fs.rules(),
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -5,11 +5,7 @@ import json
 import pytest
 
 from pants.backend.javascript import package_json
-from pants.backend.javascript.package_json import (
-    AllPackageJson,
-    PackageJson,
-    PackageJsonTarget,
-)
+from pants.backend.javascript.package_json import AllPackageJson, PackageJson, PackageJsonTarget
 from pants.engine.fs import PathGlobs
 from pants.engine.internals.native_engine import Snapshot
 from pants.engine.rules import QueryRule
@@ -20,10 +16,7 @@ from pants.util.frozendict import FrozenDict
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        rules=[
-            *package_json.rules(),
-            QueryRule(AllPackageJson, ())
-        ],
+        rules=[*package_json.rules(), QueryRule(AllPackageJson, ())],
         target_types=[PackageJsonTarget],
     )
 
@@ -56,5 +49,5 @@ def test_parses_package_jsons(rule_runner: RuleRunner) -> None:
             name="spam",
             version="0.0.2",
             snapshot=bar_package_snapshot,
-        )
+        ),
     }

--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -1,0 +1,60 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+
+import pytest
+
+from pants.backend.javascript import package_json
+from pants.backend.javascript.package_json import (
+    AllPackageJson,
+    PackageJson,
+    PackageJsonTarget,
+)
+from pants.engine.fs import PathGlobs
+from pants.engine.internals.native_engine import Snapshot
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner
+from pants.util.frozendict import FrozenDict
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *package_json.rules(),
+            QueryRule(AllPackageJson, ())
+        ],
+        target_types=[PackageJsonTarget],
+    )
+
+
+def given_package(name: str, version: str) -> str:
+    return json.dumps({"name": name, "version": version})
+
+
+def test_parses_package_jsons(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/foo/BUILD": "package_json()",
+            "src/js/foo/package.json": given_package("ham", "0.0.1"),
+            "src/js/bar/BUILD": "package_json()",
+            "src/js/bar/package.json": given_package("spam", "0.0.2"),
+        }
+    )
+    foo_package_snapshot = rule_runner.request(Snapshot, [PathGlobs(["src/js/foo/package.json"])])
+    bar_package_snapshot = rule_runner.request(Snapshot, [PathGlobs(["src/js/bar/package.json"])])
+    pkg_jsons = rule_runner.request(AllPackageJson, [])
+    assert set(pkg_jsons) == {
+        PackageJson(
+            content=FrozenDict.deep_freeze(json.loads(given_package("ham", "0.0.1"))),
+            name="ham",
+            version="0.0.1",
+            snapshot=foo_package_snapshot,
+        ),
+        PackageJson(
+            content=FrozenDict.deep_freeze(json.loads(given_package("spam", "0.0.2"))),
+            name="spam",
+            version="0.0.2",
+            snapshot=bar_package_snapshot,
+        )
+    }

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -21,7 +21,7 @@ def rule_runner() -> RuleRunner:
             *source_files.rules(),
             *config_files.rules(),
             *target_types_rules.rules(),
-            QueryRule(ProcessResult, [nodejs.NpxProcess]),
+            QueryRule(ProcessResult, [nodejs.NodeJSToolProcess]),
         ],
         target_types=[JSSourcesGeneratorTarget],
     )
@@ -31,10 +31,24 @@ def test_npx_process(rule_runner: RuleRunner):
     result = rule_runner.request(
         ProcessResult,
         [
-            nodejs.NpxProcess(
+            nodejs.NodeJSToolProcess.npx(
                 npm_package="",
                 args=("--version",),
                 description="Testing NpxProcess",
+            )
+        ],
+    )
+
+    assert result.stdout.strip() == b"8.5.5"
+
+
+def test_npm_process(rule_runner: RuleRunner):
+    result = rule_runner.request(
+        ProcessResult,
+        [
+            nodejs.NodeJSToolProcess.npm(
+                args=("--version",),
+                description="Testing NpmProcess",
             )
         ],
     )

--- a/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
@@ -30,12 +30,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_version_option_overrides_default(rule_runner: RuleRunner):
-    rule_runner.set_options(
-        [
-            "--backend-packages=['pants.backend.experimental.javascript']",
-            "--cowsay-version=cowsay@1.5.0",
-        ]
-    )
+    rule_runner.set_options(["--cowsay-version=cowsay@1.5.0"])
     tool = rule_runner.request(CowsayTool, [])
     assert tool.default_version == "cowsay@1.4.0"
     assert tool.version == "cowsay@1.5.0"

--- a/src/python/pants/backend/openapi/lint/spectral/rules.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules.py
@@ -4,7 +4,7 @@
 from dataclasses import dataclass
 from typing import Any
 
-from pants.backend.javascript.subsystems.nodejs import NpxProcess
+from pants.backend.javascript.subsystems.nodejs import NodeJSToolProcess
 from pants.backend.openapi.lint.spectral.skip_field import SkipSpectralField
 from pants.backend.openapi.lint.spectral.subsystem import SpectralSubsystem
 from pants.backend.openapi.target_types import (
@@ -89,7 +89,8 @@ async def run_spectral(
 
     process_result = await Get(
         FallibleProcessResult,
-        NpxProcess(
+        NodeJSToolProcess,
+        NodeJSToolProcess.npx(
             npm_package=spectral.version,
             args=(
                 "lint",

--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -10,7 +10,7 @@ from typing import Iterable
 
 import toml
 
-from pants.backend.javascript.subsystems.nodejs import NpxProcess
+from pants.backend.javascript.subsystems.nodejs import NodeJSToolProcess
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     InterpreterConstraintsField,
@@ -214,7 +214,8 @@ async def pyright_typecheck_partition(
     complete_pex_env = pex_environment.in_workspace()
     process = await Get(
         Process,
-        NpxProcess(
+        NodeJSToolProcess,
+        NodeJSToolProcess.npx(
             npm_package=pyright.version,
             args=(
                 f"--venv-path={complete_pex_env.pex_root}",  # Used with `venv` in config


### PR DESCRIPTION
Some fundamentals required to get a javascript _npm_ backend to work in a pants world. The heart of a npm based repo is `package.json` and `package-lock.json`. 

Resolves are determined to be each `package.json` present in a project, because of the mapping of 1:1 between `package.json` and `package-lock.json`. NPM workspaces makes this not strictly true (it's one `package-lock.json` per entire workspace), so will have to parse potential "workspaces" sections of the package.json at some point to group them.

Related to #16962