### PR TITLE
Adds support for supplying "runnable" dependencies to the `execution_dependencies` field

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -111,9 +111,7 @@ async def run_in_sandbox_request(
     runnable_dependencies = execution_environment.runnable_dependencies
 
     extra_env: dict[str, str] = dict(run_request.extra_env or {})
-    extra_path = extra_env.get("PATH", None)
-    if extra_path is not None:
-        del extra_env["PATH"]
+    extra_path = extra_env.pop("PATH", None)
 
     extra_sandbox_contents = []
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -104,13 +104,15 @@ async def run_in_sandbox_request(
     )
     dependencies_digest = execution_environment.digest
     runnable_dependencies = execution_environment.runnable_dependencies
-    
+
     immutable_input_digests = dict(run_request.immutable_input_digests or {})
-    extra_env = dict(run_request.extra_env or {})
+    extra_env: dict[str, str] = dict(run_request.extra_env or {})
     append_only_caches = dict(run_request.append_only_caches or {})
 
     if runnable_dependencies:
-        extra_env["PATH"] = extra_env.get("PATH", "") + f":{{chroot}}/{runnable_dependencies.path_component}"
+        extra_env["PATH"] = (
+            extra_env.get("PATH", "") + f":{{chroot}}/{runnable_dependencies.path_component}"
+        )
         immutable_input_digests.update(runnable_dependencies.immutable_input_digests)
         append_only_caches.update(runnable_dependencies.append_only_caches)
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -12,6 +12,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
+    AdhocToolRunnableDependenciesField,
     AdhocToolRunnableField,
     AdhocToolSourcesField,
     AdhocToolStderrFilenameField,
@@ -103,6 +104,7 @@ async def run_in_sandbox_request(
             target.address,
             target.get(AdhocToolExecutionDependenciesField).value,
             target.get(AdhocToolOutputDependenciesField).value,
+            target.get(AdhocToolRunnableDependenciesField).value,
         ),
     )
     dependencies_digest = execution_environment.digest
