### PR TITLE
Don't specify interpreter_constraints when building the release pex.

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -790,8 +790,6 @@ def build_pex(fetch: bool) -> None:
         extra_pex_args = [
             "--python-shebang",
             "/usr/bin/env python",
-            "--interpreter-constraint",
-            "CPython>=3.7,<3.10",
             *(
                 f"--platform={plat}-{abi}"
                 for plat in ("linux_x86_64", "macosx_11.0_x86_64")


### PR DESCRIPTION
We already enumerate all the `--platform`s we want in the pex. 

Adding interpreter_constraints will cause us to also try and add the current platform * py3{7,8,9} 
into the pex. 

If we're building the pex on macos x86_64 or on linux that is a no-op, since we already request 
those platforms explicitly. But for macos arm64 this fails, since we only release Pants for 
py39 on that architecture.

With this change the pex builds on M1s.
