### PR TITLE
Allow exporting codegenerated files/resources

### DIFF
--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -345,7 +345,6 @@ class FileTarget(Target):
 class GenerateFileSourceRequest(GenerateSourcesRequest):
     input = FileSourceField
     output = FileSourceField
-    exportable = False
 
 
 @rule
@@ -566,7 +565,6 @@ class ResourceTarget(Target):
 class GenerateResourceSourceRequest(GenerateSourcesRequest):
     input = ResourceSourceField
     output = ResourceSourceField
-    exportable = False
 
 
 @rule


### PR DESCRIPTION
Now with `http_source` which soon will include arbitrary URL handlers, it would be very convenient to simply use `export-codegen` to see the file Pants is using. It'll pull from the cache, which is a plus, and handles auth.