### PR TITLE
help: extend help goal to produce a JSON schema file

### DIFF
--- a/src/python/pants/help/help_json_schema.py
+++ b/src/python/pants/help/help_json_schema.py
@@ -1,0 +1,99 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+from packaging.version import Version
+
+from pants.version import VERSION
+
+GENERATED_JSON_SCHEMA_FILENAME = f"pantsbuild-{VERSION}.json"
+DOCS_URL = "https://www.pantsbuild.org"
+VERSION_MAJOR_MINOR = f"{Version(VERSION).major}.{Version(VERSION).minor}"
+
+PYTHON_TO_JSON_TYPE_MAPPING = {
+    "str": "string",
+    "bool": "boolean",
+    "list": "array",
+    "int": "number",
+    "float": "number",
+    "dict": "object",
+}
+
+# Certain default values will be expanded using local runtime environment which is undesirable.
+# This list may need to be extended as more options with environment specific default values are added.
+ENV_SPECIFIC_OPTION_DEFAULTS = {
+    "pants_config_files": ["<buildroot>/pants.toml"],
+    "pants_subprocessdir": "<buildroot>/.pids",
+    "pants_distdir": "<buildroot>/dist",
+    "pants_workdir": "<buildroot>/.pants.d",
+    "local_store_dir": "$XDG_CACHE_HOME/lmdb_store",
+    "named_caches_dir": "$XDG_CACHE_HOME/named_caches",
+}
+
+
+def simplify_option_description(description: str) -> str:
+    """Take only a first sentence out of a multi-sentence description without a final full stop.
+
+    There is an assumption that there are no newlines.
+    """
+    return re.split(r"(?<=[^A-Z].[.?]) +(?=[A-Z])", description)[0].rstrip(".")
+
+
+def get_description(option: dict, section: str) -> str:
+    """Get a shortened description with a URL to the online docs of the given option."""
+    option_help: str = option["help"].lstrip("\n").split("\n")[0]
+    option_name: str = option["config_key"]
+    simplified_option_help = simplify_option_description(option_help)
+    url = f"{DOCS_URL}/v{VERSION_MAJOR_MINOR}/docs/reference-{section.lower()}#{option_name}"
+    return f"{simplified_option_help}\n{url}"
+
+
+def get_default(option: dict) -> Any:
+    """Get default value for an option.
+
+    Ensure options that depend on any machine specific environment are properly handled. E.g.
+    `"default": "<buildroot>/.pants.d"` will be expanded to the
+    `"default": "/home/your-user.name/code/pants/.pants.d"`
+    which is not what one want to have in a schema.
+    """
+    return ENV_SPECIFIC_OPTION_DEFAULTS.get(option["config_key"], option["default"])
+
+
+def build_scope_properties(ruleset: dict, options: Iterable[dict], scope: str) -> dict:
+    """Build properties object for a single scope.
+
+    There are custom types (e.g. `file_option` or `LogLevel`) for which one cannot safely infer a
+    type, so no type is added to the ruleset. If there are choices, there is no need to provide
+    "type" for the schema (assuming all choices share the same type). If an option value can be
+    loaded from a file, a union of `string` and option's `typ` is used. Otherwise, a provided `typ`
+    field is used.
+    """
+    for option in options:
+        properties = ruleset[scope]["properties"]
+
+        properties[option["config_key"]] = {
+            "description": get_description(option, scope),
+            "default": get_default(option),
+        }
+        if option["choices"]:
+            # TODO(alte): find a safe way to sort choices
+            properties[option["config_key"]]["enum"] = option["choices"]
+        else:
+            typ = PYTHON_TO_JSON_TYPE_MAPPING.get(option["typ"])
+            # TODO(alte): do we want to maintain a mapping between special options?
+            #  `process_total_child_memory_usage` ("typ": "memory_size") -> "int"
+            #  `engine_visualize_to` ("typ": "dir_option") -> "str"
+            if typ:
+                # options may allow providing value inline or loading from a filepath string
+                if option.get("fromfile"):
+                    properties[option["config_key"]]["oneOf"] = [{"type": typ}, {"type": "string"}]
+                else:
+                    properties[option["config_key"]]["type"] = typ
+
+                # TODO(alte): see if one safely codify in the schema the fact that we support `.add` and `.remove`
+                #  semantics on arrays; e.g. `extra_requirements.add` can either be an array or an object
+                #  {add|remove: array}
+    return ruleset

