### PR TITLE
[WIP] Add a system binaries subsystem

### DIFF
--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -26,6 +26,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
     BinaryPaths,
+    SystemBinariesSubsystem,
 )
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest
 from pants.engine.internals.selectors import Get, MultiGet
@@ -129,7 +130,7 @@ async def _find_binary(
 
 
 @rule(level=LogLevel.DEBUG)
-async def create_system_binary_run_request(field_set: SystemBinaryFieldSet) -> RunRequest:
+async def create_system_binary_run_request(field_set: SystemBinaryFieldSet, system_binaries: SystemBinariesSubsystem.EnvironmentAware) -> RunRequest:
 
     assert field_set.name.value is not None
     extra_search_paths = field_set.extra_search_paths.value or ()

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -22,7 +22,7 @@ from pants.core.util_rules.adhoc_process_support import (
     ResolveExecutionDependenciesRequest,
 )
 from pants.core.util_rules.system_binaries import (
-    SEARCH_PATHS,
+    SEARCH_PATHS_GET_RID_OF_ME,
     BinaryPath,
     BinaryPathRequest,
     BinaryPaths,
@@ -64,7 +64,7 @@ async def _find_binary(
     fingerprint_dependencies: tuple[str, ...] | None,
 ) -> BinaryPath:
 
-    search_paths = tuple(extra_search_paths) + SEARCH_PATHS
+    search_paths = tuple(extra_search_paths) + SEARCH_PATHS_GET_RID_OF_ME
 
     binaries = await Get(
         BinaryPaths,

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -147,7 +147,7 @@ async def merge_extra_sandbox_contents(request: MergeExtraSandboxContents) -> Ex
 
 
 @rule
-async def add_extra_contents_to_prcess(request: AddExtraSandboxContentsToProcess) -> Process:
+async def add_extra_contents_to_process(request: AddExtraSandboxContentsToProcess) -> Process:
 
     proc = request.process
     extras = request.contents

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -11,7 +11,7 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Mapping, Sequence
+from typing import Iterable, Mapping, Sequence, Tuple
 
 from pants.core.subsystems import python_bootstrap
 from pants.core.subsystems.python_bootstrap import PythonBootstrap
@@ -24,7 +24,7 @@ from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform
 from pants.engine.process import FallibleProcessResult, Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.option.option_types import StrListOption
+from pants.option.option_types import DictOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -51,6 +51,13 @@ class SystemBinariesSubsystem(Subsystem):
             default=[*SEARCH_PATHS_GET_RID_OF_ME],
             advanced=True,
             metavar="<binary-paths>",
+            help="TODO",
+        )
+
+        _search_paths = DictOption[Tuple[str, ...]](
+            "search-paths",
+            default={},
+            advanced=True,
             help="TODO",
         )
 
@@ -553,6 +560,8 @@ async def find_binary(
 
     # TODO: This should support more granular search paths
     def search_path_for_binary(binary_name: str) -> SearchPath:
+        if binary_name in system_binaries._search_paths:
+            return SearchPath(system_binaries._search_paths[binary_name])
         return SearchPath(system_binaries._default_search_path)
 
     # Some subtle notes about executing this script:


### PR DESCRIPTION
This is an attempt at tackling #14492. It's not complete yet, but I wanted to solicit some early feedback on this approach.

I'm introducing a subsystem `system-binaries` to hold options for configuring the search paths for system binaries. As a first experiment I just made a single default search path configurable, but I'm planning to expose a dictionary mapping binary names to search paths. That way, one could granularly configure which system binaries pants will use.

The option should be environment aware, unless I misunderstood what steps doing that will involve.

Things missing:
- [ ] a dictionary search path option, mapping binary names to search paths to prefer over the default ones
- [ ] Tackling `backend.adhoc.run_system_binary`'s reliance on the hard coded default search path. Presumably, the `_find_binary` function in there should be merged with the `find_binary` rule in `core.util_rules.system_binaries` and `BinaryPathRequest` should be enhanced with the additional fingerprinting options provider for the `adhoc` rules.