### PR TITLE
docs: update What's New for 2.16

### DIFF
--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -72,7 +72,7 @@ and related target types.
 new `experimental_test_shell_command` target type.
 
 Enable the `pants.backend.experimental.adhoc` backend to add the features supplied by the Adhoc backend.
-Enanle the `pants.backend.shell` backend for the shell-related functionality including `shell_command` and
+Enable the `pants.backend.shell` backend for the shell-related functionality including `shell_command` and
 `run_shell_command` target types.
 
 #### Go
@@ -119,11 +119,16 @@ Pants now the supports the [yamllint](https://yamllint.readthedocs.io) linter fo
 
 ### Plugin API Changes
 
+Python dependency inference may now be extended by plugin authors. Use the `PythonDependencyVisitorRequest` union
+to hook into the Python dependency inference rules.
+
 The `frozen_after_init` decorator on dataclasses has been removed from many parts of the Pants codebase. Plugin
 authors should avoid use of this decorator because it will likely be removed in a future Pants version.
 
-Python dependency inference may now be extended by plugin authors. Use the `PythonDependencyVisitorRequest` union
-to hook into the Python dependency inference rules.
+The deprecated `Platform.current` has been removed. Instead, have the affectd rules take a `Platform`
+directly as a parameter and the engine will supply the relevant `Platform` instance.
+
+The `ToolCustomLockfile` and `ToolDefaultLockfile` classes [have been removed](https://github.com/pantsbuild/pants/pull/17843).
 
 ## 2.16.0.dev7 (Feb 17, 2023)
 

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -6,17 +6,74 @@
 
 The new `env` function in BUILD files allows access to environment variables in BUILD files.
 
+Run `pants help symbols` for documentation of all builtin symbols and macros provided by prelude files
+which are usable in BUILD files.
+
+The visibility rules syntax now supports matching on target names. The rules glob syntax also now uses
+the same syntax as target selectors.
+
 ### Backends
 
 #### Python
 
-The Python backend has two new linters:
+The Python backend added or improved support for various tools including:
 
-[`pydocstyle`](https://www.pydocstyle.org/) is now supported for linting Python doc strings. Enable the
+- [`pydocstyle`](https://www.pydocstyle.org/) is now supported for linting Python doc strings. Enable the
 `pants.backend.python.lint.pydocstyle` backend to add this support.
 
-[`ruff`](https://github.com/charliermarsh/ruff) is now supported for linting and formatting Python code. Enable the
+- [`ruff`](https://github.com/charliermarsh/ruff) is now supported for linting and formatting Python code. Enable the
 `pants.backend.experimental.python.lint.ruff` backend to add this support.
+
+- Pants now understands how to parse dependencies of projects using the OpenStack/Stevedore ((https://github.com/openstack/stevedore)
+project. Enable the `pants.backend.python.framework.stevedore` backend to add this support.
+
+- More Python target types now have the `environment` field and thus can execute in non-local environments.
+
+Deprecations:
+
+- The `[python].interpreter_constraints` option is now deprecated and will be removed in Pants v2.17.x. 
+This option configured default Python interpreter constraints for Python-related targets which did not
+otherwise specify their own interpreter constraints. Instead, use the `interpreter_constraints` field available on
+various Python-relate target types to explicitly specify what Python interpreters your code is compatible with.  
+
+#### Shell & Adhoc
+
+The Shell backend along with the new "Adhoc" backend have received a number of improvements so that Pants is able
+to invoke workflows involving multiple tools even if Pants does not yet have a dedicated backend for those tools.
+
+In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target
+types have graduated to no longer have the `experimental_` prefix; use `shell_command` and `run_shell_command`
+respectively instead.
+
+The improvements include:
+
+- The `shell_command` continues to provide a way to run a tool for its side effects and capture outputs from the
+tool invocation for consumption as dependencies by other target types. Several new fields have been added (or
+modified) to the `shell_command` target type to better model dependencies and what to capture for the invoked tool 
+inclding the ability to capture a tool's stdout and stderr console output.
+
+- The new `adhoc_tool` target type supplied by the Adhoc backend allows executing any "runnable" target type exported
+by another Pants backend in an execution sandbox via the `pants run` goal including capturing outputs. The outputs
+can then be consumed by another Pants target in a similar manner to the `shell_command` target type. "Runnable"
+target types include:
+  * Adhoc: `system_binary`
+  * Docker: `docker_image`
+  * Go: `go_binary`
+  * JVM: `jvm_artifact` and `deploy_jar`
+  * Python: `pex_binary`, `python_requirement`, `python_source`, and `pyoxidizer_binary`
+
+- The new `system_binary` target type supplied by the Adhoc backend wraps any system-provided tool so that the 
+tool may be invoked as a "runnable" by the `adhoc_tool` target type.
+
+- Support for running in non-local environments as specified by the `environment` field on `shell_command`
+and related target types.
+
+- Defining arbitrary shell commands as tests which can be invoked using `pants test` via the
+new `experimental_test_shell_command` target type.
+
+Enable the `pants.backend.experimental.adhoc` backend to add the features supplied by the Adhoc backend.
+Enanle the `pants.backend.shell` backend for the shell-related functionality including `shell_command` and
+`run_shell_command` target types.
 
 #### Go
 
@@ -41,14 +98,9 @@ The Go backend also now supports:
 - Compiler and other flags may be set via the `compiler_flags`, `linker_flags`, and `assembler_flags` fields
 available on various target types.
 
-#### Shell
+#### Buf
 
-A new `experimental_test_shell_command` target type has been added to allow defining arbitrary shell commands
-as tests which can be invoked using the `./pants test` goal.
-
-`experimental_shell_command` and `experimental_run_shell_command` have graduated to no longer have their `experimental_` prefixes.
-
-`shell_command` now supports the `environment` field for running in non-local environments.
+Pants is now able to discover and suplpy configuration files for the `Buf` protobuf linter. 
 
 #### New: Preamble
 
@@ -59,6 +111,19 @@ The new "preamble" plugin allows linting files to ensure they start with specifi
 
 Pants now supports the [CUE language](https://cuelang.org/) for defining, generating, and validating configuration data.
 Enable the `pants.backend.experimental.cue` backend to add this support.
+
+#### New: YamlLint
+
+Pants now the supports the [yamllint](https://yamllint.readthedocs.io) linter for YAML files. Enable the
+`pants.backend.experimental.tools.yamllint` backend to add this support.
+
+### Plugin API Changes
+
+The `frozen_after_init` decorator on dataclasses has been removed from many parts of the Pants codebase. Plugin
+authors should avoid use of this decorator because it will likely be removed in a future Pants version.
+
+Python dependency inference may now be extended by plugin authors. Use the `PythonDependencyVisitorRequest` union
+to hook into the Python dependency inference rules.
 
 ## 2.16.0.dev7 (Feb 17, 2023)
 


### PR DESCRIPTION
Update the What's New section for v2.16 including expanded coverage of Shell/Adhoc backend changes.