### PR TITLE
`shell_command`/`run_in_sandbox` workdir/output dir adjustments

### DIFF
--- a/src/python/pants/backend/shell/register.py
+++ b/src/python/pants/backend/shell/register.py
@@ -15,7 +15,7 @@ from pants.backend.shell.target_types import (
     Shunit2TestTarget,
 )
 from pants.backend.shell.target_types import rules as target_types_rules
-from pants.backend.shell.util_rules import shell_command
+from pants.backend.shell.util_rules import run_in_sandbox, shell_command
 
 
 def target_types():
@@ -35,6 +35,7 @@ def rules():
     return [
         *dependency_inference.rules(),
         *shell_command.rules(),
+        *run_in_sandbox.rules(),
         *shunit2.rules(),
         *shunit2_test_runner.rules(),
         *tailor.rules(),

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -278,8 +278,7 @@ class ShellCommandOutputsField(StringSequenceField):
     alias = "outputs"
     help = softwrap(
         """
-        Specify the shell command output files and directories, relative to the `BUILD` file's
-        directory.
+        Specify the shell command output files and directories, relative to the value of `workdir`.
 
         Use a trailing slash on directory names, i.e. `my_dir/`.
 
@@ -297,8 +296,7 @@ class ShellCommandOutputFilesField(StringSequenceField):
     default = ()
     help = softwrap(
         """
-        Specify the shell command's output files to capture, relative to the `BUILD` file's
-        directory.
+        Specify the shell command's output files to capture, relative to the value of `workdir`.
 
         For directories, use `output_directories`. At least one of `output_files` and
         `output_directories` must be specified.
@@ -316,7 +314,7 @@ class ShellCommandOutputDirectoriesField(StringSequenceField):
     help = softwrap(
         """
         Specify full directories (including recursive descendants) of output to capture from the
-        shell command, relative to the `BUILD` file's directory.
+        shell command, relative to the value of `workdir`.
 
         For individual files, use `output_files`. At least one of `output_files` and
         `output_directories` must be specified.

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -430,15 +430,21 @@ class ShellCommandLogOutputField(BoolField):
 
 class ShellCommandWorkdirField(StringField):
     alias = "workdir"
-    default = None
+    default = "."
     help = softwrap(
-        "Sets the current working directory of the command, relative to the project root. If not "
-        "set, use the project root.\n\n"
+        "Sets the current working directory of the command. "
         "To specify the location of the `BUILD` file, use `.`. Values beginning with `.` are "
         "relative to the location of the `BUILD` file.\n\n"
-        "To specify the project/build root, use `/` or the empty string."
+        "To specify the build root, use `/` or the empty string.\n\n"
+        "Values that do not begin with `.` or `/` are relative to the build root."
     )
 
+class RunShellCommandWorkdirField(ShellCommandWorkdirField):
+    default = None
+    help = softwrap(
+        "Sets the current working directory of the command that is `run`. If `None`, run the "
+        "command from the current working directory."
+    )
 
 class ShellCommandTestDependenciesField(ShellCommandExecutionDependenciesField):
     pass
@@ -536,7 +542,7 @@ class ShellCommandRunTarget(Target):
         *COMMON_TARGET_FIELDS,
         ShellCommandExecutionDependenciesField,
         ShellCommandCommandField,
-        ShellCommandWorkdirField,
+        RunShellCommandWorkdirField,
         ShellCommandIsInteractiveField,
     )
     help = softwrap(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import re
 from enum import Enum
+from typing import ClassVar, Optional
 
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.core.goals.test import RuntimePackageDependenciesField, TestTimeoutField
@@ -430,7 +431,7 @@ class ShellCommandLogOutputField(BoolField):
 
 class ShellCommandWorkdirField(StringField):
     alias = "workdir"
-    default = "."
+    default: ClassVar[Optional[str]] = "."
     help = softwrap(
         "Sets the current working directory of the command. "
         "To specify the location of the `BUILD` file, use `.`. Values beginning with `.` are "
@@ -439,12 +440,27 @@ class ShellCommandWorkdirField(StringField):
         "Values that do not begin with `.` or `/` are relative to the build root."
     )
 
+
 class RunShellCommandWorkdirField(ShellCommandWorkdirField):
     default = None
     help = softwrap(
         "Sets the current working directory of the command that is `run`. If `None`, run the "
         "command from the current working directory."
     )
+
+
+class ShellCommandOutputRootDirField(StringField):
+    alias = "root_output_directory"
+    default = "."
+    help = softwrap(
+        "Adjusts the location of files output by this command, when consumed as a dependency.\n\n"
+        "`.` or values beginning with `./` are relative to the location of the `BUILD` file.\n\n"
+        "`.` or values beginning with `./` are relative to the value of `workdir`.\n\n"
+        "To specify the build root, use `/` or the empty string.\n\n"
+        "Values that do not begin with `.` or `/` are relative to the build root.\n\n"
+        "All files output by "
+    )
+
 
 class ShellCommandTestDependenciesField(ShellCommandExecutionDependenciesField):
     pass
@@ -472,6 +488,7 @@ class ShellCommandTarget(Target):
         ShellCommandToolsField,
         ShellCommandExtraEnvVarsField,
         ShellCommandWorkdirField,
+        ShellCommandOutputRootDirField,
         EnvironmentField,
     )
     help = softwrap(
@@ -515,6 +532,7 @@ class ShellRunInSandboxTarget(Target):
         ShellCommandToolsField,
         ShellCommandExtraEnvVarsField,
         ShellCommandWorkdirField,
+        ShellCommandOutputRootDirField,
         EnvironmentField,
     )
     help = softwrap(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -431,11 +431,12 @@ class ShellCommandWorkdirField(StringField):
     alias = "workdir"
     default: ClassVar[Optional[str]] = "."
     help = softwrap(
-        "Sets the current working directory of the command. "
-        "To specify the location of the `BUILD` file, use `.`. Values beginning with `.` are "
-        "relative to the location of the `BUILD` file.\n\n"
-        "To specify the build root, use `/` or the empty string.\n\n"
-        "Values that do not begin with `.` or `/` are relative to the build root."
+        "Sets the current working directory of the command. \n\n"
+        "Values are relative to the build root, except in the following cases:\n\n"
+        "* `.` specifies the location of the `BUILD` file.\n"
+        "* Values beginning with `./` are relative to the location of the `BUILD` file.\n"
+        "* `/` or the empty string specifies the build root.\n"
+        "* Values beginning with `/` are also relative to the build root."
     )
 
 
@@ -443,7 +444,7 @@ class RunShellCommandWorkdirField(ShellCommandWorkdirField):
     default = None
     help = softwrap(
         "Sets the current working directory of the command that is `run`. If `None`, run the "
-        "command from the current working directory."
+        "command from the directory you are invoking Pants from."
     )
 
 

--- a/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
+++ b/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
@@ -133,7 +133,10 @@ async def run_in_sandbox_request(
             logger.warning(result.stderr.decode())
 
     adjusted = await _adjust_root_output_directory(
-        result.output_digest, shell_command.address, root_output_directory, working_directory
+        result.output_digest,
+        shell_command.address,
+        working_directory,
+        root_output_directory,
     )
     output = await Get(Snapshot, Digest, adjusted)
 

--- a/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
+++ b/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
@@ -10,10 +10,12 @@ from pants.backend.shell.target_types import (
     RunInSandboxRunnableField,
     RunInSandboxSourcesField,
     ShellCommandLogOutputField,
+    ShellCommandOutputRootDirField,
     ShellCommandWorkdirField,
 )
 from pants.backend.shell.util_rules.adhoc_process_support import (
     ShellCommandProcessRequest,
+    _adjust_root_output_directory,
     _execution_environment_from_dependencies,
     _parse_outputs_from_command,
 )
@@ -82,6 +84,7 @@ async def run_in_sandbox_request(
     run_field_set: RunFieldSet = field_sets.field_sets[0]
 
     working_directory = shell_command[ShellCommandWorkdirField].value or ""
+    root_output_directory = shell_command[ShellCommandOutputRootDirField].value or ""
 
     # Must be run in target environment so that the binaries/envvars match the execution
     # environment when we actually run the process.
@@ -129,7 +132,11 @@ async def run_in_sandbox_request(
         if result.stderr:
             logger.warning(result.stderr.decode())
 
-    output = await Get(Snapshot, Digest, result.output_digest)
+    adjusted = await _adjust_root_output_directory(
+        result.output_digest, shell_command.address, root_output_directory, working_directory
+    )
+    output = await Get(Snapshot, Digest, adjusted)
+
     return GeneratedSources(output)
 
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -154,7 +154,7 @@ async def run_shell_command(
     working_directory = shell_command[ShellCommandWorkdirField].value or ""
     root_output_directory = shell_command[ShellCommandOutputRootDirField].value or ""
     adjusted = await _adjust_root_output_directory(
-        result.output_digest, shell_command.address, root_output_directory, working_directory
+        result.output_digest, shell_command.address, working_directory, root_output_directory
     )
     output = await Get(Snapshot, Digest, adjusted)
     return GeneratedSources(output)

--- a/src/python/pants/core/util_rules/wrap_source_intergration_test.py
+++ b/src/python/pants/core/util_rules/wrap_source_intergration_test.py
@@ -18,6 +18,7 @@ def test_synthesized_python_is_included_in_package() -> None:
                 execution_dependencies=(),
                 output_files=["hello_world.py",],
                 workdir=".",
+                root_output_directory="/",
             )
 
             experimental_wrap_as_python_sources(


### PR DESCRIPTION
This reverts the default behaviour for `experimental_shell_command` wrt the working directory. These targets now default to using the `build_file_dir()` as their default working directory, which seems to make the most sense as a default after letting the adjustable `workdir` field bed in for a while.

This also adds `root_output_directory`, which helps cater for the majority of `relocated_files` uses that arise from running custom commands. The default behaviour is to now output a digest with the working directory's path _stripped_ from all outputs. To retain the old behaviour, you can set the `root_output_directory` to `/`.

Closes #18143
Closes #18110 