### PR TITLE
fix documentation

### DIFF
--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -99,12 +99,10 @@ For example:
 ```dockerfile project/Dockerfile
 FROM public.ecr.aws/lambda/python:3.8
 
-WORKDIR /build
 RUN yum install unzip -y
-COPY project/lambda.zip /build
-RUN unzip /build/lambda.zip -d /app
-WORKDIR /app
-CMD ["/app/lambdex_handler.handler"]
+COPY project/lambda.zip .
+RUN unzip lambda.zip -d "${LAMBDA_TASK_ROOT}"
+CMD ["lambdex_handler.handler"]
 ```
 ```python project/BUILD
 python_sources()


### PR DESCRIPTION
- To run execute the handler it has to be in the LAMBDA_TASK_ROOT directory
- The leading / in CMD leads to an import error.