### PR TITLE
javascript: Support esm modules and commonjs specific javascript file extensions

### DIFF
--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -28,7 +28,8 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
             "src/owned/BUILD": "javascript_sources()\n",
             "src/owned/OwnedFile.js": "",
             "src/unowned/UnownedFile1.js": "",
-            "src/unowned/UnownedFile2.js": "",
+            "src/unowned/UnownedFile2.mjs": "",
+            "src/unowned/UnownedFile3.cjs": "",
         }
     )
     putative_targets = rule_runner.request(
@@ -45,7 +46,7 @@ def test_find_putative_targets(rule_runner: RuleRunner) -> None:
                     JSSourcesGeneratorTarget,
                     "src/unowned",
                     "unowned",
-                    ["UnownedFile1.js", "UnownedFile2.js"],
+                    ["UnownedFile1.js", "UnownedFile2.mjs", "UnownedFile3.cjs"],
                 ),
             ]
         )

--- a/src/python/pants/backend/javascript/target_types.py
+++ b/src/python/pants/backend/javascript/target_types.py
@@ -13,7 +13,7 @@ from pants.engine.target import (
     generate_multiple_sources_field_help_message,
 )
 
-JS_FILE_EXTENSIONS = (".js",)
+JS_FILE_EXTENSIONS = (".js", ".cjs", ".mjs")
 
 
 class JSDependenciesField(Dependencies):


### PR DESCRIPTION
Adds support for the CommonJs (.cjs) and ES6 module (.mjs) file extensions to the javascript backend.

They are encouraged to be used by e.g [v8](https://v8.dev/features/modules#mjs) devs.