### PR TITLE
Streamline PexRequest creation in a few places

### DIFF
--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
@@ -82,12 +82,8 @@ async def collect_fixture_configs(
     pytest_pex, requirements_pex, prepared_sources, root_sources = await MultiGet(
         Get(
             Pex,
-            PexRequest(
-                output_filename="pytest.pex",
-                requirements=pytest.pex_requirements(),
-                interpreter_constraints=interpreter_constraints,
-                internal_only=True,
-            ),
+            PexRequest,
+            pytest.to_pex_request(interpreter_constraints=interpreter_constraints),
         ),
         Get(Pex, RequirementsPexRequest(addresses)),
         Get(

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -126,14 +126,7 @@ async def package_python_google_cloud_function(
         additional_args=additional_pex_args,
         additional_lockfile_args=additional_pex_args,
     )
-
-    lambdex_request = PexRequest(
-        output_filename="lambdex.pex",
-        internal_only=True,
-        requirements=lambdex.pex_requirements(),
-        interpreter_constraints=lambdex.interpreter_constraints,
-        main=lambdex.main,
-    )
+    lambdex_request = lambdex.to_pex_request()
 
     lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
         Get(VenvPex, PexRequest, lambdex_request),

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -226,13 +226,7 @@ async def setup_pytest_for_target(
 
     requirements_pex_get = Get(Pex, RequirementsPexRequest(addresses))
     pytest_pex_get = Get(
-        Pex,
-        PexRequest(
-            output_filename="pytest.pex",
-            requirements=pytest.pex_requirements(),
-            interpreter_constraints=interpreter_constraints,
-            internal_only=True,
-        ),
+        Pex, PexRequest, pytest.to_pex_request(interpreter_constraints=interpreter_constraints)
     )
 
     # Ensure that the empty extra output dir exists.

--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -63,12 +63,12 @@ class BuildSystem:
     build_backend: str
 
     @classmethod
-    def legacy(cls, setuptools: Setuptools) -> BuildSystem:
-        return cls(setuptools.pex_requirements(), "setuptools.build_meta:__legacy__")
+    def legacy(cls, _setuptools: Setuptools) -> BuildSystem:
+        return cls(_setuptools.pex_requirements(), "setuptools.build_meta:__legacy__")
 
 
 @rule
-async def find_build_system(request: BuildSystemRequest, setuptools: Setuptools) -> BuildSystem:
+async def find_build_system(request: BuildSystemRequest, _setuptools: Setuptools) -> BuildSystem:
     digest_contents = await Get(
         DigestContents,
         DigestSubset(
@@ -100,7 +100,7 @@ async def find_build_system(request: BuildSystemRequest, setuptools: Setuptools)
     #   the source tree is not using this specification, and tools should revert to the legacy
     #   behaviour of running setup.py."
     if ret is None:
-        ret = BuildSystem.legacy(setuptools)
+        ret = BuildSystem.legacy(_setuptools)
     return ret
 
 


### PR DESCRIPTION
Almost all clients use to_pex_request() to get a PexRequest for the tool, but a handful of places called pex_requirements() directly and then constructed a PexRequest manually using information already available in the PythonToolBase instance.

This change switches those remaining callsites to use to_pex_request().
