### PR TITLE
Errors in `--loop` wait for changes rather than re-running immediately

### DIFF
--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -440,7 +440,7 @@ impl<N: Node> Graph<N> {
     src_id: Option<EntryId>,
     context: &N::Context,
     dst_node: N,
-  ) -> Result<(N::Item, Generation), N::Error> {
+  ) -> (Result<N::Item, N::Error>, Generation) {
     // Compute information about the dst under the Graph lock, and then release it.
     let (dst_retry, mut entry, entry_id) = {
       // Get or create the destination, and then insert the dep and return its state.
@@ -478,8 +478,7 @@ impl<N: Node> Graph<N> {
       let context = context.clone();
       loop {
         match entry.get_node_result(&context, entry_id).await {
-          Ok(r) => break Ok(r),
-          Err(err) if err == N::Error::invalidated() => {
+          (Err(err), _) if err == N::Error::invalidated() => {
             let node = {
               let inner = self.inner.lock();
               inner.unsafe_entry_for_id(entry_id).node().clone()
@@ -491,7 +490,7 @@ impl<N: Node> Graph<N> {
             sleep(self.invalidation_delay).await;
             continue;
           }
-          Err(other_err) => break Err(other_err),
+          res => break res,
         }
       }
     } else {
@@ -515,8 +514,8 @@ impl<N: Node> Graph<N> {
     context: &N::Context,
     dst_node: N,
   ) -> Result<N::Item, N::Error> {
-    let (res, _generation) = self.get_inner(src_id, context, dst_node).await?;
-    Ok(res)
+    let (res, _generation) = self.get_inner(src_id, context, dst_node).await;
+    res
   }
 
   ///
@@ -536,7 +535,7 @@ impl<N: Node> Graph<N> {
     token: Option<LastObserved>,
     delay: Option<Duration>,
     context: &N::Context,
-  ) -> Result<(N::Item, LastObserved), N::Error> {
+  ) -> (Result<N::Item, N::Error>, LastObserved) {
     // If the node is currently clean at the given token, Entry::poll will delay until it has
     // changed in some way.
     if let Some(LastObserved(generation)) = token {
@@ -552,8 +551,8 @@ impl<N: Node> Graph<N> {
     };
 
     // Re-request the Node.
-    let (res, generation) = self.get_inner(None, context, node).await?;
-    Ok((res, LastObserved(generation)))
+    let (res, generation) = self.get_inner(None, context, node).await;
+    (res, LastObserved(generation))
   }
 
   ///
@@ -595,10 +594,7 @@ impl<N: Node> Graph<N> {
             .unwrap_or_else(|| panic!("Dependency not present in Graph."))
             .clone();
           async move {
-            let (_, generation) = dep_entry
-              .get_node_result(context, dep_id)
-              .await
-              .map_err(|_| ())?;
+            let (_, generation) = dep_entry.get_node_result(context, dep_id).await;
             if generation == previous_dep_generation {
               // Matched.
               Ok(())

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -14,7 +14,7 @@ generic-array = "0.14"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
-tokio = { version = "1.21", features = ["fs"] }
+tokio = { version = "1.21", features = ["io-util"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/rust/engine/src/session.rs
+++ b/src/rust/engine/src/session.rs
@@ -31,7 +31,7 @@ const STRAGGLER_LOGGING_INTERVAL: Duration = Duration::from_secs(30);
 // Root requests are limited to Select nodes, which produce (python) Values.
 pub type Root = Select;
 
-pub type ObservedValueResult = Result<(Value, Option<LastObserved>), Failure>;
+pub type ObservedValueResult = (Result<Value, Failure>, Option<LastObserved>);
 
 ///
 /// An enum for the two cases of `--[no-]dynamic-ui`.


### PR DESCRIPTION
As reported in #16727, errors occurring in a `--loop` currently retry indefinitely, because we do not preserve the `Generation` value of a Node in the case where an error is raised.

This change adjusts the signatures of `Graph` methods to preserve the `Generation` value in case of errors, and additionally allows "pollers" to be added to errored (`NotStarted`) `Node`s.

This fix is slightly different from what was [suggested on the issue](https://github.com/pantsbuild/pants/issues/16727#issuecomment-1259782970): it does _not_ reintroduce memoization of errors, as that would open a can of worms around "which" errors are safe to memoize. Instead, only the method signatures involved in `poll`ing are affected, essentially by transposing `Result<(Value, Generation), ...>` to `(Result<Value, ..>, Generation)`.

Fixes #16727.