### PR TITLE
Give pantsd more RAM by default.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -965,8 +965,8 @@ class BootstrapOptions:
     )
     pantsd_max_memory_usage = MemorySizeOption(
         advanced=True,
-        default=memory_size("1GiB"),
-        default_help_repr="1GiB",
+        default=memory_size("4GiB"),
+        default_help_repr="4GiB",
         help=softwrap(
             """
             The maximum memory usage of the pantsd process.


### PR DESCRIPTION
1GiB turns out to be too low for even medium-sized repos. Several users have remarked on this on Slack (search for "pantsd_max_memory_usage" there to see those), and we've noticed it in the Toolchain repo.

Most developer laptops have plenty of RAM. So 4GiB seems like a decent default.