### PR TITLE
Allow lambdas for `Field` and `Target` help

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -42,14 +42,14 @@ from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     alias = "handler"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         Entry point to the AWS Lambda handler.
 
@@ -229,7 +229,7 @@ async def infer_lambda_handler_dependency(
 class PythonAwsLambdaIncludeRequirements(BoolField):
     alias = "include_requirements"
     default = True
-    help = softwrap(
+    help = help_text(
         """
         Whether to resolve requirements and include them in the Pex. This is most useful with Lambda
         Layers to make code uploads smaller when deps are in layers.
@@ -243,7 +243,7 @@ class PythonAwsLambdaRuntime(StringField):
 
     alias = "runtime"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         The identifier of the AWS Lambda runtime to target (pythonX.Y).
         See https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html.
@@ -280,7 +280,7 @@ class PythonAwsLambdaRuntime(StringField):
 
 
 class PythonAwsLambdaCompletePlatforms(PexCompletePlatformsField):
-    help = softwrap(
+    help = help_text(
         f"""
         {PexCompletePlatformsField.help}
 
@@ -304,7 +304,7 @@ class PythonAWSLambda(Target):
         PythonResolveField,
         EnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A self-contained Python function suitable for uploading to AWS Lambda.
 

--- a/src/python/pants/backend/build_files/fix/deprecations/subsystem.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/subsystem.py
@@ -3,13 +3,13 @@
 
 from pants.option.option_types import SkipOption
 from pants.option.subsystem import Subsystem
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class BUILDDeprecationsFixer(Subsystem):
     options_scope = "build-deprecations-fixer"
     name = "BUILD Deprecations Fixer"
-    help = softwrap(
+    help = help_text(
         """
         A tool/plugin for fixing BUILD file deprecations (where possible).
 

--- a/src/python/pants/backend/build_files/fmt/buildifier/subsystem.py
+++ b/src/python/pants/backend/build_files/fmt/buildifier/subsystem.py
@@ -3,13 +3,13 @@
 
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class Buildifier(TemplatedExternalTool):
     options_scope = "buildifier"
     name = "Buildifier"
-    help = softwrap(
+    help = help_text(
         """
         Buildifier is a tool for formatting BUILD files with a standard convention.
 

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -20,13 +20,13 @@ from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 from pants.util.docutil import git_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ClangFormat(PythonToolBase):
     options_scope = "clang-format"
     name = "ClangFormat"
-    help = softwrap(
+    help = help_text(
         """
         The clang-format utility for formatting C/C++ (and others) code
         (https://clang.llvm.org/docs/ClangFormat.html). The clang-format binaries

--- a/src/python/pants/backend/codegen/avro/target_types.py
+++ b/src/python/pants/backend/codegen/avro/target_types.py
@@ -17,7 +17,7 @@ from pants.engine.target import (
 )
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class AvroDependenciesField(Dependencies):
@@ -49,7 +49,7 @@ class AvroSourceTarget(Target):
         AvroDependenciesField,
         AvroSourceField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single Avro file used to generate various languages.
 

--- a/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
+++ b/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
@@ -7,7 +7,7 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField
 from pants.engine.target import StringField
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ProtobufPythonInterpreterConstraintsField(InterpreterConstraintsField):
@@ -20,7 +20,7 @@ class ProtobufPythonResolveField(PythonResolveField):
 
 class PythonSourceRootField(StringField):
     alias = "python_source_root"
-    help = softwrap(
+    help = help_text(
         """
         The source root to generate Python sources under.
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -24,12 +24,12 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import doc_url, git_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class PythonProtobufSubsystem(Subsystem):
     options_scope = "python-protobuf"
-    help = softwrap(
+    help = help_text(
         f"""
         Options related to the Protobuf Python backend.
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -22,7 +22,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ProtobufDependenciesField(Dependencies):
@@ -61,7 +61,7 @@ class ProtobufSourceTarget(Target):
         ProtobufSourceField,
         ProtobufGrpcToggleField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single Protobuf file used to generate various languages.
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -21,7 +21,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionRule
 from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ThriftDependenciesField(Dependencies):
@@ -67,7 +67,7 @@ class ThriftSourceTarget(Target):
         ThriftDependenciesField,
         ThriftSourceField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single Thrift file used to generate various languages.
 

--- a/src/python/pants/backend/cue/subsystem.py
+++ b/src/python/pants/backend/cue/subsystem.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 from pants.core.util_rules.external_tool import TemplatedExternalTool
 from pants.engine.platform import Platform
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class Cue(TemplatedExternalTool):
     options_scope = "cue"
     name = "CUE"
-    help = softwrap(
+    help = help_text(
         """
         CUE is an open-source data validation language and inference engine with its roots in logic
         programming. Although the language is not a general-purpose programming language, it has

--- a/src/python/pants/backend/cue/target_types.py
+++ b/src/python/pants/backend/cue/target_types.py
@@ -11,7 +11,7 @@ from pants.engine.target import (
     Target,
     generate_multiple_sources_field_help_message,
 )
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class CuePackageSourcesField(MultipleSourcesField):
@@ -27,7 +27,7 @@ class CuePackageTarget(Target):
         *COMMON_TARGET_FIELDS,
         CuePackageSourcesField,
     )
-    help = softwrap(
+    help = help_text(
         """
         The `cue_package` target defines a CUE package. Within a module, CUE organizes files grouped
         by package. A package can be defined within the module or externally. Definitions and

--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -14,12 +14,12 @@ from pants.engine.target import (
     Target,
 )
 from pants.util.docutil import bin_name, doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class DebianSources(MultipleSourcesField):
     required = True
-    help = softwrap(
+    help = help_text(
         """
         Paths that will be included in the package to be produced such as Debian metadata files.
         You must include a DEBIAN/control file.
@@ -70,7 +70,7 @@ class DebianSources(MultipleSourcesField):
 
 class DebianSymlinks(DictStringToStringField):
     alias = "symlinks"
-    help = softwrap(
+    help = help_text(
         """
         Symlinks to create for each target being packaged.
 
@@ -88,7 +88,7 @@ class DebianInstallPrefix(StringField):
 class DebianPackageDependencies(SpecialCasedDependencies):
     alias = "packages"
     required = True
-    help = softwrap(
+    help = help_text(
         f"""
         Addresses to any targets that can be built with `{bin_name()} package`, e.g.
         `["project:app"]`.
@@ -113,7 +113,7 @@ class DebianPackage(Target):
         DebianInstallPrefix,
         DebianPackageDependencies,
     )
-    help = softwrap(
+    help = help_text(
         f""""
         A Debian package containing an artifact.
 

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -37,7 +37,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import union
 from pants.util.docutil import bin_name, doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 # Common help text to be applied to each field that supports value interpolation.
 _interpolation_help = (
@@ -49,7 +49,7 @@ _interpolation_help = (
 class DockerImageBuildArgsField(StringSequenceField):
     alias = "extra_build_args"
     default = ()
-    help = softwrap(
+    help = help_text(
         """
         Build arguments (`--build-arg`) to use when building this image.
         Entries are either strings in the form `ARG_NAME=value` to set an explicit value;
@@ -62,7 +62,7 @@ class DockerImageBuildArgsField(StringSequenceField):
 
 class DockerImageContextRootField(StringField):
     alias = "context_root"
-    help = softwrap(
+    help = help_text(
         """
         Specify which directory to use as the Docker build context root. This affects the file
         paths to use for the `COPY` and `ADD` instructions. For example, whether
@@ -106,7 +106,7 @@ class DockerImageSourceField(OptionalSingleSourceField):
     # to the user.
     default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
 
-    help = softwrap(
+    help = help_text(
         """
         The Dockerfile to use when building the Docker image.
 
@@ -119,7 +119,7 @@ class DockerImageSourceField(OptionalSingleSourceField):
 class DockerImageInstructionsField(StringSequenceField):
     alias = "instructions"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         The `Dockerfile` content, typically one instruction per list item.
 
@@ -141,7 +141,7 @@ class DockerImageInstructionsField(StringSequenceField):
 class DockerImageTagsField(StringSequenceField):
     alias = "image_tags"
     default = ("latest",)
-    help = softwrap(
+    help = help_text(
         f"""
 
         Any tags to apply to the Docker image name (the version is usually applied as a tag).
@@ -155,7 +155,7 @@ class DockerImageTagsField(StringSequenceField):
 
 class DockerImageTargetStageField(StringField):
     alias = "target_stage"
-    help = softwrap(
+    help = help_text(
         """
         Specify target build stage, rather than building the entire `Dockerfile`.
 
@@ -175,7 +175,7 @@ class DockerImageDependenciesField(Dependencies):
 class DockerImageRegistriesField(StringSequenceField):
     alias = "registries"
     default = (ALL_DEFAULT_REGISTRIES,)
-    help = softwrap(
+    help = help_text(
         """
         List of addresses or configured aliases to any Docker registries to use for the
         built image.
@@ -209,7 +209,7 @@ class DockerImageRegistriesField(StringSequenceField):
 
 class DockerImageRepositoryField(StringField):
     alias = "repository"
-    help = softwrap(
+    help = help_text(
         f"""
         The repository name for the Docker image. e.g. "<repository>/<name>".
 
@@ -256,7 +256,7 @@ class DockerBuildOptionFieldMixin(ABC):
 
 class DockerImageBuildImageLabelsOptionField(DockerBuildOptionFieldMixin, DictStringToStringField):
     alias = "image_labels"
-    help = softwrap(
+    help = help_text(
         f"""
         Provide image metadata.
 
@@ -277,7 +277,7 @@ class DockerImageBuildSecretsOptionField(
     AsyncFieldMixin, DockerBuildOptionFieldMixin, DictStringToStringField
 ):
     alias = "secrets"
-    help = softwrap(
+    help = help_text(
         """
         Secret files to expose to the build (only if BuildKit enabled).
 
@@ -316,7 +316,7 @@ class DockerImageBuildSecretsOptionField(
 class DockerImageBuildSSHOptionField(DockerBuildOptionFieldMixin, StringSequenceField):
     alias = "ssh"
     default = ()
-    help = softwrap(
+    help = help_text(
         """
         SSH agent socket or keys to expose to the build (only if BuildKit enabled)
         (format: default|<id>[=<socket>|<key>[,<key>]])
@@ -351,7 +351,7 @@ class DockerBuildOptionFieldValueMixin(Field):
 class DockerImageBuildPullOptionField(DockerBuildOptionFieldValueMixin, BoolField):
     alias = "pull"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         If true, then docker will always attempt to pull a newer version of the image.
 
@@ -377,7 +377,7 @@ class DockerBuildOptionFlagFieldMixin(BoolField, ABC):
 class DockerImageBuildSquashOptionField(DockerBuildOptionFlagFieldMixin):
     alias = "squash"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         If true, then docker will squash newly built layers into a single new layer.
 
@@ -409,7 +409,7 @@ class DockerImageTarget(Target):
         OutputPathField,
         RestartableField,
     )
-    help = softwrap(
+    help = help_text(
         """
         The `docker_image` target describes how to build and tag a Docker image.
 

--- a/src/python/pants/backend/go/goals/generate.py
+++ b/src/python/pants/backend/go/goals/generate.py
@@ -46,7 +46,7 @@ from pants.engine.target import Targets
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.dirutil import group_by_dir
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 # Adapted from Go toolchain.
 # See https://github.com/golang/go/blob/master/src/cmd/go/internal/generate/generate.go and
@@ -63,7 +63,7 @@ _GENERATE_DIRECTIVE_RE = re.compile(rb"^//go:generate[ \t](.*)$")
 
 class GoGenerateGoalSubsystem(GoalSubsystem):
     name = "go-generate"
-    help = softwrap(
+    help = help_text(
         """
         Run each command in a package described by a `//go:generate` directive. This is equivalent to running
         `go generate` on a Go package.

--- a/src/python/pants/backend/go/target_types.py
+++ b/src/python/pants/backend/go/target_types.py
@@ -27,7 +27,7 @@ from pants.engine.target import (
     ValidNumbers,
     generate_multiple_sources_field_help_message,
 )
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 # -----------------------------------------------------------------------------------------------
 # Build option fields
@@ -38,7 +38,7 @@ class GoCgoEnabledField(TriBoolField):
     """Enables Cgo support."""
 
     alias = "cgo_enabled"
-    help = softwrap(
+    help = help_text(
         """
         Enable Cgo support, which allows Go and C code to interact. This option must be enabled for any
         packages making use of Cgo to actually be compiled with Cgo support.
@@ -59,7 +59,7 @@ class GoRaceDetectorEnabledField(TriBoolField):
     """Enables the Go data race detector."""
 
     alias = "race"
-    help = softwrap(
+    help = help_text(
         """
         Enable compiling the binary with the Go data race detector.
 
@@ -70,7 +70,7 @@ class GoRaceDetectorEnabledField(TriBoolField):
 
 class GoTestRaceDetectorEnabledField(GoRaceDetectorEnabledField):
     alias = "test_race"
-    help = softwrap(
+    help = help_text(
         """
         Enable compiling this package's test binary with the Go data race detector.
 
@@ -83,7 +83,7 @@ class GoMemorySanitizerEnabledField(TriBoolField):
     """Enables the C/C++ memory sanitizer."""
 
     alias = "msan"
-    help = softwrap(
+    help = help_text(
         """
         Enable interoperation between Go code and the C/C++ "memory sanitizer."
 
@@ -95,7 +95,7 @@ class GoMemorySanitizerEnabledField(TriBoolField):
 
 class GoTestMemorySanitizerEnabledField(GoRaceDetectorEnabledField):
     alias = "test_msan"
-    help = softwrap(
+    help = help_text(
         """
         Enable interoperation between Go code and the C/C++ "memory sanitizer" when building this package's
         test binary.
@@ -110,7 +110,7 @@ class GoAddressSanitizerEnabledField(TriBoolField):
     """Enables the C/C++ address sanitizer."""
 
     alias = "asan"
-    help = softwrap(
+    help = help_text(
         """
         Enable interoperation between Go code and the C/C++ "address sanitizer."
 
@@ -122,7 +122,7 @@ class GoAddressSanitizerEnabledField(TriBoolField):
 
 class GoTestAddressSanitizerEnabledField(GoRaceDetectorEnabledField):
     alias = "test_asan"
-    help = softwrap(
+    help = help_text(
         """
         Enable interoperation between Go code and the C/C++ "address sanitizer" when building this package's
         test binary.
@@ -135,7 +135,7 @@ class GoTestAddressSanitizerEnabledField(GoRaceDetectorEnabledField):
 
 class GoAssemblerFlagsField(StringSequenceField):
     alias = "assembler_flags"
-    help = softwrap(
+    help = help_text(
         """
         Extra flags to pass to the Go assembler (i.e., `go tool asm`) when assembling Go-format assembly code.
 
@@ -161,7 +161,7 @@ class GoAssemblerFlagsField(StringSequenceField):
 
 class GoCompilerFlagsField(StringSequenceField):
     alias = "compiler_flags"
-    help = softwrap(
+    help = help_text(
         """
         Extra flags to pass to the Go compiler (i.e., `go tool compile`) when compiling Go code.
 
@@ -185,7 +185,7 @@ class GoCompilerFlagsField(StringSequenceField):
 
 class GoLinkerFlagsField(StringSequenceField):
     alias = "linker_flags"
-    help = softwrap(
+    help = help_text(
         """
         Extra flags to pass to the Go linker (i.e., `go tool link`) when linking Go binaries.
 
@@ -210,7 +210,7 @@ class GoLinkerFlagsField(StringSequenceField):
 
 class GoImportPathField(StringField):
     alias = "import_path"
-    help = softwrap(
+    help = help_text(
         """
         Import path in Go code to import this package.
 
@@ -228,7 +228,7 @@ class GoThirdPartyPackageDependenciesField(Dependencies):
 class GoThirdPartyPackageTarget(Target):
     alias = "go_third_party_package"
     core_fields = (*COMMON_TARGET_FIELDS, GoThirdPartyPackageDependenciesField, GoImportPathField)
-    help = softwrap(
+    help = help_text(
         """
         A package from a third-party Go module.
 
@@ -297,7 +297,7 @@ class GoModDependenciesField(Dependencies):
 
 class GoModTarget(TargetGenerator):
     alias = "go_mod"
-    help = softwrap(
+    help = help_text(
         """
         A first-party Go module (corresponding to a `go.mod` file).
 
@@ -404,7 +404,7 @@ class GoPackageTarget(Target):
         GoCompilerFlagsField,
         SkipGoTestsField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A first-party Go package (corresponding to a directory with `.go` files).
 
@@ -421,7 +421,7 @@ class GoPackageTarget(Target):
 
 class GoBinaryMainPackageField(StringField, AsyncFieldMixin):
     alias = "main"
-    help = softwrap(
+    help = help_text(
         """
         Address of the `go_package` with the `main` for this binary.
 
@@ -465,7 +465,7 @@ class GoBinaryTarget(Target):
 
 class GoOwningGoModAddressField(StringField):
     alias = "go_mod_address"
-    help = softwrap(
+    help = help_text(
         """
         Address of the `go_mod` target representing the Go module that this target is part of.
 

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -42,14 +42,14 @@ from pants.engine.unions import UnionRule
 from pants.source.filespec import Filespec
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class PythonGoogleCloudFunctionHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
     alias = "handler"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         Entry point to the Google Cloud Function handler.
 
@@ -228,7 +228,7 @@ class PythonGoogleCloudFunctionRuntime(StringField):
     alias = "runtime"
     default = None
     valid_choices = PythonGoogleCloudFunctionRuntimes
-    help = softwrap(
+    help = help_text(
         """
         The identifier of the Google Cloud Function runtime to target (pythonXY). See
         https://cloud.google.com/functions/docs/concepts/python-runtime.
@@ -261,7 +261,7 @@ class PythonGoogleCloudFunctionRuntime(StringField):
 
 
 class PythonGoogleCloudFunctionCompletePlatforms(PexCompletePlatformsField):
-    help = softwrap(
+    help = help_text(
         f"""
         {PexCompletePlatformsField.help}
 
@@ -282,7 +282,7 @@ class PythonGoogleCloudFunctionType(StringField):
     alias = "type"
     required = True
     valid_choices = GoogleCloudFunctionTypes
-    help = softwrap(
+    help = help_text(
         """
         The trigger type of the cloud function. Can either be 'event' or 'http'.
         See https://cloud.google.com/functions/docs/concepts/python-runtime for reference to
@@ -304,7 +304,7 @@ class PythonGoogleCloudFunction(Target):
         PythonResolveField,
         EnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A self-contained Python function suitable for uploading to Google Cloud Function.
 

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -18,7 +18,7 @@ from pants.option.option_types import (
     StrOption,
 )
 from pants.util.memo import memoized_method
-from pants.util.strutil import bullet_list, softwrap
+from pants.util.strutil import bullet_list, help_text, softwrap
 
 _VALID_PASSTHROUGH_FLAGS = [
     "--atomic",
@@ -58,7 +58,7 @@ class InvalidHelmPassthroughArgs(Exception):
         )
 
 
-registries_help = softwrap(
+registries_help = help_text(
     f"""
     Configure Helm OCI registries. The schema for a registry entry is as follows:
 

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -34,7 +34,7 @@ from pants.engine.target import (
     generate_multiple_sources_field_help_message,
 )
 from pants.util.docutil import bin_name
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 from pants.util.value_interpolation import InterpolationContext, InterpolationError
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 class HelmRegistriesField(StringSequenceField):
     alias = "registries"
     default = (ALL_DEFAULT_HELM_REGISTRIES,)
-    help = softwrap(
+    help = help_text(
         """
         List of addresses or configured aliases to any OCI registries to use for the
         built chart.
@@ -82,7 +82,7 @@ class HelmRegistriesField(StringSequenceField):
 class HelmSkipLintField(BoolField):
     alias = "skip_lint"
     default = False
-    help = softwrap(
+    help = help_text(
         f"""
         If set to true, do not run any linting in this Helm chart when running `{bin_name()}
         lint`.
@@ -93,7 +93,7 @@ class HelmSkipLintField(BoolField):
 class HelmSkipPushField(BoolField):
     alias = "skip_push"
     default = False
-    help = softwrap(
+    help = help_text(
         f"""
         If set to true, do not push this Helm chart to registries when running `{bin_name()}
         publish`.
@@ -138,7 +138,7 @@ class HelmChartDependenciesField(Dependencies):
 
 
 class HelmChartOutputPathField(OutputPathField):
-    help = softwrap(
+    help = help_text(
         f"""
         Where the built directory tree should be located.
 
@@ -168,7 +168,7 @@ class HelmChartLintStrictField(TriBoolField):
 
 class HelmChartRepositoryField(StringField):
     alias = "repository"
-    help = softwrap(
+    help = help_text(
         """
         Repository to use in the Helm registry where this chart is going to be published.
 
@@ -317,7 +317,7 @@ class HelmUnitTestTestsGeneratorTarget(TargetFilesGenerator):
 
 class HelmArtifactRegistryField(StringField):
     alias = "registry"
-    help = softwrap(
+    help = help_text(
         """
         Either registry alias (prefixed by `@`) configured in `[helm.registries]` for the
         Helm artifact or the full OCI registry URL.
@@ -327,7 +327,7 @@ class HelmArtifactRegistryField(StringField):
 
 class HelmArtifactRepositoryField(StringField):
     alias = "repository"
-    help = softwrap(
+    help = help_text(
         f"""
         Either a HTTP(S) URL to a classic repository, or a path inside an OCI registry (when
         `{HelmArtifactRegistryField.alias}` is provided).
@@ -414,7 +414,7 @@ class HelmDeploymentSourcesField(MultipleSourcesField):
 class HelmDeploymentValuesField(DictStringToStringField):
     alias = "values"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         Individual values to use when rendering a given deployment.
 
@@ -466,7 +466,7 @@ class HelmDeploymentTimeoutField(IntField):
 
 class HelmDeploymentPostRenderersField(SpecialCasedDependencies):
     alias = "post_renderers"
-    help = softwrap(
+    help = help_text(
         """
         List of runnable targets to be used to post-process the helm chart after being rendered by Helm.
 

--- a/src/python/pants/backend/javascript/lint/prettier/subsystem.py
+++ b/src/python/pants/backend/javascript/lint/prettier/subsystem.py
@@ -9,13 +9,13 @@ from typing import Iterable
 from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class Prettier(NpxToolBase):
     options_scope = "prettier"
     name = "Prettier"
-    help = softwrap(
+    help = help_text(
         """
         The Prettier utility for formatting JS/TS (and others) code
         (https://prettier.io/).

--- a/src/python/pants/backend/kotlin/target_types.py
+++ b/src/python/pants/backend/kotlin/target_types.py
@@ -28,7 +28,7 @@ from pants.jvm.target_types import (
     JvmResolveField,
     JvmRunnableSourceFieldSet,
 )
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class KotlinSourceField(SingleSourceField):
@@ -40,7 +40,7 @@ class KotlinGeneratorSourcesField(MultipleSourcesField):
 
 
 class KotlincConsumedPluginIdsField(StringSequenceField):
-    help = softwrap(
+    help = help_text(
         """
         The IDs of Kotlin compiler plugins that this source file requires.
 
@@ -190,7 +190,7 @@ class KotlincPluginArtifactField(StringField, AsyncFieldMixin):
 
 class KotlincPluginIdField(StringField):
     alias = "plugin_id"
-    help = softwrap(
+    help = help_text(
         """
         The ID for `kotlinc` to use when setting options for the plugin.
 
@@ -201,7 +201,7 @@ class KotlincPluginIdField(StringField):
 
 class KotlincPluginArgsField(StringSequenceField):
     alias = "plugin_args"
-    help = softwrap(
+    help = help_text(
         """
         Optional list of argument to pass to the plugin.
         """
@@ -216,7 +216,7 @@ class KotlincPluginTarget(Target):
         KotlincPluginIdField,
         KotlincPluginArgsField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A plugin for `kotlinc`.
 

--- a/src/python/pants/backend/plugin_development/pants_requirements.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements.py
@@ -16,7 +16,7 @@ from pants.engine.target import (
     TargetGenerator,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 from pants.version import MAJOR_MINOR, PANTS_SEMVER
 
 
@@ -28,7 +28,7 @@ class PantsRequirementsTestutilField(BoolField):
 
 class PantsRequirementsTargetGenerator(TargetGenerator):
     alias = "pants_requirements"
-    help = softwrap(
+    help = help_text(
         f"""
         Generate `python_requirement` targets for Pants itself to use with Pants plugins.
 

--- a/src/python/pants/backend/project_info/filter_targets.py
+++ b/src/python/pants/backend/project_info/filter_targets.py
@@ -18,7 +18,7 @@ from pants.util.docutil import bin_name
 from pants.util.enums import match
 from pants.util.filtering import TargetFilter, and_filters, create_filters
 from pants.util.memo import memoized
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class TargetGranularity(Enum):
@@ -29,7 +29,7 @@ class TargetGranularity(Enum):
 
 class FilterSubsystem(LineOriented, GoalSubsystem):
     name = "filter"
-    help = softwrap(
+    help = help_text(
         """
         Filter the input targets based on various criteria.
 

--- a/src/python/pants/backend/project_info/regex_lint.py
+++ b/src/python/pants/backend/project_info/regex_lint.py
@@ -18,7 +18,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +73,7 @@ class ValidationConfig:
 class RegexLintSubsystem(Subsystem):
     options_scope = "regex-lint"
     name = "regex-lint"
-    help = softwrap(
+    help = help_text(
         """
         Lint your code using regex patterns, e.g. to check for copyright headers.
 

--- a/src/python/pants/backend/python/framework/stevedore/target_types.py
+++ b/src/python/pants/backend/python/framework/stevedore/target_types.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from pants.backend.python.target_types import PythonDistribution
 from pants.engine.target import StringSequenceField, Targets
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class StevedoreNamespace(str):
@@ -33,7 +33,7 @@ class StevedoreNamespace(str):
 # This is a lot like a SpecialCasedDependencies field, but it doesn't list targets directly.
 class StevedoreNamespacesField(StringSequenceField):
     alias = "stevedore_namespaces"
-    help = softwrap(
+    help = help_text(
         f"""
         List the stevedore namespaces required by this target.
 

--- a/src/python/pants/backend/python/goals/publish.py
+++ b/src/python/pants/backend/python/goals/publish.py
@@ -23,14 +23,14 @@ from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import BoolField, StringSequenceField
 from pants.option.global_options import GlobalOptions
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 logger = logging.getLogger(__name__)
 
 
 class PythonRepositoriesField(StringSequenceField):
     alias = "repositories"
-    help = softwrap(
+    help = help_text(
         """
         List of URL addresses or Twine repository aliases where to publish the Python package.
 

--- a/src/python/pants/backend/python/macros/common_fields.py
+++ b/src/python/pants/backend/python/macros/common_fields.py
@@ -14,12 +14,12 @@ from pants.backend.python.target_types import (
 from pants.engine.addresses import Address
 from pants.engine.target import DictStringToStringSequenceField, OverridesField
 from pants.util.frozendict import FrozenDict
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ModuleMappingField(DictStringToStringSequenceField):
     alias = "module_mapping"
-    help = softwrap(
+    help = help_text(
         f"""
         A mapping of requirement names to a list of the modules they provide.
 
@@ -43,7 +43,7 @@ class ModuleMappingField(DictStringToStringSequenceField):
 
 class TypeStubsModuleMappingField(DictStringToStringSequenceField):
     alias = "type_stubs_module_mapping"
-    help = softwrap(
+    help = help_text(
         f"""
         A mapping of type-stub requirement names to a list of the modules they provide.
 
@@ -66,7 +66,7 @@ class TypeStubsModuleMappingField(DictStringToStringSequenceField):
 
 
 class RequirementsOverrideField(OverridesField):
-    help = softwrap(
+    help = help_text(
         """
         Override the field values for generated `python_requirement` targets.
 

--- a/src/python/pants/backend/python/macros/python_requirements.py
+++ b/src/python/pants/backend/python/macros/python_requirements.py
@@ -32,7 +32,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 def parse_pyproject_toml(pyproject_toml: str, *, rel_path: str) -> Iterator[PipRequirement]:
@@ -70,7 +70,7 @@ class PythonRequirementsSourceField(SingleSourceField):
 
 class PythonRequirementsTargetGenerator(TargetGenerator):
     alias = "python_requirements"
-    help = softwrap(
+    help = help_text(
         """
         Generate a `python_requirement` for each entry in a requirements.txt-style or PEP 621
         compliant pyproject.toml file. The choice of parser for the `source` field is determined

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -11,13 +11,13 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption
 from pants.util.docutil import git_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class PyOxidizer(PythonToolBase):
     options_scope = "pyoxidizer"
     name = "PyOxidizer"
-    help = softwrap(
+    help = help_text(
         """
         The PyOxidizer utility for packaging Python code in a Rust binary
         (https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer.html).

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -15,11 +15,11 @@ from pants.engine.target import (
     Target,
 )
 from pants.util.docutil import bin_name, doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class PyOxidizerOutputPathField(OutputPathField):
-    help = softwrap(
+    help = help_text(
         f"""
         Where the built directory tree should be located.
 
@@ -43,7 +43,7 @@ class PyOxidizerOutputPathField(OutputPathField):
 class PyOxidizerBinaryNameField(OutputPathField):
     alias = "binary_name"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         The name of the binary that will be output by PyOxidizer. If not set, this will default
         to the name of this target.
@@ -54,7 +54,7 @@ class PyOxidizerBinaryNameField(OutputPathField):
 class PyOxidizerEntryPointField(StringField):
     alias = "entry_point"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         Set the entry point, i.e. what gets run when executing `./my_app`, to a module.
         This represents the content of PyOxidizer's `python_config.run_module` and leaving this
@@ -71,7 +71,7 @@ class PyOxidizerEntryPointField(StringField):
 class PyOxidizerDependenciesField(Dependencies):
     required = True
     supports_transitive_excludes = True
-    help = softwrap(
+    help = help_text(
         f"""
         The addresses of `python_distribution` target(s) to include in the binary, e.g.
         `['src/python/project:dist']`.
@@ -97,7 +97,7 @@ class PyOxidizerDependenciesField(Dependencies):
 
 class PyOxidizerUnclassifiedResources(StringSequenceField):
     alias = "filesystem_resources"
-    help = softwrap(
+    help = help_text(
         """
         Adds support for listing dependencies that MUST be installed to the filesystem (e.g. Numpy).
         See https://pyoxidizer.readthedocs.io/en/stable/pyoxidizer_packaging_additional_files.html#installing-unclassified-files-on-the-filesystem
@@ -110,7 +110,7 @@ class PyOxidizerUnclassifiedResources(StringSequenceField):
 class PyOxidizerConfigSourceField(OptionalSingleSourceField):
     alias = "template"
     expected_file_extensions = (".bzlt",)
-    help = softwrap(
+    help = help_text(
         """
         If set, will use your custom configuration rather than using Pants's default template.
 
@@ -141,7 +141,7 @@ class PyOxidizerTarget(Target):
         PyOxidizerUnclassifiedResources,
         EnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single-file Python executable with a Python interpreter embedded, built via PyOxidizer.
 

--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -9,12 +9,12 @@ from pants.base.deprecated import resolve_conflicting_options
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import doc_url
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class PythonRepos(Subsystem):
     options_scope = "python-repos"
-    help = softwrap(
+    help = help_text(
         """
         External Python code repositories, such as PyPI.
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -73,7 +73,7 @@ from pants.option.subsystem import Subsystem
 from pants.source.filespec import Filespec
 from pants.util.docutil import bin_name, doc_url, git_url
 from pants.util.frozendict import FrozenDict
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ class PythonGeneratingSourcesBase(MultipleSourcesField):
 
 class InterpreterConstraintsField(StringSequenceField):
     alias = "interpreter_constraints"
-    help = softwrap(
+    help = help_text(
         f"""
         The Python interpreters this code is compatible with.
 
@@ -130,7 +130,7 @@ class InterpreterConstraintsField(StringSequenceField):
 class PythonResolveField(StringField, AsyncFieldMixin):
     alias = "resolve"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         The resolve from `[python].resolves` to use.
 
@@ -156,7 +156,7 @@ class PythonResolveField(StringField, AsyncFieldMixin):
 
 class PythonRunGoalUseSandboxField(TriBoolField):
     alias = "run_goal_use_sandbox"
-    help = softwrap(
+    help = help_text(
         """
         Whether to use a sandbox when `run`ning this target. Defaults to `[python].run_goal_use_sandbox`.
 
@@ -296,7 +296,7 @@ class ConsoleScript(MainSpecification):
 class EntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
     alias = "entry_point"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         Set the entry point, i.e. what gets run when executing `./my_app.pex`, to a module.
 
@@ -356,7 +356,7 @@ class ResolvePexEntryPointRequest:
 class PexScriptField(Field):
     alias = "script"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         Set the entry point, i.e. what gets run when executing `./my_app.pex`, to a script or
         console_script as defined by any of the distributions in the PEX.
@@ -379,7 +379,7 @@ class PexScriptField(Field):
 
 class PexArgsField(StringSequenceField):
     alias = "args"
-    help = softwrap(
+    help = help_text(
         """
         Freeze these command-line args into the PEX. Allows you to run generic entry points
         on specific arguments without creating a shim file.
@@ -389,7 +389,7 @@ class PexArgsField(StringSequenceField):
 
 class PexEnvField(DictStringToStringField):
     alias = "env"
-    help = softwrap(
+    help = help_text(
         """
         Freeze these environment variables into the PEX. Allows you to run generic entry points
         on a specific environment without creating a shim file.
@@ -399,7 +399,7 @@ class PexEnvField(DictStringToStringField):
 
 class PexPlatformsField(StringSequenceField):
     alias = "platforms"
-    help = softwrap(
+    help = help_text(
         """
         The abbreviated platforms the built PEX should be compatible with.
 
@@ -432,7 +432,7 @@ class PexPlatformsField(StringSequenceField):
 
 class PexCompletePlatformsField(SpecialCasedDependencies):
     alias = "complete_platforms"
-    help = softwrap(
+    help = help_text(
         """
         The platforms the built PEX should be compatible with.
 
@@ -451,7 +451,7 @@ class PexCompletePlatformsField(SpecialCasedDependencies):
 class PexInheritPathField(StringField):
     alias = "inherit_path"
     valid_choices = ("false", "fallback", "prefer")
-    help = softwrap(
+    help = help_text(
         """
         Whether to inherit the `sys.path` (aka PYTHONPATH) of the environment that the binary runs in.
 
@@ -473,7 +473,7 @@ class PexInheritPathField(StringField):
 class PexStripEnvField(BoolField):
     alias = "strip_pex_env"
     default = True
-    help = softwrap(
+    help = help_text(
         """
         Whether or not to strip the PEX runtime environment of `PEX*` environment variables.
 
@@ -494,7 +494,7 @@ class PexIgnoreErrorsField(BoolField):
 
 class PexShebangField(StringField):
     alias = "shebang"
-    help = softwrap(
+    help = help_text(
         """
         Set the generated PEX to use this shebang, rather than the default of PEX choosing a
         shebang based on the interpreter constraints.
@@ -507,7 +507,7 @@ class PexShebangField(StringField):
 
 class PexEmitWarningsField(TriBoolField):
     alias = "emit_warnings"
-    help = softwrap(
+    help = help_text(
         """
         Whether or not to emit PEX warnings at runtime.
 
@@ -523,7 +523,7 @@ class PexEmitWarningsField(TriBoolField):
 
 class PexResolveLocalPlatformsField(TriBoolField):
     alias = "resolve_local_platforms"
-    help = softwrap(
+    help = help_text(
         f"""
         For each of the `{PexPlatformsField.alias}` specified, attempt to find a local
         interpreter that matches.
@@ -551,7 +551,7 @@ class PexExecutionModeField(StringField):
     valid_choices = PexExecutionMode
     expected_type = str
     default = PexExecutionMode.ZIPAPP.value
-    help = softwrap(
+    help = help_text(
         f"""
         The mode the generated PEX file will run in.
 
@@ -579,7 +579,7 @@ class PexLayoutField(StringField):
     valid_choices = PexLayout
     expected_type = str
     default = PexLayout.ZIPAPP.value
-    help = softwrap(
+    help = help_text(
         f"""
         The layout used for the PEX binary.
 
@@ -607,7 +607,7 @@ class PexLayoutField(StringField):
 class PexIncludeRequirementsField(BoolField):
     alias = "include_requirements"
     default = True
-    help = softwrap(
+    help = help_text(
         """
         Whether to include the third party requirements the binary depends on in the
         packaged PEX file.
@@ -618,7 +618,7 @@ class PexIncludeRequirementsField(BoolField):
 class PexIncludeSourcesField(BoolField):
     alias = "include_sources"
     default = True
-    help = softwrap(
+    help = help_text(
         """
         Whether to include your first party sources the binary uses in the packaged PEX file.
         """
@@ -628,7 +628,7 @@ class PexIncludeSourcesField(BoolField):
 class PexIncludeToolsField(BoolField):
     alias = "include_tools"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         Whether to include Pex tools in the PEX bootstrap code.
 
@@ -641,7 +641,7 @@ class PexIncludeToolsField(BoolField):
 class PexVenvSitePackagesCopies(BoolField):
     alias = "venv_site_packages_copies"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         If execution_mode is venv, populate the venv site packages using hard links or copies of resolved PEX dependencies instead of symlinks.
 
@@ -684,7 +684,7 @@ class PexBinary(Target):
         PexEnvField,
         OutputPathField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A Python target that can be converted into an executable PEX file.
 
@@ -709,7 +709,7 @@ class PexBinary(Target):
 class PexEntryPointsField(StringSequenceField, AsyncFieldMixin):
     alias = "entry_points"
     default = None
-    help = softwrap(
+    help = help_text(
         """
         The entry points for each binary, i.e. what gets run when when executing `./my_app.pex.`
 
@@ -724,7 +724,7 @@ class PexEntryPointsField(StringSequenceField, AsyncFieldMixin):
 
 
 class PexBinariesOverrideField(OverridesField):
-    help = softwrap(
+    help = help_text(
         f"""
         Override the field values for generated `{PexBinary.alias}` targets.
 
@@ -756,7 +756,7 @@ class PexBinariesOverrideField(OverridesField):
 
 class PexBinariesGeneratorTarget(TargetGenerator):
     alias = "pex_binaries"
-    help = softwrap(
+    help = help_text(
         """
         Generate a `pex_binary` target for each entry_point in the `entry_points` field.
 
@@ -848,7 +848,7 @@ class PythonTestsDependenciesField(PythonDependenciesField):
 # TODO This field class should extend from a core `TestTimeoutField` once the deprecated options in `pytest` get removed.
 class PythonTestsTimeoutField(IntField):
     alias = "timeout"
-    help = softwrap(
+    help = help_text(
         """
         A timeout (in seconds) used by each test file belonging to this target.
 
@@ -890,7 +890,7 @@ class PythonTestsExtraEnvVarsField(TestExtraEnvVarsField):
 
 class PythonTestsXdistConcurrencyField(IntField):
     alias = "xdist_concurrency"
-    help = softwrap(
+    help = help_text(
         """
         Maximum number of CPUs to allocate to run each test file belonging to this target.
 
@@ -909,7 +909,7 @@ class PythonTestsXdistConcurrencyField(IntField):
 
 class PythonTestsBatchCompatibilityTagField(StringField):
     alias = "batch_compatibility_tag"
-    help = softwrap(
+    help = help_text(
         """
         An arbitrary value used to mark the test files belonging to this target as valid for
         batched execution.
@@ -973,7 +973,7 @@ class PythonTestTarget(Target):
         PythonTestsDependenciesField,
         PythonTestSourceField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single Python test file, written in either Pytest style or unittest style.
 
@@ -1109,7 +1109,7 @@ class PythonTestUtilsGeneratorTarget(TargetFilesGenerator):
         InterpreterConstraintsField,
     )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
-    help = softwrap(
+    help = help_text(
         """
         Generate a `python_source` target for each file in the `sources` field.
 
@@ -1141,7 +1141,7 @@ class PythonSourcesGeneratorTarget(TargetFilesGenerator):
         RestartableField,
     )
     settings_request_cls = PythonFilesGeneratorSettingsRequest
-    help = softwrap(
+    help = help_text(
         """
         Generate a `python_source` target for each file in the `sources` field.
 
@@ -1201,7 +1201,7 @@ class PythonRequirementDependenciesField(Dependencies):
 class PythonRequirementsField(_PipRequirementSequenceField):
     alias = "requirements"
     required = True
-    help = softwrap(
+    help = help_text(
         """
         A pip-style requirement string, e.g. `["Django==3.2.8"]`.
 
@@ -1222,7 +1222,7 @@ _default_module_mapping_url = git_url(
 
 class PythonRequirementModulesField(StringSequenceField):
     alias = "modules"
-    help = softwrap(
+    help = help_text(
         f"""
         The modules this requirement provides (used for dependency inference).
 
@@ -1241,7 +1241,7 @@ class PythonRequirementModulesField(StringSequenceField):
 
 class PythonRequirementTypeStubModulesField(StringSequenceField):
     alias = "type_stub_modules"
-    help = softwrap(
+    help = help_text(
         f"""
         The modules this requirement provides if the requirement is a type stub (used for
         dependency inference).
@@ -1269,7 +1269,7 @@ def normalize_module_mapping(
 class PythonRequirementResolveField(PythonResolveField):
     alias = "resolve"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         The resolve from `[python].resolves` that this requirement is included in.
 
@@ -1301,7 +1301,7 @@ class PythonRequirementTarget(Target):
         PythonRequirementResolveField,
         PythonRequirementEntryPointField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A Python requirement installable by pip.
 
@@ -1362,7 +1362,7 @@ class PythonProvidesField(ScalarField, AsyncFieldMixin):
     expected_type_help = "python_artifact(name='my-dist', **kwargs)"
     value: PythonArtifact
     required = True
-    help = softwrap(
+    help = help_text(
         f"""
         The setup.py kwargs for the external artifact built from this target.
 
@@ -1382,7 +1382,7 @@ class PythonProvidesField(ScalarField, AsyncFieldMixin):
 class PythonDistributionEntryPointsField(NestedDictStringToStringField, AsyncFieldMixin):
     alias = "entry_points"
     required = False
-    help = softwrap(
+    help = help_text(
         f"""
         Any entry points, such as `console_scripts` and `gui_scripts`.
 
@@ -1414,7 +1414,7 @@ class PythonDistributionEntryPointsField(NestedDictStringToStringField, AsyncFie
 
 
 class PythonDistributionOutputPathField(StringField, AsyncFieldMixin):
-    help = softwrap(
+    help = help_text(
         """
         The path to the directory to write the distribution file to, relative the dist directory.
 
@@ -1539,7 +1539,7 @@ class SDistConfigSettingsField(ConfigSettingsField):
 class BuildBackendEnvVarsField(StringSequenceField):
     alias = "env_vars"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         Environment variables to set when running the PEP-517 build backend.
 
@@ -1556,7 +1556,7 @@ class GenerateSetupField(TriBoolField):
     # --generate-setup-default option in the setup-py-generation scope.
     default = None
 
-    help = softwrap(
+    help = help_text(
         """
         Whether to generate setup information for this distribution, based on analyzing
         sources and dependencies. Set to False to use existing setup information, such as
@@ -1569,7 +1569,7 @@ class LongDescriptionPathField(StringField):
     alias = "long_description_path"
     required = False
 
-    help = softwrap(
+    help = help_text(
         """
         Path to a file that will be used to fill the long_description field in setup.py.
 
@@ -1600,7 +1600,7 @@ class PythonDistribution(Target):
         LongDescriptionPathField,
         PythonDistributionOutputPathField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A publishable Python setuptools distribution (e.g. an sdist or wheel).
 
@@ -1631,7 +1631,7 @@ class VCSVersionDummySourceField(OptionalSingleSourceField):
 class VersionTagRegexField(StringField):
     default = r"^(?:[\w-]+-)?(?P<version>[vV]?\d+(?:\.\d+){0,2}[^\+]*)(?:\+.*)?$"
     alias = "tag_regex"
-    help = softwrap(
+    help = help_text(
         """
         A Python regex string to extract the version string from a VCS tag.
 
@@ -1648,7 +1648,7 @@ class VersionTagRegexField(StringField):
 class VersionGenerateToField(StringField):
     required = True
     alias = "generate_to"
-    help = softwrap(
+    help = help_text(
         """
         Generate the version data to this relative path, using the template field.
 
@@ -1661,7 +1661,7 @@ class VersionGenerateToField(StringField):
 class VersionTemplateField(StringField):
     required = True
     alias = "template"
-    help = softwrap(
+    help = help_text(
         """
         Generate the version data using this format string, which takes a version format kwarg.
 
@@ -1679,7 +1679,7 @@ class VCSVersion(Target):
         VersionGenerateToField,
         VersionTemplateField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         Generates a version string from VCS state.
 

--- a/src/python/pants/backend/python/typecheck/mypy/mypyc.py
+++ b/src/python/pants/backend/python/typecheck/mypy/mypyc.py
@@ -18,13 +18,13 @@ from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequ
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import BoolField, Target
 from pants.engine.unions import UnionRule
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class UsesMyPycField(BoolField):
     alias = "uses_mypyc"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         If true, this distribution is built using mypyc.
 

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -7,13 +7,13 @@ from pants.backend.javascript.subsystems.npx_tool import NpxToolBase
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class Pyright(NpxToolBase):
     options_scope = "pyright"
     name = "Pyright"
-    help = softwrap(
+    help = help_text(
         """
         The Pyright utility for typechecking Python code
         (https://github.com/microsoft/pyright).

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -37,7 +37,7 @@ from pants.jvm.target_types import (
     JvmResolveField,
     JvmRunnableSourceFieldSet,
 )
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class ScalaSettingsRequest(TargetFilesGeneratorSettingsRequest):
@@ -67,7 +67,7 @@ class ScalaDependenciesField(Dependencies):
 
 
 class ScalaConsumedPluginNamesField(StringSequenceField):
-    help = softwrap(
+    help = help_text(
         """
         The names of Scala plugins that this source file requires.
 
@@ -169,7 +169,7 @@ class ScalatestTestsGeneratorTarget(TargetFilesGenerator):
         JvmResolveField,
     )
     settings_request_cls = ScalaSettingsRequest
-    help = softwrap(
+    help = help_text(
         f"""
         Generate a `scalatest_test` target for each file in the `sources` field (defaults to
         all files in the directory matching {ScalatestTestsGeneratorSourcesField.default}).
@@ -329,7 +329,7 @@ class ScalacPluginArtifactField(StringField, AsyncFieldMixin):
 
 class ScalacPluginNameField(StringField):
     alias = "plugin_name"
-    help = softwrap(
+    help = help_text(
         """
         The name that `scalac` should use to load the plugin.
 
@@ -345,7 +345,7 @@ class ScalacPluginTarget(Target):
         ScalacPluginArtifactField,
         ScalacPluginNameField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A plugin for `scalac`.
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -32,7 +32,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.util.enums import match
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class ShellDependenciesField(Dependencies):
@@ -145,7 +145,7 @@ class Shunit2TestTarget(Target):
         Shunit2ShellField,
         RuntimePackageDependenciesField,
     )
-    help = softwrap(
+    help = help_text(
         f"""
         A single test file for Bourne-based shell scripts using the shunit2 test framework.
 
@@ -263,7 +263,7 @@ class ShellCommandCommandField(StringField):
 class RunInSandboxRunnableField(StringField):
     alias = "runnable"
     required = True
-    help = softwrap(
+    help = help_text(
         """
         Address to a target that can be invoked by the `run` goal (and does not set
         `run_in_sandbox_behavior=NOT_SUPPORTED`). This will be executed along with any arguments
@@ -275,7 +275,7 @@ class RunInSandboxRunnableField(StringField):
 
 class ShellCommandOutputsField(StringSequenceField):
     alias = "outputs"
-    help = softwrap(
+    help = help_text(
         """
         Specify the shell command output files and directories, relative to the value of `workdir`.
 
@@ -293,7 +293,7 @@ class ShellCommandOutputFilesField(StringSequenceField):
     alias = "output_files"
     required = False
     default = ()
-    help = softwrap(
+    help = help_text(
         """
         Specify the shell command's output files to capture, relative to the value of `workdir`.
 
@@ -310,7 +310,7 @@ class ShellCommandOutputDirectoriesField(StringSequenceField):
     alias = "output_directories"
     required = False
     default = ()
-    help = softwrap(
+    help = help_text(
         """
         Specify full directories (including recursive descendants) of output to capture from the
         shell command, relative to the value of `workdir`.
@@ -330,11 +330,11 @@ class ShellCommandOutputDependenciesField(ShellDependenciesField):
     deprecated_alias = "dependencies"
     deprecated_alias_removal_version = "2.17.0.dev0"
 
-    help = softwrap(
-        """
+    help = lambda: softwrap(
+        f"""
         Any dependencies that the output artifacts require in order to be effectively consumed.
 
-        To enable legacy use cases, if `execution_dependencies` is `None`, these dependencies will
+        To enable legacy use cases, if `{ShellCommandExecutionDependenciesField.alias}` is `None`, these dependencies will
         be materialized in the command execution sandbox. This behavior is deprecated, and will be
         removed in version 2.17.0.dev0.
         """
@@ -346,7 +346,7 @@ class ShellCommandExecutionDependenciesField(SpecialCasedDependencies):
     required = False
     default = None
 
-    help = softwrap(
+    help = help_text(
         """
         The execution dependencies for this shell command.
 
@@ -403,7 +403,7 @@ class ShellCommandTimeoutField(IntField):
 class ShellCommandToolsField(StringSequenceField):
     alias = "tools"
     default = ()
-    help = softwrap(
+    help = help_text(
         """
         Specify required executable tools that might be used.
 
@@ -416,7 +416,7 @@ class ShellCommandToolsField(StringSequenceField):
 
 class ShellCommandExtraEnvVarsField(StringSequenceField):
     alias = "extra_env_vars"
-    help = softwrap(
+    help = help_text(
         """
         Additional environment variables to include in the shell process.
         Entries are strings in the form `ENV_VAR=value` to use explicitly; or just
@@ -434,7 +434,7 @@ class ShellCommandLogOutputField(BoolField):
 class ShellCommandWorkdirField(StringField):
     alias = "workdir"
     default = "."
-    help = softwrap(
+    help = help_text(
         "Sets the current working directory of the command. \n\n"
         "Values are relative to the build root, except in the following cases:\n\n"
         "* `.` specifies the location of the `BUILD` file.\n"
@@ -447,7 +447,7 @@ class ShellCommandWorkdirField(StringField):
 class RunShellCommandWorkdirField(StringField):
     alias = "workdir"
     default = "."
-    help = softwrap(
+    help = help_text(
         "Sets the current working directory of the command that is `run`. Values that begin with "
         "`.` are relative to the directory you are running Pants from. Values that begin with `/` "
         "are from your project root."
@@ -457,7 +457,7 @@ class RunShellCommandWorkdirField(StringField):
 class ShellCommandOutputRootDirField(StringField):
     alias = "root_output_directory"
     default = "/"
-    help = softwrap(
+    help = help_text(
         "Adjusts the location of files output by this command, when consumed as a dependency.\n\n"
         "Values are relative to the build root, except in the following cases:\n\n"
         "* `.` specifies the location of the `BUILD` file.\n"
@@ -496,7 +496,7 @@ class ShellCommandTarget(Target):
         ShellCommandOutputRootDirField,
         EnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Execute any external tool for its side effects.
 
@@ -542,7 +542,7 @@ class ShellRunInSandboxTarget(Target):
         RunInSandboxStderrFilenameField,
         EnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Execute any runnable target for its side effects.
 
@@ -569,7 +569,7 @@ class ShellCommandRunTarget(Target):
         ShellCommandCommandField,
         RunShellCommandWorkdirField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Run a script in the workspace, with all dependencies packaged/copied into a chroot.
 
@@ -606,7 +606,7 @@ class ShellCommandTestTarget(Target):
         SkipShellCommandTestsField,
         ShellCommandWorkdirField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Run a script as a test via the `test` goal, with all dependencies packaged/copied available in the chroot.
 

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -14,7 +14,7 @@ from pants.engine.target import (
     Target,
     generate_multiple_sources_field_help_message,
 )
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class TerraformDependenciesField(Dependencies):
@@ -40,7 +40,7 @@ class TerraformFieldSet(FieldSet):
 class TerraformModuleTarget(Target):
     alias = "terraform_module"
     core_fields = (*COMMON_TARGET_FIELDS, TerraformDependenciesField, TerraformModuleSourcesField)
-    help = softwrap(
+    help = help_text(
         """
         A single Terraform module corresponding to a directory.
 

--- a/src/python/pants/backend/tools/preamble/subsystem.py
+++ b/src/python/pants/backend/tools/preamble/subsystem.py
@@ -7,13 +7,13 @@ from typing import Sequence
 from pants.option.option_types import DictOption, SkipOption
 from pants.option.subsystem import Subsystem
 from pants.source.filespec import FilespecMatcher
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class PreambleSubsystem(Subsystem):
     options_scope = "preamble"
     name = "preamble"
-    help = softwrap(
+    help = help_text(
         """
         Formats files with a preamble, with the preamble looked up based on path.
 

--- a/src/python/pants/core/goals/package.py
+++ b/src/python/pants/core/goals/package.py
@@ -30,7 +30,7 @@ from pants.engine.target import (
 from pants.engine.unions import UnionMembership, union
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 logger = logging.getLogger(__name__)
 
@@ -59,7 +59,7 @@ class BuiltPackage:
 
 class OutputPathField(StringField, AsyncFieldMixin):
     alias = "output_path"
-    help = softwrap(
+    help = help_text(
         f"""
         Where the built asset should be located.
 

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -58,7 +58,7 @@ from pants.option.global_options import GlobalOptions
 from pants.option.option_types import ArgsListOption, BoolOption
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +111,7 @@ class RunFieldSet(FieldSet, metaclass=ABCMeta):
 class RestartableField(BoolField):
     alias = "restartable"
     default = False
-    help = softwrap(
+    help = help_text(
         """
         If true, runs of this target with the `run` goal may be interrupted and
         restarted when its input files change.
@@ -177,7 +177,7 @@ class RunInSandboxRequest(RunRequest):
 
 class RunSubsystem(GoalSubsystem):
     name = "run"
-    help = softwrap(
+    help = help_text(
         """
         Runs a binary target.
 

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -48,7 +48,7 @@ from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -269,7 +269,7 @@ class PutativeTargets(DeduplicatedCollection[PutativeTarget]):
 
 class TailorSubsystem(GoalSubsystem):
     name = "tailor"
-    help = softwrap(
+    help = help_text(
         """
         Auto-generate BUILD file targets for new source files.
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -65,7 +65,7 @@ from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
 from pants.util.meta import classproperty
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -650,7 +650,7 @@ class TestTimeoutField(IntField, metaclass=ABCMeta):
     alias = "timeout"
     required = False
     valid_numbers = ValidNumbers.positive_only
-    help = softwrap(
+    help = help_text(
         """
         A timeout (in seconds) used by each test file belonging to this target.
 
@@ -676,7 +676,7 @@ class TestTimeoutField(IntField, metaclass=ABCMeta):
 
 class TestExtraEnvVarsField(StringSequenceField, metaclass=ABCMeta):
     alias = "extra_env_vars"
-    help = softwrap(
+    help = help_text(
         """
          Additional environment variables to include in test processes.
 
@@ -1010,7 +1010,7 @@ def _unsupported_debug_adapter_rules(cls: type[TestRequest]) -> Iterable:
 
 class RuntimePackageDependenciesField(SpecialCasedDependencies):
     alias = "runtime_package_dependencies"
-    help = softwrap(
+    help = help_text(
         f"""
         Addresses to targets that can be built with the `{bin_name()} package` goal and whose
         resulting artifacts should be included in the test run.

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -48,7 +48,7 @@ from pants.option.option_types import BoolOption, EnumOption
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ class DeprecationFixerRequest(RewrittenBuildFileRequest):
 
 class UpdateBuildFilesSubsystem(GoalSubsystem):
     name = "update-build-files"
-    help = softwrap(
+    help = help_text(
         f"""
         Format and fix safe deprecations in BUILD files.
 

--- a/src/python/pants/core/subsystems/debug_adapter.py
+++ b/src/python/pants/core/subsystems/debug_adapter.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from pants.option.option_types import IntOption, StrOption
 from pants.option.subsystem import Subsystem
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 
 class DebugAdapterSubsystem(Subsystem):
     options_scope = "debug-adapter"
-    help = softwrap(
+    help = help_text(
         """
         Options used to configure and launch a Debug Adapter server.
 

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -19,14 +19,14 @@ from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.rules import Get, _uncacheable_rule, collect_rules, rule
 from pants.option.option_types import StrListOption
 from pants.option.subsystem import Subsystem
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
 
 class PythonBootstrapSubsystem(Subsystem):
     options_scope = "python-bootstrap"
-    help = softwrap(
+    help = help_text(
         """
         Options used to locate Python interpreters used by all Pants backends.
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -63,7 +63,7 @@ from pants.engine.unions import UnionRule
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 # -----------------------------------------------------------------------------------------------
 # `per_platform` object
@@ -200,7 +200,7 @@ class AssetSourceField(SingleSourceField):
     value: str | http_source | per_platform[http_source]  # type: ignore[assignment]
     # @TODO: Don't document http_source, link to it once https://github.com/pantsbuild/pants/issues/14832
     # is implemented.
-    help = softwrap(
+    help = help_text(
         """
         The source of this target.
 
@@ -331,7 +331,7 @@ class FileDependenciesField(Dependencies):
 class FileTarget(Target):
     alias = "file"
     core_fields = (*COMMON_TARGET_FIELDS, FileDependenciesField, FileSourceField)
-    help = softwrap(
+    help = help_text(
         """
         A single loose file that lives outside of code packages.
 
@@ -402,7 +402,7 @@ class RelocatedFilesSourcesField(MultipleSourcesField):
 class RelocatedFilesOriginalTargetsField(SpecialCasedDependencies):
     alias = "files_targets"
     required = True
-    help = softwrap(
+    help = help_text(
         """
         Addresses to the original `file` and `files` targets that you want to relocate, such as
         `['//:json_files']`.
@@ -416,7 +416,7 @@ class RelocatedFilesOriginalTargetsField(SpecialCasedDependencies):
 class RelocatedFilesSrcField(StringField):
     alias = "src"
     required = True
-    help = softwrap(
+    help = help_text(
         """
         The original prefix that you want to replace, such as `src/resources`.
 
@@ -429,7 +429,7 @@ class RelocatedFilesSrcField(StringField):
 class RelocatedFilesDestField(StringField):
     alias = "dest"
     required = True
-    help = softwrap(
+    help = help_text(
         """
         The new prefix that you want to add to the beginning of the path, such as `data`.
 
@@ -448,7 +448,7 @@ class RelocatedFiles(Target):
         RelocatedFilesSrcField,
         RelocatedFilesDestField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Loose files with path manipulation applied.
 
@@ -550,7 +550,7 @@ class ResourceSourceField(AssetSourceField):
 class ResourceTarget(Target):
     alias = "resource"
     core_fields = (*COMMON_TARGET_FIELDS, ResourceDependenciesField, ResourceSourceField)
-    help = softwrap(
+    help = help_text(
         """
         A single resource file embedded in a code package and accessed in a
         location-independent manner.
@@ -633,7 +633,7 @@ class GenericTargetDependenciesField(Dependencies):
 class GenericTarget(Target):
     alias = "target"
     core_fields = (*COMMON_TARGET_FIELDS, GenericTargetDependenciesField)
-    help = softwrap(
+    help = help_text(
         """
         A generic target with no specific type.
 
@@ -720,7 +720,7 @@ class TargetGeneratorSourcesHelperTarget(Target):
 
     alias = "_generator_sources_helper"
     core_fields = (*COMMON_TARGET_FIELDS, TargetGeneratorSourcesHelperSourcesField)
-    help = softwrap(
+    help = help_text(
         """
         A private helper target type used by some target generators.
 
@@ -737,7 +737,7 @@ class TargetGeneratorSourcesHelperTarget(Target):
 
 class ArchivePackagesField(SpecialCasedDependencies):
     alias = "packages"
-    help = softwrap(
+    help = help_text(
         f"""
         Addresses to any targets that can be built with `{bin_name()} package`, e.g.
         `["project:app"]`.\n\nPants will build the assets as if you had run `{bin_name()} package`.
@@ -751,7 +751,7 @@ class ArchivePackagesField(SpecialCasedDependencies):
 
 class ArchiveFilesField(SpecialCasedDependencies):
     alias = "files"
-    help = softwrap(
+    help = help_text(
         """
         Addresses to any `file`, `files`, or `relocated_files` targets to include in the
         archive, e.g. `["resources:logo"]`.
@@ -871,7 +871,7 @@ class LockfileDependenciesField(Dependencies):
 class LockfileTarget(Target):
     alias = "_lockfile"
     core_fields = (*COMMON_TARGET_FIELDS, LockfileSourceField, LockfileDependenciesField)
-    help = softwrap(
+    help = help_text(
         """
         A target for lockfiles in order to include them in the dependency graph of other targets.
 

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -43,14 +43,14 @@ from pants.option.subsystem import Subsystem
 from pants.util.enums import match
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized
-from pants.util.strutil import bullet_list, softwrap
+from pants.util.strutil import bullet_list, help_text, softwrap
 
 logger = logging.getLogger(__name__)
 
 
 class EnvironmentsSubsystem(Subsystem):
     options_scope = "environments-preview"
-    help = softwrap(
+    help = help_text(
         """
         A highly experimental subsystem to allow setting environment variables and executable
         search paths for different environments, e.g. macOS vs. Linux.
@@ -93,7 +93,7 @@ class EnvironmentField(StringField):
     alias = "environment"
     default = LOCAL_ENVIRONMENT_MATCHER
     value: str
-    help = softwrap(
+    help = help_text(
         f"""
         Specify which environment target to consume environment-sensitive options from.
 
@@ -118,7 +118,7 @@ class CompatiblePlatformsField(StringSequenceField):
     default = tuple(plat.value for plat in Platform)
     valid_choices = Platform
     value: tuple[str, ...]
-    help = softwrap(
+    help = help_text(
         f"""
         Which platforms this environment can be used with.
 
@@ -133,7 +133,7 @@ class CompatiblePlatformsField(StringSequenceField):
 
 
 class LocalFallbackEnvironmentField(FallbackEnvironmentField):
-    help = softwrap(
+    help = help_text(
         f"""
         The environment to fallback to when this local environment cannot be used because the
         field `{CompatiblePlatformsField.alias}` is not compatible with the local host.
@@ -154,7 +154,7 @@ class LocalFallbackEnvironmentField(FallbackEnvironmentField):
 class LocalEnvironmentTarget(Target):
     alias = "local_environment"
     core_fields = (*COMMON_TARGET_FIELDS, CompatiblePlatformsField, LocalFallbackEnvironmentField)
-    help = softwrap(
+    help = help_text(
         f"""
         Configuration of a local execution environment for specific platforms.
 
@@ -179,7 +179,7 @@ class DockerImageField(StringField):
     alias = "image"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         The docker image ID to use when this environment is loaded.
 
@@ -198,7 +198,7 @@ class DockerPlatformField(StringField):
     alias = "platform"
     default = None
     valid_choices = Platform
-    help = softwrap(
+    help = help_text(
         """
         If set, Docker will always use the specified platform when pulling and running the image.
 
@@ -236,7 +236,7 @@ def docker_platform_field_default_factory(
 
 
 class DockerFallbackEnvironmentField(FallbackEnvironmentField):
-    help = softwrap(
+    help = help_text(
         f"""
         The environment to fallback to when this Docker environment cannot be used because either
         the global option `--docker-execution` is false, or the
@@ -258,7 +258,7 @@ class DockerEnvironmentTarget(Target):
         DockerPlatformField,
         DockerFallbackEnvironmentField,
     )
-    help = softwrap(
+    help = help_text(
         """
         Configuration of a Docker environment used for building your code.
 
@@ -285,7 +285,7 @@ class RemoteExtraPlatformPropertiesField(StringSequenceField):
     alias = "extra_platform_properties"
     default = ()
     value: tuple[str, ...]
-    help = softwrap(
+    help = help_text(
         """
         Platform properties to set on remote execution requests.
 
@@ -298,7 +298,7 @@ class RemoteExtraPlatformPropertiesField(StringSequenceField):
 
 
 class RemoteFallbackEnvironmentField(FallbackEnvironmentField):
-    help = softwrap(
+    help = help_text(
         f"""
         The environment to fallback to when remote execution is disabled via the global option
         `--remote-execution`.
@@ -318,7 +318,7 @@ class RemoteFallbackEnvironmentField(FallbackEnvironmentField):
 class RemoteEnvironmentCacheBinaryDiscovery(BoolField):
     alias = "cache_binary_discovery"
     default = False
-    help = softwrap(
+    help = help_text(
         f"""
         If true, will cache system binary discovery, e.g. finding Python interpreters.
 
@@ -346,7 +346,7 @@ class RemoteEnvironmentTarget(Target):
         RemoteFallbackEnvironmentField,
         RemoteEnvironmentCacheBinaryDiscovery,
     )
-    help = softwrap(
+    help = help_text(
         """
         Configuration of a remote execution environment used for building your code.
 

--- a/src/python/pants/core/util_rules/wrap_source.py
+++ b/src/python/pants/core/util_rules/wrap_source.py
@@ -27,7 +27,7 @@ from pants.engine.target import (
     Targets,
 )
 from pants.engine.unions import UnionRule
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +55,7 @@ class WrapSourceInputsField(SpecialCasedDependencies):
 class WrapSourceOutputsField(StringSequenceField):
     alias = "outputs"
     required = False
-    help = softwrap(
+    help = help_text(
         "The output files that are made available in the new context by this target. If not "
         "specified, the target will capture all files with the expected extensions for this "
         "source format: see the help for the target for the specific extensions. If no extensions "
@@ -127,7 +127,7 @@ def wrap_source_rule_and_target(
             WrapSourceInputsField,
             WrapSourceOutputsField,
         )
-        help = softwrap(
+        help = help_text(
             "Allow files and sources produced by the targets specified by `inputs` to be consumed "
             f"by rules that specifically expect a `{source_field_type.__name__}`.\n\n"
             f"Note that this target does not modify the files in any way. {outputs_help}\n\n"

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -64,7 +64,7 @@ from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_method, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import bullet_list, pluralize, softwrap
+from pants.util.strutil import bullet_list, help_text, pluralize, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -2174,7 +2174,7 @@ class OptionalSingleSourceField(SourcesField, StringField):
     """
 
     alias = "source"
-    help = softwrap(
+    help = help_text(
         """
         A single file that belongs to this target.
 
@@ -2469,8 +2469,9 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
     """
 
     alias = "dependencies"
-    help = softwrap(
-        f"""
+    help = help_text(
+        softwrap(
+            f"""
         Addresses to other targets that this target depends on, e.g.
         ['helloworld/subdir:lib', 'helloworld/main.py:lib', '3rdparty:reqs#django'].
 
@@ -2491,6 +2492,7 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
         `['!helloworld/subdir:lib', '!./sibling.txt']`. Ignores are intended for false positives
         with dependency inference; otherwise, simply leave off the dependency from the BUILD file.
         """
+        )
     )
     supports_transitive_excludes = False
 
@@ -2789,7 +2791,7 @@ class SpecialCasedDependencies(StringSequenceField, AsyncFieldMixin):
 
 class Tags(StringSequenceField):
     alias = "tags"
-    help = softwrap(
+    help = help_text(
         f"""
         Arbitrary strings to describe a target.
 
@@ -2801,7 +2803,7 @@ class Tags(StringSequenceField):
 
 class DescriptionField(StringField):
     alias = "description"
-    help = softwrap(
+    help = help_text(
         f"""
         A human-readable description of the target.
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -19,6 +19,7 @@ from enum import Enum
 from pathlib import PurePath
 from typing import (
     Any,
+    Callable,
     ClassVar,
     Dict,
     Generic,
@@ -142,7 +143,7 @@ class Field:
 
     # Subclasses must define these.
     alias: ClassVar[str]
-    help: ClassVar[str]
+    help: ClassVar[str | Callable[[], str]]
 
     # Subclasses must define at least one of these two.
     default: ClassVar[ImmutableValue]
@@ -362,7 +363,7 @@ class Target:
     # Subclasses must define these
     alias: ClassVar[str]
     core_fields: ClassVar[Tuple[Type[Field], ...]]
-    help: ClassVar[str]
+    help: ClassVar[str | Callable[[], str]]
 
     removal_version: ClassVar[str | None] = None
     removal_hint: ClassVar[str | None] = None

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -42,7 +42,7 @@ from pants.option.options import Options
 from pants.option.parser import OptionValueHistory, Parser
 from pants.option.scope import ScopeInfo
 from pants.util.frozendict import LazyFrozenDict
-from pants.util.strutil import first_paragraph
+from pants.util.strutil import first_paragraph, strval
 
 
 class HelpJSONEncoder(json.JSONEncoder):
@@ -222,7 +222,7 @@ class TargetFieldHelpInfo:
         return cls(
             alias=field.alias,
             provider=provider,
-            description=field.help,
+            description=strval(field.help),
             type_hint=type_hint,
             required=field.required,
             default=(
@@ -256,11 +256,12 @@ class TargetTypeHelpInfo:
             # TargetGenerator, they are legal arguments... and that is what most help consumers
             # are interested in.
             fields.extend(target_type.moved_fields)
+        helpstr = strval(target_type.help)
         return cls(
             alias=target_type.alias,
             provider=provider,
-            summary=first_paragraph(target_type.help),
-            description=target_type.help,
+            summary=first_paragraph(helpstr),
+            description=helpstr,
             fields=tuple(
                 TargetFieldHelpInfo.create(
                     field,

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -254,7 +254,7 @@ def test_get_all_help_info():
     class QuxField(StringField):
         alias = "qux"
         default = "blahblah"
-        help = "A qux string."
+        help = lambda: "A qux string."
 
     class QuuxField(IntField):
         alias = "quux"

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -20,6 +20,7 @@ from pants.option.ranked_value import Rank, RankedValue
 from pants.option.scope import GLOBAL_SCOPE
 from pants.option.subsystem import Subsystem
 from pants.util.logging import LogLevel
+from pants.util.strutil import help_text
 
 
 class LogLevelSimple(Enum):
@@ -229,7 +230,7 @@ def test_grouping():
 def test_get_all_help_info():
     class Global(Subsystem):
         options_scope = GLOBAL_SCOPE
-        help = "Global options."
+        help = help_text("Global options.")
 
         opt1 = IntOption(default=42, help="Option 1")
         # This is special in having a short option `-l`. Make sure it works.

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 
 from pants.option.option_types import BoolOption, DictOption, IntOption, StrListOption, StrOption
 from pants.option.subsystem import Subsystem
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text, softwrap
 
 
 class JvmSubsystem(Subsystem):
     options_scope = "jvm"
-    help = softwrap(
+    help = help_text(
         """
         Options for general JVM functionality.
 

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 from abc import ABC, ABCMeta, abstractmethod
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, Optional, Tuple, Type, Union
+from typing import Callable, ClassVar, Iterable, Optional, Tuple, Type, Union
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
@@ -37,7 +37,7 @@ from pants.jvm.subsystems import JvmSubsystem
 from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized
-from pants.util.strutil import bullet_list, pluralize, softwrap
+from pants.util.strutil import bullet_list, help_text, pluralize, softwrap
 
 # -----------------------------------------------------------------------------------------------
 # Generic resolve support fields
@@ -51,7 +51,7 @@ class JvmDependenciesField(Dependencies):
 class JvmResolveField(StringField, AsyncFieldMixin):
     alias = "resolve"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         The resolve from `[jvm].resolves` to use when compiling this target.
 
@@ -75,7 +75,7 @@ class JvmResolveField(StringField, AsyncFieldMixin):
 class JvmJdkField(StringField):
     alias = "jdk"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         The major version of the JDK that this target should be built with. If not defined,
         will default to `[jvm].default_source_jdk`.
@@ -101,7 +101,7 @@ class JvmMainClassNameField(StringField):
     alias = "main"
     required = False
     default = None
-    help = softwrap(
+    help = help_text(
         """
         `.`-separated name of the JVM class containing the `main()` method to be called when
         executing this target. If not supplied, this will be calculated automatically, either by
@@ -144,7 +144,7 @@ class JvmArtifactGroupField(StringField):
     alias = "group"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         The 'group' part of a Maven-compatible coordinate to a third-party JAR artifact.
 
@@ -157,7 +157,7 @@ class JvmArtifactArtifactField(StringField):
     alias = "artifact"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         The 'artifact' part of a Maven-compatible coordinate to a third-party JAR artifact.
 
@@ -170,7 +170,7 @@ class JvmArtifactVersionField(StringField):
     alias = "version"
     required = True
     value: str
-    help = softwrap(
+    help = help_text(
         """
         The 'version' part of a Maven-compatible coordinate to a third-party JAR artifact.
 
@@ -182,7 +182,7 @@ class JvmArtifactVersionField(StringField):
 class JvmArtifactUrlField(StringField):
     alias = "url"
     required = False
-    help = softwrap(
+    help = help_text(
         """
         A URL that points to the location of this artifact.
 
@@ -199,7 +199,7 @@ class JvmArtifactUrlField(StringField):
 class JvmArtifactJarSourceField(OptionalSingleSourceField):
     alias = "jar"
     expected_file_extensions = (".jar",)
-    help = softwrap(
+    help = help_text(
         """
         A local JAR file that provides this artifact to the lockfile resolver, instead of a
         Maven repository.
@@ -229,7 +229,7 @@ class JvmArtifactJarSourceField(OptionalSingleSourceField):
 
 class JvmArtifactPackagesField(StringSequenceField):
     alias = "packages"
-    help = softwrap(
+    help = help_text(
         f"""
         The JVM packages this artifact provides for the purposes of dependency inference.
 
@@ -252,7 +252,7 @@ class JvmArtifactPackagesField(StringSequenceField):
 
 class JvmProvidesTypesField(StringSequenceField):
     alias = "experimental_provides_types"
-    help = softwrap(
+    help = help_text(
         """
         Signals that the specified types should be fulfilled by these source files during
         dependency inference.
@@ -269,7 +269,7 @@ class JvmProvidesTypesField(StringSequenceField):
 
 class JvmArtifactExcludeDependenciesField(StringSequenceField):
     alias = "excludes"
-    help = softwrap(
+    help = help_text(
         """
         A list of unversioned coordinates (i.e. `group:artifact`) that should be excluded
         as dependencies when this artifact is resolved.
@@ -285,7 +285,7 @@ class JvmArtifactExcludeDependenciesField(StringSequenceField):
 
 
 class JvmArtifactResolveField(JvmResolveField):
-    help = softwrap(
+    help = help_text(
         """
         The resolve from `[jvm].resolves` that this artifact should be included in.
 
@@ -330,7 +330,7 @@ class JvmArtifactTarget(Target):
         JvmJdkField,
         JvmMainClassNameField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A third-party JVM artifact, as identified by its Maven-compatible coordinate.
 
@@ -375,7 +375,7 @@ class JunitTestExtraEnvVarsField(TestExtraEnvVarsField):
 class JvmRequiredMainClassNameField(JvmMainClassNameField):
     required = True
     default = None
-    help = softwrap(
+    help = help_text(
         """
         `.`-separated name of the JVM class containing the `main()` method to be called when
         executing this JAR.
@@ -395,7 +395,7 @@ class JvmShadingRule(ABC):
     """
 
     alias: ClassVar[str]
-    help: ClassVar[str]
+    help: ClassVar[str | Callable[[], str]]
 
     @abstractmethod
     def encode(self) -> str:
@@ -443,7 +443,7 @@ class JvmShadingRenameRule(JvmShadingRule):
 @dataclass(frozen=True, repr=False)
 class JvmShadingRelocateRule(JvmShadingRule):
     alias = "shading_relocate"
-    help = softwrap(
+    help = help_text(
         """
         Relocates the classes under the given `package` into the new package name.
         The default target package is `__shaded_by_pants__` if none provided in
@@ -490,7 +490,7 @@ class JvmShadingZapRule(JvmShadingRule):
 @dataclass(frozen=True, repr=False)
 class JvmShadingKeepRule(JvmShadingRule):
     alias = "shading_keep"
-    help = softwrap(
+    help = help_text(
         """
         Keeps in the final artifact the occurrences of the `pattern`
         (and removes anything else).
@@ -604,7 +604,7 @@ class DeployJarDuplicateRule:
 
 class DeployJarDuplicatePolicyField(SequenceField[DeployJarDuplicateRule]):
     alias = "duplicate_policy"
-    help = softwrap(
+    help = help_text(
         f"""
         A list of the rules to apply when duplicate file entries are found in the final
         assembled JAR file.
@@ -688,7 +688,7 @@ class DeployJarTarget(Target):
         DeployJarDuplicatePolicyField,
         DeployJarShadingRulesField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A `jar` file with first and third-party code bundled for deploys.
 
@@ -715,7 +715,7 @@ class JvmWarDescriptorAddressField(SingleSourceField):
 
 class JvmWarContentField(SpecialCasedDependencies):
     alias = "content"
-    help = softwrap(
+    help = help_text(
         """
         A list of addresses to `resources` and `files` targets with content to place in the
         document root of this WAR file.
@@ -740,7 +740,7 @@ class JvmWarTarget(Target):
         JvmWarShadingRulesField,
         OutputPathField,
     )
-    help = softwrap(
+    help = help_text(
         """
         A JSR 154 "web application archive" (or "war") with first-party and third-party code bundled for
         deploys in Java Servlet containers.

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -7,7 +7,7 @@ import functools
 import inspect
 import re
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Any, ClassVar, Iterable, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Iterable, TypeVar, cast
 
 from pants import ox
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
@@ -66,7 +66,7 @@ class Subsystem(metaclass=_SubsystemMeta):
     """
 
     options_scope: str
-    help: ClassVar[str]
+    help: ClassVar[str | Callable[[], str]]
 
     # Subclasses may override these to specify a deprecated former name for this Subsystem's scope.
     # Option values can be read from the deprecated scope, but a deprecation warning will be issued.

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 import shlex
 import textwrap
-from typing import Iterable
+from typing import Callable, Iterable
 
 
 def ensure_binary(text_or_binary: bytes | str) -> bytes:
@@ -290,3 +290,10 @@ def fmt_memory_size(value: int, *, units: Iterable[str] = _MEMORY_UNITS) -> str:
         unit_idx += 1
 
     return f"{int(amount)}{units[unit_idx]}"
+
+
+def strval(val: str | Callable[[], str]) -> str:
+    if isinstance(val, str):
+        return val
+    else:
+        return val()

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -293,10 +293,7 @@ def fmt_memory_size(value: int, *, units: Iterable[str] = _MEMORY_UNITS) -> str:
 
 
 def strval(val: str | Callable[[], str]) -> str:
-    if isinstance(val, str):
-        return val
-    else:
-        return val()
+    return val if isinstance(val, str) else val()
 
 
 def help_text(val: str | Callable[[], str]) -> str | Callable[[], str]:

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -297,3 +297,16 @@ def strval(val: str | Callable[[], str]) -> str:
         return val
     else:
         return val()
+
+
+def help_text(val: str | Callable[[], str]) -> str | Callable[[], str]:
+    """Convenience method for defining an optionally lazy-evaluated softwrapped help string.
+
+    This exists because `mypy` does not respect the type hints defined on base `Field` and `Target`
+    classes.
+    """
+    # This can go away when https://github.com/python/mypy/issues/14702 is fixed
+    if isinstance(val, str):
+        return softwrap(val)
+    else:
+        return lambda: softwrap(val())  # type: ignore[operator]

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -22,7 +22,7 @@ from pants.option.option_value_container import OptionValueContainer
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import doc_url
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import softwrap
+from pants.util.strutil import help_text
 from pants.vcs.git import GitWorktree
 
 
@@ -141,7 +141,7 @@ class ChangedOptions:
 
 class Changed(Subsystem):
     options_scope = "changed"
-    help = softwrap(
+    help = help_text(
         f"""
         Tell Pants to detect what files and targets have changed from Git.
 


### PR DESCRIPTION
This allows for lazilly-deferred `f`-strings to be used in `Target` and `Field` help messages, allowing for forward-referencing classes in the same module.

Due to some [annoyance in `mypy`](https://github.com/python/mypy/issues/14702), this also adds a `help_text` helper function that ensures that types aren't narrowed by subclasses of `Field` or `Target`. This, unfortunately, represents the bulk of this PR.