### PR TITLE
Support specifying a named resolve as the superset in a PexRequirements.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -37,11 +37,13 @@ from pants.backend.python.util_rules.pex_requirements import (
     EntireLockfile,
     LoadedLockfile,
     LoadedLockfileRequest,
+    Lockfile,
 )
 from pants.backend.python.util_rules.pex_requirements import (
     PexRequirements as PexRequirements,  # Explicit re-export.
 )
 from pants.backend.python.util_rules.pex_requirements import (
+    Resolve,
     ResolvePexConfig,
     ResolvePexConfigRequest,
     validate_metadata,
@@ -422,6 +424,8 @@ async def _setup_pex_requirements(
         resolve_name = request.requirements.lockfile.resolve_name
     elif isinstance(request.requirements.from_superset, LoadedLockfile):
         resolve_name = request.requirements.from_superset.original_lockfile.resolve_name
+    elif isinstance(request.requirements.from_superset, Resolve):
+        resolve_name = request.requirements.from_superset.name
     else:
         # This implies that, currently, per-resolve options are only configurable for resolves.
         # However, if no resolve is specified, we will still load options that apply to every
@@ -433,26 +437,28 @@ async def _setup_pex_requirements(
     pip_resolver_args = [*resolve_config.pex_args(), "--resolver-version", "pip-2020-resolver"]
 
     if isinstance(request.requirements, EntireLockfile):
-        lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(request.requirements.lockfile))
+        loaded_lockfile = await Get(
+            LoadedLockfile, LoadedLockfileRequest(request.requirements.lockfile)
+        )
         argv = (
-            ["--lock", lockfile.lockfile_path, *pex_lock_resolver_args]
-            if lockfile.is_pex_native
+            ["--lock", loaded_lockfile.lockfile_path, *pex_lock_resolver_args]
+            if loaded_lockfile.is_pex_native
             else
             # We use pip to resolve a requirements.txt pseudo-lockfile, possibly with hashes.
-            ["--requirement", lockfile.lockfile_path, "--no-transitive", *pip_resolver_args]
+            ["--requirement", loaded_lockfile.lockfile_path, "--no-transitive", *pip_resolver_args]
         )
-        if lockfile.metadata and request.requirements.complete_req_strings:
+        if loaded_lockfile.metadata and request.requirements.complete_req_strings:
             validate_metadata(
-                lockfile.metadata,
+                loaded_lockfile.metadata,
                 request.interpreter_constraints,
-                lockfile.original_lockfile,
+                loaded_lockfile.original_lockfile,
                 request.requirements.complete_req_strings,
                 python_setup,
                 resolve_config,
             )
 
         return _BuildPexRequirementsSetup(
-            [lockfile.lockfile_digest], argv, lockfile.requirement_estimate
+            [loaded_lockfile.lockfile_digest], argv, loaded_lockfile.requirement_estimate
         )
 
     # TODO: This is not the best heuristic for available concurrency, since the
@@ -468,8 +474,14 @@ async def _setup_pex_requirements(
             concurrency_available,
         )
 
-    if isinstance(request.requirements.from_superset, LoadedLockfile):
-        loaded_lockfile = request.requirements.from_superset
+    if request.requirements.from_superset is not None:
+        if isinstance(request.requirements.from_superset, LoadedLockfile):
+            loaded_lockfile = request.requirements.from_superset
+        else:
+            assert isinstance(request.requirements.from_superset, Resolve)
+            lockfile = await Get(Lockfile, Resolve, request.requirements.from_superset)
+            loaded_lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(lockfile))
+
         # NB: This is also validated in the constructor.
         assert loaded_lockfile.is_pex_native
         if not request.requirements.req_strings:
@@ -497,7 +509,6 @@ async def _setup_pex_requirements(
         )
 
     # We use pip to perform a normal resolve.
-    assert request.requirements.from_superset is None
     digests = []
     argv = [*request.requirements.req_strings, *pip_resolver_args]
     if request.requirements.constraints_strings:
@@ -580,7 +591,7 @@ async def build_pex(
             subcommand=(),
             extra_args=argv,
             additional_input_digest=merged_digest,
-            description=_build_pex_description(request),
+            description=_build_pex_description(request, python_setup.resolves),
             output_files=output_files,
             output_directories=output_directories,
             concurrency_available=requirements_setup.concurrency_available,
@@ -608,7 +619,7 @@ async def build_pex(
     )
 
 
-def _build_pex_description(request: PexRequest) -> str:
+def _build_pex_description(request: PexRequest, resolve_to_lockfile: dict[str, str]) -> str:
     if request.description:
         return request.description
 
@@ -627,8 +638,15 @@ def _build_pex_description(request: PexRequest) -> str:
                 {', '.join(request.requirements.req_strings)}
                 """
             )
-        elif isinstance(request.requirements.from_superset, LoadedLockfile):
-            lockfile_path = request.requirements.from_superset.lockfile_path
+        elif request.requirements.from_superset is not None:
+            if isinstance(request.requirements.from_superset, LoadedLockfile):
+                lockfile_path = request.requirements.from_superset.lockfile_path
+            else:
+                assert isinstance(request.requirements.from_superset, Resolve)
+                # At this point we know this is a valid user resolve, so we can assume
+                # it's available in the dict. Nonetheless we use get() so that any weird error
+                # here gives a bad message rather than an outright crash.
+                lockfile_path = resolve_to_lockfile.get(request.requirements.from_superset.name, "")
             return softwrap(
                 f"""
                 Building {pluralize(len(request.requirements.req_strings), 'requirement')}

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -36,6 +36,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfileRequest,
     Lockfile,
     PexRequirements,
+    Resolve,
 )
 from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
@@ -427,8 +428,7 @@ async def _determine_requirements_for_pex_from_targets(
         chosen_resolve = await Get(
             ChosenPythonResolve, ChosenPythonResolveRequest(request.addresses)
         )
-        loaded_lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(chosen_resolve.lockfile))
-        return dataclasses.replace(requirements, from_superset=loaded_lockfile)
+        return dataclasses.replace(requirements, from_superset=Resolve(chosen_resolve.name))
 
     # Else, request the repository PEX and possibly subset it.
     repository_pex_request = await Get(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -278,15 +278,14 @@ class PexRequirements:
     # If these requirements should be resolved as a subset of either a repository PEX, or a
     # PEX-native lockfile, the superset to use. # NB: Use of a lockfile here asserts that the
     # lockfile is PEX-native, because legacy lockfiles do not support subset resolves.
-    # TODO: Once we've fully phased out "tool lockfiles", we can remove the LoadedLockfile option.
-    from_superset: Pex | LoadedLockfile | Resolve | None
+    from_superset: Pex | Resolve | None
 
     def __init__(
         self,
         req_strings: Iterable[str] = (),
         *,
         constraints_strings: Iterable[str] = (),
-        from_superset: Pex | LoadedLockfile | Resolve | None = None,
+        from_superset: Pex | Resolve | None = None,
     ) -> None:
         """
         :param req_strings: The requirement strings to resolve.
@@ -298,19 +297,6 @@ class PexRequirements:
             self, "constraints_strings", FrozenOrderedSet(sorted(constraints_strings))
         )
         object.__setattr__(self, "from_superset", from_superset)
-
-        self.__post_init__()
-
-    def __post_init__(self):
-        if isinstance(self.from_superset, LoadedLockfile) and not self.from_superset.is_pex_native:
-            raise ValueError(
-                softwrap(
-                    f"""
-                    The lockfile {self.from_superset.original_lockfile} was not in PEX's
-                    native format, and so cannot be directly used as a superset.
-                    """
-                )
-            )
 
     @classmethod
     def create_from_requirement_fields(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -48,11 +48,31 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class Resolve:
+    # A named resolve for a "user lockfile".
+    # Soon to be the only kind of lockfile, as this class will help
+    # get rid of the "tool lockfile" concept.
+    name: str
+
+
+@dataclass(frozen=True)
 class Lockfile:
     url: str
     url_description_of_origin: str
     resolve_name: str
     lockfile_hex_digest: str | None = None
+
+
+@rule
+async def get_lockfile_for_resolve(resolve: Resolve, python_setup: PythonSetup) -> Lockfile:
+    lockfile_path = python_setup.resolves.get(resolve.name)
+    if not lockfile_path:
+        raise ValueError(f"No such resolve: {resolve.name}")
+    return Lockfile(
+        url=lockfile_path,
+        url_description_of_origin=f"the resolve `{resolve.name}`",
+        resolve_name=resolve.name,
+    )
 
 
 @dataclass(frozen=True)
@@ -258,14 +278,15 @@ class PexRequirements:
     # If these requirements should be resolved as a subset of either a repository PEX, or a
     # PEX-native lockfile, the superset to use. # NB: Use of a lockfile here asserts that the
     # lockfile is PEX-native, because legacy lockfiles do not support subset resolves.
-    from_superset: Pex | LoadedLockfile | None
+    # TODO: Once we've fully phased out "tool lockfiles", we can remove the LoadedLockfile option.
+    from_superset: Pex | LoadedLockfile | Resolve | None
 
     def __init__(
         self,
         req_strings: Iterable[str] = (),
         *,
         constraints_strings: Iterable[str] = (),
-        from_superset: Pex | LoadedLockfile | None = None,
+        from_superset: Pex | LoadedLockfile | Resolve | None = None,
     ) -> None:
         """
         :param req_strings: The requirement strings to resolve.

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -801,7 +801,7 @@ def test_build_pex_description() -> None:
             requirements=requirements,
             description=description,
         )
-        assert _build_pex_description(request) == expected
+        assert _build_pex_description(request, {}) == expected
 
     repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None)
 

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -48,6 +48,7 @@ from pants.backend.python.util_rules.pex_requirements import (
     LoadedLockfileRequest,
     Lockfile,
     PexRequirements,
+    Resolve,
     ResolvePexConfig,
     ResolvePexConfigRequest,
 )
