### PR TITLE
Fix export-codgen with multiple output types from same input type (Cherry-pick of #18373)

### DIFF
--- a/src/python/pants/backend/codegen/export_codegen_goal.py
+++ b/src/python/pants/backend/codegen/export_codegen_goal.py
@@ -46,17 +46,16 @@ async def export_codegen(
     # We run all possible code generators. Running codegen requires specifying the expected
     # output_type, so we must inspect what is possible to generate.
     all_generate_request_types = union_membership.get(GenerateSourcesRequest)
-    inputs_to_outputs = {
-        req.input: req.output for req in all_generate_request_types if req.exportable
-    }
+    inputs_to_outputs = [
+        (req.input, req.output) for req in all_generate_request_types if req.exportable
+    ]
     codegen_sources_fields_with_output = []
     for tgt in targets:
         if not tgt.has_field(SourcesField):
             continue
         sources = tgt[SourcesField]
-        for input_type in inputs_to_outputs:
+        for input_type, output_type in inputs_to_outputs:
             if isinstance(sources, input_type):
-                output_type = inputs_to_outputs[input_type]
                 codegen_sources_fields_with_output.append((sources, output_type))
 
     if not codegen_sources_fields_with_output:
@@ -64,8 +63,8 @@ async def export_codegen(
             {
                 tgt_type.alias
                 for tgt_type in registered_target_types.types
-                for input_sources in inputs_to_outputs.keys()
-                if tgt_type.class_has_field(input_sources, union_membership=union_membership)
+                for input_source in {input_source for input_source, _ in inputs_to_outputs}
+                if tgt_type.class_has_field(input_source, union_membership=union_membership)
             }
         )
         logger.warning(


### PR DESCRIPTION
Having multiple codegen backends enabled for the same input type (e.g. Go and Python for Protobuf) will currently only export one of the languages' generated files. This is due to the input type (e.g. `pants.backend.codegen.protobuf.target_types.ProtobufSourceField`) being used as the key in an input -> output map, causing the backend that's enabled last to overwrite any previous backend's registered input -> output.

Fixes #15698.
