### PR TITLE
Fixes to visualisations for xdot

### DIFF
--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -555,7 +555,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                       Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
@@ -581,7 +584,11 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA), Query(B for A)
+                  /*
+                  queries:
+                    Query(A for SubA),
+                    Query(B for A)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
@@ -606,7 +613,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
@@ -632,7 +642,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba_and_b))}
@@ -671,7 +684,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, return_func=RuleFormatRequest(a, gets=[("B", "C")]))}
@@ -700,7 +716,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_b))}
@@ -733,7 +752,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, ())}
                 {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
@@ -762,7 +784,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, ())}
                 {fmt_non_param_edge(a, (), rule_type=GraphVertexType.singleton)}
@@ -866,7 +891,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
@@ -900,7 +928,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(B, SubA)}
                 {fmt_non_param_edge(B, SubA, RuleFormatRequest(b_from_a))}
@@ -938,7 +969,12 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA), Query(B for SubA), Query(C for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA),
+                    Query(B for SubA),
+                    Query(C for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, SubA)}
                 {fmt_non_param_edge(A, SubA, RuleFormatRequest(a_from_suba))}
@@ -972,7 +1008,10 @@ class TestRuleGraph:
             dedent(
                 f"""\
                 digraph {{
-                  // queries: Query(A for SubA)
+                  /*
+                  queries:
+                    Query(A for SubA)
+                  */
                   // root entries
                 {fmt_non_param_edge(A, ())}
                 {fmt_non_param_edge(RuleFormatRequest(a, gets=[("B", "D")]), (), rule_type=GraphVertexType.singleton)}

--- a/src/rust/engine/graph/src/entry.rs
+++ b/src/rust/engine/graph/src/entry.rs
@@ -895,6 +895,6 @@ impl<N: Node> Entry<N> {
       }
       None => "<None>".to_string(),
     };
-    format!("{} == {}", self.node, state).replace('"', "\\\"")
+    format!("{} == {}", self.node, state)
   }
 }

--- a/src/rust/engine/rule_graph/src/lib.rs
+++ b/src/rust/engine/rule_graph/src/lib.rs
@@ -444,7 +444,18 @@ impl<R: Rule> RuleGraph<R> {
       .collect::<Vec<String>>();
     queries_strs.sort();
     writeln!(f, "digraph {{")?;
-    writeln!(f, "  // queries: {}", queries_strs.join(", "))?;
+    writeln!(f, "  /*")?;
+    writeln!(f, "  queries:")?;
+    writeln!(
+      f,
+      "{}",
+      queries_strs
+        .iter()
+        .map(|q| format!("    {}", q))
+        .collect::<Vec<String>>()
+        .join(",\n")
+    )?;
+    writeln!(f, "  */")?;
     writeln!(f, "  // root entries")?;
     let mut root_rule_strs = self
       .rule_dependency_edges


### PR DESCRIPTION
xdot was having trouble consuming the dot files generated by the `--engine-visualize-to` option.
- the comment with the queries was all on one line, which exceeded the 16k character limit. I simply printed them on multiple lines
- the double escaping led to `unexpected char b'\\'` errors, because it found `\\\"`. We manually expand `"` to `\\\"`. I found removing that worked anyhow, I think there's escaping happening in the format call later

~I broke up the rule name and its value on separate lines, so the lines are just a bit shorter~ turns out fmt_for_graph is used by the normal fmt method, so this has wider effects.

Also I have no idea what I'm doing with Rust and just followed along when the compiler suggested things.