### PR TITLE
Fix cancelling parallel jobs.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@
 
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
 env:
   PANTS_CONFIG_FILES: +['pants.ci.toml']
   RUST_BACKTRACE: all

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -1077,7 +1077,7 @@ def generate() -> dict[Path, str]:
         {
             "name": test_workflow_name,
             "concurrency": {
-                "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}",
+                "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}",
                 "cancel-in-progress": True,
             },
             "on": {"pull_request": {}, "push": {"branches-ignore": ["dependabot/**"]}},


### PR DESCRIPTION
github.ref will have the branch name. which is wrong. github.sha will have the git sha which is what we want in this case.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

https://github.com/pantsbuild/pants/pull/18374#issuecomment-1458634149


ooooops. sorry.