@@ -110,7 +112,8 @@ async def run_in_sandbox_request(
 
     extra_env: dict[str, str] = dict(run_request.extra_env or {})
     extra_path = extra_env.get("PATH", None)
-    del extra_env["PATH"]
+    if extra_path is not None:
+        del extra_env["PATH"]
 
     extra_sandbox_contents = []
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -119,9 +119,9 @@ async def run_in_sandbox_request(
         ExtraSandboxContents(
             EMPTY_DIGEST,
             extra_path,
-            FrozenDict(run_request.immutable_input_digests or {}),
-            FrozenDict(run_request.append_only_caches or {}),
-            FrozenDict(run_request.extra_env or {}),
+            run_request.immutable_input_digests or FrozenDict(),
+            run_request.append_only_caches or FrozenDict(),
+            run_request.extra_env or FrozenDict(),
         )
     )
 
@@ -158,8 +158,8 @@ async def run_in_sandbox_request(
         argv=tuple(run_request.args + extra_args),
         timeout=None,
         input_digest=input_digest,
-        immutable_input_digests=merged_extras.immutable_input_digests,
-        append_only_caches=merged_extras.append_only_caches,
+        immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
+        append_only_caches=FrozenDict.frozen(merged_extras.append_only_caches),
         output_files=output_files,
         output_directories=output_directories,
         fetch_env_vars=(),

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -20,7 +20,6 @@ from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
 from pants.core.util_rules.adhoc_process_support import (
     ResolvedExecutionDependencies,
     ResolveExecutionDependenciesRequest,
-    runnable,
 )
 from pants.core.util_rules.system_binaries import (
     SEARCH_PATHS,
@@ -62,7 +61,7 @@ async def _find_binary(
     extra_search_paths: Iterable[str],
     fingerprint_pattern: str | None,
     fingerprint_args: tuple[str, ...] | None,
-    fingerprint_dependencies: tuple[str | runnable, ...] | None,
+    fingerprint_dependencies: tuple[str, ...] | None,
 ) -> BinaryPath:
 
     search_paths = tuple(extra_search_paths) + SEARCH_PATHS
@@ -79,7 +78,7 @@ async def _find_binary(
 
     deps = await Get(
         ResolvedExecutionDependencies,
-        ResolveExecutionDependenciesRequest(address, fingerprint_dependencies or (), None),
+        ResolveExecutionDependenciesRequest(address, (), None, fingerprint_dependencies),
     )
     rds = deps.runnable_dependencies
     env: dict[str, str] = {}

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -6,24 +6,31 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
-from typing import Iterable
+from typing import Iterable, Mapping
 
 from pants.backend.adhoc.target_types import (
     SystemBinaryExtraSearchPathsField,
     SystemBinaryFingerprintArgsField,
+    SystemBinaryFingerprintDependenciesField,
     SystemBinaryFingerprintPattern,
     SystemBinaryNameField,
 )
+from pants.build_graph.address import Address
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
+from pants.core.util_rules.adhoc_process_support import (
+    ResolvedExecutionDependencies,
+    ResolveExecutionDependenciesRequest,
+    runnable,
+)
 from pants.core.util_rules.system_binaries import (
     SEARCH_PATHS,
     BinaryPath,
     BinaryPathRequest,
     BinaryPaths,
-    BinaryPathTest,
 )
-from pants.engine.internals.native_engine import EMPTY_DIGEST
-from pants.engine.internals.selectors import Get
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import collect_rules, rule
 from pants.util.logging import LogLevel
 
@@ -39,26 +46,24 @@ class SystemBinaryFieldSet(RunFieldSet):
         SystemBinaryExtraSearchPathsField,
         SystemBinaryFingerprintPattern,
         SystemBinaryFingerprintArgsField,
+        SystemBinaryFingerprintDependenciesField,
     )
 
     name: SystemBinaryNameField
     extra_search_paths: SystemBinaryExtraSearchPathsField
     fingerprint_pattern: SystemBinaryFingerprintPattern
     fingerprint_argv: SystemBinaryFingerprintArgsField
+    fingerprint_dependencies: SystemBinaryFingerprintDependenciesField
 
 
 async def _find_binary(
+    address: Address,
     binary_name: str,
     extra_search_paths: Iterable[str],
     fingerprint_pattern: str | None,
     fingerprint_args: tuple[str, ...] | None,
+    fingerprint_dependencies: tuple[str | runnable, ...] | None,
 ) -> BinaryPath:
-
-    test = (
-        BinaryPathTest(fingerprint_args or (), fingerprint_stdout=False)
-        if fingerprint_pattern
-        else None
-    )
 
     search_paths = tuple(extra_search_paths) + SEARCH_PATHS
 
@@ -67,13 +72,46 @@ async def _find_binary(
         BinaryPathRequest(
             binary_name=binary_name,
             search_path=search_paths,
-            test=test,
         ),
     )
 
-    for binary in binaries.paths:
+    fingerprint_args = fingerprint_args or ()
+
+    deps = await Get(
+        ResolvedExecutionDependencies,
+        ResolveExecutionDependenciesRequest(address, fingerprint_dependencies or (), None),
+    )
+    rds = deps.runnable_dependencies
+    env: dict[str, str] = {}
+    append_only_caches: Mapping[str, str] = {}
+    immutable_input_digests: Mapping[str, Digest] = {}
+    if rds:
+        env = {"PATH": rds.path_component}
+        env.update(**(rds.extra_env or {}))
+        append_only_caches = rds.append_only_caches
+        immutable_input_digests = rds.immutable_input_digests
+
+    tests: tuple[FallibleProcessResult, ...] = await MultiGet(
+        Get(
+            FallibleProcessResult,
+            Process(
+                description=f"Testing candidate for `{binary_name}` at `{path.path}`",
+                argv=(path.path,) + fingerprint_args,
+                input_digest=deps.digest,
+                env=env,
+                append_only_caches=append_only_caches,
+                immutable_input_digests=immutable_input_digests,
+            ),
+        )
+        for path in binaries.paths
+    )
+
+    for test, binary in zip(tests, binaries.paths):
+        if test.exit_code != 0:
+            continue
+
         if fingerprint_pattern:
-            fingerprint = binary.fingerprint.strip()
+            fingerprint = test.stdout.decode().strip()
             match = re.match(fingerprint_pattern, fingerprint)
             if not match:
                 continue
@@ -98,10 +136,12 @@ async def create_system_binary_run_request(field_set: SystemBinaryFieldSet) -> R
     extra_search_paths = field_set.extra_search_paths.value or ()
 
     path = await _find_binary(
+        field_set.address,
         field_set.name.value,
         extra_search_paths,
         field_set.fingerprint_pattern.value,
         field_set.fingerprint_argv.value,
+        field_set.fingerprint_dependencies.value,
     )
 
     return RunRequest(

--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -105,7 +105,7 @@ def test_runnable_dependencies() -> None:
             adhoc_tool(
                 name="adhoc",
                 runnable=":bash",
-                execution_dependencies=[_runnable(name="bash", address=":bash"),],
+                runnable_dependencies=[":bash",],
                 args=["-c", "bash -c 'echo I am a duck.'"],
                 log_output=True,
                 stdout="stdout",

--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -102,11 +102,18 @@ def test_runnable_dependencies() -> None:
                 binary_name="bash",
             )
 
+            system_binary(
+                name="awk",
+                binary_name="awk",
+                fingerprint_args=["--version"],
+                fingerprint=".*",
+            )
+
             adhoc_tool(
                 name="adhoc",
                 runnable=":bash",
-                runnable_dependencies=[":bash",],
-                args=["-c", "bash -c 'echo I am a duck.'"],
+                runnable_dependencies=[":awk",],
+                args=["-c", "awk 'BEGIN {{ print \\"I am a duck.\\" }}'"],
                 log_output=True,
                 stdout="stdout",
             )

--- a/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
+++ b/src/python/pants/backend/adhoc/run_system_binary_integration_test.py
@@ -38,7 +38,7 @@ def test_system_binary_and_adhoc_tool() -> None:
 
     with setup_tmpdir(sources) as tmpdir:
         args = [
-            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python']",
+            "--backend-packages=['pants.backend.experimental.adhoc',]",
             f"--source-root-patterns=['{tmpdir}/src']",
             "export-codegen",
             f"{tmpdir}/src:adhoc",
@@ -79,7 +79,7 @@ def test_fingerprint(fingerprint: str, passes: bool) -> None:
 
     with setup_tmpdir(sources) as tmpdir:
         args = [
-            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python']",
+            "--backend-packages=['pants.backend.experimental.adhoc',]",
             f"--source-root-patterns=['{tmpdir}/src']",
             "export-codegen",
             f"{tmpdir}/src:adhoc",
@@ -91,3 +91,35 @@ def test_fingerprint(fingerprint: str, passes: bool) -> None:
         else:
             assert result.exit_code != 0
             assert "Could not find a binary with name `bash`" in result.stderr.strip()
+
+
+def test_runnable_dependencies() -> None:
+    sources = {
+        "src/BUILD": dedent(
+            """\
+            system_binary(
+                name="bash",
+                binary_name="bash",
+            )
+
+            adhoc_tool(
+                name="adhoc",
+                runnable=":bash",
+                execution_dependencies=[_runnable(name="bash", address=":bash"),],
+                args=["-c", "bash -c 'echo I am a duck.'"],
+                log_output=True,
+                stdout="stdout",
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc',]",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        assert "[INFO] I am a duck." in result.stderr.strip()

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -318,6 +318,16 @@ class SystemBinaryFingerprintArgsField(StringSequenceField):
     )
 
 
+class SystemBinaryFingerprintDependenciesField(AdhocToolExecutionDependenciesField):
+    alias = "fingerprint_dependencies"
+    help = help_text(
+        """
+        Specifies any dependencies that need to be available to the binary to complete the search
+        process. Runnable dependencies may be specified with `_runnable`.
+        """
+    )
+
+
 class SystemBinaryTarget(Target):
     alias = "system_binary"
     core_fields = (
@@ -326,6 +336,7 @@ class SystemBinaryTarget(Target):
         SystemBinaryExtraSearchPathsField,
         SystemBinaryFingerprintPattern,
         SystemBinaryFingerprintArgsField,
+        SystemBinaryFingerprintDependenciesField,
     )
     help = help_text(
         lambda: f"""

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -123,7 +123,8 @@ class AdhocToolRunnableDependenciesField(SpecialCasedDependencies):
         The execution dependencies for this command.
 
         Dependencies specified here are those required to exist on the `PATH` to make the command
-        complete successfully (interpreters specified in a `#!` command, etc).
+        complete successfully (interpreters specified in a `#!` command, etc). Note that these
+        dependencies will be made available on the `PATH` with the name of the target.
 
         See also `{AdhocToolOutputDependenciesField.alias}` and
         `{AdhocToolExecutionDependenciesField.alias}.
@@ -314,8 +315,9 @@ class SystemBinaryFingerprintDependenciesField(AdhocToolRunnableDependenciesFiel
     alias = "fingerprint_dependencies"
     help = help_text(
         """
-        Specifies any runnable dependencies that need to be available on the `PATH` when the binary is
-        run, so that the search process may complete successfully.
+        Specifies any runnable dependencies that need to be available on the `PATH` when the binary
+        is run, so that the search process may complete successfully. The name of the target must
+        be the name of the runnable dependency that is called by this binary.
         """
     )
 

--- a/src/python/pants/backend/experimental/adhoc/register.py
+++ b/src/python/pants/backend/experimental/adhoc/register.py
@@ -3,8 +3,6 @@
 
 from pants.backend.adhoc import adhoc_tool, run_system_binary
 from pants.backend.adhoc.target_types import AdhocToolTarget, SystemBinaryTarget
-from pants.build_graph.build_file_aliases import BuildFileAliases
-from pants.core.util_rules.adhoc_process_support import runnable
 
 
 def target_types():
@@ -19,11 +17,3 @@ def rules():
         *adhoc_tool.rules(),
         *run_system_binary.rules(),
     ]
-
-
-def build_file_aliases():
-    return BuildFileAliases(
-        objects={
-            "_runnable": runnable,
-        },
-    )

--- a/src/python/pants/backend/experimental/adhoc/register.py
+++ b/src/python/pants/backend/experimental/adhoc/register.py
@@ -3,6 +3,8 @@
 
 from pants.backend.adhoc import adhoc_tool, run_system_binary
 from pants.backend.adhoc.target_types import AdhocToolTarget, SystemBinaryTarget
+from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.util_rules.adhoc_process_support import runnable
 
 
 def target_types():
@@ -17,3 +19,11 @@ def rules():
         *adhoc_tool.rules(),
         *run_system_binary.rules(),
     ]
+
+
+def build_file_aliases():
+    return BuildFileAliases(
+        objects={
+            "_runnable": runnable,
+        },
+    )

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -15,6 +15,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
+    AdhocToolRunnableDependenciesField,
     AdhocToolTimeoutField,
     AdhocToolWorkdirField,
 )
@@ -300,6 +301,10 @@ class ShellCommandExecutionDependenciesField(AdhocToolExecutionDependenciesField
     pass
 
 
+class ShellCommandRunnableDependenciesField(AdhocToolRunnableDependenciesField):
+    pass
+
+
 class ShellCommandSourcesField(MultipleSourcesField):
     # We solely register this field for codegen to work.
     alias = "_sources"
@@ -369,6 +374,7 @@ class ShellCommandTarget(Target):
         *COMMON_TARGET_FIELDS,
         ShellCommandOutputDependenciesField,
         ShellCommandExecutionDependenciesField,
+        ShellCommandRunnableDependenciesField,
         ShellCommandCommandField,
         ShellCommandLogOutputField,
         ShellCommandOutputsField,
@@ -414,6 +420,7 @@ class ShellCommandRunTarget(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         ShellCommandExecutionDependenciesField,
+        ShellCommandRunnableDependenciesField,
         ShellCommandCommandField,
         RunShellCommandWorkdirField,
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -154,9 +154,9 @@ async def _prepare_process_request_from_target(
         output_files=output_files,
         output_directories=output_directories,
         fetch_env_vars=shell_command.get(ShellCommandExtraEnvVarsField).value or (),
-        append_only_caches=merged_extras.append_only_caches,
+        append_only_caches=FrozenDict.frozen(merged_extras.append_only_caches),
         supplied_env_var_values=FrozenDict(extra_env),
-        immutable_input_digests=merged_extras.immutable_input_digests,
+        immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,
         log_output=shell_command[ShellCommandLogOutputField].value,
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -20,6 +20,7 @@ from pants.backend.shell.target_types import (
     ShellCommandOutputFilesField,
     ShellCommandOutputRootDirField,
     ShellCommandOutputsField,
+    ShellCommandRunnableDependenciesField,
     ShellCommandSourcesField,
     ShellCommandTarget,
     ShellCommandTimeoutField,
@@ -91,6 +92,7 @@ async def _prepare_process_request_from_target(
             shell_command.address,
             shell_command.get(ShellCommandExecutionDependenciesField).value,
             shell_command.get(ShellCommandOutputDependenciesField).value,
+            shell_command.get(ShellCommandRunnableDependenciesField).value,
         ),
     )
     dependencies_digest = execution_environment.digest
@@ -256,6 +258,7 @@ async def _interactive_shell_command(
             shell_command.address,
             shell_command.get(ShellCommandExecutionDependenciesField).value,
             shell_command.get(ShellCommandOutputDependenciesField).value,
+            shell_command.get(ShellCommandRunnableDependenciesField).value,
         ),
     )
     dependencies_digest = execution_environment.digest

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -114,11 +114,14 @@ async def _prepare_process_request_from_target(
 
     runnable_dependencies = execution_environment.runnable_dependencies
     if runnable_dependencies:
-        supplied_env_var_values["PATH"] = supplied_env_var_values.get("PATH", "") + f":{{chroot}}/{runnable_dependencies.path_component}"
+        supplied_env_var_values["PATH"] = (
+            supplied_env_var_values.get("PATH", "")
+            + f":{{chroot}}/{runnable_dependencies.path_component}"
+        )
         _safe_update(supplied_env_var_values, runnable_dependencies.extra_env)
         _safe_update(immutable_input_digests, runnable_dependencies.immutable_input_digests)
         append_only_caches = runnable_dependencies.append_only_caches
-        
+
     return AdhocProcessRequest(
         description=description,
         address=shell_command.address,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -156,7 +156,7 @@ async def _prepare_process_request_from_target(
         fetch_env_vars=shell_command.get(ShellCommandExtraEnvVarsField).value or (),
         append_only_caches=merged_extras.append_only_caches,
         supplied_env_var_values=FrozenDict(extra_env),
-        immutable_input_digests=FrozenDict(merged_extras.immutable_input_digests),
+        immutable_input_digests=merged_extras.immutable_input_digests,
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,
         log_output=shell_command[ShellCommandLogOutputField].value,
     )

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -292,7 +292,6 @@ def _runnable_dependency_shim(
     return dedent(
         f"""\
         #!{bash}
-        echo $_PANTS_SHIM_ROOT > /dev/stderr
         {env_str}
         exec {binary} "$@"
         """

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -86,9 +86,9 @@ class ResolvedExecutionDependencies:
 @dataclass(frozen=True)
 class RunnableDependencies:
     path_component: str
-    immutable_input_digests: FrozenDict[str, Digest]
-    append_only_caches: FrozenDict[str, str]
-    extra_env: FrozenDict[str, str]
+    immutable_input_digests: Mapping[str, Digest]
+    append_only_caches: Mapping[str, str]
+    extra_env: Mapping[str, str]
 
 
 #
@@ -100,9 +100,9 @@ class RunnableDependencies:
 class ExtraSandboxContents:
     digest: Digest
     path: str | None
-    immutable_input_digests: FrozenDict[str, Digest]
-    append_only_caches: FrozenDict[str, str]
-    extra_env: FrozenDict[str, str]
+    immutable_input_digests: Mapping[str, Digest]
+    append_only_caches: Mapping[str, str]
+    extra_env: Mapping[str, str]
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -349,9 +349,12 @@ V = TypeVar("V")
 
 
 def _safe_update(d1: dict[K, V], d2: Mapping[K, V]) -> dict[K, V]:
+    """Updates `d1` with the values from `d2`, raising an exception if a key exists in both
+    dictionaries, but with a different value."""
+
     for k, v in d2.items():
         if k in d1 and d1[k] != v:
-            raise ValueError("Beep")
+            raise ValueError(f"Key {k} was specified in both dictionaries with different values.")
         d1[k] = v
     return d1
 

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -240,7 +240,7 @@ async def _resolve_runnable_dependencies(
             raise ValueError(
                 "One or more runnable dependencies have mutually incompatible environments."
             )
-        
+
     digest, shim_digest = await MultiGet(
         Get(Digest, MergeDigests(digests)), Get(Digest, CreateDigest(shims))
     )

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -84,20 +84,6 @@ class ResolvedExecutionDependencies:
 
 
 @dataclass(frozen=True)
-class runnable:
-    """Allows for an execution dependency to be specified as `runnable`.
-
-    When resolved, the dependency will be available on the `PATH` with the name `name`.
-
-    `runnable` dependencies are not resolved transitively, and must be defined on the target that
-    wants to run those dependencies.
-    """
-
-    name: str
-    address: str
-
-
-@dataclass(frozen=True)
 class RunnableDependencies:
     path_component: str
     immutable_input_digests: FrozenDict[str, Digest]

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -129,7 +129,9 @@ async def _resolve_runnable_dependencies(
         logger.warning(f"{field_set=}")
 
     runnables = await MultiGet(
-        Get(RunInSandboxRequest, RunFieldSet, field_set.field_sets[0]) for field_set in fspt if field_set.field_sets
+        Get(RunInSandboxRequest, RunFieldSet, field_set.field_sets[0])
+        for field_set in fspt
+        if field_set.field_sets
     )
 
     digests: list[Digest] = []

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1778,7 +1778,7 @@ class SequenceField(Generic[T], Field):
 
             @classmethod
             def compute_value(
-                cls, raw_value: Optional[Iterable[MyPluginObject]], *, address: Address
+                cls, raw_value: Optional[Iterable[MyPluginObject]], address: Address
             ) -> Optional[Tuple[MyPluginObject, ...]]:
                 return super().compute_value(raw_value, address=address)
     """

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -64,6 +64,15 @@ class FrozenDict(Mapping[K, V]):
 
         return cls({k: _freeze(v) for k, v in data.items()})
 
+    @staticmethod
+    def frozen(to_freeze: Mapping[K, V]) -> FrozenDict[K, V]:
+        """Returns a `FrozenDict` containing the keys and values of `to_freeze`.
+
+        If `to_freeze` is already a `FrozenDict`, returns the same object.
+        """
+
+        return to_freeze if isinstance(to_freeze, FrozenDict) else FrozenDict(to_freeze)
+
     def __getitem__(self, k: K) -> V:
         return self._data[k]
 

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -166,3 +166,13 @@ def test_lazy_frozen_dict() -> None:
 
     # Hash value should be stable regardless if we've loaded the values or not.
     assert hash(ld1) == hashvalue
+
+
+def test_frozendict_dot_frozen() -> None:
+    a = {1: 2}
+    b = FrozenDict(a)
+    frozen_a = FrozenDict.frozen(a)
+    frozen_b = FrozenDict.frozen(b)
+
+    assert frozen_a == FrozenDict(a)
+    assert frozen_b is b


### PR DESCRIPTION
This adds a `runnable_dependencies` field to `adhoc_tool` and `shell_command`, as well as a `fingerprint_dependencies` field to `system_binary`.

This allows users of `adhoc_tool`/`shell_command` allows users to write rules that consume a pinned version of `yarn`, which in turn calls a pinned version of `node`.

This partially addresses #18320, but makes `BUILD` files extremely repetitive at the moment, so does not constitute a full solution to the problem. This PR is intended in the spirit of "if we can't make it easy, at least make it possible".

