### PR TITLE
docs: fix typos and some language updates

### DIFF
--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -50,7 +50,7 @@ The improvements include:
 - The `shell_command` continues to provide a way to run a tool for its side effects and capture outputs from the
 tool invocation for consumption as dependencies by other target types. Several new fields have been added (or
 modified) to the `shell_command` target type to better model dependencies and what to capture for the invoked tool 
-inclding the ability to capture a tool's stdout and stderr console output.
+including the ability to capture a tool's stdout and stderr console output.
 
 - The new `adhoc_tool` target type supplied by the Adhoc backend allows executing any "runnable" target type exported
 by another Pants backend in an execution sandbox via the `pants run` goal including capturing outputs. The outputs
@@ -84,7 +84,7 @@ The main change is that Pants will now compile Go SDK packages from scratch and 
 the prebuilt package archives distributed with the Go SDK. Go v1.20 will no longer ship with those
 prebuilt package archives, and so this change was necessary for Pants to continue to work 
 with Go v1.20 and later releases. (It is also a correctness issue since Pants will now be able to
-apply compiler options consistently when building Go SDK packages.)
+apply compiler options consistently to both first-party Go code and Go SDK packages.)
 
 The Pants team would appreciate if the community could try out 2.16.x with your Go code as an additional
 check to ensure there are no regressions.
@@ -94,13 +94,13 @@ The Go backend also now supports:
 - Code coverage can now analyze coverage for packages beyond just the package under test via the new
 `--go-test-cover-packages` option.
 - Numerous bug fixes to the Cgo support.
-- Race detector is supported via the `race` field now available on `go_binary` targets.
+- The [data race detector](https://go.dev/doc/articles/race_detector) is supported via the `race` field now available on `go_binary` targets.
 - Compiler and other flags may be set via the `compiler_flags`, `linker_flags`, and `assembler_flags` fields
 available on various target types.
 
 #### Buf
 
-Pants is now able to discover and suplpy configuration files for the `Buf` protobuf linter. 
+Pants is now able to discover and supply configuration files for the `Buf` protobuf linter.
 
 #### New: Preamble
 
@@ -125,7 +125,7 @@ to hook into the Python dependency inference rules.
 The `frozen_after_init` decorator on dataclasses has been removed from many parts of the Pants codebase. Plugin
 authors should avoid use of this decorator because it will likely be removed in a future Pants version.
 
-The deprecated `Platform.current` has been removed. Instead, have the affectd rules take a `Platform`
+The deprecated `Platform.current` has been removed. Instead, have the affected rules take a `Platform`
 directly as a parameter and the engine will supply the relevant `Platform` instance.
 
 The `ToolCustomLockfile` and `ToolDefaultLockfile` classes [have been removed](https://github.com/pantsbuild/pants/pull/17843).


### PR DESCRIPTION
Fix some typos in the What's New section which I introduced in a prior commit.