### PR TITLE
Fixup release docs for docs/. (Cherry-pick of #18440 & #18441)

### DIFF
--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -188,15 +188,23 @@ $ git push upstream 2.9.x
 Step 2: Update this docs site
 -----------------------------
 
+Note that this step can currently only be performed by a subset of maintainers due to a paid maximum number of seats. If you do not have a readme.com account, contact someone in the `#maintainers-confidential` channel in Slack to help out.
+
 ### `dev0` - set up the new version
 
 Go to the [documentation dashboard](https://dash.readme.com/). In the top left dropdown, where it says the current version, click "Manage versions". Click "Add new version" and use a "v" with the minor release number, e.g. "v2.9". Fork from the prior release. Mark this new version as public by clicking on "Is public?"
 
 Also, update the [Changelog](doc:changelog) page with the new release series at the top of the table. It's okay if there are no "highlights" yet.
 
+### Sync the `docs/` content
+
+See the `docs/NOTES.md` for instructions setting up the the necessary Node tooling your first time.
+You'll need to 1st login as outlined there via some variant of `npx rdme login --project pants ...`.
+On the relevant release branch, run `npx rdme docs docs/markdown --version v<pants major>.<pants minor>`; e.g: `npx rdme docs docs/markdown --version v2.8`.
+
 ### Regenerate the references
 
-On the relevant release branch, run `pants run build-support/bin/generate_docs.py -- --sync --api-key <key>` with your key from <https://dash.readme.com/project/pants/v2.8/api-key>.
+Still on the relevant release branch, run `pants run build-support/bin/generate_docs.py -- --sync --api-key <key>` with your key from <https://dash.readme.com/project/pants/v2.8/api-key>.
 
 ### `stable` releases - Update the default docsite
 


### PR DESCRIPTION
Update the release instructions for docs/. (#18440)

Previously this was being handled out of band by folks in the know.

(cherry picked from commit 81aeb2f46e12b57b11427c4c160e38e4c2256086)

Improve release docs publishing instructions. (#18441)

The login bit was elided and the warning about readme.com access was down lower. Leave the lower warning but call out the requirement for a readme.com account up front.

(cherry picked from commit 89a1458d51a37395a56f9961f60ab34c3f08557d)