### PR TITLE
go: cleanup `go-dump-import-path-mapping` debug goal

### DIFF
--- a/src/python/pants/backend/go/goals/debug_goals.py
+++ b/src/python/pants/backend/go/goals/debug_goals.py
@@ -122,12 +122,10 @@ async def dump_go_import_paths_for_module(
     targets: UnexpandedTargets, console: Console
 ) -> DumpGoImportPathsForModule:
     for tgt in targets:
-        console.write_stdout(
-            f"Target: {tgt.address} ({tgt.__class__} ({isinstance(tgt, GoModTarget)})\n"
-        )
         if not isinstance(tgt, GoModTarget):
             continue
 
+        console.write_stdout(f"{tgt.address}:\n")
         package_mapping = await Get(
             GoModuleImportPathsMapping, GoImportPathMappingRequest(tgt.address)
         )


### PR DESCRIPTION
Cleanup the `go-dump-import-path-mapping` debug goal to not print extraneous information.