### PR TITLE
Expand on 2.16 shell/adhoc what's new, and some other sections

### DIFF
--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -41,14 +41,14 @@ a small number of interpreter minor versions, e.g., `interpreter_constraints = [
 
 #### Shell & Adhoc
 
-The Shell backend along with the new "Adhoc" backend have received a number of improvements so that
+The Shell backend along with the new `pants.backend.experimental.adhoc` backend have received a number of improvements so that
 Pants is able to invoke workflows involving multiple tools even if Pants does not yet have a
 dedicated backend for those tools.
 
 The shell support can be used to compile third party libraries, run tools from ecosystems Pants
 doesn't yet directly support and other similar code-generation tasks. The adhoc tool support can be
 used for first-party code generation, using the full power of existing backends that define
-executable targets. For instance, exporting a OpenAPI schema from a Python API server, letting pants
+executable targets. For instance, exporting a OpenAPI schema from a Python API server, letting Pants
 manage the interpreters and dependencies required.
 
 In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -31,15 +31,20 @@ project. Enable the `pants.backend.python.framework.stevedore` backend to add th
 
 Deprecations:
 
-- The `[python].interpreter_constraints` option is now deprecated and will be removed in Pants v2.17.x. 
-This option configured default Python interpreter constraints for Python-related targets which did not
-otherwise specify their own interpreter constraints. Instead, use the `interpreter_constraints` field available on
-various Python-relate target types to explicitly specify what Python interpreters your code is compatible with.  
+- The default value of `CPython>=3.7,<4` for the `[python].interpreter_constraints` option is now
+deprecated and will be removed in Pants v2.17.x.  This options sets Python interpreter
+constraints for Python-related targets which did not otherwise specify their own interpreter
+constraints. Instead of relying on this default, explicitly set the
+`[python].interpreter_constraints` option appropriately. We recommend constraining to a single
+interpreter minor version if you can, e.g., `interpreter_constraints = ['==3.11.*']`, or at least
+a small number of interpreter minor versions, e.g., `interpreter_constraints = ['>=3.10,<3.12']`.
 
 #### Shell & Adhoc
 
-The Shell backend along with the new "Adhoc" backend have received a number of improvements so that Pants is able
-to invoke workflows involving multiple tools even if Pants does not yet have a dedicated backend for those tools.
+The Shell backend along with the new "Adhoc" backend have received a number of improvements so that
+Pants is able to invoke workflows involving multiple tools even if Pants does not yet have a
+dedicated backend for those tools. For instance, compiling third party libraries or importing and running tools
+from ecosystems Pants doesn't yet directly support.
 
 In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target
 types have graduated to no longer have the `experimental_` prefix; use `shell_command` and `run_shell_command`
@@ -47,10 +52,21 @@ respectively instead.
 
 The improvements include:
 
-- The `shell_command` continues to provide a way to run a tool for its side effects and capture outputs from the
-tool invocation for consumption as dependencies by other target types. Several new fields have been added (or
-modified) to the `shell_command` target type to better model dependencies and what to capture for the invoked tool 
-including the ability to capture a tool's stdout and stderr console output.
+- The `shell_command` continues to provide a way to run a tool for its side effects and capture
+outputs from the tool invocation for consumption as dependencies by other target types, but has had several improvements:
+
+  - the `dependencies` field has been separated three fields: `execution_dependencies` for
+    dependencies required to execute the command, `output_dependencies` for dependencies required to
+    use the output, and `runnable_dependencies` for targets that need to exist as directly
+    executable on the sandbox's `PATH`
+  - the `outputs` field has been separated into `output_files` and `output_directories`
+  - the directory in which the command is invoked can be controlled via the new `workdir` field
+  - the location of the output files when consumed as a dependency can be controlled via the new `root_output_directory` field
+
+- Preserving symlinks as symlinks in process output, rather than resolving them to their target
+file. This eliminates the need for work-arounds in `shell_command`s that happen to generate
+semantically-relevant symlinks, such as the contents of `node_modules/.bin` if using `shell_command`
+to invoke `npm ci` or `npm install`.
 
 - The new `adhoc_tool` target type supplied by the Adhoc backend allows executing any "runnable" target type exported
 by another Pants backend in an execution sandbox via the `pants run` goal including capturing outputs. The outputs
@@ -104,7 +120,7 @@ Pants is now able to discover and supply configuration files for the `Buf` proto
 
 #### New: Preamble
 
-The new "preamble" plugin allows linting files to ensure they start with specific text. Enable the
+The new "preamble" plugin allows linting files to ensure they start with specific text, such as a copyright header. Enable the
 `pants.backend.tools.preamble` backend to add this support.
 
 #### New: CUE

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -43,8 +43,13 @@ a small number of interpreter minor versions, e.g., `interpreter_constraints = [
 
 The Shell backend along with the new "Adhoc" backend have received a number of improvements so that
 Pants is able to invoke workflows involving multiple tools even if Pants does not yet have a
-dedicated backend for those tools. For instance, compiling third party libraries or importing and running tools
-from ecosystems Pants doesn't yet directly support.
+dedicated backend for those tools.
+
+The shell support can be used to compile third party libraries, run tools from ecosystems Pants
+doesn't yet directly support and other similar code-generation tasks. The adhoc tool support can be
+used for first-party code generation, using the full power of existing backends that define
+executable targets. For instance, exporting a OpenAPI schema from a Python API server, letting pants
+manage the interpreters and dependencies required.
 
 In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target
 types have graduated to no longer have the `experimental_` prefix; use `shell_command` and `run_shell_command`


### PR DESCRIPTION
This expands on the "What's new" added in #18416 by:

- expanding on the Shell & Adhoc section. I did a bunch of the testing and so have a little bit of a sense of what's relevant/helpful for migrating, but maybe that's too much detail for these "what's new" notes?
- clarifying the #18390 deprecation: AIUI it's just the default value of `[python].interpreter_constraints` that's deprecated, not the whole option. That is, after 2.17, that option will still exist, but be required. (This copies a chunk of the deprecation text from that PR.)
- adding an example to the Preamble section