### PR TITLE
Visibility: support matching on target names.

### DIFF
--- a/docs/markdown/Using Pants/validating-dependencies.md
+++ b/docs/markdown/Using Pants/validating-dependencies.md
@@ -7,7 +7,7 @@ createdAt: "2022-12-12T09:10:16.427Z"
 updatedAt: "2022-12-12T03:00:53.427Z"
 ---
 
-Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. With these rules a dependency between two files (or targets) may be set for entire directory trees down to single files. A target may be selected not only by its file path but also by target type, name and tags.
+Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. With these rules a dependency between two files (or targets) may be set for entire directory trees down to single files. A target may be selected not only by its file path but also by target type, name, and tags.
 
 To jump right in, start with [enabling the backend](doc:validating-dependencies#enable-visibility-backend) and add some rules to your BUILD files.
 
@@ -180,9 +180,9 @@ __dependencies_rules__(
 )
 ```
 
-The selector and rule share a common syntax (refered to as a __target rule spec__), that is a dictionary value with properties describing what targets it applies to, and together this pair of selector(s) and rules is called a __rule set__. A rule set may have multiple selectors wrapped in a list/tuple and the rules may be spread out or grouped in any fashion. Allowing to group rules like this allows for easier re-use/insertion of rules from macros or similar.
+The selector and rule share a common syntax (refered to as a __target rule spec__), that is a dictionary value with properties describing what targets it applies to. Together, this pair of selector(s) and rules is called a __rule set__. A rule set may have multiple selectors wrapped in a list/tuple and the rules may be spread out or grouped in any fashion. Grouping rules like this makes it easier to re-use/insert rules from macros or similar.
 
-The __target rule spec__ has four properties: `type`, `name`, `tags` and `path`. From the above example, when determining which rule set to apply for the dependencies of `src/a/main.py` Pants will look for the first selector for `src/a/BUILD` that satisifies the properties `type=python_sources`, `tags=["apps"]` and `path=src/a/main.py`. The selection is based on exclusion so only when there is a property value and it doesn't match the targets property it will move on to the next selector, so the lack of a property will be considered to match anything. Consequently an empty target spec would match all targets but as this is coneptually not very clear when reading the rules it is disallowed and will yield an error if used.
+The __target rule spec__ has four properties: `type`, `name`, `tags`, and `path`. From the above example, when determining which rule set to apply for the dependencies of `src/a/main.py` Pants will look for the first selector for `src/a/BUILD` that satisifies the properties `type=python_sources`, `tags=["apps"]`, and `path=src/a/main.py`. The selection is based on exclusion so only when there is a property value and it doesn't match the target's property it will move on to the next selector; the lack of a property will be considered to match anything. Consequently an empty target spec would match all targets, but this is disallowed and will raise an error if used because it is conceptually not very clear when reading the rules.
 
 The values of a __target rule spec__ supports wildcard patterns (or globs) in order to have a single selector match multiple different targets, as described in [glob syntax](doc:targets#glob-syntax). When listing multiple values for the `tags` property, the target must have all of them in order to match. Spread the tags over multiple selectors in order to switch from _AND_ to _OR_ as required. The target `type` to match against will be that of the type used in the BUILD file, as the path (and target address) may refer to a generated target it is the target generators type that will be used during the selector matching process.
 
@@ -233,7 +233,7 @@ __dependents_rules__(
 )
 ```
 
-There are some syntactic sugar for __target rule specs__ so they may be declared in a more concise text form rather than as a dictionary (we have used this for the rules already--this is also the form on which they are presented in messages from Pants, when possible). The syntax is `<type>[path:name](tags, ...)`. Empty parts are optional and can be left out, and if only `path` (and/or `name`) is provided the enclosing square brackets are optional. Providing all the selectors from the previous example code block in string form for reference:
+There is some syntactic sugar for __target rule specs__ so they may be declared in a more concise text form rather than as a dictionary (we have used this text form for the rules already--this is also the form in which they are presented in messages from Pants, when possible). The syntax is `<type>[path:name](tags, ...)`. Empty parts are optional and can be left out, and if only `path` (and/or `name`) is provided the enclosing square brackets are optional. For reference, the string form of the selectors in the previous example code block would look like this:
 
 ```python
 python_sources            # {"type": python_sources}  -- target types works as strings when used bare
@@ -241,7 +241,7 @@ python_sources            # {"type": python_sources}  -- target types works as s
 "<python_*>(any-python)"  # {"type": "python_*", "tags":["any-python"]}
 "<*>(libs)"               # {"type": "*", "tags":["libs"]}
 "[special-cased.py]"      # {"path": "special-cased.py"}
-# May omit square brackets when only providing a path/name:
+# May omit square brackets when only providing a path and/or name:
 "special-cased.py"        # {"path": "special-cased.py"}
 ":my-target-name"         # {"name": "my-target-name"}
 "//src/**:named-*"        # {"path": "//src/**", "name": "named-*"}
@@ -266,9 +266,9 @@ The previous example, using this alternative syntax for the selectors, would loo
 Glob syntax
 -----------
 
-The visibility rules are all about matching globs. There are two wildcards, the `*` to match anything except `/` and the `**` to match anything including any `/`. (For paths that is non-recursive and recursive globbing respectively.)
+The visibility rules are all about matching globs. There are two wildcards: the `*` matches anything except `/`, and the `**` matches anything including `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
-Globs are matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) on the end of the path glob, it will match to the end of the value. An example where this is usefull is for matching on file names regardless of where in the project tree they are:
+A glob is matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) on the end of the path glob, it will match to the end of the value. An example where this is useful is for matching on file names regardless of where in the project tree they are:
 
 ```
 .py

--- a/docs/markdown/Using Pants/validating-dependencies.md
+++ b/docs/markdown/Using Pants/validating-dependencies.md
@@ -7,7 +7,7 @@ createdAt: "2022-12-12T09:10:16.427Z"
 updatedAt: "2022-12-12T03:00:53.427Z"
 ---
 
-Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. Using file globs this may be set from entire directory trees down to single files. Targets may be selected not only by its file path but also by target type and tags.
+Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. With these rules a dependency between two files (or targets) may be set for entire directory trees down to single files. Targets may be selected not only by its file path but also by target type, name and tags.
 
 To jump right in, start with [enabling the backend](doc:validating-dependencies#enable-visibility-backend) and add some rules to your BUILD files.
 
@@ -180,13 +180,11 @@ __dependencies_rules__(
 )
 ```
 
