### PR TITLE
Add the `environment` field to most Python binary target types (Cherry-pick of #18144)

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -32,6 +32,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -57,6 +58,7 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
     runtime: PythonAwsLambdaRuntime
     complete_platforms: PexCompletePlatformsField
     output_path: OutputPathField
+    environment: EnvironmentField
 
 
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -14,6 +14,7 @@ from pants.backend.python.dependency_inference.rules import PythonInferSubsystem
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -267,6 +268,7 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaRuntime,
         PexCompletePlatformsField,
         PythonResolveField,
+        EnvironmentField,
     )
     help = softwrap(
         f"""

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -32,6 +32,7 @@ from pants.core.goals.package import (
     PackageFieldSet,
 )
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -56,6 +57,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
     complete_platforms: PexCompletePlatformsField
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
+    environment: EnvironmentField
 
 
 @rule(desc="Create Python Google Cloud Function", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -15,6 +15,7 @@ from pants.backend.python.dependency_inference.rules import PythonInferSubsystem
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -267,6 +268,7 @@ class PythonGoogleCloudFunction(Target):
         PexCompletePlatformsField,
         PythonGoogleCloudFunctionType,
         PythonResolveField,
+        EnvironmentField,
     )
     help = softwrap(
         f"""

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -38,6 +38,7 @@ from pants.core.goals.package import (
 )
 from pants.core.goals.run import RunFieldSet
 from pants.core.target_types import FileSourceField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     TransitiveTargets,
@@ -74,6 +75,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
     venv_site_packages_copies: PexVenvSitePackagesCopies
+    environment: EnvironmentField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -25,6 +25,7 @@ from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
+from pants.core.util_rules.environments import EnvironmentField
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.fs import (
     AddPrefix,
@@ -65,6 +66,7 @@ class PyOxidizerFieldSet(PackageFieldSet):
     unclassified_resources: PyOxidizerUnclassifiedResources
     template: PyOxidizerConfigSourceField
     output_path: PyOxidizerOutputPathField
+    environment: EnvironmentField
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.core.goals.package import OutputPathField
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
@@ -138,6 +139,7 @@ class PyOxidizerTarget(Target):
         PyOxidizerDependenciesField,
         PyOxidizerEntryPointField,
         PyOxidizerUnclassifiedResources,
+        EnvironmentField,
     )
     help = softwrap(
         f"""


### PR DESCRIPTION
This change adds the `environment` field to uncontroversial Python binary target types, and fixes its application to `pex_binary`.

Of note, it does _not_ add the field to `python_distribution` (yet), because we might potentially want a more magical solution for Python distributions, given that they are very frequently cross-platform. That same argument _might_ apply to `pex_binary`, but that change would require a deprecation cycle at this point.

Fixes #18141, and fixes #18149.
