### PR TITLE
Docker environment uses a volume for named caches (Cherry-pick of #18327)

### DIFF
--- a/src/rust/engine/process_execution/src/cache_tests.rs
+++ b/src/rust/engine/process_execution/src/cache_tests.rs
@@ -30,7 +30,7 @@ fn create_local_runner() -> (Box<dyn CommandRunnerTrait>, Store, TempDir) {
     store.clone(),
     runtime.clone(),
     base_dir.path().to_owned(),
-    NamedCaches::new(named_cache_dir),
+    NamedCaches::new_local(named_cache_dir),
     ImmutableInputs::new(store.clone(), base_dir.path()).unwrap(),
     KeepSandboxes::Never,
   ));

--- a/src/rust/engine/process_execution/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/src/docker_tests.rs
@@ -540,6 +540,38 @@ async fn all_containing_directories_for_outputs_are_created() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn outputs_readable_only_by_container_user_are_captured() {
+  skip_if_no_docker_available_in_macos_ci!();
+
+  let result = run_command_via_docker(
+    Process::new(vec![
+      SH_PATH.to_string(),
+      "-c".to_owned(),
+      format!(
+        // Ensure that files are only readable by the container user (which on Linux would usually
+        // mean that a non-root user outside the container would not have access).
+        "/bin/mkdir birds/falcons && echo -n {} > cats/roland.ext && chmod o-r -R birds cats",
+        TestData::roland().string()
+      ),
+    ])
+    .output_files(relative_paths(&["cats/roland.ext"]).collect())
+    .output_directories(relative_paths(&["birds/falcons"]).collect())
+    .docker(IMAGE.to_owned()),
+  )
+  .await
+  .unwrap();
+
+  assert_eq!(result.stdout_bytes, "".as_bytes());
+  assert_eq!(result.stderr_bytes, "".as_bytes());
+  assert_eq!(result.original.exit_code, 0);
+  assert_eq!(
+    result.original.output_directory,
+    TestDirectory::nested_dir_and_file().directory_digest()
+  );
+  assert_eq!(result.original.platform, platform_for_tests().unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn output_empty_dir() {
   skip_if_no_docker_available_in_macos_ci!();
 
@@ -731,7 +763,7 @@ async fn run_command_via_docker_in_dir(
   let executor = executor.unwrap_or_else(|| task_executor::Executor::new());
   let store =
     store.unwrap_or_else(|| Store::local_only(executor.clone(), store_dir.path()).unwrap());
-  let (_caches_dir, named_caches, immutable_inputs) =
+  let (_caches_dir, _named_caches, immutable_inputs) =
     named_caches_and_immutable_inputs(store.clone());
   let docker = Box::new(DockerOnceCell::new());
   let image_pull_cache = Box::new(ImagePullCache::new());
@@ -741,7 +773,6 @@ async fn run_command_via_docker_in_dir(
     &docker,
     &image_pull_cache,
     dir.clone(),
-    named_caches,
     immutable_inputs,
     cleanup,
   )?;

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -767,7 +767,7 @@ pub(crate) fn named_caches_and_immutable_inputs(
 
   (
     root,
-    NamedCaches::new(named_cache_dir),
+    NamedCaches::new_local(named_cache_dir),
     ImmutableInputs::new(store, &root_path).unwrap(),
   )
 }

--- a/src/rust/engine/process_execution/src/nailgun/tests.rs
+++ b/src/rust/engine/process_execution/src/nailgun/tests.rs
@@ -20,7 +20,7 @@ fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs) {
   let pool = NailgunPool::new(base_dir.clone(), size, store.clone(), executor);
   (
     pool,
-    NamedCaches::new(named_caches_dir.path().to_owned()),
+    NamedCaches::new_local(named_caches_dir.path().to_owned()),
     ImmutableInputs::new(store, &base_dir).unwrap(),
   )
 }

--- a/src/rust/engine/process_execution/src/named_caches.rs
+++ b/src/rust/engine/process_execution/src/named_caches.rs
@@ -1,11 +1,15 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
+use async_oncecell::OnceCell;
 use deepsize::DeepSizeOf;
+use futures::{FutureExt, TryFutureExt};
+use parking_lot::Mutex;
 use serde::Serialize;
 
 use crate::WorkdirSymlink;
-use fs::{default_cache_path, safe_create_dir_all_ioerror, RelativePath};
+use fs::{default_cache_path, RelativePath};
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, PartialEq, Hash, PartialOrd, Ord, Serialize)]
 pub struct CacheName(String);
@@ -30,75 +34,108 @@ impl CacheName {
   }
 }
 
