### PR TITLE
Fix commit collision between #17480 and #18431.

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem_test.py
@@ -23,7 +23,6 @@ from pants.util.ordered_set import FrozenOrderedSet
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-
     ruff_lockfile_sentinel = _get_generated_lockfile_sentinel(subsystem_rules(), Ruff)
 
     return RuleRunner(


### PR DESCRIPTION
#17480 and #18431 collided, such that a changed file was not re-formatted by the new version of `black`.