### PR TITLE
Refactors `experimental_shell_command`-related files to better separate concerns

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -450,7 +450,7 @@ class RunShellCommandWorkdirField(StringField):
     help = softwrap(
         "Sets the current working directory of the command that is `run`. Values that begin with "
         "`.` are relative to the directory you are running Pants from. Values that begin with `/` "
-        "are from the root of your filesystem."
+        "are from your project root."
     )
 
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import re
 from enum import Enum
-from typing import ClassVar, Optional
 
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.core.goals.test import RuntimePackageDependenciesField, TestTimeoutField
@@ -376,13 +375,6 @@ class RunInSandboxSourcesField(MultipleSourcesField):
     expected_num_files = 0
 
 
-class ShellCommandIsInteractiveField(MultipleSourcesField):
-    # We use this to determine whether this is an interactive process.
-    alias = "_is_interactive"
-    uses_source_roots = False
-    expected_num_files = 0
-
-
 class RunInSandboxArgumentsField(StringSequenceField):
     alias = "args"
     default = ()
@@ -441,7 +433,7 @@ class ShellCommandLogOutputField(BoolField):
 
 class ShellCommandWorkdirField(StringField):
     alias = "workdir"
-    default: ClassVar[Optional[str]] = "."
+    default = "."
     help = softwrap(
         "Sets the current working directory of the command. \n\n"
         "Values are relative to the build root, except in the following cases:\n\n"
@@ -452,11 +444,13 @@ class ShellCommandWorkdirField(StringField):
     )
 
 
-class RunShellCommandWorkdirField(ShellCommandWorkdirField):
-    default = None
+class RunShellCommandWorkdirField(StringField):
+    alias = "workdir"
+    default = "."
     help = softwrap(
-        "Sets the current working directory of the command that is `run`. If `None`, run the "
-        "command from the directory you are invoking Pants from."
+        "Sets the current working directory of the command that is `run`. Values that begin with "
+        "`.` are relative to the directory you are running Pants from. Values that begin with `/` "
+        "are from the root of your filesystem."
     )
 
 
@@ -574,7 +568,6 @@ class ShellCommandRunTarget(Target):
         ShellCommandExecutionDependenciesField,
         ShellCommandCommandField,
         RunShellCommandWorkdirField,
