### PR TITLE
Use `EnvironmentAwarePackageRequest` in many more contexts. (Cherry-pick of #18203)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -13,6 +13,7 @@ python_test_utils(name="test_utils")
 docker_environment(
     name="docker_env",
     image="python:3.9",
+    python_bootstrap_search_path=["<PATH>"],
 )
 
 # See `build-support/reapi-sample-server/README.md` for information on how to use this environment

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -26,6 +26,7 @@ from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.core.goals import package
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
     FilesGeneratorTarget,
@@ -50,6 +51,7 @@ def rule_runner() -> RuleRunner:
             *package_pex_binary.rules(),
             *python_target_types_rules(),
             *target_rules(),
+            *package.rules(),
             QueryRule(BuiltPackage, (PythonAwsLambdaFieldSet,)),
         ],
         target_types=[

--- a/src/python/pants/backend/docker/goals/package_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_integration_test.py
@@ -24,7 +24,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *docker_rules(),
             *source_files_rules(),
-            package.find_all_packageable_targets,
+            *package.rules(),
             QueryRule(BuiltPackage, [DockerFieldSet]),
         ],
         target_types=[DockerImageTarget],

--- a/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
+++ b/src/python/pants/backend/docker/lint/hadolint/rules_integration_test.py
@@ -28,7 +28,7 @@ def rule_runner() -> RuleRunner:
             *docker_rules(),
             *external_tool.rules(),
             *hadolint_rules(),
-            package.find_all_packageable_targets,
+            *package.rules(),
             *source_files.rules(),
             QueryRule(Partitions, [HadolintRequest.PartitionRequest]),
             QueryRule(LintResult, [HadolintRequest.Batch]),

--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -24,7 +24,7 @@ from pants.backend.docker.util_rules.docker_build_env import (
 from pants.backend.docker.utils import get_hash, suggest_renames
 from pants.backend.docker.value_interpolation import DockerBuildArgsInterpolationValue
 from pants.backend.shell.target_types import ShellSourceField
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
@@ -290,7 +290,7 @@ async def create_docker_build_context(request: DockerBuildContextRequest) -> Doc
 
     # Package binary dependencies for build context.
     embedded_pkgs = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set)
+        Get(BuiltPackage, EnvironmentAwarePackageRequest(field_set))
         for field_set in embedded_pkgs_per_target.field_sets
         # Exclude docker images, unless build_upstream_images is true.
         if (

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -30,6 +30,7 @@ from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.core.goals import package
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
     FilesGeneratorTarget,
@@ -54,6 +55,7 @@ def rule_runner() -> RuleRunner:
             *target_rules(),
             *python_target_types_rules(),
             *core_target_types_rules(),
+            *package.rules(),
             QueryRule(BuiltPackage, (PythonGoogleCloudFunctionFieldSet,)),
         ],
         target_types=[

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -18,6 +18,7 @@ from pants.backend.helm.target_types import (
 )
 from pants.backend.helm.testutil import HELM_CHART_FILE
 from pants.backend.helm.util_rules.tool import HelmBinary
+from pants.core.goals import package
 from pants.core.goals.deploy import DeployProcess
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
@@ -32,6 +33,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *helm_deploy_rules(),
             *source_files.rules(),
+            *package.rules(),
             QueryRule(HelmBinary, ()),
             QueryRule(DeployProcess, (DeployHelmDeploymentFieldSet,)),
         ],

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -34,6 +34,7 @@ from pants.backend.helm.util_rules.renderer_test import _read_file_from_digest
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.backend.shell import shell_command
 from pants.backend.shell.target_types import ShellCommandRunTarget, ShellSourcesGeneratorTarget
+from pants.core.goals import package
 from pants.core.goals.run import rules as run_rules
 from pants.core.util_rules import source_files
 from pants.engine.addresses import Address
@@ -72,6 +73,7 @@ def rule_runner() -> RuleRunner:
             *post_renderer.rules(),
             *run_rules(),
             *shell_command.rules(),
+            *package.rules(),
             custom_test_image_tags,
             UnionRule(DockerImageTagsRequest, CustomTestImageTagRequest),
             QueryRule(HelmPostRenderer, (HelmDeploymentPostRendererRequest,)),

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -33,6 +33,7 @@ from pants.backend.python.target_types import (
     PythonTestUtilsGeneratorTarget,
 )
 from pants.backend.python.util_rules import local_dists, pex_from_targets
