### PR TITLE
Adds `system_binary` target, which can be used to reproducibly find a pre-installed binary for use with `adhoc_tool`

### DIFF
--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -82,7 +82,7 @@ async def _find_binary(
         return binary
 
     raise ValueError(
-        f"Could not find a binary with `{binary_name}`"
+        f"Could not find a binary with name `{binary_name}`"
         + (
             ""
             if not fingerprint_pattern

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -61,11 +61,13 @@ async def _find_binary(
         else None
     )
 
+    search_paths = tuple(extra_search_paths) + SEARCH_PATHS
+
     binaries = await Get(
         BinaryPaths,
         BinaryPathRequest(
             binary_name=binary_name,
-            search_path=(tuple(extra_search_paths) + SEARCH_PATHS),
+            search_path=search_paths,
             test=test,
         ),
     )
@@ -79,7 +81,15 @@ async def _find_binary(
 
         return binary
 
-    raise ValueError(f"Could not find a binary with `{binary_name}` with the provided constraints.")
+    raise ValueError(
+        f"Could not find a binary with `{binary_name}`"
+        + (
+            ""
+            if not fingerprint_pattern
+            else f" with output matching `{fingerprint_pattern}` when run with arguments `{' '.join(fingerprint_args or ())}`"
+        )
+        + f". The following paths were searched: {', '.join(search_paths)}."
+    )
 
 
 @rule(level=LogLevel.DEBUG)

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -1,0 +1,108 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.adhoc.target_types import (
+    SystemBinaryExtraSearchPathsField,
+    SystemBinaryFingerprintArgsField,
+    SystemBinaryFingerprintPattern,
+    SystemBinaryNameField,
+)
+from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
+from pants.core.util_rules.system_binaries import (
+    SEARCH_PATHS,
+    BinaryPath,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryPathTest,
+)
+from pants.engine.internals.native_engine import EMPTY_DIGEST
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule, rule_helper
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SystemBinaryFieldSet(RunFieldSet):
+    run_in_sandbox_behavior = RunInSandboxBehavior.RUN_REQUEST_HERMETIC
+
+    required_fields = (
+        SystemBinaryNameField,
+        SystemBinaryExtraSearchPathsField,
+        SystemBinaryFingerprintPattern,
+        SystemBinaryFingerprintArgsField,
+    )
+
+    name: SystemBinaryNameField
+    extra_search_paths: SystemBinaryExtraSearchPathsField
+    fingerprint_pattern: SystemBinaryFingerprintPattern
+    fingerprint_argv: SystemBinaryFingerprintArgsField
+
+
+@rule_helper
+async def _find_binary(
+    binary_name: str,
+    extra_search_paths: Iterable[str],
+    fingerprint_pattern: str | None,
+    fingerprint_args: tuple[str, ...] | None,
+) -> BinaryPath:
+
+    test = (
+        BinaryPathTest(fingerprint_args or (), fingerprint_stdout=False)
+        if fingerprint_pattern
+        else None
+    )
+
+    binaries = await Get(
+        BinaryPaths,
+        BinaryPathRequest(
+            binary_name=binary_name,
+            search_path=(tuple(extra_search_paths) + SEARCH_PATHS),
+            test=test,
+        ),
+    )
+
+    for binary in binaries.paths:
+        if fingerprint_pattern:
+            fingerprint = binary.fingerprint.strip()
+            match = re.match(fingerprint_pattern, fingerprint)
+            if not match:
+                continue
+
+        return binary
+
+    raise ValueError(f"Could not find a binary with `{binary_name}` with the provided constraints.")
+
+
+@rule(level=LogLevel.DEBUG)
+async def create_system_binary_run_request(field_set: SystemBinaryFieldSet) -> RunRequest:
+
+    assert field_set.name.value is not None
+    extra_search_paths = field_set.extra_search_paths.value or ()
+
+    path = await _find_binary(
+        field_set.name.value,
+        extra_search_paths,
+        field_set.fingerprint_pattern.value,
+        field_set.fingerprint_argv.value,
+    )
+
+    return RunRequest(
+        digest=EMPTY_DIGEST,
+        args=[path.path],
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+        *SystemBinaryFieldSet.rules(),
+    ]

--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -1,0 +1,96 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+import pytest
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+
+
+def test_system_binary_and_adhoc_tool() -> None:
+    sources = {
+        "src/test_file.txt": dedent(
+            """\
+            I am a duck.
+            """
+        ),
+        "src/BUILD": dedent(
+            """\
+            files(name="files", sources=["*.txt",])
+
+            system_binary(
+                name="cat",
+                binary_name="cat",
+            )
+
+            adhoc_tool(
+                name="adhoc",
+                runnable=":cat",
+                execution_dependencies=[":files",],
+                args=["test_file.txt",],
+                log_output=True,
+                stdout="stdout",
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python']",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        assert "[INFO] I am a duck." in result.stderr.strip()
+
+
+@pytest.mark.parametrize(
+    ("fingerprint,passes"),
+    (
+        (r"Binary Name v6\.32\.1", True),
+        (r"(.*)v6\.(.*)", True),
+        (r"Binary Name v6\.99999\.1", False),
+    ),
+)
+def test_fingerprint(fingerprint: str, passes: bool) -> None:
+    sources = {
+        "src/BUILD": dedent(
+            f"""\
+            system_binary(
+                name="bash",
+                binary_name="bash",
+                fingerprint=r"{fingerprint}",
+                fingerprint_args=("-c", "echo Binary Name v6.32.1",),
+            )
+
+            adhoc_tool(
+                name="adhoc",
+                runnable=":bash",
+                args=["-c","echo I am a duck!"],
+                log_output=True,
+                stdout="stdout",
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python']",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        if passes:
+            assert result.exit_code == 0
+            assert "[INFO] I am a duck!" in result.stderr.strip()
+        else:
+            assert result.exit_code != 0
+            assert (
+                "Could not find a binary with `bash` with the provided constraints."
+                in result.stderr.strip()
+            )

--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -90,7 +90,4 @@ def test_fingerprint(fingerprint: str, passes: bool) -> None:
             assert "[INFO] I am a duck!" in result.stderr.strip()
         else:
             assert result.exit_code != 0
-            assert (
-                "Could not find a binary with `bash` with the provided constraints."
-                in result.stderr.strip()
-            )
+            assert "Could not find a binary with name `bash`" in result.stderr.strip()

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -252,15 +252,6 @@ class AdhocToolTarget(Target):
 # `system_binary` target
 # ---
 
-"""
-system_binary(
-    binary_name="sh",
-    extra_search_paths=["/bin", "/opt"],
-    fingerprint_args=["--version"],
-    fingerprint_regex="blah",
-)
-"""
-
 
 class SystemBinaryNameField(StringField):
     alias = "binary_name"

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -307,7 +307,7 @@ class SystemBinaryTarget(Target):
         paths provided, as well as default search paths. If
         `{SystemBinaryFingerprintPattern.alias}` is specified, each binary that is located will be
         executed with the arguments from `{SystemBinaryFingerprintArgsField.alias}`. Any binaries
-        that do not match the pattern will be excluded.
+        whose output does not match the pattern will be excluded.
 
         The first non-excluded binary will be the one that is resolved.
         """

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -246,3 +246,78 @@ class AdhocToolTarget(Target):
             shell_sources(name="scripts")
         """
     )
+
+
+# ---
+# `system_binary` target
+# ---
+
+"""
+system_binary(
+    binary_name="sh",
+    extra_search_paths=["/bin", "/opt"],
+    fingerprint_args=["--version"],
+    fingerprint_regex="blah",
+)
+"""
+
+
+class SystemBinaryNameField(StringField):
+    alias = "binary_name"
+    required = True
+    help = "The name of the binary to find."
+
+
+class SystemBinaryExtraSearchPathsField(StringSequenceField):
+    alias = "extra_search_paths"
+    default = ()
+    help = help_text(
+        """
+        Extra search paths to look for the binary. These take priority over Pants' default
+        search paths.
+        """
+    )
+
+
+class SystemBinaryFingerprintPattern(StringField):
+    alias = "fingerprint"
+    required = False
+    default = None
+    help = help_text(
+        """
+        A regular expression which will be used to match the fingerprint outputs from
+        candidate binaries found during the search process.
+        """
+    )
+
+
+class SystemBinaryFingerprintArgsField(StringSequenceField):
+    alias = "fingerprint_args"
+    default = ()
+    help = help_text(
+        "Specifies arguments that will be used to run the binary during the search process."
+    )
+
+
+class SystemBinaryTarget(Target):
+    alias = "system_binary"
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        SystemBinaryNameField,
+        SystemBinaryExtraSearchPathsField,
+        SystemBinaryFingerprintPattern,
+        SystemBinaryFingerprintArgsField,
+    )
+    help = help_text(
+        lambda: f"""
+        A system binary that can be run with `pants run` or consumed by `{AdhocToolTarget.alias}`.
+
+        Pants will search for binaries with name `{SystemBinaryNameField.alias}` in the search
+        paths provided, as well as default search paths. If
+        `{SystemBinaryFingerprintPattern.alias}` is specified, each binary that is located will be
+        executed with the arguments from `{SystemBinaryFingerprintArgsField.alias}`. Any binaries
+        that do not match the pattern will be excluded.
+
+        The first non-excluded binary will be the one that is resolved.
+        """
+    )

--- a/src/python/pants/backend/experimental/adhoc/register.py
+++ b/src/python/pants/backend/experimental/adhoc/register.py
@@ -1,17 +1,19 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.backend.adhoc import adhoc_tool
-from pants.backend.adhoc.target_types import AdhocToolTarget
+from pants.backend.adhoc import adhoc_tool, run_system_binary
+from pants.backend.adhoc.target_types import AdhocToolTarget, SystemBinaryTarget
 
 
 def target_types():
     return [
         AdhocToolTarget,
+        SystemBinaryTarget,
     ]
 
 
 def rules():
     return [
         *adhoc_tool.rules(),
+        *run_system_binary.rules(),
     ]


### PR DESCRIPTION
This adds a `system_binary` target to the `adhoc` backend, which allows you to specify a pre-installed binary as the `runnable` for `adhoc_tool`. For POSIX-style tools, there's limited value here, but if there are installable tools which have vastly different semantics between versions (e.g. `node`), this allows you to run a version-checking command, and check against a regex for compatibility.

Closes #18180
