### PR TITLE
Bump to a new version of buildgrid to fix a pinning issue.

### DIFF
--- a/build-support/reapi-sample-server/Dockerfile
+++ b/build-support/reapi-sample-server/Dockerfile
@@ -16,7 +16,7 @@ RUN /tmp/download_install.sh buildbox-run-hosttools 5fc4184de288f19d40a90c649846
 
 # Install buildgrid.
 RUN git clone https://gitlab.com/BuildGrid/buildgrid.git && \
-    git -C buildgrid reset --hard 82341d090db55e11257d92ea38f9afd61fa15486
+    git -C buildgrid reset --hard 55011817110dec2478b2321ae43d835e91d78f70
 
 RUN pip install ./buildgrid
 

--- a/pants.remote-execution.toml
+++ b/pants.remote-execution.toml
@@ -17,4 +17,4 @@ remote_execution_address = "grpc://127.0.0.1:50051"
 remote_instance_name = ""
 
 # TODO: See https://gitlab.com/BuildGrid/buildgrid/-/blob/master/buildgrid/server/server.py#L212-222
-process_execution_remote_parallelism = 8
+process_execution_remote_parallelism = 4


### PR DESCRIPTION
Bumps our use of Buildgrid to include [a pin for a floating dependency](https://gitlab.com/BuildGrid/buildgrid/-/commit/55011817110dec2478b2321ae43d835e91d78f70).