### PR TITLE
docs: add "What's New" section to 2.16 release notes

### DIFF
--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -1,5 +1,20 @@
 # 2.16.x Release Series
 
+## What's New
+
+### Go
+
+The Go backend has received a large number of changes in order to be ready for Go v1.20
+and to make continued progress on [stabilizing the Go backend](https://github.com/pantsbuild/pants/issues/17447).
+
+The main change is that Pants will now compile Go SDK packages from scratch and no longer rely on
+the prebuilt package archives distributed with the Go SDK. Go v1.20 will no longer ship with those
+prebuilt package archives, and so this change was necessary for Pants to continue to work 
+with Go v1.20 and later releases. (It is also a correctness issue since Pants will now be able to
+apply compiler options consistently when building Go SDK packages.)
+
+The Pants team would appreciate if the community could try out 2.16.x with your Go code as an additional
+check to ensure there are no regressions.
 
 ## 2.16.0.dev6 (Jan 29, 2023)
 


### PR DESCRIPTION
Add a manually-written "What's New" section to the v2.16.x release notes documenting the Go changes at a high level.