### PR TITLE
Switch store code from `Option<Digest>` to `Fingerprint`

### DIFF
--- a/src/rust/engine/cache/src/lib.rs
+++ b/src/rust/engine/cache/src/lib.rs
@@ -75,10 +75,7 @@ impl PersistentCache {
     // rather than storing the value under its _own_ Fingerprint, the value is stored under the
     // Fingerprint of the CacheKey.
     let fingerprint = Digest::of_bytes(&key.to_bytes()).hash;
-    self
-      .store
-      .store_bytes(Some(fingerprint), value, false)
-      .await?;
+    self.store.store_bytes(fingerprint, value, false).await?;
     Ok(())
   }
 

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -20,16 +20,11 @@ async fn assert_store_bytes(
   bytes: Bytes,
   expected_digest: Digest,
 ) {
-  let one_pass_digest = store
-    .store_bytes(entry_type, None, bytes.clone(), false)
-    .await
-    .unwrap();
-  let two_pass_digest = store
+  let digest = store
     .store(entry_type, false, true, move || Ok(bytes.clone().reader()))
     .await
     .unwrap();
-  assert_eq!(expected_digest, one_pass_digest);
-  assert_eq!(one_pass_digest, two_pass_digest);
+  assert_eq!(expected_digest, digest);
 }
 
 #[tokio::test]
@@ -143,26 +138,21 @@ async fn garbage_collect_nothing_to_do() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes = Bytes::from("0123456789");
+  let fingerprint = Fingerprint::from_hex_string(
+    "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
+  )
+  .unwrap();
+  let digest = Digest::new(fingerprint, 10);
+
   store
-    .store_bytes(EntryType::File, None, bytes.clone(), false)
+    .store_bytes(EntryType::File, fingerprint, bytes.clone(), false)
     .await
     .expect("Error storing");
   store
     .shrink(10, ShrinkBehavior::Fast)
     .expect("Error shrinking");
   assert_eq!(
-    load_bytes(
-      &store,
-      EntryType::File,
-      Digest::new(
-        Fingerprint::from_hex_string(
-          "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
-        )
-        .unwrap(),
-        10
-      )
-    )
-    .await,
+    load_bytes(&store, EntryType::File, digest).await,
     Ok(Some(bytes))
   );
 }
@@ -172,15 +162,15 @@ async fn garbage_collect_nothing_to_do_with_lease() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   let bytes = Bytes::from("0123456789");
-  store
-    .store_bytes(EntryType::File, None, bytes.clone(), false)
-    .await
-    .expect("Error storing");
   let file_fingerprint = Fingerprint::from_hex_string(
     "84d89877f0d4041efb6bf91a16f0248f2fd573e6af05c19f96bedb9f882f7882",
   )
   .unwrap();
   let file_digest = Digest::new(file_fingerprint, 10);
+  store
+    .store_bytes(EntryType::File, file_fingerprint, bytes.clone(), false)
+    .await
+    .expect("Error storing");
   store
     .lease_all(vec![(file_digest, EntryType::File)].into_iter())
     .await
@@ -210,7 +200,7 @@ async fn garbage_collect_expired() {
   // Store something (in a store with a shortened lease). Confirm that it hasn't immediately
   // expired, and then wait for it to expire.
   store
-    .store_bytes(EntryType::File, None, bytes.clone(), true)
+    .store_bytes(EntryType::File, file_fingerprint, bytes.clone(), true)
     .await
     .expect("Error storing");
   assert_eq!(
@@ -251,11 +241,11 @@ async fn garbage_collect_remove_one_of_two_files_no_leases() {
   .unwrap();
   let digest_2 = Digest::new(fingerprint_2, 10);
   store
-    .store_bytes(EntryType::File, None, bytes_1.clone(), false)
+    .store_bytes(EntryType::File, fingerprint_1, bytes_1.clone(), false)
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::File, None, bytes_2.clone(), false)
+    .store_bytes(EntryType::File, fingerprint_2, bytes_2.clone(), false)
     .await
     .expect("Error storing");
   store
@@ -296,11 +286,11 @@ async fn garbage_collect_remove_both_files_no_leases() {
   .unwrap();
   let digest_2 = Digest::new(fingerprint_2, 10);
   store
-    .store_bytes(EntryType::File, None, bytes_1.clone(), false)
+    .store_bytes(EntryType::File, fingerprint_1, bytes_1.clone(), false)
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::File, None, bytes_2.clone(), false)
+    .store_bytes(EntryType::File, fingerprint_2, bytes_2.clone(), false)
     .await
     .expect("Error storing");
   store
@@ -327,11 +317,21 @@ async fn garbage_collect_remove_one_of_two_directories_no_leases() {
 
   let store = new_store(dir.path());
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::Directory, None, other_testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      other_testdir.fingerprint(),
+      other_testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   store
@@ -364,12 +364,22 @@ async fn garbage_collect_remove_file_with_leased_directory() {
   let testdata = TestData::forty_chars();
 
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), true)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      true,
+    )
     .await
     .expect("Error storing");
 
   store
-    .store_bytes(EntryType::File, None, testdata.bytes(), false)
+    .store_bytes(
+      EntryType::File,
+      testdata.fingerprint(),
+      testdata.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
 
@@ -397,12 +407,22 @@ async fn garbage_collect_remove_file_while_leased_file() {
   let testdir = TestDirectory::containing_roland();
 
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   let forty_chars = TestData::forty_chars();
   store
-    .store_bytes(EntryType::File, None, forty_chars.bytes(), true)
+    .store_bytes(
+      EntryType::File,
+      forty_chars.fingerprint(),
+      forty_chars.bytes(),
+      true,
+    )
     .await
     .expect("Error storing");
 
@@ -429,17 +449,28 @@ async fn garbage_collect_fail_because_too_many_leases() {
 
   let testdir = TestDirectory::containing_roland();
   let forty_chars = TestData::forty_chars();
+  let roland = TestData::roland();
 
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), true)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      true,
+    )
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::File, None, forty_chars.bytes(), true)
+    .store_bytes(
+      EntryType::File,
+      forty_chars.fingerprint(),
+      forty_chars.bytes(),
+      true,
+    )
     .await
     .expect("Error storing");
   store
