### PR TITLE
Removing more unwraps from FFI layer

### DIFF
--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -32,12 +32,10 @@ fn test_display() {
 #[test]
 fn test_scope() {
   let env = env([("PANTS_PYTHON_EXAMPLE", "true")]);
-  assert!(
-    env
-      .get_bool(&option_id!(["python"], "example"))
-      .unwrap()
-      .unwrap()
-  );
+  assert!(env
+    .get_bool(&option_id!(["python"], "example"))
+    .unwrap()
+    .unwrap());
 }
 
 #[test]

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -32,8 +32,7 @@ fn test_display() {
 #[test]
 fn test_scope() {
   let env = env([("PANTS_PYTHON_EXAMPLE", "true")]);
-  assert_eq!(
-    true,
+  assert!(
     env
       .get_bool(&option_id!(["python"], "example"))
       .unwrap()

--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -393,7 +393,7 @@ impl<'a> process_execution::CommandRunner for CommandRunner<'a> {
         let exclusive_spawn = prepare_workdir(
           workdir.path().to_owned(),
           &req,
-          req.input_digests.input_files.clone(),
+          req.input_digests.inputs.clone(),
           self.store.clone(),
           self.executor.clone(),
           &named_caches,

--- a/src/rust/engine/process_execution/pe_nailgun/src/lib.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/lib.rs
@@ -209,7 +209,7 @@ impl process_execution::CommandRunner for CommandRunner {
         let exclusive_spawn = prepare_workdir(
           nailgun_process.workdir_path().to_owned(),
           &client_req,
-          client_req.input_digests.input_files.clone(),
+          client_req.input_digests.inputs.clone(),
           self.store.clone(),
           self.executor.clone(),
           &self.named_caches,

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -368,7 +368,7 @@ impl NailgunProcess {
     prepare_workdir(
       workdir.path().to_owned(),
       &startup_options,
-      startup_options.input_digests.input_files.clone(),
+      startup_options.input_digests.inputs.clone(),
       store.clone(),
       executor.clone(),
       named_caches,

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -908,7 +908,7 @@ async fn successful_with_only_call_to_execute() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -959,7 +959,7 @@ async fn successful_after_reconnect_with_wait_execution() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1014,7 +1014,7 @@ async fn successful_after_reconnect_from_retryable_error() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1079,7 +1079,7 @@ async fn creates_executing_workunit() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1259,7 +1259,7 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1313,7 +1313,7 @@ async fn sends_headers() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1515,7 +1515,7 @@ async fn ensure_inline_stdio_is_stored() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &echo_roland_request(),
       None,
       None,
@@ -1601,7 +1601,7 @@ async fn bad_result_bytes() {
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
-        execute_request: crate::remote::make_execute_request(
+        execute_request: process_execution::make_execute_request(
           &execute_request,
           None,
           None,
@@ -1650,7 +1650,7 @@ async fn initial_response_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1705,7 +1705,7 @@ async fn initial_response_missing_response_and_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1751,7 +1751,7 @@ async fn fails_after_retry_limit_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1815,7 +1815,7 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     let op_name = "foo-bar".to_owned();
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &execute_request,
       None,
       None,
@@ -1898,7 +1898,7 @@ async fn execute_missing_file_uploads_if_known() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = crate::remote::make_execute_request(
+    } = process_execution::make_execute_request(
       &cat_roland_request(),
       None,
       None,
@@ -1920,7 +1920,7 @@ async fn execute_missing_file_uploads_if_known() {
           ]),
         },
         ExpectedAPICall::Execute {
-          execute_request: crate::remote::make_execute_request(
+          execute_request: process_execution::make_execute_request(
             &cat_roland_request(),
             None,
             None,

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -1,7 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::collections::{BTreeMap, BTreeSet, HashSet};
-use std::convert::TryInto;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -909,8 +908,8 @@ async fn successful_with_only_call_to_execute() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -960,8 +959,8 @@ async fn successful_after_reconnect_with_wait_execution() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1015,8 +1014,8 @@ async fn successful_after_reconnect_from_retryable_error() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1080,8 +1079,8 @@ async fn creates_executing_workunit() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1260,8 +1259,8 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1314,8 +1313,8 @@ async fn sends_headers() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1516,8 +1515,8 @@ async fn ensure_inline_stdio_is_stored() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &echo_roland_request().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &echo_roland_request(),
       None,
       None,
       &store,
@@ -1602,8 +1601,8 @@ async fn bad_result_bytes() {
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
-        execute_request: process_execution::make_execute_request(
-          &execute_request.clone().try_into().unwrap(),
+        execute_request: crate::remote::make_execute_request(
+          &execute_request,
           None,
           None,
           &store,
@@ -1651,8 +1650,8 @@ async fn initial_response_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1706,8 +1705,8 @@ async fn initial_response_missing_response_and_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1752,8 +1751,8 @@ async fn fails_after_retry_limit_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1816,8 +1815,8 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     let op_name = "foo-bar".to_owned();
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request.clone().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &execute_request,
       None,
       None,
       &store,
@@ -1899,8 +1898,8 @@ async fn execute_missing_file_uploads_if_known() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &cat_roland_request().try_into().unwrap(),
+    } = crate::remote::make_execute_request(
+      &cat_roland_request(),
       None,
       None,
       &store,
@@ -1921,8 +1920,8 @@ async fn execute_missing_file_uploads_if_known() {
           ]),
         },
         ExpectedAPICall::Execute {
-          execute_request: process_execution::make_execute_request(
-            &cat_roland_request().try_into().unwrap(),
+          execute_request: crate::remote::make_execute_request(
+            &cat_roland_request(),
             None,
             None,
             &store,

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -908,15 +908,9 @@ async fn successful_with_only_call_to_execute() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -959,15 +953,9 @@ async fn successful_after_reconnect_with_wait_execution() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![
@@ -1014,15 +1002,9 @@ async fn successful_after_reconnect_from_retryable_error() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     let execute_request_2 = execute_request.clone();
 
@@ -1079,15 +1061,9 @@ async fn creates_executing_workunit() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1259,15 +1235,9 @@ async fn server_sending_triggering_timeout_with_deadline_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1313,15 +1283,9 @@ async fn sends_headers() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1515,15 +1479,9 @@ async fn ensure_inline_stdio_is_stored() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &echo_roland_request(),
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&echo_roland_request(), None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1650,15 +1608,9 @@ async fn initial_response_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1705,15 +1657,9 @@ async fn initial_response_missing_response_and_error() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![ExpectedAPICall::Execute {
@@ -1751,15 +1697,9 @@ async fn fails_after_retry_limit_exceeded() {
   let mock_server = {
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![
@@ -1815,15 +1755,9 @@ async fn fails_after_retry_limit_exceeded_with_stream_close() {
     let op_name = "foo-bar".to_owned();
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &execute_request,
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&execute_request, None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![
@@ -1898,15 +1832,9 @@ async fn execute_missing_file_uploads_if_known() {
 
     let EntireExecuteRequest {
       execute_request, ..
-    } = process_execution::make_execute_request(
-      &cat_roland_request(),
-      None,
-      None,
-      &store,
-      None,
-    )
-    .await
-    .unwrap();
+    } = process_execution::make_execute_request(&cat_roland_request(), None, None, &store, None)
+      .await
+      .unwrap();
 
     mock::execution_server::TestServer::new(
       mock::execution_server::MockExecution::new(vec![

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -281,7 +281,7 @@ impl super::CommandRunner for CommandRunner {
         let exclusive_spawn = prepare_workdir(
           workdir.path().to_owned(),
           &req,
-          req.input_digests.input_files.clone(),
+          req.input_digests.inputs.clone(),
           self.store.clone(),
           self.executor.clone(),
           &self.named_caches,

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -433,6 +433,7 @@ impl Core {
               err
             )
           })?;
+        // TODO: Use the once_cell::Lazy here
         let pem_re = Regex::new(PEM_RE_STR).unwrap();
         let certs_res: Result<Vec<reqwest::Certificate>, _> = pem_re
           .find_iter(&content)

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -433,7 +433,6 @@ impl Core {
               err
             )
           })?;
-        // TODO: Use the once_cell::Lazy here
         let pem_re = Regex::new(PEM_RE_STR).unwrap();
         let certs_res: Result<Vec<reqwest::Certificate>, _> = pem_re
           .find_iter(&content)

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -561,7 +561,7 @@ fn interactive_process(
       prepare_workdir(
         tempdir.path().to_owned(),
         &process,
-        process.input_digests.input_files.clone(),
+        process.input_digests.inputs.clone(),
         context.core.store(),
         context.core.executor.clone(),
         &context.core.named_caches,

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -301,8 +301,11 @@ impl ExecuteProcess {
   ) -> Result<InputDigests, StoreError> {
     let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
       let value = (**value).as_ref(py);
-      let input_files = lift_directory_digest(externs::getattr(value, "input_digest").map_err(|err| format!("Error retrieving `input_digest`: {err}"))?)
-        .map_err(|err| format!("Error parsing input_digest {err}"))?;
+      let input_files = lift_directory_digest(
+        externs::getattr(value, "input_digest")
+          .map_err(|err| format!("Error retrieving `input_digest`: {err}"))?,
+      )
+      .map_err(|err| format!("Error parsing input_digest {err}"))?;
       let immutable_inputs =
         externs::getattr_from_str_frozendict::<&PyAny>(value, "immutable_input_digests")
           .into_iter()
@@ -383,8 +386,7 @@ impl ExecuteProcess {
         .map_err(|e| format!("Failed to get `execution_slot_variable` for field: {e}"))?;
 
     let concurrency_available: usize = externs::getattr(value, "concurrency_available")
-        .map_err(|e| format!("Failed to get `concurrency_available` for field: {e}"))?;
-
+      .map_err(|e| format!("Failed to get `concurrency_available` for field: {e}"))?;
 
     let cache_scope: ProcessCacheScope = {
       let cache_scope_enum = externs::getattr(value, "cache_scope")
@@ -396,7 +398,7 @@ impl ExecuteProcess {
 
     let remote_cache_speculation_delay = std::time::Duration::from_millis(
       externs::getattr::<i32>(value, "remote_cache_speculation_delay_millis")
-        .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64
+        .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64,
     );
 
     Ok(Process {
@@ -1033,11 +1035,10 @@ impl DownloadedFile {
       let py_download_file_val = self.0.to_value();
       let py_download_file = (*py_download_file_val).as_ref(py);
       let url_str: String = externs::getattr(py_download_file, "url")
-          .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
+        .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
       let auth_headers = externs::getattr_from_str_frozendict(py_download_file, "auth_headers");
-      let py_file_digest: PyFileDigest =
-        externs::getattr(py_download_file, "expected_digest")
-          .map_err(|e| format!("Failed to get `expected_digest` for field: {e}"))?;
+      let py_file_digest: PyFileDigest = externs::getattr(py_download_file, "expected_digest")
+        .map_err(|e| format!("Failed to get `expected_digest` for field: {e}"))?;
       let res: NodeResult<(String, Digest, BTreeMap<String, String>)> =
         Ok((url_str, py_file_digest.0, auth_headers));
       res

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -302,8 +302,7 @@ impl ExecuteProcess {
     let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
       let value = (**value).as_ref(py);
       let input_files = lift_directory_digest(
-        externs::getattr(value, "input_digest")
-          .map_err(|err| format!("Error retrieving `input_digest`: {err}"))?,
+        externs::getattr(value, "input_digest")?
       )
       .map_err(|err| format!("Error parsing input_digest {err}"))?;
       let immutable_inputs =
@@ -311,8 +310,7 @@ impl ExecuteProcess {
           .into_iter()
           .map(|(path, digest)| Ok((RelativePath::new(path)?, lift_directory_digest(digest)?)))
           .collect::<Result<BTreeMap<_, _>, String>>()?;
-      let use_nailgun = externs::getattr::<Vec<String>>(value, "use_nailgun")
-        .map_err(|err| format!("Failed to get field `use_nailgun`: {err}"))?
+      let use_nailgun = externs::getattr::<Vec<String>>(value, "use_nailgun")?
         .into_iter()
         .map(RelativePath::new)
         .collect::<Result<BTreeSet<_>, _>>()?;
@@ -342,20 +340,17 @@ impl ExecuteProcess {
       .map(RelativePath::new)
       .transpose()?;
 
-    let output_files = externs::getattr::<Vec<String>>(value, "output_files")
-      .map_err(|err| format!("Failed to get field `output_files`: {err}"))?
+    let output_files = externs::getattr::<Vec<String>>(value, "output_files")?
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
 
-    let output_directories = externs::getattr::<Vec<String>>(value, "output_directories")
-      .map_err(|err| format!("Failed to get field `output_directories`: {err}"))?
+    let output_directories = externs::getattr::<Vec<String>>(value, "output_directories")?
       .into_iter()
       .map(RelativePath::new)
       .collect::<Result<_, _>>()?;
 
-    let timeout_in_seconds: f64 = externs::getattr(value, "timeout_seconds")
-      .map_err(|err| format!("Failed to get field `timeout_seconds`: {err}"))?;
+    let timeout_in_seconds: f64 = externs::getattr(value, "timeout_seconds")?;
 
     let timeout = if timeout_in_seconds < 0.0 {
       None
@@ -363,11 +358,9 @@ impl ExecuteProcess {
       Some(Duration::from_millis((timeout_in_seconds * 1000.0) as u64))
     };
 
-    let description: String = externs::getattr(value, "description")
-      .map_err(|err| format!("Failed to get field `description`: {err}"))?;
+    let description: String = externs::getattr(value, "description")?;
 
-    let py_level = externs::getattr(value, "level")
-      .map_err(|err| format!("Failed to get field `level`: {err}"))?;
+    let py_level = externs::getattr(value, "level")?;
 
     let level = externs::val_to_log_level(py_level)?;
 
@@ -385,14 +378,11 @@ impl ExecuteProcess {
       externs::getattr_as_optional_string(value, "execution_slot_variable")
         .map_err(|e| format!("Failed to get `execution_slot_variable` for field: {e}"))?;
 
-    let concurrency_available: usize = externs::getattr(value, "concurrency_available")
-      .map_err(|e| format!("Failed to get `concurrency_available` for field: {e}"))?;
+    let concurrency_available: usize = externs::getattr(value, "concurrency_available")?;
 
     let cache_scope: ProcessCacheScope = {
-      let cache_scope_enum = externs::getattr(value, "cache_scope")
-        .map_err(|e| format!("Failed to get `cache_scope` for field: {e}"))?;
-      externs::getattr::<String>(cache_scope_enum, "name")
-        .map_err(|e| format!("Failed to get `name` for field: {e}"))?
+      let cache_scope_enum = externs::getattr(value, "cache_scope")?;
+      externs::getattr::<String>(cache_scope_enum, "name")?
         .try_into()?
     };
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -312,7 +312,7 @@ impl ExecuteProcess {
           .map(|(path, digest)| Ok((RelativePath::new(path)?, lift_directory_digest(digest)?)))
           .collect::<Result<BTreeMap<_, _>, String>>()?;
       let use_nailgun = externs::getattr::<Vec<String>>(value, "use_nailgun")
-        .map_err(|err| format!("Failed to get value `use_nailgun`: {err}"))?
+        .map_err(|err| format!("Failed to get field `use_nailgun`: {err}"))?
         .into_iter()
         .map(RelativePath::new)
         .collect::<Result<BTreeSet<_>, _>>()?;

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -301,10 +301,8 @@ impl ExecuteProcess {
   ) -> Result<InputDigests, StoreError> {
     let input_digests_fut: Result<_, String> = Python::with_gil(|py| {
       let value = (**value).as_ref(py);
-      let input_files = lift_directory_digest(
-        externs::getattr(value, "input_digest")?
-      )
-      .map_err(|err| format!("Error parsing input_digest {err}"))?;
+      let input_files = lift_directory_digest(externs::getattr(value, "input_digest")?)
+        .map_err(|err| format!("Error parsing input_digest {err}"))?;
       let immutable_inputs =
         externs::getattr_from_str_frozendict::<&PyAny>(value, "immutable_input_digests")
           .into_iter()
@@ -382,8 +380,7 @@ impl ExecuteProcess {
 
     let cache_scope: ProcessCacheScope = {
       let cache_scope_enum = externs::getattr(value, "cache_scope")?;
-      externs::getattr::<String>(cache_scope_enum, "name")?
-        .try_into()?
+      externs::getattr::<String>(cache_scope_enum, "name")?.try_into()?
     };
 
     let remote_cache_speculation_delay = std::time::Duration::from_millis(

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1024,8 +1024,7 @@ impl DownloadedFile {
       let url_str: String = externs::getattr(py_download_file, "url")
         .map_err(|e| format!("Failed to get `url` for field: {e}"))?;
       let auth_headers = externs::getattr_from_str_frozendict(py_download_file, "auth_headers");
-      let py_file_digest: PyFileDigest = externs::getattr(py_download_file, "expected_digest")
-        .map_err(|e| format!("Failed to get `expected_digest` for field: {e}"))?;
+      let py_file_digest: PyFileDigest = externs::getattr(py_download_file, "expected_digest")?;
       let res: NodeResult<(String, Digest, BTreeMap<String, String>)> =
         Ok((url_str, py_file_digest.0, auth_headers));
       res


### PR DESCRIPTION
Clears out more of #13608.

Key changes:

- Removed unwraps from FFI layer, mainly in `nodes.rs`.
- Removed redundant `clone().try_into().unwrap()` that converted a `Process` to a `Process` in the `remote_tests.rs`. This seems to have been legacy from when `Process` was actually MEPR.
- Renamed `input_files` to `inputs` in the `InputDigests` struct, inline with the `immutable_inputs` attribute.