### PR TITLE
python: teach tailor goal to create resource targets for py.typed marker files

### DIFF
--- a/src/python/pants/backend/python/goals/tailor.py
+++ b/src/python/pants/backend/python/goals/tailor.py
@@ -98,20 +98,18 @@ async def _find_resource_py_typed_targets(
     """Find resource targets that may be created after discovering any `py.typed` files."""
     all_py_typed_files = await Get(Paths, PathGlobs, py_typed_files_globs)
     unowned_py_typed_files = set(all_py_typed_files.files) - set(all_owned_sources)
-    classified_unowned_py_typed_files = {ResourceTarget: unowned_py_typed_files}
 
     putative_targets = []
-    for tgt_type, paths in classified_unowned_py_typed_files.items():
-        for dirname, filenames in group_by_dir(paths).items():
-            putative_targets.append(
-                PutativeTarget.for_target_type(
-                    tgt_type,
-                    kwargs={"source": "py.typed"},
-                    path=dirname,
-                    name=None,
-                    triggering_sources=sorted(filenames),
-                )
+    for dirname, filenames in group_by_dir(unowned_py_typed_files).items():
+        putative_targets.append(
+            PutativeTarget.for_target_type(
+                ResourceTarget,
+                kwargs={"source": "py.typed"},
+                path=dirname,
+                name="py_typed",
+                triggering_sources=sorted(filenames),
             )
+        )
     return putative_targets
 
 

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -21,6 +21,7 @@ from pants.backend.python.target_types import (
     PythonTestUtilsGeneratorTarget,
 )
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.core.target_types import ResourceTarget
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -298,6 +299,32 @@ def test_find_putative_targets_for_entry_points(rule_runner: RuleRunner) -> None
                     "__main__",
                     [],
                     kwargs={"entry_point": "__main__.py"},
+                ),
+            ]
+        )
+        == pts
+    )
+
+
+def test_find_putative_targets_for_py_typed_marker_files(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files({"src/python/foo/py.typed": ""})
+    rule_runner.set_options(["--python-tailor-py-typed-targets"])
+    pts = rule_runner.request(
+        PutativeTargets,
+        [
+            PutativePythonTargetsRequest(("src/python/foo",)),
+            AllOwnedSources([]),
+        ],
+    )
+    assert (
+        PutativeTargets(
+            [
+                PutativeTarget.for_target_type(
+                    ResourceTarget,
+                    path="src/python/foo",
+                    name="foo",
+                    triggering_sources=("py.typed",),
+                    kwargs={"source": "py.typed"},
                 ),
             ]
         )

--- a/src/python/pants/backend/python/goals/tailor_test.py
+++ b/src/python/pants/backend/python/goals/tailor_test.py
@@ -322,7 +322,7 @@ def test_find_putative_targets_for_py_typed_marker_files(rule_runner: RuleRunner
                 PutativeTarget.for_target_type(
                     ResourceTarget,
                     path="src/python/foo",
-                    name="foo",
+                    name="py_typed",
                     triggering_sources=("py.typed",),
                     kwargs={"source": "py.typed"},
                 ),

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -482,6 +482,15 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
+    tailor_py_typed_targets = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            If true, add `resource` targets for marker files named `py.typed` with the `tailor` goal.
+            """
+        ),
+        advanced=True,
+    )
     macos_big_sur_compatibility = BoolOption(
         default=False,
         help=softwrap(

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -483,7 +483,7 @@ class PythonSetup(Subsystem):
         advanced=True,
     )
     tailor_py_typed_targets = BoolOption(
-        default=False,
+        default=True,
         help=softwrap(
             """
             If true, add `resource` targets for marker files named `py.typed` with the `tailor` goal.

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -80,7 +80,6 @@ def default_sources_for_target_type(tgt_type: type[Target]) -> tuple[str, ...]:
     return tuple()
 
 
-@memoized
 def has_source_or_sources_field(tgt_type: type[Target]) -> bool:
     """Tell whether a given target type has a `source` or `sources` field.
 

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -80,6 +80,19 @@ def default_sources_for_target_type(tgt_type: type[Target]) -> tuple[str, ...]:
     return tuple()
 
 
+@memoized
+def has_source_or_sources_field(tgt_type: type[Target]) -> bool:
+    """Tell whether a given target type has a `source` or `sources` field.
+
+    This may be useful when determining whether it's possible to tailor a target with the passed
+    source(s) field value if the target doesn't have such a field in the first place.
+    """
+    for field in tgt_type.core_fields:
+        if issubclass(field, (OptionalSingleSourceField, MultipleSourcesField)):
+            return True
+    return False
+
+
 @dataclass(order=True, frozen=True)
 class PutativeTarget:
     """A potential target to add, detected by various heuristics.
@@ -145,8 +158,9 @@ class PutativeTarget:
                 )
             )
 
-        default_sources = default_sources_for_target_type(target_type)
-        if (explicit_sources or triggering_sources) and not default_sources:
+        if (explicit_sources or triggering_sources) and not has_source_or_sources_field(
+            target_type
+        ):
             raise AssertionError(
                 softwrap(
                     f"""
@@ -156,6 +170,7 @@ class PutativeTarget:
                     """
                 )
             )
+        default_sources = default_sources_for_target_type(target_type)
         owned_sources = explicit_sources or default_sources or tuple()
         return cls(
             path,

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -23,6 +23,7 @@ from pants.core.goals.tailor import (
     TailorSubsystem,
     UniquelyNamedPutativeTargets,
     default_sources_for_target_type,
+    has_source_or_sources_field,
     make_content_str,
 )
 from pants.core.util_rules import source_files
@@ -148,6 +149,12 @@ def test_default_sources_for_target_type() -> None:
     assert default_sources_for_target_type(FortranLibraryTarget) == FortranLibrarySources.default
     assert default_sources_for_target_type(FortranTestsTarget) == FortranTestsSources.default
     assert default_sources_for_target_type(FortranModule) == tuple()
+
+
+def test_has_source_or_sources_field() -> None:
+    assert has_source_or_sources_field(FortranLibraryTarget)
+    assert has_source_or_sources_field(FortranTestsTarget)
+    assert not has_source_or_sources_field(FortranModule)
 
 
 def test_make_content_str() -> None:


### PR DESCRIPTION
Work towards https://github.com/pantsbuild/pants/issues/12843

This PR makes it possible to produce `resource` targets for `py.typed` marker files that make it possible for `mypy` and other compatible type checkers to regard the Python package as typed.

```
❯ find . -name "py.typed"   
./src/python/pants/backend/awslambda/py.typed
./src/python/pants/backend/python/goals/py.typed
./src/python/pants/py.typed
./src/python/pants/testutil/py.typed

❯ ./pants tailor --python-tailor-py-typed-targets --check src::   
Would update src/python/pants/backend/awslambda/BUILD:
  - Add resource target awslambda0
Would create src/python/pants/backend/experimental/tools/yamllint/BUILD:
  - Add python_sources target yamllint
Would update src/python/pants/backend/python/goals/BUILD:
  - Add resource target goals0

To fix `tailor` failures, run `./pants tailor`.
```

Existing `py.typed` files that are owned by other resources are ignored and only new ones are suggested to be created.