### PR TITLE
Docker environment uses a volume for named caches

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -99,7 +99,7 @@ jobs:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
-      run: ./cargo test --tests -- --nocapture
+      run: ./cargo test --tests -- --nocapture --test-threads=8
     strategy:
       matrix:
         python-version:
@@ -212,9 +212,7 @@ jobs:
 
         ./cargo check --benches
 
-        ./cargo doc
-
-        '
+        ./cargo doc'
     strategy:
       matrix:
         python-version:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,7 +102,7 @@ jobs:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
-      run: ./cargo test --tests -- --nocapture
+      run: ./cargo test --tests -- --nocapture --test-threads=8
     strategy:
       matrix:
         python-version:
@@ -217,9 +217,7 @@ jobs:
 
         ./cargo check --benches
 
-        ./cargo doc
-
-        '
+        ./cargo doc'
     strategy:
       matrix:
         python-version:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -316,6 +316,14 @@ class Helper:
             ret["PANTS_CONFIG_FILES"] = "+['pants.ci.toml','pants.ci.aarch64.toml']"
         return ret
 
+    def maybe_append_cargo_test_parallelism(self, cmd: str) -> str:
+        if self.platform == Platform.LINUX_ARM64:
+            # TODO: The ARM64 runner has enough cores to reliably trigger #18191 using
+            # our default settings. We lower parallelism here as a bandaid to work around
+            # #18191 until it can be resolved.
+            return f"{cmd} --test-threads=8"
+        return cmd
+
     def wrap_cmd(self, cmd: str) -> str:
         if self.platform == Platform.MACOS11_ARM64:
             # The self-hosted M1 runner is an X86_64 binary that runs under Rosetta,
