### PR TITLE
Synthesized lockfile targets should never err on missing lockfiles. (Cherry-pick of #18406)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -37,6 +37,7 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules import ancestor_files, pex
 from pants.backend.python.util_rules.ancestor_files import AncestorFiles, AncestorFilesRequest
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core import target_types
 from pants.core.target_types import AllAssetTargets, AllAssetTargetsByPath, AllAssetTargetsRequest
 from pants.core.util_rules import stripped_source_files
@@ -52,7 +53,6 @@ from pants.engine.target import (
     Targets,
 )
 from pants.engine.unions import UnionRule
-from pants.option.global_options import OwnersNotFoundBehavior
 from pants.option.option_types import BoolOption, EnumOption, IntOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import bin_name, doc_url
@@ -511,7 +511,7 @@ async def infer_python_conftest_dependencies(
     owners = await MultiGet(
         # NB: Because conftest.py files effectively always have content, we require an
         # owning target.
-        Get(Owners, OwnersRequest((f,), OwnersNotFoundBehavior.error))
+        Get(Owners, OwnersRequest((f,), GlobMatchErrorBehavior.error))
         for f in conftest_files.snapshot.files
     )
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -29,6 +29,7 @@ from pants.engine.fs import (
     FileDigest,
     FileEntry,
     MergeDigests,
+    PathGlobs,
     RemovePrefix,
     Snapshot,
 )
@@ -46,6 +47,7 @@ from pants.engine.target import (
     HydrateSourcesRequest,
     InvalidFieldTypeException,
     MultipleSourcesField,
+    OptionalSingleSourceField,
     OverridesField,
     SingleSourceField,
     SourcesField,
@@ -58,6 +60,7 @@ from pants.engine.target import (
     generate_multiple_sources_field_help_message,
 )
 from pants.engine.unions import UnionRule
+from pants.option.global_options import UnmatchedBuildFileGlobs
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -726,9 +729,19 @@ async def package_archive_target(field_set: ArchiveFieldSet) -> BuiltPackage:
 # -----------------------------------------------------------------------------------------------
 
 
-class LockfileSourceField(SingleSourceField):
+class LockfileSourceField(OptionalSingleSourceField):
+    """Source field for synthesized `_lockfile` targets.
+
+    It is special in that it always ignores any missing files, regardless of the global
+    `--unmatched-build-file-globs` option.
+    """
+
     uses_source_roots = False
     required = True
+    value: str
+
+    def path_globs(self, unmatched_build_file_globs: UnmatchedBuildFileGlobs) -> PathGlobs:  # type: ignore[misc]
+        return super().path_globs(UnmatchedBuildFileGlobs.ignore())
 
 
 class LockfileDependenciesField(Dependencies):

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -24,6 +24,7 @@ from pants.core.target_types import (
     FileSourceField,
     FileTarget,
     HTTPSource,
+    LockfileSourceField,
     RelocatedFiles,
     RelocateFilesViaCodegenRequest,
     ResourceTarget,
@@ -32,13 +33,14 @@ from pants.core.target_types import rules as target_type_rules
 from pants.core.util_rules import archive, source_files, system_binaries
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, FileContent
+from pants.engine.fs import EMPTY_SNAPSHOT, DigestContents, FileContent, GlobMatchErrorBehavior
 from pants.engine.target import (
     GeneratedSources,
     SourcesField,
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
+from pants.option.global_options import UnmatchedBuildFileGlobs
 from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 
 
@@ -427,3 +429,18 @@ def test_http_source_filename(url, expected):
 def test_invalid_http_source(kwargs, exc_match):
     with exc_match:
         HTTPSource(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "error_behavior", [GlobMatchErrorBehavior.warn, GlobMatchErrorBehavior.error]
+)
+def test_lockfile_glob_match_error_behavior(
+    error_behavior: GlobMatchErrorBehavior,
+) -> None:
+    lockfile_source = LockfileSourceField("test.lock", Address("", target_name="lockfile-test"))
+    assert (
+        GlobMatchErrorBehavior.ignore
+        == lockfile_source.path_globs(
+            UnmatchedBuildFileGlobs(error_behavior)
+        ).glob_match_error_behavior
+    )

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -88,11 +88,7 @@ from pants.engine.target import (
     _generate_file_level_targets,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.option.global_options import (
-    GlobalOptions,
-    OwnersNotFoundBehavior,
-    UnmatchedBuildFileGlobs,
-)
+from pants.option.global_options import GlobalOptions, UnmatchedBuildFileGlobs
 from pants.util.docutil import bin_name, doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -742,7 +738,7 @@ async def coarsened_targets(
 
 def _log_or_raise_unmatched_owners(
     file_paths: Sequence[PurePath],
-    owners_not_found_behavior: OwnersNotFoundBehavior,
+    owners_not_found_behavior: GlobMatchErrorBehavior,
     ignore_option: str | None = None,
 ) -> None:
     option_msg = (
@@ -768,7 +764,7 @@ def _log_or_raise_unmatched_owners(
         f"{doc_url('create-initial-build-files')}.{option_msg}"
     )
 
-    if owners_not_found_behavior == OwnersNotFoundBehavior.warn:
+    if owners_not_found_behavior == GlobMatchErrorBehavior.warn:
         logger.warning(msg)
     else:
         raise ResolveError(msg)
@@ -783,7 +779,7 @@ class OwnersRequest:
     """
 
     sources: tuple[str, ...]
-    owners_not_found_behavior: OwnersNotFoundBehavior = OwnersNotFoundBehavior.ignore
+    owners_not_found_behavior: GlobMatchErrorBehavior = GlobMatchErrorBehavior.ignore
     filter_by_global_options: bool = False
     match_if_owning_build_file_included_in_sources: bool = False
 
@@ -891,7 +887,7 @@ async def find_owners(
 
     if (
         unmatched_sources
-        and owners_request.owners_not_found_behavior != OwnersNotFoundBehavior.ignore
+        and owners_request.owners_not_found_behavior != GlobMatchErrorBehavior.ignore
     ):
         _log_or_raise_unmatched_owners(
             [PurePath(path) for path in unmatched_sources], owners_request.owners_not_found_behavior
@@ -909,7 +905,7 @@ async def find_owners(
 def extract_unmatched_build_file_globs(
     global_options: GlobalOptions,
 ) -> UnmatchedBuildFileGlobs:
-    return global_options.unmatched_build_file_globs
+    return UnmatchedBuildFileGlobs(global_options.unmatched_build_file_globs)
 
 
 class AmbiguousCodegenImplementationsException(Exception):

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2051,7 +2051,7 @@ class SourcesField(AsyncFieldMixin, Field):
         # Use fields default error behavior if defined, if we use default globs else the provided
         # error behavior.
         error_behavior = (
-            unmatched_build_file_globs.to_glob_match_error_behavior()
+            unmatched_build_file_globs.error_behavior
             if conjunction == GlobExpansionConjunction.all_match
             or self.default_glob_match_error_behavior is None
             else self.default_glob_match_error_behavior
@@ -2816,7 +2816,7 @@ class OverridesField(AsyncFieldMixin, Field):
         return tuple(
             PathGlobs(
                 [relativize_glob(glob)],
-                glob_match_error_behavior=unmatched_build_file_globs.to_glob_match_error_behavior(),
+                glob_match_error_behavior=unmatched_build_file_globs.error_behavior,
                 description_of_origin=f"the `overrides` field for {address}",
             )
             for glob in overrides_keys

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1047,7 +1047,7 @@ def test_multiple_sources_path_globs(
         default_glob_match_error_behavior = GlobMatchErrorBehavior.ignore
 
     sources = TestMultipleSourcesField(field_value, Address("test"))
-    actual = sources.path_globs(UnmatchedBuildFileGlobs.warn)
+    actual = sources.path_globs(UnmatchedBuildFileGlobs.warn())
     for attr, expect in zip(expected._fields, expected):
         if expect is not SKIP:
             assert getattr(actual, attr) == expect
@@ -1107,7 +1107,7 @@ def test_single_source_path_globs(
 
     sources = TestSingleSourceField(field_value, Address("test"))
 
-    actual = sources.path_globs(UnmatchedBuildFileGlobs.warn)
+    actual = sources.path_globs(UnmatchedBuildFileGlobs.warn())
     for attr, expect in zip(expected._fields, expected):
         if expect is not SKIP:
             assert getattr(actual, attr) == expect
@@ -1417,7 +1417,7 @@ def test_overrides_field_normalization() -> None:
         {"foo.ext": tgt1_override, ("foo.ext", "bar*.ext"): tgt2_override}, Address("dir")
     )
     globs = OverridesField.to_path_globs(
-        Address("dir"), path_field.flatten(), UnmatchedBuildFileGlobs.error
+        Address("dir"), path_field.flatten(), UnmatchedBuildFileGlobs.error()
     )
     assert [path_globs.globs for path_globs in globs] == [
         ("dir/foo.ext",),

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -32,7 +32,7 @@ def calculate_specs(
 ) -> Specs:
     """Determine the specs for a given Pants run."""
     global_options = options.for_global_scope()
-    unmatched_cli_globs = global_options.unmatched_cli_globs.to_glob_match_error_behavior()
+    unmatched_cli_globs = global_options.unmatched_cli_globs
     specs = SpecsParser().parse_specs(
         options.specs,
         description_of_origin="CLI arguments",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
 from pathlib import Path, PurePath
-from typing import Any, Callable, Type, cast
+from typing import Any, Callable, Type, TypeVar, cast
 
 from pants.base.build_environment import (
     get_buildroot,
@@ -74,36 +74,40 @@ class DynamicUIRenderer(Enum):
     experimental_prodash = "experimental-prodash"
 
 
-class UnmatchedBuildFileGlobs(Enum):
+_G = TypeVar("_G", bound="_GlobMatchErrorBehaviorOptionBase")
+
+
+@dataclass(frozen=True)
+class _GlobMatchErrorBehaviorOptionBase:
+    """This class exists to have dedicated types per global option of the `GlobMatchErrorBehavior`
+    so we can extract the relevant option in a rule to limit the scope of downstream rules to avoid
+    depending on the entire global options data."""
+
+    error_behavior: GlobMatchErrorBehavior
+
+    @classmethod
+    def ignore(cls: type[_G]) -> _G:
+        return cls(GlobMatchErrorBehavior.ignore)
+
+    @classmethod
+    def warn(cls: type[_G]) -> _G:
+        return cls(GlobMatchErrorBehavior.warn)
+
+    @classmethod
+    def error(cls: type[_G]) -> _G:
+        return cls(GlobMatchErrorBehavior.error)
+
+
+class UnmatchedBuildFileGlobs(_GlobMatchErrorBehaviorOptionBase):
     """What to do when globs do not match in BUILD files."""
 
-    warn = "warn"
-    error = "error"
 
-    def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
-        return GlobMatchErrorBehavior(self.value)
-
-
-class UnmatchedCliGlobs(Enum):
+class UnmatchedCliGlobs(_GlobMatchErrorBehaviorOptionBase):
     """What to do when globs do not match in CLI args."""
 
-    ignore = "ignore"
-    warn = "warn"
-    error = "error"
 
-    def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
-        return GlobMatchErrorBehavior(self.value)
-
-
-class OwnersNotFoundBehavior(Enum):
+class OwnersNotFoundBehavior(_GlobMatchErrorBehaviorOptionBase):
     """What to do when a file argument cannot be mapped to an owning target."""
-
-    ignore = "ignore"
-    warn = "warn"
-    error = "error"
-
-    def to_glob_match_error_behavior(self) -> GlobMatchErrorBehavior:
-        return GlobMatchErrorBehavior(self.value)
 
 
 @enum.unique
@@ -1620,7 +1624,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
     )
 
     unmatched_build_file_globs = EnumOption(
-        default=UnmatchedBuildFileGlobs.warn,
+        default=GlobMatchErrorBehavior.warn,
         help=softwrap(
             """
             What to do when files and globs specified in BUILD files, such as in the
@@ -1634,7 +1638,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         advanced=True,
     )
     unmatched_cli_globs = EnumOption(
-        default=UnmatchedCliGlobs.error,
+        default=GlobMatchErrorBehavior.error,
         help=softwrap(
             """
             What to do when command line arguments, e.g. files and globs like `dir::`, cannot be


### PR DESCRIPTION
Fixes #18404 
