### PR TITLE
Relativize the pants_bin_name if necessary. (Cherry-pick of #18204)

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -79,7 +79,7 @@ class PantsRunner:
             stderr_fileno=stderr_fileno,
         ):
             # N.B. We inline imports to speed up the python thin client run, and avoids importing
-            # engine types until after the runner has had a chance to set PANTS_BIN_NAME.
+            # engine types until after the runner has had a chance to set __PANTS_BIN_NAME.
 
             if self._should_run_with_pantsd(global_bootstrap_options):
                 from pants.bin.remote_pants_runner import RemotePantsRunner

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterable, Mapping, Sequence
 
-from pants.base.build_environment import get_default_pants_config_file, pants_version
+from pants.base.build_environment import get_buildroot, get_default_pants_config_file, pants_version
 from pants.base.exceptions import BuildConfigurationError
 from pants.engine.unions import UnionMembership
 from pants.option.alias import CliAlias
@@ -178,7 +178,9 @@ class OptionsBootstrapper:
             # avoid needing to lazily import code to avoid chicken-and-egg-problems. This is the
             # earliest place it makes sense to do so and is generically used by both the local and
             # remote pants runners.
-            os.environ["PANTS_BIN_NAME"] = bootstrap_option_values.pants_bin_name
+            os.environ["__PANTS_BIN_NAME"] = munge_bin_name(
+                bootstrap_option_values.pants_bin_name, get_buildroot()
+            )
 
             env_tuples = tuple(
                 sorted(
@@ -301,3 +303,19 @@ class OptionsBootstrapper:
         GlobalOptions.validate_instance(options.for_global_scope())
         self.alias.check_name_conflicts(options.known_scope_to_info)
         return options
+
+
+def munge_bin_name(pants_bin_name: str, build_root: str) -> str:
+    # Determine a useful bin name to embed in help strings.
+    # The bin name gets embedded in help comments in generated lockfiles,
+    # so we never want to use an abspath.
+    if os.path.isabs(pants_bin_name):
+        pants_bin_name = os.path.realpath(pants_bin_name)
+        build_root = os.path.realpath(os.path.abspath(build_root))
+        # If it's in the buildroot, use the relpath from there. Otherwise use the basename.
+        pants_bin_relpath = os.path.relpath(pants_bin_name, build_root)
+        if pants_bin_relpath.startswith(".."):
+            pants_bin_name = os.path.basename(pants_bin_name)
+        else:
+            pants_bin_name = os.path.join(".", pants_bin_relpath)
+    return pants_bin_name

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from pants.base.build_environment import get_buildroot
 from pants.engine.unions import UnionMembership
 from pants.option.option_value_container import OptionValueContainer
-from pants.option.options_bootstrapper import OptionsBootstrapper
+from pants.option.options_bootstrapper import OptionsBootstrapper, munge_bin_name
 from pants.option.scope import ScopeInfo
 from pants.util.contextutil import temporary_file, temporary_file_path
 from pants.util.logging import LogLevel
@@ -467,3 +467,19 @@ class TestOptionsBootstrapper:
             "<ignored>",
             config_arg,
         ) == ob.bootstrap_args
+
+
+def test_munge_bin_name():
+    build_root = "/my/repo"
+
+    def munge(bin_name: str) -> str:
+        return munge_bin_name(bin_name, build_root)
+
+    assert munge("pants") == "pants"
+    assert munge("pantsv2") == "pantsv2"
+    assert munge("bin/pantsv2") == "bin/pantsv2"
+    assert munge("./pants") == "./pants"
+    assert munge(os.path.join(build_root, "pants")) == "./pants"
+    assert munge(os.path.join(build_root, "bin", "pants")) == "./bin/pants"
+    assert munge("/foo/pants") == "pants"
+    assert munge("/foo/bar/pants") == "pants"

--- a/src/python/pants/util/dirutil.py
+++ b/src/python/pants/util/dirutil.py
@@ -83,7 +83,9 @@ def safe_mkdir_for(path: str, clean: bool = False) -> None:
 
     If it's not there, create it. If it is, no-op.
     """
-    safe_mkdir(os.path.dirname(path), clean=clean)
+    dirname = os.path.dirname(path)
+    if dirname:
+        safe_mkdir(dirname, clean=clean)
 
 
 def safe_file_dump(

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -36,4 +36,8 @@ def bin_name() -> str:
     # However, this assumption really breaks down when we go to test pants (or a plugin author goes
     # to test their plugin). Therefore we give a fallback and have integration test(s) to assert
     # we've set this at the right point in time.
-    return os.environ.get("PANTS_BIN_NAME", "./pants")  # noqa: PANTSBIN
+    #
+    # Note that __PANTS_BIN_NAME is set in options_bootstrapper.py based on the value of the
+    # pants_bin_name global option, so you cannot naively modify this by setting __PANTS_BIN_NAME
+    # externally. You must set that option value in one of the usual ways.
+    return os.environ.get("__PANTS_BIN_NAME", "./pants")  # noqa: PANTSBIN


### PR DESCRIPTION
We don't want to use an abspath in lockfile headers.
