### PR TITLE
Update the stated release target to match our desired reality.

### DIFF
--- a/docs/markdown/Contributions/releases/release-strategy.md
+++ b/docs/markdown/Contributions/releases/release-strategy.md
@@ -10,7 +10,7 @@ Pants release cycles flow through:
 
 1. `dev` releases from the `main` branch,
 2. an `a` (alpha) release, which is the first on a stable branch,
-3. `rc` releases, which have begun to stabilize, and might viably become a stable release
+3. `rc` releases, which have begun to stabilize on a stable branch, and will become a stable release
 4. stable releases, which are our most trusted.
 
 Pants follows semantic versioning, along with using regular time-based dev releases. We follow a strict [Deprecation policy](doc:deprecation-policy).
@@ -24,7 +24,7 @@ Pants follows semantic versioning, along with using regular time-based dev relea
 Stable releases
 ---------------
 
-Stable releases occur roughly every month. They have been vetted through at least one alpha and one release candidate.
+Stable releases occur roughly every six weeks. They have been vetted through at least one alpha and one release candidate.
 
 Stable releases are named with the major, minor, and patch version (with no suffix). For example, `2.1.0` or `2.2.1`.
 


### PR DESCRIPTION
For most of the last year, we managed to hit a six week target. The 2.15.x and 2.16.x releases have both slipped to longer than that, but right now six weeks is the rough consensus, and the docs should be accurate.