### PR TITLE
Default to the new "Dependents" header in the py_constraints report.

### DIFF
--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -54,7 +54,7 @@ class PyConstraintsSubsystem(Outputting, GoalSubsystem):
     )
 
     summary_use_new_header = BoolOption(
-        default=False,
+        default=True,
         help=softwrap(
             """
             If False, use the legacy, misleading `#Dependees` header name in the summary CSV table.

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints_test.py
@@ -110,7 +110,7 @@ def test_render_constraints(rule_runner: RuleRunner) -> None:
 
 def test_constraints_summary(rule_runner: RuleRunner) -> None:
     write_files(rule_runner)
-    result = run_goal(rule_runner, ["--summary", "--summary-use-new-header"])
+    result = run_goal(rule_runner, ["--summary"])
     assert result.stdout == dedent(
         """\
         Target,Constraints,Transitive Constraints,# Dependencies,# Dependents\r


### PR DESCRIPTION
As planned - the default flips to True in 2.16.x and the old "Dependees" header goes away entirely in 2.17.x.