### PR TITLE
Update module mapping for attrs

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -9,7 +9,7 @@ DEFAULT_MODULE_MAPPING = {
     "ansicolors": ("colors",),
     "apache-airflow": ("airflow",),
     "atlassian-python-api": ("atlassian",),
-    "attrs": ("attr",),
+    "attrs": ("attr", "attrs"),
     # Azure
     "azure-common": ("azure.common",),
     "azure-core": ("azure.core",),


### PR DESCRIPTION
Add the `attrs` module to list of modules provided by `attrs` package.  It was added in version 21.3.0.

Fixes #18401