### PR TITLE
Deprecate the default interpreter constraints.

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -85,7 +85,7 @@ class PythonSetup(Subsystem):
     def interpreter_constraints(self) -> tuple[str, ...]:
         # TODO: In 2.17.0.dev0 we should set the default above to None and tweak the message here
         #  appropriately.
-        if not self.options.is_default("interpreter_constraints"):
+        if self.options.is_default("interpreter_constraints"):
             warn_or_error(
                 "2.17.0.dev0",
                 "the factory default interpreter constraints value",

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -10,6 +10,7 @@ from typing import Iterable, List, Optional, TypeVar, cast
 
 from packaging.utils import canonicalize_name
 
+from pants.base.deprecated import warn_or_error
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.option.option_types import (
     BoolOption,
@@ -62,7 +63,7 @@ class PythonSetup(Subsystem):
     default_interpreter_constraints = ["CPython>=3.7,<4"]
     default_interpreter_universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
 
-    interpreter_constraints = StrListOption(
+    _interpreter_constraints = StrListOption(
         default=default_interpreter_constraints,
         help=softwrap(
             """
@@ -79,6 +80,34 @@ class PythonSetup(Subsystem):
         advanced=True,
         metavar="<requirement>",
     )
+
+    @memoized_property
+    def interpreter_constraints(self) -> tuple[str, ...]:
+        # TODO: In 2.17.0.dev0 we should set the default above to None and tweak the message here
+        #  appropriately.
+        if not self.options.is_default("interpreter_constraints"):
+            warn_or_error(
+                "2.17.0.dev0",
+                "the factory default interpreter constraints value",
+                softwrap(
+                    f"""\
+                    You're relying on the default interpreter constraints that ship with Pants
+                    ({self._interpreter_constraints}). This default is deprecated, in favor of
+                    explicitly specifying the interpreter versions your code is actually intended to
+                    run against.
+
+                    You specify interpreter constraints using the `interpreter_constraints` option in
+                    the `[python]` section of pants.toml. We recommend constraining to a single interpreter
+                    minor version if you can, e.g., `interpreter_constraints = ['==3.11.*']`, or at
+                    least a small number of interpreter minor versions, e.g., `interpreter_constraints
+                    = ['>=3.10,<3.12']`. See {doc_url("python-interpreter-compatibility")} for details.
+
+                    Set explicit interpreter constraints now to get rid of this warning.
+                    """
+                ),
+            )
+        return self._interpreter_constraints
+
     interpreter_versions_universe = StrListOption(
         default=default_interpreter_universe,
         help=softwrap(

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -122,7 +122,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
             to "#cores")
         :param fromfile: If True, allows the user to specify a string value (starting with "@")
             which represents a file to read the option's value from.
-        :param metvar: Sets what users see in `./pants help` as possible values for the flag.
+        :param metavar: Sets what users see in `./pants help` as possible values for the flag.
             The default is based on the option type (E.g. "<str>" or "<int>").
         :param mutually_exclusive_group: If specified disallows all other options using the same
             value to also be specified by the user.


### PR DESCRIPTION
They cause a lot more harm than good. E.g., they cause lockfile generation to be a lot slower than necessary. There is no way we can pick a sensible default here, we cannot know what interpreters people are using in their repos, nor which python language versions their code is compatible with, so no default we pick can be correct.