### PR TITLE
Delegate lockfile requirement validation to Pex when possible.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -450,6 +450,9 @@ async def _setup_pex_requirements(
                 loaded_lockfile.metadata,
                 request.interpreter_constraints,
                 loaded_lockfile.original_lockfile,
+                # We're using the entire lockfile, so there is no Pex subsetting operation we
+                # can delegate requirement validation to.  So we do our naive string-matching
+                # validation.
                 request.requirements.complete_req_strings,
                 python_setup,
                 resolve_config,
@@ -486,7 +489,12 @@ async def _setup_pex_requirements(
                 loaded_lockfile.metadata,
                 request.interpreter_constraints,
                 loaded_lockfile.original_lockfile,
-                request.requirements.req_strings,
+                # Don't validate user requirements when subsetting a resolve, as Pex's
+                # validation during the subsetting is far more precise than our naive string
+                # comparison. For example, if a lockfile was generated with `foo==1.2.3`
+                # and we want to resolve `foo>=1.0.0` or just `foo` out of it, Pex will do
+                # so successfully, while our naive validation would fail.
+                [],
                 python_setup,
                 resolve_config,
             )


### PR DESCRIPTION
Our lockfile metadata validation code performs various checks. Among them, it checks
that the requirements we want to satisfy from the lockfile were among those used to generate it.

We perform this check naively - we expect each exact requirement string to have been used at
generation time. But this is overly strict: If we generated with `foo==1.2.3` and now we want 
to satisfy `foo>=1.0.0,<2` or just `foo` from that lockfile, our check will fail, even though the
lockfile does satisfy that requirement.

Pex, however, will perform precise validation in the course of the subsetting operation.
So this change skips our naive validation when we know we're about to ask Pex to subset.

We don't skip this when we're using the entire lockfile, with no subsetting, since in that case
we have no other validation.