### PR TITLE
go: update pass-through `go test` options for Go v1.20

### DIFF
--- a/src/python/pants/backend/go/go_sources/gentestflags.go
+++ b/src/python/pants/backend/go/go_sources/gentestflags.go
@@ -55,7 +55,7 @@ func testFlags() map[string]bool {
 		name := strings.TrimPrefix(f.Name, "test.")
 
 		switch name {
-		case "testlogfile", "paniconexit0", "fuzzcachedir", "fuzzworker":
+		case "testlogfile", "paniconexit0", "fuzzcachedir", "fuzzworker", "gocoverdir":
 		// These flags are only for use by cmd/go.
 		default:
 			expectsValue := true

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -94,6 +94,7 @@ TEST_FLAGS = {
     "run": True,
     "short": False,
     "shuffle": True,
+    "skip": True,
     "timeout": True,
     "trace": True,
     "v": False,


### PR DESCRIPTION
Update the list of pass-through `go test` options for Go v1.20.