### PR TITLE
docs: add What's New section for 2.15.x release notes (#18226)

### DIFF
--- a/src/python/pants/notes/2.15.x.md
+++ b/src/python/pants/notes/2.15.x.md
@@ -1,5 +1,102 @@
 # 2.15.x Release Series
 
+## What's New
+
+Pants 2.15 brings support for several new features:
+
+### Environments
+
+Pants now supports alternate execution "environments" for build actions. These "environments" can be explicitly
+configured as desired via several new target types (including having multiple environments of the same type).
+The new `environment` field on many targets tells Pants which environment to use for a particular target. 
+
+Pants previously supported local execution (which is now configured by the `local_environment` target type) and
+remote execution via the Remote Execution API (which is now configured by the `remote_environment` target type).
+
+New in Pants 2.15 is support for executing build actions within a Docker container configured via the
+`docker_environment` target type.
+
+See the [Environments documentation](https://www.pantsbuild.org/v2.15/docs/environments) for more information.
+
+### Test Batching
+
+`./pants test` now supports batching compatible tests together so that they execute in the same process.
+This can improve performance of test execution by sharing test environment setup across multiple test files,
+but must be balanced against the impact on caching and concurrency.
+
+The Python backend is the first user of the test batching support. 
+
+### New goal: `fix`
+
+The `fix` goal has been added to run tools which generally will perform more invasive changes on your source
+files than the `fmt` goal. The `fmt` goal remains for tools which merely format code without making
+semantic changes.
+
+### Backends
+
+#### Python
+
+Several changes have been made to the Python backend:
+
+- Support for the new Environments feature. Relevant targets now have a new `environment` field
+to configure which environment to use for that target.
+- Batched execution of `pytest` tests.
+- Support for `lcov` coverage format.
+- Support for `pyright` typechecking.
+- Python lockfiles are now represented in the build graph via synthetic targets.
+- Upgrades to default version of several tools including coverage and Flake8.
+
+#### Go 
+
+The Go backend received several changes including:
+
+- Basic support for Cgo
+- Coverage reports can be generated in HTML and not just the raw data file used by `go tool cover`.
+- Support for [the `golangci-lint` linter](https://www.pantsbuild.org/v2.15/docs/go#golangci-lint).
+- Support for multiple `go_mod` targets in same repository.
+- A new `go-generate` custom goal to run `go generate` on any `//go:generate` instructions in a package.
+- `$GOROOT/bin` is now prepended to `PATH` when running tests to enable them to easily find the `go` binary for
+the Go toolchain in use.
+
+Note: Due to certain changes in Go v1.20, Pants 2.15.x and earlier Pants versions will not work with Go v1.20
+and later releases. Instead, use Pants v2.16.x or later Pants versions to support Go v1.20 and later releases.
+
+#### New: OpenAPI
+
+The new OpenAPI backend provides support for linting OpenAPI API specifications using the `spectral` tool
+and generating Java code from the OpenAPI specifications.
+
+Enable the `pants.backend.experimental.openapi` backend for base OpenAPI support,
+the `pants.backend.experimental.openapi.lint.spectral` backend for linting support, and
+the `pants.backend.experimental.openapi.codegen.java` backend for Java code generation support.
+
+### Plugin API changes
+
+Several changes were made to the Plugin API including the changes highlighted below. Read the
+[Plugin upgrade guide](https://www.pantsbuild.org/v2.15/docs/plugin-upgrade-guide#215) for a full description 
+of the changes highlighted below (as well as other changes not highlighted here), including how to migrate
+existing plugins.
+
+#### Formatters / Linters 
+
+The schema used for formatters and linters has been changed in order to allow for formatters and linters which
+do not require a target on which to operate. See the [applicable section of the Plugin upgrade guide](https://www.pantsbuild.org/v2.15/docs/plugin-upgrade-guide#lint-and-fmt-schema-changes)
+for the specific changes.
+
+#### Batched Tests
+
+The plugin API used by the `test` goal has been changed significantly to support the explicit batching of tests. See the
+[applicable section of the Plugin upgrade guide](https://www.pantsbuild.org/v2.15/docs/plugin-upgrade-guide#test-schema-changes)
+for the specific changes.
+
+#### Synthetic Targets
+
+Plugins may now add "synthetic targets" to the build graph to create freestanding targets programmatically.
+These synthetic targets can also be generator targets in order to further create generated targets. See the
+[plugin documentation for the Synthetic Targets API](https://www.pantsbuild.org/v2.15/docs/target-api-concepts#synthetic-targets-api)
+for more information.
+
+
 ## 2.15.0rc5 (Feb 10, 2023)
 
 ### Bug fixes


### PR DESCRIPTION
Add a basic What's New section to the 2.15.x release notes. This has been cherry-picked forward from the `2.15.x` branch.