### PR TITLE
Add `python311` runtime to `python_google_cloud_function` target

### DIFF
--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -220,6 +220,7 @@ class PythonGoogleCloudFunctionRuntimes(Enum):
     PYTHON_38 = "python38"
     PYTHON_39 = "python39"
     PYTHON_310 = "python310"
+    PYTHON_311 = "python311"
 
 
 class PythonGoogleCloudFunctionRuntime(StringField):

--- a/src/python/pants/backend/google_cloud_function/python/target_types_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types_test.py
@@ -52,6 +52,8 @@ def rule_runner() -> RuleRunner:
         ["python37", 3, 7],
         ["python38", 3, 8],
         ["python39", 3, 9],
+        ["python310", 3, 10],
+        ["python311", 3, 11],
     ),
 )
 def test_to_interpreter_version(runtime: str, expected_major: int, expected_minor: int) -> None:

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -6,7 +6,7 @@
 // {
 //   "version": 3,
 //   "valid_for_interpreter_constraints": [
-//     "CPython<3.10,>=3.7"
+//     "CPython<3.12,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "lambdex==0.1.9"
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "9b56d1c4399aa25b53fe15682a6544d103a77a15cf9cc0db7019c71940ffbaf3",
-              "url": "https://files.pythonhosted.org/packages/91/08/1495e676efd182de386c9bb59e7d5c63c17c601fac10d9548185609a0695/pex-2.1.125-py2.py3-none-any.whl"
+              "hash": "fef7b5536bc07a69388b64a419164b573e25d4aeae503091d832cb5603438e99",
+              "url": "https://files.pythonhosted.org/packages/66/43/8c5d97f4acbfb38fd3a0e46f235e6e9d9d20f224dffacecd2bb76093e3fd/pex-2.1.126-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "87ad0cf4d55b870051cb3e705deda479e944cf1627e8fd8ecc243a4c8559587d",
-              "url": "https://files.pythonhosted.org/packages/72/cb/073ae88de4b14b916c12c0786edbe53941db7fea1a6270e3fdb8c2a49544/pex-2.1.125.tar.gz"
+              "hash": "3fcd6cf993815f2a2ad1d826ea194e35bca3c82f485f9886e9e681e400566b15",
+              "url": "https://files.pythonhosted.org/packages/75/b5/f12684a46ede450a44fa985ece3a310478208a7ff866c24b8b0b6e1ea089/pex-2.1.126.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -68,7 +68,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.125"
+          "version": "2.1.126"
         }
       ],
       "platform_tag": null
@@ -82,7 +82,7 @@
     "lambdex==0.1.9"
   ],
   "requires_python": [
-    "<3.10,>=3.7"
+    "<3.12,>=3.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -22,7 +22,7 @@ class Lambdex(PythonToolBase):
     default_main = ConsoleScript("lambdex")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython<4,>=3.7"]
+    default_interpreter_constraints = ["CPython>=3.7,<3.12"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -22,7 +22,7 @@ class Lambdex(PythonToolBase):
     default_main = ConsoleScript("lambdex")
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.7,<3.10"]
+    default_interpreter_constraints = ["CPython<4,>=3.7"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/18399

### Changes 
- Add `python311` runtime to `python_google_cloud_function` target
- Update `default_interpreter_constraints` of `lamdex` to support the latest python interpreters