### PR TITLE
go: fix backend to work when run in non-local environments

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -22,7 +22,7 @@ from pants.backend.codegen.protobuf.target_types import rules as protobuf_target
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import test
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -81,7 +81,6 @@ def rule_runner() -> RuleRunner:
         target_types=[
             GoModTarget,
             GoPackageTarget,
-            GoSdkTarget,
             ProtobufSourceTarget,
             ProtobufSourcesGeneratorTarget,
         ],

--- a/src/python/pants/backend/experimental/go/register.py
+++ b/src/python/pants/backend/experimental/go/register.py
@@ -11,8 +11,6 @@ from pants.backend.go.target_types import (
     GoModTarget,
     GoPackageSourcesField,
     GoPackageTarget,
-    GoSdkPackageTarget,
-    GoSdkTarget,
     GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
@@ -49,8 +47,6 @@ def target_types():
         GoThirdPartyPackageTarget,
         GoBinaryTarget,
         *wrap_golang.target_types,
-        GoSdkTarget,
-        GoSdkPackageTarget,
     ]
 
 

--- a/src/python/pants/backend/go/dependency_inference_test.py
+++ b/src/python/pants/backend/go/dependency_inference_test.py
@@ -9,7 +9,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -52,7 +52,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, (GoTestRequest.Batch,)),
             QueryRule(ProcessResult, (GoSdkProcess,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget, GoSdkTarget],
+        target_types=[GoModTarget, GoPackageTarget, GoBinaryTarget],
     )
     rule_runner.set_options(["--go-test-args=-v"], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/check_test.py
+++ b/src/python/pants/backend/go/goals/check_test.py
@@ -10,7 +10,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import check
 from pants.backend.go.goals.check import GoCheckFieldSet, GoCheckRequest
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -44,7 +44,7 @@ def rule_runner() -> RuleRunner:
             *target_type_rules.rules(),
             QueryRule(CheckResults, [GoCheckRequest]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
+        target_types=[GoModTarget, GoPackageTarget],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/goals/generate_test.py
+++ b/src/python/pants/backend/go/goals/generate_test.py
@@ -11,7 +11,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import generate
 from pants.backend.go.goals.generate import GoGenerateGoal, OverwriteMergeDigests, _expand_env
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -50,7 +50,7 @@ def rule_runner() -> RuleRunner:
             get_filtered_environment,
             QueryRule(DigestContents, (OverwriteMergeDigests,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
+        target_types=[GoModTarget, GoPackageTarget],
         preserve_tmpdirs=True,
     )
     rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)

--- a/src/python/pants/backend/go/goals/package_binary_integration_test.py
+++ b/src/python/pants/backend/go/goals/package_binary_integration_test.py
@@ -12,7 +12,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -52,7 +52,6 @@ def rule_runner() -> RuleRunner:
             GoBinaryTarget,
             GoModTarget,
             GoPackageTarget,
-            GoSdkTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/goals/tailor_test.py
+++ b/src/python/pants/backend/go/goals/tailor_test.py
@@ -12,7 +12,7 @@ from pants.backend.go.goals.tailor import (
     has_package_main,
 )
 from pants.backend.go.goals.tailor import rules as go_tailor_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -50,7 +50,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoBinaryTarget,
             GoPackageTarget,
-            GoSdkTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -11,7 +11,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
 from pants.backend.go.goals.test import transform_test_args
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -56,7 +56,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(TestResult, [GoTestRequest.Batch]),
             QueryRule(ProcessResult, [GoSdkProcess]),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
     rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
     return rule_runner

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -13,7 +13,7 @@ from pants.backend.go.lint.golangci_lint import skip_field
 from pants.backend.go.lint.golangci_lint.rules import GolangciLintFieldSet, GolangciLintRequest
 from pants.backend.go.lint.golangci_lint.rules import rules as golangci_lint_rules
 from pants.backend.go.lint.golangci_lint.subsystem import GolangciLint
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -35,7 +35,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
+        target_types=[GoModTarget, GoPackageTarget],
         rules=[
             *assembly.rules(),
             *build_pkg.rules(),

--- a/src/python/pants/backend/go/lint/vet/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/vet/rules_integration_test.py
@@ -13,7 +13,7 @@ from pants.backend.go.lint.vet import skip_field
 from pants.backend.go.lint.vet.rules import GoVetFieldSet, GoVetRequest
 from pants.backend.go.lint.vet.rules import rules as go_vet_rules
 from pants.backend.go.lint.vet.subsystem import GoVetSubsystem
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -36,7 +36,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget],
+        target_types=[GoModTarget, GoPackageTarget],
         rules=[
             *skip_field.rules(),
             *go_vet_rules(),

--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -15,14 +15,10 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappingsHook,
 )
 from pants.backend.go.target_types import (
-    DEFAULT_GO_SDK_ADDR,
     GoImportPathField,
     GoModSourcesField,
     GoModTarget,
     GoPackageSourcesField,
-    GoSdkImportPathField,
-    GoSdkPackageTarget,
-    GoSdkTarget,
     GoThirdPartyPackageDependenciesField,
     GoThirdPartyPackageTarget,
 )
@@ -54,8 +50,6 @@ from pants.core.target_types import (
 from pants.engine.addresses import Address
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.fs import Digest, Snapshot
-from pants.engine.internals.synthetic_targets import SyntheticAddressMaps, SyntheticTargetsRequest
-from pants.engine.internals.target_adaptor import TargetAdaptor
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
@@ -98,7 +92,6 @@ async def go_map_import_paths_by_module(
         tgt
         for tgt in all_targets
         if (tgt.has_field(GoImportPathField) or tgt.has_field(GoPackageSourcesField))
-        and not tgt.has_field(GoSdkImportPathField)
     ]
 
     owning_go_mod_targets = await MultiGet(
@@ -416,77 +409,6 @@ async def generate_targets_from_go_mod(
     return GeneratedTargets(request.generator, result)
 
 
-# -----------------------------------------------------------------------------------------------
-# `go_sdk` and `go_sdk_package` target types
-# -----------------------------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class GoSdkSyntheticTargetsRequest(SyntheticTargetsRequest):
-    path: str = SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS
-
-
-@rule
-async def generate_go_sdk_synthetic_targets(
-    request: GoSdkSyntheticTargetsRequest,
-) -> SyntheticAddressMaps:
-    return SyntheticAddressMaps.for_targets_request(
-        request,
-        [
-            (
-                "BUILD._go_sdk",
-                [TargetAdaptor(GoSdkTarget.alias, name=DEFAULT_GO_SDK_ADDR.target_name)],
-            )
-        ],
-    )
-
-
-class GenerateTargetsFromGoSdkRequest(GenerateTargetsRequest):
-    generate_from = GoSdkTarget
-
-
-@rule(desc="Generate `_go_sdk_package` targets from `_go_sdk` target", level=LogLevel.DEBUG)
-async def generate_targets_from_go_sdk(
-    request: GenerateTargetsFromGoSdkRequest,
-    union_membership: UnionMembership,
-) -> GeneratedTargets:
-    generator_addr = request.generator.address
-
-    stdlib_packages, stdlib_packages_race = await MultiGet(
-        Get(
-            GoStdLibPackages,
-            GoStdLibPackagesRequest(with_race_detector=False),
-        ),
-        Get(
-            GoStdLibPackages,
-            GoStdLibPackagesRequest(with_race_detector=True),
-        ),
-    )
-
-    def create_tgt(import_path: str) -> GoSdkPackageTarget:
-        # Note: We do not set any dependencies for the target because the target's dependencies
-        # could vary based on the environment due to conditional compilation for environment
-        # attributes like the OS or architecture.
-        #
-        # The dependencies for the `_go_sdk_package target` will be evaluated by the build rules where the
-        # environment is actually known. (If `_go_sdk` were made into a user-visible target type, then
-        # dependency inference might also work at that point to supply dependencies.)
-        return GoSdkPackageTarget(
-            {
-                **request.template,
-                GoSdkImportPathField.alias: import_path,
-            },
-            # E.g. `//:default_go_sdk#net/http`.
-            generator_addr.create_generated(import_path),
-            union_membership,
-            residence_dir=generator_addr.spec_path,
-        )
-
-    import_paths = {*stdlib_packages.keys(), *stdlib_packages_race.keys()}
-    result = tuple(create_tgt(import_path) for import_path in sorted(import_paths))
-    return GeneratedTargets(request.generator, result)
-
-
 def rules():
     return (
         *collect_rules(),
@@ -496,7 +418,5 @@ def rules():
         UnionRule(InferDependenciesRequest, InferGoPackageDependenciesRequest),
         UnionRule(InferDependenciesRequest, InferGoThirdPartyPackageDependenciesRequest),
         UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoModRequest),
-        UnionRule(GenerateTargetsRequest, GenerateTargetsFromGoSdkRequest),
         UnionRule(GoModuleImportPathsMappingsHook, FirstPartyGoModuleImportPathsMappingsHook),
-        UnionRule(SyntheticTargetsRequest, GoSdkSyntheticTargetsRequest),
     )

--- a/src/python/pants/backend/go/target_type_rules_test.py
+++ b/src/python/pants/backend/go/target_type_rules_test.py
@@ -9,14 +9,12 @@ import pytest
 
 from pants.backend.go import target_type_rules
 from pants.backend.go.target_types import (
-    DEFAULT_GO_SDK_ADDR,
     GoBinaryMainPackageField,
     GoBinaryTarget,
     GoImportPathField,
     GoModTarget,
     GoPackageSourcesField,
     GoPackageTarget,
-    GoSdkTarget,
     GoThirdPartyPackageTarget,
 )
 from pants.backend.go.util_rules import (
@@ -78,7 +76,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoBinaryTarget,
-            GoSdkTarget,
             GenericTarget,
         ],
     )
@@ -147,7 +144,6 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
     go_mod_file_tgts = {Address("foo", relative_file_path=fp) for fp in ("go.mod", "go.sum")}
 
     assert get_deps(Address("foo/cmd")) == {
-        Address("", target_name="default_go_sdk", generated_name="fmt"),
         Address("foo/pkg"),
     }
     assert get_deps(Address("foo/pkg")) == {Address("foo", generated_name="rsc.io/quote")}
@@ -156,8 +152,6 @@ def test_go_package_dependency_inference(rule_runner: RuleRunner) -> None:
         *go_mod_file_tgts,
     }
     assert get_deps(Address("foo", generated_name="rsc.io/sampler")) == {
-        Address("", target_name="default_go_sdk", generated_name="os"),
-        Address("", target_name="default_go_sdk", generated_name="strings"),
         Address("foo", generated_name="golang.org/x/text/language"),
         *go_mod_file_tgts,
     }
@@ -323,15 +317,3 @@ def test_determine_main_pkg_for_go_binary(rule_runner: RuleRunner) -> None:
         get_main(Address("ambiguous"))
     with engine_error(InvalidFieldException, contains="must point to a `go_package` target"):
         get_main(Address("explicit_wrong_type"))
-
-
-# -----------------------------------------------------------------------------------------------
-# `_go_sdk` and `_go_sdk_package` target types
-# -----------------------------------------------------------------------------------------------
-
-
-def test_go_sdk_target_exists(rule_runner: RuleRunner) -> None:
-    _ = rule_runner.get_target(DEFAULT_GO_SDK_ADDR)
-    fmt_pkg_tgt = rule_runner.get_target(DEFAULT_GO_SDK_ADDR.create_generated("fmt"))
-    addrs = rule_runner.request(Addresses, [DependenciesRequest(fmt_pkg_tgt[Dependencies])])
-    assert len(addrs) > 0, "no dependencies were inferred for `fmt` _go_sdk_package target type"

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -477,38 +477,3 @@ class GoOwningGoModAddressField(StringField):
         for that single `go_mod` target.
         """
     )
-
-
-# -----------------------------------------------------------------------------------------------
-# `go_sdk` and `go_sdk_package` target types
-# -----------------------------------------------------------------------------------------------
-
-
-DEFAULT_GO_SDK_ADDR = Address("", target_name="default_go_sdk")
-
-
-class GoSdkPackageDependenciesField(Dependencies):
-    pass
-
-
-class GoSdkImportPathField(GoImportPathField):
-    pass
-
-
-class GoSdkPackageTarget(Target):
-    alias = "_go_sdk_package"
-    core_fields = (
-        *COMMON_TARGET_FIELDS,
-        GoSdkImportPathField,
-        GoSdkPackageDependenciesField,
-    )
-    help = "Internal-only target: Represents a Go SDK package."
-
-
-class GoSdkTarget(TargetGenerator):
-    alias = "_go_sdk"
-    generated_target_cls = GoSdkPackageTarget
-    core_fields = (*COMMON_TARGET_FIELDS,)
-    help = "Internal-only: Go SDK generator target"
-    copied_fields = COMMON_TARGET_FIELDS
-    moved_fields = ()

--- a/src/python/pants/backend/go/util_rules/assembly_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/assembly_integration_test.py
@@ -14,7 +14,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -58,7 +58,6 @@ def rule_runner() -> RuleRunner:
             GoBinaryTarget,
             GoModTarget,
             GoPackageTarget,
-            GoSdkTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/build_opts_test.py
+++ b/src/python/pants/backend/go/util_rules/build_opts_test.py
@@ -13,7 +13,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_opts,
@@ -73,7 +73,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoBinaryTarget,
-            GoSdkTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -407,11 +407,8 @@ async def setup_build_go_package_target_request(
             continue
 
         if remaining_import not in stdlib_packages:
-            raise ValueError(
-                f"While building `{request.address}`, the dependency import path `{remaining_import}` "
-                "was not provided by any first party package, third party dependnecy, nor the standard "
-                "library. Please check whether the correct import path was used."
-            )
+            continue
+
         stdlib_build_request_gets.append(
             Get(
                 FallibleBuildGoPackageRequest,

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -10,12 +10,10 @@ from typing import ClassVar, Type, cast
 from pants.backend.go.dependency_inference import GoModuleImportPathsMapping
 from pants.backend.go.target_type_rules import GoImportPathMappingRequest
 from pants.backend.go.target_types import (
-    DEFAULT_GO_SDK_ADDR,
     GoAssemblerFlagsField,
     GoCompilerFlagsField,
     GoImportPathField,
     GoPackageSourcesField,
-    GoSdkPackageDependenciesField,
     GoThirdPartyPackageDependenciesField,
 )
 from pants.backend.go.util_rules import build_opts
@@ -41,18 +39,13 @@ from pants.backend.go.util_rules.go_mod import (
     OwningGoModRequest,
 )
 from pants.backend.go.util_rules.goroot import GoRoot
-from pants.backend.go.util_rules.import_analysis import (
-    INTRINSIC_SDK_PACKAGES,
-    GoStdLibPackages,
-    GoStdLibPackagesRequest,
-)
+from pants.backend.go.util_rules.import_analysis import GoStdLibPackages, GoStdLibPackagesRequest
 from pants.backend.go.util_rules.pkg_pattern import match_simple_pattern
 from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
 )
 from pants.build_graph.address import Address
-from pants.engine.addresses import Addresses
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName
 from pants.engine.internals.graph import AmbiguousCodegenImplementationsException
@@ -89,8 +82,8 @@ class BuildGoPackageTargetRequest(EngineAwareParameter):
     # If True, then force coverage instead of applying import path patterns from `build_opts.coverage_config`.
     with_coverage: bool = False
 
-    # Extra dependencies to force on the target. Useful for implicit linker dependencies.
-    extra_dependencies: tuple[Address, ...] = ()
+    # Extra standard library dependencies to force on the target. Useful for implicit linker dependencies.
+    extra_stdlib_dependencies: tuple[str, ...] = ()
 
     def debug_hint(self) -> str:
         return str(self.address)
@@ -101,6 +94,12 @@ class BuildGoPackageTargetRequest(EngineAwareParameter):
                 "`BuildGoPackageTargetRequest.for_tests` and `BuildGoPackageTargetRequest.for_xtests` "
                 "cannot be set together."
             )
+
+
+@dataclass(frozen=True)
+class BuildGoPackageRequestForStdlibRequest:
+    import_path: str
+    build_opts: GoBuildOptions
 
 
 @union(in_scope_types=[EnvironmentName])
@@ -172,9 +171,7 @@ async def setup_build_go_package_target_request(
         return codegen_result
 
     embed_config: EmbedConfig | None = None
-    is_stdlib = False
     import_map: FrozenDict[str, str] = FrozenDict({})
-    override_direct_dependencies: Targets | None = None
 
     if target.has_field(GoPackageSourcesField):
         _maybe_first_party_pkg_analysis, _maybe_first_party_pkg_digest = await MultiGet(
@@ -299,54 +296,6 @@ async def setup_build_go_package_target_request(
         fortran_files = _third_party_pkg_info.f_files
         prebuilt_object_files = _third_party_pkg_info.syso_files
 
-    elif target.has_field(GoSdkPackageDependenciesField):
-        import_path = target[GoImportPathField].value
-
-        stdlib_packages = await Get(
-            GoStdLibPackages,
-            GoStdLibPackagesRequest(
-                with_race_detector=request.build_opts.with_race_detector,
-                cgo_enabled=request.build_opts.cgo_enabled,
-            ),
-        )
-
-        pkg_info = stdlib_packages[import_path]
-
-        # Go SDK packages can only import from the Go SDK. Gather the addresses for those imports now since the
-        # environment is known now and any conditional compilation will be in effect. We cannot do this when
-        # generating the synthetic target `//:default_go_sdk` because only the local environment is available then.
-        #
-        # Note: If the _go_sdk target type is ever exposed to the user, then consider just using dependency
-        # inference then (which should have the environment available). We cannot use dependency inference yet
-        # because that causes a rule graph cycle with how we are using the synthetic target.
-        sdk_direct_dependency_addrs = {
-            DEFAULT_GO_SDK_ADDR.create_generated(dep_import_path)
-            for dep_import_path in pkg_info.imports
-            if dep_import_path not in {"builtin", "C", "unsafe"}
-        }
-        override_direct_dependencies = await Get(
-            Targets, Addresses(sorted(sdk_direct_dependency_addrs))
-        )
-
-        imports = set(pkg_info.imports)
-        import_map = pkg_info.import_map
-        dir_path = pkg_info.pkg_source_path
-        pkg_name = pkg_info.name
-        digest = EMPTY_DIGEST
-        minimum_go_version = goroot.version
-        go_file_names = pkg_info.go_files
-        s_files = pkg_info.s_files
-        embed_config = None  # TODO: Eventually needs to be filled in.
-        cgo_files = pkg_info.cgo_files
-        cgo_flags = pkg_info.cgo_flags
-        c_files = pkg_info.c_files
-        h_files = pkg_info.h_files
-        cxx_files = pkg_info.cxx_files
-        objc_files = pkg_info.m_files
-        fortran_files = pkg_info.f_files
-        prebuilt_object_files = pkg_info.syso_files
-        is_stdlib = True
-
     else:
         raise AssertionError(
             f"Unknown how to build `{target.alias}` target at address {request.address} with Go. "
@@ -372,37 +321,24 @@ async def setup_build_go_package_target_request(
         if assembler_flags_field and assembler_flags_field.value:
             pkg_specific_assembler_flags = assembler_flags_field.value
 
-    def make_stdlib_dep(import_path: str) -> Address:
-        return DEFAULT_GO_SDK_ADDR.create_generated(import_path)
+    # Add implicit dependencies for Cgo generated code.
+    # Note: This rule does not apply to standard library so we do not need to be concerned with excluding these
+    # dependencies if we were actually building one of these packages. See the counterpart logic below in the
+    # other rule.
+    extra_stdlib_dependencies = set(request.extra_stdlib_dependencies)
+    if cgo_files:
+        extra_stdlib_dependencies.update(["runtime/cgo", "syscall"])
 
-    extra_dependencies_addrs = []
-    if cgo_files and (not is_stdlib or import_path != "runtime/cgo"):
-        extra_dependencies_addrs.append(make_stdlib_dep("runtime/cgo"))
-    if cgo_files and (
-        not is_stdlib
-        or import_path not in ("runtime/cgo", "runtime/race", "runtime/msan", "runtime/asan")
-    ):
-        extra_dependencies_addrs.append(make_stdlib_dep("syscall"))
-
-    direct_dependencies, extra_dependencies = await MultiGet(
-        Get(Targets, DependenciesRequest(target[Dependencies])),
-        Get(Targets, Addresses([*request.extra_dependencies, *extra_dependencies_addrs])),
-    )
-
-    if override_direct_dependencies is not None:
-        direct_dependencies = override_direct_dependencies
+    direct_dependencies = await Get(Targets, DependenciesRequest(target[Dependencies]))
 
     first_party_dep_import_path_targets = []
-    third_party_or_stdlib_dep_import_path_targets = []
+    third_party_dep_import_path_targets = []
     codegen_dep_import_path_targets = []
     for dep in direct_dependencies:
         if dep.has_field(GoPackageSourcesField):
             first_party_dep_import_path_targets.append(dep)
         elif dep.has_field(GoImportPathField):
-            # Ensure marker packages C and unsafe do not show up as dependencies.
-            dep_import_path = dep[GoImportPathField].value
-            if dep_import_path not in {"builtin", "C", "unsafe"}:
-                third_party_or_stdlib_dep_import_path_targets.append(dep)
+            third_party_dep_import_path_targets.append(dep)
         elif bool(maybe_get_codegen_request_type(dep, request.build_opts, union_membership)):
             codegen_dep_import_path_targets.append(dep)
 
@@ -417,17 +353,31 @@ async def setup_build_go_package_target_request(
         )
     }
 
-    pkg_dependency_addresses_set = {tgt.address for tgt in extra_dependencies}
+    remaining_imports_set = {*imports, *extra_stdlib_dependencies}
+    pkg_dependency_addresses_set: set[Address] = set()
+
     pkg_dependency_addresses_set.update(
         address
         for dep_import_path, address in first_party_dep_import_paths.items()
-        if dep_import_path in imports
+        if dep_import_path in remaining_imports_set
     )
+    remaining_imports_set.difference_update(
+        dep_import_path
+        for dep_import_path in first_party_dep_import_paths.keys()
+        if dep_import_path in remaining_imports_set
+    )
+
     pkg_dependency_addresses_set.update(
         dep_tgt.address
-        for dep_tgt in third_party_or_stdlib_dep_import_path_targets
-        if dep_tgt[GoImportPathField].value in imports
+        for dep_tgt in third_party_dep_import_path_targets
+        if dep_tgt[GoImportPathField].value in remaining_imports_set
     )
+    remaining_imports_set.difference_update(
+        dep_tgt[GoImportPathField].value
+        for dep_tgt in third_party_dep_import_path_targets
+        if dep_tgt[GoImportPathField].value in remaining_imports_set
+    )
+
     if codegen_dep_import_path_targets:
         go_mod_addr = await Get(OwningGoMod, OwningGoModRequest(request.address))
         import_paths_mapping = await Get(
@@ -440,8 +390,37 @@ async def setup_build_go_package_target_request(
             if codegen_dep_import_path is None:
                 # TODO: Emit warning?
                 continue
-            if codegen_dep_import_path in imports:
+            if codegen_dep_import_path in remaining_imports_set:
                 pkg_dependency_addresses_set.add(dep_tgt.address)
+                remaining_imports_set.difference_update([codegen_dep_import_path])
+
+    stdlib_packages = await Get(
+        GoStdLibPackages,
+        GoStdLibPackagesRequest(
+            with_race_detector=request.build_opts.with_race_detector,
+            cgo_enabled=request.build_opts.cgo_enabled,
+        ),
+    )
+    stdlib_build_request_gets = []
+    for remaining_import in remaining_imports_set:
+        if remaining_import in {"builtin", "C", "unsafe"}:
+            continue
+
+        if remaining_import not in stdlib_packages:
+            raise ValueError(
+                f"While building `{request.address}`, the dependency import path `{remaining_import}` "
+                "was not provided by any first party package, third party dependnecy, nor the standard "
+                "library. Please check whether the correct import path was used."
+            )
+        stdlib_build_request_gets.append(
+            Get(
+                FallibleBuildGoPackageRequest,
+                BuildGoPackageRequestForStdlibRequest(
+                    import_path=remaining_import,
+                    build_opts=request.build_opts,
+                ),
+            )
+        )
 
     pkg_dependency_addresses = sorted(pkg_dependency_addresses_set)
     maybe_pkg_direct_dependencies = await MultiGet(
@@ -451,6 +430,7 @@ async def setup_build_go_package_target_request(
         )
         for address in pkg_dependency_addresses
     )
+    pkg_stdlib_dependencies = await MultiGet(stdlib_build_request_gets)
 
     pkg_direct_dependencies = []
     for maybe_pkg_dep in maybe_pkg_direct_dependencies:
@@ -459,6 +439,10 @@ async def setup_build_go_package_target_request(
                 maybe_pkg_dep,
                 dependency_failed=True,
             )
+        pkg_direct_dependencies.append(maybe_pkg_dep.request)
+
+    for maybe_pkg_dep in pkg_stdlib_dependencies:
+        assert maybe_pkg_dep.request
         pkg_direct_dependencies.append(maybe_pkg_dep.request)
 
     # Allow xtest packages to depend on the base package (with tests).
@@ -501,14 +485,13 @@ async def setup_build_go_package_target_request(
         fortran_files=fortran_files,
         prebuilt_object_files=prebuilt_object_files,
         minimum_go_version=minimum_go_version,
-        direct_dependencies=tuple(pkg_direct_dependencies),
+        direct_dependencies=tuple(sorted(pkg_direct_dependencies, key=lambda p: p.import_path)),
         import_map=import_map,
         for_tests=request.for_tests,
         embed_config=embed_config,
         with_coverage=with_coverage,
         pkg_specific_compiler_flags=tuple(pkg_specific_compiler_flags),
         pkg_specific_assembler_flags=tuple(pkg_specific_assembler_flags),
-        is_stdlib=is_stdlib,
     )
     return FallibleBuildGoPackageRequest(result, import_path)
 
@@ -522,6 +505,77 @@ def required_build_go_package_request(
     raise Exception(
         f"Failed to determine metadata to compile {fallible_request.import_path}:\n"
         f"{fallible_request.stderr}"
+    )
+
+
+@rule
+async def setup_build_go_package_target_request_for_stdlib(
+    request: BuildGoPackageRequestForStdlibRequest,
+    goroot: GoRoot,
+) -> FallibleBuildGoPackageRequest:
+    stdlib_packages = await Get(
+        GoStdLibPackages,
+        GoStdLibPackagesRequest(
+            with_race_detector=request.build_opts.with_race_detector,
+            cgo_enabled=request.build_opts.cgo_enabled,
+        ),
+    )
+
+    pkg_info = stdlib_packages[request.import_path]
+
+    direct_dependency_import_pats = set(pkg_info.imports)
+    if pkg_info.cgo_files:
+        if request.import_path != "runtime/cgo":
+            direct_dependency_import_pats.add("runtime/cgo")
+        if pkg_info.import_path not in (
+            "runtime/cgo",
+            "runtime/race",
+            "runtime/msan",
+            "runtime/asan",
+        ):
+            direct_dependency_import_pats.add("syscall")
+
+    direct_dependencies_wrapped = await MultiGet(
+        Get(
+            FallibleBuildGoPackageRequest,
+            BuildGoPackageRequestForStdlibRequest(
+                import_path=dep_import_path,
+                build_opts=request.build_opts,
+            ),
+        )
+        for dep_import_path in sorted(direct_dependency_import_pats)
+        if dep_import_path not in {"builtin", "C", "unsafe"}
+    )
+
+    direct_dependencies: list[BuildGoPackageRequest] = []
+    for dep in direct_dependencies_wrapped:
+        assert dep.request is not None
+        direct_dependencies.append(dep.request)
+    direct_dependencies.sort(key=lambda p: p.import_path)
+
+    return FallibleBuildGoPackageRequest(
+        request=BuildGoPackageRequest(
+            import_path=pkg_info.import_path,
+            pkg_name=pkg_info.name,
+            digest=EMPTY_DIGEST,
+            dir_path=pkg_info.pkg_source_path,
+            build_opts=request.build_opts,
+            go_files=pkg_info.go_files,
+            s_files=pkg_info.s_files,
+            direct_dependencies=tuple(direct_dependencies),
+            import_map=pkg_info.import_map,
+            minimum_go_version=goroot.version,
+            cgo_files=pkg_info.cgo_files,
+            c_files=pkg_info.c_files,
+            header_files=pkg_info.h_files,
+            cxx_files=pkg_info.cxx_files,
+            objc_files=pkg_info.m_files,
+            fortran_files=pkg_info.f_files,
+            prebuilt_object_files=pkg_info.syso_files,
+            cgo_flags=pkg_info.cgo_flags,
+            is_stdlib=True,
+        ),
+        import_path=request.import_path,
     )
 
 

--- a/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target_test.py
@@ -16,12 +16,7 @@ from pants.backend.go.dependency_inference import (
     GoModuleImportPathsMappings,
     GoModuleImportPathsMappingsHook,
 )
-from pants.backend.go.target_types import (
-    GoModTarget,
-    GoOwningGoModAddressField,
-    GoPackageTarget,
-    GoSdkTarget,
-)
+from pants.backend.go.target_types import GoModTarget, GoOwningGoModAddressField, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -184,7 +179,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             FilesGeneratorTarget,
-            GoSdkTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})

--- a/src/python/pants/backend/go/util_rules/cgo_test.py
+++ b/src/python/pants/backend/go/util_rules/cgo_test.py
@@ -14,7 +14,7 @@ from pants.backend.go import target_type_rules
 from pants.backend.go.goals import package_binary
 from pants.backend.go.goals.package_binary import GoBinaryFieldSet
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoBinaryTarget, GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -72,7 +72,6 @@ def rule_runner() -> RuleRunner:
             GoModTarget,
             GoPackageTarget,
             GoBinaryTarget,
-            GoSdkTarget,
             ResourceTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/coverage_test.py
+++ b/src/python/pants/backend/go/util_rules/coverage_test.py
@@ -9,7 +9,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as test_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -65,7 +65,7 @@ def rule_runner() -> RuleRunner:
             QueryRule(CoverageReports, (GoCoverageDataCollection,)),
             QueryRule(DigestContents, (Digest,)),
         ],
-        target_types=[GoModTarget, GoPackageTarget, GoSdkTarget, FileTarget],
+        target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
     rule_runner.set_options(
         ["--go-test-args=-v -bench=.", "--test-use-coverage"], env_inherit={"PATH"}

--- a/src/python/pants/backend/go/util_rules/embed_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/embed_integration_test.py
@@ -17,7 +17,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.goals.test import GoTestFieldSet, GoTestRequest
 from pants.backend.go.goals.test import rules as _test_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -59,7 +59,6 @@ def rule_runner() -> RuleRunner:
         target_types=[
             GoModTarget,
             GoPackageTarget,
-            GoSdkTarget,
             ResourceTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/first_party_pkg_test.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.target_types import GoModTarget, GoPackageTarget, GoSdkTarget
+from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
     build_pkg,
@@ -55,7 +55,6 @@ def rule_runner() -> RuleRunner:
         target_types=[
             GoModTarget,
             GoPackageTarget,
-            GoSdkTarget,
             ResourcesGeneratorTarget,
         ],
     )

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -4,28 +4,16 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from dataclasses import dataclass
 
 import ijson.backends.python as ijson
 
-from pants.backend.go.dependency_inference import (
-    GoImportPathsMappingAddressSet,
-    GoModuleImportPathsMapping,
-    GoModuleImportPathsMappings,
-    GoModuleImportPathsMappingsHook,
-)
-from pants.backend.go.target_types import DEFAULT_GO_SDK_ADDR
 from pants.backend.go.util_rules import go_mod
 from pants.backend.go.util_rules.cgo import CGoCompilerFlags
-from pants.backend.go.util_rules.go_mod import AllGoModTargets
 from pants.backend.go.util_rules.sdk import GoSdkProcess
-from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
-
-# from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -115,61 +103,8 @@ async def analyze_go_stdlib_packages(request: GoStdLibPackagesRequest) -> GoStdL
     return GoStdLibPackages(stdlib_packages)
 
 
-class GoSdkImportPathsMappingsHook(GoModuleImportPathsMappingsHook):
-    pass
-
-
-@rule(desc="Analyze and map Go import paths for the Go SDK.", level=LogLevel.DEBUG)
-async def go_map_import_paths_by_module(
-    _request: GoSdkImportPathsMappingsHook,
-    all_go_mod_targets: AllGoModTargets,
-) -> GoModuleImportPathsMappings:
-    import_paths_by_module: dict[Address, dict[str, set[Address]]] = defaultdict(
-        lambda: defaultdict(set)
-    )
-
-    stdlib_packages = await Get(
-        GoStdLibPackages,
-        GoStdLibPackagesRequest(with_race_detector=False),
-    )
-
-    # Replicate the Go SDK imports path to all Go modules.
-    # TODO: This will need to change eventually for multiple Go SDK support.
-    for import_path in stdlib_packages.keys():
-        for go_mod_tgt in all_go_mod_targets:
-            import_paths_by_module[go_mod_tgt.address][import_path].add(
-                DEFAULT_GO_SDK_ADDR.create_generated(import_path)
-            )
-
-    return GoModuleImportPathsMappings(
-        FrozenDict(
-            {
-                go_mod_addr: GoModuleImportPathsMapping(
-                    mapping=FrozenDict(
-                        {
-                            import_path: GoImportPathsMappingAddressSet(
-                                addresses=tuple(sorted(addresses)), infer_all=False
-                            )
-                            for import_path, addresses in import_path_mapping.items()
-                        }
-                    ),
-                    address_to_import_path=FrozenDict(
-                        {
-                            address: import_path
-                            for import_path, addresses in import_path_mapping.items()
-                            for address in addresses
-                        }
-                    ),
-                )
-                for go_mod_addr, import_path_mapping in import_paths_by_module.items()
-            }
-        )
-    )
-
-
 def rules():
     return (
         *collect_rules(),
         *go_mod.rules(),
-        # UnionRule(GoModuleImportPathsMappingsHook, GoSdkImportPathsMappingsHook),
     )

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -24,7 +24,8 @@ from pants.build_graph.address import Address
 from pants.engine.internals.selectors import Get
 from pants.engine.process import ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.unions import UnionRule
+
+# from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
@@ -170,5 +171,5 @@ def rules():
     return (
         *collect_rules(),
         *go_mod.rules(),
-        UnionRule(GoModuleImportPathsMappingsHook, GoSdkImportPathsMappingsHook),
+        # UnionRule(GoModuleImportPathsMappingsHook, GoSdkImportPathsMappingsHook),
     )


### PR DESCRIPTION
Fix the Go backend not being able to run in non-local environments.

- Link to Go SDK on package-by-package basis by inspecting imports to see if they originate in the Go SDK.
- Remove the `_go_sdk` synthetic target and related `_go_sdk_package` targets as they are no longer needed.
