### PR TITLE
Upgrade Pex to 2.1.124.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ humbug==0.2.7
 importlib_resources==5.0.*
 ijson==3.1.4
 packaging==21.3
-pex==2.1.123
+pex==2.1.124
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "importlib_resources==5.0.*",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.123",
+//     "pex==2.1.124",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1072,13 +1072,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e53b385a2606c6ec7a95af27c84740553541f75c16d8fa8a91dfe379ab503858",
-              "url": "https://files.pythonhosted.org/packages/19/5d/8ab564f1d70552678a5af52f49d19906f0e15744aa16a1b2f58331718882/pex-2.1.123-py2.py3-none-any.whl"
+              "hash": "8a25311c5b64d6fdd245392929713b1b75f1415ecbd0fc3cb8f07a48e4f1aae7",
+              "url": "https://files.pythonhosted.org/packages/6e/19/1cdfd6027e1634069b0a82c1862817e817e1f73b3e87a21ee7c78fccc289/pex-2.1.124-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5cf8c7aa5f21ae0c6626e0ffc217bffb052e01def38ff75bf739095fd784288a",
-              "url": "https://files.pythonhosted.org/packages/66/2f/794f1fcc40b597514f1d4f92f1f409fd219e7cfaf45667f37910b9579866/pex-2.1.123.tar.gz"
+              "hash": "73f465a29dfbfb1c705421c612a17230f424bb4c583afc460e4968cd1e37f9ac",
+              "url": "https://files.pythonhosted.org/packages/cb/29/ce322937886352a5617d13465acedb5712bcd08886a79c68c52caa201188/pex-2.1.124.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1086,7 +1086,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.123"
+          "version": "2.1.124"
         },
         {
           "artifacts": [
@@ -2112,19 +2112,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "28d2d7f5c31ff8ed4d9d2e396ce906c49d37523c3ec207d03d3b1695755a7199",
-              "url": "https://files.pythonhosted.org/packages/92/33/0963e75be2426cd570a36deb5ac8ff94560a04c0c04f526d81d7088e6bc3/types_urllib3-1.26.25.7-py3-none-any.whl"
+              "hash": "95ea847fbf0bf675f50c8ae19a665baedcf07e6b4641662c4c3c72e7b2edf1a9",
+              "url": "https://files.pythonhosted.org/packages/30/29/3ae36523276099dfe4835014875a464c745e8588bf8bec3cab1cb7850d34/types_urllib3-1.26.25.8-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "df4d3e5472bf8830bd74eac12d56e659f88662ba040c7d106bf3a5bee26fff28",
-              "url": "https://files.pythonhosted.org/packages/fc/89/d95f839ae26e80d221fcc25dd8bf272121e6be00eaee081483b8145261a5/types-urllib3-1.26.25.7.tar.gz"
+              "hash": "ecf43c42d8ee439d732a1110b4901e9017a79a38daca26f08e42c8460069392c",
+              "url": "https://files.pythonhosted.org/packages/03/58/5294b587731ecd9255778b7db574fae40a9113e184e6f62652d8952c5cf6/types-urllib3-1.26.25.8.tar.gz"
             }
           ],
           "project_name": "types-urllib3",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.26.25.7"
