### PR TITLE
go: disable coverage redesign experiment on Go v1.20+

### DIFF
--- a/src/python/pants/backend/go/util_rules/sdk.py
+++ b/src/python/pants/backend/go/util_rules/sdk.py
@@ -125,8 +125,18 @@ async def setup_go_sdk_process(
         # TODO: Maybe could just use MAJOR.MINOR for version part here?
         "__PANTS_GO_SDK_CACHE_KEY": f"{goroot.version}/{goroot.goos}/{goroot.goarch}",
     }
+
     if request.replace_sandbox_root_in_args:
         env[GoSdkRunSetup.SANDBOX_ROOT_ENV] = "1"
+
+    # Disable the "coverage redesign" experiment on Go v1.20+ for now since Pants does not yet support it.
+    if goroot.is_compatible_version("1.20"):
+        exp_str = env.get("GOEXPERIMENT", "")
+        exp_fields = exp_str.split(",") if exp_str != "" else []
+        exp_fields = [exp for exp in exp_fields if exp != "coverageredesign"]
+        if "nocoverageredesign" not in exp_fields:
+            exp_fields.append("nocoverageredesign")
+        env["GOEXPERIMENT"] = ",".join(exp_fields)
 
     return Process(
         argv=[bash.path, go_sdk_run.script.path, *request.command],


### PR DESCRIPTION
Disable the "coverage redesign" experiment on Go v1.20+ since Pants does not yet support it. `src/python/pants/backend/go/util_rules/coverage_test.py` fails on Go v1.20 without this PR.

Closes https://github.com/pantsbuild/pants/issues/18194.