### PR TITLE
use valid container/app names in helm examples

### DIFF
--- a/docs/markdown/Helm/helm-deployments.md
+++ b/docs/markdown/Helm/helm-deployments.md
@@ -102,12 +102,12 @@ image: example.com/registry/my-app:latest
 apiVersion: v1
 kind: Pod
 metadata:
-  name: my_pod
+  name: my-pod
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   containers:
-    - name: my_app
+    - name: my-app
       # Uses the `image` value entry from the deployment inputs
       image: {{ .Values.image }}
 ```


### PR DESCRIPTION
Trying to have helm template with the underscores gives:
```
Error: UPGRADE FAILED: failed to create resource: Pod "my_pod" is invalid: [metadata.name: Invalid value: "my_pod": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'), spec.containers[0].name: Invalid value: "my_app": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]
```