-#[derive(Clone)]
-pub struct NamedCaches {
-  ///
-  /// The absolute path to the base of the directory storing named caches. Pants "owns" this
-  /// directory, and may clear or otherwise prune it at any time.
-  ///
-  local_base: PathBuf,
+///
+/// Named caches are concurrency safe caches in a filesystem, subdivided by cache name.
+///
+/// Pants "owns" named caches, and may clear or otherwise prune them at any time.
+///
+struct Inner {
+  /// The absolute path to the base of the directory storing named caches. This may be a local or
+  /// remote/virtualized path.
+  base_path: PathBuf,
+  /// An initializer function used to initialize a named cache at the given absolute path, once per
+  /// NamedCaches instance.
+  #[allow(clippy::type_complexity)]
+  initializer: Box<dyn Fn(&Path) -> futures::future::BoxFuture<Result<(), String>> + Send + Sync>,
+  /// Caches which have been initialized.
+  initialized: Mutex<HashMap<PathBuf, Arc<OnceCell<()>>>>,
 }
 
+#[derive(Clone)]
+pub struct NamedCaches(Arc<Inner>);
+
 impl NamedCaches {
-  pub fn new(local_base: PathBuf) -> NamedCaches {
-    NamedCaches { local_base }
+  /// Create a NamedCache, potentially in a virtualized filesystem. Cache entries will be created
+  /// using the given initializer function.
+  pub fn new(
+    base_path: PathBuf,
+    initializer: impl Fn(&Path) -> futures::future::BoxFuture<Result<(), String>>
+      + Send
+      + Sync
+      + 'static,
+  ) -> Self {
+    Self(Arc::new(Inner {
+      base_path,
+      initializer: Box::new(initializer),
+      initialized: Mutex::default(),
+    }))
   }
 
-  pub fn base_dir(&self) -> &Path {
-    &self.local_base
+  /// Create a NamedCache in the local filesystem.
+  pub fn new_local(base_path: PathBuf) -> Self {
+    Self::new(base_path, |dst| {
+      tokio::fs::create_dir_all(dst)
+        .map_err(|e| format!("Failed to create path {}: {e}", dst.display()))
+        .boxed()
+    })
+  }
+
+  pub fn base_path(&self) -> &Path {
+    &self.0.base_path
   }
 
   // This default suffix is also hard-coded into the Python options code in global_options.py
-  pub fn default_path() -> PathBuf {
+  pub fn default_local_path() -> PathBuf {
     default_cache_path().join("named_caches")
   }
 
-  ///
-  /// Returns symlinks to create for the given set of NamedCaches.
-  ///
-  pub fn local_paths<'a>(
-    &'a self,
-    caches: &'a BTreeMap<CacheName, RelativePath>,
-  ) -> Result<Vec<WorkdirSymlink>, String> {
-    let symlinks = caches
-      .iter()
-      .map(move |(cache_name, workdir_rel_path)| WorkdirSymlink {
-        src: workdir_rel_path.clone(),
-        dst: self.local_base.join(&cache_name.0),
-      })
-      .collect::<Vec<_>>();
-
-    for symlink in &symlinks {
-      safe_create_dir_all_ioerror(&symlink.dst).map_err(|err| {
-        format!(
-          "Error creating directory {}: {:?}",
-          symlink.dst.display(),
-          err
-        )
-      })?
+  fn cache_cell(&self, path: PathBuf) -> Arc<OnceCell<()>> {
+    let mut cells = self.0.initialized.lock();
+    if let Some(cell) = cells.get(&path) {
+      cell.clone()
+    } else {
+      let cell = Arc::new(OnceCell::new());
+      cells.insert(path, cell.clone());
+      cell
     }
-
-    Ok(symlinks)
   }
 
   ///
-  /// An iterator over platform properties that should be added for the given named caches, and the
-  /// given named cache namespace value.
+  /// Returns symlinks to create for the given set of NamedCaches, initializing them if necessary.
   ///
-  /// See https://docs.google.com/document/d/1n_MVVGjrkTKTPKHqRPlyfFzQyx2QioclMG_Q3DMUgYk/edit#.
-  ///
-  pub fn platform_properties<'a>(
+  pub async fn paths<'a>(
+    &'a self,
     caches: &'a BTreeMap<CacheName, RelativePath>,
-    namespace: &'a Option<String>,
-  ) -> impl Iterator<Item = (String, String)> + 'a {
-    namespace
-      .iter()
-      .map(|ns| ("x_append_only_cache_namespace".to_owned(), ns.to_owned()))
-      .chain(caches.iter().map(move |(cache_name, cache_dest)| {
-        (
-          format!("x_append_only_cache:{}", cache_name.0),
-          cache_dest.display().to_string(),
-        )
-      }))
+  ) -> Result<Vec<WorkdirSymlink>, String> {
+    // Collect the symlinks to create, and their destination cache cells.
+    let (symlinks, initialization_futures): (Vec<_>, Vec<_>) = {
+      caches
+        .iter()
+        .map(move |(cache_name, workdir_rel_path)| {
+          let symlink = WorkdirSymlink {
+            src: workdir_rel_path.clone(),
+            dst: self.0.base_path.join(&cache_name.0),
+          };
+
+          // Create the initialization future under the lock, but await it outside.
+          let dst: PathBuf = symlink.dst.clone();
+          let named_caches: NamedCaches = self.clone();
+          let initialization_future = async move {
+            named_caches
+              .cache_cell(dst.clone())
+              .get_or_try_init(async move { (named_caches.0.initializer)(&dst).await })
+              .await?;
+            Ok::<_, String>(())
+          };
+
+          (symlink, initialization_future)
+        })
+        .unzip()
+    };
+
+    // Ensure that all cache destinations have been created.
+    futures::future::try_join_all(initialization_futures).await?;
+
+    Ok(symlinks)
   }
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -344,10 +344,10 @@ async fn main() {
       store.clone(),
       executor,
       workdir.clone(),
-      NamedCaches::new(
+      NamedCaches::new_local(
         args
           .named_cache_path
-          .unwrap_or_else(NamedCaches::default_path),
+          .unwrap_or_else(NamedCaches::default_local_path),
       ),
       ImmutableInputs::new(store.clone(), &workdir).unwrap(),
       KeepSandboxes::Never,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -243,7 +243,6 @@ impl Core {
       &DOCKER,
       &IMAGE_PULL_CACHE,
       local_execution_root_dir.to_path_buf(),
-      named_caches.clone(),
       immutable_inputs.clone(),
       exec_strategy_opts.local_keep_sandboxes,
     )?);
@@ -532,7 +531,7 @@ impl Core {
     };
 
     let immutable_inputs = ImmutableInputs::new(store.clone(), &local_execution_root_dir)?;
-    let named_caches = NamedCaches::new(named_caches_dir);
+    let named_caches = NamedCaches::new_local(named_caches_dir);
     let command_runners = Self::make_command_runners(
       &full_store,
       &store,


### PR DESCRIPTION
As reported in #18308, using a bind mount for named caches can result in the cache contents being owned by root on Linux. Additionally, we suspect that on macOS, hardlinks within the named caches could cause issues like https://github.com/pantsbuild/pants/issues/18162#issuecomment-1432238187.

This change moves to using a volume per Docker image hash to store named caches. This avoids both of the above issues by avoiding bind mounts for named caches, and should likely also be faster on macOS (where virtualization of the bind mount filesystem is a performance bottleneck).

And as reported in #18306, a similar ownership issue also applies (on Linux) to the bind mount used for inputs and outputs. To resolve that, this change also `chmod`s outputs (on Linux) to ensure that the host machine is able to capture them.

Fixes #18308 and fixes #18306.