@@ -533,19 +541,23 @@ def bootstrap_jobs(
         # We pass --tests to skip doc tests because our generated protos contain
         # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
         # pass on GHA MacOS containers.
-        step_cmd = helper.wrap_cmd("./cargo test --tests -- --nocapture")
+        step_cmd = helper.wrap_cmd(
+            helper.maybe_append_cargo_test_parallelism("./cargo test --tests -- --nocapture")
+        )
     elif rust_testing == RustTesting.ALL:
         human_readable_job_name += ", test and lint Rust"
         human_readable_step_name = "Test and lint Rust"
         # We pass --tests to skip doc tests because our generated protos contain
         # invalid doc tests in their comments.
-        step_cmd = dedent(
-            """\
-            ./build-support/bin/check_rust_pre_commit.sh
-            ./cargo test --all --tests -- --nocapture
-            ./cargo check --benches
-            ./cargo doc
-            """
+        step_cmd = "\n".join(
+            [
+                "./build-support/bin/check_rust_pre_commit.sh",
+                helper.maybe_append_cargo_test_parallelism(
+                    "./cargo test --all --tests -- --nocapture"
+                ),
+                "./cargo check --benches",
+                "./cargo doc",
+            ]
         )
     else:
         raise ValueError(f"Unrecognized RustTesting value: {rust_testing}")

--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -32,7 +32,7 @@ fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
     store.clone(),
     runtime,
     base_dir.path().to_owned(),
-    NamedCaches::new(named_cache_dir),
+    NamedCaches::new_local(named_cache_dir),
     ImmutableInputs::new(store.clone(), base_dir.path()).unwrap(),
     KeepSandboxes::Never,
   ));

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -11,9 +11,12 @@ use bollard::container::{CreateContainerOptions, LogOutput, RemoveContainerOptio
 use bollard::exec::StartExecResults;
 use bollard::image::CreateImageOptions;
 use bollard::service::CreateImageInfo;
+use bollard::volume::CreateVolumeOptions;
 use bollard::{errors::Error as DockerError, Docker};
+use bytes::BytesMut;
 use futures::stream::BoxStream;
-use futures::{StreamExt, TryFutureExt};
+use futures::{FutureExt, StreamExt, TryFutureExt};
+use hashing::Digest;
 use log::Level;
 use nails::execution::ExitCode;
 use once_cell::sync::Lazy;
@@ -23,8 +26,8 @@ use task_executor::Executor;
 use workunit_store::{in_workunit, Metric, RunningWorkunit};
 
 use crate::local::{
-  apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, CapturedWorkdir, ChildOutput,
-  KeepSandboxes,
+  apply_chroot, collect_child_outputs, create_sandbox, prepare_workdir, setup_run_sh_script,
+  CapturedWorkdir, ChildOutput, KeepSandboxes,
 };
 use crate::{
   Context, FallibleProcessResultWithPlatform, NamedCaches, Platform, Process, ProcessError,
@@ -47,7 +50,6 @@ pub struct CommandRunner<'a> {
   executor: Executor,
   docker: &'a DockerOnceCell,
   work_dir_base: PathBuf,
-  named_caches: NamedCaches,
   immutable_inputs: ImmutableInputs,
   keep_sandboxes: KeepSandboxes,
   container_cache: ContainerCache<'a>,
@@ -283,24 +285,17 @@ impl<'a> CommandRunner<'a> {
     docker: &'a DockerOnceCell,
     image_pull_cache: &'a ImagePullCache,
     work_dir_base: PathBuf,
-    named_caches: NamedCaches,
     immutable_inputs: ImmutableInputs,
     keep_sandboxes: KeepSandboxes,
   ) -> Result<Self, String> {
-    let container_cache = ContainerCache::new(
-      docker,
-      image_pull_cache,
-      &work_dir_base,
-      &named_caches,
-      &immutable_inputs,
-    )?;
+    let container_cache =
+      ContainerCache::new(docker, image_pull_cache, &work_dir_base, &immutable_inputs)?;
 
     Ok(CommandRunner {
       store,
       executor,
       docker,
       work_dir_base,
-      named_caches,
       immutable_inputs,
       keep_sandboxes,
       container_cache,
@@ -338,6 +333,20 @@ impl<'a> super::CommandRunner for CommandRunner<'a> {
           self.keep_sandboxes,
         )?;
 
+        // Obtain ID of the base container in which to run the execution for this process.
+        let (container_id, named_caches) = {
+          let ProcessExecutionStrategy::Docker(image) = &req.execution_strategy else {
+            return Err(ProcessError::Unclassified(
+                "The Docker execution strategy was not set on the Process, but \
+                 the Docker CommandRunner was used.".to_owned()))
+          };
+
+          self
+            .container_cache
+            .container_for_image(image, &req.platform, &context.build_id)
+            .await?
+        };
+
         // Start working on a mutable version of the process.
         let mut req = req;
 
@@ -370,7 +379,7 @@ impl<'a> super::CommandRunner for CommandRunner<'a> {
           req.input_digests.input_files.clone(),
           self.store.clone(),
           self.executor.clone(),
-          &self.named_caches,
+          &named_caches,
           &self.immutable_inputs,
           Some(Path::new(NAMED_CACHES_BASE_PATH_IN_CONTAINER)),
           Some(Path::new(IMMUTABLE_INPUTS_BASE_PATH_IN_CONTAINER)),
@@ -386,7 +395,7 @@ impl<'a> super::CommandRunner for CommandRunner<'a> {
             self.store.clone(),
             self.executor.clone(),
             workdir.path().to_owned(),
-            sandbox_path_in_container,
+            (container_id, sandbox_path_in_container),
             exclusive_spawn,
             req.platform,
           )
@@ -435,23 +444,17 @@ impl<'a> super::CommandRunner for CommandRunner<'a> {
 
 #[async_trait]
 impl<'a> CapturedWorkdir for CommandRunner<'a> {
-  type WorkdirToken = String;
+  type WorkdirToken = (String, String);
 
   async fn run_in_workdir<'s, 'c, 'w, 'r>(
     &'s self,
-    context: &'c Context,
+    _context: &'c Context,
     _workdir_path: &'w Path,
-    sandbox_path_in_container: Self::WorkdirToken,
+    (container_id, sandbox_path_in_container): Self::WorkdirToken,
     req: Process,
     _exclusive_spawn: bool,
   ) -> Result<BoxStream<'r, Result<ChildOutput, String>>, String> {
     let docker = self.docker.get().await?;
-
-    let env = req
-      .env
-      .iter()
-      .map(|(key, value)| format!("{key}={value}"))
-      .collect::<Vec<_>>();
 
     let working_dir = req
       .working_directory
@@ -463,30 +466,54 @@ impl<'a> CapturedWorkdir for CommandRunner<'a> {
         format!("Unable to convert working directory due to non UTF-8 characters: {s:?}")
       })?;
 
-    let image = match req.execution_strategy {
-      ProcessExecutionStrategy::Docker(image) => Ok(image),
-      _ => Err("The Docker execution strategy was not set on the Process, but the Docker CommandRunner was used.")
-    }?;
+    Command::new(req.argv)
+      .env(req.env)
+      .working_dir(working_dir)
+      .spawn(docker, container_id)
+      .await
+  }
+}
 
-    // Obtain ID of the base container in which to run the execution for this process.
-    let container_id = self
-      .container_cache
-      .container_id_for_image(&image, &req.platform, &context.build_id)
-      .await?;
+/// A loose clone of `std::process:Command` for Docker `exec`.
+struct Command(bollard::exec::CreateExecOptions<String>);
 
-    let config = bollard::exec::CreateExecOptions {
-      env: Some(env),
-      cmd: Some(req.argv),
-      working_dir: Some(working_dir),
+impl Command {
+  fn new(argv: Vec<String>) -> Self {
+    Self(bollard::exec::CreateExecOptions {
+      cmd: Some(argv),
       attach_stdout: Some(true),
       attach_stderr: Some(true),
       ..bollard::exec::CreateExecOptions::default()
-    };
+    })
+  }
 
-    log::trace!("creating execution with config: {:?}", &config);
+  fn working_dir(&mut self, working_dir: String) -> &mut Self {
+    self.0.working_dir = Some(working_dir);
+    self
+  }
+
+  fn env<I: IntoIterator<Item = (String, String)>>(&mut self, env: I) -> &mut Self {
+    self.0.env = Some(
+      env
+        .into_iter()
+        .map(|(key, value)| format!("{key}={value}"))
+        .collect(),
+    );
+    self
+  }
+
+  /// Execute the command that has been specified, and return a stream of ChildOutputs.
+  ///
+  /// NB: See the TODO on the `ChildOutput` definition.
+  async fn spawn<'a, 'b>(
+    &'a mut self,
+    docker: &'a Docker,
+    container_id: String,
+  ) -> Result<BoxStream<'b, Result<ChildOutput, String>>, String> {
+    log::trace!("creating execution with config: {:?}", self.0);
 
     let exec = docker
-      .create_exec::<String>(&container_id, config)
+      .create_exec::<String>(&container_id, self.0.clone())
       .await
       .map_err(|err| format!("Failed to create Docker execution in container: {err:?}"))?;
 
@@ -544,19 +571,20 @@ impl<'a> CapturedWorkdir for CommandRunner<'a> {
   }
 }
 
+/// Container ID and NamedCaches for that container. async_oncecell::OnceCell is used so that
+/// multiple tasks trying to access an initializing container do not try to start multiple
+/// containers.
+type CachedContainer = Arc<OnceCell<(String, NamedCaches)>>;
+
 /// Caches running containers so that build actions can be invoked by running "executions"
 /// within those cached containers.
 struct ContainerCache<'a> {
   docker: &'a DockerOnceCell,
   image_pull_cache: &'a ImagePullCache,
   work_dir_base: String,
-  named_caches_base_dir: String,
   immutable_inputs_base_dir: String,
-  /// Cache that maps image name to container ID. async_oncecell::OnceCell is used so that
-  /// multiple tasks trying to access an initializing container do not try to start multiple
-  /// containers.
-  #[allow(clippy::type_complexity)]
-  containers: Mutex<BTreeMap<(String, Platform), Arc<OnceCell<String>>>>,
+  /// Cache that maps image name / platform to a cached container.
+  containers: Mutex<BTreeMap<(String, Platform), CachedContainer>>,
 }
 
 impl<'a> ContainerCache<'a> {
@@ -564,7 +592,6 @@ impl<'a> ContainerCache<'a> {
     docker: &'a DockerOnceCell,
     image_pull_cache: &'a ImagePullCache,
     work_dir_base: &Path,
-    named_caches: &NamedCaches,
     immutable_inputs: &ImmutableInputs,
   ) -> Result<Self, String> {
     let work_dir_base = work_dir_base
@@ -572,15 +599,6 @@ impl<'a> ContainerCache<'a> {
       .into_os_string()
       .into_string()
       .map_err(|s| format!("Unable to convert workdir_path due to non UTF-8 characters: {s:?}"))?;
-
-    let named_caches_base_dir = named_caches
-      .base_dir()
-      .to_path_buf()
-      .into_os_string()
-      .into_string()
-      .map_err(|s| {
-        format!("Unable to convert named_caches workdir due to non UTF-8 characters: {s:?}")
-      })?;
 
     let immutable_inputs_base_dir = immutable_inputs
       .workdir()
@@ -595,12 +613,13 @@ impl<'a> ContainerCache<'a> {
       docker,
       image_pull_cache,
       work_dir_base,
-      named_caches_base_dir,
       immutable_inputs_base_dir,
       containers: Mutex::default(),
     })
   }
 
+  /// Creates a container, and creates (if necessary) and attaches a volume for image specific
+  /// (named) caches.
   async fn make_container(
     docker: Docker,
     image: String,
@@ -608,7 +627,6 @@ impl<'a> ContainerCache<'a> {
     image_pull_scope: ImagePullScope,
     image_pull_cache: ImagePullCache,
     work_dir_base: String,
-    named_caches_base_dir: String,
     immutable_inputs_base_dir: String,
   ) -> Result<String, String> {
     // Pull the image.
@@ -622,12 +640,16 @@ impl<'a> ContainerCache<'a> {
       )
       .await?;
 
+    let named_cache_volume_name = Self::maybe_make_named_cache_volume(&docker, &image)
+      .await
+      .map_err(|e| format!("Failed to create named cache volume for {image}: {e}"))?;
+
     let config = bollard::container::Config {
       entrypoint: Some(vec!["/bin/sh".to_string()]),
       host_config: Some(bollard::service::HostConfig {
         binds: Some(vec![
           format!("{work_dir_base}:{SANDBOX_BASE_PATH_IN_CONTAINER}"),
-          format!("{named_caches_base_dir}:{NAMED_CACHES_BASE_PATH_IN_CONTAINER}",),
+          format!("{named_cache_volume_name}:{NAMED_CACHES_BASE_PATH_IN_CONTAINER}",),
           // DOCKER-TODO: Consider making this bind mount read-only.
           format!("{immutable_inputs_base_dir}:{IMMUTABLE_INPUTS_BASE_PATH_IN_CONTAINER}"),
         ]),
@@ -656,12 +678,6 @@ impl<'a> ContainerCache<'a> {
       .await
       .map_err(|err| format!("Failed to create Docker container: {err:?}"))?;
 
-    log::trace!(
-      "created container `{}` for image `{}`",
-      &container.id,
-      image
-    );
-
     docker
       .start_container::<String>(&container.id, None)
       .await
@@ -672,7 +688,7 @@ impl<'a> ContainerCache<'a> {
         )
       })?;
 
-    log::trace!(
+    log::debug!(
       "started container `{}` for image `{}`",
       &container.id,
       image
@@ -681,14 +697,86 @@ impl<'a> ContainerCache<'a> {
     Ok(container.id)
   }
 
-  /// Return the container ID of a container running `image` for use as a place to invoke
-  /// build actions as executions within the cached container.
-  pub async fn container_id_for_image(
+  /// Creates a volume for named caches for the given image name. In production usage, the image
+  /// name will have been expanded to include its SHA256 fingerprint, so the named cache will be
+  /// dedicated to a particular image version. That is conservative, so we might consider making
+  /// it configurable whether the image version is attached in future releases.
+  async fn maybe_make_named_cache_volume(
+    docker: &Docker,
+    image: &str,
+  ) -> Result<String, DockerError> {
+    let image_hash = Digest::of_bytes(image.as_bytes())
+      .hash
+      .to_hex()
+      .chars()
+      .take(12)
+      .collect::<String>();
+    let named_cache_volume_name = format!("pants-named-caches-{image_hash}");
+    // TODO: Use a filter on volume name.
+    let volume_exists = docker
+      .list_volumes::<&str>(None)
+      .await?
+      .volumes
+      .map(|volumes| volumes.iter().any(|v| v.name == named_cache_volume_name))
+      .unwrap_or(false);
+    if volume_exists {
+      return Ok(named_cache_volume_name);
+    }
+
+    let mut labels = HashMap::new();
+    labels.insert("image_name", image);
+    docker
+      .create_volume::<&str>(CreateVolumeOptions {
+        name: &named_cache_volume_name,
+        driver: "local",
+        labels,
+        ..CreateVolumeOptions::default()
+      })
+      .await?;
+
+    Ok(named_cache_volume_name)
+  }
+
+  async fn make_named_cache_directory(
+    docker: Docker,
+    container_id: String,
+    directory: PathBuf,
+  ) -> Result<(), String> {
+    let directory = directory.into_os_string().into_string().map_err(|s| {
+      format!("Unable to convert named cache path to string due to non UTF-8 characters: {s:?}")
+    })?;
+    let child_outputs = Command::new(vec![
+      "mkdir".to_owned(),
+      "-p".to_owned(),
+      directory.to_owned(),
+    ])
+    .spawn(&docker, container_id)
+    .await?;
+
+    let mut stdout = BytesMut::with_capacity(8192);
+    let mut stderr = BytesMut::with_capacity(8192);
+    let exit_code = collect_child_outputs(&mut stdout, &mut stderr, child_outputs).await?;
+    if exit_code == 0 {
+      Ok(())
+    } else {
+      Err(format!(
+        "Failed to create parent directory for named cache in Docker container:\n\
+         stdout:\n{}\n\
+         stderr:\n{}\n",
+        String::from_utf8_lossy(&stdout),
+        String::from_utf8_lossy(&stderr)
+      ))
+    }
+  }
+
+  /// Return the container ID and NamedCaches for a container running `image` for use as a place
+  /// to invoke build actions as executions within the cached container.
+  pub async fn container_for_image(
     &self,
     image: &str,
     platform: &Platform,
     build_generation: &str,
-  ) -> Result<String, String> {
+  ) -> Result<(String, NamedCaches), String> {
     let docker = self.docker.get().await?;
     let docker = docker.clone();
 
@@ -701,23 +789,36 @@ impl<'a> ContainerCache<'a> {
     };
 
     let work_dir_base = self.work_dir_base.clone();
-    let named_caches_base_dir = self.named_caches_base_dir.clone();
     let immutable_inputs_base_dir = self.immutable_inputs_base_dir.clone();
     let image_pull_scope = ImagePullScope::new(build_generation);
 
     let container_id = container_id_cell
       .get_or_try_init(async move {
-        Self::make_container(
-          docker,
+        let container_id = Self::make_container(
+          docker.clone(),
           image.to_string(),
           *platform,
           image_pull_scope,
           self.image_pull_cache.clone(),
           work_dir_base,
-          named_caches_base_dir,
           immutable_inputs_base_dir,
         )
-        .await
+        .await?;
+
+        let named_caches = {
+          let docker = docker.to_owned();
+          let container_id = container_id.clone();
+          NamedCaches::new(NAMED_CACHES_BASE_PATH_IN_CONTAINER.into(), move |dst| {
+            ContainerCache::make_named_cache_directory(
+              docker.clone(),
+              container_id.clone(),
+              dst.to_owned(),
+            )
+            .boxed()
+          })
+        };
+
+        Ok::<_, String>((container_id, named_caches))
       })
       .await?;
 
@@ -749,7 +850,7 @@ impl<'a> ContainerCache<'a> {
       .cloned()
       .collect::<Vec<_>>();
 
-    let removal_futures = container_ids.into_iter().map(|id| async move {
+    let removal_futures = container_ids.into_iter().map(|(id, _)| async move {
       let remove_options = RemoveContainerOptions {
         force: true,
         ..RemoveContainerOptions::default()

--- a/src/rust/engine/process_execution/src/docker.rs
+++ b/src/rust/engine/process_execution/src/docker.rs
@@ -488,7 +488,9 @@ impl<'a> CapturedWorkdir for CommandRunner<'a> {
     req: &Process,
   ) -> Result<(), String> {
     // Docker on Linux will frequently produce root-owned output files in bind mounts, because we
-    // do not assume anything about the users that exist in the image.
+    // do not assume anything about the users that exist in the image. But Docker on macOS (at least
+    // version 14.6.2 using gRPC-FUSE filesystem virtualization) creates files in bind mounts as the
+    // user running Docker. See https://github.com/pantsbuild/pants/issues/18306.
     //
     // TODO: Changing permissions allows the files to be captured, but not for them to be removed.
     // See https://github.com/pantsbuild/pants/issues/18329.

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -733,7 +733,7 @@ async fn run_command_via_docker_in_dir(
   let executor = executor.unwrap_or_else(task_executor::Executor::new);
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
-  let (_caches_dir, named_caches, immutable_inputs) =
+  let (_caches_dir, _named_caches, immutable_inputs) =
     named_caches_and_immutable_inputs(store.clone());
   let docker = Box::new(DockerOnceCell::new());
   let image_pull_cache = Box::new(ImagePullCache::new());
@@ -743,7 +743,6 @@ async fn run_command_via_docker_in_dir(
     &docker,
     &image_pull_cache,
     dir.clone(),
-    named_caches,
     immutable_inputs,
     cleanup,
   )?;

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -769,7 +769,7 @@ pub(crate) fn named_caches_and_immutable_inputs(
 
   (
     root,
-    NamedCaches::new(named_cache_dir),
+    NamedCaches::new_local(named_cache_dir),
     ImmutableInputs::new(store, &root_path).unwrap(),
   )
 }

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -22,7 +22,7 @@ fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let pool = NailgunPool::new(base_dir.clone(), size, store.clone(), executor);
   (
     pool,
-    NamedCaches::new(named_caches_dir.path().to_owned()),
+    NamedCaches::new_local(named_caches_dir.path().to_owned()),
     ImmutableInputs::new(store, &base_dir).unwrap(),
   )
 }

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -1,12 +1,16 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use async_oncecell::OnceCell;
 use deepsize::DeepSizeOf;
+use futures::{FutureExt, TryFutureExt};
+use parking_lot::Mutex;
 use serde::Serialize;
 
-use fs::{default_cache_path, safe_create_dir_all_ioerror, RelativePath};
+use fs::{default_cache_path, RelativePath};
 use store::WorkdirSymlink;
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize)]
@@ -31,75 +35,108 @@ impl CacheName {
   }
 }
 
-#[derive(Clone)]
-pub struct NamedCaches {
-  ///
-  /// The absolute path to the base of the directory storing named caches. Pants "owns" this
-  /// directory, and may clear or otherwise prune it at any time.
-  ///
-  local_base: PathBuf,
+///
+/// Named caches are concurrency safe caches in a filesystem, subdivided by cache name.
+///
+/// Pants "owns" named caches, and may clear or otherwise prune them at any time.
+///
+struct Inner {
+  /// The absolute path to the base of the directory storing named caches. This may be a local or
+  /// remote/virtualized path.
+  base_path: PathBuf,
+  /// An initializer function used to initialize a named cache at the given absolute path, once per
+  /// NamedCaches instance.
+  #[allow(clippy::type_complexity)]
+  initializer: Box<dyn Fn(&Path) -> futures::future::BoxFuture<Result<(), String>> + Send + Sync>,
+  /// Caches which have been initialized.
+  initialized: Mutex<HashMap<PathBuf, Arc<OnceCell<()>>>>,
 }
 
+#[derive(Clone)]
+pub struct NamedCaches(Arc<Inner>);
+
 impl NamedCaches {
-  pub fn new(local_base: PathBuf) -> NamedCaches {
-    NamedCaches { local_base }
+  /// Create a NamedCache, potentially in a virtualized filesystem. Cache entries will be created
+  /// using the given initializer function.
+  pub fn new(
+    base_path: PathBuf,
+    initializer: impl Fn(&Path) -> futures::future::BoxFuture<Result<(), String>>
+      + Send
+      + Sync
+      + 'static,
+  ) -> Self {
+    Self(Arc::new(Inner {
+      base_path,
+      initializer: Box::new(initializer),
+      initialized: Mutex::default(),
+    }))
   }
 
-  pub fn base_dir(&self) -> &Path {
-    &self.local_base
+  /// Create a NamedCache in the local filesystem.
+  pub fn new_local(base_path: PathBuf) -> Self {
+    Self::new(base_path, |dst| {
+      tokio::fs::create_dir_all(dst)
+        .map_err(|e| format!("Failed to create path {}: {e}", dst.display()))
+        .boxed()
+    })
+  }
+
+  pub fn base_path(&self) -> &Path {
+    &self.0.base_path
   }
 
   // This default suffix is also hard-coded into the Python options code in global_options.py
-  pub fn default_path() -> PathBuf {
+  pub fn default_local_path() -> PathBuf {
     default_cache_path().join("named_caches")
   }
 
-  ///
-  /// Returns symlinks to create for the given set of NamedCaches.
-  ///
-  pub fn local_paths<'a>(
-    &'a self,
-    caches: &'a BTreeMap<CacheName, RelativePath>,
-  ) -> Result<Vec<WorkdirSymlink>, String> {
-    let symlinks = caches
-      .iter()
-      .map(move |(cache_name, workdir_rel_path)| WorkdirSymlink {
-        src: workdir_rel_path.clone(),
-        dst: self.local_base.join(&cache_name.0),
-      })
-      .collect::<Vec<_>>();
-
-    for symlink in &symlinks {
-      safe_create_dir_all_ioerror(&symlink.dst).map_err(|err| {
-        format!(
-          "Error creating directory {}: {:?}",
-          symlink.dst.display(),
-          err
-        )
-      })?
+  fn cache_cell(&self, path: PathBuf) -> Arc<OnceCell<()>> {
+    let mut cells = self.0.initialized.lock();
+    if let Some(cell) = cells.get(&path) {
+      cell.clone()
+    } else {
+      let cell = Arc::new(OnceCell::new());
+      cells.insert(path, cell.clone());
+      cell
     }
-
-    Ok(symlinks)
   }
 
   ///
-  /// An iterator over platform properties that should be added for the given named caches, and the
-  /// given named cache namespace value.
+  /// Returns symlinks to create for the given set of NamedCaches, initializing them if necessary.
   ///
-  /// See <https://docs.google.com/document/d/1n_MVVGjrkTKTPKHqRPlyfFzQyx2QioclMG_Q3DMUgYk/edit#>.
-  ///
-  pub fn platform_properties<'a>(
+  pub async fn paths<'a>(
+    &'a self,
     caches: &'a BTreeMap<CacheName, RelativePath>,
-    namespace: &'a Option<String>,
-  ) -> impl Iterator<Item = (String, String)> + 'a {
-    namespace
-      .iter()
-      .map(|ns| ("x_append_only_cache_namespace".to_owned(), ns.to_owned()))
-      .chain(caches.iter().map(move |(cache_name, cache_dest)| {
-        (
-          format!("x_append_only_cache:{}", cache_name.0),
-          cache_dest.display().to_string(),
-        )
-      }))
+  ) -> Result<Vec<WorkdirSymlink>, String> {
+    // Collect the symlinks to create, and their destination cache cells.
+    let (symlinks, initialization_futures): (Vec<_>, Vec<_>) = {
+      caches
+        .iter()
+        .map(move |(cache_name, workdir_rel_path)| {
+          let symlink = WorkdirSymlink {
+            src: workdir_rel_path.clone(),
+            dst: self.0.base_path.join(&cache_name.0),
+          };
+
+          // Create the initialization future under the lock, but await it outside.
+          let dst: PathBuf = symlink.dst.clone();
+          let named_caches: NamedCaches = self.clone();
+          let initialization_future = async move {
+            named_caches
+              .cache_cell(dst.clone())
+              .get_or_try_init(async move { (named_caches.0.initializer)(&dst).await })
+              .await?;
+            Ok::<_, String>(())
+          };
+
+          (symlink, initialization_future)
+        })
+        .unzip()
+    };
+
+    // Ensure that all cache destinations have been created.
+    futures::future::try_join_all(initialization_futures).await?;
+
+    Ok(symlinks)
   }
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -344,10 +344,10 @@ async fn main() {
       store.clone(),
       executor,
       workdir.clone(),
-      NamedCaches::new(
+      NamedCaches::new_local(
         args
           .named_cache_path
-          .unwrap_or_else(NamedCaches::default_path),
+          .unwrap_or_else(NamedCaches::default_local_path),
       ),
       ImmutableInputs::new(store.clone(), &workdir).unwrap(),
       KeepSandboxes::Never,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -245,7 +245,6 @@ impl Core {
       &DOCKER,
       &IMAGE_PULL_CACHE,
       local_execution_root_dir.to_path_buf(),
-      named_caches.clone(),
       immutable_inputs.clone(),
       exec_strategy_opts.local_keep_sandboxes,
     )?);
@@ -535,7 +534,7 @@ impl Core {
     };
 
     let immutable_inputs = ImmutableInputs::new(store.clone(), &local_execution_root_dir)?;
-    let named_caches = NamedCaches::new(named_caches_dir);
+    let named_caches = NamedCaches::new_local(named_caches_dir);
     let command_runners = Self::make_command_runners(
       &full_store,
       &store,


### PR DESCRIPTION
As reported in #18308, using a bind mount for named caches can result in the cache contents being owned by root on Linux. Additionally, we suspect that on macOS, hardlinks within the named caches could cause issues like https://github.com/pantsbuild/pants/issues/18162#issuecomment-1432238187.

This change moves to using a volume per Docker image hash to store named caches. This avoids both of the above issues by avoiding bind mounts for named caches, and should likely also be faster on macOS (where virtualization of the bind mount filesystem is a performance bottleneck).

And as reported in #18306, a similar ownership issue also applies (on Linux) to the bind mount used for inputs and outputs. To resolve that, this change also `chmod`s outputs (on Linux) to ensure that the host machine is able to capture them.

Fixes #18308 and fixes #18306.