--- a/src/python/pants/help/help_json_schema_test.py
+++ b/src/python/pants/help/help_json_schema_test.py
@@ -1,0 +1,206 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+
+import pytest
+
+from pants.help.help_json_schema import VERSION_MAJOR_MINOR, simplify_option_description
+from pants.help.help_printer import HelpPrinter
+
+
+@pytest.mark.parametrize(
+    "description,output",
+    [
+        (
+            "Sentence starts here and ends without a full stop",
+            "Sentence starts here and ends without a full stop",
+        ),
+        ("Sentence starts here and ends here.", "Sentence starts here and ends here"),
+        (
+            "We run `./pants goal` and stop here, then continue.",
+            "We run `./pants goal` and stop here, then continue",
+        ),
+        (
+            "We run `./pants goal` and stop here. After that, we continue.",
+            "We run `./pants goal` and stop here",
+        ),
+        (
+            "We run `./pants goal` and then e.g. finish.",
+            "We run `./pants goal` and then e.g. finish",
+        ),
+        (
+            "We run `./pants goal` and then stop here.With a missing whitespace after dot, a new sentence starts here.",
+            "We run `./pants goal` and then stop here.With a missing whitespace after dot, a new sentence starts here",
+        ),
+        (
+            "Sentence starts here and ends here.\n\nA new sentence goes on in a new paragraph.",
+            "Sentence starts here and ends here.\n\nA new sentence goes on in a new paragraph",
+        ),
+        (
+            "Path to a .pypirc config. (https://packaging.python.org/specifications/pypirc/). Set this.",
+            "Path to a .pypirc config. (https://packaging.python.org/specifications/pypirc/)",
+        ),
+        (
+            "Use this (4-space indentation). ('AOSP' is the Android Open Source Project.)",
+            "Use this (4-space indentation). ('AOSP' is the Android Open Source Project.)",
+        ),
+    ],
+)
+def test_simplify_option_description(description: str, output: str) -> None:
+    assert simplify_option_description(description) == output
+
+
+def test_get_json_schema():
+    sample_all_help_output = {
+        "scope_to_help_info": {
+            "": {
+                "advanced": [
+                    {
+                        "choices": None,
+                        "comma_separated_choices": None,
+                        "comma_separated_display_args": "--[no-]log-show-rust-3rdparty",
+                        "config_key": "log_show_rust_3rdparty",
+                        "default": False,
+                        "deprecated_message": None,
+                        "deprecation_active": False,
+                        "display_args": ["--[no-]log-show-rust-3rdparty"],
+                        "env_var": "PANTS_LOG_SHOW_RUST_3RDPARTY",
+                        "fromfile": False,
+                        "help": "Whether to show/hide logging done by 3rdparty Rust crates used by the Pants engine.",
+                        "removal_hint": None,
+                        "removal_version": None,
+                        "scoped_cmd_line_args": [
+                            "--log-show-rust-3rdparty",
+                            "--no-log-show-rust-3rdparty",
+                        ],
+                        "target_field_name": None,
+                        "typ": "bool",
+                        "unscoped_cmd_line_args": [
+                            "--log-show-rust-3rdparty",
+                            "--no-log-show-rust-3rdparty",
+                        ],
+                        "value_history": {
+                            "ranked_values": [
+                                {"details": None, "rank": "NONE", "value": None},
+                                {"details": None, "rank": "HARDCODED", "value": False},
+                            ]
+                        },
+                    },
+                    {
+                        "choices": None,
+                        "comma_separated_choices": None,
+                        "comma_separated_display_args": "--ignore-warnings=\"['<str>', '<str>', ...]\"",
+                        "config_key": "ignore_warnings",
+                        "default": [],
+                        "deprecated_message": None,
+                        "deprecation_active": False,
+                        "display_args": ["--ignore-warnings=\"['<str>', '<str>', ...]\""],
+                        "env_var": "PANTS_IGNORE_WARNINGS",
+                        "fromfile": False,
+                        "help": "Ignore logs and warnings matching these strings.\n\nNormally, Pants will look for literal matches from the start of the log/warning message, but you can prefix the ignore with `$regex$` for Pants to instead treat your string as a regex pattern. For example:\n\n    ignore_warnings = [\n        \"DEPRECATED: option 'config' in scope 'flake8' will be removed\",\n        '$regex$:No files\\s*'\n    ]",
+                        "removal_hint": None,
+                        "removal_version": None,
+                        "scoped_cmd_line_args": ["--ignore-warnings"],
+                        "target_field_name": None,
+                        "typ": "list",
+                        "unscoped_cmd_line_args": ["--ignore-warnings"],
+                        "value_history": {
+                            "ranked_values": [
+                                {"details": "", "rank": "NONE", "value": []},
+                                {"details": "", "rank": "HARDCODED", "value": []},
+                            ]
+                        },
+                    },
+                ],
+                "basic": [
+                    {
+                        "choices": ["trace", "debug", "info", "warn", "error"],
+                        "comma_separated_choices": "trace, debug, info, warn, error",
+                        "comma_separated_display_args": "-l=<LogLevel>, --level=<LogLevel>",
+                        "config_key": "level",
+                        "default": "info",
+                        "deprecated_message": None,
+                        "deprecation_active": False,
+                        "display_args": ["-l=<LogLevel>", "--level=<LogLevel>"],
+                        "env_var": "PANTS_LEVEL",
+                        "fromfile": False,
+                        "help": "Set the logging level.",
+                        "removal_hint": None,
+                        "removal_version": None,
+                        "scoped_cmd_line_args": ["-l", "--level"],
+                        "target_field_name": None,
+                        "typ": "LogLevel",
+                        "unscoped_cmd_line_args": ["-l", "--level"],
+                        "value_history": {
+                            "ranked_values": [
+                                {"details": None, "rank": "NONE", "value": None},
+                                {"details": None, "rank": "HARDCODED", "value": "info"},
+                            ]
+                        },
+                    }
+                ],
+                "deprecated": [
+                    {
+                        "choices": None,
+                        "comma_separated_choices": None,
+                        "comma_separated_display_args": "--[no-]process-cleanup",
+                        "config_key": "process_cleanup",
+                        "default": True,
+                        "deprecated_message": "Deprecated, is scheduled to be removed in version: 3.0.0.dev0.",
+                        "deprecation_active": True,
+                        "display_args": ["--[no-]process-cleanup"],
+                        "env_var": "PANTS_PROCESS_CLEANUP",
+                        "fromfile": False,
+                        "help": "\nIf false, Pants will not clean up local directories used as chroots for running processes. Pants will log their location so that you can inspect the chroot, and run the `__run.sh` script to recreate the process using the same argv and environment variables used by Pants. This option is useful for debugging.",
+                        "removal_hint": "Use the `keep_sandboxes` option instead.",
+                        "removal_version": "3.0.0.dev0",
+                        "scoped_cmd_line_args": ["--process-cleanup", "--no-process-cleanup"],
+                        "target_field_name": None,
+                        "typ": "bool",
+                        "unscoped_cmd_line_args": ["--process-cleanup", "--no-process-cleanup"],
+                        "value_history": {
+                            "ranked_values": [
+                                {"details": None, "rank": "NONE", "value": None},
+                                {"details": None, "rank": "HARDCODED", "value": True},
+                            ]
+                        },
+                    }
+                ],
+                "deprecated_scope": None,
+                "description": "Options to control the overall behavior of Pants.",
+                "is_goal": False,
+                "provider": "pants.core",
+                "scope": "",
+            }
+        }
+    }
+    schema = HelpPrinter._get_json_schema(json.dumps(sample_all_help_output))
+    assert schema["$schema"]
+    assert schema["description"]
+
+    # all options should be included
+    collected_properties = schema["properties"]["GLOBAL"]["properties"].keys()
+    assert all(
+        [
+            key in collected_properties
+            for key in ["log_show_rust_3rdparty", "ignore_warnings", "level"]
+        ]
+    )
+
+    # deprecated fields shouldn't be included
+    assert "process_cleanup" not in collected_properties
+
+    # an option description should be a single sentence with a URL to the option docs section
+    assert schema["properties"]["GLOBAL"]["properties"]["level"]["description"] == (
+        f"Set the logging level\nhttps://www.pantsbuild.org/v{VERSION_MAJOR_MINOR}/docs/reference-global#level"
+    )
+
+    # options should be part of the enum
+    # TODO(alte): ensure enum is sorted once implemented
+    assert sorted(schema["properties"]["GLOBAL"]["properties"]["level"]["enum"]) == [
+        "debug",
+        "error",
+        "info",
+        "trace",
+        "warn",
+    ]


### PR DESCRIPTION
Work towards https://github.com/pantsbuild/pants/issues/18126.

This PR extends the `help` goal to produce a JSON schema file. Similarly to the `help-all` goal, `./pants help json-schema` sends the JSON schema contents to the stdout which can be piped to a file.

```
$ ./pants help json-schema > "pantsbuild-$(./pants version).json"
```

The functionality remains identical to what has been developed as an initial prototype in `build-support/bin/generate_json_schema.py` (the outputs produced are identical). The `build-support` files of the prototype are going to be removed in a separate PR.