### PR TITLE
Adjust the default for `root_output_directory`

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -465,10 +465,11 @@ class ShellCommandOutputRootDirField(StringField):
     default = "/"
     help = softwrap(
         "Adjusts the location of files output by this command, when consumed as a dependency.\n\n"
-        "`.` or values beginning with `./` are relative to the location of the `BUILD` file.\n\n"
-        "`.` or values beginning with `./` are relative to the value of `workdir`.\n\n"
-        "To specify the build root, use `/` or the empty string.\n\n"
-        "Values that do not begin with `.` or `/` are relative to the build root."
+        "Values are relative to the build root, except in the following cases:\n\n"
+        "* `.` specifies the location of the `BUILD` file.\n"
+        "* Values beginning with `./` are relative to the location of the `BUILD` file.\n"
+        "* `/` or the empty string specifies the build root.\n"
+        "* Values beginning with `/` are also relative to the build root."
     )
 
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -462,14 +462,13 @@ class RunShellCommandWorkdirField(ShellCommandWorkdirField):
 
 class ShellCommandOutputRootDirField(StringField):
     alias = "root_output_directory"
-    default = "."
+    default = "/"
     help = softwrap(
         "Adjusts the location of files output by this command, when consumed as a dependency.\n\n"
         "`.` or values beginning with `./` are relative to the location of the `BUILD` file.\n\n"
         "`.` or values beginning with `./` are relative to the value of `workdir`.\n\n"
         "To specify the build root, use `/` or the empty string.\n\n"
-        "Values that do not begin with `.` or `/` are relative to the build root.\n\n"
-        "All files output by "
+        "Values that do not begin with `.` or `/` are relative to the build root."
     )
 
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -134,6 +134,7 @@ def test_sources_and_files(rule_runner: RuleRunner) -> None:
                   output_files=["message.txt"],
                   output_directories=["res"],
                   command="./script.sh",
+                  root_output_directory=".",
                 )
 
                 files(
@@ -177,6 +178,7 @@ def test_quotes_command(rule_runner: RuleRunner) -> None:
                   tools=["echo", "tee"],
                   command='echo "foo bar" | tee out.log',
                   output_files=["out.log"],
+                  root_output_directory=".",
                 )
                 """
             ),
@@ -200,7 +202,6 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
                   tools=["echo"],
                   output_files=["../msg"],
                   command="echo 'shell_command:a' > ../msg",
-                  root_output_directory="/",
                 )
                 """
             ),
@@ -212,7 +213,6 @@ def test_chained_shell_commands(rule_runner: RuleRunner) -> None:
                   output_files=["../msg"],
                   command="echo 'shell_command:b' >> ../msg",
                   execution_dependencies=["src/a:msg"],
-                  root_output_directory="/",
                 )
                 """
             ),
@@ -339,7 +339,8 @@ def test_shell_command_masquerade_as_a_files_target(rule_runner: RuleRunner) -> 
                   name="content-gen",
                   command="echo contents > contents.txt",
                   tools=["echo"],
-                  output_files=["contents.txt"]
+                  output_files=["contents.txt"],
+                  root_output_directory=".",
                 )
                 """
             ),
@@ -744,6 +745,7 @@ def test_run_runnable_in_sandbox(rule_runner: RuleRunner) -> None:
                   name="run_fruitcake",
                   runnable=":fruitcake",
                   output_files=["fruitcake.txt"],
+                  root_output_directory=".",
                 )
                 """
             ),
@@ -814,6 +816,7 @@ def test_run_in_sandbox_capture_stdout_err(rule_runner: RuleRunner) -> None:
                   runnable=":fruitcake",
                   stdout="stdout",
                   stderr="stderr",
+                  root_output_directory=".",
                 )
                 """
             ),
@@ -840,7 +843,6 @@ def test_relative_directories(rule_runner: RuleRunner) -> None:
                   tools=["echo"],
                   command='echo foosh > ../foosh.txt',
                   output_files=["../foosh.txt"],
-                  root_output_directory="/",
                 )
                 """
             ),
@@ -864,7 +866,6 @@ def test_relative_directories_2(rule_runner: RuleRunner) -> None:
                   tools=["echo"],
                   command='echo foosh > ../newdir/foosh.txt',
                   output_files=["../newdir/foosh.txt"],
-                  root_output_directory="/",
                 )
                 """
             ),
@@ -888,7 +889,6 @@ def test_cannot_escape_build_root(rule_runner: RuleRunner) -> None:
                   tools=["echo"],
                   command='echo foosh > ../../invalid.txt',
                   output_files=["../../invalid.txt"],
-                  root_output_directory="/",
                 )
                 """
             ),
@@ -938,7 +938,6 @@ def test_working_directory_special_values(
                   runnable=":fruitcake",
                   output_files=["fruitcake.txt"],
                   workdir="{workdir}",
-                  root_output_directory="/",
                 )
                 """
             ),


### PR DESCRIPTION
With this change, the defaults for `workdir` and `root_output_directory` are now identical to what they were when we started all of this `shell_command` improvement work. The good news is that they're now adjustable :)

Closes #18190.