-        ShellCommandIsInteractiveField,
     )
     help = softwrap(
         """

--- a/src/python/pants/backend/shell/util_rules/adhoc_process_support.py
+++ b/src/python/pants/backend/shell/util_rules/adhoc_process_support.py
@@ -9,7 +9,7 @@ import os
 import re
 import shlex
 from dataclasses import dataclass
-from typing import Mapping, Union
+from typing import Union
 
 from pants.backend.shell.target_types import (
     ShellCommandExecutionDependenciesField,
@@ -26,15 +26,7 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
-from pants.engine.fs import (
-    EMPTY_DIGEST,
-    CreateDigest,
-    Digest,
-    Directory,
-    FileContent,
-    MergeDigests,
-    Snapshot,
-)
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, MergeDigests, Snapshot
 from pants.engine.internals.native_engine import RemovePrefix
 from pants.engine.process import Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule, rule_helper
@@ -169,7 +161,6 @@ async def _adjust_root_output_directory(
     address: Address,
     working_directory: str,
     root_output_directory: str,
-    extra_files: Mapping[str, bytes] = FrozenDict(),
 ) -> Digest:
 
     working_directory = _parse_working_directory(working_directory, address)
@@ -177,15 +168,6 @@ async def _adjust_root_output_directory(
 
     if new_root == "":
         return digest
-
-    if extra_files:
-        extra_digest = await Get(
-            Digest,
-            CreateDigest(
-                FileContent(f"{new_root}/{name}", content) for name, content in extra_files.items()
-            ),
-        )
-        digest = await Get(Digest, MergeDigests((digest, extra_digest)))
 
     return await Get(Digest, RemovePrefix(digest, new_root))
 

--- a/src/python/pants/backend/shell/util_rules/adhoc_process_support.py
+++ b/src/python/pants/backend/shell/util_rules/adhoc_process_support.py
@@ -47,10 +47,9 @@ logger = logging.getLogger(__name__)
 class ShellCommandProcessRequest:
     description: str
     address: Address
-    shell_name: str
     working_directory: str
     root_output_directory: str
-    command: str
+    argv: tuple[str, ...]
     timeout: int | None
     input_digest: Digest
     immutable_input_digests: FrozenDict[str, Digest] | None
@@ -214,9 +213,8 @@ async def prepare_shell_command_process(
 
     description = shell_command.description
     address = shell_command.address
-    shell_name = shell_command.shell_name
     working_directory = _parse_working_directory(shell_command.working_directory or "", address)
-    command = shell_command.command
+    argv = shell_command.argv
     timeout: int | None = shell_command.timeout
     output_files = shell_command.output_files
     output_directories = shell_command.output_directories
@@ -244,7 +242,7 @@ async def prepare_shell_command_process(
     input_digest = await Get(Digest, MergeDigests([shell_command.input_digest, work_dir]))
 
     proc = Process(
-        argv=(bash.path, "-c", command, shell_name),
+        argv=argv,
         description=f"Running {description}",
         env=command_env,
         input_digest=input_digest,

--- a/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
+++ b/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import shlex
 
 from pants.backend.shell.target_types import (
     RunInSandboxArgumentsField,
@@ -104,10 +103,9 @@ async def run_in_sandbox_request(
     process_request = ShellCommandProcessRequest(
         description=description,
         address=shell_command.address,
-        shell_name=shell_command.address.spec,
         working_directory=working_directory,
         root_output_directory=root_output_directory,
-        command=" ".join(shlex.quote(arg) for arg in (run_request.args + extra_args)),
+        argv=tuple(run_request.args + extra_args),
         timeout=None,
         input_digest=input_digest,
         immutable_input_digests=FrozenDict(run_request.immutable_input_digests or {}),

--- a/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
+++ b/src/python/pants/backend/shell/util_rules/run_in_sandbox.py
@@ -106,7 +106,6 @@ async def run_in_sandbox_request(
         description=description,
         address=shell_command.address,
         shell_name=shell_command.address.spec,
-        interactive=False,
         working_directory=working_directory,
         command=" ".join(shlex.quote(arg) for arg in (run_request.args + extra_args)),
         timeout=None,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -143,7 +143,7 @@ async def prepare_process_request_from_target(
 class RunShellCommand(RunFieldSet):
     required_fields = (
         ShellCommandCommandField,
-        ShellCommandWorkdirField,
+        RunShellCommandWorkdirField,
     )
     run_in_sandbox_behavior = RunInSandboxBehavior.NOT_SUPPORTED
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -181,8 +181,6 @@ async def _interactive_shell_command(
     shell_name = shell_command.address.spec
     working_directory = shell_command[RunShellCommandWorkdirField].value
 
-    logger.warning(f"{shell_command=} {working_directory=}")
-
     if working_directory is None:
         raise ValueError("Working directory must be not be `None` for interactive processes.")
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -104,7 +104,7 @@ async def _prepare_process_request_from_target(
         description=description,
         address=shell_command.address,
         working_directory=working_directory,
-        root_output_directory=shell_command[ShellCommandOutputRootDirField].value or "",
+        root_output_directory=shell_command.get(ShellCommandOutputRootDirField).value or "",
         argv=(bash.path, "-c", command, shell_command.address.spec),
         timeout=shell_command.get(ShellCommandTimeoutField).value,
         input_digest=dependencies_digest,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -22,8 +22,8 @@ from pants.backend.shell.target_types import (
     ShellCommandWorkdirField,
 )
 from pants.backend.shell.util_rules.adhoc_process_support import (
+    AdhocProcessRequest,
     AdhocProcessResult,
-    ShellCommandProcessRequest,
     _execution_environment_from_dependencies,
     _parse_outputs_from_command,
 )
@@ -68,7 +68,7 @@ async def _prepare_process_request_from_target(
     shell_command: Target,
     shell_setup: ShellSetup.EnvironmentAware,
     bash: BashBinary,
-) -> ShellCommandProcessRequest:
+) -> AdhocProcessRequest:
     description = f"the `{shell_command.alias}` at `{shell_command.address}`"
 
     working_directory = shell_command[ShellCommandWorkdirField].value
@@ -100,7 +100,7 @@ async def _prepare_process_request_from_target(
     immutable_input_digests = resolved_tools.immutable_input_digests
     supplied_env_var_values = {"PATH": resolved_tools.path_component}
 
-    return ShellCommandProcessRequest(
+    return AdhocProcessRequest(
         description=description,
         address=shell_command.address,
         working_directory=working_directory,
@@ -126,7 +126,7 @@ async def run_adhoc_result_from_target(
     bash: BashBinary,
 ) -> AdhocProcessResult:
     scpr = await _prepare_process_request_from_target(request.target, shell_setup, bash)
-    return await Get(AdhocProcessResult, ShellCommandProcessRequest, scpr)
+    return await Get(AdhocProcessResult, AdhocProcessRequest, scpr)
 
 
 @rule
@@ -137,7 +137,7 @@ async def prepare_process_request_from_target(
 ) -> Process:
     # Needed to support `experimental_test_shell_command`
     scpr = await _prepare_process_request_from_target(request.target, shell_setup, bash)
-    return await Get(Process, ShellCommandProcessRequest, scpr)
+    return await Get(Process, AdhocProcessRequest, scpr)
 
 
 class RunShellCommand(RunFieldSet):

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -949,3 +949,33 @@ def test_working_directory_special_values(
         Address("src", target_name="run_fruitcake"),
         expected_contents={os.path.join(file_location, "fruitcake.txt"): "fruitcake\n"},
     )
+
+
+def test_missing_tool_called(
+    caplog,
+    rule_runner: RuleRunner,
+) -> None:
+    caplog.set_level(logging.INFO)
+    caplog.clear()
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                """\
+                experimental_shell_command(
+                  name="gerald-is-not-here",
+                  command="gerald hello",
+                  log_output=True,
+                )
+                """
+            )
+        }
+    )
+
+    with pytest.raises(ExecutionError):
+        assert_shell_command_result(
+            rule_runner,
+            Address("src", target_name="gerald-is-not-here"),
+            expected_contents={},
+        )
+
+    assert "requires the names of any external commands" in caplog.text

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -19,7 +19,7 @@ from pants.backend.shell.target_types import (
     ShellRunInSandboxTarget,
     ShellSourcesGeneratorTarget,
 )
-from pants.backend.shell.util_rules.adhoc_process_support import ShellCommandProcessRequest
+from pants.backend.shell.util_rules.adhoc_process_support import AdhocProcessRequest
 from pants.backend.shell.util_rules.run_in_sandbox import GenerateFilesFromRunInSandboxRequest
 from pants.backend.shell.util_rules.run_in_sandbox import rules as run_in_sandbox_rules
 from pants.backend.shell.util_rules.shell_command import (
@@ -61,7 +61,7 @@ def rule_runner() -> RuleRunner:
             *run_python_source_rules(),
             QueryRule(GeneratedSources, [GenerateFilesFromShellCommandRequest]),
             QueryRule(GeneratedSources, [GenerateFilesFromRunInSandboxRequest]),
-            QueryRule(Process, [ShellCommandProcessRequest]),
+            QueryRule(Process, [AdhocProcessRequest]),
             QueryRule(Process, [EnvironmentName, ShellCommandProcessFromTargetRequest]),
             QueryRule(RunRequest, [RunShellCommand]),
             QueryRule(SourceFiles, [SourceFilesRequest]),


### PR DESCRIPTION
Previously, `prepare_shell_command_process` in `adhoc_process_support` handled separate use cases for `experimental_shell_command`, `experimental_run_shell_command` and `experimental_run_in_sandbox`.

That was complex to reason about, and ended up making the code more repetitive and complicated than it needed to be. This PR does a few things, in well-encapsulated commits (for review purposes, anyway):

* Handles `experimental_run_shell_command` in its own functions, removing support for `interactive` from the functions that otherwise handle non-interactive processes
* De-duplicates post-processing code from `experimental_shell_command` and `experimental_run_in_sandbox`
* Adjusts the common request type to no longer require a `shlex`-ed command line, allowing fewer nested `bash` processes for `experimental_run_in_sandbox` and opening the door to support for different shells for `experimental_shell_command`
* Common request types now refer to _adhoc processes_ per #18082

This work will enable splitting `experimental_run_in_sandbox` into its own `experimental` namespace.