@@ -710,6 +711,11 @@ def test_setup_pex_requirements() -> None:
             rule_args=[request, create_subsystem(PythonSetup)],
             mock_gets=[
                 MockGet(
+                    output_type=Lockfile,
+                    input_types=(Resolve,),
+                    mock=lambda _: lockfile_obj,
+                ),
+                MockGet(
                     output_type=LoadedLockfile,
                     input_types=(LoadedLockfileRequest,),
                     mock=lambda _: create_loaded_lockfile(is_pex_lock),
@@ -770,7 +776,7 @@ def test_setup_pex_requirements() -> None:
 
     # Subset of Pex lockfile.
     assert_setup(
-        PexRequirements(["req1"], from_superset=create_loaded_lockfile(is_pex_lock=True)),
+        PexRequirements(["req1"], from_superset=Resolve("resolve")),
         _BuildPexRequirementsSetup(
             [lockfile_digest], ["req1", "--lock", lockfile_path, *pex_args], 1
         ),


### PR DESCRIPTION
This named resolve must be a user resolve defined in [python].resolves.

This will allow us to move towards specifying a user resolve as the source to resolve a tool from.  We can't use the existing LoadedLockfile superset for this, because we don't have access to the PythonSetup subsystem (which provides the list of resolves) when we construct the PexRequirements for a tool, so we don't know which lockfile the name corresponds to.