### PR TITLE
Add default gha 1000:1000 user to GHA images.

### DIFF
--- a/build-support/wheel_build_aarch64/Dockerfile
+++ b/build-support/wheel_build_aarch64/Dockerfile
@@ -16,3 +16,8 @@ RUN curl -LO "https://go.dev/dl/go1.17.1.linux-arm64.tar.gz" && \
     tar -C /usr/local -xzf go1.17.1.linux-arm64.tar.gz
 
 ENV PATH="${PATH}:/usr/local/go/bin"
+
+RUN groupadd -g 1000 gha && \
+    adduser -u 1000 -g 1000 gha
+
+USER gha

--- a/build-support/wheel_build_x86_64/Dockerfile
+++ b/build-support/wheel_build_x86_64/Dockerfile
@@ -8,3 +8,8 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install && \
     rm -rf ./aws && \
     rm -f awscliv2.zip
+
+RUN groupadd -g 1000 gha && \
+    adduser -u 1000 -g 1000 gha
+
+USER gha


### PR DESCRIPTION
This will help avoid problems both with file permissions for files shared
between the container and host as well as allow more software to run as
expected with a proper user and homedir.