### PR TITLE
Upgrade Pex to 2.1.128.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ humbug==0.2.7
 importlib_resources==5.0.*
 ijson==3.1.4
 packaging==21.3
-pex==2.1.127
+pex==2.1.128
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "importlib_resources==5.0.*",
 //     "mypy-typing-asserts==0.1.1",
 //     "packaging==21.3",
-//     "pex==2.1.127",
+//     "pex==2.1.128",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -1072,13 +1072,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cac5df2b8b1550825e58715a29c369307a5883c1e9d3b001470cdd73a41c6d0c",
-              "url": "https://files.pythonhosted.org/packages/de/e6/2c3f422fd5aeae05b32364af810f45cd779ecc7d6ea0c986e3eaea1f5a07/pex-2.1.127-py2.py3-none-any.whl"
+              "hash": "d5d1c707ed6f234b09cf5ec98bfab55a19fde2d01ecf03853025e6e0c796fdb5",
+              "url": "https://files.pythonhosted.org/packages/92/0c/11f18dd09c289a187efbd2a17d93554fdf15b2e0fd4b1b76e3cf657ffa21/pex-2.1.128-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30b06b283611e572226ffa0a4e84abb8da8e7e0d3cd5bae156ab5ecc00096574",
-              "url": "https://files.pythonhosted.org/packages/c6/ae/0d1ba41fc16d36b71dfc9da0c1244241bbbfffd414745bee05dbe9afe0f7/pex-2.1.127.tar.gz"
+              "hash": "91c564640f0e529dbb77851a733d346fc8d6bbeb8384cd0efc6233e457015e6d",
+              "url": "https://files.pythonhosted.org/packages/8a/07/687cca82b5932e041f1280ca087c752becf85989e6b2f035481721139975/pex-2.1.128.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1086,7 +1086,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.127"
+          "version": "2.1.128"
         },
         {
           "artifacts": [
@@ -1199,98 +1199,98 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7c5b94d598c90f2f46b3a983ffb46ab806a67099d118ae0da7ef21a2a4033b28",
-              "url": "https://files.pythonhosted.org/packages/c7/18/9b9da08649715f0ee99db6f416b32649b2209aa9d23c87ea636670aac071/pydantic-1.10.5-py3-none-any.whl"
+              "hash": "acc6783751ac9c9bc4680379edd6d286468a1dc8d7d9906cd6f1186ed682b2b0",
+              "url": "https://files.pythonhosted.org/packages/dd/73/cc7e962d40a7c6abf7dd210d3ba78afccb17dd2fb6d9c3ef7add028ef010/pydantic-1.10.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "532e97c35719f137ee5405bd3eeddc5c06eb91a032bc755a44e34a712420daf3",
-              "url": "https://files.pythonhosted.org/packages/10/1d/14dcf2aa8cde579271eee6928d1611b81987da5c21bf7c8ca467c8d2b82f/pydantic-1.10.5-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "4ca83739c1263a044ec8b79df4eefc34bbac87191f0a513d00dd47d46e307a65",
+              "url": "https://files.pythonhosted.org/packages/0f/03/dd06b3194227b063b70bb896e8996497cf9a552a6a0ace60befadc44cab3/pydantic-1.10.6-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "51782fd81f09edcf265823c3bf43ff36d00db246eca39ee765ef58dc8421a642",
-              "url": "https://files.pythonhosted.org/packages/1f/b6/436e7d212bbaf146164ef3579f1574bcd195bb1dd571b5a10aa307fc8302/pydantic-1.10.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "476f6674303ae7965730a382a8e8d7fae18b8004b7b69a56c3d8fa93968aa21c",
+              "url": "https://files.pythonhosted.org/packages/1a/5b/60b9cdffb9aea6d9dcc04a5991eb9dd3e36c4006c58847a09472637081c4/pydantic-1.10.6-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e337ac83686645a46db0e825acceea8e02fca4062483f40e9ae178e8bd1103a",
-              "url": "https://files.pythonhosted.org/packages/28/59/5d2fc3499d9ce8ce48ee7e00f043d5cc429a9198bd96c3512809428ade15/pydantic-1.10.5.tar.gz"
+              "hash": "415a3f719ce518e95a92effc7ee30118a25c3d032455d13e121e3840985f2efd",
+              "url": "https://files.pythonhosted.org/packages/2e/bb/92faa4c5e88786d4f1b7d157b7fba300e99638dc49a1059f8b1f983f758b/pydantic-1.10.6-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3f9d9b2be177c3cb6027cd67fbf323586417868c06c3c85d0d101703136e6b31",
-              "url": "https://files.pythonhosted.org/packages/3f/49/e00c1e4d1525ed01b58bb210509ca4d80eb2d587f0e3772f04fa9116951b/pydantic-1.10.5-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "4c19eb5163167489cb1e0161ae9220dadd4fc609a42649e7e84a8fa8fff7a80f",
+              "url": "https://files.pythonhosted.org/packages/37/3b/2589fddb22425a1c29894501947da0bd094105e9a22f09d44bddb3121728/pydantic-1.10.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bd46a0e6296346c477e59a954da57beaf9c538da37b9df482e50f836e4a7d4bb",
-              "url": "https://files.pythonhosted.org/packages/40/61/00570f1b5436ccbbb7ec393a079aee83d8720c97dad039365a2ea0d7a055/pydantic-1.10.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "751f008cd2afe812a781fd6aa2fb66c620ca2e1a13b6a2152b1ad51553cb4b77",
+              "url": "https://files.pythonhosted.org/packages/37/cc/3abca5751da2cefb01413c270a467cf2e6b3250e8eb208625c8109ece56d/pydantic-1.10.6-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ce1612e98c6326f10888df951a26ec1a577d8df49ddcaea87773bfbe23ba5cc",
-              "url": "https://files.pythonhosted.org/packages/53/68/2a14076f6d68393cee66dcd6a35bf8c93e9fc27db4d9a91589f9b154e04b/pydantic-1.10.5-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "43cdeca8d30de9a897440e3fb8866f827c4c31f6c73838e3a01a14b03b067b1d",
+              "url": "https://files.pythonhosted.org/packages/39/45/04e7cb7f2cb59bf6f6302c503531a8e50056e1b19d040c144d9e30f263ef/pydantic-1.10.6-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "76c930ad0746c70f0368c4596020b736ab65b473c1f9b3872310a835d852eb19",
-              "url": "https://files.pythonhosted.org/packages/63/01/7c36f13cab83f7a72da53003a1d5e7238f055c2bcae60b90a5fd2bc7c2cc/pydantic-1.10.5-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "3a2be0a0f32c83265fd71a45027201e1278beaa82ea88ea5b345eea6afa9ac7f",
+              "url": "https://files.pythonhosted.org/packages/48/e7/445974641d4a8a031fa96122d542e504d03d7e0f7824b36954336e7de11f/pydantic-1.10.6-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3353072625ea2a9a6c81ad01b91e5c07fa70deb06368c71307529abf70d23325",
-              "url": "https://files.pythonhosted.org/packages/65/78/9c2c5689c69c1469104769ba7409997f08c08ecc9d56f90e2edf845bdf4f/pydantic-1.10.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "12e837fd320dd30bd625be1b101e3b62edc096a49835392dcf418f1a5ac2b832",
+              "url": "https://files.pythonhosted.org/packages/4b/7c/2d8f431a995f8d0241f82bf64a293b3b46671884bca970fa9decda772d3c/pydantic-1.10.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b473d00ccd5c2061fd896ac127b7755baad233f8d996ea288af14ae09f8e0d1e",
-              "url": "https://files.pythonhosted.org/packages/7a/5a/35a1f25b31208f406df6b828aede5fa2ed74bc2310e4f484ad9a7b0a2047/pydantic-1.10.5-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "528dcf7ec49fb5a84bf6fe346c1cc3c55b0e7603c2123881996ca3ad79db5bfc",
+              "url": "https://files.pythonhosted.org/packages/69/8a/7f6107354a4ae9c3b94448981083a767549d45d105de3055e59277a1a1c1/pydantic-1.10.6-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b429f7c457aebb7fbe7cd69c418d1cd7c6fdc4d3c8697f45af78b8d5a7955760",
-              "url": "https://files.pythonhosted.org/packages/89/c7/a55f25e6161d1de2dc9b2c5a3691213f10a5c6f65e655c33ea56cb0bddbe/pydantic-1.10.5-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "3091d2eaeda25391405e36c2fc2ed102b48bac4b384d42b2267310abae350ca6",
+              "url": "https://files.pythonhosted.org/packages/73/ba/35725b0aee7a34e35e6c00f369645649f92de1e5105349a209b29a829a69/pydantic-1.10.6-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "663d2dd78596c5fa3eb996bc3f34b8c2a592648ad10008f98d1348be7ae212fb",
-              "url": "https://files.pythonhosted.org/packages/9b/62/672879ef41f0782b48ec1a1bb1241e68f770e46a3acc09ea8565c1c2897c/pydantic-1.10.5-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "53de12b4608290992a943801d7756f18a37b7aee284b9ffa794ee8ea8153f8e2",
+              "url": "https://files.pythonhosted.org/packages/76/1d/f55ebbfa6d00c95f0e471c148916859a96f7eee3af369dcc7d503aa0dbd4/pydantic-1.10.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "58e41dd1e977531ac6073b11baac8c013f3cd8706a01d3dc74e86955be8b2c0c",
-              "url": "https://files.pythonhosted.org/packages/a0/4e/4defb6a0294288fde74164791626e553fc8c9f34a7bda625a982ceffa9b5/pydantic-1.10.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "012c99a9c0d18cfde7469aa1ebff922e24b0c706d03ead96940f5465f2c9cf62",
+              "url": "https://files.pythonhosted.org/packages/88/09/1bc6ad530de4551e4bfbd7672d82e7b40b1207241145a6314478a172184c/pydantic-1.10.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca9075ab3de9e48b75fa8ccb897c34ccc1519177ad8841d99f7fd74cf43be5bf",
-              "url": "https://files.pythonhosted.org/packages/b0/44/b08588a7036c668f307c7ad97d8601940791fc7943c9d6f715424364a75c/pydantic-1.10.5-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "cf95adb0d1671fc38d8c43dd921ad5814a735e7d9b4d9e437c088002863854fd",
+              "url": "https://files.pythonhosted.org/packages/8b/87/200171b36005368bc4c114f01cb9e8ae2a3f3325a47da8c710cc58cfd00c/pydantic-1.10.6.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a4b0aab29061262065bbdede617ef99cc5914d1bf0ddc8bcd8e3d7928d85bd6",
-              "url": "https://files.pythonhosted.org/packages/c9/fb/d8df7a150c1ecaf768b706f80730626b09c8cca479c685abe736625268d5/pydantic-1.10.5-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "163e79386c3547c49366e959d01e37fc30252285a70619ffc1b10ede4758250a",
+              "url": "https://files.pythonhosted.org/packages/a3/c3/d1360d4a8c8dea047b12c383cd5710720d7b31c1277f95d6b53e1307eebc/pydantic-1.10.6-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c428c0f64a86661fb4873495c4fac430ec7a7cef2b8c1c28f3d1a7277f9ea5ab",
-              "url": "https://files.pythonhosted.org/packages/d4/47/951763175d317975ba9c7e8df0a087ff19fc955a04bebd56841d34fa5509/pydantic-1.10.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "587d92831d0115874d766b1f5fddcdde0c5b6c60f8c6111a394078ec227fca6d",
+              "url": "https://files.pythonhosted.org/packages/ad/61/d5edbe39b070fa666ce95353084be1c5aea209601b2221204cb41a1635f2/pydantic-1.10.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "87f831e81ea0589cd18257f84386bf30154c5f4bed373b7b75e5cb0b5d53ea87",
-              "url": "https://files.pythonhosted.org/packages/e6/24/d9ff5e94c23c778447b7ad19c18c47228121cd12e60c7f71b925b9c628d4/pydantic-1.10.5-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "ea4e2a7cb409951988e79a469f609bba998a576e6d7b9791ae5d1e0619e1c0f2",
+              "url": "https://files.pythonhosted.org/packages/bf/0d/80f666d9951485ce05ec2e62f3c2ef313e2a272a6fefbd0e7d48163dabd9/pydantic-1.10.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3257bd714de9db2102b742570a56bf7978e90441193acac109b1f500290f5718",
-              "url": "https://files.pythonhosted.org/packages/f0/64/1c98e2a96f70cc651253713bb464a604f7f5dd575a0bcc07e7434a2b3347/pydantic-1.10.5-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "6195ca908045054dd2d57eb9c39a5fe86409968b8040de8c2240186da0769da7",
+              "url": "https://files.pythonhosted.org/packages/cb/7e/47b7f6d47673b0f42a08b5e4ca95bdb99aa89136bc453866042cca9a36c7/pydantic-1.10.6-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "36e44a4de37b8aecffa81c081dbfe42c4d2bf9f6dff34d03dce157ec65eb0f15",
-              "url": "https://files.pythonhosted.org/packages/ff/11/9db43f7cd6fe4f22170b282f9742b2d3b645d7d84cecc5221b4d7c50af44/pydantic-1.10.5-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "60184e80aac3b56933c71c48d6181e630b0fbc61ae455a63322a66a23c14731a",
+              "url": "https://files.pythonhosted.org/packages/f5/56/64028e205064748d6015a1afd6111c06f2b90982636850a3e157a7180ed5/pydantic-1.10.6-cp37-cp37m-musllinux_1_1_i686.whl"
             }
           ],
           "project_name": "pydantic",