+          "version": "1.26.25.8"
         },
         {
           "artifacts": [
@@ -2733,19 +2733,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7",
-              "url": "https://files.pythonhosted.org/packages/a8/7d/90189265f0a9bcdf79b1143b77b0ef6dca0a5f13783f1e1efa4d7d7eafca/zipp-3.14.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb",
-              "url": "https://files.pythonhosted.org/packages/ab/47/b47d02b741e0aa6f998fc80457d3dfc05cb7732ef480597c2971cbc79260/zipp-3.14.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
+            "big-O; extra == \"testing\"",
             "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
@@ -2764,15 +2764,15 @@
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.14.0"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.123",
-  "pip_version": "23.0",
+  "pex_version": "2.1.124",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2788,7 +2788,7 @@
     "importlib_resources==5.0.*",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.123",
+    "pex==2.1.124",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/pants.toml
+++ b/pants.toml
@@ -140,7 +140,7 @@ venv_use_symlinks = true
 interpreter_constraints = [">=3.7,<3.10"]
 macos_big_sur_compatibility = true
 enable_resolves = true
-pip_version = "23.0"
+pip_version = "23.0.1"
 
 [python.resolves]
 python-default = "3rdparty/python/user_reqs.lock"

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -26,6 +26,7 @@ from pants.backend.python.target_types import (
     PexScriptField,
     PexShebangField,
     PexStripEnvField,
+    PexVenvHermeticScripts,
     PexVenvSitePackagesCopies,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
@@ -82,6 +83,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     include_sources: PexIncludeSourcesField
     include_tools: PexIncludeToolsField
     venv_site_packages_copies: PexVenvSitePackagesCopies
+    venv_hermetic_scripts: PexVenvHermeticScripts
     environment: EnvironmentField
 
     @property
@@ -108,6 +110,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append("--include-tools")
         if self.venv_site_packages_copies.value is True:
             args.append("--venv-site-packages-copies")
+        if self.venv_hermetic_scripts.value is False:
+            args.append("--non-hermetic-venv-scripts")
         return tuple(args)
 
 

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e53b385a2606c6ec7a95af27c84740553541f75c16d8fa8a91dfe379ab503858",
-              "url": "https://files.pythonhosted.org/packages/19/5d/8ab564f1d70552678a5af52f49d19906f0e15744aa16a1b2f58331718882/pex-2.1.123-py2.py3-none-any.whl"
+              "hash": "8a25311c5b64d6fdd245392929713b1b75f1415ecbd0fc3cb8f07a48e4f1aae7",
+              "url": "https://files.pythonhosted.org/packages/6e/19/1cdfd6027e1634069b0a82c1862817e817e1f73b3e87a21ee7c78fccc289/pex-2.1.124-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5cf8c7aa5f21ae0c6626e0ffc217bffb052e01def38ff75bf739095fd784288a",
-              "url": "https://files.pythonhosted.org/packages/66/2f/794f1fcc40b597514f1d4f92f1f409fd219e7cfaf45667f37910b9579866/pex-2.1.123.tar.gz"
+              "hash": "73f465a29dfbfb1c705421c612a17230f424bb4c583afc460e4968cd1e37f9ac",
+              "url": "https://files.pythonhosted.org/packages/cb/29/ce322937886352a5617d13465acedb5712bcd08886a79c68c52caa201188/pex-2.1.124.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -68,15 +68,15 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.123"
+          "version": "2.1.124"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.123",
-  "pip_version": "23.0",
+  "pex_version": "2.1.124",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "lambdex==0.1.9"

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -34,6 +34,7 @@ class PipVersion(enum.Enum):
     V22_3 = "22.3"
     V22_3_1 = "22.3.1"
     V23_0 = "23.0"
+    V23_0_1 = "23.0.1"
 
 
 @enum.unique

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -650,6 +650,21 @@ class PexVenvSitePackagesCopies(BoolField):
     )
 
 
+class PexVenvHermeticScripts(BoolField):
+    alias = "venv_hermetic_scripts"
+    default = True
+    help = help_text(
+        """
+        If execution_mode is "venv", emit a hermetic venv `pex` script and hermetic console scripts.
+
+        The venv `pex` script and the venv console scripts are constructed to be hermetic by
+        default; Python is executed with `-sE` to restrict the `sys.path` to the PEX venv contents
+        only. Setting this field to `False` elides the Python `-sE` restrictions and can be used to
+        interoperate with frameworks that use `PYTHONPATH` manipulation to run code.
+        """
+    )
+
+
 _PEX_BINARY_COMMON_FIELDS = (
     EnvironmentField,
     InterpreterConstraintsField,
@@ -669,6 +684,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexIncludeSourcesField,
     PexIncludeToolsField,
     PexVenvSitePackagesCopies,
+    PexVenvHermeticScripts,
     RestartableField,
 )
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -38,9 +38,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.123"
+    default_version = "v2.1.124"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.123,<3.0"
+    version_constraints = ">=2.1.124,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -49,8 +49,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "3a2cba02946eb8859393906673bb56ecf6ebee72961bc8f3ca1ae754493733c6",
-                    "4076395",
+                    "5088d00bc89cfaac537846413d8456caa3b2b021d9a5ce6b423635dd1a57b84c",
+                    "4077988",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
Add support for Pip version "23.0.1" and dogfood this. Also add a new
`venv_hermetic_scripts` field to `pex_binary` that plumbs through to
the new `--non-hermetic-venv-scripts` `pex` option.

The Pex changelog is here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.124