### PR TITLE
Upgrade Pex to 2.1.125.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ humbug==0.2.7
 importlib_resources==5.0.*
 ijson==3.1.4
 packaging==21.3
-pex==2.1.124
+pex==2.1.125
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "importlib_resources==5.0.*",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.124",
+//     "pex==2.1.125",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1072,13 +1072,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8a25311c5b64d6fdd245392929713b1b75f1415ecbd0fc3cb8f07a48e4f1aae7",
-              "url": "https://files.pythonhosted.org/packages/6e/19/1cdfd6027e1634069b0a82c1862817e817e1f73b3e87a21ee7c78fccc289/pex-2.1.124-py2.py3-none-any.whl"
+              "hash": "9b56d1c4399aa25b53fe15682a6544d103a77a15cf9cc0db7019c71940ffbaf3",
+              "url": "https://files.pythonhosted.org/packages/91/08/1495e676efd182de386c9bb59e7d5c63c17c601fac10d9548185609a0695/pex-2.1.125-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73f465a29dfbfb1c705421c612a17230f424bb4c583afc460e4968cd1e37f9ac",
-              "url": "https://files.pythonhosted.org/packages/cb/29/ce322937886352a5617d13465acedb5712bcd08886a79c68c52caa201188/pex-2.1.124.tar.gz"
+              "hash": "87ad0cf4d55b870051cb3e705deda479e944cf1627e8fd8ecc243a4c8559587d",
+              "url": "https://files.pythonhosted.org/packages/72/cb/073ae88de4b14b916c12c0786edbe53941db7fea1a6270e3fdb8c2a49544/pex-2.1.125.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1086,7 +1086,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.124"
+          "version": "2.1.125"
         },
         {
           "artifacts": [
@@ -2771,7 +2771,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.124",
+  "pex_version": "2.1.125",
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
@@ -2788,7 +2788,7 @@
     "importlib_resources==5.0.*",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.124",
+    "pex==2.1.125",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8a25311c5b64d6fdd245392929713b1b75f1415ecbd0fc3cb8f07a48e4f1aae7",
-              "url": "https://files.pythonhosted.org/packages/6e/19/1cdfd6027e1634069b0a82c1862817e817e1f73b3e87a21ee7c78fccc289/pex-2.1.124-py2.py3-none-any.whl"
+              "hash": "9b56d1c4399aa25b53fe15682a6544d103a77a15cf9cc0db7019c71940ffbaf3",
+              "url": "https://files.pythonhosted.org/packages/91/08/1495e676efd182de386c9bb59e7d5c63c17c601fac10d9548185609a0695/pex-2.1.125-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73f465a29dfbfb1c705421c612a17230f424bb4c583afc460e4968cd1e37f9ac",
-              "url": "https://files.pythonhosted.org/packages/cb/29/ce322937886352a5617d13465acedb5712bcd08886a79c68c52caa201188/pex-2.1.124.tar.gz"
+              "hash": "87ad0cf4d55b870051cb3e705deda479e944cf1627e8fd8ecc243a4c8559587d",
+              "url": "https://files.pythonhosted.org/packages/72/cb/073ae88de4b14b916c12c0786edbe53941db7fea1a6270e3fdb8c2a49544/pex-2.1.125.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -68,14 +68,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.124"
+          "version": "2.1.125"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.124",
+  "pex_version": "2.1.125",
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -38,7 +38,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.124"
+    default_version = "v2.1.125"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.124,<3.0"
 
@@ -49,8 +49,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "5088d00bc89cfaac537846413d8456caa3b2b021d9a5ce6b423635dd1a57b84c",
-                    "4077988",
+                    "1da1ef933429f15b218c98c6b960f30adfd0221fc5284c1d8facac09923692f8",
+                    "4080732",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This picks up support for building sdists for foreign platforms when
it turns out the sdist builds to a foreign platform compatible wheel.

The release notes are here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.125