### PR TITLE
Give dedicated threads names

### DIFF
--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -584,7 +584,7 @@ impl Core {
 
     let watcher = if watch_filesystem {
       let w = InvalidationWatcher::new(executor.clone(), build_root.clone(), ignorer.clone())?;
-      w.start(&graph);
+      w.start(&graph)?;
       Some(w)
     } else {
       None

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -54,7 +54,7 @@ async fn receive_watch_event_on_file_change() {
   let invalidatable = Arc::new(TestInvalidatable::default());
   let ignorer = GitignoreStyleExcludes::empty();
   let watcher = setup_watch(ignorer, build_root.clone(), file_path.clone()).await;
-  watcher.start(&invalidatable);
+  watcher.start(&invalidatable).unwrap();
 
   // Update the content of the file being watched.
   let new_content = "stnetnoc".as_bytes().to_vec();
@@ -86,7 +86,7 @@ async fn ignore_file_events_matching_patterns_in_pants_ignore() {
   let invalidatable = Arc::new(TestInvalidatable::default());
   let ignorer = GitignoreStyleExcludes::create(vec!["/foo".to_string()]).unwrap();
   let watcher = setup_watch(ignorer, build_root, file_path.clone()).await;
-  watcher.start(&invalidatable);
+  watcher.start(&invalidatable).unwrap();
 
   // Update the content of the file being watched.
   let new_content = "stnetnoc".as_bytes().to_vec();
@@ -120,7 +120,8 @@ async fn liveness_watch_error() {
     build_root,
     liveness_sender,
     event_receiver,
-  );
+  )
+  .unwrap();
 
   // Should not exit.
   assert_eq!(


### PR DESCRIPTION
Give dedicated threads names to assist in debugging. Otherwise, the OS will occasionally give them the names of _other_ threads ([see](https://github.com/pantsbuild/pants/issues/18211#issuecomment-1424546525)), which is the opposite of helpful.