### PR TITLE
Deprecates `experimental_run_shell_command` in favour of `run_shell_command`

### DIFF
--- a/docs/markdown/Helm/helm-deployments.md
+++ b/docs/markdown/Helm/helm-deployments.md
@@ -279,7 +279,7 @@ data:
 type: Opaque
 ```
 ```python src/deploy/BUILD
-experimental_run_shell_command(
+run_shell_command(
   name="vals",
   command="vals eval -f -",
 )
@@ -290,7 +290,7 @@ helm_deployment(
 )
 ```
 
-In the previous example we define a `shell_command` target that will invoke the `vals eval` command (`vals` needs to be installed in the local machine) as part of the Helm post-rendering machinery, which will result on the `ref+vault` reference being replaced by the actual value stored in Vault at the given path.
+In the previous example we define a `run_shell_command` target that will invoke the `vals eval` command (`vals` needs to be installed in the local machine) as part of the Helm post-rendering machinery, which will result on the `ref+vault` reference being replaced by the actual value stored in Vault at the given path.
 
 > 📘 Using multiple post-renderers
 >

--- a/docs/markdown/Shell/run-shell-commands.md
+++ b/docs/markdown/Shell/run-shell-commands.md
@@ -48,9 +48,9 @@ In case there are resulting files that should be captured and passed to any cons
 > 
 > We are gathering feedback on this target before we promote it from its experimental status. Please reach out to us on [Slack](doc:getting-help) or [GitHub](https://github.com/pantsbuild/pants) with your ideas or issues.
 
-The `experimental_run_shell_command` target
+The `run_shell_command` target
 -------------------------------------------
 
-Unlike `shell_command`, the [`experimental_run_shell_command` target](doc:reference-experimental_run_shell_command) runs directly in your workspace, without sandboxing.
+Unlike `shell_command`, the [`run_shell_command` target](doc:reference-run_shell_command) runs directly in your workspace, without sandboxing.
 
 This target type allows you to formalize the Pants dependencies of shell scripts, and track when their impact on your workspace might have changed. But since its outputs cannot be captured, it must be a root target in your build graph (i.e.: it may not be consumed by other targets).

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -276,7 +276,7 @@ def test_use_simple_extra_post_renderer(rule_runner: RuleRunner) -> None:
                 """\
               shell_sources(name="scripts")
 
-              experimental_run_shell_command(
+              run_shell_command(
                 name="custom_post_renderer",
                 command="src/shell/my-script.sh",
                 execution_dependencies=[":scripts"]

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -408,7 +408,9 @@ class ShellCommandTarget(Target):
 
 
 class ShellCommandRunTarget(Target):
-    alias = "experimental_run_shell_command"
+    alias = "run_shell_command"
+    deprecated_alias = "run_shell_command"
+    deprecated_alias_removal_version = "2.18.0.dev0"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ShellCommandExecutionDependenciesField,
@@ -421,7 +423,7 @@ class ShellCommandRunTarget(Target):
 
         Example BUILD file:
 
-            experimental_run_shell_command(
+            run_shell_command(
                 command="./scripts/my-script.sh --data-files-dir={chroot}",
                 execution_dependencies=["src/project/files:data"],
             )
@@ -468,7 +470,7 @@ class ShellCommandTestTarget(Target):
         The `command` may use either `{chroot}` on the command line, or the `$CHROOT`
         environment variable to get the root directory for where any dependencies are located.
 
-        In contrast to the `experimental_run_shell_command`, this target is intended to run shell commands as tests
+        In contrast to the `run_shell_command`, this target is intended to run shell commands as tests
         and will only run them via the `test` goal.
         """
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command_integration_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_integration_test.py
@@ -10,7 +10,7 @@ def test_passthrough_args() -> None:
     sources = {
         "src/BUILD": dedent(
             """\
-            experimental_run_shell_command(
+            run_shell_command(
                 name="args-test",
                 command='echo "cmd name (arg 0)=$0, args:$@"',
             )

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -547,12 +547,12 @@ def test_run_shell_command_request(rule_runner: RuleRunner) -> None:
         {
             "src/BUILD": dedent(
                 """\
-                experimental_run_shell_command(
+                run_shell_command(
                   name="test",
                   command="some cmd string",
                 )
 
-                experimental_run_shell_command(
+                run_shell_command(
                   name="cd-test",
                   command="some cmd string",
                   workdir="src/with space'n quote",

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -103,7 +103,7 @@ async def resolve_execution_environment(
         execution_dependencies = Addresses()
         warn_or_error(
             "2.17.0.dev0",
-            ("Using `dependencies` to specify execution-time dependencies for `shell_command` "),
+            "Using `dependencies` to specify execution-time dependencies for `shell_command` ",
             (
                 "To clear this warning, use the `output_dependencies` and `execution_dependencies`"
                 "fields. Set `execution_dependencies=()` if you have no execution-time "

--- a/testprojects/src/python/BUILD
+++ b/testprojects/src/python/BUILD
@@ -19,7 +19,7 @@ files(name="print_env_directory", sources=["print_env/**/*"])
 
 files(name="sources_directory", sources=["sources/**/*"])
 
-experimental_run_shell_command(
+run_shell_command(
     name="cmd",
     command='{ find {chroot} -type f; echo "in: $CHROOT"; } | tee output.log',
     execution_dependencies=[":hello_directory"],


### PR DESCRIPTION
Also addresses various code review issues noticed post-merge in #18255