### PR TITLE
[WIP] go: vendored modules support

### DIFF
--- a/src/python/pants/backend/go/target_type_rules.py
+++ b/src/python/pants/backend/go/target_type_rules.py
@@ -21,10 +21,6 @@ from pants.backend.go.target_types import (
     GoPackageSourcesField,
     GoThirdPartyPackageDependenciesField,
     GoThirdPartyPackageTarget,
-    GoVendoredModuleDirPath,
-    GoVendoredModuleImportPathField,
-    GoVendoredPackageDigestField,
-    GoVendoredPackageDirPath,
     GoVendoredPackageTarget,
 )
 from pants.backend.go.util_rules import build_opts, first_party_pkg, import_analysis, vendor
@@ -387,20 +383,11 @@ async def generate_targets_from_go_mod(
 
     def generate_vendored_target(
         pkg_import_path: str,
-        module_import_path: str,
-        module_digest: Digest,
-        module_dir_path: str,
-        pkg_dir_path: str,
     ) -> GoVendoredPackageTarget:
-        module_digest_str = f"{module_digest.fingerprint}/{module_digest.serialized_bytes_length}"
         return GoVendoredPackageTarget(
             {
                 **request.template,
                 GoImportPathField.alias: pkg_import_path,
-                GoVendoredModuleImportPathField.alias: module_import_path,
-                GoVendoredPackageDigestField.alias: module_digest_str,  # TODO: Can this be `Digest` directly?
-                GoVendoredModuleDirPath.alias: str(module_dir_path),
-                GoVendoredPackageDirPath.alias: str(pkg_import_path),
             },
             # E.g. `src/go:mod#github.com/google/uuid`.
             generator_addr.create_generated(pkg_import_path),
@@ -413,10 +400,6 @@ async def generate_targets_from_go_mod(
         vendor_module_targets.append(
             generate_vendored_target(
                 pkg_import_path=pkg_analysis_info.analysis.import_path,
-                module_import_path=pkg_analysis_info.module_import_path,
-                module_digest=pkg_analysis_info.analysis.digest,
-                module_dir_path=pkg_analysis_info.module_dir_path,
-                pkg_dir_path=pkg_analysis_info.analysis.dir_path,
             )
         )
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -252,6 +252,69 @@ class GoThirdPartyPackageTarget(Target):
 
 
 # -----------------------------------------------------------------------------------------------
+# `go_vendor_package` target generator
+# -----------------------------------------------------------------------------------------------
+
+
+class GoVendoredPackageDependenciesField(Dependencies):
+    pass
+
+
+class GoVendoredModuleImportPathField(StringField):
+    alias = "_module_import_path"
+    help = ""
+
+
+class GoVendoredModuleDirPath(StringField):
+    alias = "_module_dir_path"
+    help = ""
+
+
+class GoVendoredPackageDirPath(StringField):
+    alias = "_pkg_dir_path"
+    help = ""
+
+
+class GoVendoredPackageDigestField(StringField):
+    alias = "_pkg_digest"
+    help = softwrap(
+        """
+        The digest for the vendored package. It will include all of the sources for the vendored module.
+        """
+    )
+
+
+class GoVendoredPackageTarget(Target):
+    alias = "_go_vendored_package"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        GoVendoredPackageDependenciesField,
+        GoImportPathField,
+        GoVendoredModuleImportPathField,
+    )
+
+    help = softwrap(
+        """
+        A package from a vendored third-party Go module.
+
+        You should not explicitly create this target in BUILD files. Instead, add a `go_mod`
+        target where you have your vendored packages, which will generate
+        `_go_vendored_package` targets for you.
+        """
+    )
+
+    def validate(self) -> None:
+        if not self.address.is_generated_target:
+            raise InvalidTargetException(
+                f"The `{self.alias}` target type should not be manually created in BUILD "
+                f"files, but it was created for {self.address}.\n\n"
+                "Instead, add a `go_mod` target where you have your `go.mod` file, which will "
+                f"generate `{self.alias}` targets for you based on the `require` directives in "
+                f"your `go.mod`."
+            )
+
+
+# -----------------------------------------------------------------------------------------------
 # `go_mod` target generator
 # -----------------------------------------------------------------------------------------------
 

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -260,37 +260,12 @@ class GoVendoredPackageDependenciesField(Dependencies):
     pass
 
 
-class GoVendoredModuleImportPathField(StringField):
-    alias = "_module_import_path"
-    help = ""
-
-
-class GoVendoredModuleDirPath(StringField):
-    alias = "_module_dir_path"
-    help = ""
-
-
-class GoVendoredPackageDirPath(StringField):
-    alias = "_pkg_dir_path"
-    help = ""
-
-
-class GoVendoredPackageDigestField(StringField):
-    alias = "_pkg_digest"
-    help = softwrap(
-        """
-        The digest for the vendored package. It will include all of the sources for the vendored module.
-        """
-    )
-
-
 class GoVendoredPackageTarget(Target):
     alias = "_go_vendored_package"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         GoVendoredPackageDependenciesField,
         GoImportPathField,
-        GoVendoredModuleImportPathField,
     )
 
     help = softwrap(

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -17,6 +17,11 @@ from pants.backend.go.target_types import (
     GoImportPathField,
     GoPackageSourcesField,
     GoThirdPartyPackageDependenciesField,
+    GoVendoredModuleDirPath,
+    GoVendoredModuleImportPathField,
+    GoVendoredPackageDependenciesField,
+    GoVendoredPackageDigestField,
+    GoVendoredPackageDirPath,
 )
 from pants.backend.go.util_rules import build_opts
 from pants.backend.go.util_rules.build_opts import GoBuildOptions
@@ -49,8 +54,10 @@ from pants.backend.go.util_rules.import_analysis import (
 )
 from pants.backend.go.util_rules.pkg_pattern import match_simple_pattern
 from pants.backend.go.util_rules.third_party_pkg import (
+    FallibleThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysis,
     ThirdPartyPkgAnalysisRequest,
+    VendoredPkgAnalysisRequest,
 )
 from pants.build_graph.address import Address
 from pants.engine.engine_aware import EngineAwareParameter
@@ -304,6 +311,57 @@ async def setup_build_go_package_target_request(
         objc_files = _third_party_pkg_info.m_files
         fortran_files = _third_party_pkg_info.f_files
         prebuilt_object_files = _third_party_pkg_info.syso_files
+
+    elif target.has_field(GoVendoredPackageDependenciesField):
+        module_import_path = target[GoVendoredModuleImportPathField].value
+        assert module_import_path is not None
+        pkg_import_path = target[GoImportPathField].value
+        module_dir_path = target[GoVendoredModuleDirPath].value
+        assert module_dir_path is not None
+        pkg_dir_path = target[GoVendoredPackageDirPath].value
+        assert pkg_dir_path is not None
+
+        pkg_digest_fields_str = target[GoVendoredPackageDigestField].value
+        assert pkg_digest_fields_str is not None
+        pkg_digest_fields = pkg_digest_fields_str.split("/", 2)
+        pkg_digest = Digest(pkg_digest_fields[0], int(pkg_digest_fields[1]))
+
+        _maybe_vendored_pkg_info = await Get(
+            FallibleThirdPartyPkgAnalysis,
+            VendoredPkgAnalysisRequest(
+                digest=pkg_digest,
+                module_import_path=module_import_path,
+                pkg_import_path=pkg_import_path,
+                module_dir_path=module_dir_path,
+                pkg_dir_path=pkg_dir_path,
+                build_opts=request.build_opts,
+            ),
+        )
+        if _maybe_vendored_pkg_info.analysis is None:
+            return FallibleBuildGoPackageRequest(
+                None,
+                _maybe_vendored_pkg_info.import_path,
+                exit_code=_maybe_vendored_pkg_info.exit_code,
+                stderr=_maybe_vendored_pkg_info.stderr,
+            )
+        _vendored_pkg_info = _maybe_vendored_pkg_info.analysis
+
+        imports = set(_vendored_pkg_info.imports)
+        dir_path = _vendored_pkg_info.dir_path
+        pkg_name = _vendored_pkg_info.name
+        digest = _vendored_pkg_info.digest
+        minimum_go_version = _vendored_pkg_info.minimum_go_version
+        go_file_names = _vendored_pkg_info.go_files
+        s_files = _vendored_pkg_info.s_files
+        embed_config = _vendored_pkg_info.embed_config
+        cgo_files = _vendored_pkg_info.cgo_files
+        cgo_flags = _vendored_pkg_info.cgo_flags
+        c_files = _vendored_pkg_info.c_files
+        h_files = _vendored_pkg_info.h_files
+        cxx_files = _vendored_pkg_info.cxx_files
+        objc_files = _vendored_pkg_info.m_files
+        fortran_files = _vendored_pkg_info.f_files
+        prebuilt_object_files = _vendored_pkg_info.syso_files
 
     else:
         raise AssertionError(

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -19,6 +19,7 @@ from pants.backend.go.target_types import (
 from pants.backend.go.util_rules import binary
 from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
 from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.backend.go.util_rules.vendor import VendoredModuleMetadata
 from pants.base.specs import AncestorGlobSpec, RawSpecs
 from pants.build_graph.address import Address, AddressInput
 from pants.engine.engine_aware import EngineAwareParameter
@@ -217,6 +218,7 @@ class GoModInfo:
     digest: Digest
     mod_path: str
     minimum_go_version: str | None
+    vendor_modules: tuple[VendoredModuleMetadata, ...]
 
 
 @dataclass(frozen=True)
@@ -264,6 +266,7 @@ async def determine_go_mod_info(
         digest=sources_digest,
         mod_path=go_mod_path,
         minimum_go_version=module_metadata.get("Go"),
+        vendor_modules=(),
     )
 
 

--- a/src/python/pants/backend/go/util_rules/go_mod.py
+++ b/src/python/pants/backend/go/util_rules/go_mod.py
@@ -15,6 +15,7 @@ from pants.backend.go.target_types import (
     GoOwningGoModAddressField,
     GoPackageSourcesField,
     GoThirdPartyPackageDependenciesField,
+    GoVendoredPackageDependenciesField,
 )
 from pants.backend.go.util_rules import binary
 from pants.backend.go.util_rules.binary import GoBinaryMainPackage, GoBinaryMainPackageRequest
@@ -182,8 +183,11 @@ async def find_owning_go_mod(
         )
         return OwningGoMod(nearest_go_mod_result.address)
 
-    if target.has_field(GoThirdPartyPackageDependenciesField):
-        # For `go_third_party_package` targets, use the generator which is the owning `go_mod` target.
+    if target.has_field(GoThirdPartyPackageDependenciesField) or target.has_field(
+        GoVendoredPackageDependenciesField
+    ):
+        # For `go_third_party_package` and `_go_vendored_package` targets, use the generator which is the
+        # owning `go_mod` target.
         generator_address = target.address.maybe_convert_to_target_generator()
         return OwningGoMod(generator_address)
 

--- a/src/python/pants/backend/go/util_rules/vendor_integration_test.py
+++ b/src/python/pants/backend/go/util_rules/vendor_integration_test.py
@@ -1,0 +1,135 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import os
+import subprocess
+from textwrap import dedent
+
+import pytest
+
+from pants.backend.go import target_type_rules
+from pants.backend.go.goals import package_binary
+from pants.backend.go.goals.package_binary import GoBinaryFieldSet
+from pants.backend.go.target_types import (
+    GoBinaryTarget,
+    GoModTarget,
+    GoPackageTarget,
+    GoVendoredPackageTarget,
+)
+from pants.backend.go.util_rules import (
+    assembly,
+    build_pkg,
+    build_pkg_target,
+    first_party_pkg,
+    go_mod,
+    implicit_linker_deps,
+    import_analysis,
+    link,
+    sdk,
+    third_party_pkg,
+    vendor,
+)
+from pants.build_graph.address import Address
+from pants.core.goals.package import BuiltPackage
+from pants.engine.rules import QueryRule
+from pants.engine.target import Target
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *assembly.rules(),
+            *build_pkg.rules(),
+            *build_pkg_target.rules(),
+            *first_party_pkg.rules(),
+            *go_mod.rules(),
+            *implicit_linker_deps.rules(),
+            *import_analysis.rules(),
+            *link.rules(),
+            *package_binary.rules(),
+            *sdk.rules(),
+            *target_type_rules.rules(),
+            *third_party_pkg.rules(),
+            *vendor.rules(),
+            QueryRule(BuiltPackage, (GoBinaryFieldSet,)),
+        ],
+        target_types=[
+            GoBinaryTarget,
+            GoModTarget,
+            GoPackageTarget,
+            GoVendoredPackageTarget,
+        ],
+    )
+    rule_runner.set_options([], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    return rule_runner
+
+
+def build_package(rule_runner: RuleRunner, binary_target: Target) -> BuiltPackage:
+    field_set = GoBinaryFieldSet.create(binary_target)
+    result = rule_runner.request(BuiltPackage, [field_set])
+    rule_runner.write_digest(result.digest)
+    return result
+
+
+def test_basic_vendored_package(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo/BUILD": dedent(
+                """\
+            go_mod(name="mod")
+            go_package()
+            go_binary(name="bin")
+            """
+            ),
+            "foo/go.mod": dedent(
+                """\
+            module example.pantsbuild.org/main
+            require lib.pantsbuild.org/concat v0.0.1
+            """
+            ),
+            "foo/main.go": dedent(
+                """\
+            package main
+            import (
+              "fmt"
+              "os"
+              "lib.pantsbuild.org/concat"
+            )
+            func main() {
+              x := os.Args[1]
+              y := os.Args[2]
+              fmt.Printf("%s\n", concat.Join(x, y))
+            }
+            """
+            ),
+            "foo/vendor/module.txt": dedent(
+                """\
+            # lib.pantsbuild.org/concat v0.0.1
+            ## explicit; go 1.17
+            lib.pantsbuild.org/concat
+            """
+            ),
+            "foo/vendor/lib.pantsbuild.org/concat/concat.go": dedent(
+                """\
+            package concat
+            func Join(x, y string) string {
+              return x + y
+            }
+            """
+            ),
+        }
+    )
+
+    binary_tgt = rule_runner.get_target(Address("foo", target_name="bin"))
+    built_package = build_package(rule_runner, binary_tgt)
+    assert len(built_package.artifacts) == 1
+    assert built_package.artifacts[0].relpath == "bin"
+
+    result = subprocess.run(
+        [os.path.join(rule_runner.build_root, "bin"), "Hello ", " world!"], stdout=subprocess.PIPE
+    )
+    assert result.returncode == 0
+    assert result.stdout == b"Hello world!\n"


### PR DESCRIPTION
Add support for vendoring third-party modules under the `vendor` directory of a Go module.

Closes https://github.com/pantsbuild/pants/issues/12768.