### PR TITLE
Use new Linux aarch64 wheel build image.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -328,8 +328,7 @@ jobs:
     timeout-minutes: 60
   build_wheels_linux_arm64:
     container:
-      image: registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v2-2e4d40b8b5
-      options: --user 1000:1000
+      image: registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v3-8384c5cf
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
@@ -372,7 +371,6 @@ jobs:
         '
     - env:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
-        PANTS_SUBPROCESS_ENVIRONMENT_ENV_VARS: HOME
       name: Build wheels
       run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 

--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -862,14 +862,7 @@ def build_pex(fetch: bool) -> None:
     green(f"Built {dest}")
 
     # We filter out Pants options like `PANTS_CONFIG_FILES` and disable certain internal backends.
-    env = {
-        k: v
-        for k, v in env.items()
-        # We retain PANTS_SUBPROCESS_ENVIRONMENT_ENV_VARS as a special-case hack for Linux aarch64
-        # CI where HOME needs to be punched through to make in-container Pants execution of Python
-        # dist builds work.
-        if k == "PANTS_SUBPROCESS_ENVIRONMENT_ENV_VARS" or not k.startswith("PANTS_")
-    }
+    env = {k: v for k, v in env.items() if not k.startswith("PANTS_")}
     env.update(DISABLED_BACKENDS_CONFIG)
     # NB: Set `--concurrent` so that if this script is running under `pantsd`, the validation
     # won't kill it.

--- a/build-support/bin/classify_changed_files.py
+++ b/build-support/bin/classify_changed_files.py
@@ -28,7 +28,7 @@ _release_globs = [
     "src/python/pants/notes/*",
     "src/python/pants/init/BUILD",
     "build-support/bin/release.sh",
-    "build-support/bin/release_helper.py",
+    "build-support/bin/_release_helper.py",
 ]
 _ci_config_globs = [
     "build-support/bin/classify_changed_files.py",


### PR DESCRIPTION
This undoes the hacks added in #18230.