### PR TITLE
Always explicitly shutdown executors (Cherry-pick of #18216)

### DIFF
--- a/src/python/pants/bin/local_pants_runner.py
+++ b/src/python/pants/bin/local_pants_runner.py
@@ -119,7 +119,7 @@ class LocalPantsRunner:
             bootstrap_options = options.bootstrap_option_values()
             assert bootstrap_options is not None
             scheduler = EngineInitializer.setup_graph(
-                bootstrap_options, build_config, dynamic_remote_options
+                bootstrap_options, build_config, dynamic_remote_options, executor
             )
         with options_initializer.handle_unknown_flags(options_bootstrapper, env, raise_=True):
             global_options = options.for_global_scope()

--- a/src/python/pants/init/engine_initializer.py
+++ b/src/python/pants/init/engine_initializer.py
@@ -188,7 +188,7 @@ class EngineInitializer:
         bootstrap_options: OptionValueContainer,
         build_configuration: BuildConfiguration,
         dynamic_remote_options: DynamicRemoteOptions,
-        executor: PyExecutor | None = None,
+        executor: PyExecutor,
         is_bootstrap: bool = False,
     ) -> GraphScheduler:
         build_root = get_buildroot()

--- a/src/rust/engine/src/externs/nailgun.rs
+++ b/src/rust/engine/src/externs/nailgun.rs
@@ -34,10 +34,10 @@ struct PyNailgunClient {
 #[pymethods]
 impl PyNailgunClient {
   #[new]
-  fn __new__(port: u16, py_executor: PyExecutor) -> Self {
+  fn __new__(port: u16, py_executor: &PyExecutor) -> Self {
     Self {
       port,
-      executor: py_executor.0,
+      executor: py_executor.0.clone(),
     }
   }
 

--- a/src/rust/engine/src/externs/testutil.rs
+++ b/src/rust/engine/src/externs/testutil.rs
@@ -41,7 +41,7 @@ impl PyStubCASBuilder {
     Ok(PyStubCASBuilder(self.0.clone()))
   }
 
-  fn build(&mut self, py_executor: PyExecutor) -> PyResult<PyStubCAS> {
+  fn build(&mut self, py_executor: &PyExecutor) -> PyResult<PyStubCAS> {
     let mut builder_opt = self.0.lock();
     let builder = builder_opt
       .take()

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -239,6 +239,12 @@ impl Executor {
       log::warn!("Executor shutdown took unexpectedly long: tasks were likely leaked!");
     }
   }
+
+  /// Returns true if `shutdown` has been called for this Executor. Always returns true for
+  /// borrowed Executors.
+  pub fn is_shutdown(&self) -> bool {
+    self.runtime.lock().is_none()
+  }
 }
 
 /// Store "tail" tasks which are async tasks that can execute concurrently with regular


### PR DESCRIPTION
Always explicitly shutdown executors, to avoid them being dropped on arbitrary threads (including under the GIL).

Fixes #18211.
