### PR TITLE
Prep for having build file symbol info.

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -95,7 +95,7 @@ async def evaluate_preludes(
     for file_content in prelude_digest_contents:
         try:
             file_content_str = file_content.content.decode()
-            content = compile(file_content_str, file_content.path, "exec")
+            content = compile(file_content_str, file_content.path, "exec", dont_inherit=True)
             exec(content, globals, locals)
         except Exception as e:
             raise Exception(f"Error parsing prelude file {file_content.path}: {e}")
@@ -107,7 +107,7 @@ async def evaluate_preludes(
     # Ensure preludes can reference each other by populating the shared globals object with references
     # to the other symbols
     globals.update(locals)
-    return BuildFilePreludeSymbols(FrozenDict(locals))
+    return BuildFilePreludeSymbols.from_namespace(locals)
 
 
 @rule

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -71,7 +71,7 @@ def test_parse_address_family_empty() -> None:
             ),
             BootstrapStatus(in_progress=False),
             BuildFileOptions(("BUILD",)),
-            BuildFilePreludeSymbols(FrozenDict(), FrozenDict()),
+            BuildFilePreludeSymbols(FrozenDict()),
             AddressFamilyDir("/dev/null"),
             RegisteredTargetTypes({}),
             UnionMembership({}),

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -42,7 +42,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         path,
         build_file,
         parser,
-        BuildFilePreludeSymbols(FrozenDict()),
+        BuildFilePreludeSymbols(FrozenDict(), FrozenDict()),
         EnvironmentVars({}),
         False,
         BuildFileDefaultsParserState.create(

--- a/src/python/pants/engine/internals/mapper_test.py
+++ b/src/python/pants/engine/internals/mapper_test.py
@@ -42,7 +42,7 @@ def parse_address_map(build_file: str, *, ignore_unrecognized_symbols: bool = Fa
         path,
         build_file,
         parser,
-        BuildFilePreludeSymbols(FrozenDict(), FrozenDict()),
+        BuildFilePreludeSymbols(FrozenDict()),
         EnvironmentVars({}),
         False,
         BuildFileDefaultsParserState.create(

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from difflib import get_close_matches
 from io import StringIO
 from pathlib import PurePath
-from typing import Any, Callable, Mapping
+from typing import Any, Callable, Mapping, TypeVar
 
 from pants.base.deprecated import warn_or_error
 from pants.base.exceptions import MappingError
@@ -27,6 +27,8 @@ from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.memo import memoized_property
 from pants.util.strutil import softwrap
+
+T = TypeVar("T")
 
 
 @dataclass(frozen=True)
@@ -78,6 +80,7 @@ class ParseState(threading.local):
         self._filepath: str | None = None
         self._target_adaptors: list[TargetAdaptor] = []
         self._is_bootstrap: bool | None = None
+        self._env_vars: EnvironmentVars | None = None
 
     def reset(
         self,
@@ -86,38 +89,51 @@ class ParseState(threading.local):
         defaults: BuildFileDefaultsParserState,
         dependents_rules: BuildFileDependencyRulesParserState | None,
         dependencies_rules: BuildFileDependencyRulesParserState | None,
+        env_vars: EnvironmentVars,
     ) -> None:
         self._is_bootstrap = is_bootstrap
         self._defaults = defaults
         self._dependents_rules = dependents_rules
         self._dependencies_rules = dependencies_rules
+        self._env_vars = env_vars
         self._filepath = filepath
         self._target_adaptors.clear()
 
     def add(self, target_adaptor: TargetAdaptor) -> None:
         self._target_adaptors.append(target_adaptor)
 
-    def filepath(self) -> str:
-        if self._filepath is None:
-            raise AssertionError(
-                "The BUILD file filepath was accessed before being set. This indicates a "
-                "programming error in Pants. Please file a bug report at "
-                "https://github.com/pantsbuild/pants/issues/new."
-            )
-        return self._filepath
-
     def parsed_targets(self) -> list[TargetAdaptor]:
         return list(self._target_adaptors)
 
+    def _prelude_check(self, name: str, value: T | None, closure_supported: bool = True) -> T:
+        if value is not None:
+            return value
+        note = (
+            (
+                " If used in a prelude file, it must be within a function that is called from a BUILD"
+                " file."
+            )
+            if closure_supported
+            else ""
+        )
+        raise NameError(
+            softwrap(
+                f"""
+                The BUILD file {name} may only be used in BUILD files.{note}
+                """
+            )
+        )
+
+    def filepath(self) -> str:
+        return self._prelude_check("`build_file_dir`", self._filepath)
+
     @property
     def defaults(self) -> BuildFileDefaultsParserState:
-        if self._defaults is None:
-            raise AssertionError(
-                "The BUILD file __defaults__ was accessed before being set. This indicates a "
-                "programming error in Pants. Please file a bug report at "
-                "https://github.com/pantsbuild/pants/issues/new."
-            )
-        return self._defaults
+        return self._prelude_check("`__defaults__`", self._defaults)
+
+    @property
+    def env_vars(self) -> EnvironmentVars:
+        return self._prelude_check("`env`", self._env_vars, closure_supported=False)
 
     @property
     def is_bootstrap(self) -> bool:
@@ -127,6 +143,9 @@ class ParseState(threading.local):
                 "https://github.com/pantsbuild/pants/issues/new"
             )
         return self._is_bootstrap
+
+    def get_env(self, name: str, *args, **kwargs) -> Any:
+        return self.env_vars.get(name, *args, **kwargs)
 
     def set_defaults(
         self, *args: SetDefaultsT, ignore_unknown_fields: bool = False, **kwargs
@@ -251,6 +270,7 @@ class Parser:
         symbols: dict[str, Any] = {
             **object_aliases.objects,
             "build_file_dir": lambda: PurePath(parse_state.filepath()).parent,
+            "env": parse_state.get_env,
             "__defaults__": parse_state.set_defaults,
             "__dependents_rules__": parse_state.set_dependents_rules,
             "__dependencies_rules__": parse_state.set_dependencies_rules,
@@ -286,10 +306,10 @@ class Parser:
             defaults=defaults,
             dependents_rules=dependents_rules,
             dependencies_rules=dependencies_rules,
+            env_vars=env_vars,
         )
 
         global_symbols: dict[str, Any] = {
-            "env": env_vars.get,
             **self._symbols,
             **extra_symbols.symbols,
         }
@@ -315,6 +335,7 @@ class Parser:
                         defaults=defaults,
                         dependents_rules=dependents_rules,
                         dependencies_rules=dependencies_rules,
+                        env_vars=env_vars,
                     )
                     continue
                 break

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -41,7 +41,7 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
         parser.parse(
             "dir/BUILD",
             "\nx = 'hello'\n\nimport os\n",
-            BuildFilePreludeSymbols(FrozenDict(), FrozenDict()),
+            BuildFilePreludeSymbols(FrozenDict()),
             EnvironmentVars({}),
             False,
             defaults_parser_state,
@@ -67,7 +67,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             object_aliases=build_file_aliases,
             ignore_unrecognized_symbols=False,
         )
-        prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}), FrozenDict())
+        prelude_symbols = BuildFilePreludeSymbols.from_namespace(FrozenDict({"prelude": 0}))
         fmt_extra_sym = str(extra_targets)[1:-1] + (", ") if len(extra_targets) != 0 else ""
         with pytest.raises(ParseError) as exc:
             parser.parse(

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -41,7 +41,7 @@ def test_imports_banned(defaults_parser_state: BuildFileDefaultsParserState) -> 
         parser.parse(
             "dir/BUILD",
             "\nx = 'hello'\n\nimport os\n",
-            BuildFilePreludeSymbols(FrozenDict()),
+            BuildFilePreludeSymbols(FrozenDict(), FrozenDict()),
             EnvironmentVars({}),
             False,
             defaults_parser_state,
@@ -67,7 +67,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             object_aliases=build_file_aliases,
             ignore_unrecognized_symbols=False,
         )
-        prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}))
+        prelude_symbols = BuildFilePreludeSymbols(FrozenDict({"prelude": 0}), FrozenDict())
         fmt_extra_sym = str(extra_targets)[1:-1] + (", ") if len(extra_targets) != 0 else ""
         with pytest.raises(ParseError) as exc:
             parser.parse(


### PR DESCRIPTION
Work towards #18117 
Most notably https://github.com/pantsbuild/pants/discussions/18117#discussioncomment-4887812

Also improved error feedback in case of misuse of symbols in prelude files.

Commits independently reviewable.