### PR TITLE
Adjusts `BinaryShims` to use native digest operations and `immutable_input_digests`

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -39,6 +39,26 @@ Many rules that create `RunRequest`s can be used verbatim, but others may make a
 We expect to deprecate `RUN_REQUEST_NOT_HERMETIC` and `NOT_SUPPORTED` in a few versions time: these options are provided to give you some time to make your existing rules match the semantics of `RUN_REQUEST_HERMETIC`, or to add a `CUSTOM` rule.
 
 
+### `BinaryShimsRequest` no longer accepts `output_directory`
+
+`BinaryShims` now produces all of its shim scripts in the root of its `digest`, and provides helper methods for use with `immutable_input_digests` and the `PATH` environment variable. It also produces a unique directory name so that multiple rules can be called to populate `PATH`.
+
+Consider using these helper methods in favor of the old behavior:
+
+```
+process = Process(
+    immutable_input_digests=binary_shims.immutable_input_digests,
+    env={"PATH": binary_shims.path_component},
+)
+```
+
+You can replicate the previous behavior using `AddDigest`:
+
+```
+new_digest = await Get(Digest, AddDigest(binary_shims.digest, output_directory))
+```
+
+
 2.15
 ----
 

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -11,10 +11,10 @@ from pants.backend.codegen.protobuf.target_types import (
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
 from pants.core.util_rules.system_binaries import (
+    BinaryShims,
     BinaryShimsRequest,
     DiffBinary,
     DiffBinaryRequest,
-    UnprefixedBinaryShims,
 )
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
@@ -67,12 +67,11 @@ async def run_buf_format(
     diff_binary = await Get(DiffBinary, DiffBinaryRequest())
     download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
     binary_shims_get = Get(
-        UnprefixedBinaryShims,
+        BinaryShims,
         BinaryShimsRequest,
         BinaryShimsRequest.for_paths(
             diff_binary,
             rationale="run `buf format`",
-            output_directory=".bin",
         ),
     )
     downloaded_buf, binary_shims = await MultiGet(download_buf_get, binary_shims_get)

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -14,8 +14,8 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
     BinaryPathTest,
+    BinaryShims,
     BinaryShimsRequest,
-    UnprefixedBinaryShims,
 )
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest
@@ -143,12 +143,11 @@ async def find_docker(
         return DockerBinary(first_path.path, first_path.fingerprint)
 
     tools = await Get(
-        UnprefixedBinaryShims,
+        BinaryShims,
         BinaryShimsRequest,
         BinaryShimsRequest.for_binaries(
             *docker_options.tools,
             rationale="use docker",
-            output_directory="bin",
             search_path=search_path,
         ),
     )

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -14,8 +14,8 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
     BinaryPathTest,
-    BinaryShims,
     BinaryShimsRequest,
+    UnprefixedBinaryShims,
 )
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest
@@ -143,7 +143,7 @@ async def find_docker(
         return DockerBinary(first_path.path, first_path.fingerprint)
 
     tools = await Get(
-        BinaryShims,
+        UnprefixedBinaryShims,
         BinaryShimsRequest,
         BinaryShimsRequest.for_binaries(
             *docker_options.tools,
@@ -152,9 +152,8 @@ async def find_docker(
             search_path=search_path,
         ),
     )
-    tools_path = ".shims"
-    extra_env = {"PATH": os.path.join("{chroot}", tools_path, tools.bin_directory)}
-    extra_input_digests = {tools_path: tools.digest}
+    extra_env = {"PATH": tools.path_component}
+    extra_input_digests = tools.immutable_input_digests
 
     return DockerBinary(
         first_path.path,

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -450,7 +450,7 @@ async def create_binary_shims(
     ]
 
     digest = await Get(Digest, CreateDigest(scripts))
-    cache_name = f"_binary_shims{digest.fingerprint}"
+    cache_name = f"_binary_shims_{digest.fingerprint}"
 
     return BinaryShims(digest, cache_name)
 

--- a/src/python/pants/core/util_rules/system_binaries_test.py
+++ b/src/python/pants/core/util_rules/system_binaries_test.py
@@ -17,10 +17,9 @@ from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
     BinaryPaths,
+    BinaryShims,
     BinaryShimsRequest,
     PythonBinary,
-    UnprefixedBinaryShims,
-    UnprefixedBinaryShimsRequest,
 )
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.internals.selectors import Get
@@ -54,8 +53,7 @@ def rule_runner() -> RuleRunner:
             python_binary_version,
             QueryRule(PythonBinaryVersion, []),
             QueryRule(BinaryPaths, [BinaryPathRequest]),
-            QueryRule(UnprefixedBinaryShims, [BinaryShimsRequest]),
-            QueryRule(UnprefixedBinaryShims, [UnprefixedBinaryShimsRequest]),
+            QueryRule(BinaryShims, [BinaryShimsRequest]),
             QueryRule(DigestContents, [Digest]),
         ]
     )
@@ -170,12 +168,11 @@ def test_python_interpreter_search_path_file_entries() -> None:
 
 def test_binary_shims_request(rule_runner: RuleRunner) -> None:
     result = rule_runner.request(
-        UnprefixedBinaryShims,
+        BinaryShims,
         [
             BinaryShimsRequest.for_binaries(
                 "ls",
                 rationale="test the binary shims feature",
-                output_directory=".bin",
                 search_path=("/usr/bin", "/bin"),
             )
         ],
@@ -201,12 +198,11 @@ def test_binary_shims_request(rule_runner: RuleRunner) -> None:
 def test_binary_shims_paths(rule_runner: RuleRunner, tmp_path: Path) -> None:
     binary_path_abs = str(tmp_path / "bin" / "mybin")
     result = rule_runner.request(
-        UnprefixedBinaryShims,
+        BinaryShims,
         [
             BinaryShimsRequest.for_paths(
                 BinaryPath(binary_path_abs),
                 rationale="test the binary shims feature",
-                output_directory=".bin",
             )
         ],
     )


### PR DESCRIPTION
Per feedback on #18168, this reimplements `BinaryShims` to match the (accidental) re-implementation from over there.

* Shim scripts are created in the root of a digest using `FileContent(..., is_executable=True)`
* The shims directory is given a unique name, allowing for multiple rules to populate `PATH` (probably useful in `shell_command` at some point)
* Shims are installed using `immutable_input_digests`, which automatically puts them in a location in the sandbox that matches the directory name.