### PR TITLE
Get rid of the LockfileContent class

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -266,8 +266,8 @@ async def export_virtualenv_for_resolve(
     if lockfile_path:
         # It's a user resolve.
         lockfile = Lockfile(
-            file_path=lockfile_path,
-            file_path_description_of_origin=f"the resolve `{resolve}`",
+            url=lockfile_path,
+            url_description_of_origin=f"the resolve `{resolve}`",
             resolve_name=resolve,
         )
 

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -221,8 +221,8 @@ class MyPy(PythonToolBase):
             requirements = PexRequirements(self.extra_type_stubs)
         else:
             tool_lockfile = Lockfile(
-                file_path=self.extra_type_stubs_lockfile,
-                file_path_description_of_origin=(
+                url=self.extra_type_stubs_lockfile,
+                url_description_of_origin=(
                     f"the option `[{self.options_scope}].extra_type_stubs_lockfile`"
                 ),
                 lockfile_hex_digest=calculate_invalidation_digest(self.extra_type_stubs),

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
     LoadedLockfileRequest,
-    Lockfile, strip_comments_from_pex_json_lockfile,
+    Lockfile,
+    strip_comments_from_pex_json_lockfile,
 )
 from pants.base.exceptions import EngineError
 from pants.core.goals.generate_lockfiles import LockfileDiff, LockfilePackages, PackageName

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -19,8 +19,7 @@ if TYPE_CHECKING:
 from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
     LoadedLockfileRequest,
-    Lockfile,
-    LockfileContent,
+    Lockfile, strip_comments_from_pex_json_lockfile,
 )
 from pants.base.exceptions import EngineError
 from pants.core.goals.generate_lockfiles import LockfileDiff, LockfilePackages, PackageName
@@ -72,24 +71,28 @@ def _pex_lockfile_requirements(
 
 
 @rule_helper
-async def _parse_lockfile(lockfile: Lockfile | LockfileContent) -> FrozenDict[str, Any] | None:
+async def _parse_lockfile(lockfile: Lockfile) -> FrozenDict[str, Any] | None:
     try:
         loaded = await Get(
             LoadedLockfile,
             LoadedLockfileRequest(lockfile),
         )
         fc = await Get(DigestContents, Digest, loaded.lockfile_digest)
-        parsed_lockfile = json.loads(fc[0].content)
-        return FrozenDict.deep_freeze(parsed_lockfile)
+        parsed = await _parse_lockfile_content(next(iter(fc)).content, lockfile.url)
+        return parsed
     except EngineError:
         # May fail in case the file doesn't exist, which is expected when parsing the "old" lockfile
         # the first time a new lockfile is generated.
         return None
+
+
+@rule_helper
+async def _parse_lockfile_content(content: bytes, url: str) -> FrozenDict[str, Any] | None:
+    try:
+        parsed_lockfile = json.loads(content)
+        return FrozenDict.deep_freeze(parsed_lockfile)
     except json.JSONDecodeError as e:
-        file_path = (
-            lockfile.url if isinstance(lockfile, Lockfile) else lockfile.file_content.path
-        )
-        logger.debug(f"{file_path}: Failed to parse lockfile contents: {e}")
+        logger.debug(f"{url}: Failed to parse lockfile contents: {e}")
         return None
 
 
@@ -97,17 +100,14 @@ async def _parse_lockfile(lockfile: Lockfile | LockfileContent) -> FrozenDict[st
 async def _generate_python_lockfile_diff(
     digest: Digest, resolve_name: str, path: str
 ) -> LockfileDiff:
-    new_content = await Get(DigestContents, Digest, digest)
-    new = await _parse_lockfile(
-        LockfileContent(
-            file_content=next(c for c in new_content if c.path == path),
-            resolve_name=resolve_name,
-        )
-    )
+    new_digest_contents = await Get(DigestContents, Digest, digest)
+    new_content = next(c for c in new_digest_contents if c.path == path).content
+    new_content = strip_comments_from_pex_json_lockfile(new_content)
+    new = await _parse_lockfile_content(new_content, path)
     old = await _parse_lockfile(
         Lockfile(
             url=path,
-            url_description_of_origin="generated lockfile",
+            url_description_of_origin="existing lockfile",
             resolve_name=resolve_name,
         )
     )

--- a/src/python/pants/backend/python/util_rules/lockfile_diff.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_diff.py
@@ -87,7 +87,7 @@ async def _parse_lockfile(lockfile: Lockfile | LockfileContent) -> FrozenDict[st
         return None
     except json.JSONDecodeError as e:
         file_path = (
-            lockfile.file_path if isinstance(lockfile, Lockfile) else lockfile.file_content.path
+            lockfile.url if isinstance(lockfile, Lockfile) else lockfile.file_content.path
         )
         logger.debug(f"{file_path}: Failed to parse lockfile contents: {e}")
         return None
@@ -106,8 +106,8 @@ async def _generate_python_lockfile_diff(
     )
     old = await _parse_lockfile(
         Lockfile(
-            file_path=path,
-            file_path_description_of_origin="generated lockfile",
+            url=path,
+            url_description_of_origin="generated lockfile",
             resolve_name=resolve_name,
         )
     )

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -618,7 +618,7 @@ def _build_pex_description(request: PexRequest) -> str:
     if isinstance(request.requirements, EntireLockfile):
         lockfile = request.requirements.lockfile
         if isinstance(lockfile, Lockfile):
-            desc_suffix = f"from {lockfile.file_path}"
+            desc_suffix = f"from {lockfile.url}"
         else:
             desc_suffix = f"from {lockfile.file_content.path}"
     else:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -37,7 +37,6 @@ from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
     LoadedLockfileRequest,
-    Lockfile,
 )
 from pants.backend.python.util_rules.pex_requirements import (
     PexRequirements as PexRequirements,  # Explicit re-export.
@@ -617,10 +616,7 @@ def _build_pex_description(request: PexRequest) -> str:
 
     if isinstance(request.requirements, EntireLockfile):
         lockfile = request.requirements.lockfile
-        if isinstance(lockfile, Lockfile):
-            desc_suffix = f"from {lockfile.url}"
-        else:
-            desc_suffix = f"from {lockfile.file_content.path}"
+        desc_suffix = f"from {lockfile.url}"
     else:
         if not request.requirements.req_strings:
             return f"Building {request.output_filename}"

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -568,7 +568,7 @@ async def get_repository_pex(
         PexRequest(
             description=softwrap(
                 f"""
-                Installing {chosen_resolve.lockfile.file_path} for the resolve
+                Installing {chosen_resolve.lockfile.url} for the resolve
                 `{chosen_resolve.name}`
                 """
             ),

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -279,8 +279,8 @@ async def choose_python_resolve(
     return ChosenPythonResolve(
         name=chosen_resolve,
         lockfile=Lockfile(
-            file_path=python_setup.resolves[chosen_resolve],
-            file_path_description_of_origin=(
+            url=python_setup.resolves[chosen_resolve],
+            url_description_of_origin=(
                 f"the resolve `{chosen_resolve}` (from `[python].resolves`)"
             ),
             resolve_name=chosen_resolve,

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib.resources
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -46,7 +47,6 @@ from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
     LoadedLockfileRequest,
-    LockfileContent,
     PexRequirements,
 )
 from pants.backend.python.util_rules.pex_test_utils import get_all_data
@@ -174,16 +174,16 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     repository_pex__constraints = Mock()
 
     def assert_setup(
-        mode: RequirementMode,
+        _mode: RequirementMode,
         *,
-        internal_only: bool,
-        platforms: bool,
+        _internal_only: bool,
+        _platforms: bool,
         include_requirements: bool = True,
         run_against_entire_lockfile: bool = False,
         expected: PexRequirements | PexRequest,
     ) -> None:
-        lockfile_used = mode in (RequirementMode.PEX_LOCKFILE, RequirementMode.NON_PEX_LOCKFILE)
-        requirement_constraints_used = mode in (
+        lockfile_used = _mode in (RequirementMode.PEX_LOCKFILE, RequirementMode.NON_PEX_LOCKFILE)
+        requirement_constraints_used = _mode in (
             RequirementMode.CONSTRAINTS_RESOLVE_ALL,
             RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
         )
@@ -192,15 +192,15 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             PythonSetup,
             enable_resolves=lockfile_used,
             run_against_entire_lockfile=run_against_entire_lockfile,
-            resolve_all_constraints=mode != RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
+            resolve_all_constraints=_mode != RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
             requirement_constraints="foo.constraints" if requirement_constraints_used else None,
         )
         pex_from_targets_request = PexFromTargetsRequest(
             Addresses(),
             output_filename="foo",
             include_requirements=include_requirements,
-            platforms=PexPlatforms(["foo"] if platforms else []),
-            internal_only=internal_only,
+            platforms=PexPlatforms(["foo"] if _platforms else []),
+            internal_only=_internal_only,
         )
         resolved_pex_requirements = PexRequirements(
             req_strings,
@@ -210,12 +210,12 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         )
 
         # NB: We recreate that platforms should turn off first creating a repository.pex.
-        if lockfile_used and not platforms:
+        if lockfile_used and not _platforms:
             mock_repository_pex_request = OptionalPexRequest(
                 maybe_pex_request=repository_pex_request__lockfile
             )
             mock_repository_pex = OptionalPex(maybe_pex=repository_pex__lockfile)
-        elif mode == RequirementMode.CONSTRAINTS_RESOLVE_ALL and not platforms:
+        elif _mode == RequirementMode.CONSTRAINTS_RESOLVE_ALL and not _platforms:
             mock_repository_pex_request = OptionalPexRequest(
                 maybe_pex_request=repository_pex_request__constraints
             )
@@ -243,7 +243,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
                     input_types=(LoadedLockfileRequest,),
                     mock=lambda _: (
                         loaded_lockfile__pex
-                        if mode == RequirementMode.PEX_LOCKFILE
+                        if _mode == RequirementMode.PEX_LOCKFILE
                         else loaded_lockfile__not_pex
                     ),
                 ),
@@ -267,8 +267,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         assert_setup(
             mode,
             include_requirements=False,
-            internal_only=False,
-            platforms=False,
+            _internal_only=False,
+            _platforms=False,
             expected=PexRequirements(),
         )
 
@@ -278,29 +278,29 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for internal_only in (True, False):
         assert_setup(
             RequirementMode.PEX_LOCKFILE,
-            internal_only=internal_only,
-            platforms=False,
+            _internal_only=internal_only,
+            _platforms=False,
             expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
         )
     assert_setup(
         RequirementMode.PEX_LOCKFILE,
-        internal_only=False,
-        platforms=True,
+        _internal_only=False,
+        _platforms=True,
         expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
     )
     for platforms in (True, False):
         assert_setup(
             RequirementMode.PEX_LOCKFILE,
-            internal_only=False,
+            _internal_only=False,
             run_against_entire_lockfile=True,
-            platforms=platforms,
+            _platforms=platforms,
             expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
         )
     assert_setup(
         RequirementMode.PEX_LOCKFILE,
-        internal_only=True,
+        _internal_only=True,
         run_against_entire_lockfile=True,
-        platforms=False,
+        _platforms=False,
         expected=repository_pex_request__lockfile,
     )
 
@@ -310,39 +310,39 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for internal_only in (False, True):
         assert_setup(
             RequirementMode.NON_PEX_LOCKFILE,
-            internal_only=internal_only,
-            platforms=False,
+            _internal_only=internal_only,
+            _platforms=False,
             expected=PexRequirements(
                 req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
             ),
         )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
-        internal_only=False,
-        platforms=True,
+        _internal_only=False,
+        _platforms=True,
         expected=PexRequirements(req_strings, constraints_strings=req_strings, from_superset=None),
     )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
-        internal_only=False,
+        _internal_only=False,
         run_against_entire_lockfile=True,
-        platforms=False,
+        _platforms=False,
         expected=PexRequirements(
             req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
         ),
     )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
-        internal_only=False,
+        _internal_only=False,
         run_against_entire_lockfile=True,
-        platforms=True,
+        _platforms=True,
         expected=PexRequirements(req_strings, constraints_strings=req_strings, from_superset=None),
     )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
-        internal_only=True,
+        _internal_only=True,
         run_against_entire_lockfile=True,
-        platforms=False,
+        _platforms=False,
         expected=repository_pex_request__lockfile,
     )
 
@@ -352,8 +352,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for internal_only in (False, True):
         assert_setup(
             RequirementMode.CONSTRAINTS_RESOLVE_ALL,
-            internal_only=internal_only,
-            platforms=False,
+            _internal_only=internal_only,
+            _platforms=False,
             expected=PexRequirements(
                 req_strings,
                 constraints_strings=global_requirement_constraints,
@@ -362,17 +362,17 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         )
     assert_setup(
         RequirementMode.CONSTRAINTS_RESOLVE_ALL,
-        internal_only=False,
-        platforms=True,
+        _internal_only=False,
+        _platforms=True,
         expected=PexRequirements(
             req_strings, constraints_strings=global_requirement_constraints, from_superset=None
         ),
     )
     assert_setup(
         RequirementMode.CONSTRAINTS_RESOLVE_ALL,
-        internal_only=False,
+        _internal_only=False,
         run_against_entire_lockfile=True,
-        platforms=False,
+        _platforms=False,
         expected=PexRequirements(
             req_strings,
             constraints_strings=global_requirement_constraints,
@@ -381,18 +381,18 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     )
     assert_setup(
         RequirementMode.CONSTRAINTS_RESOLVE_ALL,
-        internal_only=False,
+        _internal_only=False,
         run_against_entire_lockfile=True,
-        platforms=True,
+        _platforms=True,
         expected=PexRequirements(
             req_strings, constraints_strings=global_requirement_constraints, from_superset=None
         ),
     )
     assert_setup(
         RequirementMode.CONSTRAINTS_RESOLVE_ALL,
-        internal_only=True,
+        _internal_only=True,
         run_against_entire_lockfile=True,
-        platforms=False,
+        _platforms=False,
         expected=repository_pex_request__constraints,
     )
 
@@ -401,8 +401,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for internal_only in (True, False):
         assert_setup(
             RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
-            internal_only=internal_only,
-            platforms=platforms,
+            _internal_only=internal_only,
+            _platforms=platforms,
             expected=PexRequirements(
                 req_strings, constraints_strings=global_requirement_constraints
             ),
@@ -410,8 +410,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for platforms in (True, False):
         assert_setup(
             RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
-            internal_only=False,
-            platforms=platforms,
+            _internal_only=False,
+            _platforms=platforms,
             expected=PexRequirements(
                 req_strings, constraints_strings=global_requirement_constraints
             ),
@@ -421,14 +421,14 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     for internal_only in (True, False):
         assert_setup(
             RequirementMode.NO_LOCKS,
-            internal_only=internal_only,
-            platforms=False,
+            _internal_only=internal_only,
+            _platforms=False,
             expected=PexRequirements(req_strings),
         )
     assert_setup(
         RequirementMode.NO_LOCKS,
-        internal_only=False,
-        platforms=True,
+        _internal_only=False,
+        _platforms=True,
         expected=PexRequirements(req_strings),
     )
 
@@ -596,16 +596,16 @@ def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None
         constraints_file: str | None,
         resolve_all_constraints: bool | None,
         *,
-        additional_args: Iterable[str] = (),
-        additional_lockfile_args: Iterable[str] = (),
+        _additional_args: Iterable[str] = (),
+        _additional_lockfile_args: Iterable[str] = (),
     ) -> PexRequest:
         args = ["--backend-packages=pants.backend.python"]
         request = PexFromTargetsRequest(
             [Address("", target_name="app")],
             output_filename="demo.pex",
             internal_only=True,
-            additional_args=additional_args,
-            additional_lockfile_args=additional_lockfile_args,
+            additional_args=_additional_args,
+            additional_lockfile_args=_additional_lockfile_args,
         )
         if resolve_all_constraints is not None:
             args.append(f"--python-resolve-all-constraints={resolve_all_constraints!r}")
@@ -615,7 +615,7 @@ def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None
         args.append(f"--python-repos-repos={find_links}")
         rule_runner.set_options(args, env_inherit={"PATH"})
         pex_request = rule_runner.request(PexRequest, [request])
-        assert OrderedSet(additional_args).issubset(OrderedSet(pex_request.additional_args))
+        assert OrderedSet(_additional_args).issubset(OrderedSet(pex_request.additional_args))
         return pex_request
 
     additional_args = ["--strip-pex-env"]
@@ -630,8 +630,8 @@ def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None
     pex_req2 = get_pex_request(
         constraints1_filename,
         resolve_all_constraints=True,
-        additional_args=additional_args,
-        additional_lockfile_args=additional_lockfile_args,
+        _additional_args=additional_args,
+        _additional_lockfile_args=additional_lockfile_args,
     )
     pex_req2_reqs = pex_req2.requirements
     assert isinstance(pex_req2_reqs, PexRequirements)
@@ -807,12 +807,11 @@ def test_lockfile_requirements_selection(
         mode_files.update({"3rdparty/python/default.lock": setuptools_poetry_lockfile})
     else:
         assert mode == ResolveMode.pex
-
-        requirements = rule_runner.request(Setuptools, []).pex_requirements()
-        assert isinstance(requirements, EntireLockfile)
-        assert isinstance(requirements.lockfile, LockfileContent)
+        lock_content = importlib.resources.read_binary(
+            "pants.backend.python.subsystems", "setuptools.lock"
+        )
         mode_files.update(
-            {"3rdparty/python/default.lock": requirements.lockfile.file_content.content}
+            {"3rdparty/python/default.lock": lock_content}
         )
 
     rule_runner.write_files(mode_files)

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -810,9 +810,7 @@ def test_lockfile_requirements_selection(
         lock_content = importlib.resources.read_binary(
             "pants.backend.python.subsystems", "setuptools.lock"
         )
-        mode_files.update(
-            {"3rdparty/python/default.lock": lock_content}
-        )
+        mode_files.update({"3rdparty/python/default.lock": lock_content})
 
     rule_runner.write_files(mode_files)
 

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import importlib.resources
 import logging
-import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable, Iterator
 from urllib.parse import urlparse
@@ -97,7 +96,7 @@ class LoadedLockfileRequest:
     lockfile: Lockfile | LockfileContent
 
 
-def _strip_comments_from_pex_json_lockfile(lockfile_bytes: bytes) -> bytes:
+def strip_comments_from_pex_json_lockfile(lockfile_bytes: bytes) -> bytes:
     """Pex does not like the header Pants adds to lockfiles, as it violates JSON.
 
     Note that we only strip lines starting with `//`, which is all that Pants will ever add. If
@@ -204,7 +203,7 @@ async def load_lockfile(
     is_pex_native = is_probably_pex_json_lockfile(lock_bytes)
     if is_pex_native:
         header_delimiter = "//"
-        stripped_lock_bytes = _strip_comments_from_pex_json_lockfile(lock_bytes)
+        stripped_lock_bytes = strip_comments_from_pex_json_lockfile(lock_bytes)
         lockfile_digest = await Get(
             Digest,
             CreateDigest([FileContent(lockfile_path, stripped_lock_bytes)]),

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -165,6 +165,12 @@ async def load_lockfile(
     python_setup: PythonSetup,
 ) -> LoadedLockfile:
     lockfile = request.lockfile
+    # TODO: Fold "resource://" URL support into the DownloadFile primitive, instead of
+    #  manually handling it here. That would also give us support for https:// URLs for tool
+    #  lockfiles (e.g., we could choose to download the default_lockfile_url instead of
+    #  embedding the lockfiles as resources). This would require capturing the SHA256 of
+    #  every current tool lockfile, and we need to think through the consequences of
+    #  downloading lockfiles, so we punt for now.
     parts = urlparse(lockfile.url)
     # urlparse retains the leading / in URLs with a netloc.
     lockfile_path = parts.path[1:] if parts.path.startswith("/") else parts.path

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -17,9 +17,9 @@ from pants.backend.python.util_rules.pex_requirements import (
     ResolvePexConfig,
     ResolvePexConstraintsFile,
     _pex_lockfile_requirement_count,
-    strip_comments_from_pex_json_lockfile,
     get_metadata,
     is_probably_pex_json_lockfile,
+    strip_comments_from_pex_json_lockfile,
     validate_metadata,
 )
 from pants.core.util_rules.lockfile_metadata import (

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -17,7 +17,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     ResolvePexConfig,
     ResolvePexConstraintsFile,
     _pex_lockfile_requirement_count,
-    _strip_comments_from_pex_json_lockfile,
+    strip_comments_from_pex_json_lockfile,
     get_metadata,
     is_probably_pex_json_lockfile,
     validate_metadata,
@@ -249,7 +249,7 @@ def test_is_probably_pex_json_lockfile():
 
 def test_strip_comments_from_pex_json_lockfile() -> None:
     def assert_stripped(lock: str, expected: str) -> None:
-        assert _strip_comments_from_pex_json_lockfile(lock.encode()).decode() == expected
+        assert strip_comments_from_pex_json_lockfile(lock.encode()).decode() == expected
 
     assert_stripped("{}", "{}")
     assert_stripped(

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -152,8 +152,8 @@ def test_validate_lockfiles(
         ["bad-req"] if invalid_reqs else [str(r) for r in METADATA.requirements]
     )
     lockfile = Lockfile(
-        file_path="lock.txt",
-        file_path_description_of_origin="foo",
+        url="lock.txt",
+        url_description_of_origin="foo",
         resolve_name="a",
     )
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -396,7 +396,7 @@ def test_lockfiles(rule_runner: RuleRunner) -> None:
     def create_lock(path: str) -> None:
         lock = Lockfile(
             path,
-            file_path_description_of_origin="foo",
+            url_description_of_origin="foo",
             resolve_name="a",
         )
         create_pex_and_get_pex_info(
@@ -681,7 +681,7 @@ def test_setup_pex_requirements() -> None:
     lockfile_path = "foo.lock"
     lockfile_digest = rule_runner.make_snapshot_of_empty_files([lockfile_path]).digest
     lockfile_obj = Lockfile(
-        lockfile_path, file_path_description_of_origin="foo", resolve_name="resolve"
+        lockfile_path, url_description_of_origin="foo", resolve_name="resolve"
     )
 
     def create_loaded_lockfile(is_pex_lock: bool) -> LoadedLockfile:
@@ -844,8 +844,8 @@ def test_build_pex_description() -> None:
     assert_description(
         EntireLockfile(
             Lockfile(
-                file_path="lock.txt",
-                file_path_description_of_origin="foo",
+                url="lock.txt",
+                url_description_of_origin="foo",
                 resolve_name="a",
             )
         ),
@@ -872,21 +872,12 @@ def test_lockfile_validation(rule_runner: RuleRunner) -> None:
     ).add_header_to_lockfile(b"", regenerate_command="regen", delimeter="#")
     rule_runner.write_files({"lock.txt": lock_content.decode()})
 
-    lockfile = Lockfile(
+    _lockfile = Lockfile(
         "lock.txt",
-        file_path_description_of_origin="a test",
+        url_description_of_origin="a test",
         resolve_name="a",
     )
     with engine_error(InvalidLockfileError):
         create_pex_and_get_all_data(
-            rule_runner, requirements=EntireLockfile(lockfile, ("ansicolors",))
-        )
-
-    lockfile_content = LockfileContent(
-        FileContent("lock.txt", lock_content),
-        resolve_name="a",
-    )
-    with engine_error(InvalidLockfileError):
-        create_pex_and_get_all_data(
-            rule_runner, requirements=EntireLockfile(lockfile_content, ("ansicolors",))
+            rule_runner, requirements=EntireLockfile(_lockfile, ("ansicolors",))
         )

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -47,7 +47,6 @@ from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfile,
     LoadedLockfileRequest,
     Lockfile,
-    LockfileContent,
     PexRequirements,
     ResolvePexConfig,
     ResolvePexConfigRequest,
@@ -519,7 +518,7 @@ def test_local_requirements_and_path_mappings(
         rule_runner.write_files({"test.lock": lock_file_content.content})
         lockfile_obj = EntireLockfile(
             Lockfile(url="test.lock", url_description_of_origin="test", resolve_name="test"),
-            (wheel_req_str,)
+            (wheel_req_str,),
         )
 
         # Wipe cache to ensure `--path-mappings` works.
@@ -682,9 +681,7 @@ def test_setup_pex_requirements() -> None:
 
     lockfile_path = "foo.lock"
     lockfile_digest = rule_runner.make_snapshot_of_empty_files([lockfile_path]).digest
-    lockfile_obj = Lockfile(
-        lockfile_path, url_description_of_origin="foo", resolve_name="resolve"
-    )
+    lockfile_obj = Lockfile(lockfile_path, url_description_of_origin="foo", resolve_name="resolve")
 
     def create_loaded_lockfile(is_pex_lock: bool) -> LoadedLockfile:
         return LoadedLockfile(
@@ -835,8 +832,9 @@ def test_build_pex_description() -> None:
 
     assert_description(
         EntireLockfile(
-            LockfileContent(
-                file_content=FileContent("lock.txt", b""),
+            Lockfile(
+                url="lock.txt",
+                url_description_of_origin="test",
                 resolve_name="a",
             )
         ),

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -516,8 +516,10 @@ def test_local_requirements_and_path_mappings(
         assert b"${WHEEL_DIR}/ansicolors-1.1.8-py2.py3-none-any.whl" in lock_file_content.content
         assert b"files.pythonhosted.org" not in lock_file_content.content
 
+        rule_runner.write_files({"test.lock": lock_file_content.content})
         lockfile_obj = EntireLockfile(
-            LockfileContent(lock_file_content, resolve_name="test"), (wheel_req_str,)
+            Lockfile(url="test.lock", url_description_of_origin="test", resolve_name="test"),
+            (wheel_req_str,)
         )
 
         # Wipe cache to ensure `--path-mappings` works.

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -142,7 +142,7 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
     )
 
     def assert_ics(
-        lockfile: str,
+        lckfile: str,
         expected: list[str],
         *,
         ics: RankedValue = RankedValue(Rank.HARDCODED, Black.default_interpreter_constraints),
@@ -150,7 +150,7 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
     ) -> None:
         black = create_subsystem(
             Black,
-            lockfile=lockfile,
+            lockfile=lckfile,
             interpreter_constraints=ics,
             version="v",
             extra_requirements=[],
@@ -163,7 +163,7 @@ def test_find_python_interpreter_constraints_from_lockfile() -> None:
             is_pex_native=True,
             as_constraints_strings=None,
             original_lockfile=Lockfile(
-                "black.lock", file_path_description_of_origin="foo", resolve_name="black"
+                "black.lock", url_description_of_origin="foo", resolve_name="black"
             ),
         )
         result = run_rule_with_mocks(


### PR DESCRIPTION
This is a step towards greater unification of user and tool lockfiles.

LockfileContent existed primarily to carry the default lockfile content for tools, as read
from a resource. This led to a lot of `Lockfile | LockfileContent` type signatures and
subsequent type-testing on the receiving end. 

Instead, the Lockfile class now takes an URL instead of a path (with path-like URLs still supported), 
and we introduce a `resource://package/path` URL to represent lockfiles embedded in the Pants
binary as a resource.