### PR TITLE
Remove SecondaryOwnerMixin

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -34,7 +34,6 @@ from pants.engine.target import (
     InferredDependencies,
     InvalidFieldException,
     InvalidTargetException,
-    SecondaryOwnerMixin,
     StringField,
     Target,
 )
@@ -45,7 +44,7 @@ from pants.util.docutil import doc_url
 from pants.util.strutil import help_text, softwrap
 
 
-class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
+class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin):
     alias = "handler"
     required = True
     value: str

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -34,7 +34,6 @@ from pants.engine.target import (
     InferredDependencies,
     InvalidFieldException,
     InvalidTargetException,
-    SecondaryOwnerMixin,
     StringField,
     Target,
 )
@@ -45,7 +44,7 @@ from pants.util.docutil import doc_url
 from pants.util.strutil import help_text
 
 
-class PythonGoogleCloudFunctionHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
+class PythonGoogleCloudFunctionHandlerField(StringField, AsyncFieldMixin):
     alias = "handler"
     required = True
     value: str

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -54,7 +54,6 @@ from pants.engine.target import (
     OptionalSingleSourceField,
     OverridesField,
     ScalarField,
-    SecondaryOwnerMixin,
     SingleSourceField,
     SpecialCasedDependencies,
     StringField,
@@ -293,7 +292,7 @@ class ConsoleScript(MainSpecification):
         return self.name
 
 
-class EntryPointField(AsyncFieldMixin, SecondaryOwnerMixin, Field):
+class EntryPointField(AsyncFieldMixin, Field):
     alias = "entry_point"
     default = None
     help = help_text(

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -3,23 +3,12 @@
 
 from __future__ import annotations
 
-import dataclasses
 import logging
 from abc import ABCMeta
 from dataclasses import dataclass
 from enum import Enum
 from itertools import filterfalse, tee
-from typing import (
-    Callable,
-    ClassVar,
-    Iterable,
-    Mapping,
-    NamedTuple,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import Callable, ClassVar, Iterable, Mapping, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import final
 
@@ -39,7 +28,6 @@ from pants.engine.target import (
     BoolField,
     FieldSet,
     NoApplicableTargetsBehavior,
-    SecondaryOwnerMixin,
     Target,
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
@@ -212,11 +200,6 @@ class Run(Goal):
     environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
-class RankedFieldSets(NamedTuple):
-    primary: tuple[RunFieldSet, ...]
-    secondary: tuple[RunFieldSet, ...]
-
-
 def _partition(
     iterable: Iterable[_T], pred: Callable[[_T], bool]
 ) -> tuple[tuple[_T, ...], tuple[_T, ...]]:
@@ -236,45 +219,20 @@ async def _find_what_to_run(
         ),
     )
 
-    primary_target: Target | None = None
-    primary_target_rfs: RankedFieldSets | None = None
-
-    for target, field_sets in targets_to_valid_field_sets.mapping.items():
-        rfs = RankedFieldSets(
-            *_partition(
-                field_sets,
-                lambda field_set: not any(
-                    isinstance(getattr(field_set, field.name), SecondaryOwnerMixin)
-                    for field in dataclasses.fields(field_set)
-                ),
-            )
+    if len(targets_to_valid_field_sets.mapping) > 1:
+        raise TooManyTargetsException(
+            targets_to_valid_field_sets.mapping, goal_description=goal_description
         )
-        # In the case of multiple Targets/FieldSets, prefer the "primary" ones to the "secondary" ones.
-        if (
-            primary_target is None
-            or primary_target_rfs is None  # impossible, but satisfies mypy
-            or (rfs.primary and not primary_target_rfs.primary)
-        ):
-            primary_target = target
-            primary_target_rfs = rfs
-        elif (rfs.primary and primary_target_rfs.primary) or (
-            rfs.secondary and primary_target_rfs.secondary
-        ):
-            raise TooManyTargetsException(
-                targets_to_valid_field_sets.mapping, goal_description=goal_description
-            )
 
-    assert primary_target is not None
-    assert primary_target_rfs is not None
-    field_sets = primary_target_rfs.primary or primary_target_rfs.secondary
+    target, field_sets = next(iter(targets_to_valid_field_sets.mapping.items()))
     if len(field_sets) > 1:
         raise AmbiguousImplementationsException(
-            primary_target,
-            primary_target_rfs.primary + primary_target_rfs.secondary,
+            target,
+            field_sets,
             goal_description=goal_description,
         )
 
-    return field_sets[0], primary_target
+    return field_sets[0], target
 
 
 @goal_rule

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import sys
-from dataclasses import dataclass
 from typing import Iterable, Mapping, cast
 
 import pytest
@@ -29,16 +28,13 @@ from pants.engine.internals.specs_rules import (
 )
 from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.target import (
-    Field,
     FieldSet,
-    SecondaryOwnerMixin,
     Target,
     TargetRootsToFieldSets,
     TargetRootsToFieldSetsRequest,
 )
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import GlobalOptions, KeepSandboxes
-from pants.source.filespec import Filespec
 from pants.testutil.option_util import create_goal_subsystem, create_subsystem
 from pants.testutil.rule_runner import (
     MockEffect,
@@ -72,14 +68,6 @@ def create_mock_run_debug_adapter_request(
 class TestRunFieldSet(RunFieldSet):
     required_fields = ()
     run_in_sandbox_behavior = RunInSandboxBehavior.NOT_SUPPORTED
-
-
-@dataclass(frozen=True)
-class TestRunSecondaryFieldSet(RunFieldSet):
-    required_fields = ()
-    run_in_sandbox_behavior = RunInSandboxBehavior.NOT_SUPPORTED
-
-    just_borrowing: SecondaryOwnerField
 
 
 class TestBinaryTarget(Target):
@@ -144,8 +132,8 @@ def single_target_run(
             ],
             union_membership=UnionMembership(
                 {
-                    RunFieldSet: [TestRunFieldSet, TestRunSecondaryFieldSet],
-                    RunDebugAdapterRequest: [TestRunFieldSet, TestRunSecondaryFieldSet],
+                    RunFieldSet: [TestRunFieldSet],
+                    RunDebugAdapterRequest: [TestRunFieldSet],
                 },
             ),
         )
@@ -198,78 +186,6 @@ def test_multi_field_set_error(rule_runner: RuleRunner) -> None:
     target = TestBinaryTarget({}, Address("some/addr"))
     fs1 = TestRunFieldSet.create(target)
     fs2 = TestRunFieldSet.create(target)
-    with pytest.raises(AmbiguousImplementationsException):
-        single_target_run(
-            rule_runner, program_text=program_text, targets_to_field_sets={target: [fs1, fs2]}
-        )
-
-
-class SecondaryOwnerField(SecondaryOwnerMixin, Field):
-    alias = "borrowed"
-    default = None
-
-    def filespec(self) -> Filespec:
-        return Filespec(includes=[])
-
-
-def test_filters_secondary_owners_single_target(rule_runner: RuleRunner) -> None:
-    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
-    target = TestBinaryTarget({}, Address("some/addr"))
-    fs1 = TestRunFieldSet.create(target)
-    fs2 = TestRunSecondaryFieldSet.create(target)
-    res = single_target_run(
-        rule_runner,
-        program_text=program_text,
-        targets_to_field_sets={target: [fs1, fs2]},
-    )
-    assert res.exit_code == 0
-
-
-def test_filters_secondary_owners_multi_target(rule_runner: RuleRunner) -> None:
-    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
-    t1 = TestBinaryTarget({}, Address("some/addr1"))
-    fs1 = TestRunFieldSet.create(t1)
-    t2 = TestBinaryTarget({}, Address("some/addr2"))
-    fs2 = TestRunSecondaryFieldSet.create(t2)
-    res = single_target_run(
-        rule_runner,
-        program_text=program_text,
-        targets_to_field_sets={t1: [fs1], t2: [fs2]},
-    )
-    assert res.exit_code == 0
-
-
-def test_only_secondary_owner_ok_single_target(rule_runner: RuleRunner) -> None:
-    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
-    target = TestBinaryTarget({}, Address("some/addr"))
-    field_set = TestRunSecondaryFieldSet.create(target)
-    res = single_target_run(
-        rule_runner,
-        program_text=program_text,
-        targets_to_field_sets={target: [field_set]},
-    )
-    assert res.exit_code == 0
-
-
-def test_only_secondary_owner_error_multi_target(rule_runner: RuleRunner) -> None:
-    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
-    t1 = TestBinaryTarget({}, Address("some/addr1"))
-    fs1 = TestRunSecondaryFieldSet.create(t1)
-    t2 = TestBinaryTarget({}, Address("some/addr2"))
-    fs2 = TestRunSecondaryFieldSet.create(t2)
-    with pytest.raises(TooManyTargetsException):
-        single_target_run(
-            rule_runner,
-            program_text=program_text,
-            targets_to_field_sets={t1: [fs1], t2: [fs2]},
-        )
-
-
-def test_only_secondary_multi_field_set_error(rule_runner: RuleRunner) -> None:
-    program_text = f'#!{sys.executable}\nprint("hello")'.encode()
-    target = TestBinaryTarget({}, Address("some/addr"))
-    fs1 = TestRunSecondaryFieldSet.create(target)
-    fs2 = TestRunSecondaryFieldSet.create(target)
     with pytest.raises(AmbiguousImplementationsException):
         single_target_run(
             rule_runner, program_text=program_text, targets_to_field_sets={target: [fs1, fs2]}

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -65,7 +65,6 @@ from pants.engine.target import (
     MultipleSourcesField,
     OverridesField,
     RegisteredTargetTypes,
-    SecondaryOwnerMixin,
     SourcesField,
     SourcesPaths,
     SourcesPathsRequest,
@@ -863,18 +862,6 @@ async def find_owners(
             matching_files = set(
                 candidate_tgt.get(SourcesField).filespec_matcher.matches(list(sources_set))
             )
-            # Also consider secondary ownership, meaning it's not a `SourcesField` field with
-            # primary ownership, but the target still should match the file. We can't use
-            # `tgt.get()` because this is a mixin, and there technically may be >1 field.
-            secondary_owner_fields = tuple(
-                field
-                for field in candidate_tgt.field_values.values()
-                if isinstance(field, SecondaryOwnerMixin)
-            )
-            for secondary_owner_field in secondary_owner_fields:
-                matching_files.update(
-                    *secondary_owner_field.filespec_matcher.matches(list(sources_set))
-                )
             if not matching_files and not (
                 owners_request.match_if_owning_build_file_included_in_sources
                 and bfa.rel_path in sources_set

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -8,7 +8,7 @@ import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent
-from typing import Iterable, List, Set, Tuple, Type, cast
+from typing import Iterable, List, Set, Tuple, Type
 
 import pytest
 
@@ -53,7 +53,6 @@ from pants.engine.target import (
     InvalidFieldException,
     MultipleSourcesField,
     OverridesField,
-    SecondaryOwnerMixin,
     SingleSourceField,
     SourcesPaths,
     SourcesPathsRequest,
@@ -67,7 +66,6 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
 )
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.source.filespec import Filespec
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 from pants.util.ordered_set import FrozenOrderedSet
 
@@ -684,20 +682,6 @@ def test_find_all_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     assert {t.address for t in all_unexpanded} == {*expected, Address("", target_name="generator")}
 
 
-class MockSecondaryOwnerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
-    alias = "secondary_owner_field"
-    required = True
-
-    @property
-    def filespec(self) -> Filespec:
-        return {"includes": [os.path.join(self.address.spec_path, cast(str, self.value))]}
-
-
-class MockSecondaryOwnerTarget(Target):
-    alias = "secondary_owner"
-    core_fields = (MockSecondaryOwnerField,)
-
-
 @pytest.fixture
 def owners_rule_runner() -> RuleRunner:
     return RuleRunner(
@@ -708,7 +692,6 @@ def owners_rule_runner() -> RuleRunner:
             MockTarget,
             MockTargetGenerator,
             MockGeneratedTarget,
-            MockSecondaryOwnerTarget,
         ],
         # NB: The `graph` module masks the environment is most/all positions. We disable the
         # inherent environment so that the positions which do require the environment are

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -12,7 +12,7 @@ import logging
 import os.path
 import textwrap
 import zlib
-from abc import ABC, ABCMeta, abstractmethod
+from abc import ABC, ABCMeta
 from collections import deque
 from dataclasses import dataclass
 from enum import Enum
@@ -2399,44 +2399,6 @@ class SourcesPathsRequest(EngineAwareParameter):
 
     def debug_hint(self) -> str:
         return self.field.address.spec
-
-
-class SecondaryOwnerMixin(ABC):
-    """Add to a Field for the target to work with file arguments and `--changed-since`, without it
-    needing a `SourcesField`.
-
-    Why use this? In a dependency inference world, multiple targets including the same file in the
-    `sources` field causes issues due to ambiguity over which target to use. So, only one target
-    should have "primary ownership" of the file. However, you may still want other targets to be
-    used when that file is included in file arguments. For example, a `python_source` target
-    being the primary owner of the `.py` file, but a `pex_binary` still working with file
-    arguments for that file. Secondary ownership means that the target won't be used for things like
-    dependency inference and hydrating sources, but file arguments will still work.
-
-    There should be a primary owner of the file(s), e.g. the `python_source` in the above example.
-    Typically, you will want to add a dependency inference rule to infer a dep on that primary
-    owner.
-
-    All associated files must live in the BUILD target's directory or a subdirectory to work
-    properly, like the `sources` field.
-    """
-
-    @property
-    @abstractmethod
-    def filespec(self) -> Filespec:
-        """A dictionary in the form {'globs': ['full/path/to/f.ext']} representing the field's
-        associated files.
-
-        Typically, users should use a file name/glob relative to the BUILD file, like the `sources`
-        field. Then, you can use `os.path.join(self.address.spec_path, self.value)` to relative to
-        the build root.
-        """
-
-    @memoized_property
-    def filespec_matcher(self) -> FilespecMatcher:
-        # Note: memoized because parsing the globs is expensive:
-        # https://github.com/pantsbuild/pants/issues/16122
-        return FilespecMatcher(self.filespec["includes"], self.filespec.get("excludes", []))
 
 
 def targets_with_sources_types(


### PR DESCRIPTION
This change removes SecondaryOwnerMixin. It's currently only used by Python, and the "multiple targets match" logic is still faulty/non-helpful (errors on primary + 2 secondarys), it also errors on things like the `paths` goal.

I think this is only removing the case where we'd error because for `run` we already prefer the python source.