-The rules are just string values using a [glob syntax](doc:targets#glob-syntax) for pattern matching and may be grouped together for readability (how rules are grouped does not affect how they are applied). The selector is a dictionary value with properties describing what targets its associated rules apply to and together this pair of selector(s) and rules is called a __rule set__. A rule set may have multiple selectors wrapped in a list/tuple.
+The selector and rule share a common syntax (refered to as a __target rule spec__), that is a dictionary value with properties describing what targets it applies to, and together this pair of selector(s) and rules is called a __rule set__. A rule set may have multiple selectors wrapped in a list/tuple and the rules may be spread out or grouped in any fashion. Allowing to group rules like this allows for easier re-use/insertion of rules from macros or similar.
 
-The selector has three properties: `type`, `tags` and `path`. From the above example, when determining which rule set to apply for the dependencies of `src/a/main.py` Pants will look for the first selector for `src/a/BUILD` that satisifies the properties `type=python_sources`, `tags=["apps"]` and `path=src/a/main.py`. The selection is based on exclusion so only when there is a property value and it doesn't match the targets property it will move on to the next selector, so the lack of a property will be considered to match anything. Consequently an empty selector matches all targets.
+The __target rule spec__ has four properties: `type`, `name`, `tags` and `path`. From the above example, when determining which rule set to apply for the dependencies of `src/a/main.py` Pants will look for the first selector for `src/a/BUILD` that satisifies the properties `type=python_sources`, `tags=["apps"]` and `path=src/a/main.py`. The selection is based on exclusion so only when there is a property value and it doesn't match the targets property it will move on to the next selector, so the lack of a property will be considered to match anything. Consequently an empty target spec would match all targets but as this is coneptually not very clear when reading the rules it is disallowed and will yield an error if used.
 
-The values of a selector supports wildcard patterns (or globs) in order to have a single selector match multiple different targets. The `path` property uses the same [glob syntax](doc:targets#glob-syntax) as the rules, while `type` and `tags` use a simpler one described below. When listing multiple values for the `tags` property, the target must have all of them in order to match. Spread the tags over multiple selectors in order to switch from AND to OR as required. The target `type` to match against will be that of the type used in the BUILD file, as the path (and target address) may refer to a generated target it is the target generators type that will be used during the selector matching process.
-
-The simpler glob syntax used by the `type` and `tags` selector values only supports `*` as a match anything and is otherwise case sensitive.
+The values of a __target rule spec__ supports wildcard patterns (or globs) in order to have a single selector match multiple different targets, as described in [glob syntax](doc:targets#glob-syntax). When listing multiple values for the `tags` property, the target must have all of them in order to match. Spread the tags over multiple selectors in order to switch from _AND_ to _OR_ as required. The target `type` to match against will be that of the type used in the BUILD file, as the path (and target address) may refer to a generated target it is the target generators type that will be used during the selector matching process.
 
 The selectors are matched against the target in the order they are defined in the BUILD file, and the first rule set with a selector that is a match will be selected. The rules from the selected rule set is then matched in order against the path of the **target on the other end** of the dependency link. This is worth reading again; Using the above example again, the rules defined in `src/a/BUILD` will be matched against `src/b/lib.py` while the `path` selector will be matched against `src/a/main.py`.
 
@@ -214,7 +212,9 @@ __dependents_rules__(
     (  # Using multiple selectors
       {"type": "python_*", "tags":["any-python"]},
       {"type": "*", "tags":["libs"]},
-      {"path": "special-cased.py"}
+      {"path": "special-cased.py"},
+      {"name": "my-target-name"},
+      {"path": "//src/**", "name": "named-*"},
     ),
     (  # Grouping rules for readability
       (  # Deny rules
@@ -233,16 +233,18 @@ __dependents_rules__(
 )
 ```
 
-There are some syntactic sugar for selectors so they may be declared in a more concise text form rather than as a dictionary (this is also the form on which they are presented in messages from Pants, when possible). The syntax is `<type>(tags, ...)[path]`. Empty parts are optional and can be left out, and if only `path` is provided the enclosing square brackets are optional. Providing all the selectors from the previous example code block in string form for reference:
+There are some syntactic sugar for __target rule specs__ so they may be declared in a more concise text form rather than as a dictionary (we have used this for the rules already--this is also the form on which they are presented in messages from Pants, when possible). The syntax is `<type>[path:name](tags, ...)`. Empty parts are optional and can be left out, and if only `path` (and/or `name`) is provided the enclosing square brackets are optional. Providing all the selectors from the previous example code block in string form for reference:
 
 ```python
-python_sources  # {"type": python_sources}  -- target types works as strings when used bare
-"<python_sources>"  # {"type": "python_sources"}
+python_sources            # {"type": python_sources}  -- target types works as strings when used bare
+"<python_sources>"        # {"type": "python_sources"}
 "<python_*>(any-python)"  # {"type": "python_*", "tags":["any-python"]}
-"<*>(libs)"  # {"type": "*", "tags":["libs"]}
-"[special-cased.py]"  # {"path": "special-cased.py"}
-# May omit square brackets when only providing a path:
-"special-cased.py"  # {"path": "special-cased.py"}
+"<*>(libs)"               # {"type": "*", "tags":["libs"]}
+"[special-cased.py]"      # {"path": "special-cased.py"}
+# May omit square brackets when only providing a path/name:
+"special-cased.py"        # {"path": "special-cased.py"}
+":my-target-name"         # {"name": "my-target-name"}
+"//src/**:named-*"        # {"path": "//src/**", "name": "named-*"}
 ```
 
 The previous example, using this alternative syntax for the selectors, would look like:
@@ -253,6 +255,8 @@ The previous example, using this alternative syntax for the selectors, would loo
       "<python_*>(any-python)",
       "<*>(libs)",
       "special-cased.py",
+      ":my-target-name",
+      "//src/**:named-*",
     ),
     ...
   )
@@ -262,7 +266,9 @@ The previous example, using this alternative syntax for the selectors, would loo
 Glob syntax
 -----------
 
-The visibility rules support a basic glob syntax, using `*` as a match anything non-recursively with the `**` variant being for a recursive match anything. All rules are matched until the end of the path it is being applied to, so if there is not trailing wildcard (`*` or `**`) the end of the rule glob will match the end of the path. This allows for matching on file types/names regardless of where in the project tree they are:
+The visibility rules is all about matching globs. There are two primary kinds of globs supported, the simple glob syntax and the path glob syntax. Simple globs only supports `*` as a match anything and is otherwise case sensitive and are used for all glob values except for the `path` part of a __target rule spec__. The path glob syntax is described further below.
+
+Path globs have two wildcards, the `*` as a match anything non-recursively and the `**` for a recursive match anything. All globs are matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) the end of the path glob it will match until the end of the path. This allows for matching on file names regardless of where in the project tree they are:
 ```
 .py
 my_source.py
@@ -289,7 +295,7 @@ some/directory/*
 
 So far the rule globs have been matched from anywhere in the matched to path up to the end. To ensure the path begins with a certain pattern we'd have to provide full paths in our rules, like `src/python/proj/lib/file.py` if we want to make sure that our `file.py` is from the `src/` tree. To avoid lengthy and rigid rule globs hurting refactorings etc, there's a concept of "anchoring" the rule. That will apply the rule glob from a fixed point in the matched to path, and there are three such points: project root, rule declaration path and rule invocation path. The difference between declaration and invocation is explained below.
 
-#### Anchoring mode
+#### Anchoring mode for path globs
 
 The glob prefix specifies which "anchoring mode" to use, and are:
 

--- a/docs/markdown/Using Pants/validating-dependencies.md
+++ b/docs/markdown/Using Pants/validating-dependencies.md
@@ -266,9 +266,10 @@ The previous example, using this alternative syntax for the selectors, would loo
 Glob syntax
 -----------
 
-The visibility rules are all about matching globs. There are two kinds of glob syntax: the simple glob syntax and the path glob syntax. Simple globs only support `*` to match anything and are otherwise case sensitive, and are used for all glob values except for the `path` part of a __target rule spec__. The path glob syntax is described further below.
+The visibility rules are all about matching globs. There are two wildcards, the `*` to match anything except `/` and the `**` to match anything including any `/`. (For paths that is non-recursive and recursive globbing respectively.)
 
-Path globs have two wildcards, the `*` to match anything non-recursively and the `**` to match anything recursively. Each glob is matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) on the end of the path glob, it will match to the end of the path. This allows for matching on file names regardless of where in the project tree they are:
+Globs are matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) on the end of the path glob, it will match to the end of the value. An example where this is usefull is for matching on file names regardless of where in the project tree they are:
+
 ```
 .py
 my_source.py
@@ -279,11 +280,7 @@ Any leading wildcards may be used to emphasize this if desired, but will functio
 ```
 *.py
 */my_source.py
-*/my_*.py
-
-**/*.py
-**/*my_source.py
-**/*my_*.py
+**/my_*.py
 ```
 
 When providing a file name, like `my_source.py` it will be assumed that it will be the full name, so `another_my_source.py` will _not_ be considered a match in that case.

--- a/docs/markdown/Using Pants/validating-dependencies.md
+++ b/docs/markdown/Using Pants/validating-dependencies.md
@@ -7,7 +7,7 @@ createdAt: "2022-12-12T09:10:16.427Z"
 updatedAt: "2022-12-12T03:00:53.427Z"
 ---
 
-Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. With these rules a dependency between two files (or targets) may be set for entire directory trees down to single files. Targets may be selected not only by its file path but also by target type, name and tags.
+Visibility rules are the mechanism by which to control who may depend on whom. It is an implementation of Pants's dependency rules API. With these rules a dependency between two files (or targets) may be set for entire directory trees down to single files. A target may be selected not only by its file path but also by target type, name and tags.
 
 To jump right in, start with [enabling the backend](doc:validating-dependencies#enable-visibility-backend) and add some rules to your BUILD files.
 
@@ -266,9 +266,9 @@ The previous example, using this alternative syntax for the selectors, would loo
 Glob syntax
 -----------
 
-The visibility rules is all about matching globs. There are two primary kinds of globs supported, the simple glob syntax and the path glob syntax. Simple globs only supports `*` as a match anything and is otherwise case sensitive and are used for all glob values except for the `path` part of a __target rule spec__. The path glob syntax is described further below.
+The visibility rules are all about matching globs. There are two kinds of glob syntax: the simple glob syntax and the path glob syntax. Simple globs only support `*` to match anything and are otherwise case sensitive, and are used for all glob values except for the `path` part of a __target rule spec__. The path glob syntax is described further below.
 
-Path globs have two wildcards, the `*` as a match anything non-recursively and the `**` for a recursive match anything. All globs are matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) the end of the path glob it will match until the end of the path. This allows for matching on file names regardless of where in the project tree they are:
+Path globs have two wildcards, the `*` to match anything non-recursively and the `**` to match anything recursively. Each glob is matched until the end of the value it is being applied to, so if there is no trailing wildcard (`*` or `**`) on the end of the path glob, it will match to the end of the path. This allows for matching on file names regardless of where in the project tree they are:
 ```
 .py
 my_source.py

--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -8,7 +8,6 @@ import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from fnmatch import fnmatchcase
 from typing import Any, Pattern
 
 from pants.engine.addresses import Address
@@ -20,6 +19,40 @@ from pants.util.strutil import softwrap
 def is_path_glob(spec: str) -> bool:
     """Check if `spec` should be treated as a `path` glob."""
     return len(spec) > 0 and spec[0].isalnum() or spec[0] in "_.:/*"
+
+
+def glob_to_regexp(pattern: str, snap_to_path: bool = False) -> str:
+    # Escape regexp characters, then restore any `*`s.
+    glob = re.escape(pattern).replace(r"\*", "*")
+    # Translate recursive `**` globs to regexp, any adjacent `/` is optional.
+    glob = glob.replace("/**", r"(/.<<$>>)?")
+    glob = glob.replace("**/", r"/?\b")
+    glob = glob.replace("**", r".<<$>>")
+    # Translate `*` to match any path segment.
+    glob = glob.replace("*", r"[^/]<<$>>")
+    # Restore `*`s that was "escaped" during translation.
+    glob = glob.replace("<<$>>", r"*")
+    # Snap to closest `/`
+    if snap_to_path and glob and glob[0].isalnum():
+        glob = r"/?\b" + glob
+
+    return glob + r"$"
+
+
+@dataclass(frozen=True)
+class Glob:
+    raw: str
+    regexp: Pattern = field(compare=False)
+
+    @classmethod
+    def create(cls, pattern: str) -> Glob:
+        return cls(pattern, re.compile(glob_to_regexp(pattern)))
+
+    def match(self, value: str) -> bool:
+        return bool(re.match(self.regexp, value))
+
+    def __str__(self) -> str:
+        return self.raw
 
 
 class PathGlobAnchorMode(Enum):
@@ -90,27 +123,9 @@ class PathGlob:
         return cls.create(  # type: ignore[call-arg]
             raw=pattern,
             anchor_mode=anchor_mode,
-            glob=cls._translate_pattern_to_regexp(pattern, snap_to_path=snap_to_path),
+            glob=glob_to_regexp(pattern, snap_to_path=snap_to_path),
             uplvl=uplvl,
         )
-
-    @staticmethod
-    def _translate_pattern_to_regexp(pattern: str, snap_to_path: bool) -> str:
-        # Escape regexp characters, then restore any `*`s.
-        glob = re.escape(pattern).replace(r"\*", "*")
-        # Translate recursive `**` globs to regexp, any adjacent `/` is optional.
-        glob = glob.replace("/**", r"(/.<<$>>)?")
-        glob = glob.replace("**/", r"/?\b")
-        glob = glob.replace("**", r".<<$>>")
-        # Translate `*` to match any path segment.
-        glob = glob.replace("*", r"[^/]<<$>>")
-        # Restore `*`s that was "escaped" during translation.
-        glob = glob.replace("<<$>>", r"*")
-        # Snap to closest `/`
-        if snap_to_path and glob and glob[0].isalnum():
-            glob = r"/?\b" + glob
-
-        return glob + r"$"
 
     def _match_path(self, path: str, base: str) -> str | None:
         if self.anchor_mode is PathGlobAnchorMode.INVOKED_PATH:
@@ -144,14 +159,14 @@ RULE_REGEXP = "|".join(
 
 @dataclass(frozen=True)
 class TargetGlob:
-    type_: str | None
-    name: str | None
+    type_: Glob | None
+    name: Glob | None
     path: PathGlob | None
-    tags: tuple[str, ...] | None
+    tags: tuple[Glob, ...] | None
 
     def __post_init__(self) -> None:
         for what, value in (("type", self.type_), ("name", self.name)):
-            if not isinstance(value, (str, type(None))):
+            if not isinstance(value, (Glob, type(None))):
                 raise ValueError(f"invalid target {what}, expected glob but got: {value!r}")
         if not isinstance(self.path, (PathGlob, type(None))):
             raise ValueError(f"invalid target path, expected glob but got: {self.path!r}")
@@ -172,7 +187,7 @@ class TargetGlob:
         type_ = f"<{self.type_}>" if self.type_ else ""
         name = f":{self.name}" if self.name else ""
         tags = (
-            f"({', '.join(str(tag) if ',' not in tag else repr(tag) for tag in self.tags)})"
+            f"({', '.join(str(tag) if ',' not in tag.raw else repr(tag.raw) for tag in self.tags)})"
             if self.tags
             else ""
         )
@@ -186,10 +201,16 @@ class TargetGlob:
         cls: type[TargetGlob],
         type_: str | None,
         name: str | None,
-        path: PathGlob | None,
+        path: str | None,
+        base: str,
         tags: tuple[str, ...] | None,
     ) -> TargetGlob:
-        return cls(type_=type_, path=path, name=name, tags=tags)
+        return cls(
+            type_=Glob.create(type_) if type_ else None,
+            path=PathGlob.parse(path, base) if path else None,
+            name=Glob.create(name) if name else None,
+            tags=tuple(Glob.create(tag) for tag in tags) if tags else None,
+        )
 
     @classmethod
     def parse(cls: type[TargetGlob], spec: str | Mapping[str, Any], base: str) -> TargetGlob:
@@ -206,7 +227,8 @@ class TargetGlob:
         return cls.create(  # type: ignore[call-arg]
             type_=spec_dict.get("type"),
             name=spec_dict.get("name"),
-            path=(PathGlob.parse(spec_dict["path"], base) if spec_dict.get("path") else None),
+            path=spec_dict.get("path"),
+            base=base,
             tags=cls._parse_tags(spec_dict.get("tags")),
         )
 
@@ -265,10 +287,10 @@ class TargetGlob:
             return False
 
         # target type
-        if self.type_ and not fnmatchcase(adaptor.type_alias, self.type_):
+        if self.type_ and not self.type_.match(adaptor.type_alias):
             return False
         # target name
-        if self.name and not fnmatchcase(address.target_name, self.name):
+        if self.name and not self.name.match(address.target_name):
             return False
         # target path (includes filename for source targets)
         if self.path and not self.path.match(self.address_path(address), base):
@@ -280,9 +302,7 @@ class TargetGlob:
             if not isinstance(target_tags, Sequence) or isinstance(target_tags, str):
                 # Bad tags value
                 return False
-            if not all(
-                any(fnmatchcase(str(tag), pattern) for tag in target_tags) for pattern in self.tags
-            ):
+            if not all(any(glob.match(str(tag)) for tag in target_tags) for glob in self.tags):
                 return False
 
         # Nothing rules this target out.

--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -18,7 +18,7 @@ from pants.util.strutil import softwrap
 
 def is_path_glob(spec: str) -> bool:
     """Check if `spec` should be treated as a `path` glob."""
-    return len(spec) > 0 and spec[0].isalnum() or spec[0] in "_.:/*"
+    return len(spec) > 0 and (spec[0].isalnum() or spec[0] in "_.:/*")
 
 
 def glob_to_regexp(pattern: str, snap_to_path: bool = False) -> str:

--- a/src/python/pants/backend/visibility/glob.py
+++ b/src/python/pants/backend/visibility/glob.py
@@ -44,7 +44,7 @@ class PathGlobAnchorMode(Enum):
 @dataclass(frozen=True)
 class PathGlob:
     raw: str
-    anchor_mode: PathGlobAnchorMode = field(compare=False)
+    anchor_mode: PathGlobAnchorMode
     glob: Pattern = field(compare=False)
     uplvl: int
 

--- a/src/python/pants/backend/visibility/glob_test.py
+++ b/src/python/pants/backend/visibility/glob_test.py
@@ -274,6 +274,10 @@ def test_pathglob_match(glob: PathGlob, tests: tuple[tuple[str, str, bool], ...]
         ("(tag-a)", "(tag-a)"),
         ("(tag-a  ,  tag-b)", "(tag-a, tag-b)"),
         ("<file*>(foo, bar)[baz.txt]", "<file*>[baz.txt](foo, bar)"),
+        (":name", ":name"),
+        (dict(name="name"), ":name"),
+        (dict(path="src/*", name="name"), "src/*:name"),
+        (dict(type="target", path="src", name="name"), "<target>[src:name]"),
     ],
 )
 def test_target_glob_parse_spec(target_spec: str | Mapping[str, Any], expected: str) -> None:
@@ -283,7 +287,6 @@ def test_target_glob_parse_spec(target_spec: str | Mapping[str, Any], expected: 
 @pytest.mark.parametrize(
     "expected, target_spec",
     [
-        (False, "!*"),
         (True, "*"),
         (True, "<file>"),
         (True, "(tag-c)"),
@@ -295,6 +298,12 @@ def test_target_glob_parse_spec(target_spec: str | Mapping[str, Any], expected: 
         (True, "<file>(tag-a, tag-c)[src/file.ext]"),
         (False, "<file>(tag-a, tag-b)[src/file.ext]"),
         (False, "<resource>"),
+        (False, ":name"),
+        (True, ":src"),
+        (True, ":*"),
+        (False, "other.txt:src"),
+        (True, "file.ext:src"),
+        (True, "src/file.ext:src"),
     ],
 )
 def test_targetglob_match(expected: bool, target_spec: str) -> None:

--- a/src/python/pants/backend/visibility/rule_types.py
+++ b/src/python/pants/backend/visibility/rule_types.py
@@ -40,7 +40,7 @@ class BuildFileVisibilityRulesError(DependencyRulesError):
         example = (
             pformat((tuple(map(str, ruleset.selectors)), *map(str, ruleset.rules), "!*"))
             if ruleset is not None
-            else '(<target patterns>, <existing rules...>, "!*"),'
+            else '(<target selector(s)>, <rule(s), ...>, "!*"),'
         )
         return cls(
             softwrap(
@@ -132,7 +132,7 @@ class VisibilityRuleSet:
                     At least one target selector must have a filtering rule that can match
                     something, for example:
 
-                        ("python_*", {rules})
+                        ("<python_*>", {rules})
                     """
                 )
             )
@@ -141,12 +141,12 @@ class VisibilityRuleSet:
     def parse(cls, build_file: str, arg: Any) -> VisibilityRuleSet:
         """Translate input `arg` from BUILD file call.
 
-        The arg is a rule spec tuple with two or more elements, where the first is the target type
-        pattern(s) and the rest are rules.
+        The arg is a rule spec tuple with two or more elements, where the first is the target
+        selector(s) and the rest are target rules.
         """
         if not isinstance(arg, Sequence) or isinstance(arg, str) or len(arg) < 2:
             raise ValueError(
-                "Invalid rule spec, expected (<target type pattern(s)>, <rule>, ...) "
+                "Invalid rule spec, expected (<target selector(s)>, <rule(s)>, <rule(s)>, ...) "
                 f"but got: {arg!r}"
             )
 

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os.path
 import re
 from pathlib import PurePath
 from textwrap import dedent
@@ -127,7 +128,7 @@ def test_flatten(expected, xs) -> None:
 
 
 @pytest.mark.parametrize(
-    "expected, rule, path, relpath",
+    "expected, spec, path, relpath",
     [
         (True, "src/a", "src/a", ""),
         (True, "?src/a", "src/a", ""),
@@ -153,10 +154,18 @@ def test_flatten(expected, xs) -> None:
         (True, "my_file.ext", "path/my_file.ext", ""),
         (False, "my_file.ext", "not_my_file.ext", ""),
         (True, "*my_file.ext", "path/some_of_my_file.ext", ""),
+        (True, ":tgt-*", "where/ever/it/is.from", "no/matter/how/far"),
+        (True, "<target>", "src/a", ""),
+        (False, "<target>[src/b]", "src/a", ""),
+        (False, "<file>", "src/a", ""),
     ],
 )
-def test_visibility_rule(expected: bool, rule: str, path: str, relpath: str) -> None:
-    assert parse_rule(rule).match(path, relpath) == expected
+def test_visibility_rule(expected: bool, spec: str, path: str, relpath: str) -> None:
+    rule = parse_rule(spec)
+    address = Address(
+        os.path.dirname(path), relative_file_path=os.path.basename(path), target_name="tgt-name"
+    )
+    assert expected == rule.match(address, TargetAdaptor("target", None), relpath)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For greater flexibility the target rules now supports filtering on target name:
```python
  (
    "some/**/path:my-target*",
    ...
  )
```

This also adjusts the rules glob syntax to support the same syntax used for the selectors, so there is now only a single visibility rules syntax that applies to both selectors and rules.

Closes #18368 