### PR TITLE
[internal] Err out with helpful message if no Python found.

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -71,6 +71,8 @@ function determine_python() {
     fi
     echo "${interpreter_path}" && return 0
   done
+  echo "pants: failed to find suitable Python interpreter, looking for: ${candidate_versions[*]}" >&2
+  return 1
 }
 
 function is_macos_arm() {


### PR DESCRIPTION
Closes #17533

I ran into this with a borked environment, and this would've saved me quite a few brain-cycles.
