### PR TITLE
Relativize the pants_bin_name if necessary.

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -79,7 +79,7 @@ class PantsRunner:
             stderr_fileno=stderr_fileno,
         ):
             # N.B. We inline imports to speed up the python thin client run, and avoids importing
-            # engine types until after the runner has had a chance to set PANTS_BIN_NAME.
+            # engine types until after the runner has had a chance to set __PANTS_BIN_NAME.
 
             if self._should_run_with_pantsd(global_bootstrap_options):
                 from pants.bin.remote_pants_runner import RemotePantsRunner

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -311,11 +311,7 @@ def munge_bin_name(pants_bin_name: str) -> str:
     # Determine a useful bin name to embed in help strings.
     # The bin name gets embedded in help comments in generated lockfiles,
     # so we never want to use an abspath.
-    print(f"111111 {pants_bin_name}")
     if os.path.isabs(pants_bin_name):
-        buildroot = get_buildroot()
-        print(f"22222222 {pants_bin_name} XXXXXX {buildroot}")
-        print(f"33333333 {os.path.realpath(pants_bin_name)} YYYYY {os.path.realpath(buildroot)}")
         # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
         pants_bin_relpath = os.path.relpath(
             os.path.realpath(pants_bin_name), os.path.realpath(get_buildroot())

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -311,7 +311,11 @@ def munge_bin_name(pants_bin_name: str) -> str:
     # Determine a useful bin name to embed in help strings.
     # The bin name gets embedded in help comments in generated lockfiles,
     # so we never want to use an abspath.
+    print(f"111111 {pants_bin_name}")
     if os.path.isabs(pants_bin_name):
+        buildroot = get_buildroot()
+        print(f"22222222 {pants_bin_name} XXXXXX {buildroot}")
+        print(f"33333333 {os.path.realpath(pants_bin_name)} YYYYY {os.path.realpath(buildroot)}")
         # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
         pants_bin_relpath = os.path.relpath(
             os.path.realpath(pants_bin_name), os.path.realpath(get_buildroot())

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -313,7 +313,9 @@ def munge_bin_name(pants_bin_name: str) -> str:
     # so we never want to use an abspath.
     if os.path.isabs(pants_bin_name):
         # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
-        pants_bin_relpath = os.path.relpath(pants_bin_name, get_buildroot())
+        pants_bin_relpath = os.path.relpath(
+            os.path.realpath(pants_bin_name), os.path.realpath(get_buildroot())
+        )
         if pants_bin_relpath.startswith(".."):
             pants_bin_name = os.path.basename(pants_bin_name)
         else:

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -178,7 +178,9 @@ class OptionsBootstrapper:
             # avoid needing to lazily import code to avoid chicken-and-egg-problems. This is the
             # earliest place it makes sense to do so and is generically used by both the local and
             # remote pants runners.
-            os.environ["__PANTS_BIN_NAME"] = munge_bin_name(bootstrap_option_values.pants_bin_name)
+            os.environ["__PANTS_BIN_NAME"] = munge_bin_name(
+                bootstrap_option_values.pants_bin_name, get_buildroot()
+            )
 
             env_tuples = tuple(
                 sorted(
@@ -307,15 +309,15 @@ class OptionsBootstrapper:
         return options
 
 
-def munge_bin_name(pants_bin_name: str) -> str:
+def munge_bin_name(pants_bin_name: str, build_root: str) -> str:
     # Determine a useful bin name to embed in help strings.
     # The bin name gets embedded in help comments in generated lockfiles,
     # so we never want to use an abspath.
     if os.path.isabs(pants_bin_name):
+        pants_bin_name = os.path.realpath(pants_bin_name)
+        build_root = os.path.realpath(os.path.abspath(build_root))
         # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
-        pants_bin_relpath = os.path.relpath(
-            os.path.realpath(pants_bin_name), os.path.realpath(get_buildroot())
-        )
+        pants_bin_relpath = os.path.relpath(pants_bin_name, build_root)
         if pants_bin_relpath.startswith(".."):
             pants_bin_name = os.path.basename(pants_bin_name)
         else:

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -13,8 +13,7 @@ from pants.engine.unions import UnionMembership
 from pants.option.option_value_container import OptionValueContainer
 from pants.option.options_bootstrapper import OptionsBootstrapper, munge_bin_name
 from pants.option.scope import ScopeInfo
-from pants.util.contextutil import pushd, temporary_dir, temporary_file, temporary_file_path
-from pants.util.dirutil import touch
+from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.logging import LogLevel
 
 
@@ -471,15 +470,16 @@ class TestOptionsBootstrapper:
 
 
 def test_munge_bin_name():
-    with temporary_dir(root_dir=os.getcwd()) as build_root:
-        build_root = os.path.realpath(os.path.abspath(build_root))
-        with pushd(build_root):
-            touch("BUILD_ROOT")
-            assert munge_bin_name("pants") == "pants"
-            assert munge_bin_name("pantsv2") == "pantsv2"
-            assert munge_bin_name("bin/pantsv2") == "bin/pantsv2"
-            assert munge_bin_name("./pants") == "./pants"
-            assert munge_bin_name(os.path.join(build_root, "pants")) == "./pants"
-            assert munge_bin_name(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
-            assert munge_bin_name("/foo/pants") == "pants"
-            assert munge_bin_name("/foo/bar/pants") == "pants"
+    build_root = "/my/repo"
+
+    def munge(bin_name: str) -> str:
+        return munge_bin_name(bin_name, build_root)
+
+    assert munge("pants") == "pants"
+    assert munge("pantsv2") == "pantsv2"
+    assert munge("bin/pantsv2") == "bin/pantsv2"
+    assert munge("./pants") == "./pants"
+    assert munge(os.path.join(build_root, "pants")) == "./pants"
+    assert munge(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
+    assert munge("/foo/pants") == "pants"
+    assert munge("/foo/bar/pants") == "pants"

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -471,7 +471,7 @@ class TestOptionsBootstrapper:
 
 
 def test_munge_bin_name():
-    with temporary_dir() as build_root:
+    with temporary_dir(root_dir=os.getcwd()) as build_root:
         build_root = os.path.realpath(os.path.abspath(build_root))
         with pushd(build_root):
             touch("BUILD_ROOT")

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -479,7 +479,10 @@ def test_munge_bin_name():
             assert munge_bin_name("pantsv2") == "pantsv2"
             assert munge_bin_name("bin/pantsv2") == "bin/pantsv2"
             assert munge_bin_name("./pants") == "./pants"
-            assert munge_bin_name(os.path.join(build_root, "pants")) == "./pants"
-            assert munge_bin_name(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
+            assert munge_bin_name(os.path.abspath(os.path.join(build_root, "pants"))) == "./pants"
+            assert (
+                munge_bin_name(os.path.abspath(os.path.join(build_root, "bin", "pants")))
+                == "./bin/pants"
+            )
             assert munge_bin_name("/foo/pants") == "pants"
             assert munge_bin_name("/foo/bar/pants") == "pants"

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -472,17 +472,14 @@ class TestOptionsBootstrapper:
 
 def test_munge_bin_name():
     with temporary_dir() as build_root:
-        build_root = os.path.realpath(build_root)
-        touch(os.path.join(build_root, "BUILD_ROOT"))
+        build_root = os.path.realpath(os.path.abspath(build_root))
         with pushd(build_root):
+            touch("BUILD_ROOT")
             assert munge_bin_name("pants") == "pants"
             assert munge_bin_name("pantsv2") == "pantsv2"
             assert munge_bin_name("bin/pantsv2") == "bin/pantsv2"
             assert munge_bin_name("./pants") == "./pants"
-            assert munge_bin_name(os.path.abspath(os.path.join(build_root, "pants"))) == "./pants"
-            assert (
-                munge_bin_name(os.path.abspath(os.path.join(build_root, "bin", "pants")))
-                == "./bin/pants"
-            )
+            assert munge_bin_name(os.path.join(build_root, "pants")) == "./pants"
+            assert munge_bin_name(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
             assert munge_bin_name("/foo/pants") == "pants"
             assert munge_bin_name("/foo/bar/pants") == "pants"

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -84,7 +84,9 @@ def safe_mkdir_for(path: str | Path, clean: bool = False) -> None:
 
     If it's not there, create it. If it is, no-op.
     """
-    safe_mkdir(os.path.dirname(path), clean=clean)
+    dirname = os.path.dirname(path)
+    if dirname:
+        safe_mkdir(dirname, clean=clean)
 
 
 def safe_file_dump(

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -36,4 +36,8 @@ def bin_name() -> str:
     # However, this assumption really breaks down when we go to test pants (or a plugin author goes
     # to test their plugin). Therefore we give a fallback and have integration test(s) to assert
     # we've set this at the right point in time.
-    return os.environ.get("PANTS_BIN_NAME", "./pants")  # noqa: PANTSBIN
+    #
+    # Note that __PANTS_BIN_NAME is set in options_bootstrapper.py based on the value of the
+    # pants_bin_name global option, so you cannot naively modify this by setting __PANTS_BIN_NAME
+    # externally. You must set that option value in one of the usual ways.
+    return os.environ.get("__PANTS_BIN_NAME", "./pants")  # noqa: PANTSBIN


### PR DESCRIPTION
We don't want to use an abspath in lockfile headers.