@@ -1300,7 +1300,7 @@
             "typing-extensions>=4.2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "1.10.5"
+          "version": "1.10.6"
         },
         {
           "artifacts": [
@@ -2771,7 +2771,7 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.127",
+  "pex_version": "2.1.128",
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
@@ -2788,7 +2788,7 @@
     "importlib_resources==5.0.*",
     "mypy-typing-asserts==0.1.1",
     "packaging==21.3",
-    "pex==2.1.127",
+    "pex==2.1.128",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cac5df2b8b1550825e58715a29c369307a5883c1e9d3b001470cdd73a41c6d0c",
-              "url": "https://files.pythonhosted.org/packages/de/e6/2c3f422fd5aeae05b32364af810f45cd779ecc7d6ea0c986e3eaea1f5a07/pex-2.1.127-py2.py3-none-any.whl"
+              "hash": "d5d1c707ed6f234b09cf5ec98bfab55a19fde2d01ecf03853025e6e0c796fdb5",
+              "url": "https://files.pythonhosted.org/packages/92/0c/11f18dd09c289a187efbd2a17d93554fdf15b2e0fd4b1b76e3cf657ffa21/pex-2.1.128-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30b06b283611e572226ffa0a4e84abb8da8e7e0d3cd5bae156ab5ecc00096574",
-              "url": "https://files.pythonhosted.org/packages/c6/ae/0d1ba41fc16d36b71dfc9da0c1244241bbbfffd414745bee05dbe9afe0f7/pex-2.1.127.tar.gz"
+              "hash": "91c564640f0e529dbb77851a733d346fc8d6bbeb8384cd0efc6233e457015e6d",
+              "url": "https://files.pythonhosted.org/packages/8a/07/687cca82b5932e041f1280ca087c752becf85989e6b2f035481721139975/pex-2.1.128.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -68,14 +68,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.127"
+          "version": "2.1.128"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.127",
+  "pex_version": "2.1.128",
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -38,7 +38,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.127"
+    default_version = "v2.1.128"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.124,<3.0"
 
@@ -49,8 +49,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "0e8e7cd9abb5f9e7d88fb5b0de023c67eaeefe502e804b01ed775705b4c8ca87",
-                    "4081107",
+                    "a48a461a9e9f490476aa75976dbe58d3263691a8895a53d11fdaaf8a3bc223a5",
+                    "4081603",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This picks up a fix for a performance regression introduced in 2.1.120.
This is particularly important for Pants since it affects the speed of
subsetting packed venv PEXes which Pants uses extensively.

The Pex changelog is here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.128