### PR TITLE
python: collect files with '[tool.ruff' sections as candidates for Ruff config files

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -105,7 +105,7 @@ class Ruff(PythonToolBase):
             specified_option_name=f"[{self.options_scope}].config",
             discovery=self.config_discovery,
             check_existence=["ruff.toml", *(os.path.join(d, "ruff.toml") for d in ("", *dirs))],
-            check_content={"pyproject.toml": b"[tool.ruff]"},
+            check_content={"pyproject.toml": b"[tool.ruff"},
         )
 
 


### PR DESCRIPTION
Closes #18411 

The Ruff configuration can be specified using the `[tool.ruff]` section, but also using any other arbitrary section that Ruff supports, e.g. 

```
[tool.ruff.per-file-ignores]
"__init__.py" = ["E402"]
"path/to/file.py" = ["E402"]
```

For other tools such as `mypy` or `pyright`, we search for the sections with an open end:

https://github.com/pantsbuild/pants/blob/5f3f251a378f780daac07e0e5409c9a132571a89/src/python/pants/backend/python/typecheck/mypy/subsystem.py#L205

https://github.com/pantsbuild/pants/blob/4d612a50bf5de1374acb9736b804c81f6d17d183/src/python/pants/backend/python/typecheck/pyright/subsystem.py#L58


We should also do the same for Ruff otherwise config files with only extended sections (i.e. without the `[tool.ruff]` section) won't be picked up.