### PR TITLE
docs: use an example black version that does not explode

### DIFF
--- a/docs/markdown/Python/python-goals/python-package-goal.md
+++ b/docs/markdown/Python/python-goals/python-package-goal.md
@@ -55,7 +55,7 @@ Usually, you'll want to use `entry_point`, which lets you specify a module and o
 
 ```
 ❯ ./dist/black.pex --version
-python -m black, version 21.10b0
+python -m black, 23.1.0 (compiled: yes)
 ```
 
 You can also leave off both fields, which will cause `./dist/my_app.pex` to launch a Python interpreter with all the relevant code and dependencies loaded.
@@ -126,7 +126,7 @@ Unlike using `entry_point` with a file name, this does not work with file argume
 You can set the `script` to any `console_script` or script exposed by your third-party requirements.
 
 ```python helloworld/BUILD
-python_requirement(name="black_req", requirements=["black==21.10b0"])
+python_requirement(name="black_req", requirements=["black==23.1.0"])
 
 pex_binary(
   name="black_bin",


### PR DESCRIPTION
If someone tried to follow this example they would get: ImportError: cannot import name '_unicodefun' from 'click'

Historical details at https://github.com/psf/black/issues/2964