### PR TITLE
Add the `environment` field to most Python binary target types

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -32,6 +32,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
@@ -58,6 +59,7 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
     runtime: PythonAwsLambdaRuntime
     complete_platforms: PythonAwsLambdaCompletePlatforms
     output_path: OutputPathField
+    environment: EnvironmentField
 
 
 @rule

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -18,6 +18,7 @@ from pants.backend.python.dependency_inference.subsystem import (
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -301,6 +302,7 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaRuntime,
         PythonAwsLambdaCompletePlatforms,
         PythonResolveField,
+        EnvironmentField,
     )
     help = softwrap(
         f"""

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -32,6 +32,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
@@ -57,6 +58,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
     complete_platforms: PythonGoogleCloudFunctionCompletePlatforms
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
+    environment: EnvironmentField
 
 
 @rule

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -19,6 +19,7 @@ from pants.backend.python.dependency_inference.subsystem import (
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -301,6 +302,7 @@ class PythonGoogleCloudFunction(Target):
         PythonGoogleCloudFunctionCompletePlatforms,
         PythonGoogleCloudFunctionType,
         PythonResolveField,
+        EnvironmentField,
     )
     help = softwrap(
         f"""

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -40,6 +40,7 @@ from pants.core.goals.package import (
 )
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     TransitiveTargets,
@@ -81,6 +82,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
     venv_site_packages_copies: PexVenvSitePackagesCopies
+    environment: EnvironmentField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -25,6 +25,7 @@ from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
+from pants.core.util_rules.environments import EnvironmentField
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -67,6 +68,7 @@ class PyOxidizerFieldSet(PackageFieldSet, RunFieldSet):
     unclassified_resources: PyOxidizerUnclassifiedResources
     template: PyOxidizerConfigSourceField
     output_path: PyOxidizerOutputPathField
+    environment: EnvironmentField
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -138,6 +139,7 @@ class PyOxidizerTarget(Target):
         PyOxidizerDependenciesField,
         PyOxidizerEntryPointField,
         PyOxidizerUnclassifiedResources,
+        EnvironmentField,
     )
     help = softwrap(
         f"""


### PR DESCRIPTION
This change adds the `environment` field to uncontroversial Python binary target types, and fixes its application to `pex_binary`.

Of note, it does _not_ add the field to `python_distribution` (yet), because we might potentially want a more magical solution for Python distributions, given that they are very frequently cross-platform. That same argument _might_ apply to `pex_binary`, but that change would require a deprecation cycle at this point.

Fixes #18141, and fixes #18149.