### PR TITLE
go: add backends which were missing from distribution

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -36,6 +36,8 @@ target(
         "src/python/pants/backend/experimental/cue",
         "src/python/pants/backend/experimental/debian",
         "src/python/pants/backend/experimental/go",
+        "src/python/pants/backend/experimental/go/debug_goals",
+        "src/python/pants/backend/experimental/go/lint/golangci_lint",
         "src/python/pants/backend/experimental/go/lint/vet",
         "src/python/pants/backend/experimental/helm",
         "src/python/pants/backend/experimental/java",


### PR DESCRIPTION
Add two missing Go backends which were missing from the distribution.