### PR TITLE
Fix `paths` issue with transitive excludes.

### DIFF
--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -70,7 +70,7 @@ def find_paths_breadth_first(
         current_edge = (prev_target, target)
 
         if current_edge not in visited_edges:
-            for dep in adjacency_lists[target]:
+            for dep in adjacency_lists.get(target, []):
                 dep_path = cur_path + [dep.address]
                 if dep.address == to_target:
                     yield dep_path

--- a/src/python/pants/backend/project_info/paths_test.py
+++ b/src/python/pants/backend/project_info/paths_test.py
@@ -4,12 +4,16 @@
 from __future__ import annotations
 
 import json
+from textwrap import dedent
 from typing import ClassVar, List
 
 import pytest
 
 from pants.backend.project_info.paths import PathsGoal
 from pants.backend.project_info.paths import rules as paths_rules
+from pants.backend.python.macros import python_requirements
+from pants.backend.python.macros.python_requirements import PythonRequirementsTargetGenerator
+from pants.backend.python.target_types import PexBinary
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Dependencies, OptionalSingleSourceField, Target
 from pants.testutil.rule_runner import RuleRunner
@@ -33,7 +37,13 @@ class MockTarget(Target):
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    runner = RuleRunner(rules=paths_rules(), target_types=[MockTarget])
+    runner = RuleRunner(
+        rules=(
+            *paths_rules(),
+            *python_requirements.rules(),
+        ),
+        target_types=[MockTarget, PexBinary, PythonRequirementsTargetGenerator],
+    )
     runner.write_files(
         {
             "base/base.txt": "",
@@ -43,6 +53,26 @@ def rule_runner() -> RuleRunner:
             "intermediate2/BUILD": "tgt(dependencies=['base'])",
             "leaf/BUILD": "tgt(dependencies=['intermediate', 'intermediate2'])",
             "island/BUILD": "tgt()",
+            "3rdparty/BUILD": dedent(
+                """\
+                python_requirements(
+                  overrides={
+                    "lib": {
+                      "dependencies": ("#lib-pluginA", "#lib-pluginB"),
+                    },
+                  },
+                )
+                """
+            ),
+            "3rdparty/requirements.txt": dedent(
+                """\
+                lib
+                lib-pluginA
+                lib-pluginB
+                """
+            ),
+            "src/prj/a/BUILD": "pex_binary(dependencies=['3rdparty#lib', '!!3rdparty#lib-pluginA'])",
+            "src/prj/b/BUILD": "pex_binary(dependencies=['3rdparty#lib'])",
         }
     )
     return runner
@@ -121,4 +151,13 @@ def test_multiple_paths(rule_runner: RuleRunner) -> None:
             ["leaf:leaf", "intermediate:intermediate", "base:base"],
             ["leaf:leaf", "intermediate2:intermediate2", "base:base"],
         ],
+    )
+
+
+def test_excluded_paths(rule_runner: RuleRunner) -> None:
+    assert_paths(
+        rule_runner,
+        path_from="src/prj/a",
+        path_to="src/prj/b",
+        expected=[],
     )


### PR DESCRIPTION
Error for test before the fix was:
```
E       pants.engine.internals.scheduler.ExecutionError: 1 Exception encountered:
E
E       Engine traceback:
E         in select
E           ..
E         in pants.backend.project_info.paths.paths
E           `paths` goal
E
E       Traceback (most recent call last):
E         File "/private/var/folders/y2/6t5bbk554wv5h6w_qlgpcpnm0000gr/T/pants-sandbox-gbcg46/src/python/pants/engine/internals/selectors.py", line 623, in native_engine_generator_send
E           res = rule.send(arg) if err is None else rule.throw(throw or err)
E         File "/private/var/folders/y2/6t5bbk554wv5h6w_qlgpcpnm0000gr/T/pants-sandbox-gbcg46/src/python/pants/backend/project_info/paths.py", line 133, in paths
E           for path in find_paths_breadth_first(adjacency_lists, root.address, destination.address):
E         File "/private/var/folders/y2/6t5bbk554wv5h6w_qlgpcpnm0000gr/T/pants-sandbox-gbcg46/src/python/pants/backend/project_info/paths.py", line 73, in find_paths_breadth_first
E           for dep in adjacency_lists[target]:
E       KeyError: Address(3rdparty#lib-pluginA)
```