-    .store_bytes(EntryType::File, None, TestData::roland().bytes(), false)
+    .store_bytes(EntryType::File, roland.fingerprint(), roland.bytes(), false)
     .await
     .expect("Error storing");
 
@@ -463,8 +494,9 @@ async fn write_one_meg(store: &ByteStore, byte: u8) {
   for _ in 0..1024 * 1024 {
     bytes.put_u8(byte);
   }
+  let fingerprint = Fingerprint::from_bytes_unsafe(&bytes);
   store
-    .store_bytes(EntryType::File, None, bytes.freeze(), false)
+    .store_bytes(EntryType::File, fingerprint, bytes.freeze(), false)
     .await
     .expect("Error storing");
 }
@@ -502,7 +534,12 @@ async fn entry_type_for_file() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
@@ -519,7 +556,12 @@ async fn entry_type_for_directory() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
@@ -536,7 +578,12 @@ async fn entry_type_for_missing() {
   let dir = TempDir::new().unwrap();
   let store = new_store(dir.path());
   store
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Error storing");
   prime_store_with_file_bytes(&store, testdata.bytes()).await;
@@ -624,10 +671,12 @@ pub async fn load_bytes(
 }
 
 async fn prime_store_with_file_bytes(store: &ByteStore, bytes: Bytes) -> Digest {
+  let digest = Digest::of_bytes(&bytes);
   store
-    .store_bytes(EntryType::File, None, bytes, false)
+    .store_bytes(EntryType::File, digest.hash, bytes, false)
     .await
-    .expect("Error storing file bytes")
+    .expect("Error storing file bytes");
+  digest
 }
 
 fn get_directory_size(path: &Path) -> usize {

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -494,7 +494,7 @@ async fn write_one_meg(store: &ByteStore, byte: u8) {
   for _ in 0..1024 * 1024 {
     bytes.put_u8(byte);
   }
-  let fingerprint = Fingerprint::from_bytes_unsafe(&bytes);
+  let fingerprint = Digest::of_bytes(&bytes).hash;
   store
     .store_bytes(EntryType::File, fingerprint, bytes.freeze(), false)
     .await

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -121,7 +121,12 @@ async fn load_file_prefers_local() {
   let testdata = TestData::roland();
 
   crate::local_tests::new_store(dir.path())
-    .store_bytes(EntryType::File, None, testdata.bytes(), false)
+    .store_bytes(
+      EntryType::File,
+      testdata.fingerprint(),
+      testdata.bytes(),
+      false,
+    )
     .await
     .expect("Store failed");
 
@@ -140,7 +145,12 @@ async fn load_directory_prefers_local() {
   let testdir = TestDirectory::containing_roland();
 
   crate::local_tests::new_store(dir.path())
-    .store_bytes(EntryType::Directory, None, testdir.bytes(), false)
+    .store_bytes(
+      EntryType::Directory,
+      testdir.fingerprint(),
+      testdir.bytes(),
+      false,
+    )
     .await
     .expect("Store failed");
 

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -20,7 +20,6 @@ use crate::tasks::Intrinsic;
 use crate::types::Types;
 use crate::Failure;
 
-use bytes::Bytes;
 use futures::future::{BoxFuture, FutureExt, TryFutureExt};
 use futures::try_join;
 use indexmap::IndexMap;
@@ -441,13 +440,13 @@ fn create_digest_to_digest(
 
   let mut typed_paths: Vec<TypedPath> = Vec::with_capacity(items.len());
   let mut file_digests: HashMap<PathBuf, Digest> = HashMap::with_capacity(items.len());
-  let mut bytes_to_store: Vec<(Option<Digest>, Bytes)> = Vec::with_capacity(new_file_count);
+  let mut items_to_store = Vec::with_capacity(new_file_count);
 
   for item in &items {
     match item {
       CreateDigestItem::FileContent(path, bytes, is_executable) => {
         let digest = Digest::of_bytes(bytes);
-        bytes_to_store.push((Some(digest), bytes.clone()));
+        items_to_store.push((digest.hash, bytes.clone()));
         typed_paths.push(TypedPath::File {
           path,
           is_executable: *is_executable,
@@ -475,8 +474,7 @@ fn create_digest_to_digest(
   let store = context.core.store();
   let trie = DigestTrie::from_unique_paths(typed_paths, &file_digests).unwrap();
   async move {
-    // The digests returned here are already in the `file_digests` map.
-    let _ = store.store_file_bytes_batch(bytes_to_store, true).await?;
+    store.store_file_bytes_batch(items_to_store, true).await?;
     let gil = Python::acquire_gil();
     let value = Snapshot::store_directory_digest(gil.python(), trie.into())?;
     Ok(value)


### PR DESCRIPTION
Prefactor for #18153, and overall cleanup.

The only reason I could think of wanting `Option<>` is if we saved ourselves an extra pass of the data when consuming the bytes, but the ultimate consumer was `src/rust/engine/sharded_lmdb/src/lib.rs` which just hashed the bytes (in a sync thread too!).