### PR TITLE
Adds fields to capture stdout/stderr to `experimental_run_in_sandbox`

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -389,6 +389,18 @@ class RunInSandboxArgumentsField(StringSequenceField):
     help = f"Extra arguments to pass into the `{RunInSandboxRunnableField.alias}` field."
 
 
+class RunInSandboxStdoutFilenameField(StringField):
+    alias = "stdout"
+    default = None
+    help = "A filename to capture the contents of `stdout` to, relative to the value of `workdir`."
+
+
+class RunInSandboxStderrFilenameField(StringField):
+    alias = "stderr"
+    default = None
+    help = "A filename to capture the contents of `stdout` to, relative to the value of `workdir`."
+
+
 class ShellCommandTimeoutField(IntField):
     alias = "timeout"
     default = 30
@@ -532,6 +544,8 @@ class ShellRunInSandboxTarget(Target):
         ShellCommandExtraEnvVarsField,
         ShellCommandWorkdirField,
         ShellCommandOutputRootDirField,
+        RunInSandboxStdoutFilenameField,
+        RunInSandboxStderrFilenameField,
         EnvironmentField,
     )
     help = softwrap(

--- a/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
+++ b/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
@@ -9,6 +9,8 @@ from pants.backend.shell.target_types import (
     RunInSandboxArgumentsField,
     RunInSandboxRunnableField,
     RunInSandboxSourcesField,
+    RunInSandboxStderrFilenameField,
+    RunInSandboxStdoutFilenameField,
     ShellCommandLogOutputField,
     ShellCommandOutputRootDirField,
     ShellCommandWorkdirField,
@@ -132,11 +134,18 @@ async def run_in_sandbox_request(
         if result.stderr:
             logger.warning(result.stderr.decode())
 
+    extras = (
+        (shell_command[RunInSandboxStdoutFilenameField].value, result.stdout),
+        (shell_command[RunInSandboxStderrFilenameField].value, result.stderr),
+    )
+    extra_contents = {i: j for i, j in extras if i}
+
     adjusted = await _adjust_root_output_directory(
         result.output_digest,
         shell_command.address,
         working_directory,
         root_output_directory,
+        extra_files=extra_contents,
     )
     output = await Get(Snapshot, Digest, adjusted)
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -764,6 +764,44 @@ def test_run_runnable_in_sandbox_with_workdir(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_run_in_sandbox_capture_stdout_err(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/fruitcake.py": dedent(
+                """\
+                import sys
+                print("fruitcake")
+                print("inconceivable", file=sys.stderr)
+                """
+            ),
+            "src/BUILD": dedent(
+                """\
+                python_source(
+                    source="fruitcake.py",
+                    name="fruitcake",
+                )
+
+                experimental_run_in_sandbox(
+                  name="run_fruitcake",
+                  runnable=":fruitcake",
+                  stdout="stdout",
+                  stderr="stderr",
+                )
+                """
+            ),
+        }
+    )
+
+    assert_run_in_sandbox_result(
+        rule_runner,
+        Address("src", target_name="run_fruitcake"),
+        expected_contents={
+            "stderr": "inconceivable\n",
+            "stdout": "fruitcake\n",
+        },
+    )
+
+
 def test_relative_directories(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
This adds `stdout=` and `stderr=` fields to `experimental_run_in_sandbox`, allowing users to include those streams in the output from such a target.

Closes #18087.