+from pants.core.goals import package
 from pants.core.goals.test import (
     TestDebugAdapterRequest,
     TestDebugRequest,
@@ -71,6 +72,7 @@ def rule_runner() -> RuleRunner:
             *target_types_rules.rules(),
             *local_dists.rules(),
             *setup_py.rules(),
+            *package.rules(),
             QueryRule(Partitions, (PyTestRequest.PartitionRequest,)),
             QueryRule(TestResult, (PyTestRequest.Batch,)),
             QueryRule(TestDebugRequest, (PyTestRequest.Batch,)),

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -23,7 +23,12 @@ from pants.backend.python.packaging.pyoxidizer.target_types import (
 )
 from pants.backend.python.target_types import GenerateSetupField, WheelField
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
-from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
+from pants.core.goals.package import (
+    BuiltPackage,
+    BuiltPackageArtifact,
+    EnvironmentAwarePackageRequest,
+    PackageFieldSet,
+)
 from pants.core.goals.run import RunDebugAdapterRequest, RunFieldSet, RunRequest
 from pants.core.util_rules.environments import EnvironmentField
 from pants.core.util_rules.system_binaries import BashBinary
@@ -107,7 +112,8 @@ async def package_pyoxidizer_binary(
         FieldSetsPerTarget, FieldSetsPerTargetRequest(PackageFieldSet, direct_deps)
     )
     built_packages = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set) for field_set in deps_field_sets.field_sets
+        Get(BuiltPackage, EnvironmentAwarePackageRequest(field_set))
+        for field_set in deps_field_sets.field_sets
     )
     wheel_paths = [
         artifact.relpath

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -12,7 +12,7 @@ from pathlib import PurePath
 from typing import Any, ClassVar, Iterable, Optional, TypeVar, cast
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
-from pants.core.goals.package import BuiltPackage, PackageFieldSet
+from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.core.util_rules.distdir import DistDir
 from pants.core.util_rules.environments import (
@@ -994,7 +994,8 @@ async def build_runtime_package_dependencies(
         FieldSetsPerTarget, FieldSetsPerTargetRequest(PackageFieldSet, tgts)
     )
     packages = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set) for field_set in field_sets_per_tgt.field_sets
+        Get(BuiltPackage, EnvironmentAwarePackageRequest(field_set))
+        for field_set in field_sets_per_tgt.field_sets
     )
     return BuiltPackageDependencies(packages)
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -11,9 +11,11 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Optional, Sequence, Union, cast
 
+from pants.core.goals import package
 from pants.core.goals.package import (
     BuiltPackage,
     BuiltPackageArtifact,
+    EnvironmentAwarePackageRequest,
     OutputPathField,
     PackageFieldSet,
 )
@@ -681,7 +683,7 @@ async def package_archive_target(field_set: ArchiveFieldSet) -> BuiltPackage:
         FieldSetsPerTarget, FieldSetsPerTargetRequest(PackageFieldSet, package_targets)
     )
     packages = await MultiGet(
-        Get(BuiltPackage, PackageFieldSet, field_set)
+        Get(BuiltPackage, EnvironmentAwarePackageRequest(field_set))
         for field_set in package_field_sets_per_target.field_sets
     )
 
@@ -767,6 +769,7 @@ class LockfilesGeneratorTarget(TargetFilesGenerator):
 def rules():
     return (
         *collect_rules(),
+        *package.rules(),
         UnionRule(GenerateSourcesRequest, GenerateResourceSourceRequest),
         UnionRule(GenerateSourcesRequest, GenerateFileSourceRequest),
         UnionRule(GenerateSourcesRequest, RelocateFilesViaCodegenRequest),


### PR DESCRIPTION
Many locations which requested `BuiltPackage` were not doing so in an environment-aware fashion, which meant that the environments of any relevant `PackageFieldSet`s would not be respected. This meant that this example from the documentation was broken: https://www.pantsbuild.org/v2.15/docs/environments#use-a-docker_environment-to-build-the-inputs-to-a-docker_image

Uses `EnvironmentAwarePackageRequest` in more locations (but not in any `run` goals, since we have not yet determined the semantics we want in that case), and add a test for the example case.
