### PR TITLE
Add yamllint to the list of backends

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -262,6 +262,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.experimental.scala",
         "pants.backend.experimental.scala.lint.scalafmt",
         "pants.backend.experimental.terraform",
+        "pants.backend.experimental.tools.yamllint",
         "pants.backend.google_cloud_function.python",
         "pants.backend.plugin_development",
         "pants.backend.python",

--- a/src/python/pants/backend/experimental/tools/yamllint/BUILD
+++ b/src/python/pants/backend/experimental/tools/yamllint/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/src/python/pants/backend/experimental/tools/yamllint/BUILD
+++ b/src/python/pants/backend/experimental/tools/yamllint/BUILD
@@ -1,1 +1,3 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 python_sources()

--- a/src/python/pants/backend/experimental/tools/yamllint/register.py
+++ b/src/python/pants/backend/experimental/tools/yamllint/register.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 from typing import Iterable
 
-from pants.engine.rules import Rule
-from pants.engine.unions import UnionRule
+from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.tools.yamllint import rules as yamllint_rules
 from pants.backend.tools.yamllint import subsystem as subsystem
-from pants.backend.python.goals import lockfile as python_lockfile
+from pants.engine.rules import Rule
+from pants.engine.unions import UnionRule
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -62,6 +62,7 @@ target(
         "src/python/pants/backend/experimental/scala/debug_goals",
         "src/python/pants/backend/experimental/scala/lint/scalafmt",
         "src/python/pants/backend/experimental/terraform",
+        "src/python/pants/backend/experimental/tools/yamllint",
         "src/python/pants/backend/experimental/visibility",
         "src/python/pants/backend/google_cloud_function/python",
         "src/python/pants/backend/plugin_development",


### PR DESCRIPTION
My original PR to add a `yamllint` backend forgot to add it to the `plugins` target for the main `pants` executable. As a result, while my testing worked when running from sources, it did not work when trying to actually use the backend with a `pants` release.

Hopefully, this PR rectifies the issue.