### PR TITLE
golang: add support for passthrough args for gofmt

### DIFF
--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -7,7 +7,7 @@ import os.path
 from dataclasses import dataclass
 
 from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
-from pants.backend.go.lint.gofmt.subsystem import GofmtSubsystem
+from pants.backend.go.lint.gofmt.subsystem import SUPPORTED_GOFMT_ARGS, GofmtSubsystem
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
@@ -18,7 +18,6 @@ from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import pluralize
 
 
@@ -43,14 +42,11 @@ class GoFmtUnsupportedArgsPassedError(Exception):
     pass
 
 
-SupportedGoFmtArgs = FrozenOrderedSet(("-e", "-r", "-s"))
-
-
 async def _validate_gofmt_args(args: tuple[str, ...]):
     """Validate that args passed to the gofmt are supported."""
-    if not set(args).issubset(SupportedGoFmtArgs):
+    if not set(args).issubset(SUPPORTED_GOFMT_ARGS):
         raise GoFmtUnsupportedArgsPassedError(
-            f"Only {tuple(SupportedGoFmtArgs)} flags can be passed."
+            f"Only {tuple(SUPPORTED_GOFMT_ARGS)} flags can be passed."
         )
 
 

--- a/src/python/pants/backend/go/lint/gofmt/rules.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules.py
@@ -7,7 +7,11 @@ import os.path
 from dataclasses import dataclass
 
 from pants.backend.go.lint.gofmt.skip_field import SkipGofmtField
-from pants.backend.go.lint.gofmt.subsystem import SUPPORTED_GOFMT_ARGS, GofmtSubsystem
+from pants.backend.go.lint.gofmt.subsystem import (
+    SUPPORTED_GOFMT_ARGS,
+    SUPPORTED_GOFMT_ARGS_AS_HELP,
+    GofmtSubsystem,
+)
 from pants.backend.go.target_types import GoPackageSourcesField
 from pants.backend.go.util_rules import goroot
 from pants.backend.go.util_rules.goroot import GoRoot
@@ -46,7 +50,7 @@ async def _validate_gofmt_args(args: tuple[str, ...]):
     """Validate that args passed to the gofmt are supported."""
     if not set(args).issubset(SUPPORTED_GOFMT_ARGS):
         raise GoFmtUnsupportedArgsPassedError(
-            f"Only {tuple(SUPPORTED_GOFMT_ARGS)} flags can be passed."
+            f"Only the following style related options are supported: {SUPPORTED_GOFMT_ARGS_AS_HELP}."
         )
 
 

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -10,7 +10,7 @@ import pytest
 from pants.backend.go import target_type_rules
 from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
-from pants.backend.go.lint.gofmt.subsystem import SUPPORTED_GOFMT_ARGS
+from pants.backend.go.lint.gofmt.subsystem import SUPPORTED_GOFMT_ARGS_AS_HELP
 from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
@@ -186,7 +186,7 @@ def test_failing_gofmt_flags(rule_runner: RuleRunner) -> None:
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
-    with pytest.raises(ExecutionError, match=str(tuple(SUPPORTED_GOFMT_ARGS))):
+    with pytest.raises(ExecutionError, match=SUPPORTED_GOFMT_ARGS_AS_HELP):
         run_gofmt(rule_runner, [tgt], extra_args=["--gofmt-args=-unsupported"])
 
     fmt_result = run_gofmt(

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -8,8 +8,9 @@ from textwrap import dedent
 import pytest
 
 from pants.backend.go import target_type_rules
-from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest, SupportedGoFmtArgs
+from pants.backend.go.lint.gofmt.rules import GofmtFieldSet, GofmtRequest
 from pants.backend.go.lint.gofmt.rules import rules as gofmt_rules
+from pants.backend.go.lint.gofmt.subsystem import SUPPORTED_GOFMT_ARGS
 from pants.backend.go.target_types import GoModTarget, GoPackageTarget
 from pants.backend.go.util_rules import (
     assembly,
@@ -185,7 +186,7 @@ def test_failing_gofmt_flags(rule_runner: RuleRunner) -> None:
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
-    with pytest.raises(ExecutionError, match=str(tuple(SupportedGoFmtArgs))):
+    with pytest.raises(ExecutionError, match=str(tuple(SUPPORTED_GOFMT_ARGS))):
         run_gofmt(rule_runner, [tgt], extra_args=["--gofmt-args=-unsupported"])
 
     fmt_result = run_gofmt(

--- a/src/python/pants/backend/go/lint/gofmt/subsystem.py
+++ b/src/python/pants/backend/go/lint/gofmt/subsystem.py
@@ -3,6 +3,9 @@
 
 from pants.option.option_types import ArgsListOption, SkipOption
 from pants.option.subsystem import Subsystem
+from pants.util.ordered_set import FrozenOrderedSet
+
+SUPPORTED_GOFMT_ARGS = FrozenOrderedSet(("-e", "-r", "-s"))
 
 
 class GofmtSubsystem(Subsystem):
@@ -11,4 +14,7 @@ class GofmtSubsystem(Subsystem):
     help = "Gofmt-specific options."
 
     skip = SkipOption("fmt", "lint")
-    args = ArgsListOption(example="-s")
+    args = ArgsListOption(
+        example="-s -e",
+        extra_help=f"Only the following style related options are supported: {tuple(SUPPORTED_GOFMT_ARGS)}.",
+    )

--- a/src/python/pants/backend/go/lint/gofmt/subsystem.py
+++ b/src/python/pants/backend/go/lint/gofmt/subsystem.py
@@ -6,6 +6,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.ordered_set import FrozenOrderedSet
 
 SUPPORTED_GOFMT_ARGS = FrozenOrderedSet(("-e", "-r", "-s"))
+SUPPORTED_GOFMT_ARGS_AS_HELP = ", ".join([f"`{arg}`" for arg in SUPPORTED_GOFMT_ARGS])
 
 
 class GofmtSubsystem(Subsystem):
@@ -16,5 +17,5 @@ class GofmtSubsystem(Subsystem):
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(
         example="-s -e",
-        extra_help=f"Only the following style related options are supported: {tuple(SUPPORTED_GOFMT_ARGS)}.",
+        extra_help=f"Only the following style related options are supported: {SUPPORTED_GOFMT_ARGS_AS_HELP}.",
     )

--- a/src/python/pants/backend/go/lint/gofmt/subsystem.py
+++ b/src/python/pants/backend/go/lint/gofmt/subsystem.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from pants.option.option_types import SkipOption
+from pants.option.option_types import ArgsListOption, SkipOption
 from pants.option.subsystem import Subsystem
 
 
@@ -11,3 +11,4 @@ class GofmtSubsystem(Subsystem):
     help = "Gofmt-specific options."
 
     skip = SkipOption("fmt", "lint")
+    args = ArgsListOption(example="-s")


### PR DESCRIPTION
Closes #12822 

This PR makes it possible to pass (some) arguments to the `gofmt` program to be able to use the flags that `gofmt` provides. 

E.g. running `gofmt -s` on

```
fmt.Println(version[1:len(version)])
```

would result in simplified (`-s`) code:

```
fmt.Println(version[1:])
``` 

The interface:

```
$ ./pants fmt --gofmt-args="-s" cmd/greeter_en/main.go
```

or with the `pants.toml`:

```
[gofmt]
args = ["-s", "-e"]
```