### PR TITLE
Audit and update requirements for Python tools. (cherrypick #18431)

### DIFF
--- a/3rdparty/python/flake8.lock
+++ b/3rdparty/python/flake8.lock
@@ -12,7 +12,7 @@
 //     "flake8-2020<2,>=1.7.0",
 //     "flake8-comprehensions<4.0,>=3.10.0",
 //     "flake8-no-implicit-concat",
-//     "flake8<5.1,>=5.0.4"
+//     "flake8<7,>=5.0.4"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -190,19 +190,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
-              "url": "https://files.pythonhosted.org/packages/5d/87/1ec3fcc09d2c04b977eabf8a1083222f82eaa2f46d5a4f85f403bf8e7b30/more_itertools-9.0.0-py3-none-any.whl"
+              "hash": "d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3",
+              "url": "https://files.pythonhosted.org/packages/85/01/e2678ee4e0d7eed4fd6be9e5b043fff9d22d245d06c8c91def8ced664189/more_itertools-9.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab",
-              "url": "https://files.pythonhosted.org/packages/13/b3/397aa9668da8b1f0c307bc474608653d46122ae0563d1d32f60e24fa0cbd/more-itertools-9.0.0.tar.gz"
+              "hash": "cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d",
+              "url": "https://files.pythonhosted.org/packages/2e/d0/bea165535891bd1dcb5152263603e902c0ec1f4c9a2e152cc4adff6b3a38/more-itertools-9.1.0.tar.gz"
             }
           ],
           "project_name": "more-itertools",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "9.0.0"
+          "version": "9.1.0"
         },
         {
           "artifacts": [
@@ -244,37 +244,37 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
-              "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-              "url": "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-              "url": "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "url": "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
+            "big-O; extra == \"testing\"",
             "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
@@ -289,24 +289,25 @@
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.11.0"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "flake8-2020<2,>=1.7.0",
     "flake8-comprehensions<4.0,>=3.10.0",
     "flake8-no-implicit-concat",
-    "flake8<5.1,>=5.0.4"
+    "flake8<7,>=5.0.4"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/3rdparty/python/mypy.lock
+++ b/3rdparty/python/mypy.lock
@@ -10,8 +10,8 @@
 //   ],
 //   "generated_with_requirements": [
 //     "mypy-typing-asserts",
-//     "mypy==0.961",
-//     "strawberry-graphql<0.96,>=0.95.1"
+//     "mypy==1.1.1",
+//     "strawberry-graphql==0.159.1"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -53,176 +53,121 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48",
-              "url": "https://files.pythonhosted.org/packages/c2/f1/df59e28c642d583f7dacffb1e0965d0e00b218e0186d7858ac5233dce840/click-8.1.3-py3-none-any.whl"
+              "hash": "5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3",
+              "url": "https://files.pythonhosted.org/packages/f8/39/e5143e7ec70939d2076c1165ae9d4a3815597019c4d797b7f959cf778600/graphql_core-3.2.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-              "url": "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz"
-            }
-          ],
-          "project_name": "click",
-          "requires_dists": [
-            "colorama; platform_system == \"Windows\"",
-            "importlib-metadata; python_version < \"3.8\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "8.1.3"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "9b460f60320be01c7f3b1766cf3e406933003008055079b9d983b8f3988f4400",
-              "url": "https://files.pythonhosted.org/packages/05/c3/bbdf432c196aec04d9ac6a12a88d10ac50fe412115bdb917add4b963d113/graphql_core-3.1.7-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "62ec192150ccecd9a18cfb79e3e72eb7d1fd68fb594ef19c40099b6deec8ef0c",
-              "url": "https://files.pythonhosted.org/packages/20/48/44502a3d0d39d1b094d84fdddbb49d28003dadfd4427527e14b341e43a38/graphql-core-3.1.7.tar.gz"
+              "hash": "06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676",
+              "url": "https://files.pythonhosted.org/packages/ee/a6/94df9045ca1bac404c7b394094cd06713f63f49c7a4d54d99b773ae81737/graphql-core-3.2.3.tar.gz"
             }
           ],
           "project_name": "graphql-core",
-          "requires_dists": [],
-          "requires_python": "<4,>=3.6",
-          "version": "3.1.7"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313",
-              "url": "https://files.pythonhosted.org/packages/e1/16/1f59f5d87d256012e9cdf0e8af8810965fa253e835cfecce64f4b11d4f2d/importlib_metadata-5.1.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
-              "url": "https://files.pythonhosted.org/packages/32/5a/e0d75c8010295ae6746f379f5324bc726076dfc426548bfa6f0763fce870/importlib_metadata-5.1.0.tar.gz"
-            }
-          ],
-          "project_name": "importlib-metadata",
           "requires_dists": [
-            "flake8<5; extra == \"testing\"",
-            "flufl.flake8; extra == \"testing\"",
-            "furo; extra == \"docs\"",
-            "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
-            "ipython; extra == \"perf\"",
-            "jaraco.packaging>=9; extra == \"docs\"",
-            "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "packaging; extra == \"testing\"",
-            "pyfakefs; extra == \"testing\"",
-            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest-checkdocs>=2.4; extra == \"testing\"",
-            "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
-            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest-perf>=0.9.2; extra == \"testing\"",
-            "pytest>=6; extra == \"testing\"",
-            "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx>=3.5; extra == \"docs\"",
-            "typing-extensions>=3.6.4; python_version < \"3.8\"",
-            "zipp>=0.5"
+            "typing-extensions<5,>=4.2; python_version < \"3.8\""
           ],
-          "requires_python": ">=3.7",
-          "version": "5.1.0"
+          "requires_python": "<4,>=3.6",
+          "version": "3.2.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66",
-              "url": "https://files.pythonhosted.org/packages/cb/30/03a46a37902348b309aa5fe8a92636b9417fdcea77e20dfc1455581a0ae7/mypy-0.961-py3-none-any.whl"
+              "hash": "4e4e8b362cdf99ba00c2b218036002bdcdf1e0de085cdb296a49df03fb31dfc4",
+              "url": "https://files.pythonhosted.org/packages/a4/0b/3a30f50287e42a4230320fa2eac25eb3017d38a7c31f083d407ab627607c/mypy-1.1.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932",
-              "url": "https://files.pythonhosted.org/packages/31/73/71ae84ece879f7c6fd5fbbe7c750c4663dcbd53fa5c7fa7023be59af27f5/mypy-0.961-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "ce61663faf7a8e5ec6f456857bfbcec2901fbdb3ad958b778403f63b9e606a1b",
+              "url": "https://files.pythonhosted.org/packages/2a/28/8485aad67750b3374443d28bad3eed947737cf425a640ea4be4ac70a7827/mypy-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5",
-              "url": "https://files.pythonhosted.org/packages/5e/5a/1b46c161aacdff572632695a483e64ea908089b5c1b6bb92c7e59685c889/mypy-0.961-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "9401e33814cec6aec8c03a9548e9385e0e228fc1b8b0a37b9ea21038e64cdd8a",
+              "url": "https://files.pythonhosted.org/packages/30/da/808ceaf2bcf23a9e90156c7b11b41add8dd5a009ee48159ec820d04d97bd/mypy-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492",
-              "url": "https://files.pythonhosted.org/packages/67/48/e73045183ce9824d98365f18255a79d0b01638f40a0a68f898dc8f3cebcc/mypy-0.961.tar.gz"
+              "hash": "59bbd71e5c58eed2e992ce6523180e03c221dcd92b52f0e792f291d67b15a71c",
+              "url": "https://files.pythonhosted.org/packages/47/9f/34f6a2254f7d39b8c4349b8ac480c233d37c377faf2c67c6ef925b3af0ab/mypy-1.1.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b",
-              "url": "https://files.pythonhosted.org/packages/7e/10/617b3a85123226906353fa8c5d574390ee1899fae2fe3e62109f87f48f4e/mypy-0.961-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "ae9ceae0f5b9059f33dbc62dea087e942c0ccab4b7a003719cb70f9b8abfa32f",
+              "url": "https://files.pythonhosted.org/packages/62/54/be80f8d01f5cf72f774a77f9f750527a6fa733f09f78b1da30e8fa3914e6/mypy-1.1.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6",
-              "url": "https://files.pythonhosted.org/packages/83/ac/29e343bc9423c7061d55ba061ad58af2143f26fbf4ab57c9817286ab10ce/mypy-0.961-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "b7c7b708fe9a871a96626d61912e3f4ddd365bf7f39128362bc50cbd74a634d5",
+              "url": "https://files.pythonhosted.org/packages/7e/32/1b161731d19580c55d3d7c04b8ace80dc7cf42d852adf750f348a485068f/mypy-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d",
-              "url": "https://files.pythonhosted.org/packages/99/99/c1d2e6d00b7336b67b033beec51c346017f33c3d5e36e1cf62239310b950/mypy-0.961-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "c1c10fa12df1232c936830839e2e935d090fc9ee315744ac33b8a32216b93707",
+              "url": "https://files.pythonhosted.org/packages/8c/3d/a8d518bb06952484ada20897878a7a14741536f43514dcfecfac0676aa01/mypy-1.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e",
-              "url": "https://files.pythonhosted.org/packages/a0/dc/8356726d7964f4418a9cc197395b220921c55259ba55d9d20f07c001a8e3/mypy-0.961-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "d64c28e03ce40d5303450f547e07418c64c241669ab20610f273c9e6290b4b0b",
+              "url": "https://files.pythonhosted.org/packages/b8/06/3d72d1b316ceec347874c4285fad8bf17e3fb21bb7848c1a942df239e44a/mypy-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950",
-              "url": "https://files.pythonhosted.org/packages/b4/5f/6f116003e4ddb472912c13f999127d658e56a210177e23c9d6b1538a5184/mypy-0.961-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "19ba15f9627a5723e522d007fe708007bae52b93faab00f95d72f03e1afa9598",
+              "url": "https://files.pythonhosted.org/packages/b8/72/385f3aeaaf262325454ac7f569eb81ac623464871df23d9778c864d04c6c/mypy-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6",
-              "url": "https://files.pythonhosted.org/packages/d3/c1/044316d783ce5ff2df602cc7562c6a6a2c1f8500d1449e1e0d06a36a8ae1/mypy-0.961-cp38-cp38-macosx_10_9_universal2.whl"
+              "hash": "4b398d8b1f4fba0e3c6463e02f8ad3346f71956b92287af22c9b12c3ec965a9f",
+              "url": "https://files.pythonhosted.org/packages/be/d5/5588a2ee0d77189626a57b555b6b006dda6d5b0083f16c6be0c2d761cd7b/mypy-1.1.1-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648",
-              "url": "https://files.pythonhosted.org/packages/e3/66/9942860fc360e529dbd695b1da3dd80336095d0d3c956e416eb656fba7dd/mypy-0.961-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "0a28a76785bf57655a8ea5eb0540a15b0e781c807b5aa798bd463779988fa1d5",
+              "url": "https://files.pythonhosted.org/packages/d3/35/a0892864f1c128dc6449ee69897f9db7a64de2c16f41c14640dd22251b1b/mypy-1.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813",
-              "url": "https://files.pythonhosted.org/packages/f6/fa/fc6a127fd06f266f2e615b2ee8cd4ab8a49adecc740965ceec072569427c/mypy-0.961-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "64cc3afb3e9e71a79d06e3ed24bb508a6d66f782aff7e56f628bf35ba2e0ba51",
+              "url": "https://files.pythonhosted.org/packages/e1/a6/331cff5f7476904a2ebe6ed7cee2310b6be583ff6d45609ea0e0d67fd39d/mypy-1.1.1-cp38-cp38-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2b0c373d071593deefbcdd87ec8db91ea13bd8f1328d44947e88beae21e8d5e9",
+              "url": "https://files.pythonhosted.org/packages/f6/57/93e676773f91141127329a56e2238eac506a78f6fb0ae0650a53fcc1355d/mypy-1.1.1-cp38-cp38-musllinux_1_1_x86_64.whl"
             }
           ],
           "project_name": "mypy",
           "requires_dists": [
             "lxml; extra == \"reports\"",
-            "mypy-extensions>=0.4.3",
+            "mypy-extensions>=1.0.0",
+            "pip; extra == \"install-types\"",
             "psutil>=4.0; extra == \"dmypy\"",
             "tomli>=1.1.0; python_version < \"3.11\"",
             "typed-ast<2,>=1.4.0; extra == \"python2\"",
             "typed-ast<2,>=1.4.0; python_version < \"3.8\"",
             "typing-extensions>=3.10"
           ],
-          "requires_python": ">=3.6",
-          "version": "0.961"
+          "requires_python": ">=3.7",
+          "version": "1.1.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-              "url": "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl"
+              "hash": "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+              "url": "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
-              "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz"
+              "hash": "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782",
+              "url": "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz"
             }
           ],
           "project_name": "mypy-extensions",
-          "requires_dists": [
-            "typing>=3.5.3; python_version < \"3.5\""
-          ],
-          "requires_python": null,
-          "version": "0.4.3"
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "1.0.0"
         },
         {
           "artifacts": [
@@ -241,26 +186,6 @@
           "requires_dists": [],
           "requires_python": "<4.0,>=3.7",
           "version": "0.1.1"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
-              "url": "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1",
-              "url": "https://files.pythonhosted.org/packages/e0/ef/5905cd3642f2337d44143529c941cc3a02e5af16f0f65f81cbef7af452bb/Pygments-2.13.0.tar.gz"
-            }
-          ],
-          "project_name": "pygments",
-          "requires_dists": [
-            "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
-          ],
-          "requires_python": ">=3.6",
-          "version": "2.13.0"
         },
         {
           "artifacts": [
@@ -286,41 +211,6 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f7bb5f611fc600d15fa47b3974c8aa16e93724513b49b5f95c81e6624c83fa43",
-              "url": "https://files.pythonhosted.org/packages/46/40/a933ac570bf7aad12a298fc53458115cc74053474a72fbb8201d7dc06d3d/python-multipart-0.0.5.tar.gz"
-            }
-          ],
-          "project_name": "python-multipart",
-          "requires_dists": [
-            "six>=1.4.0"
-          ],
-          "requires_python": null,
-          "version": "0.0.5"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "bd8710dd26752039c668604f6be2aaf741b56f7811c5924a4dcdfd74359244f3",
-              "url": "https://files.pythonhosted.org/packages/df/60/6436b0d8e47feeb2b56ae8a702994d4edb110be9c7310ea6e8918a1a85b0/sentinel-0.3.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "f28143aa4716dbc8f6193f5682176a3c33cd26aaae05d9ecf66c186a9887cc2d",
-              "url": "https://files.pythonhosted.org/packages/5b/78/0c8e4b41ee425be92888bc118af7c15fc7b771a7e495d7b48b223cd6c382/sentinel-0.3.0.tar.gz"
-            }
-          ],
-          "project_name": "sentinel",
-          "requires_dists": [
-            "varname>=0.1; extra == \"varname\""
-          ],
-          "requires_python": "<4.0,>=3.6",
-          "version": "0.3.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
               "hash": "8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254",
               "url": "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl"
             },
@@ -339,41 +229,42 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a92920ea484f69bd3d3b5417e79d0961bc9ea62fc8e77290fc9628abbecf1085",
-              "url": "https://files.pythonhosted.org/packages/1b/f7/e1177111402d7d1a37f1591b90672c9fe2a1e0fc13a13430932862a79ba9/strawberry_graphql-0.95.5-py3-none-any.whl"
+              "hash": "f16c3efcb3b33e8f35ddbbe640e61e67efeeeb05d313416ae10336b8d2c7a69b",
+              "url": "https://files.pythonhosted.org/packages/a2/cf/abbb0f44c059f61a562d386e79d1b8adb4def370a6e99f26033002caf2e2/strawberry_graphql-0.159.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "82ce6c6a6bb6a3e181a46384c5aed52e1ae3bc861ac223979254f994ceba471c",
-              "url": "https://files.pythonhosted.org/packages/41/ea/77fc939e5c0875f1729ae4bff3e4dd999865d52131c4e727b657d4ab954f/strawberry-graphql-0.95.5.tar.gz"
+              "hash": "25b56e294ed032e69c066fe0ac802a724f4364c2d70d903e6a9b41d8c62f5add",
+              "url": "https://files.pythonhosted.org/packages/2b/49/90df8aca12c7e213ccb70712391b19b5bdc0607bef3ced15e2664acac0f2/strawberry_graphql-0.159.1.tar.gz"
             }
           ],
           "project_name": "strawberry-graphql",
           "requires_dists": [
-            "Django<4,>=2.2; python_version < \"3.8\" and extra == \"django\"",
-            "Django<5,>=2.2; python_version >= \"3.8\" and extra == \"django\"",
+            "Django>=3.2; extra == \"django\"",
             "aiohttp<4.0.0,>=3.7.4.post0; extra == \"aiohttp\"",
-            "asgiref<4.0,>=3.2; extra == \"django\"",
-            "backports.cached-property<2.0.0,>=1.0.1",
+            "asgiref<4.0,>=3.2; extra == \"django\" or extra == \"channels\"",
+            "backports.cached-property<2.0.0,>=1.0.2; python_version < \"3.8\"",
             "chalice<2.0,>=1.22; extra == \"chalice\"",
-            "click<9.0,>=7.0",
+            "channels>=3.0.5; extra == \"channels\"",
+            "click<9.0,>=7.0; extra == \"debug-server\" or extra == \"cli\"",
             "fastapi>=0.65.2; extra == \"fastapi\"",
-            "flask<2.0,>=1.1; extra == \"flask\"",
-            "graphql-core<3.2.0,>=3.1.0",
+            "flask>=1.1; extra == \"flask\"",
+            "graphql-core<3.3.0,>=3.2.0",
+            "libcst>=0.4.7; extra == \"debug\" or extra == \"debug-server\" or extra == \"cli\"",
             "opentelemetry-api<2; extra == \"opentelemetry\"",
             "opentelemetry-sdk<2; extra == \"opentelemetry\"",
             "pydantic<2; extra == \"pydantic\"",
-            "pygments<3.0,>=2.3",
+            "pygments<3.0,>=2.3; extra == \"debug-server\" or extra == \"cli\"",
             "python-dateutil<3.0.0,>=2.7.0",
-            "python-multipart<0.0.6,>=0.0.5",
-            "sanic<22.0.0,>=20.12.2; extra == \"sanic\"",
-            "sentinel<0.4.0,>=0.3.0",
-            "starlette<0.17.0,>=0.13.6; extra == \"asgi\" or extra == \"debug-server\"",
+            "python-multipart<0.0.6,>=0.0.5; extra == \"asgi\" or extra == \"debug-server\" or extra == \"fastapi\"",
+            "rich>=12.0.0; extra == \"debug\" or extra == \"debug-server\" or extra == \"cli\"",
+            "sanic>=20.12.2; extra == \"sanic\"",
+            "starlette>=0.13.6; extra == \"asgi\" or extra == \"debug-server\"",
             "typing_extensions<5.0.0,>=3.7.4",
-            "uvicorn<0.18.0,>=0.11.6; extra == \"debug-server\""
+            "uvicorn<0.21.0,>=0.11.6; extra == \"debug-server\""
           ],
           "requires_python": "<4.0,>=3.7",
-          "version": "0.95.5"
+          "version": "0.159.1"
         },
         {
           "artifacts": [
@@ -465,68 +356,32 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
-              "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-              "url": "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.4.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-              "url": "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "url": "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
-            }
-          ],
-          "project_name": "zipp",
-          "requires_dists": [
-            "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
-            "furo; extra == \"docs\"",
-            "jaraco.functools; extra == \"testing\"",
-            "jaraco.itertools; extra == \"testing\"",
-            "jaraco.packaging>=9; extra == \"docs\"",
-            "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "more-itertools; extra == \"testing\"",
-            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest-checkdocs>=2.4; extra == \"testing\"",
-            "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
-            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest>=6; extra == \"testing\"",
-            "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx>=3.5; extra == \"docs\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "3.11.0"
+          "version": "4.5.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.127",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "mypy-typing-asserts",
-    "mypy==0.961",
-    "strawberry-graphql<0.96,>=0.95.1"
+    "mypy==1.1.1",
+    "strawberry-graphql==0.159.1"
   ],
   "requires_python": [
     "<3.10,>=3.7"

--- a/3rdparty/python/pytest.lock
+++ b/3rdparty/python/pytest.lock
@@ -56,51 +56,47 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c",
-              "url": "https://files.pythonhosted.org/packages/f2/bc/d817287d1aa01878af07c19505fafd1165cd6a119e9d0821ca1d1c20312d/attrs-22.1.0-py2.py3-none-any.whl"
+              "hash": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+              "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-              "url": "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+              "hash": "c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99",
+              "url": "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz"
             }
           ],
           "project_name": "attrs",
           "requires_dists": [
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"dev\"",
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests\"",
+            "attrs[docs,tests]; extra == \"dev\"",
+            "attrs[tests-no-zope]; extra == \"tests\"",
+            "attrs[tests]; extra == \"cov\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
             "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
-            "coverage[toml]>=5.0.2; extra == \"dev\"",
-            "coverage[toml]>=5.0.2; extra == \"tests\"",
-            "coverage[toml]>=5.0.2; extra == \"tests_no_zope\"",
-            "furo; extra == \"dev\"",
+            "coverage-enable-subprocess; extra == \"cov\"",
+            "coverage[toml]>=5.3; extra == \"cov\"",
             "furo; extra == \"docs\"",
-            "hypothesis; extra == \"dev\"",
-            "hypothesis; extra == \"tests\"",
+            "hypothesis; extra == \"tests-no-zope\"",
             "hypothesis; extra == \"tests_no_zope\"",
-            "mypy!=0.940,>=0.900; extra == \"dev\"",
-            "mypy!=0.940,>=0.900; extra == \"tests\"",
-            "mypy!=0.940,>=0.900; extra == \"tests_no_zope\"",
-            "pre-commit; extra == \"dev\"",
-            "pympler; extra == \"dev\"",
-            "pympler; extra == \"tests\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
+            "myst-parser; extra == \"docs\"",
+            "pympler; extra == \"tests-no-zope\"",
             "pympler; extra == \"tests_no_zope\"",
-            "pytest-mypy-plugins; extra == \"dev\"",
-            "pytest-mypy-plugins; extra == \"tests\"",
-            "pytest-mypy-plugins; extra == \"tests_no_zope\"",
-            "pytest>=4.3.0; extra == \"dev\"",
-            "pytest>=4.3.0; extra == \"tests\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests-no-zope\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests_no_zope\"",
+            "pytest-xdist[psutil]; extra == \"tests-no-zope\"",
+            "pytest-xdist[psutil]; extra == \"tests_no_zope\"",
+            "pytest>=4.3.0; extra == \"tests-no-zope\"",
             "pytest>=4.3.0; extra == \"tests_no_zope\"",
-            "sphinx-notfound-page; extra == \"dev\"",
             "sphinx-notfound-page; extra == \"docs\"",
-            "sphinx; extra == \"dev\"",
             "sphinx; extra == \"docs\"",
-            "zope.interface; extra == \"dev\"",
+            "sphinxcontrib-towncrier; extra == \"docs\"",
+            "towncrier; extra == \"docs\"",
             "zope.interface; extra == \"docs\"",
             "zope.interface; extra == \"tests\""
           ],
-          "requires_python": ">=3.5",
-          "version": "22.1.0"
+          "requires_python": ">=3.6",
+          "version": "22.2.0"
         },
         {
           "artifacts": [
@@ -124,203 +120,208 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a",
-              "url": "https://files.pythonhosted.org/packages/6e/e6/b31a4b2aa9489da59b35ee0ea4259d6fe9b321a1eaa6492f19342d03d53b/coverage-6.5.0-pp36.pp37.pp38-none-any.whl"
+              "hash": "436313d129db7cf5b4ac355dd2bd3f7c7e5294af077b090b85de75f8458b8616",
+              "url": "https://files.pythonhosted.org/packages/9e/de/989111fbf70f00912513912b3111072680154ec713b3f3d523636832965d/coverage-7.2.1-pp37.pp38.pp39-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398",
-              "url": "https://files.pythonhosted.org/packages/02/7a/a45f3958442d50b9a930a62f0dba9ee502521213ebd016203c2890ea212f/coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5d2b9b5e70a21474c105a133ba227c61bc95f2ac3b66861143ce39a5ea4b3f84",
+              "url": "https://files.pythonhosted.org/packages/06/64/cf8b320fcedbca7216e050c0529364241a0746eecff2d521fa31575b997f/coverage-7.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c",
-              "url": "https://files.pythonhosted.org/packages/05/63/a789b462075395d34f8152229dccf92b25ca73eac05b3f6cd75fa5017095/coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "bdd3f2f285ddcf2e75174248b2406189261a79e7fedee2ceeadc76219b6faa0e",
+              "url": "https://files.pythonhosted.org/packages/1c/89/b2f00ae4d1267aeed0026e68b17a6357afe52c1f773dff9c595da4b88977/coverage-7.2.1-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba",
-              "url": "https://files.pythonhosted.org/packages/07/82/79fa21ceca9a9b091eb3c67e27eb648dade27b2c9e1eb23af47232a2a365/coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "80559eaf6c15ce3da10edb7977a1548b393db36cbc6cf417633eca05d84dd1ed",
+              "url": "https://files.pythonhosted.org/packages/24/8d/d9d880cb7319cc06eab02757a0fb3f623c6e7613d16d297cfdf249d4926d/coverage-7.2.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79",
-              "url": "https://files.pythonhosted.org/packages/0d/ef/8735875a8dc09e1c4e484a5436c8b4148731b70daccc6f203c50b05e7505/coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "9e872b082b32065ac2834149dc0adc2a2e6d8203080501e1e3c3c77851b466f9",
+              "url": "https://files.pythonhosted.org/packages/2d/24/06ad2452717337ed45a928107fc5d91601a4a79692012ee86dc06782ab51/coverage-7.2.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae",
-              "url": "https://files.pythonhosted.org/packages/10/9e/68e384940179713640743a010ac7f7c813d1087c8730a9c0bdfa73bdffd7/coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "834c2172edff5a08d78e2f53cf5e7164aacabeb66b369f76e7bb367ca4e2d993",
+              "url": "https://files.pythonhosted.org/packages/2f/e3/15f85c7527577907ddf354f45ad212c3882012c92186d45baa553cff47e3/coverage-7.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04",
-              "url": "https://files.pythonhosted.org/packages/13/f3/c6025ba30f2ce21d20d5332c3819880fe8afdfc008c2e2f9c075c7b67543/coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "f29351393eb05e6326f044a7b45ed8e38cb4dcc38570d12791f271399dc41431",
+              "url": "https://files.pythonhosted.org/packages/36/51/e0a33466be7083709db9325167349ffeeedc419bb73864f72c8280e25aae/coverage-7.2.1-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4",
-              "url": "https://files.pythonhosted.org/packages/15/b0/3639d84ee8a900da0cf6450ab46e22517e4688b6cec0ba8ab6f8166103a2/coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8dca3c1706670297851bca1acff9618455122246bdae623be31eca744ade05ec",
+              "url": "https://files.pythonhosted.org/packages/3d/f5/97bdecac0c23ec52d2ddf4cae5d6de3c69c4441f1b1e448ff7975f91d37b/coverage-7.2.1-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe",
-              "url": "https://files.pythonhosted.org/packages/18/95/27f80dcd8273171b781a19d109aeaed7f13d78ef6d1e2f7134a5826fd1b4/coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4dd34a935de268a133e4741827ae951283a28c0125ddcdbcbba41c4b98f2dfef",
+              "url": "https://files.pythonhosted.org/packages/44/39/5efa733d0508d31565faf2761998f2e0417bfbb5bf4269b64384c7f5031a/coverage-7.2.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466",
-              "url": "https://files.pythonhosted.org/packages/2f/8b/ca3fe3cfbd66d63181f6e6a06b8b494bb327ba8222d2fa628b392b9ad08a/coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "d9256d4c60c4bbfec92721b51579c50f9e5062c21c12bec56b55292464873508",
+              "url": "https://files.pythonhosted.org/packages/47/83/d5353ffb69cd7cfb32e146475d10b6ebba930d9eb323e508933df0d02434/coverage-7.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75",
-              "url": "https://files.pythonhosted.org/packages/36/f3/5cbd79cf4cd059c80b59104aca33b8d05af4ad5bf5b1547645ecee716378/coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "99f4dd81b2bb8fc67c3da68b1f5ee1650aca06faa585cbc6818dbf67893c6d58",
+              "url": "https://files.pythonhosted.org/packages/4a/80/44c734492221b7e065bd8a2856c3f2f4650664abad70aab5e22a9d71a984/coverage-7.2.1-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0",
-              "url": "https://files.pythonhosted.org/packages/3c/7d/d5211ea782b193ab8064b06dc0cc042cf1a4ca9c93a530071459172c550f/coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8649371570551d2fd7dee22cfbf0b61f1747cdfb2b7587bb551e4beaaa44cb97",
+              "url": "https://files.pythonhosted.org/packages/4e/42/eca4b81b6fb43731dba91dbf35af617fe4999ee4270132eb2a9cd90b8566/coverage-7.2.1-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e",
-              "url": "https://files.pythonhosted.org/packages/40/3b/cd68cb278c4966df00158811ec1e357b9a7d132790c240fc65da57e10013/coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "fac6343bae03b176e9b58104a9810df3cdccd5cfed19f99adfa807ffbf43cf9b",
+              "url": "https://files.pythonhosted.org/packages/4e/6b/7d9c6c23aa227b91bc2f85f197406b899a4469c6e0d182d499eb2a515e91/coverage-7.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b",
-              "url": "https://files.pythonhosted.org/packages/4b/66/6e588f5dfc93ccedd06d6785c8143f17bb92b89247d50128d8789e9588d0/coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "7f099da6958ddfa2ed84bddea7515cb248583292e16bb9231d151cd528eab657",
+              "url": "https://files.pythonhosted.org/packages/4f/1a/a3106f807989fa33aa6e378a11cfd4df6873f243c0406122cc2fd03c4c3c/coverage-7.2.1-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795",
-              "url": "https://files.pythonhosted.org/packages/50/cf/455930004231fa87efe8be06d13512f34e070ddfee8b8bf5a050cdc47ab3/coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "3a209d512d157379cc9ab697cbdbb4cfd18daa3e7eebaa84c3d20b6af0037384",
+              "url": "https://files.pythonhosted.org/packages/50/aa/b799631d7c990e777da1a6ba85ccf5194180c79d49f20a1acb1306a18a13/coverage-7.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518",
-              "url": "https://files.pythonhosted.org/packages/58/2c/213861cec1d9f6451d29c0b1838769b558f6a8c6844b001f6e98c37c4b1b/coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "570c21a29493b350f591a4b04c158ce1601e8d18bdcd21db136fbb135d75efa6",
+              "url": "https://files.pythonhosted.org/packages/51/61/2bab4add265c0fcf0a4372ab9e647405f157a9c5cdcbab1e0b7b117f92fa/coverage-7.2.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84",
-              "url": "https://files.pythonhosted.org/packages/5c/66/38d1870cb7cf62da49add1d6803fdbcdef632b2808b5c80bcac35b7634d8/coverage-6.5.0.tar.gz"
+              "hash": "cb5f152fb14857cbe7f3e8c9a5d98979c4c66319a33cad6e617f0067c9accdc4",
+              "url": "https://files.pythonhosted.org/packages/59/7b/250aa653d48f6dccc553dd95739aac5ed7880ee99358b0d5aa0f13d1a338/coverage-7.2.1-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d",
-              "url": "https://files.pythonhosted.org/packages/61/a6/af54588e2091693026df94b09106ee10dcbcdc8c9b2c3989149e6e44a324/coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "a81dbcf6c6c877986083d00b834ac1e84b375220207a059ad45d12f6e518a4e3",
+              "url": "https://files.pythonhosted.org/packages/61/fb/3a9756915a126b138e69f2eef2118b64f126250e6e67d597821eb23dcaf2/coverage-7.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc",
-              "url": "https://files.pythonhosted.org/packages/63/e9/f23e8664ec4032d7802a1cf920853196bcbdce7b56408e3efe1b2da08f3c/coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "5928b85416a388dd557ddc006425b0c37e8468bd1c3dc118c1a3de42f59e2a54",
+              "url": "https://files.pythonhosted.org/packages/6e/1b/3cc2589eae54eee6d5535e5437883fafd9e5b598961a21a6c0459ad97666/coverage-7.2.1-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f",
-              "url": "https://files.pythonhosted.org/packages/64/7f/13f5d58f5ca41182d7020af5257c8fd08ddf33921d2a28cf66753571c278/coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "e4d70c853f0546855f027890b77854508bdb4d6a81242a9d804482e667fff6e6",
+              "url": "https://files.pythonhosted.org/packages/7b/36/afdf9ae3cf36ad922599df32b5517f48be389761869907bf89670eecd362/coverage-7.2.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91",
-              "url": "https://files.pythonhosted.org/packages/6a/63/8e82513b7e4a1b8d887b4e85c1c2b6c9b754a581b187c0b084f3330ac479/coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8d3843ca645f62c426c3d272902b9de90558e9886f15ddf5efe757b12dd376f5",
+              "url": "https://files.pythonhosted.org/packages/7b/f9/5b9e843989ab7461e97f0cba987f78fb043adc8975e65af9eb9bda22c3a2/coverage-7.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef",
-              "url": "https://files.pythonhosted.org/packages/6b/ba/ef67c1e859b8ddd8cafb81199986ff702efcd4ee5d373670a0bc0a293d1f/coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0f8318ed0f3c376cfad8d3520f496946977abde080439d6689d7799791457454",
+              "url": "https://files.pythonhosted.org/packages/7c/f6/3c1715c27e3251baa578b469f3c266b48623d3bce4ea08509a636e11447c/coverage-7.2.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5",
-              "url": "https://files.pythonhosted.org/packages/6b/f2/919f0fdc93d3991ca074894402074d847be8ac1e1d78e7e9e1c371b69a6f/coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0339dc3237c0d31c3b574f19c57985fcbe494280153bbcad33f2cdf469f4ac3e",
+              "url": "https://files.pythonhosted.org/packages/85/97/8b13f1afcdef9d8deb65ffb8f70f6d1519dacecf269f80349c3b424eca2e/coverage-7.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c",
-              "url": "https://files.pythonhosted.org/packages/76/44/78c1936c2bd9e7705f170d5e413ed34d9d6d7d0324757786627f88df1514/coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "c77f2a9093ccf329dd523a9b2b3c854c20d2a3d968b6def3b820272ca6732242",
+              "url": "https://files.pythonhosted.org/packages/8d/4a/3518606d4b110df4f3e77bd52c241ae8a84c6dc74fac7c2a8e809449e541/coverage-7.2.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa",
-              "url": "https://files.pythonhosted.org/packages/78/98/253ce0cfcc3b352d3072940940ed44a035614f2abe781477f77038d21d9f/coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "e191a63a05851f8bce77bc875e75457f9b01d42843f8bd7feed2fc26bbe60833",
+              "url": "https://files.pythonhosted.org/packages/94/91/c708f837c5550ff5447203e29f5273d9b20959fa48753bcfe58cd522fbef/coverage-7.2.1-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3",
-              "url": "https://files.pythonhosted.org/packages/85/03/9dcc8b7e269cfeaf5519d433d841a7d78f283c5fb016385d4690e1aedfc1/coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "f3d07edb912a978915576a776756069dede66d012baa503022d3a0adba1b6afa",
+              "url": "https://files.pythonhosted.org/packages/aa/9f/9d5ffcca635f09cb92e66afb149996889ea8cb7408bec5e908d36686bf8a/coverage-7.2.1-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b",
-              "url": "https://files.pythonhosted.org/packages/89/58/5ec19b43a6511288511f64fc4763d95af8403f5926e7e4556e6b29b03a26/coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "abacd0a738e71b20e224861bc87e819ef46fedba2fb01bc1af83dfd122e9c319",
+              "url": "https://files.pythonhosted.org/packages/af/ff/bf04eeb95213c25a5ef718e1e70b6e476f4e6f48b00d62860f3a8facd3ef/coverage-7.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660",
-              "url": "https://files.pythonhosted.org/packages/89/a2/cbf599e50bb4be416e0408c4cf523c354c51d7da39935461a9687e039481/coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "ae82c988954722fa07ec5045c57b6d55bc1a0890defb57cf4a712ced65b26ddd",
+              "url": "https://files.pythonhosted.org/packages/bb/2d/0011ba3d37d53a840728390a86120f7316ec059a656afe42386abc67bfaa/coverage-7.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f",
-              "url": "https://files.pythonhosted.org/packages/a1/6b/7efeeffc7559150a705931b2144b936042c561e63ef248f0e0d9f4523d74/coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "b1991a6d64231a3e5bbe3099fb0dd7c9aeaa4275ad0e0aeff4cb9ef885c62ba2",
+              "url": "https://files.pythonhosted.org/packages/bc/d8/a06bc91226ff1940547934af0c514acd17510cf9b9a54b13046e5f2d9538/coverage-7.2.1-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b",
-              "url": "https://files.pythonhosted.org/packages/a3/a0/4c59586df0511b18f7b59593672a4baadacef8f393024052d59c6222477c/coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "09643fb0df8e29f7417adc3f40aaf379d071ee8f0350ab290517c7004f05360b",
+              "url": "https://files.pythonhosted.org/packages/bf/4e/bb6008789e813f6930179757acdd409f0056e48ef687416bed819464a79c/coverage-7.2.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62",
-              "url": "https://files.pythonhosted.org/packages/a8/d9/b367c52cb1297414ba967e38fe9b5338ee4700a2d1592fc78532dc9f882f/coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "3004765bca3acd9e015794e5c2f0c9a05587f5e698127ff95e9cfba0d3f29339",
+              "url": "https://files.pythonhosted.org/packages/c8/33/f3cf1fd69b2de5c9d63836c517bd0082fa6db53aa5068ae7df9acf115b9e/coverage-7.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4",
-              "url": "https://files.pythonhosted.org/packages/ac/bc/c9d4fd6b3494d2cc1e26f4b98eb19206b92a59094617ad02d5689ac9d3c4/coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "87dc37f16fb5e3a28429e094145bf7c1753e32bb50f662722e378c5851f7fdc6",
+              "url": "https://files.pythonhosted.org/packages/d4/94/fb0c114600331faead0abd61d8182fcc67030f0711dd5841d7c9a36cdaf0/coverage-7.2.1-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b",
-              "url": "https://files.pythonhosted.org/packages/bd/a0/e263b115808226fdb2658f1887808c06ac3f1b579ef5dda02309e0d54459/coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "97a3189e019d27e914ecf5c5247ea9f13261d22c3bb0cfcfd2a9b179bb36f8b1",
+              "url": "https://files.pythonhosted.org/packages/d4/e1/c6c41180badec9d558bcbdb989792acd414fd93336b8c0a8d91ffe2e3a4a/coverage-7.2.1-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a",
-              "url": "https://files.pythonhosted.org/packages/c0/18/2a0a9b3c29376ce04ceb7ca2948559dad76409a2c9b3f664756581101e16/coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "0bd7e628f6c3ec4e7d2d24ec0e50aae4e5ae95ea644e849d92ae4805650b4c4e",
+              "url": "https://files.pythonhosted.org/packages/d9/c5/8a6ad089d9d9a15f94f40957d804e7712767f8ac458eca55b02a73d249d6/coverage-7.2.1-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53",
-              "url": "https://files.pythonhosted.org/packages/c4/8d/5ec7d08f4601d2d792563fe31db5e9322c306848fec1e65ec8885927f739/coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "cca7c0b7f5881dfe0291ef09ba7bb1582cb92ab0aeffd8afb00c700bf692415a",
+              "url": "https://files.pythonhosted.org/packages/da/f6/6c8f89d02dd9fda71ec61a5baa4d210017f2eb0bb57d4dd513d98d875867/coverage-7.2.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f",
-              "url": "https://files.pythonhosted.org/packages/c8/e8/e712b61abf1282ce3ac9826473ab4b245a4319303cce2e4115a8de1435f2/coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "49567ec91fc5e0b15356da07a2feabb421d62f52a9fff4b1ec40e9e19772f5f8",
+              "url": "https://files.pythonhosted.org/packages/e4/ae/489a39a3615a23000f731ddd0a8d397f771b42ab2d0404fd6607f0a38c42/coverage-7.2.1-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d",
-              "url": "https://files.pythonhosted.org/packages/cd/48/65d314e702b4a7095ea96da0a319a5a377e594354a4a6badde483832bb5a/coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "8a6450da4c7afc4534305b2b7d8650131e130610cea448ff240b6ab73d7eab63",
+              "url": "https://files.pythonhosted.org/packages/e5/a9/62aabc67971d2fd439474b05cfc25c852b28bb6dfe8082c5b665652899f5/coverage-7.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf",
-              "url": "https://files.pythonhosted.org/packages/d6/0f/012a7370aaf61123a222b34b657dedc63e03ce2af8d064ac5c5afe14f29c/coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "861cc85dfbf55a7a768443d90a07e0ac5207704a9f97a8eb753292a7fcbdfcfc",
+              "url": "https://files.pythonhosted.org/packages/f2/08/ed8f2266db3f851de17df7a5923157d2444969af283daf99ca572c4c724d/coverage-7.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e",
-              "url": "https://files.pythonhosted.org/packages/e5/fb/11982f5faf2990d4d9159e01a12bbf0a7d7873893d4d2e2acec012ad69ae/coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "b2167d116309f564af56f9aa5e75ef710ef871c5f9b313a83050035097b56820",
+              "url": "https://files.pythonhosted.org/packages/f3/ff/0bf7a9497dc91e4b0f11656a50c95fd1e641d912a281a0b0921d20fa5760/coverage-7.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745",
-              "url": "https://files.pythonhosted.org/packages/ea/52/c08080405329326a7ff16c0dfdb4feefaa8edd7446413df67386fe1bbfe0/coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "78d2c3dde4c0b9be4b02067185136b7ee4681978228ad5ec1278fa74f5ca3e99",
+              "url": "https://files.pythonhosted.org/packages/f5/70/9400b5c37f43d8e39527f9209cc7b1db96b5f16a6a3da2ccd8f75465d567/coverage-7.2.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2ef6cae70168815ed91388948b5f4fcc69681480a0061114db737f957719f03",
+              "url": "https://files.pythonhosted.org/packages/f9/06/5f6555205d13f8811558b73fa37596519272fb077ad7f9faa4e4162a23a4/coverage-7.2.1-cp310-cp310-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "coverage",
@@ -328,7 +329,7 @@
             "tomli; python_full_version <= \"3.11.0a6\" and extra == \"toml\""
           ],
           "requires_python": ">=3.7",
-          "version": "6.5.0"
+          "version": "7.2.1"
         },
         {
           "artifacts": [
@@ -372,26 +373,26 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "35d24b728e48b7e0a12bdb69386d3bfc7eef4fe922d0ac1cd70d6e5c11630bae",
-              "url": "https://files.pythonhosted.org/packages/fd/d5/3ab4777d15535bf712e1d3509b7bdfc01ed4da7c935679f84bd454fbb0fe/icdiff-2.0.5.tar.gz"
+              "hash": "a2673b335d671e64fc73c44e1eaa0aa01fd0e68354e58ee17e863ab29912a79a",
+              "url": "https://files.pythonhosted.org/packages/b6/11/542ff30f2c399d71126e55b64d41cb5caa78ddf7ce557fddf45607a41fe8/icdiff-2.0.6.tar.gz"
             }
           ],
           "project_name": "icdiff",
           "requires_dists": [],
           "requires_python": null,
-          "version": "2.0.5"
+          "version": "2.0.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313",
-              "url": "https://files.pythonhosted.org/packages/e1/16/1f59f5d87d256012e9cdf0e8af8810965fa253e835cfecce64f4b11d4f2d/importlib_metadata-5.1.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
-              "url": "https://files.pythonhosted.org/packages/32/5a/e0d75c8010295ae6746f379f5324bc726076dfc426548bfa6f0763fce870/importlib_metadata-5.1.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -414,30 +415,31 @@
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "5.1.0"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-              "url": "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl"
+              "hash": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32",
-              "url": "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz"
+              "hash": "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+              "url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz"
             }
           ],
           "project_name": "iniconfig",
           "requires_dists": [],
-          "requires_python": null,
-          "version": "1.1.1"
+          "requires_python": ">=3.7",
+          "version": "2.0.0"
         },
         {
           "artifacts": [
@@ -611,19 +613,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "957e2148ba0e1a3b282772e791ef1d8083648bc131c8ab0c1feba110ce1146c3",
-              "url": "https://files.pythonhosted.org/packages/8f/7b/42582927d281d7cb035609cd3a543ffac89b74f3f4ee8e1c50914bcb57eb/packaging-22.0-py3-none-any.whl"
+              "hash": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+              "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2198ec20bd4c017b8f9717e00f0c8714076fc2fd93816750ab48e2c41de2cfd3",
-              "url": "https://files.pythonhosted.org/packages/6b/f7/c240d7654ddd2d2f3f328d8468d4f1f876865f6b9038b146bec0a6737c65/packaging-22.0.tar.gz"
+              "hash": "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97",
+              "url": "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz"
             }
           ],
           "project_name": "packaging",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "22.0"
+          "version": "23.0"
         },
         {
           "artifacts": [
@@ -734,21 +736,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305",
-              "url": "https://files.pythonhosted.org/packages/eb/37/791f1a6edd13c61cac85282368aa68cb0f3f164440fdf60032f2cc6ca34e/prompt_toolkit-3.0.36-py3-none-any.whl"
+              "hash": "45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f",
+              "url": "https://files.pythonhosted.org/packages/87/3f/1f5a0ff475ae6481f4b0d45d4d911824d3218b94ee2a97a8cb84e5569836/prompt_toolkit-3.0.38-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63",
-              "url": "https://files.pythonhosted.org/packages/fb/93/180be2342f89f16543ec4eb3f25083b5b84eba5378f68efff05409fb39a9/prompt_toolkit-3.0.36.tar.gz"
+              "hash": "23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
+              "url": "https://files.pythonhosted.org/packages/4b/bb/75cdcd356f57d17b295aba121494c2333d26bfff1a837e6199b8b83c415a/prompt_toolkit-3.0.38.tar.gz"
             }
           ],
           "project_name": "prompt-toolkit",
           "requires_dists": [
             "wcwidth"
           ],
-          "requires_python": ">=3.6.2",
-          "version": "3.0.36"
+          "requires_python": ">=3.7.0",
+          "version": "3.0.38"
         },
         {
           "artifacts": [
@@ -790,13 +792,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42",
-              "url": "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl"
+              "hash": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
+              "url": "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1",
-              "url": "https://files.pythonhosted.org/packages/e0/ef/5905cd3642f2337d44143529c941cc3a02e5af16f0f65f81cbef7af452bb/Pygments-2.13.0.tar.gz"
+              "hash": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
+              "url": "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz"
             }
           ],
           "project_name": "pygments",
@@ -804,7 +806,7 @@
             "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
           ],
           "requires_python": ">=3.6",
-          "version": "2.13.0"
+          "version": "2.14.0"
         },
         {
           "artifacts": [
@@ -900,13 +902,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8",
-              "url": "https://files.pythonhosted.org/packages/0c/36/c56ef2aea73912190cdbcc39aaa860db8c07c1a5ce8566994ec9425453db/pytest_forked-1.4.0-py3-none-any.whl"
+              "hash": "810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0",
+              "url": "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e",
-              "url": "https://files.pythonhosted.org/packages/f1/bc/0121a2e386b261b69f4f5aa48e5304c947451dce70d68628cb28d5cd0d28/pytest-forked-1.4.0.tar.gz"
+              "hash": "4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f",
+              "url": "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz"
             }
           ],
           "project_name": "pytest-forked",
@@ -914,8 +916,8 @@
             "py",
             "pytest>=3.10"
           ],
-          "requires_python": ">=3.6",
-          "version": "1.4.0"
+          "requires_python": ">=3.7",
+          "version": "1.6.0"
         },
         {
           "artifacts": [
@@ -1005,13 +1007,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-              "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
-              "url": "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -1038,7 +1040,7 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
@@ -1050,6 +1052,7 @@
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
@@ -1062,7 +1065,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "65.6.3"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
@@ -1086,59 +1089,57 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57ba2ba951632eeab9388fa45f342a5402060a5cc9f0bb942f760fafb6641581",
-              "url": "https://files.pythonhosted.org/packages/cb/1e/7b8ae7bbc4c0d4b913cabb345c2ac98450bbd9cfe90ee2be275019037932/traitlets-5.7.1-py3-none-any.whl"
+              "hash": "9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8",
+              "url": "https://files.pythonhosted.org/packages/77/75/c28e9ef7abec2b7e9ff35aea3e0be6c1aceaf7873c26c95ae1f0d594de71/traitlets-5.9.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fde8f62c05204ead43c2c1b9389cfc85befa7f54acb5da28529d671175bb4108",
-              "url": "https://files.pythonhosted.org/packages/0b/db/9adbbb2bef9a43ecfa4f1cbcec1d662adade10262328a4b7ef65effc6341/traitlets-5.7.1.tar.gz"
+              "hash": "f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9",
+              "url": "https://files.pythonhosted.org/packages/39/c3/205e88f02959712b62008502952707313640369144a7fded4cbc61f48321/traitlets-5.9.0.tar.gz"
             }
           ],
           "project_name": "traitlets",
           "requires_dists": [
-            "black>=22.6.0; extra == \"lint\"",
-            "mdformat>0.7; extra == \"lint\"",
-            "mypy>=0.990; extra == \"typing\"",
+            "argcomplete>=2.0; extra == \"test\"",
             "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"test\"",
             "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-mock; extra == \"test\"",
             "pytest; extra == \"test\"",
-            "ruff>=0.0.156; extra == \"lint\"",
             "sphinx; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "5.7.1"
+          "version": "5.9.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
-              "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-              "url": "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-              "url": "https://files.pythonhosted.org/packages/59/7c/e39aca596badaf1b78e8f547c807b04dae603a433d3e7a7e04d67f2ef3e5/wcwidth-0.2.5-py2.py3-none-any.whl"
+              "hash": "795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
+              "url": "https://files.pythonhosted.org/packages/20/f4/c0584a25144ce20bfcf1aecd041768b8c762c1eb0aa77502a3f0baa83f11/wcwidth-0.2.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83",
-              "url": "https://files.pythonhosted.org/packages/89/38/459b727c381504f361832b9e5ace19966de1a235d73cdbdea91c771a1155/wcwidth-0.2.5.tar.gz"
+              "hash": "a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0",
+              "url": "https://files.pythonhosted.org/packages/5e/5f/1e4bd82a9cc1f17b2c2361a2d876d4c38973a997003ba5eb400e8a932b6c/wcwidth-0.2.6.tar.gz"
             }
           ],
           "project_name": "wcwidth",
@@ -1146,25 +1147,25 @@
             "backports.functools-lru-cache>=1.2.1; python_version < \"3.2\""
           ],
           "requires_python": null,
-          "version": "0.2.5"
+          "version": "0.2.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-              "url": "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "url": "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
+            "big-O; extra == \"testing\"",
             "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
@@ -1179,18 +1180,19 @@
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.11.0"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "ipdb",

--- a/build-support/bin/_generate_all_lockfiles_helper.py
+++ b/build-support/bin/_generate_all_lockfiles_helper.py
@@ -217,6 +217,10 @@ def update_default_lockfiles(specified: list[str] | None) -> None:
         "--concurrent",
         f"--python-interpreter-constraints={repr(PythonSetup.default_interpreter_constraints)}",
         *itertools.chain.from_iterable(tool.args for tool in AllTools),
+        # `generate_all_lockfiles.sh` will have overridden this option to solve the chicken
+        # and egg problem from https://github.com/pantsbuild/pants/issues/12457. We must
+        # restore it here so that the lockfile gets generated properly.
+        "--python-enable-resolves",
         "generate-lockfiles",
     ]
     if specified:

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -134,7 +134,7 @@ class DocUrlRewriter:
 class TitleFinder(HTMLParser):
     """Grabs the page title out of a docsite page."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self._in_title: bool = False
         self._title: str | None = None
@@ -559,6 +559,7 @@ class ReferenceGenerator:
 
         The individual reference pages are nested under these parent pages.
         """
+
         # Docs appear on the site in creation order.  If we only create new docs
         # that don't already exist then they will appear at the end, instead of in
         # alphabetical order. So we first delete all previous docs, then recreate them.

--- a/build-support/flake8/bin_name_checker.py
+++ b/build-support/flake8/bin_name_checker.py
@@ -23,11 +23,11 @@ def check_for_hardcoded_pants_bin_name(
     violations: list[tuple[int, int]] = []
 
     class Visitor(ast.NodeVisitor):
-        def __init__(self):
+        def __init__(self) -> None:
             self._docstrings: list[str | None] = []
 
         def visit_docstringable(self, node: ast.AST):
-            self._docstrings.append(ast.get_docstring(node, clean=False))
+            self._docstrings.append(ast.get_docstring(node, clean=False))  # type: ignore[arg-type]
             self.generic_visit(node)
             self._docstrings.pop()
 

--- a/build-support/migration-support/fix_deprecated_globs_usage.py
+++ b/build-support/migration-support/fix_deprecated_globs_usage.py
@@ -230,7 +230,7 @@ def generate_possibly_new_build(build_file: Path) -> Optional[List[str]]:
             ]
             for bundle_func in bundle_funcs:
                 # Every `bundle` is guaranteed to have a `fileset` defined.
-                fileset_arg: [ast.keyword] = next(  # type: ignore[misc]
+                fileset_arg: ast.keyword = next(
                     kwarg for kwarg in bundle_func.keywords if kwarg.arg == "fileset"
                 )
                 if not isinstance(fileset_arg.value, ast.Call):

--- a/pants.toml
+++ b/pants.toml
@@ -205,7 +205,7 @@ timeout_default = 60
 interpreter_constraints = [">=3.7,<3.10"]
 extra_requirements.add = [
   "mypy-typing-asserts",
-  "strawberry-graphql>=0.95.1,<0.96",
+  "strawberry-graphql==0.159.1",
 ]
 lockfile = "3rdparty/python/mypy.lock"
 

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -63,7 +63,6 @@ async def _find_binary(
     fingerprint_args: tuple[str, ...] | None,
     fingerprint_dependencies: tuple[str, ...] | None,
 ) -> BinaryPath:
-
     search_paths = tuple(extra_search_paths) + SEARCH_PATHS
 
     binaries = await Get(
@@ -130,7 +129,6 @@ async def _find_binary(
 
 @rule(level=LogLevel.DEBUG)
 async def create_system_binary_run_request(field_set: SystemBinaryFieldSet) -> RunRequest:
-
     assert field_set.name.value is not None
     extra_search_paths = field_set.extra_search_paths.value or ()
 

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from typing import ClassVar
+
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -24,7 +26,7 @@ class AdhocToolDependenciesField(Dependencies):
 
 
 class AdhocToolRunnableField(StringField):
-    alias = "runnable"
+    alias: ClassVar[str] = "runnable"
     required = True
     help = help_text(
         lambda: f"""
@@ -38,7 +40,7 @@ class AdhocToolRunnableField(StringField):
 
 
 class AdhocToolOutputFilesField(StringSequenceField):
-    alias = "output_files"
+    alias: ClassVar[str] = "output_files"
     required = False
     default = ()
     help = help_text(
@@ -57,7 +59,7 @@ class AdhocToolOutputFilesField(StringSequenceField):
 
 
 class AdhocToolOutputDirectoriesField(StringSequenceField):
-    alias = "output_directories"
+    alias: ClassVar[str] = "output_directories"
     required = False
     default = ()
     help = help_text(
@@ -77,7 +79,7 @@ class AdhocToolOutputDirectoriesField(StringSequenceField):
 
 class AdhocToolOutputDependenciesField(AdhocToolDependenciesField):
     supports_transitive_excludes = True
-    alias = "output_dependencies"
+    alias: ClassVar[str] = "output_dependencies"
     deprecated_alias = "dependencies"
     deprecated_alias_removal_version = "2.17.0.dev0"
 
@@ -93,7 +95,7 @@ class AdhocToolOutputDependenciesField(AdhocToolDependenciesField):
 
 
 class AdhocToolExecutionDependenciesField(SpecialCasedDependencies):
-    alias = "execution_dependencies"
+    alias: ClassVar[str] = "execution_dependencies"
     required = False
     default = None
 
@@ -114,7 +116,7 @@ class AdhocToolExecutionDependenciesField(SpecialCasedDependencies):
 
 
 class AdhocToolRunnableDependenciesField(SpecialCasedDependencies):
-    alias = "runnable_dependencies"
+    alias: ClassVar[str] = "runnable_dependencies"
     required = False
     default = None
 
@@ -134,13 +136,13 @@ class AdhocToolRunnableDependenciesField(SpecialCasedDependencies):
 
 class AdhocToolSourcesField(MultipleSourcesField):
     # We solely register this field for codegen to work.
-    alias = "_sources"
+    alias: ClassVar[str] = "_sources"
     uses_source_roots = False
     expected_num_files = 0
 
 
 class AdhocToolArgumentsField(StringSequenceField):
-    alias = "args"
+    alias: ClassVar[str] = "args"
     default = ()
     help = help_text(
         lambda: f"Extra arguments to pass into the `{AdhocToolRunnableField.alias}` field."
@@ -148,7 +150,7 @@ class AdhocToolArgumentsField(StringSequenceField):
 
 
 class AdhocToolStdoutFilenameField(StringField):
-    alias = "stdout"
+    alias: ClassVar[str] = "stdout"
     default = None
     help = help_text(
         lambda: f"""
@@ -159,7 +161,7 @@ class AdhocToolStdoutFilenameField(StringField):
 
 
 class AdhocToolStderrFilenameField(StringField):
-    alias = "stderr"
+    alias: ClassVar[str] = "stderr"
     default = None
     help = help_text(
         lambda: f"""
@@ -170,14 +172,14 @@ class AdhocToolStderrFilenameField(StringField):
 
 
 class AdhocToolTimeoutField(IntField):
-    alias = "timeout"
+    alias: ClassVar[str] = "timeout"
     default = 30
     help = "Command execution timeout (in seconds)."
     valid_numbers = ValidNumbers.positive_only
 
 
 class AdhocToolExtraEnvVarsField(StringSequenceField):
-    alias = "extra_env_vars"
+    alias: ClassVar[str] = "extra_env_vars"
     help = help_text(
         """
         Additional environment variables to provide to the process.
@@ -189,13 +191,13 @@ class AdhocToolExtraEnvVarsField(StringSequenceField):
 
 
 class AdhocToolLogOutputField(BoolField):
-    alias = "log_output"
+    alias: ClassVar[str] = "log_output"
     default = False
     help = "Set to true if you want the output logged to the console."
 
 
 class AdhocToolWorkdirField(StringField):
-    alias = "workdir"
+    alias: ClassVar[str] = "workdir"
     default = "."
     help = help_text(
         """
@@ -212,7 +214,7 @@ class AdhocToolWorkdirField(StringField):
 
 
 class AdhocToolOutputRootDirField(StringField):
-    alias = "root_output_directory"
+    alias: ClassVar[str] = "root_output_directory"
     default = "/"
     help = help_text(
         """Adjusts the location of files output by this target, when consumed as a dependency.
@@ -228,7 +230,7 @@ class AdhocToolOutputRootDirField(StringField):
 
 
 class AdhocToolTarget(Target):
-    alias = "adhoc_tool"
+    alias: ClassVar[str] = "adhoc_tool"
     deprecated_alias = "experimental_run_in_sandbox"
     deprecated_alias_removal_version = "2.17.0.dev0"
     core_fields = (
@@ -275,13 +277,13 @@ class AdhocToolTarget(Target):
 
 
 class SystemBinaryNameField(StringField):
-    alias = "binary_name"
+    alias: ClassVar[str] = "binary_name"
     required = True
     help = "The name of the binary to find."
 
 
 class SystemBinaryExtraSearchPathsField(StringSequenceField):
-    alias = "extra_search_paths"
+    alias: ClassVar[str] = "extra_search_paths"
     default = ()
     help = help_text(
         """
@@ -292,7 +294,7 @@ class SystemBinaryExtraSearchPathsField(StringSequenceField):
 
 
 class SystemBinaryFingerprintPattern(StringField):
-    alias = "fingerprint"
+    alias: ClassVar[str] = "fingerprint"
     required = False
     default = None
     help = help_text(
@@ -304,7 +306,7 @@ class SystemBinaryFingerprintPattern(StringField):
 
 
 class SystemBinaryFingerprintArgsField(StringSequenceField):
-    alias = "fingerprint_args"
+    alias: ClassVar[str] = "fingerprint_args"
     default = ()
     help = help_text(
         "Specifies arguments that will be used to run the binary during the search process."
@@ -312,7 +314,7 @@ class SystemBinaryFingerprintArgsField(StringSequenceField):
 
 
 class SystemBinaryFingerprintDependenciesField(AdhocToolRunnableDependenciesField):
-    alias = "fingerprint_dependencies"
+    alias: ClassVar[str] = "fingerprint_dependencies"
     help = help_text(
         """
         Specifies any runnable dependencies that need to be available on the `PATH` when the binary
@@ -323,7 +325,7 @@ class SystemBinaryFingerprintDependenciesField(AdhocToolRunnableDependenciesFiel
 
 
 class SystemBinaryTarget(Target):
-    alias = "system_binary"
+    alias: ClassVar[str] = "system_binary"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         SystemBinaryNameField,

--- a/src/python/pants/backend/cc/lint/clangformat/clangformat.lock
+++ b/src/python/pants/backend/cc/lint/clangformat/clangformat.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "clang-format==14.0.3"
-//   ]
+//     "clang-format<16,>=14.0.3"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,54 +31,50 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "00afee65c015d4c017d5b56524fc4a59829e5986ac159f0ab2c2147540a2b31a",
-              "url": "https://files.pythonhosted.org/packages/65/56/eb18d61a085ba018395155a2d658e0ee3aff0821a0b16d3d431b5ecec83b/clang_format-14.0.3-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "0343cd5f0cf33c3d552ebacbd2604e1a1342163ed7e5cb750c0a1495aae96340",
+              "url": "https://files.pythonhosted.org/packages/1c/73/b2bec18c8c4bfa15ef0a7f4793032c3a07536fdd42e30d245cfd1214da8b/clang_format-15.0.7-py2.py3-none-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2c7da4ff143146fe7b80894efd32842f45d58a3bd30e8fb559ce86b961700a3c",
-              "url": "https://files.pythonhosted.org/packages/2f/a7/01eebdafa44ca579383eb088dd6aa2179aa8c0bd661db17a6e52a5c5032b/clang_format-14.0.3-py2.py3-none-macosx_10_9_universal2.whl"
+              "hash": "6bb879288a08cf646e2930f1f69b197bae90003a6c6abacd7beabed340a9752f",
+              "url": "https://files.pythonhosted.org/packages/04/d3/d76f880a779b52a483a6a25a0721b1307a97c1ec54ee270fa808da4806fa/clang_format-15.0.7-py2.py3-none-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7dce28e40f2af48b1d0d5a0211562e592395d32c58483c0cafd75e7cf3297b55",
-              "url": "https://files.pythonhosted.org/packages/4f/9e/be1a223599b501a116048fdb5ed3e96fee68ae5afcac4608f885b04265f5/clang_format-14.0.3-py2.py3-none-manylinux_2_12_i686.manylinux2010_i686.whl"
+              "hash": "a81115f042e59a042e6600d034d15a75dbd2830fae98eb806830380054f49fe7",
+              "url": "https://files.pythonhosted.org/packages/40/d3/d19eee7328238c74f543e67fa68a986f785e689799030b54372cf4f8fb09/clang_format-15.0.7-py2.py3-none-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b15a04d5c6ca463104518c461ef203f62f2a0b639d4e49d1362e2344ce25ec89",
-              "url": "https://files.pythonhosted.org/packages/66/91/52e3e26b31945dd2e58f0cdbd0697f424cb4bbd9ad254a3f800a3d3d2993/clang_format-14.0.3-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0983aa108920a84a84358a1a045537311ad77c3fcb60fdec2af0aad71d53bd1d",
+              "url": "https://files.pythonhosted.org/packages/8b/c5/88311aa52cb936776f42c246c66a75da21fd9ce2e6058779544dcc316982/clang_format-15.0.7-py2.py3-none-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "73bc0bd21eacdee30b85e1315a6cff5685531d89905c3411de91816fc7cbce75",
-              "url": "https://files.pythonhosted.org/packages/91/19/b484a5df518e83fdf45482ce2396392932c5636c4a785b5d9c57d965b305/clang-format-14.0.3.tar.gz"
+              "hash": "60954c571394354200912e72ce10454b96016af879771df39d09d605ceaec035",
+              "url": "https://files.pythonhosted.org/packages/9a/f5/61b4c55df2a3a966ce9c97ccd1cbc81810bfdb562cc8d298d382ed92a983/clang-format-15.0.7.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "778e4acc74e1dcbd8197dcf49142b4102242a83881fb117b86727c01e74c6941",
-              "url": "https://files.pythonhosted.org/packages/a3/4d/866c1f4bafd8ab2b957c7713aa2ae4db1363f781fb02fdd77ff531813abf/clang_format-14.0.3-py2.py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0925179fa10c444a07bdff5db6981868d07f109f1d8b5e5eaecc4f3b028e48a1",
-              "url": "https://files.pythonhosted.org/packages/b1/42/1a523349b0ae0ebcedb6278fade1fa5e0b303f9a18a480a342e4242d30bc/clang_format-14.0.3-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "f5a7815754c48cd9ffb14b2f306690f08b8ad8050cc7735c05c6caba046faee3",
+              "url": "https://files.pythonhosted.org/packages/e2/de/9afd3245007dac0ac64caec68c27b765ddba2325b261dc01643100dacd93/clang_format-15.0.7-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             }
           ],
           "project_name": "clang-format",
           "requires_dists": [],
           "requires_python": null,
-          "version": "14.0.3"
+          "version": "15.0.7"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "clang-format==14.0.3"
+    "clang-format<16,>=14.0.3"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -39,7 +39,6 @@ class ClangFormatRequest(FmtTargetsRequest):
 
 @rule(level=LogLevel.DEBUG)
 async def clangformat_fmt(request: ClangFormatRequest.Batch, clangformat: ClangFormat) -> FmtResult:
-
     # Look for any/all of the clang-format configuration files (recurse sub-dirs)
     config_files_get = Get(
         ConfigFiles,

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -34,8 +34,9 @@ class ClangFormat(PythonToolBase):
         """
     )
 
-    default_version = "clang-format==14.0.3"
+    default_version = "clang-format>=14.0.3,<16"
     default_main = ConsoleScript("clang-format")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt
+++ b/src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt
@@ -153,12 +153,6 @@ serialized_bytes_length = 78146
 [[entries]]
 file_name = "org.apache.avro_avro-compiler_1.11.0.jar"
 [[entries.directDependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.fasterxml.jackson.core"
 artifact = "jackson-databind"
 version = "2.12.5"
@@ -174,6 +168,12 @@ packaging = "jar"
 group = "org.apache.commons"
 artifact = "commons-lang3"
 version = "3.12.0"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -189,15 +189,9 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -214,20 +208,26 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
 artifact = "commons-lang3"
 version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.slf4j"
 artifact = "slf4j-api"
 version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
 packaging = "jar"
 
 
@@ -242,14 +242,14 @@ serialized_bytes_length = 110491
 [[entries]]
 file_name = "org.apache.avro_avro-ipc-jetty_1.11.0.jar"
 [[entries.directDependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "org.apache.avro"
+artifact = "avro-ipc"
+version = "1.11.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-ipc"
+artifact = "avro"
 version = "1.11.0"
 packaging = "jar"
 
@@ -260,21 +260,21 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
+group = "org.eclipse.jetty"
+artifact = "jetty-servlet"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -284,21 +284,75 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-databind"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.annotation"
+artifact = "javax.annotation-api"
+version = "1.3.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.apache.avro"
 artifact = "avro-ipc"
 version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-http"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-io"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -315,74 +369,8 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.eclipse.jetty"
-artifact = "jetty-http"
+artifact = "jetty-servlet"
 version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-databind"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-io"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.annotation"
-artifact = "javax.annotation-api"
-version = "1.3.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -392,15 +380,27 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -415,9 +415,9 @@ serialized_bytes_length = 13508
 [[entries]]
 file_name = "org.apache.avro_avro-ipc_1.11.0.jar"
 [[entries.directDependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -427,21 +427,9 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.github.luben"
 artifact = "zstd-jni"
 version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -451,9 +439,21 @@ version = "1.3.2"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -463,9 +463,9 @@ version = "1.9"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -475,15 +475,9 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -493,27 +487,9 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.github.luben"
 artifact = "zstd-jni"
 version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -523,9 +499,33 @@ version = "1.3.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -535,9 +535,9 @@ version = "1.9"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -559,13 +559,13 @@ packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-ipc"
+artifact = "avro-ipc-jetty"
 version = "1.11.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-ipc-jetty"
+artifact = "avro-ipc"
 version = "1.11.0"
 packaging = "jar"
 
@@ -582,21 +582,81 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-databind"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.annotation"
+artifact = "javax.annotation-api"
+version = "1.3.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-ipc-jetty"
+version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.apache.avro"
 artifact = "avro-ipc"
 version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-http"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-io"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -613,80 +673,8 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.eclipse.jetty"
-artifact = "jetty-http"
+artifact = "jetty-servlet"
 version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-ipc-jetty"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-databind"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-io"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.annotation"
-artifact = "javax.annotation-api"
-version = "1.3.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -696,15 +684,27 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -719,15 +719,44 @@ serialized_bytes_length = 188158
 [[entries]]
 file_name = "org.apache.avro_avro-tools_1.11.0.jar"
 [[entries.directDependencies]]
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "commons-cli"
+artifact = "commons-cli"
+version = "1.4"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "net.sf.jopt-simple"
+artifact = "jopt-simple"
+version = "5.0.4"
+packaging = "jar"
+
+[[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "trevni-core"
+artifact = "avro-compiler"
 version = "1.11.0"
 packaging = "jar"
-classifier = "tests"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
 artifact = "avro-ipc"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.apache.avro"
+artifact = "avro-mapred"
 version = "1.11.0"
 packaging = "jar"
 
@@ -738,24 +767,6 @@ version = "1.11.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.apache.avro"
-artifact = "avro-mapred"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "org.apache.avro"
 artifact = "trevni-avro"
 version = "1.11.0"
@@ -769,24 +780,6 @@ packaging = "jar"
 classifier = "tests"
 
 [[entries.directDependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "commons-cli"
-artifact = "commons-cli"
-version = "1.4"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "org.apache.avro"
 artifact = "trevni-core"
 version = "1.11.0"
@@ -794,8 +787,15 @@ packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-compiler"
+artifact = "trevni-core"
 version = "1.11.0"
+packaging = "jar"
+classifier = "tests"
+
+[[entries.directDependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -805,15 +805,15 @@ version = "1.7.32"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "net.sf.jopt-simple"
-artifact = "jopt-simple"
-version = "5.0.4"
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -823,15 +823,100 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-databind"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "commons-cli"
+artifact = "commons-cli"
+version = "1.4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.annotation"
+artifact = "javax.annotation-api"
+version = "1.3.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "log4j"
+artifact = "log4j"
+version = "1.2.17"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "net.sf.jopt-simple"
+artifact = "jopt-simple"
+version = "5.0.4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-compiler"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-ipc-jetty"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-ipc"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-mapred"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "trevni-avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "trevni-avro"
+version = "1.11.0"
+packaging = "jar"
+classifier = "tests"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "trevni-core"
+version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -842,9 +927,33 @@ packaging = "jar"
 classifier = "tests"
 
 [[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-ipc"
-version = "1.11.0"
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-http"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-io"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -861,129 +970,8 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.eclipse.jetty"
-artifact = "jetty-http"
+artifact = "jetty-servlet"
 version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "log4j"
-artifact = "log4j"
-version = "1.2.17"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-ipc-jetty"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-databind"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-io"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-mapred"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "trevni-avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "trevni-avro"
-version = "1.11.0"
-packaging = "jar"
-classifier = "tests"
-
-[[entries.dependencies]]
-group = "javax.annotation"
-artifact = "javax.annotation-api"
-version = "1.3.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "commons-cli"
-artifact = "commons-cli"
-version = "1.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "trevni-core"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-compiler"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-log4j12"
-version = "1.7.32"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -993,21 +981,33 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "net.sf.jopt-simple"
-artifact = "jopt-simple"
-version = "5.0.4"
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-log4j12"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -1052,9 +1052,9 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1064,15 +1064,15 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
 packaging = "jar"
 
 
@@ -1088,13 +1088,13 @@ serialized_bytes_length = 593627
 file_name = "org.apache.avro_trevni-avro_1.11.0.jar"
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro"
+artifact = "avro-mapred"
 version = "1.11.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-mapred"
+artifact = "avro"
 version = "1.11.0"
 packaging = "jar"
 
@@ -1117,21 +1117,93 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-databind"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.annotation"
+artifact = "javax.annotation-api"
+version = "1.3.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-ipc-jetty"
+version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.apache.avro"
 artifact = "avro-ipc"
 version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-mapred"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "trevni-core"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-http"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-io"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1148,92 +1220,8 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.eclipse.jetty"
-artifact = "jetty-http"
+artifact = "jetty-servlet"
 version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-ipc-jetty"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-databind"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-io"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-mapred"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.annotation"
-artifact = "javax.annotation-api"
-version = "1.3.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "trevni-core"
-version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1243,15 +1231,27 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -1267,13 +1267,13 @@ serialized_bytes_length = 43455
 file_name = "org.apache.avro_trevni-avro_jar_tests_1.11.0.jar"
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro"
+artifact = "avro-mapred"
 version = "1.11.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.apache.avro"
-artifact = "avro-mapred"
+artifact = "avro"
 version = "1.11.0"
 packaging = "jar"
 
@@ -1296,21 +1296,93 @@ version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-compress"
-version = "1.21"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-core"
+version = "2.12.5"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-servlet"
-version = "9.4.43.v20210629"
+group = "com.fasterxml.jackson.core"
+artifact = "jackson-databind"
+version = "2.12.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.luben"
+artifact = "zstd-jni"
+version = "1.5.0-4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.annotation"
+artifact = "javax.annotation-api"
+version = "1.3.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-ipc-jetty"
+version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.apache.avro"
 artifact = "avro-ipc"
 version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro-mapred"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "avro"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.avro"
+artifact = "trevni-core"
+version = "1.11.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-compress"
+version = "1.21"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.commons"
+artifact = "commons-lang3"
+version = "3.12.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.velocity"
+artifact = "velocity-engine-core"
+version = "2.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-http"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-io"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1327,92 +1399,8 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.eclipse.jetty"
-artifact = "jetty-http"
+artifact = "jetty-servlet"
 version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-ipc-jetty"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.velocity"
-artifact = "velocity-engine-core"
-version = "2.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-databind"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-io"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.luben"
-artifact = "zstd-jni"
-version = "1.5.0-4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "avro-mapred"
-version = "1.11.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.commons"
-artifact = "commons-lang3"
-version = "3.12.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.32"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.annotation"
-artifact = "javax.annotation-api"
-version = "1.3.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.xerial.snappy"
-artifact = "snappy-java"
-version = "1.1.8.4"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.tukaani"
-artifact = "xz"
-version = "1.9"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.avro"
-artifact = "trevni-core"
-version = "1.11.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1422,15 +1410,27 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.fasterxml.jackson.core"
-artifact = "jackson-core"
-version = "2.12.5"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.eclipse.jetty"
 artifact = "jetty-util"
 version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.32"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.tukaani"
+artifact = "xz"
+version = "1.9"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.xerial.snappy"
+artifact = "snappy-java"
+version = "1.1.8.4"
 packaging = "jar"
 
 
@@ -1666,9 +1666,9 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-server"
-version = "9.4.43.v20210629"
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1684,9 +1684,9 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
+group = "org.eclipse.jetty"
+artifact = "jetty-server"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1772,15 +1772,9 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-security"
-version = "9.4.43.v20210629"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.eclipse.jetty"
-artifact = "jetty-server"
-version = "9.4.43.v20210629"
+group = "javax.servlet"
+artifact = "javax.servlet-api"
+version = "3.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1796,9 +1790,15 @@ version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "javax.servlet"
-artifact = "javax.servlet-api"
-version = "3.1.0"
+group = "org.eclipse.jetty"
+artifact = "jetty-security"
+version = "9.4.43.v20210629"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.eclipse.jetty"
+artifact = "jetty-server"
+version = "9.4.43.v20210629"
 packaging = "jar"
 
 [[entries.dependencies]]

--- a/src/python/pants/backend/codegen/avro/java/rules.py
+++ b/src/python/pants/backend/codegen/avro/java/rules.py
@@ -154,7 +154,6 @@ async def compile_avro_source(
         overridden_input_digest: Digest | None = None,
         overridden_output_dir: str | None = None,
     ) -> JvmProcess:
-
         return JvmProcess(
             jdk=jdk,
             argv=(

--- a/src/python/pants/backend/codegen/protobuf/python/mypy_protobuf.lock
+++ b/src/python/pants/backend/codegen/protobuf/python/mypy_protobuf.lock
@@ -52,65 +52,60 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "b98d0148f84e3a3c569e19f52103ca1feacdac0d2df8d6533cf983d1fda28462",
-              "url": "https://files.pythonhosted.org/packages/d4/9f/5cb64224bdd4695f5b024a05a4bea31af1d8e3127d45a74161631fe8180e/protobuf-4.21.12-py3-none-any.whl"
+              "hash": "c3325803095fb4c2a48649c321d2fbde59f8fbfcb9bfc7a86df27d112831c571",
+              "url": "https://files.pythonhosted.org/packages/2b/ed/8f2113e3446bc98555cce3a17403180f86c70a51b9e61ef973e9c8df7179/protobuf-4.22.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "299ea899484ee6f44604deb71f424234f654606b983cb496ea2a53e3c63ab791",
-              "url": "https://files.pythonhosted.org/packages/05/b6/6e9b82445e3561132a871e38f5601b12749beb5305eaa085d7f0c59728c9/protobuf-4.21.12-cp37-abi3-macosx_10_9_universal2.whl"
+              "hash": "e894e9ae603e963f0842498c4cd5d39c6a60f0d7e4c103df50ee939564298658",
+              "url": "https://files.pythonhosted.org/packages/1e/bf/54a989c36c1f2486d9b16f9ae423ca0060710a92408f1fed1a30c0368f85/protobuf-4.22.0-cp37-abi3-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d1736130bce8cf131ac7957fa26880ca19227d4ad68b4888b3be0dea1f95df97",
-              "url": "https://files.pythonhosted.org/packages/76/74/28f42d3e6b0c7bffaa04348a631de7a22c3d81d1564753301d058c80fff5/protobuf-4.21.12-cp37-abi3-manylinux2014_aarch64.whl"
+              "hash": "7c535d126e7dcc714105ab20b418c4fedbd28f8b8afc42b7350b1e317bbbcc71",
+              "url": "https://files.pythonhosted.org/packages/7f/cf/7ae0168ab8b18b2ecbf5f1443d200c3ea5b71b9723443319abdde781335a/protobuf-4.22.0-cp37-abi3-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7cd532c4566d0e6feafecc1059d04c7915aec8e182d1cf7adee8b24ef1e2e6ab",
-              "url": "https://files.pythonhosted.org/packages/ba/dd/f8a01b146bf45ac12a829bbc599e6590aa6a6849ace7d28c42d77041d6ab/protobuf-4.21.12.tar.gz"
+              "hash": "86c3d20428b007537ba6792b475c0853bba7f66b1f60e610d913b77d94b486e4",
+              "url": "https://files.pythonhosted.org/packages/89/80/d5fc86e6d6761e353b67e616be29224c17a66064ffced0c6f2e3829e3dd8/protobuf-4.22.0-cp37-abi3-manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a53fd3f03e578553623272dc46ac2f189de23862e68565e83dde203d41b76fc5",
-              "url": "https://files.pythonhosted.org/packages/c6/3b/33f3bd47dbfdd17ed87024b6473b26ee3a8c3303f019e91557b2654703a4/protobuf-4.21.12-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "78a28c9fa223998472886c77042e9b9afb6fe4242bd2a2a5aced88e3f4422aa7",
-              "url": "https://files.pythonhosted.org/packages/e7/a2/3273c05fc5d959fa90de6453ebd6d45c6d4fab3ec212d631625ea5780921/protobuf-4.21.12-cp37-abi3-manylinux2014_x86_64.whl"
+              "hash": "652d8dfece122a24d98eebfef30e31e455d300efa41999d1182e015984ac5930",
+              "url": "https://files.pythonhosted.org/packages/f6/95/797a257a5db4a91dc2bc864c487ead56440014d741933a28c86d966b949e/protobuf-4.22.0.tar.gz"
             }
           ],
           "project_name": "protobuf",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.21.12"
+          "version": "4.22.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aeefcf39d637016998b3c7b699750847071b555f7c2e0c9873d42ab6103d1a39",
-              "url": "https://files.pythonhosted.org/packages/fa/e0/f2702df79f66d872532ce39227144264892afc75d28ce2e361145ddd79ca/types_protobuf-4.21.0.2-py3-none-any.whl"
+              "hash": "1e59294618c9518f35f17ae1a3d866cdf7e998eb4b9907d41e9ebe5b84fde636",
+              "url": "https://files.pythonhosted.org/packages/91/f6/f73471cf2b6fc6deba2a18f78f3ff3f57a6c6e9fd515bef0591932c330e7/types_protobuf-4.22.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7df483d34ad3fcb1fa7fff1073560d596c9ac1f419cfa851b220c9a93386c998",
-              "url": "https://files.pythonhosted.org/packages/76/1f/42d910af25cee072790184965704f1ea5c8e4a8210aeae9d4a29d752a3fc/types-protobuf-4.21.0.2.tar.gz"
+              "hash": "bf2b414d815dc387c0a041d9207db054c7cdb94591bb233d9b71a85243e05efc",
+              "url": "https://files.pythonhosted.org/packages/25/c5/f1a63233ff535f83fa40f19454472612d34cedf486f1d264c8215bc020d0/types-protobuf-4.22.0.0.tar.gz"
             }
           ],
           "project_name": "types-protobuf",
           "requires_dists": [],
           "requires_python": null,
-          "version": "4.21.0.2"
+          "version": "4.22.0.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "mypy-protobuf==3.4.0"

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_module_mapper.py
@@ -41,7 +41,6 @@ async def map_protobuf_to_python_modules(
     python_setup: PythonSetup,
     _: PythonProtobufMappingMarker,
 ) -> FirstPartyPythonMappingImpl:
-
     stripped_file_per_target = await MultiGet(
         Get(StrippedFileName, StrippedFileNameRequest(tgt[ProtobufSourceField].file_path))
         for tgt in protobuf_targets

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -74,6 +74,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
     help = "Configuration of the mypy-protobuf type stub generation plugin."
 
     default_version = "mypy-protobuf==3.4.0"
+    default_requirements = ["mypy-protobuf>=3.4.0,<4"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt
+++ b/src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt
@@ -115,27 +115,27 @@ version = "0.9.3"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
+group = "com.google.protobuf"
+artifact = "protobuf-java"
+version = "3.15.8"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.thesamet.scalapb"
+artifact = "protoc-bridge_2.13"
+version = "0.9.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -151,15 +151,15 @@ version = "26"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.google.protobuf"
-artifact = "protobuf-java"
-version = "3.15.8"
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.thesamet.scalapb"
-artifact = "protoc-bridge_2.13"
-version = "0.9.3"
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 
@@ -227,45 +227,9 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "io.github.alexarchambault"
-artifact = "concurrent-reference-hash-map"
-version = "1.0.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.argonaut"
-artifact = "argonaut_2.13"
-version = "6.2.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier-util_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.fusesource.jansi"
-artifact = "jansi"
-version = "1.18"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.1"
+group = "com.chuusai"
+artifact = "shapeless_2.13"
+version = "2.3.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -275,9 +239,9 @@ version = "1.2.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.chuusai"
-artifact = "shapeless_2.13"
-version = "2.3.3"
+group = "com.thesamet.scalapb"
+artifact = "protoc-bridge_2.13"
+version = "0.9.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -287,9 +251,9 @@ version = "26"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "io.github.alexarchambault.windows-ansi"
-artifact = "windows-ansi"
-version = "0.0.3"
+group = "io.argonaut"
+artifact = "argonaut_2.13"
+version = "6.2.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -305,9 +269,45 @@ version = "2.0.16"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.thesamet.scalapb"
-artifact = "protoc-bridge_2.13"
-version = "0.9.3"
+group = "io.get-coursier"
+artifact = "coursier-util_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault.windows-ansi"
+artifact = "windows-ansi"
+version = "0.0.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault"
+artifact = "concurrent-reference-hash-map"
+version = "1.0.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.fusesource.jansi"
+artifact = "jansi"
+version = "1.18"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.1"
 packaging = "jar"
 
 
@@ -340,15 +340,15 @@ version = "0.9.3"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "dev.dirs"
 artifact = "directories"
 version = "26"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 
@@ -369,21 +369,15 @@ version = "0.11.6"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "io.get-coursier"
-artifact = "coursier_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.thesamet.scalapb"
 artifact = "protoc-cache-coursier_2.13"
 version = "0.9.3"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
+group = "io.get-coursier"
+artifact = "coursier_2.13"
+version = "2.0.16"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -392,82 +386,10 @@ artifact = "scala-collection-compat_2.13"
 version = "2.5.0"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "com.thesamet.scalapb"
-artifact = "compilerplugin_2.13"
-version = "0.11.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.github.alexarchambault"
-artifact = "concurrent-reference-hash-map"
-version = "1.0.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.thesamet.scalapb"
-artifact = "protoc-cache-coursier_2.13"
-version = "0.9.3"
-packaging = "jar"
-
-[[entries.dependencies]]
+[[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.argonaut"
-artifact = "argonaut_2.13"
-version = "6.2.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier-util_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.fusesource.jansi"
-artifact = "jansi"
-version = "1.18"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.alexarchambault"
-artifact = "argonaut-shapeless_6.2_2.13"
-version = "1.2.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.thesamet.scalapb"
-artifact = "protoc-gen_2.13"
-version = "0.9.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -477,21 +399,9 @@ version = "2.3.3"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "dev.dirs"
-artifact = "directories"
-version = "26"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.github.alexarchambault.windows-ansi"
-artifact = "windows-ansi"
-version = "0.0.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier-cache_2.13"
-version = "2.0.16"
+group = "com.github.alexarchambault"
+artifact = "argonaut-shapeless_6.2_2.13"
+version = "1.2.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -501,15 +411,105 @@ version = "3.15.8"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier-core_2.13"
-version = "2.0.16"
+group = "com.thesamet.scalapb"
+artifact = "compilerplugin_2.13"
+version = "0.11.6"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "com.thesamet.scalapb"
 artifact = "protoc-bridge_2.13"
 version = "0.9.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.thesamet.scalapb"
+artifact = "protoc-cache-coursier_2.13"
+version = "0.9.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.thesamet.scalapb"
+artifact = "protoc-gen_2.13"
+version = "0.9.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "dev.dirs"
+artifact = "directories"
+version = "26"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.argonaut"
+artifact = "argonaut_2.13"
+version = "6.2.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier-cache_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier-core_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier-util_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault.windows-ansi"
+artifact = "windows-ansi"
+version = "0.0.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault"
+artifact = "concurrent-reference-hash-map"
+version = "1.0.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.fusesource.jansi"
+artifact = "jansi"
+version = "1.18"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.1"
 packaging = "jar"
 
 
@@ -544,14 +544,14 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.1"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
+artifact = "scala-reflect"
+version = "2.13.1"
 packaging = "jar"
 
 
@@ -584,21 +584,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "io.get-coursier"
 artifact = "coursier-util_2.13"
 version = "2.0.16"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
+group = "io.github.alexarchambault.windows-ansi"
+artifact = "windows-ansi"
+version = "0.0.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -608,9 +602,15 @@ version = "1.18"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "io.github.alexarchambault.windows-ansi"
-artifact = "windows-ansi"
-version = "0.0.3"
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 
@@ -637,33 +637,15 @@ version = "1.0.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.github.alexarchambault"
-artifact = "concurrent-reference-hash-map"
-version = "1.0.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -673,9 +655,27 @@ version = "2.0.16"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "io.github.alexarchambault"
+artifact = "concurrent-reference-hash-map"
+version = "1.0.0"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.scala-lang.modules"
 artifact = "scala-collection-compat_2.13"
 version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 
@@ -690,18 +690,12 @@ serialized_bytes_length = 1295823
 [[entries]]
 file_name = "io.get-coursier_coursier-util_2.13_2.0.16.jar"
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.6"
@@ -711,6 +705,12 @@ packaging = "jar"
 group = "org.scala-lang.modules"
 artifact = "scala-collection-compat_2.13"
 version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
 packaging = "jar"
 
 
@@ -749,51 +749,9 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "io.github.alexarchambault"
-artifact = "concurrent-reference-hash-map"
-version = "1.0.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.argonaut"
-artifact = "argonaut_2.13"
-version = "6.2.5"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.get-coursier"
-artifact = "coursier-util_2.13"
-version = "2.0.16"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.fusesource.jansi"
-artifact = "jansi"
-version = "1.18"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.1"
+group = "com.chuusai"
+artifact = "shapeless_2.13"
+version = "2.3.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -803,15 +761,9 @@ version = "1.2.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.chuusai"
-artifact = "shapeless_2.13"
-version = "2.3.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "io.github.alexarchambault.windows-ansi"
-artifact = "windows-ansi"
-version = "0.0.3"
+group = "io.argonaut"
+artifact = "argonaut_2.13"
+version = "6.2.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -824,6 +776,54 @@ packaging = "jar"
 group = "io.get-coursier"
 artifact = "coursier-core_2.13"
 version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.get-coursier"
+artifact = "coursier-util_2.13"
+version = "2.0.16"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault.windows-ansi"
+artifact = "windows-ansi"
+version = "0.0.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "io.github.alexarchambault"
+artifact = "concurrent-reference-hash-map"
+version = "1.0.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.fusesource.jansi"
+artifact = "jansi"
+version = "1.18"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.1"
 packaging = "jar"
 
 

--- a/src/python/pants/backend/codegen/thrift/scrooge/scrooge.default.lockfile.txt
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scrooge.default.lockfile.txt
@@ -86,42 +86,6 @@ serialized_bytes_length = 2228009
 [[entries]]
 file_name = "com.twitter_scrooge-generator_2.13_21.12.0.jar"
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-parser-combinators_2.13"
-version = "1.1.2"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "com.google.code.findbugs"
-artifact = "jsr305"
-version = "2.0.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.apache.thrift"
-artifact = "libthrift"
-version = "0.10.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.codehaus.plexus"
-artifact = "plexus-utils"
-version = "1.5.4"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "commons-cli"
-artifact = "commons-cli"
-version = "1.3.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.github.scopt"
 artifact = "scopt_2.13"
 version = "4.0.0-RC2"
@@ -133,40 +97,58 @@ artifact = "compiler"
 version = "0.8.18"
 packaging = "jar"
 
-[[entries.dependencies]]
+[[entries.directDependencies]]
+group = "com.google.code.findbugs"
+artifact = "jsr305"
+version = "2.0.1"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "commons-cli"
+artifact = "commons-cli"
+version = "1.3.1"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.apache.thrift"
+artifact = "libthrift"
+version = "0.10.0"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.codehaus.plexus"
+artifact = "plexus-utils"
+version = "1.5.4"
+packaging = "jar"
+
+[[entries.directDependencies]]
 group = "org.scala-lang.modules"
 artifact = "scala-parser-combinators_2.13"
 version = "1.1.2"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.scopt"
+artifact = "scopt_2.13"
+version = "4.0.0-RC2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.github.spullara.mustache.java"
+artifact = "compiler"
+version = "0.8.18"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "com.google.code.findbugs"
 artifact = "jsr305"
 version = "2.0.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.12"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "commons-logging"
-artifact = "commons-logging"
-version = "1.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.thrift"
-artifact = "libthrift"
-version = "0.10.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.codehaus.plexus"
-artifact = "plexus-utils"
-version = "1.5.4"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -188,9 +170,39 @@ version = "1.9"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "commons-logging"
+artifact = "commons-logging"
+version = "1.2"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.apache.httpcomponents"
 artifact = "httpclient"
 version = "4.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.httpcomponents"
+artifact = "httpcore"
+version = "4.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.apache.thrift"
+artifact = "libthrift"
+version = "0.10.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.codehaus.plexus"
+artifact = "plexus-utils"
+version = "1.5.4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-parser-combinators_2.13"
+version = "1.1.2"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -200,21 +212,9 @@ version = "2.13.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.github.scopt"
-artifact = "scopt_2.13"
-version = "4.0.0-RC2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.spullara.mustache.java"
-artifact = "compiler"
-version = "0.8.18"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apache.httpcomponents"
-artifact = "httpcore"
-version = "4.4.1"
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.12"
 packaging = "jar"
 
 
@@ -346,21 +346,15 @@ version = "1.7.12"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.slf4j"
-artifact = "slf4j-api"
-version = "1.7.12"
+group = "commons-codec"
+artifact = "commons-codec"
+version = "1.9"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "commons-logging"
 artifact = "commons-logging"
 version = "1.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "commons-codec"
-artifact = "commons-codec"
-version = "1.9"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -373,6 +367,12 @@ packaging = "jar"
 group = "org.apache.httpcomponents"
 artifact = "httpcore"
 version = "4.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.slf4j"
+artifact = "slf4j-api"
+version = "1.7.12"
 packaging = "jar"
 
 

--- a/src/python/pants/backend/docker/subsystems/dockerfile.lock
+++ b/src/python/pants/backend/docker/subsystems/dockerfile.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "dockerfile==3.2.0"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -49,14 +53,15 @@
           "project_name": "dockerfile",
           "requires_dists": [],
           "requires_python": ">=3.6.1",
-          "version": "3.2"
+          "version": "3.2.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "dockerfile==3.2.0"

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -44,6 +44,7 @@ class DockerfileParser(PythonToolRequirementsBase):
     help = "Used to parse Dockerfile build specs to infer their dependencies."
 
     default_version = "dockerfile==3.2.0"
+    default_requirements = ["dockerfile>=3.2.0,<4"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/go/subsystems/golang.py
+++ b/src/python/pants/backend/go/subsystems/golang.py
@@ -23,7 +23,6 @@ class GolangSubsystem(Subsystem):
     help = "Options for Golang support."
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
-
         env_vars_used_by_options = ("PATH",)
 
         _go_search_paths = StrListOption(

--- a/src/python/pants/backend/go/util_rules/go_bootstrap.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap.py
@@ -27,7 +27,6 @@ class GoBootstrap:
 async def _go_search_paths(
     env_tgt: EnvironmentTarget, golang_subsystem: GolangSubsystem, paths: Iterable[str]
 ) -> tuple[str, ...]:
-
     resolve_standard, resolve_local = "<ASDF>" in paths, "<ASDF_LOCAL>" in paths
 
     if resolve_standard or resolve_local:
@@ -113,7 +112,6 @@ def _error_if_not_compatible_with_asdf(
 async def resolve_go_bootstrap(
     golang_subsystem: GolangSubsystem, golang_env_aware: GolangSubsystem.EnvironmentAware
 ) -> GoBootstrap:
-
     _error_if_not_compatible_with_asdf(
         golang_env_aware.env_tgt, golang_env_aware.raw_go_search_paths
     )

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -279,7 +279,6 @@ class GoogleCloudFunctionTypes(Enum):
 
 
 class PythonGoogleCloudFunctionType(StringField):
-
     alias = "type"
     required = True
     valid_choices = GoogleCloudFunctionTypes

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -87,7 +87,7 @@ async def analyse_deployment(request: AnalyseHelmDeploymentRequest) -> HelmDeplo
     # Build YAML index of Docker image refs for future processing during depedendecy inference or post-rendering.
     image_refs_index: MutableYamlIndex[str] = MutableYamlIndex()
     for manifest in parsed_manifests:
-        for (idx, path, image_ref) in manifest.found_image_refs:
+        for idx, path, image_ref in manifest.found_image_refs:
             image_refs_index.insert(
                 file_path=PurePath(manifest.filename),
                 document_index=idx,

--- a/src/python/pants/backend/helm/goals/deploy.py
+++ b/src/python/pants/backend/helm/goals/deploy.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class DeployHelmDeploymentFieldSet(HelmDeploymentFieldSet, DeployFieldSet):
-
     timeout: HelmDeploymentTimeoutField
 
 

--- a/src/python/pants/backend/helm/resolve/artifacts.py
+++ b/src/python/pants/backend/helm/resolve/artifacts.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Iterable, cast
 
@@ -42,8 +42,9 @@ class DuplicateHelmChartNamesFound(Exception):
 
 class HelmArtifactLocationSpec(ABC):
     @property
+    @abstractmethod
     def spec(self) -> str:
-        pass
+        ...
 
     @property
     def is_url(self) -> bool:

--- a/src/python/pants/backend/helm/subsystems/BUILD
+++ b/src/python/pants/backend/helm/subsystems/BUILD
@@ -13,7 +13,7 @@ python_tests(name="tests")
 python_requirement(
     name="yamlpath",
     requirements=[
-        "yamlpath>=3.6,<3.7",
+        "yamlpath>=3.7,<4",
         "ruamel.yaml>=0.15.96,!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.21",
     ],
     resolve="helm-post-renderer",

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.lock
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.lock
@@ -31,22 +31,22 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ad924b42c2e27a1ac58e432166cc4588f5b80747de02d0d35b1ecbd3e7d57207",
-              "url": "https://files.pythonhosted.org/packages/2a/c0/a1372bd95578778aae8dc5359e4f8ec03a94479d2f36e30543298d30c48a/autopep8-2.0.0-py2.py3-none-any.whl"
+              "hash": "86e9303b5e5c8160872b2f5ef611161b2893e9bfe8ccc7e2f76385947d57a2f1",
+              "url": "https://files.pythonhosted.org/packages/3c/24/4eadb64c81c10b354b0c2b6a54a3542c3ce112954cc4effff038beafb009/autopep8-2.0.2-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8b1659c7f003e693199f52caffdc06585bb0716900bbc6a7442fd931d658c077",
-              "url": "https://files.pythonhosted.org/packages/ac/71/48b7fde78ef09f4636a9b81f926b879d0230f90768483c441f22059d2474/autopep8-2.0.0.tar.gz"
+              "hash": "f9849cdd62108cb739dbcdbfb7fdcc9a30d1b63c4cc3e1c1f893b5360941b61c",
+              "url": "https://files.pythonhosted.org/packages/b2/03/49cb49b37a4d51721ece9c628eb9441f9a4e26ee98ad6e5505238d5b2d7a/autopep8-2.0.2.tar.gz"
             }
           ],
           "project_name": "autopep8",
           "requires_dists": [
-            "pycodestyle>=2.9.1",
-            "tomli"
+            "pycodestyle>=2.10.0",
+            "tomli; python_version < \"3.11\""
           ],
-          "requires_python": null,
-          "version": "2.0.0"
+          "requires_python": ">=3.6",
+          "version": "2.0.2"
         },
         {
           "artifacts": [
@@ -154,19 +154,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f9f17d2aec496a9aa6b76f53e3b614c965223c061982d434d160f930c698a9db",
-              "url": "https://files.pythonhosted.org/packages/68/aa/5fc646cae6e997c3adf3b0a7e257cda75cff21fcba15354dffd67789b7bb/cachetools-5.2.0-py3-none-any.whl"
+              "hash": "429e1a1e845c008ea6c85aa35d4b98b65d6a9763eeef3e37e92728a12d1de9d4",
+              "url": "https://files.pythonhosted.org/packages/db/14/2b48a834d349eee94677e8702ea2ef98b7c674b090153ea8d3f6a788584e/cachetools-5.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a94c6402995a99c3970cc7e4884bb60b4a8639938157eeed436098bf9831757",
-              "url": "https://files.pythonhosted.org/packages/c2/6f/278225c5a070a18a76f85db5f1238f66476579fa9b04cda3722331dcc90f/cachetools-5.2.0.tar.gz"
+              "hash": "13dfddc7b8df938c21a940dfa6557ce6e94a2f1cdfa58eb90c805721d58f2c14",
+              "url": "https://files.pythonhosted.org/packages/4d/91/5837e9f9e77342bb4f3ffac19ba216eef2cd9b77d67456af420e7bafe51d/cachetools-5.3.0.tar.gz"
             }
           ],
           "project_name": "cachetools",
           "requires_dists": [],
           "requires_python": "~=3.7",
-          "version": "5.2.0"
+          "version": "5.3.0"
         },
         {
           "artifacts": [
@@ -190,21 +190,329 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f",
-              "url": "https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl"
+              "hash": "3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
+              "url": "https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
-              "url": "https://files.pythonhosted.org/packages/a1/34/44964211e5410b051e4b8d2869c470ae8a68ae274953b1c7de6d98bbcf94/charset-normalizer-2.1.1.tar.gz"
+              "hash": "3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
+              "url": "https://files.pythonhosted.org/packages/00/47/f14533da238134f5067fb1d951eb03d5c4be895d6afb11c7ebd07d111acb/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
+              "url": "https://files.pythonhosted.org/packages/01/c7/0407de35b70525dba2a58a2724a525cf882ee76c3d2171d834463c5d2881/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
+              "url": "https://files.pythonhosted.org/packages/0a/67/8d3d162ec6641911879651cdef670c3c6136782b711d7f8e82e2fffe06e0/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
+              "url": "https://files.pythonhosted.org/packages/12/12/c5c39f5a149cd6788d2e40cea5618bae37380e2754fcdf53dc9e01bdd33a/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
+              "url": "https://files.pythonhosted.org/packages/12/68/4812f9b05ac0a2b7619ac3dd7d7e3fc52c12006b84617021c615fc2fcf42/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
+              "url": "https://files.pythonhosted.org/packages/13/b7/21729a6d512246aa0bb872b90aea0d9fcd1b293762cdb1d1d33c01140074/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
+              "url": "https://files.pythonhosted.org/packages/16/58/19fd2f62e6ff44ba0db0cd44b584790555e2cde09293149f4409d654811b/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
+              "url": "https://files.pythonhosted.org/packages/18/36/7ae10a3dd7f9117b61180671f8d1e4802080cca88ad40aaabd3dad8bab0e/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
+              "url": "https://files.pythonhosted.org/packages/1c/9b/de2adc43345623da8e7c958719528a42b6d87d2601017ce1187d43b8a2d7/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
+              "url": "https://files.pythonhosted.org/packages/1f/be/c6c76cf8fcf6918922223203c83ba8192eff1c6a709e8cfec7f5ca3e7d2d/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
+              "url": "https://files.pythonhosted.org/packages/21/16/1b0d8fdcb81bbf180976af4f867ce0f2244d303ab10d452fde361dec3b5c/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
+              "url": "https://files.pythonhosted.org/packages/23/13/cf5d7bb5bc95f120df64d6c470581189df51d7f011560b2a06a395b7a120/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
+              "url": "https://files.pythonhosted.org/packages/2c/2f/ec805104098085728b7cb610deede7195c6fa59f51942422f02cc427b6f6/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
+              "url": "https://files.pythonhosted.org/packages/31/8b/81c3515a69d06b501fcce69506af57a7a19bd9f42cabd1a667b1b40f2c55/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
+              "url": "https://files.pythonhosted.org/packages/33/10/c87ba15f779f8251ae55fa147631339cd91e7af51c3c133d2687c6e41800/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
+              "url": "https://files.pythonhosted.org/packages/33/97/9967fb2d364a9da38557e4af323abcd58cc05bdd8f77e9fd5ae4882772cc/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
+              "url": "https://files.pythonhosted.org/packages/45/3d/fa2683f5604f99fba5098a7313e5d4846baaecbee754faf115907f21a85f/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
+              "url": "https://files.pythonhosted.org/packages/4e/11/f7077d78b18aca8ea3186a706c0221aa2bc34c442a3d3bdf3ad401a29052/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
+              "url": "https://files.pythonhosted.org/packages/4f/18/92866f050f7114ba38aba4f4a69f83cc2a25dc2e5a8af4b44fd1bfd6d528/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
+              "url": "https://files.pythonhosted.org/packages/4f/7c/af43743567a7da2a069b4f9fa31874c3c02b963cd1fb84fe1e7568a567e6/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
+              "url": "https://files.pythonhosted.org/packages/4f/a2/9031ba4a008e11a21d7b7aa41751290d2f2035a2f14ecb6e589771a17c47/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
+              "url": "https://files.pythonhosted.org/packages/56/24/5f2dedcf3d0673931b6200c410832ae44b376848bc899dbf1fa6c91c4ebe/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
+              "url": "https://files.pythonhosted.org/packages/5d/2b/4d8c80400c04ae3c8dbc847de092e282b5c7b17f8f9505d68bb3e5815c71/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
+              "url": "https://files.pythonhosted.org/packages/61/e3/ad9ae58b28482d1069eba1edec2be87701f5dd6fd6024a665020d66677a0/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
+              "url": "https://files.pythonhosted.org/packages/67/30/dbab1fe5ab2ce5d3d517ad9936170d896e9687f3860a092519f1fe359812/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
+              "url": "https://files.pythonhosted.org/packages/67/df/660e9665ace7ad711e275194a86cb757fb4d4e513fae5ff3d39573db4984/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
+              "url": "https://files.pythonhosted.org/packages/68/77/af702eba147ba963b27eb00832cef6b8c4cb9fcf7404a476993876434b93/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
+              "url": "https://files.pythonhosted.org/packages/69/22/66351781e668158feef71c5e3b059a79ecc9efc3ef84a45888b0f3a933d5/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
+              "url": "https://files.pythonhosted.org/packages/6d/59/59a3f4d8a59ee270da77f9e954a0e284c9d6884d39ec69d696d9aa5ff2f2/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
+              "url": "https://files.pythonhosted.org/packages/72/90/667a6bc6abe42fc10adf4cd2c1e1c399d78e653dbac4c8018350843d4ab7/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
+              "url": "https://files.pythonhosted.org/packages/74/5f/361202de730532028458b729781b8435f320e31a622c27f30e25eec80513/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
+              "url": "https://files.pythonhosted.org/packages/74/f1/d0b8385b574f7e086fb6709e104b696707bd3742d54a6caf0cebbb7e975b/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
+              "url": "https://files.pythonhosted.org/packages/82/b9/51b66a647be8685dee75b7807e0f750edf5c1e4f29bc562ad285c501e3c7/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
+              "url": "https://files.pythonhosted.org/packages/84/23/f60cda6c70ae922ad78368982f06e7fef258fba833212f26275fe4727dc4/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
+              "url": "https://files.pythonhosted.org/packages/85/e8/18d408d8fe29a56012c10d6b15960940b83f06620e9d7481581cdc6d9901/charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
+              "url": "https://files.pythonhosted.org/packages/94/70/23981e7bf098efbc4037e7c66d28a10e950d9296c08c6dea8ef290f9c79e/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
+              "url": "https://files.pythonhosted.org/packages/9a/f1/ff81439aa09070fee64173e6ca6ce1342f2b1cca997bcaae89e443812684/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
+              "url": "https://files.pythonhosted.org/packages/9e/62/a1e0a8f8830c92014602c8a88a1a20b8a68d636378077381f671e6e1cec9/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
+              "url": "https://files.pythonhosted.org/packages/a2/6c/5167f08da5298f383036c33cb749ab5b3405fd07853edc8314c6882c01b8/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
+              "url": "https://files.pythonhosted.org/packages/a4/03/355281b62c26712a50c6a9dd75339d8cdd58488fd7bf2556ba1320ebd315/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
+              "url": "https://files.pythonhosted.org/packages/a9/83/138d2624fdbcb62b7e14715eb721d44347e41a1b4c16544661e940793f49/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
+              "url": "https://files.pythonhosted.org/packages/ac/7f/62d5dff4e9cb993e4b0d4ea78a74cc84d7d92120879529e0ce0965765936/charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+              "url": "https://files.pythonhosted.org/packages/ac/c5/990bc41a98b7fa2677c665737fdf278bb74ad4b199c56b6b564b3d4cbfc5/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
+              "url": "https://files.pythonhosted.org/packages/b0/55/d8ef4c8c7d2a8b3a16e7d9b03c59475c2ee96a0e0c90b14c99faaac0ee3b/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
+              "url": "https://files.pythonhosted.org/packages/bb/dc/58fdef3ab85e8e7953a8b89ef1d2c06938b8ad88d9617f22967e1a90e6b8/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
+              "url": "https://files.pythonhosted.org/packages/c2/35/dfb4032f5712747d3dcfdd19d0768f6d8f60910ae24ed066ecbf442be013/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
+              "url": "https://files.pythonhosted.org/packages/c6/ab/43ea052756b2f2dcb6a131897811c0e2704b0288f090336217d3346cd682/charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
+              "url": "https://files.pythonhosted.org/packages/c9/8c/a76dd9f2c8803eb147e1e715727f5c3ba0ef39adaadf66a7b3698c113180/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
+              "url": "https://files.pythonhosted.org/packages/cc/f6/21a66e524658bd1dd7b89ac9d1ee8f7823f2d9701a2fbc458ab9ede53c63/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
+              "url": "https://files.pythonhosted.org/packages/d5/92/86c0f0e66e897f6818c46dadef328a5b345d061688f9960fc6ca1fd03dbe/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
+              "url": "https://files.pythonhosted.org/packages/d7/4c/37ad75674e8c6bc22ab01bef673d2d6e46ee44203498c9a26aa23959afe5/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
+              "url": "https://files.pythonhosted.org/packages/d8/ca/a7ff600781bf1e5f702ba26bb82f2ba1d3a873a3f8ad73cc44c79dfaefa9/charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
+              "url": "https://files.pythonhosted.org/packages/dd/39/6276cf5a395ffd39b77dadf0e2fcbfca8dbfe48c56ada250c40086055143/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
+              "url": "https://files.pythonhosted.org/packages/e1/7c/398600268fc98b7e007f5a716bd60903fff1ecff75e45f5700212df5cd76/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
+              "url": "https://files.pythonhosted.org/packages/e1/b4/53678b2a14e0496fc167fe9b9e726ad33d670cfd2011031aa5caeee6b784/charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
+              "url": "https://files.pythonhosted.org/packages/e5/aa/9d2d60d6a566423da96c15cd11cbb88a70f9aff9a4db096094ee19179cab/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
+              "url": "https://files.pythonhosted.org/packages/ea/38/d31c7906c4be13060c1a5034087966774ef33ab57ff2eee76d71265173c3/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab",
+              "url": "https://files.pythonhosted.org/packages/f2/b7/e21e16c98575616f4ce09dc766dbccdac0ca119c176b184d46105e971a84/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
+              "url": "https://files.pythonhosted.org/packages/f2/d7/6ee92c11eda3f3c9cac1e059901092bfdf07388be7d2e60ac627527eee62/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
+              "url": "https://files.pythonhosted.org/packages/f4/0a/8c03913ed1eca9d831db0c28759edb6ce87af22bb55dbc005a52525a75b6/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
+              "url": "https://files.pythonhosted.org/packages/f6/0f/de1c4030fd669e6719277043e3b0f152a83c118dd1020cf85b51d443d04a/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
+              "url": "https://files.pythonhosted.org/packages/f8/ed/500609cb2457b002242b090c814549997424d72690ef3058cfdfca91f68b/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
+              "url": "https://files.pythonhosted.org/packages/fa/8e/2e5c742c3082bce3eea2ddd5b331d08050cda458bc362d71c48e07a44719/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl"
             }
           ],
           "project_name": "charset-normalizer",
-          "requires_dists": [
-            "unicodedata2; extra == \"unicode_backport\""
-          ],
-          "requires_python": ">=3.6.0",
-          "version": "2.1.1"
+          "requires_dists": [],
+          "requires_python": ">=3.7.0",
+          "version": "3.1.0"
         },
         {
           "artifacts": [
@@ -231,13 +539,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6897b93556d8d807ad70701bb89f000183aea366ca7ed94680828b37437a4994",
-              "url": "https://files.pythonhosted.org/packages/59/18/f8201fa70cbc7bebc14a50e891783c88c277a9158e9c8c07a9044ecd98eb/google_auth-2.15.0-py2.py3-none-any.whl"
+              "hash": "2fef3cf94876d1a0e204afece58bb4d83fb57228aaa366c64045039fda6770a2",
+              "url": "https://files.pythonhosted.org/packages/93/c4/16f8ad44ed7544244a9883f35cc99dc96378652a0ec7cc39028b1c697a1e/google_auth-2.16.2-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "72f12a6cfc968d754d7bdab369c5c5c16032106e52d32c6dfd8484e4c01a6d1f",
-              "url": "https://files.pythonhosted.org/packages/52/a6/72c80f4a0b37c2c32d35636b2373bdf07c1dad81b109f9361742d3aa1cbe/google-auth-2.15.0.tar.gz"
+              "hash": "07e14f34ec288e3f33e00e2e3cc40c8942aa5d4ceac06256a28cd8e786591420",
+              "url": "https://files.pythonhosted.org/packages/09/be/56d3c1db93d85e53ffa4eb26a2f41b0df9ba00317ee1f253121c63489d03/google-auth-2.16.2.tar.gz"
             }
           ],
           "project_name": "google-auth",
@@ -252,12 +560,13 @@
             "pyopenssl>=20.0.0; extra == \"pyopenssl\"",
             "pyu2f>=0.1.5; extra == \"reauth\"",
             "requests<3.0.0dev,>=2.20.0; extra == \"aiohttp\"",
+            "requests<3.0.0dev,>=2.20.0; extra == \"requests\"",
             "rsa<4.6; python_version < \"3.6\"",
             "rsa<5,>=3.1.4; python_version >= \"3.6\"",
             "six>=1.9.0"
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "2.15.0"
+          "version": "2.16.2"
         },
         {
           "artifacts": [
@@ -299,13 +608,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d84d17e21670ec07990e1044a99efe8d615d860fd176fc29ef5c306068fda313",
-              "url": "https://files.pythonhosted.org/packages/e1/16/1f59f5d87d256012e9cdf0e8af8810965fa253e835cfecce64f4b11d4f2d/importlib_metadata-5.1.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5059f9f1e8e41f80e9c56c2ee58811450c31984dfa625329ffd7c0dad88a73b",
-              "url": "https://files.pythonhosted.org/packages/32/5a/e0d75c8010295ae6746f379f5324bc726076dfc426548bfa6f0763fce870/importlib_metadata-5.1.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -328,12 +637,13 @@
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "5.1.0"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
@@ -370,21 +680,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-              "url": "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl"
+              "hash": "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+              "url": "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
-              "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz"
+              "hash": "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782",
+              "url": "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz"
             }
           ],
           "project_name": "mypy-extensions",
-          "requires_dists": [
-            "typing>=3.5.3; python_version < \"3.5\""
-          ],
-          "requires_python": null,
-          "version": "0.4.3"
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "1.0.0"
         },
         {
           "artifacts": [
@@ -413,46 +721,48 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
-              "url": "https://files.pythonhosted.org/packages/3c/29/c07c3a976dbe37c56e381e058c11e8738cb3a0416fc842a310461f8bb695/pathspec-0.10.3-py3-none-any.whl"
+              "hash": "3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+              "url": "https://files.pythonhosted.org/packages/e6/be/1a973593d7ce7ac9d1a793b81eb265c152a62f34825169fbd7c4e4548e34/pathspec-0.11.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6",
-              "url": "https://files.pythonhosted.org/packages/32/1a/6baf904503c3e943cae9605c9c88a43b964dea5b59785cf956091b341b08/pathspec-0.10.3.tar.gz"
+              "hash": "64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc",
+              "url": "https://files.pythonhosted.org/packages/f4/8e/f91cffb32740b251cff04cad1e7cdd2c710582c735a01f56307316c148f2/pathspec-0.11.0.tar.gz"
             }
           ],
           "project_name": "pathspec",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.10.3"
+          "version": "0.11.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1a89a12377800c81983db6be069ec068eee989748799b946cce2a6e80dcc54ca",
-              "url": "https://files.pythonhosted.org/packages/87/69/cd019a9473bcdfb38983e2d550ccb239264fc4c2fc32c42ac1b1cc2506b6/platformdirs-2.6.0-py3-none-any.whl"
+              "hash": "13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a",
+              "url": "https://files.pythonhosted.org/packages/ca/de/a33823fe54d52ea72fdae011115d737a2642d441c93b68ed17455a328e4c/platformdirs-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b46ffafa316e6b83b47489d240ce17173f123a9b9c83282141c3daf26ad9ac2e",
-              "url": "https://files.pythonhosted.org/packages/ec/4c/9af851448e55c57b30a13a72580306e628c3b431d97fdae9e0b8d4fa3685/platformdirs-2.6.0.tar.gz"
+              "hash": "accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef",
+              "url": "https://files.pythonhosted.org/packages/8f/5f/01180534cebac14f3a792bf2f74fc99d34531c950c308fdebd9721e85550/platformdirs-3.1.0.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
-            "furo>=2022.9.29; extra == \"docs\"",
+            "covdefaults>=2.2.2; extra == \"test\"",
+            "furo>=2022.12.7; extra == \"docs\"",
             "proselint>=0.13; extra == \"docs\"",
             "pytest-cov>=4; extra == \"test\"",
             "pytest-mock>=3.10; extra == \"test\"",
-            "pytest>=7.2; extra == \"test\"",
-            "sphinx-autodoc-typehints>=1.19.4; extra == \"docs\"",
-            "sphinx>=5.3; extra == \"docs\""
+            "pytest>=7.2.1; extra == \"test\"",
+            "sphinx-autodoc-typehints!=1.23.4,>=1.22; extra == \"docs\"",
+            "sphinx>=6.1.3; extra == \"docs\"",
+            "typing-extensions>=4.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "2.6.0"
+          "version": "3.1.0"
         },
         {
           "artifacts": [
@@ -662,13 +972,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
-              "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl"
+              "hash": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+              "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-              "url": "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz"
+              "hash": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
+              "url": "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -676,12 +986,12 @@
             "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
             "certifi>=2017.4.17",
             "chardet<6,>=3.0.2; extra == \"use_chardet_on_py3\"",
-            "charset-normalizer<3,>=2",
+            "charset-normalizer<4,>=2",
             "idna<4,>=2.5",
             "urllib3<1.27,>=1.21.1"
           ],
           "requires_python": "<4,>=3.7",
-          "version": "2.28.1"
+          "version": "2.28.2"
         },
         {
           "artifacts": [
@@ -859,13 +1169,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54",
-              "url": "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75",
-              "url": "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -892,7 +1202,7 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
             "pytest-timeout; extra == \"testing\"",
@@ -904,6 +1214,7 @@
             "sphinx-favicon; extra == \"docs\"",
             "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\"",
@@ -916,7 +1227,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "65.6.3"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
@@ -1046,31 +1357,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
-              "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-              "url": "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.4.0"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "47cc05d99aaa09c9e72ed5809b60e7ba354e64b59c9c173ac3018642d8bb41fc",
-              "url": "https://files.pythonhosted.org/packages/65/0c/cc6644eaa594585e5875f46f3c83ee8762b647b51fc5b0fb253a242df2dc/urllib3-1.26.13-py2.py3-none-any.whl"
+              "hash": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1",
+              "url": "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c083dd0dce68dbfbe1129d5271cb90f9447dea7d52097c6e0126120c521ddea8",
-              "url": "https://files.pythonhosted.org/packages/c2/51/32da03cf19d17d46cce5c731967bf58de9bd71db3a379932f53b094deda4/urllib3-1.26.13.tar.gz"
+              "hash": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+              "url": "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -1087,19 +1398,19 @@
             "urllib3-secure-extra; extra == \"secure\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.26.13"
+          "version": "1.26.14"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d6b06432f184438d99ac1f456eaf22fe1ade524c3dd16e661142dc54e9cba574",
-              "url": "https://files.pythonhosted.org/packages/78/d5/2b5719b738791cd798e8f097eba4bb093ff5efca5cef2f3d37a72daa111f/websocket_client-1.4.2-py3-none-any.whl"
+              "hash": "cdf5877568b7e83aa7cf2244ab56a3213de587bbe0ce9d8b9600fc77b455d89e",
+              "url": "https://files.pythonhosted.org/packages/6d/9a/6c793729c9d48fcca155ce55e4dfafacffb7fb52a62e3ae2198846c31af6/websocket_client-1.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d6e8f90ca8e2dd4e8027c4561adeb9456b54044312dba655e7cae652ceb9ae59",
-              "url": "https://files.pythonhosted.org/packages/75/af/1d13b93e7a21aca7f8ab8645fcfcfad21fc39716dc9dce5dc2a97f73ff78/websocket-client-1.4.2.tar.gz"
+              "hash": "3f09e6d8230892547132177f575a4e3e73cfdf06526e20cc02aa1c3b47184d40",
+              "url": "https://files.pythonhosted.org/packages/8b/94/696484b0c13234c91b316bc3d82d432f9b589a9ef09d016875a31c670b76/websocket-client-1.5.1.tar.gz"
             }
           ],
           "project_name": "websocket-client",
@@ -1111,25 +1422,25 @@
             "wsaccel; extra == \"optional\""
           ],
           "requires_python": ">=3.7",
-          "version": "1.4.2"
+          "version": "1.5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
-              "url": "https://files.pythonhosted.org/packages/d8/20/256eb3f3f437c575fb1a2efdce5e801a5ce3162ea8117da96c43e6ee97d8/zipp-3.11.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766",
-              "url": "https://files.pythonhosted.org/packages/8e/b3/8b16a007184714f71157b1a71bbe632c5d66dd43bc8152b3c799b13881e1/zipp-3.11.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
+            "big-O; extra == \"testing\"",
             "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
@@ -1144,18 +1455,19 @@
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.11.0"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "hikaru==0.11.0b"

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -38,6 +38,7 @@ class HelmKubeParserSubsystem(PythonToolRequirementsBase):
     help = "Analyses K8S manifests rendered by Helm."
 
     default_version = "hikaru==0.11.0b"
+    default_requirements = ["hikaru>=0.11.0b,<1"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.10"]

--- a/src/python/pants/backend/helm/subsystems/post_renderer.lock
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.lock
@@ -10,7 +10,7 @@
 //   ],
 //   "generated_with_requirements": [
 //     "ruamel.yaml!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.21,>=0.15.96",
-//     "yamlpath<3.7,>=3.6"
+//     "yamlpath<4,>=3.7"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -200,13 +200,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3737e8a68d42f287b75683d780a79d0f6da37ee80d7cb31302c5c39465cea4d4",
-              "url": "https://files.pythonhosted.org/packages/3f/ef/2ef83291f0fdd9db472eec6160c58a1971f211ba645e1ca33ad80affef4d/yamlpath-3.6.9-py3-none-any.whl"
+              "hash": "95c03a06c8f80d948eace7711fa2afb24cae35e420b39fb8a314801c43617e40",
+              "url": "https://files.pythonhosted.org/packages/a1/42/f5ea613197aecb2f336d8626ba2471b7f4cc8cd494e4a5cd7e0493ae0c2f/yamlpath-3.7.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80fb151f6c6814186f39a66ee30f6c491ef37caf3eef3443f8e66791c6c30fb8",
-              "url": "https://files.pythonhosted.org/packages/75/2a/ab8cfab5e8446c45268b82dac331b27adcc6eebfe65d627f00dde25758b1/yamlpath-3.6.9.tar.gz"
+              "hash": "73caa5ba7646aa158b3afa6c6ebd7667c658c207981e0c18023aa254060dd773",
+              "url": "https://files.pythonhosted.org/packages/bf/bc/d940c64c5a603a4b4aefa6c053d6dad1a70a360f82da677807ac6d38073c/yamlpath-3.7.0.tar.gz"
             }
           ],
           "project_name": "yamlpath",
@@ -215,19 +215,19 @@
             "ruamel.yaml!=0.17.18,<=0.17.21,>0.17.5"
           ],
           "requires_python": ">3.6.0",
-          "version": "3.6.9"
+          "version": "3.7.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "ruamel.yaml!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.21,>=0.15.96",
-    "yamlpath<3.7,>=3.6"
+    "yamlpath<4,>=3.7"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -48,10 +48,11 @@ class HelmPostRendererSubsystem(PythonToolRequirementsBase):
     options_scope = "helm-post-renderer"
     help = "Used perform modifications to the final output produced by Helm charts when they've been fully rendered."
 
-    default_version = "yamlpath>=3.6,<3.7"
+    default_version = "yamlpath>=3.7.0,<4"
     default_extra_requirements = [
         "ruamel.yaml>=0.15.96,!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.21"
     ]
+    default_requirements = ["yamlpath>=3.6.0,<4", *default_extra_requirements]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.10"]

--- a/src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt
+++ b/src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt
@@ -46,21 +46,21 @@ version = "30.1.1-jre"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.google.guava"
-artifact = "listenablefuture"
-version = "9999.0-empty-to-avoid-conflict-with-guava"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.google.j2objc"
-artifact = "j2objc-annotations"
-version = "1.3"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.google.code.findbugs"
 artifact = "jsr305"
 version = "3.0.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.google.errorprone"
+artifact = "error_prone_annotations"
+version = "2.5.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.google.guava"
+artifact = "failureaccess"
+version = "1.0.1"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -71,14 +71,14 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "com.google.guava"
-artifact = "failureaccess"
-version = "1.0.1"
+artifact = "listenablefuture"
+version = "9999.0-empty-to-avoid-conflict-with-guava"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.google.errorprone"
-artifact = "error_prone_annotations"
-version = "2.5.1"
+group = "com.google.j2objc"
+artifact = "j2objc-annotations"
+version = "1.3"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -112,21 +112,15 @@ serialized_bytes_length = 4617
 [[entries]]
 file_name = "com.google.guava_guava_30.1.1-jre.jar"
 [[entries.directDependencies]]
-group = "com.google.guava"
-artifact = "listenablefuture"
-version = "9999.0-empty-to-avoid-conflict-with-guava"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "com.google.j2objc"
-artifact = "j2objc-annotations"
-version = "1.3"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.google.code.findbugs"
 artifact = "jsr305"
 version = "3.0.2"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "com.google.errorprone"
+artifact = "error_prone_annotations"
+version = "2.5.1"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -136,9 +130,15 @@ version = "1.0.1"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "com.google.errorprone"
-artifact = "error_prone_annotations"
-version = "2.5.1"
+group = "com.google.guava"
+artifact = "listenablefuture"
+version = "9999.0-empty-to-avoid-conflict-with-guava"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "com.google.j2objc"
+artifact = "j2objc-annotations"
+version = "1.3"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -148,21 +148,15 @@ version = "3.8.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.google.guava"
-artifact = "listenablefuture"
-version = "9999.0-empty-to-avoid-conflict-with-guava"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.google.j2objc"
-artifact = "j2objc-annotations"
-version = "1.3"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.google.code.findbugs"
 artifact = "jsr305"
 version = "3.0.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.google.errorprone"
+artifact = "error_prone_annotations"
+version = "2.5.1"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -172,9 +166,15 @@ version = "1.0.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.google.errorprone"
-artifact = "error_prone_annotations"
-version = "2.5.1"
+group = "com.google.guava"
+artifact = "listenablefuture"
+version = "9999.0-empty-to-avoid-conflict-with-guava"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.google.j2objc"
+artifact = "j2objc-annotations"
+version = "1.3"
 packaging = "jar"
 
 [[entries.dependencies]]

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -39,7 +39,6 @@ class PrettierFmtRequest(FmtTargetsRequest):
 
 @rule(level=LogLevel.DEBUG)
 async def prettier_fmt(request: PrettierFmtRequest.Batch, prettier: Prettier) -> FmtResult:
-
     # Look for any/all of the Prettier configuration files
     config_files = await Get(
         ConfigFiles,

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -164,7 +164,10 @@ async def analyze_kotlin_source_dependencies(
     parser_lockfile_request = await Get(
         GenerateJvmLockfileFromTool, KotlinParserToolLockfileSentinel()
     )
-    (tool_classpath, prefixed_source_files_digest,) = await MultiGet(
+    (
+        tool_classpath,
+        prefixed_source_files_digest,
+    ) = await MultiGet(
         Get(
             ToolClasspath,
             ToolClasspathRequest(lockfile=parser_lockfile_request),

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -81,7 +81,6 @@ def find_paths_breadth_first(
 
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
-
     path_from = paths_subsystem.from_
     path_to = paths_subsystem.to
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -475,7 +475,7 @@ async def infer_python_dependencies_via_source(
 
     inferred_deps = import_deps | asset_deps
 
-    _ = await _handle_unowned_imports(
+    await _handle_unowned_imports(
         request.field_set.address,
         python_infer_subsystem.unowned_dependency_behavior,
         python_setup,

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -932,7 +932,6 @@ class TestFindOtherOwners:
         assert not r.value
 
     def test_other_owners_found_in_single_resolve(self, _imports_rule_runner: RuleRunner):
-
         _imports_rule_runner.write_files(
             {
                 "other/BUILD": dedent(
@@ -960,7 +959,6 @@ class TestFindOtherOwners:
         ]
 
     def test_other_owners_found_in_multiple_resolves(self, _imports_rule_runner: RuleRunner):
-
         _imports_rule_runner.write_files(
             {
                 "other/BUILD": dedent(

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -115,8 +115,9 @@ class CoverageSubsystem(PythonToolBase):
     options_scope = "coverage-py"
     help = "Configuration for Python test coverage measurement."
 
-    default_version = "coverage[toml]>=6.5,<6.6"
+    default_version = "coverage[toml]>=6.5,<8"
     default_main = ConsoleScript("coverage")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -97,7 +97,7 @@ class PytestPluginSetup:
 
 
 @union(in_scope_types=[EnvironmentName])
-@dataclass(frozen=True)  # type: ignore[misc]
+@dataclass(frozen=True)
 class PytestPluginSetupRequest(ABC):
     """A request to set up the test environment before Pytest runs, e.g. to set up databases.
 
@@ -465,7 +465,6 @@ async def run_python_tests(
     batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata],
     test_subsystem: TestSubsystem,
 ) -> TestResult:
-
     setup = await Get(
         TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
     )

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -293,7 +293,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
             f"{PACKAGE}/BUILD": dedent(
                 """\
                 python_tests(name='py2', interpreter_constraints=['==2.7.*'])
-                python_tests(name='py3', interpreter_constraints=['>=3.6.*'])
+                python_tests(name='py3', interpreter_constraints=['>=3.6.0'])
                 """
             ),
         }

--- a/src/python/pants/backend/python/goals/run_python_requirement.py
+++ b/src/python/pants/backend/python/goals/run_python_requirement.py
@@ -90,7 +90,6 @@ def _invert_module_mapping(
 async def _resolve_entry_point(
     module_mapping: InvertedModuleMapping, field_set: PythonRequirementFieldSet
 ) -> EntryPoint:
-
     modules = field_set.modules.value
     reqs = field_set.requirements.value
     entry_point_raw = field_set.entry_point.value
@@ -133,7 +132,6 @@ async def create_python_requirement_run_request(
     python_setup: PythonSetup,
     module_mapping: ThirdPartyPythonModuleMapping,
 ) -> RunRequest:
-
     addresses = [field_set.address]
 
     resolve = field_set.resolve.value

--- a/src/python/pants/backend/python/goals/setup_py.py
+++ b/src/python/pants/backend/python/goals/setup_py.py
@@ -277,7 +277,7 @@ class SetupKwargs:
 # authors. To resolve `SetupKwargs`, call `await Get(SetupKwargs, ExportedTarget)`, which handles
 # running any custom implementations vs. using the default implementation.
 @union(in_scope_types=[EnvironmentName])
-@dataclass(frozen=True)  # type: ignore[misc]
+@dataclass(frozen=True)
 class SetupKwargsRequest(ABC):
     """A request to allow setting the kwargs passed to the `setup()` function.
 

--- a/src/python/pants/backend/python/lint/add_trailing_comma/add_trailing_comma.lock
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/add_trailing_comma.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "add-trailing-comma==2.2.3"
+//     "add-trailing-comma<3,>=2.2.3"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -31,13 +31,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e8d928f8a31fc06140fa99802df0789b5f58c9b45b2a32252d7d4b59c46a9d03",
-              "url": "https://files.pythonhosted.org/packages/7a/4f/948fd4616a590c2dc9e0de2d3802750df5ec6b529ee0da44f29f454311dc/add_trailing_comma-2.2.3-py2.py3-none-any.whl"
+              "hash": "88fc66ddb7554b3519529f8e14d6c793d1ae66ccd2a7d0d5396a421d955eb521",
+              "url": "https://files.pythonhosted.org/packages/33/4e/fa5fdbb3cfc7aad2866700f13900bc7e05b75129e239af08b9d380b8ac92/add_trailing_comma-2.4.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d118070060a40be1f6b7f0bcc2f7be3b9f88d22eb9511b5d7a6535fa9fa74571",
-              "url": "https://files.pythonhosted.org/packages/fb/69/9d3fdec1979d5b00f2c0b194c07bb3c4f61293ad20e28572c1871734fb6b/add_trailing_comma-2.2.3.tar.gz"
+              "hash": "76c0e8a95cb4c06a7d9182db61573bb5253a76ee3a2bd0126b481cc0b4871713",
+              "url": "https://files.pythonhosted.org/packages/05/a8/1bfd5ea8add9d7243a63788d132b30bbc706bb9225d45baf1ada5aac5271/add_trailing_comma-2.4.0.tar.gz"
             }
           ],
           "project_name": "add-trailing-comma",
@@ -45,35 +45,36 @@
             "tokenize-rt>=3.0.1"
           ],
           "requires_python": ">=3.7",
-          "version": "2.2.3"
+          "version": "2.4.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8",
-              "url": "https://files.pythonhosted.org/packages/2f/e2/654a25ad594df2eb07f76e405f6f261d8fa9b5c06eb1e78549a086245455/tokenize_rt-4.2.1-py2.py3-none-any.whl"
+              "hash": "c67772c662c6b3dc65edf66808577968fb10badfc2042e3027196bed4daf9e5a",
+              "url": "https://files.pythonhosted.org/packages/8d/12/4c7495f25b4c9131706f3aaffb185d4de32c02a6ee49d875e929c5b7c919/tokenize_rt-5.0.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94",
-              "url": "https://files.pythonhosted.org/packages/2c/9c/d7c5d9e83bf5a2b52f9505ac3ce092c8788d10632ad8341b649a0906852a/tokenize_rt-4.2.1.tar.gz"
+              "hash": "3160bc0c3e8491312d0485171dea861fc160a240f5f5766b72a1165408d10740",
+              "url": "https://files.pythonhosted.org/packages/40/01/fb40ea8c465f680bf7aa3f5bee39c62ba8b7f52c38048c27aa95aff4f779/tokenize_rt-5.0.0.tar.gz"
             }
           ],
           "project_name": "tokenize-rt",
           "requires_dists": [],
-          "requires_python": ">=3.6.1",
-          "version": "4.2.1"
+          "requires_python": ">=3.7",
+          "version": "5.0.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.103",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "add-trailing-comma==2.2.3"
+    "add-trailing-comma<3,>=2.2.3"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -23,8 +23,9 @@ class AddTrailingComma(PythonToolBase):
     name = "add-trailing-comma"
     help = "The add-trailing-comma Python code formatter (https://github.com/asottile/add-trailing-comma)."
 
-    default_version = "add-trailing-comma==2.2.3"
+    default_version = "add-trailing-comma>=2.2.3,<3"
     default_main = ConsoleScript("add-trailing-comma")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/autoflake/autoflake.lock
+++ b/src/python/pants/backend/python/lint/autoflake/autoflake.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "autoflake==1.4"
-//   ]
+//     "autoflake<3,>=1.4"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,44 +31,69 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "61a353012cff6ab94ca062823d1fb2f692c4acda51c76ff83a8d77915fba51ea",
-              "url": "https://files.pythonhosted.org/packages/11/2e/0a7618eb5e69483d62b0f86c8d1eb7fdca2c2781f6f0cd5f3a3286398475/autoflake-1.4.tar.gz"
+              "hash": "143b0843667734af53532c443e950c787316b9b1155b2273558260b44836e8e4",
+              "url": "https://files.pythonhosted.org/packages/7b/68/13f71734e97fb6fc24baf2ec9e4971ead3a3d54bfc1a44f143ce6a2b53e8/autoflake-2.0.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1ce520131b7f396915242fe91e57221f4d42408529bbe3ae93adafed286591e0",
+              "url": "https://files.pythonhosted.org/packages/93/6d/9d77459da32a30304405c6939d456f7dd0c263bddf419fc24a753dbce6da/autoflake-2.0.1.tar.gz"
             }
           ],
           "project_name": "autoflake",
           "requires_dists": [
-            "pyflakes>=1.1.0"
+            "pyflakes>=3.0.0",
+            "tomli>=2.0.1; python_version < \"3.11\""
           ],
-          "requires_python": null,
-          "version": "1.4"
+          "requires_python": ">=3.7",
+          "version": "2.0.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e",
-              "url": "https://files.pythonhosted.org/packages/43/fb/38848eb494af7df9aeb2d7673ace8b213313eb7e391691a79dbaeb6a838f/pyflakes-2.4.0-py2.py3-none-any.whl"
+              "hash": "ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf",
+              "url": "https://files.pythonhosted.org/packages/af/4c/b1c7008aa7788b3e26c06c60aa18da7d3aa1f00e344aa3f18ac92768854b/pyflakes-3.0.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
-              "url": "https://files.pythonhosted.org/packages/15/60/c577e54518086e98470e9088278247f4af1d39cb43bcbd731e2c307acd6a/pyflakes-2.4.0.tar.gz"
+              "hash": "ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd",
+              "url": "https://files.pythonhosted.org/packages/f2/51/506ddcfab10d708e8460554cc1cf37c727a6a2cccbad8dfe57766cfce33c/pyflakes-3.0.1.tar.gz"
             }
           ],
           "project_name": "pyflakes",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
-          "version": "2.4"
+          "requires_python": ">=3.6",
+          "version": "3.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "url": "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
+            }
+          ],
+          "project_name": "tomli",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "2.0.1"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "autoflake==1.4"
+    "autoflake<3,>=1.4"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -23,8 +23,9 @@ class Autoflake(PythonToolBase):
     name = "Autoflake"
     help = "The Autoflake Python code formatter (https://github.com/myint/autoflake)."
 
-    default_version = "autoflake==1.4"
+    default_version = "autoflake>=1.4,<3"
     default_main = ConsoleScript("autoflake")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/bandit/bandit.lock
+++ b/src/python/pants/backend/python/lint/bandit/bandit.lock
@@ -4,15 +4,19 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "GitPython==3.1.18",
+//     "GitPython>=3.1.24",
 //     "bandit<1.8,>=1.7.0",
 //     "setuptools"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -63,97 +67,101 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8033ad4e853066ba6ca92050b9df2f89301b8fc8bf7e9324d412a63f8bf1a8fd",
-              "url": "https://files.pythonhosted.org/packages/a3/7c/5d747655049bfbf75b5fcec57c8115896cb78d6fafa84f6d3ef4c0f13a98/gitdb-4.0.9-py3-none-any.whl"
+              "hash": "c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7",
+              "url": "https://files.pythonhosted.org/packages/21/a6/35f83efec687615c711fe0a09b67e58f6d1254db27b1013119de46f450bd/gitdb-4.0.10-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bac2fd45c0a1c9cf619e63a90d62bdc63892ef92387424b855792a6cabe789aa",
-              "url": "https://files.pythonhosted.org/packages/fc/44/64e02ef96f20b347385f0e9c03098659cb5a1285d36c3d17c56e534d80cf/gitdb-4.0.9.tar.gz"
+              "hash": "6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a",
+              "url": "https://files.pythonhosted.org/packages/4b/47/dc98f3d5d48aa815770e31490893b92c5f1cd6c6cf28dd3a8ae0efffac14/gitdb-4.0.10.tar.gz"
             }
           ],
           "project_name": "gitdb",
           "requires_dists": [
             "smmap<6,>=3.0.1"
           ],
-          "requires_python": ">=3.6",
-          "version": "4.0.9"
+          "requires_python": ">=3.7",
+          "version": "4.0.10"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fce760879cd2aebd2991b3542876dc5c4a909b30c9d69dfc488e504a8db37ee8",
-              "url": "https://files.pythonhosted.org/packages/bc/91/b38c4fabb6e5092ab23492ded4f318ab7299b19263272b703478038c0fbc/GitPython-3.1.18-py3-none-any.whl"
+              "hash": "f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d",
+              "url": "https://files.pythonhosted.org/packages/9e/8a/d1e02cc111d65b0346f70abb83c51f8593e7134bf694a4a56d1a470caaf7/GitPython-3.1.31-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b838a895977b45ab6f0cc926a9045c8d1c44e2b653c1fcc39fe91f42c6e8f05b",
-              "url": "https://files.pythonhosted.org/packages/29/22/3d591875078c1c5e7e11b478616821995053968a74b76043c55448c46381/GitPython-3.1.18.tar.gz"
+              "hash": "8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573",
+              "url": "https://files.pythonhosted.org/packages/5f/11/2b0f60686dbda49028cec8c66bd18a5e82c96d92eef4bc34961e35bb3762/GitPython-3.1.31.tar.gz"
             }
           ],
           "project_name": "gitpython",
           "requires_dists": [
             "gitdb<5,>=4.0.1",
-            "typing-extensions>=3.7.4.0; python_version < \"3.8\""
+            "typing-extensions>=3.7.4.3; python_version < \"3.8\""
           ],
-          "requires_python": ">=3.6",
-          "version": "3.1.18"
+          "requires_python": ">=3.7",
+          "version": "3.1.31"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
-              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
           "requires_dists": [
+            "flake8<5; extra == \"testing\"",
             "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
             "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
             "ipython; extra == \"perf\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
             "packaging; extra == \"testing\"",
             "pyfakefs; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.12"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e547125940bcc052856ded43be8e101f63828c2d94239ffbe2b327ba3d5ccf0a",
-              "url": "https://files.pythonhosted.org/packages/1b/ef/0621aa0e422dda72dc89b61972e5a28d5a947c22fdff83a5d69fdbc1949a/pbr-5.9.0-py2.py3-none-any.whl"
+              "hash": "567f09558bae2b3ab53cb3c1e2e33e726ff3338e7bae3db5dc954b3a44eef12b",
+              "url": "https://files.pythonhosted.org/packages/01/06/4ab11bf70db5a60689fc521b636849c8593eb67a2c6bdf73a16c72d16a12/pbr-5.11.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8dca2f4b43560edef58813969f52a56cef023146cbb8931626db80e6c1c4308",
-              "url": "https://files.pythonhosted.org/packages/96/9f/f4bc832eeb4ae723b86372277da56a5643b0ad472a95314e8f516a571bb0/pbr-5.9.0.tar.gz"
+              "hash": "aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3",
+              "url": "https://files.pythonhosted.org/packages/02/d8/acee75603f31e27c51134a858e0dea28d321770c5eedb9d1d673eb7d3817/pbr-5.11.1.tar.gz"
             }
           ],
           "project_name": "pbr",
           "requires_dists": [],
           "requires_python": ">=2.6",
-          "version": "5.9"
+          "version": "5.11.1"
         },
         {
           "artifacts": [
@@ -184,6 +192,11 @@
             },
             {
               "algorithm": "sha256",
+              "hash": "432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
+              "url": "https://files.pythonhosted.org/packages/56/8f/e8b49ad21d26111493dc2d5cae4d7efbd0e2e065440665f5023515f87f64/PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
               "hash": "77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
               "url": "https://files.pythonhosted.org/packages/5e/f4/7b4bb01873be78fc9fde307f38f62e380b7111862c165372cf094ca2b093/PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
@@ -199,6 +212,11 @@
             },
             {
               "algorithm": "sha256",
+              "hash": "dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
+              "url": "https://files.pythonhosted.org/packages/68/3f/c027422e49433239267c62323fbc6320d6ac8d7d50cf0cb2a376260dad5f/PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
               "hash": "213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba",
               "url": "https://files.pythonhosted.org/packages/6c/3d/524c642f3db37e7e7ab8d13a3f8b0c72d04a619abc19100097d987378fc6/PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
@@ -206,6 +224,11 @@
               "algorithm": "sha256",
               "hash": "cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
               "url": "https://files.pythonhosted.org/packages/77/da/e845437ffe0dffae4e7562faf23a4f264d886431c5d2a2816c853288dc8e/PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
+              "url": "https://files.pythonhosted.org/packages/7f/d9/6a0d14ac8d3b5605dc925d177c1d21ee9f0b7b39287799db1e50d197b2f4/PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
@@ -221,6 +244,11 @@
               "algorithm": "sha256",
               "hash": "819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
               "url": "https://files.pythonhosted.org/packages/9d/f6/7e91fbb58c9ee528759aea5892e062cccb426720c5830ddcce92eba00ff1/PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
+              "url": "https://files.pythonhosted.org/packages/cb/5f/05dd91f5046e2256e35d885f3b8f0f280148568f08e1bf20421887523e9a/PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
@@ -251,24 +279,29 @@
               "algorithm": "sha256",
               "hash": "055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
               "url": "https://files.pythonhosted.org/packages/f5/6f/b8b4515346af7c33d3b07cd8ca8ea0700ca72e8d7a750b2b87ac0268ca4e/PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
+              "url": "https://files.pythonhosted.org/packages/f8/54/799b059314b13e1063473f76e908f44106014d18f54b16c83a16edccd5ec/PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "pyyaml",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "6"
+          "version": "6.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -278,6 +311,7 @@
             "filelock>=3.4.0; extra == \"testing\"",
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
@@ -286,7 +320,6 @@
             "jaraco.path>=3.2.0; extra == \"testing\"",
             "jaraco.path>=3.2.0; extra == \"testing-integration\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "mock; extra == \"testing\"",
             "pip-run>=8.8; extra == \"testing\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
@@ -295,18 +328,22 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
+            "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest; extra == \"testing-integration\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
             "tomli; extra == \"testing-integration\"",
@@ -316,7 +353,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
@@ -334,19 +371,19 @@
           "project_name": "smmap",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "5"
+          "version": "5.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "a547de73308fd7e90075bb4d301405bebf705292fa90a90fc3bcf9133f58616c",
-              "url": "https://files.pythonhosted.org/packages/7a/bc/fcce9e50da73ea23af6d236e05e15db8a02da1099a5e0a479451bcea3833/stevedore-3.5.0-py3-none-any.whl"
+              "hash": "fa2630e3d0ad3e22d4914aff2501445815b9a4467a6edc49387c667a38faf5bf",
+              "url": "https://files.pythonhosted.org/packages/6d/8d/8dbd1e502e06e58550ed16c879303f83609d52ac31de0cd6a2403186148a/stevedore-3.5.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f40253887d8712eaa2bb0ea3830374416736dc8ec0e22f5a65092c1174c44335",
-              "url": "https://files.pythonhosted.org/packages/67/73/cd693fde78c3b2397d49ad2c6cdb082eb0b6a606188876d61f53bae16293/stevedore-3.5.0.tar.gz"
+              "hash": "cf99f41fc0d5a4f185ca4d3d42b03be9011b0a1ec1a4ea1a282be1b4b306dcc2",
+              "url": "https://files.pythonhosted.org/packages/80/a3/7db17f998684ee1c225cfae74ccca4b369118419c07be48991f30e942c31/stevedore-3.5.2.tar.gz"
             }
           ],
           "project_name": "stevedore",
@@ -355,66 +392,73 @@
             "pbr!=2.1.0,>=2.0.0"
           ],
           "requires_python": ">=3.6",
-          "version": "3.5"
+          "version": "3.5.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.3"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099",
-              "url": "https://files.pythonhosted.org/packages/80/0e/16a7ee38617aab6a624e95948d314097cc2669edae9b02ded53309941cfc/zipp-3.8.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
-              "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
-            "func-timeout; extra == \"testing\"",
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.8"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "GitPython==3.1.18",
+    "GitPython>=3.1.24",
     "bandit<1.8,>=1.7.0",
     "setuptools"
   ],

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -132,7 +132,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
             "BUILD": dedent(
                 """\
                 python_sources(name="py2", interpreter_constraints=["==2.7.*"])
-                python_sources(name="py3", interpreter_constraints=[">=3.6"])
+                python_sources(name="py3", interpreter_constraints=[">=3.7"])
                 """
             ),
         }
@@ -168,7 +168,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert "f.py (syntax error while parsing AST from file)" in batched_py2_result.stdout
 
     assert batched_py3_result.exit_code == 0
-    assert batched_py3_result.partition_description == "['CPython>=3.6']"
+    assert batched_py3_result.partition_description == "['CPython>=3.7']"
     assert "No issues identified." in batched_py3_result.stdout
 
 
@@ -197,16 +197,14 @@ def test_skip(rule_runner: RuleRunner) -> None:
     assert not result
 
 
-@pytest.mark.skipif(
-    not (has_python_version("3.6") or has_python_version("3.7")), reason="Missing requisite Python"
-)
+@pytest.mark.skipif(not (has_python_version("3.7")), reason="Missing requisite Python")
 def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.py": "aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n",
             # NB: `bandit-aws` does not currently work with Python 3.8. See
             #  https://github.com/pantsbuild/pants/issues/10545.
-            "BUILD": "python_sources(name='t', interpreter_constraints=['>=3.6,<3.8'])",
+            "BUILD": "python_sources(name='t', interpreter_constraints=['>=3.7,<3.8'])",
         }
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -54,11 +54,11 @@ class Bandit(PythonToolBase):
     default_extra_requirements = [
         "setuptools",
         # GitPython 3.1.20 was yanked because it breaks Python 3.8+, but Poetry's lockfile
-        # generation still tries to use it. Upgrade this to the newest version once released or
-        # when switching away from Poetry.
-        "GitPython==3.1.18",
+        # generation still tries to use it.
+        "GitPython>=3.1.24",
     ]
     default_main = ConsoleScript("bandit")
+    default_requirements = [default_version, *default_extra_requirements]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.bandit", "bandit.lock")

--- a/src/python/pants/backend/python/lint/black/black.lock
+++ b/src/python/pants/backend/python/lint/black/black.lock
@@ -4,14 +4,18 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "black==22.6.0",
+//     "black<24,>=22.6.0",
 //     "typing-extensions>=3.10.0.0; python_version < \"3.10\""
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -28,83 +32,103 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c",
-              "url": "https://files.pythonhosted.org/packages/2b/70/1d0e33a4df4ed73e9f02f698a29b5d94ff58e39f029c939ecf96a10fb1f3/black-22.6.0-py3-none-any.whl"
+              "hash": "7a0f701d314cfa0896b9001df70a530eb2472babb76086344e688829efd97d32",
+              "url": "https://files.pythonhosted.org/packages/18/99/bb1be0ff3a7e912679ad234a3c4884fa7689dfcc4eae85bddb6c04feaa62/black-23.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f",
-              "url": "https://files.pythonhosted.org/packages/07/eb/a757135497a3be31ab8c00ef239070c7277ad11b618104950a756bcab3c1/black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl"
+              "hash": "8178318cb74f98bc571eef19068f6ab5613b3e59d4f47771582f04e175570ed8",
+              "url": "https://files.pythonhosted.org/packages/01/8a/065d0a59c1ebe13186b12a2fa3965a41fc1588828709995e2630004d216e/black-23.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee",
-              "url": "https://files.pythonhosted.org/packages/19/b0/13864fd5f3090ca5379f3dcf6034f1e4f02b59620e7b8b5c6f0c85622c0b/black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "b0bd97bea8903f5a2ba7219257a44e3f1f9d00073d6cc1add68f0beec69692ac",
+              "url": "https://files.pythonhosted.org/packages/15/11/533355217b1cc4a6df3263048060c1527f733d4720e158de2085293112bb/black-23.1.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e",
-              "url": "https://files.pythonhosted.org/packages/1a/84/203163902ee26bcf1beaef582ee0c8df3f325da3e961b68d2ece959e19d3/black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "49f7b39e30f326a34b5c9a4213213a6b221d7ae9d58ec70df1c4a307cf2a1580",
+              "url": "https://files.pythonhosted.org/packages/20/de/eff8e3ccc22b5c2be1265a9e61f1006d03e194519a3ca2e83dd8483dbbb5/black-23.1.0-cp38-cp38-macosx_10_16_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c",
-              "url": "https://files.pythonhosted.org/packages/1d/d2/bc58bae8ec35f5a3c796d71d5bda113060678483e623a019fb889edd8d97/black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl"
+              "hash": "2bf649fda611c8550ca9d7592b69f0637218c2369b7744694c5e4902873b2f3a",
+              "url": "https://files.pythonhosted.org/packages/32/a7/1d207427b87780c505a41c9430d26362e729954503b8ffba27c4f53a6810/black-23.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b",
-              "url": "https://files.pythonhosted.org/packages/2b/d9/7331e50dad8d5149a9e2285766960ac6b732ae9b3b9796e10916ad88ff61/black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "57c18c5165c1dbe291d5306e53fb3988122890e57bd9b3dcb75f967f13411a26",
+              "url": "https://files.pythonhosted.org/packages/3e/c0/abc7031d670d211e4e2a063910d587dfcb62ce469631e779b23b66653442/black-23.1.0-cp310-cp310-macosx_10_16_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e",
-              "url": "https://files.pythonhosted.org/packages/3e/fd/5e47b4d77549909e484de906a69fccc3fcfb782131d8b449073ad8b3ed3e/black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "a29650759a6a0944e7cca036674655c2f0f63806ddecc45ed40b7b8aa314b651",
+              "url": "https://files.pythonhosted.org/packages/43/bc/5232fd6b0fd6d6177140cfb7d8f0f0e06638e2a750122767e265beb91161/black-23.1.0-cp39-cp39-macosx_10_16_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c",
-              "url": "https://files.pythonhosted.org/packages/40/d1/3f366d7887d1fb6e3e487a6c975a9e9e13618757ed0d5427197fa9e28290/black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "bb460c8561c8c1bec7824ecbc3ce085eb50005883a6203dcfb0122e95797ee06",
+              "url": "https://files.pythonhosted.org/packages/77/11/db2ae5bf93af5185086d9b1baf4ce369ca34c3a01835230873aa9163d52d/black-23.1.0-cp39-cp39-macosx_10_16_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9",
-              "url": "https://files.pythonhosted.org/packages/61/11/551b0d067a7e6836fc0997ab36ee46ec65259fea8f30104f4870092f3301/black-22.6.0.tar.gz"
+              "hash": "c1c476bc7b7d021321e7d93dc2cbd78ce103b84d5a4cf97ed535fbc0d6660648",
+              "url": "https://files.pythonhosted.org/packages/7e/fe/6c05c3f9255b7b498cfb88faa85b45329f1b7b0ecb444ebdc6b74ffa1457/black-23.1.0-cp311-cp311-macosx_10_16_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807",
-              "url": "https://files.pythonhosted.org/packages/63/96/814e02033701f51701444d5505b5e2594453b1f7e913764a097b1f701633/black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "a8471939da5e824b891b25751955be52ee7f8a30a916d570a5ba8e0f2eb2ecad",
+              "url": "https://files.pythonhosted.org/packages/96/af/3361b34907efbfd9d55af453488be2282f831d98b7d201248b38d4c44346/black-23.1.0-cp37-cp37m-macosx_10_16_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69",
-              "url": "https://files.pythonhosted.org/packages/80/ff/cfcfa4cdb42d8fff75b6b4dc355a1186a95de4714df8cc2a60f69f7b17f8/black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl"
+              "hash": "bfffba28dc52a58f04492181392ee380e95262af14ee01d4bc7bb1b1c6ca8d27",
+              "url": "https://files.pythonhosted.org/packages/9a/ee/549e8be7f635cabcc3c7c3f2c3b27971dc32735155631b9ef2dcb1bd861f/black-23.1.0-cp311-cp311-macosx_10_16_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2",
-              "url": "https://files.pythonhosted.org/packages/9b/22/ff6d904dcb6f92bd7c20b178ed0aa9e6814ae6452df6c573806dbc465b85/black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "a59db0a2094d2259c554676403fa2fac3473ccf1354c1c63eccf7ae65aac8ab6",
+              "url": "https://files.pythonhosted.org/packages/a4/ec/934e89820289e6952922fa5965aec0e046ed65da168ffb0515af1e3364e1/black-23.1.0-cp38-cp38-macosx_10_16_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def",
-              "url": "https://files.pythonhosted.org/packages/a7/51/d0acd9f74a946a825a148dcc392433c2332ae405967d76292b9e64712dc8/black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "c91dfc2c2a4e50df0026f88d2215e166616e0c80e86004d0003ece0488db2739",
+              "url": "https://files.pythonhosted.org/packages/ae/93/1e62fe94ab531bdc3f6cbbbd5b518727277bf40f695777b4097db5da2a38/black-23.1.0-cp39-cp39-macosx_10_16_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849",
-              "url": "https://files.pythonhosted.org/packages/ac/9d/b06f45e8dff2b10bf4644ba7a74490538c0272ae48308e04c6f551671b89/black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "2a951cc83ab535d248c89f300eccbd625e80ab880fbcfb5ac8afb5f01a258ac9",
+              "url": "https://files.pythonhosted.org/packages/b7/33/8e074fd8b86a1c8668f5493ed28929d87bdccb6aa68c2975b47a02f92287/black-23.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6",
-              "url": "https://files.pythonhosted.org/packages/e7/fe/4533d110ddced851a359cbbb162685814719690ee01939a34be023410854/black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "e6663f91b6feca5d06f2ccd49a10f254f9298cc1f7f49c46e498a0771b507104",
+              "url": "https://files.pythonhosted.org/packages/be/f9/11e401323cd5b4e53d138fc880564765466a86acd2d4b50d7c8cdd048c18/black-23.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad",
-              "url": "https://files.pythonhosted.org/packages/fc/37/032c45b55f901ee3fe780fbc17fe2dc262c809d94de1288201350d8d680b/black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "9880d7d419bb7e709b37e28deb5e68a49227713b623c72b2b931028ea65f619b",
+              "url": "https://files.pythonhosted.org/packages/cf/fe/dda4b7eedb9d4dc46e306b814f7838cd9026907fdc889f75eb9f6d47d414/black-23.1.0-cp310-cp310-macosx_10_16_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b6a92a41ee34b883b359998f0c8e6eb8e99803aa8bf3123bf2b2e6fec505a221",
+              "url": "https://files.pythonhosted.org/packages/d0/cb/0a38ffdafbb4b3f337adaf1b79aeaf4b8a21ed18835acad6349e46c78c80/black-23.1.0-cp310-cp310-macosx_10_16_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "162e37d49e93bd6eb6f1afc3e17a3d23a823042530c37c3c42eeeaf026f38468",
+              "url": "https://files.pythonhosted.org/packages/dd/19/875b5006e40ea69a4120671f50317100b24732f2b877203722c91bc4eef3/black-23.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0052dba51dec07ed029ed61b18183942043e00008ec65d5028814afaab9a22fd",
+              "url": "https://files.pythonhosted.org/packages/e6/0a/9a5fca4a2ca07d4dbc3b00445c9353f05ea182b000f68c9ad6ba1da87a47/black-23.1.0-cp38-cp38-macosx_10_16_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "382998821f58e5c8238d3166c492139573325287820963d2f7de4d518bd76958",
+              "url": "https://files.pythonhosted.org/packages/f1/89/ccc28cb74a66c094b609295b009b5e0350c10b75661d2450eeed2f60ce37/black-23.1.0-cp311-cp311-macosx_10_16_x86_64.whl"
             }
           ],
           "project_name": "black",
@@ -112,19 +136,19 @@
             "aiohttp>=3.7.4; extra == \"d\"",
             "click>=8.0.0",
             "colorama>=0.4.3; extra == \"colorama\"",
-            "dataclasses>=0.6; python_version < \"3.7\"",
             "ipython>=7.8.0; extra == \"jupyter\"",
             "mypy-extensions>=0.4.3",
+            "packaging>=22.0",
             "pathspec>=0.9.0",
             "platformdirs>=2",
             "tokenize-rt>=3.2.0; extra == \"jupyter\"",
-            "tomli>=1.1.0; python_full_version < \"3.11.0a7\"",
+            "tomli>=1.1.0; python_version < \"3.11\"",
             "typed-ast>=1.4.2; python_version < \"3.8\" and implementation_name == \"cpython\"",
             "typing-extensions>=3.10.0.0; python_version < \"3.10\"",
             "uvloop>=0.15.2; extra == \"uvloop\""
           ],
-          "requires_python": ">=3.6.2",
-          "version": "22.6"
+          "requires_python": ">=3.7",
+          "version": "23.1.0"
         },
         {
           "artifacts": [
@@ -151,103 +175,125 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
-              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
           "requires_dists": [
+            "flake8<5; extra == \"testing\"",
             "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
             "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
             "ipython; extra == \"perf\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
             "packaging; extra == \"testing\"",
             "pyfakefs; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.12"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
-              "url": "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl"
+              "hash": "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
+              "url": "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
-              "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz"
+              "hash": "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782",
+              "url": "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz"
             }
           ],
           "project_name": "mypy-extensions",
-          "requires_dists": [
-            "typing>=3.5.3; python_version < \"3.5\""
-          ],
-          "requires_python": null,
-          "version": "0.4.3"
+          "requires_dists": [],
+          "requires_python": ">=3.5",
+          "version": "1.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-              "url": "https://files.pythonhosted.org/packages/42/ba/a9d64c7bcbc7e3e8e5f93a52721b377e994c22d16196e2b0f1236774353a/pathspec-0.9.0-py2.py3-none-any.whl"
+              "hash": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+              "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
-              "url": "https://files.pythonhosted.org/packages/f6/33/436c5cb94e9f8902e59d1d544eb298b83c84b9ec37b5b769c5a0ad6edb19/pathspec-0.9.0.tar.gz"
+              "hash": "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97",
+              "url": "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz"
+            }
+          ],
+          "project_name": "packaging",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "23.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+              "url": "https://files.pythonhosted.org/packages/e6/be/1a973593d7ce7ac9d1a793b81eb265c152a62f34825169fbd7c4e4548e34/pathspec-0.11.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc",
+              "url": "https://files.pythonhosted.org/packages/f4/8e/f91cffb32740b251cff04cad1e7cdd2c710582c735a01f56307316c148f2/pathspec-0.11.0.tar.gz"
             }
           ],
           "project_name": "pathspec",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.9"
+          "requires_python": ">=3.7",
+          "version": "0.11.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-              "url": "https://files.pythonhosted.org/packages/ed/22/967181c94c3a4063fe64e15331b4cb366bdd7dfbf46fcb8ad89650026fec/platformdirs-2.5.2-py3-none-any.whl"
+              "hash": "13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a",
+              "url": "https://files.pythonhosted.org/packages/ca/de/a33823fe54d52ea72fdae011115d737a2642d441c93b68ed17455a328e4c/platformdirs-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19",
-              "url": "https://files.pythonhosted.org/packages/ff/7b/3613df51e6afbf2306fc2465671c03390229b55e3ef3ab9dd3f846a53be6/platformdirs-2.5.2.tar.gz"
+              "hash": "accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef",
+              "url": "https://files.pythonhosted.org/packages/8f/5f/01180534cebac14f3a792bf2f74fc99d34531c950c308fdebd9721e85550/platformdirs-3.1.0.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
-            "furo>=2021.7.5b38; extra == \"docs\"",
-            "proselint>=0.10.2; extra == \"docs\"",
-            "pytest-cov>=2.7; extra == \"test\"",
-            "pytest-mock>=3.6; extra == \"test\"",
-            "pytest>=6; extra == \"test\"",
-            "sphinx-autodoc-typehints>=1.12; extra == \"docs\"",
-            "sphinx>=4; extra == \"docs\""
+            "covdefaults>=2.2.2; extra == \"test\"",
+            "furo>=2022.12.7; extra == \"docs\"",
+            "proselint>=0.13; extra == \"docs\"",
+            "pytest-cov>=4; extra == \"test\"",
+            "pytest-mock>=3.10; extra == \"test\"",
+            "pytest>=7.2.1; extra == \"test\"",
+            "sphinx-autodoc-typehints!=1.23.4,>=1.22; extra == \"docs\"",
+            "sphinx>=6.1.3; extra == \"docs\"",
+            "typing-extensions>=4.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "2.5.2"
+          "version": "3.1.0"
         },
         {
           "artifacts": [
@@ -359,60 +405,67 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.3"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099",
-              "url": "https://files.pythonhosted.org/packages/80/0e/16a7ee38617aab6a624e95948d314097cc2669edae9b02ded53309941cfc/zipp-3.8.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
-              "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
-            "func-timeout; extra == \"testing\"",
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.8"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "black==22.6.0",
+    "black<24,>=22.6.0",
     "typing-extensions>=3.10.0.0; python_version < \"3.10\""
   ],
   "requires_python": [

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -51,8 +51,9 @@ class Black(PythonToolBase):
     name = "Black"
     help = "The Black Python code formatter (https://black.readthedocs.io/)."
 
-    default_version = "black==22.6.0"
+    default_version = "black>=22.6.0,<24"
     default_main = ConsoleScript("black")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/docformatter/docformatter.lock
+++ b/src/python/pants/backend/python/lint/docformatter/docformatter.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "docformatter<1.5,>=1.4"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -56,7 +60,8 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "docformatter<1.5,>=1.4"

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -24,6 +24,7 @@ class Docformatter(PythonToolBase):
 
     default_version = "docformatter>=1.4,<1.5"
     default_main = ConsoleScript("docformatter")
+    default_requirements = ["docformatter>=1.4,<1.6"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/flake8/flake8.lock
+++ b/src/python/pants/backend/python/lint/flake8/flake8.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "flake8<5.1,>=5.0.4"
+//     "flake8<7,>=5.0.4"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -84,7 +84,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.6",
-          "version": "4.2"
+          "version": "4.2.0"
         },
         {
           "artifacts": [
@@ -102,7 +102,7 @@
           "project_name": "mccabe",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "0.7"
+          "version": "0.7.0"
         },
         {
           "artifacts": [
@@ -138,43 +138,43 @@
           "project_name": "pyflakes",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2.5"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e",
-              "url": "https://files.pythonhosted.org/packages/0b/8e/f1a0a5a76cfef77e1eb6004cb49e5f8d72634da638420b9ea492ce8305e8/typing_extensions-4.4.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-              "url": "https://files.pythonhosted.org/packages/e3/a7/8f4e456ef0adac43f452efc2d0e4b242ab831297f1bac60ac815d37eb9cf/typing_extensions-4.4.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.4"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980",
-              "url": "https://files.pythonhosted.org/packages/09/85/302c153615db93e9197f13e02f448b3f95d7d786948f2fb3d6d5830a481b/zipp-3.9.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
-              "url": "https://files.pythonhosted.org/packages/41/2e/1341c5634c25e7254df01ec1f6cbd2bcdee3e647709e7c3647d1b362e3ac/zipp-3.9.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
+            "big-O; extra == \"testing\"",
             "flake8<5; extra == \"testing\"",
-            "func-timeout; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
@@ -185,25 +185,26 @@
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
             "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.9"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.108",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "flake8<5.1,>=5.0.4"
+    "flake8<7,>=5.0.4"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -66,8 +66,9 @@ class Flake8(PythonToolBase):
     name = "Flake8"
     help = "The Flake8 Python linter (https://flake8.pycqa.org/)."
 
-    default_version = "flake8>=5.0.4,<5.1"
+    default_version = "flake8>=5.0.4,<7"
     default_main = ConsoleScript("flake8")
+    default_requirements = [default_version]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.flake8", "flake8.lock")

--- a/src/python/pants/backend/python/lint/isort/isort.lock
+++ b/src/python/pants/backend/python/lint/isort/isort.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "isort[colors,pyproject]<6.0,>=5.9.3"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,50 +31,52 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
-              "url": "https://files.pythonhosted.org/packages/77/8b/7550e87b2d308a1b711725dfaddc19c695f8c5fa413c640b2be01662f4e6/colorama-0.4.5-py2.py3-none-any.whl"
+              "hash": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4",
-              "url": "https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz"
+              "hash": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+              "url": "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
             }
           ],
           "project_name": "colorama",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.4.5"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7",
+          "version": "0.4.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-              "url": "https://files.pythonhosted.org/packages/b8/5b/f18e227df38b94b4ee30d2502fd531bebac23946a2497e5595067a561274/isort-5.10.1-py3-none-any.whl"
+              "hash": "ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746",
+              "url": "https://files.pythonhosted.org/packages/5f/f6/c55db45970fbd14de6ab72082f1b8a143c3a69aa031c1e0dd4b9ecc8d496/isort-5.11.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
-              "url": "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz"
+              "hash": "6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db",
+              "url": "https://files.pythonhosted.org/packages/67/63/18cc5c2f9084d3f91ce704f2b5c8e17bedd777244e7732c21a31992b0a78/isort-5.11.5.tar.gz"
             }
           ],
           "project_name": "isort",
           "requires_dists": [
             "colorama<0.5.0,>=0.4.3; extra == \"colors\"",
-            "pip-api; extra == \"requirements_deprecated_finder\"",
-            "pipreqs; extra == \"pipfile_deprecated_finder\" or extra == \"requirements_deprecated_finder\"",
-            "requirementslib; extra == \"pipfile_deprecated_finder\"",
+            "pip-api; extra == \"requirements-deprecated-finder\"",
+            "pip-shims>=0.5.2; extra == \"pipfile-deprecated-finder\"",
+            "pipreqs; extra == \"pipfile-deprecated-finder\" or extra == \"requirements-deprecated-finder\"",
+            "requirementslib; extra == \"pipfile-deprecated-finder\"",
             "setuptools; extra == \"plugins\""
           ],
-          "requires_python": "<4.0,>=3.6.1",
-          "version": "5.10.1"
+          "requires_python": ">=3.7.0",
+          "version": "5.11.5"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "isort[colors,pyproject]<6.0,>=5.9.3"

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -30,6 +30,7 @@ class Isort(PythonToolBase):
 
     default_version = "isort[pyproject,colors]>=5.9.3,<6.0"
     default_main = ConsoleScript("isort")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/pydocstyle/pydocstyle.lock
+++ b/src/python/pants/backend/python/lint/pydocstyle/pydocstyle.lock
@@ -31,22 +31,63 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4",
-              "url": "https://files.pythonhosted.org/packages/87/67/4df10786068766000518c6ad9c4a614e77585a12ab8f0654c776757ac9dc/pydocstyle-6.1.1-py3-none-any.whl"
+              "hash": "8a8a81bcf996e74fee46f0d16bd3eaa382a7eb20fd82445c3ad11f4090334116",
+              "url": "https://files.pythonhosted.org/packages/d0/98/c277899f5aa21f6e6946e1c83f2af650cbfee982763ffb91db07ff7d3a13/importlib_metadata-4.13.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1d41b7c459ba0ee6c345f2eb9ae827cab14a7533a88c5c6f7e94923f72df92dc",
-              "url": "https://files.pythonhosted.org/packages/4c/30/4cdea3c8342ad343d41603afc1372167c224a04dc5dc0bf4193ccb39b370/pydocstyle-6.1.1.tar.gz"
+              "hash": "dd0173e8f150d6815e098fd354f6414b0f079af4644ddfe90c71e2fc6174346d",
+              "url": "https://files.pythonhosted.org/packages/55/12/ab288357b884ebc807e3f4eff63ce5ba6b941ba61499071bf19f1bbc7f7f/importlib_metadata-4.13.0.tar.gz"
+            }
+          ],
+          "project_name": "importlib-metadata",
+          "requires_dists": [
+            "flake8<5; extra == \"testing\"",
+            "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
+            "ipython; extra == \"perf\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "packaging; extra == \"testing\"",
+            "pyfakefs; extra == \"testing\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-perf>=0.9.2; extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
+            "typing-extensions>=3.6.4; python_version < \"3.8\"",
+            "zipp>=0.5"
+          ],
+          "requires_python": ">=3.7",
+          "version": "4.13.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019",
+              "url": "https://files.pythonhosted.org/packages/36/ea/99ddefac41971acad68f14114f38261c1f27dac0b3ec529824ebc739bdaa/pydocstyle-6.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1",
+              "url": "https://files.pythonhosted.org/packages/e9/5c/d5385ca59fd065e3c6a5fe19f9bc9d5ea7f2509fa8c9c22fb6b2031dd953/pydocstyle-6.3.0.tar.gz"
             }
           ],
           "project_name": "pydocstyle",
           "requires_dists": [
-            "snowballstemmer",
-            "toml; extra == \"toml\""
+            "importlib-metadata<5.0.0,>=2.0.0; python_version < \"3.8\"",
+            "snowballstemmer>=2.2.0",
+            "tomli>=1.2.3; python_version < \"3.11\" and extra == \"toml\""
           ],
           "requires_python": ">=3.6",
-          "version": "6.1.1"
+          "version": "6.3.0"
         },
         {
           "artifacts": [
@@ -70,27 +111,82 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
-              "url": "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl"
+              "hash": "939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+              "url": "https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f",
-              "url": "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz"
+              "hash": "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f",
+              "url": "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
             }
           ],
-          "project_name": "toml",
+          "project_name": "tomli",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.6",
-          "version": "0.10.2"
+          "requires_python": ">=3.7",
+          "version": "2.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
+            }
+          ],
+          "project_name": "typing-extensions",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "4.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
+            }
+          ],
+          "project_name": "zipp",
+          "requires_dists": [
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
+            "jaraco.itertools; extra == \"testing\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.113",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "pydocstyle[toml]<7.0,>=6.1.1"

--- a/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
@@ -45,6 +45,7 @@ class Pydocstyle(PythonToolBase):
 
     default_version = "pydocstyle[toml]>=6.1.1,<7.0"
     default_main = ConsoleScript("pydocstyle")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/pylint/pylint.lock
+++ b/src/python/pants/backend/python/lint/pylint/pylint.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "pylint<2.15,>=2.13.0"
-//   ]
+//     "pylint<3,>=2.13.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -51,163 +55,184 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302",
-              "url": "https://files.pythonhosted.org/packages/12/ff/3b1a8f5d59600393506c64fa14d13afdfe6fe79ed65a18d64026fe9f8356/dill-0.3.5.1-py2.py3-none-any.whl"
+              "hash": "a07ffd2351b8c678dfc4a856a3005f8067aea51d6ba6c700796a4d9e280f39f0",
+              "url": "https://files.pythonhosted.org/packages/be/e3/a84bf2e561beed15813080d693b4b27573262433fced9c1d1fea59e60553/dill-0.3.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86",
-              "url": "https://files.pythonhosted.org/packages/59/46/634d5316ee8984e7dac658fb2e297a19f50a1f4007b09acb9c7c4e15bd67/dill-0.3.5.1.tar.gz"
+              "hash": "e5db55f3687856d8fbdab002ed78544e1c4559a130302693d839dfe8f93f2373",
+              "url": "https://files.pythonhosted.org/packages/7c/e7/364a09134e1062d4d5ff69b853a56cf61c223e0afcc6906b6832bcd51ea8/dill-0.3.6.tar.gz"
             }
           ],
           "project_name": "dill",
           "requires_dists": [
             "objgraph>=1.7.2; extra == \"graph\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7",
-          "version": "0.3.5.1"
+          "requires_python": ">=3.7",
+          "version": "0.3.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7",
-              "url": "https://files.pythonhosted.org/packages/b8/5b/f18e227df38b94b4ee30d2502fd531bebac23946a2497e5595067a561274/isort-5.10.1-py3-none-any.whl"
+              "hash": "ba1d72fb2595a01c7895a5128f9585a5cc4b6d395f1c8d514989b9a7eb2a8746",
+              "url": "https://files.pythonhosted.org/packages/5f/f6/c55db45970fbd14de6ab72082f1b8a143c3a69aa031c1e0dd4b9ecc8d496/isort-5.11.5-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951",
-              "url": "https://files.pythonhosted.org/packages/ab/e9/964cb0b2eedd80c92f5172f1f8ae0443781a9d461c1372a3ce5762489593/isort-5.10.1.tar.gz"
+              "hash": "6be1f76a507cb2ecf16c7cf14a37e41609ca082330be4e3436a18ef74add55db",
+              "url": "https://files.pythonhosted.org/packages/67/63/18cc5c2f9084d3f91ce704f2b5c8e17bedd777244e7732c21a31992b0a78/isort-5.11.5.tar.gz"
             }
           ],
           "project_name": "isort",
           "requires_dists": [
             "colorama<0.5.0,>=0.4.3; extra == \"colors\"",
-            "pip-api; extra == \"requirements_deprecated_finder\"",
-            "pipreqs; extra == \"pipfile_deprecated_finder\" or extra == \"requirements_deprecated_finder\"",
-            "requirementslib; extra == \"pipfile_deprecated_finder\"",
+            "pip-api; extra == \"requirements-deprecated-finder\"",
+            "pip-shims>=0.5.2; extra == \"pipfile-deprecated-finder\"",
+            "pipreqs; extra == \"pipfile-deprecated-finder\" or extra == \"requirements-deprecated-finder\"",
+            "requirementslib; extra == \"pipfile-deprecated-finder\"",
             "setuptools; extra == \"plugins\""
           ],
-          "requires_python": "<4.0,>=3.6.1",
-          "version": "5.10.1"
+          "requires_python": ">=3.7.0",
+          "version": "5.11.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84",
-              "url": "https://files.pythonhosted.org/packages/41/8a/57d41c53cabc5e4aa8858514b8a8332f5512f7db5365acef6040114daa22/lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl"
+              "hash": "09763491ce220c0299688940f8dc2c5d05fd1f45af1e42e636b2e8b2303e4382",
+              "url": "https://files.pythonhosted.org/packages/5c/76/0b16dc53e9ee5b24c621d808f46cca11e5e86c602b6bcd6dc27f9504af5b/lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fccdf7c2c5821a8cbd0a9440a456f5050492f2270bd54e94360cac663398739b",
-              "url": "https://files.pythonhosted.org/packages/0d/0c/4a96799cec6daae24c991ee62b57ee7935273cfbdafb92cf68ba304be79a/lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "946d27deaff6cf8452ed0dba83ba38839a87f4f7a9732e8f9fd4107b21e6ff07",
+              "url": "https://files.pythonhosted.org/packages/00/74/46a68f51457639c0cd79e385e2f49c0fa7324470997ac096108669c1e182/lazy_object_proxy-1.9.0-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b9e89b87c707dd769c4ea91f7a31538888aad05c116a59820f28d59b3ebfe25a",
-              "url": "https://files.pythonhosted.org/packages/1a/66/0a1ab970f0e925fbf56296e7464367c4650f3c1ec53fe85af489285c1325/lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "9f5fa4a61ce2438267163891961cfd5e32ec97a2c444e5b842d574251ade27d2",
+              "url": "https://files.pythonhosted.org/packages/11/fe/be1eb76d83f1b5242c492b410ce86c59db629c0b0f0f8e75018dfd955c30/lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "553b0f0d8dbf21890dd66edd771f9b1b5f51bd912fa5f26de4449bfc5af5e029",
-              "url": "https://files.pythonhosted.org/packages/1d/45/f5304f3b32c3333af45f880b814cd9b310a03d3c2a5b36b2826b27d15b71/lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "f0117049dd1d5635bbff65444496c90e0baa48ea405125c088e93d9cf4525b11",
+              "url": "https://files.pythonhosted.org/packages/16/f2/e74981dedeb1a858cd5db9bcec81c4107da374249bc6894613472e01996f/lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "39b0e26725c5023757fc1ab2a89ef9d7ab23b84f9251e28f9cc114d5b59c1b09",
-              "url": "https://files.pythonhosted.org/packages/28/25/a4c87ad33bf3fcc9f3b30a23ddd08fa31974c66509f2684e51e0af04c767/lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "5f83ac4d83ef0ab017683d715ed356e30dd48a93746309c8f3517e1287523ef4",
+              "url": "https://files.pythonhosted.org/packages/18/1b/04ac4490a62ae1916f88e629e74192ada97d74afc927453d005f003e5a8f/lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a57d51ed2997e97f3b8e3500c984db50a554bb5db56c50b5dab1b41339b37e36",
-              "url": "https://files.pythonhosted.org/packages/3c/bb/ecf283b044c6ac5d6a7182792861b2e12f1bc905b8ae2d1d52f403f3e1dc/lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "e8c6cfb338b133fbdbc5cfaa10fe3c6aeea827db80c978dbd13bc9dd8526b7d4",
+              "url": "https://files.pythonhosted.org/packages/1d/5d/25b9007c65f45805e711b56beac50ba395214e9e556cc8ee57f0882f88a9/lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "91ba172fc5b03978764d1df5144b4ba4ab13290d7bab7a50f12d8117f8630c38",
-              "url": "https://files.pythonhosted.org/packages/45/9f/405023669e74d96d3c221832fdea58fdd4a6faaef569146c34bf4072813e/lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "659fb5809fa4629b8a1ac5106f669cfc7bef26fbb389dda53b3e010d1ac4ebae",
+              "url": "https://files.pythonhosted.org/packages/20/c0/8bab72a73607d186edad50d0168ca85bd2743cfc55560c9d721a94654b20/lazy-object-proxy-1.9.0.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "4dca6244e4121c74cc20542c2ca39e5c4a5027c81d112bfb893cf0790f96f57e",
-              "url": "https://files.pythonhosted.org/packages/4c/b2/8e7fa4469a33daf487db8c718e1e13d99ad3c590da133abd5f835ebb8b9f/lazy_object_proxy-1.7.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "721532711daa7db0d8b779b0bb0318fa87af1c10d7fe5e52ef30f8eff254d0cd",
+              "url": "https://files.pythonhosted.org/packages/27/a1/7cc10ca831679c5875c18ae6e0a468f7787ecd31fdd53598f91ea50df58d/lazy_object_proxy-1.9.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8561da8b3dd22d696244d6d0d5330618c993a215070f473b699e00cf1f3f6443",
-              "url": "https://files.pythonhosted.org/packages/54/da/022607b44f7476f0f387041b7c26329b5219b13d6c23e8d4405df217e18e/lazy_object_proxy-1.7.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "66a3de4a3ec06cd8af3f61b8e1ec67614fbb7c995d02fa224813cb7afefee701",
+              "url": "https://files.pythonhosted.org/packages/31/ad/e8605300f51061284cc57ca0f4ef582047c7f309bda1bb1c3c19b64af5c9/lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07fa44286cda977bd4803b656ffc1c9b7e3bc7dff7d34263446aec8f8c96f88a",
-              "url": "https://files.pythonhosted.org/packages/5c/96/2c984706be60a1671177f57ba9f6b17a11b4cbf1b6704f3839ad6addc284/lazy_object_proxy-1.7.1-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "7322c3d6f1766d4ef1e51a465f47955f1e8123caee67dd641e67d539a534d006",
+              "url": "https://files.pythonhosted.org/packages/4c/a4/cdd6f41a675a89ab584c78019a24adc533829764bcc85b0e24ed2678020c/lazy_object_proxy-1.9.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd7ed7429dbb6c494aa9bc4e09d94b778a3579be699f9d67da7e6804c422d3de",
-              "url": "https://files.pythonhosted.org/packages/61/08/2b64bc9c9807e9f996f9562f43d6737cf5a5ecc5be2081a13fe50b9479c0/lazy_object_proxy-1.7.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "660c94ea760b3ce47d1855a30984c78327500493d396eac4dfd8bd82041b22be",
+              "url": "https://files.pythonhosted.org/packages/4e/cb/aca3f4d89d3efbed724fd9504a96dafbe2d903ea908355a335acb110a5cd/lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7096a5e0c1115ec82641afbdd70451a144558ea5cf564a896294e346eb611be1",
-              "url": "https://files.pythonhosted.org/packages/69/b8/b97b53de2c3f62cecf8f79ae64f209714034cb888a3b76a0c8fc10728161/lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "bfb38f9ffb53b942f2b5954e0f610f1e721ccebe9cce9025a38c8ccf4a5183a4",
+              "url": "https://files.pythonhosted.org/packages/51/28/5c6dfb51df2cbb6d771a3b0d009f1edeab01f5cb16303ce32764b01636c0/lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4",
-              "url": "https://files.pythonhosted.org/packages/75/93/3fc1cc28f71dd10b87a53b9d809602d7730e84cc4705a062def286232a9c/lazy-object-proxy-1.7.1.tar.gz"
+              "hash": "e7c21c95cae3c05c14aafffe2865bbd5e377cfc1348c4f7751d9dc9a48ca4bda",
+              "url": "https://files.pythonhosted.org/packages/69/1f/51657d681711476287c9ff643428be0f9663addc1d341d4be1bad89290bd/lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "70ed0c2b380eb6248abdef3cd425fc52f0abd92d2b07ce26359fcbc399f636ad",
-              "url": "https://files.pythonhosted.org/packages/79/18/c13e90a35cc6bba07ff53ae9c6f7da739a2e143eddc487ff1c92686bf595/lazy_object_proxy-1.7.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "212774e4dfa851e74d393a2370871e174d7ff0ebc980907723bb67d25c8a7c30",
+              "url": "https://files.pythonhosted.org/packages/70/e7/f3735f8e47cb29a207568c5b8d28d9f5673228789b66cb0c48d488a37f94/lazy_object_proxy-1.9.0-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4ce15276a1a14549d7e81c243b887293904ad2d94ad767f42df91e75fd7b5b6",
-              "url": "https://files.pythonhosted.org/packages/7e/57/6dd110b383018165baf51f50020dba4667ede29542d089869a603f021357/lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "18b78ec83edbbeb69efdc0e9c1cb41a3b1b1ed11ddd8ded602464c3fc6020494",
+              "url": "https://files.pythonhosted.org/packages/82/ac/d079d3ad377ba72e29d16ac077f8626ad4d3f55369c93168d0b81153d9a2/lazy_object_proxy-1.9.0-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b",
-              "url": "https://files.pythonhosted.org/packages/97/0d/c722b060a46b9b87701896759fa0ccc4a8c19f13b4a6ed4df7f4b2fdfbec/lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "b40387277b0ed2d0602b8293b94d7257e17d1479e257b4de114ea11a8cb7f2d7",
+              "url": "https://files.pythonhosted.org/packages/86/93/e921f7a795e252df7248e0d220dc69a9443ad507fe258dea51a32e5435ca/lazy_object_proxy-1.9.0-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e368b7f7eac182a59ff1f81d5f3802161932a41dc1b1cc45c1f757dc876b5d2c",
-              "url": "https://files.pythonhosted.org/packages/a9/97/9905761dd3a34446560e8dfe1a4d8bb61796fd9d330eae833b5b8b1de220/lazy_object_proxy-1.7.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "d9e25ef10a39e8afe59a5c348a4dbf29b4868ab76269f81ce1674494e2565a6e",
+              "url": "https://files.pythonhosted.org/packages/a7/51/6626c133e966698d53d65bcd90e34ad4986c5f0968c2328b3e9de51dbcf1/lazy_object_proxy-1.9.0-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f769457a639403073968d118bc70110e7dce294688009f5c24ab78800ae56dc8",
-              "url": "https://files.pythonhosted.org/packages/be/0d/b34afd15214c7a70b246d9de36cf912dab5bac0c34d84ab1e8ab21d49239/lazy_object_proxy-1.7.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "9e7551208b2aded9c1447453ee366f1c4070602b3d932ace044715d89666899b",
+              "url": "https://files.pythonhosted.org/packages/a8/32/c1a67f76ec6923a8a8b1bc006b7cb3d195e386e03fe56e20fe38fce0321e/lazy_object_proxy-1.9.0-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6ecbb350991d6434e1388bee761ece3260e5228952b1f0c46ffc800eb313ff42",
-              "url": "https://files.pythonhosted.org/packages/c1/d5/509b11c6679c30f3ddbf91cb3c119defbc0c6806b33a79ed0e00c3816c1f/lazy_object_proxy-1.7.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "189bbd5d41ae7a498397287c408617fe5c48633e7755287b21d741f7db2706a9",
+              "url": "https://files.pythonhosted.org/packages/b0/78/78962cb6f6d31a952acbc54e7838a5a85d952144973bd6e7ad24323dd466/lazy_object_proxy-1.9.0-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a6e94c7b02641d1311228a102607ecd576f70734dc3d5e22610111aeacba8a0",
-              "url": "https://files.pythonhosted.org/packages/eb/37/7c8366d4cf80e1da5664d1e593bbf1ec7b2730c72a4d4cac4ec2d1e292c2/lazy_object_proxy-1.7.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "cbf9b082426036e19c6924a9ce90c740a9861e2bdc27a4834fd0a910742ac1e8",
+              "url": "https://files.pythonhosted.org/packages/b1/80/2d9583fa8e5ac47ef183d811d26d833477b7ed02b64c17dd2ede68a3f9cf/lazy_object_proxy-1.9.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "043651b6cb706eee4f91854da4a089816a6606c1428fd391573ef8cb642ae4f7",
-              "url": "https://files.pythonhosted.org/packages/f9/65/3682bca4b766f5b96f1cf86a35f593b738d78a98bc2c44efb9abf6b0cf16/lazy_object_proxy-1.7.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "f699ac1c768270c9e384e4cbd268d6e67aebcfae6cd623b4d7c3bfde5a35db59",
+              "url": "https://files.pythonhosted.org/packages/c9/8f/c8aab72c72634de0c726a98a1e4c84a93ef20049ee0427c871214f6a58d5/lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fd45683c3caddf83abbb1249b653a266e7069a09f486daa8863fb0e7496a9fdb",
-              "url": "https://files.pythonhosted.org/packages/fd/80/60d6ef4fd8736e743a2b91b84de0e16448dbc6ba08fa2ee071830bc36bb1/lazy_object_proxy-1.7.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2d0daa332786cf3bb49e10dc6a17a52f6a8f9601b4cf5c295a4f85854d61de63",
+              "url": "https://files.pythonhosted.org/packages/cd/b6/84efe6e878e94f20cf9564ac3ede5e98d37c692b07080aef50cc4341052e/lazy_object_proxy-1.9.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1aa3de4088c89a1b69f8ec0dcc169aa725b0ff017899ac568fe44ddc1396df46",
+              "url": "https://files.pythonhosted.org/packages/d0/f4/95999792ce5f9223bac10cb31b1724723ecd0ba13e081c5fb806d7f5b9c4/lazy_object_proxy-1.9.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8fa02eaab317b1e9e03f69aab1f91e120e7899b392c4fc19807a8278a07a97e8",
+              "url": "https://files.pythonhosted.org/packages/db/92/284ab10a6d0f82da36a20d9c1464c30bb318d1a6dd0ae476de9f890e7abd/lazy_object_proxy-1.9.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9cd077f3d04a58e83d04b20e334f678c2b0ff9879b9375ed107d5d07ff160171",
+              "url": "https://files.pythonhosted.org/packages/ed/9b/44c370c8bbba32fd0217b4f15ca99f750d669d653c7f1eefa051627710e8/lazy_object_proxy-1.9.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "79a31b086e7e68b24b99b23d57723ef7e2c6d81ed21007b6281ebcd1688acb0a",
+              "url": "https://files.pythonhosted.org/packages/fc/8d/8e0fbfeec6e51184326e0886443e44142ce22d89fa9e9c3152900e654fa0/lazy_object_proxy-1.9.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             }
           ],
           "project_name": "lazy-object-proxy",
           "requires_dists": [],
-          "requires_python": ">=3.6",
-          "version": "1.7.1"
+          "requires_python": ">=3.7",
+          "version": "1.9.0"
         },
         {
           "artifacts": [
@@ -225,34 +250,36 @@
           "project_name": "mccabe",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "0.7"
+          "version": "0.7.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-              "url": "https://files.pythonhosted.org/packages/ed/22/967181c94c3a4063fe64e15331b4cb366bdd7dfbf46fcb8ad89650026fec/platformdirs-2.5.2-py3-none-any.whl"
+              "hash": "13b08a53ed71021350c9e300d4ea8668438fb0046ab3937ac9a29913a1a1350a",
+              "url": "https://files.pythonhosted.org/packages/ca/de/a33823fe54d52ea72fdae011115d737a2642d441c93b68ed17455a328e4c/platformdirs-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19",
-              "url": "https://files.pythonhosted.org/packages/ff/7b/3613df51e6afbf2306fc2465671c03390229b55e3ef3ab9dd3f846a53be6/platformdirs-2.5.2.tar.gz"
+              "hash": "accc3665857288317f32c7bebb5a8e482ba717b474f3fc1d18ca7f9214be0cef",
+              "url": "https://files.pythonhosted.org/packages/8f/5f/01180534cebac14f3a792bf2f74fc99d34531c950c308fdebd9721e85550/platformdirs-3.1.0.tar.gz"
             }
           ],
           "project_name": "platformdirs",
           "requires_dists": [
             "appdirs==1.4.4; extra == \"test\"",
-            "furo>=2021.7.5b38; extra == \"docs\"",
-            "proselint>=0.10.2; extra == \"docs\"",
-            "pytest-cov>=2.7; extra == \"test\"",
-            "pytest-mock>=3.6; extra == \"test\"",
-            "pytest>=6; extra == \"test\"",
-            "sphinx-autodoc-typehints>=1.12; extra == \"docs\"",
-            "sphinx>=4; extra == \"docs\""
+            "covdefaults>=2.2.2; extra == \"test\"",
+            "furo>=2022.12.7; extra == \"docs\"",
+            "proselint>=0.13; extra == \"docs\"",
+            "pytest-cov>=4; extra == \"test\"",
+            "pytest-mock>=3.10; extra == \"test\"",
+            "pytest>=7.2.1; extra == \"test\"",
+            "sphinx-autodoc-typehints!=1.23.4,>=1.22; extra == \"docs\"",
+            "sphinx>=6.1.3; extra == \"docs\"",
+            "typing-extensions>=4.4; python_version < \"3.8\""
           ],
           "requires_python": ">=3.7",
-          "version": "2.5.2"
+          "version": "3.1.0"
         },
         {
           "artifacts": [
@@ -286,13 +313,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -302,6 +329,7 @@
             "filelock>=3.4.0; extra == \"testing\"",
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
@@ -310,7 +338,6 @@
             "jaraco.path>=3.2.0; extra == \"testing\"",
             "jaraco.path>=3.2.0; extra == \"testing-integration\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "mock; extra == \"testing\"",
             "pip-run>=8.8; extra == \"testing\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
@@ -319,18 +346,22 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
+            "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest; extra == \"testing-integration\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
             "tomli; extra == \"testing-integration\"",
@@ -340,7 +371,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
@@ -452,197 +483,243 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.3"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe",
-              "url": "https://files.pythonhosted.org/packages/f9/3c/110e52b9da396a4ef3a0521552a1af9c7875a762361f48678c1ac272fd7e/wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "64b1df0f83706b4ef4cfb4fb0e4c2669100fd7ecacfb59e091fad300d4e04640",
+              "url": "https://files.pythonhosted.org/packages/f8/f8/e068dafbb844c1447c55b23c921f3d338cddaba4ea53187a7dd0058452d9/wrapt-1.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f",
-              "url": "https://files.pythonhosted.org/packages/07/06/2b4aaaa4403f766c938f9780c700d7399726bce3dfd94f5a57c4e5b9dc68/wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "21f6d9a0d5b3a207cdf7acf8e58d7d13d463e639f0c7e01d82cdb671e6cb7923",
+              "url": "https://files.pythonhosted.org/packages/0c/6e/f80c23efc625c10460240e31dcb18dd2b34b8df417bc98521fbfd5bc2e9a/wrapt-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735",
-              "url": "https://files.pythonhosted.org/packages/0a/61/330f24065b8f2fc02f94321092a24e0c30aefcbac89ab5c860e180366c9f/wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "76407ab327158c510f44ded207e2f76b657303e17cb7a572ffe2f5a8a48aa04d",
+              "url": "https://files.pythonhosted.org/packages/0f/9a/179018bb3f20071f39597cd38fc65d6285d7b89d57f6c51f502048ed28d9/wrapt-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a",
-              "url": "https://files.pythonhosted.org/packages/0d/dc/3f588e42e09fb5170349924366587319e1e49d50a1a58dbe78d6046ca812/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "f2e69b3ed24544b0d3dbe2c5c0ba5153ce50dcebb576fdc4696d52aa22db6034",
+              "url": "https://files.pythonhosted.org/packages/18/f6/659d7c431a57da9c9a86945834ab2bf512f1d9ebefacea49135a0135ef1a/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d",
-              "url": "https://files.pythonhosted.org/packages/11/eb/e06e77394d6cf09977d92bff310cb0392930c08a338f99af6066a5a98f92/wrapt-1.14.1.tar.gz"
+              "hash": "0970ddb69bba00670e58955f8019bec4a42d1785db3faa043c33d81de2bf843c",
+              "url": "https://files.pythonhosted.org/packages/1e/3c/cb96dbcafbf3a27413fb15e0a1997c4610283f895dc01aca955cd2fda8b9/wrapt-1.15.0-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1",
-              "url": "https://files.pythonhosted.org/packages/12/cd/da6611401655ac2b8496b316ad9e21a3fd4f8e62e2c3b3e3c50207770517/wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "b67b819628e3b748fd3c2192c15fb951f549d0f47c0449af0764d7647302fda3",
+              "url": "https://files.pythonhosted.org/packages/23/0a/9964d7141b8c5e31c32425d3412662a7873aaf0c0964166f4b37b7db51b6/wrapt-1.15.0-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc",
-              "url": "https://files.pythonhosted.org/packages/23/8b/e4de40ac2fa6d53e694310c576e160bec3db8a282fbdcd5596544f6bc69e/wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "63424c681923b9f3bfbc5e3205aafe790904053d42ddcc08542181a30a7a51bd",
+              "url": "https://files.pythonhosted.org/packages/29/41/f05bf85417473cf6fe4eec7396c63762e5a457a42102bd1b8af059af6586/wrapt-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015",
-              "url": "https://files.pythonhosted.org/packages/2a/86/c9ef2fa4899ec069c8efe43fc92ca2ba0c5a7921cfaf83090030cf7b1487/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "a74d56552ddbde46c246b5b89199cb3fd182f9c346c784e1a93e4dc3f5ec9975",
+              "url": "https://files.pythonhosted.org/packages/2b/fb/c31489631bb94ac225677c1090f787a4ae367614b5277f13dbfde24b2b69/wrapt-1.15.0-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456",
-              "url": "https://files.pythonhosted.org/packages/33/cd/7335d8b82ff0a442581ab37a8d275ad76b4c1f33ace63c1a4d7c23791eee/wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "d5fe3e099cf07d0fb5a1e23d399e5d4d1ca3e6dfcbe5c8570ccff3e9208274f7",
+              "url": "https://files.pythonhosted.org/packages/2d/47/16303c59a890696e1a6fd82ba055fc4e0f793fb4815b5003f1f85f7202ce/wrapt-1.15.0-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af",
-              "url": "https://files.pythonhosted.org/packages/36/ee/944dc7e5462662270e8a379755bcc543fc8f09029866288060dc163ed5b4/wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "5c5aa28df055697d7c37d2099a7bc09f559d5053c3349b1ad0c39000e611d317",
+              "url": "https://files.pythonhosted.org/packages/47/dd/bee4d33058656c0b2e045530224fcddd9492c354af5d20499e5261148dcb/wrapt-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86",
-              "url": "https://files.pythonhosted.org/packages/38/38/5b338163b3b4f1ab718306984678c3d180b85a25d72654ea4c61aa6b0968/wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "76e9c727a874b4856d11a32fb0b389afc61ce8aaf281ada613713ddeadd1cfec",
+              "url": "https://files.pythonhosted.org/packages/48/65/0061e7432ca4b635e96e60e27e03a60ddaca3aeccc30e7415fed0325c3c2/wrapt-1.15.0-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2",
-              "url": "https://files.pythonhosted.org/packages/39/4d/34599a47c8a41b3ea4986e14f728c293a8a96cd6c23663fe33657c607d34/wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "d787272ed958a05b2c86311d3a4135d3c2aeea4fc655705f074130aa57d71653",
+              "url": "https://files.pythonhosted.org/packages/4a/7b/c63103817bd2f3b0145608ef642ce90d8b6d1e5780d218bce92e93045e06/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c",
-              "url": "https://files.pythonhosted.org/packages/40/f4/7be7124a06c14b92be53912f93c8dc84247f1cb93b4003bed460a430d1de/wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "74934ebd71950e3db69960a7da29204f89624dde411afbfb3b4858c1409b1e98",
+              "url": "https://files.pythonhosted.org/packages/5d/c4/3cc25541ec0404dd1d178e7697a34814d77be1e489cd6f8cb055ac688314/wrapt-1.15.0-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77",
-              "url": "https://files.pythonhosted.org/packages/49/a8/528295a24655f901148177355edb6a22b84abb2abfadacc1675643c1434a/wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "780c82a41dc493b62fc5884fb1d3a3b81106642c5c5c78d6a0d4cbe96d62ba7e",
+              "url": "https://files.pythonhosted.org/packages/65/be/3ae5afe9d78d97595b28914fa7e375ebc6329549d98f02768d5a08f34937/wrapt-1.15.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4",
-              "url": "https://files.pythonhosted.org/packages/50/d5/bf619c4d204fe8888460f65222b465c7ecfa43590fdb31864fe0e266da29/wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "56374914b132c702aa9aa9959c550004b8847148f95e1b824772d453ac204a72",
+              "url": "https://files.pythonhosted.org/packages/6b/b0/bde5400fdf6d18cb7ef527831de0f86ac206c4da1670b67633e5a547b05f/wrapt-1.15.0-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f",
-              "url": "https://files.pythonhosted.org/packages/5e/d3/bd44864e0274b7e162e2a68c71fffbd8b3a7b620efd23320fd0f70333cff/wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "078e2a1a86544e644a68422f881c48b84fef6d18f8c7a957ffd3f2e0a74a0d4a",
+              "url": "https://files.pythonhosted.org/packages/78/f2/106d90140a93690eab240fae76759d62dae639fcec1bd098eccdb83aa38f/wrapt-1.15.0-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3",
-              "url": "https://files.pythonhosted.org/packages/6a/12/76bbe26dc39d05f1a7be8d570d91c87bb79297e08e885148ed670ed17b7b/wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "2fbfbca668dd15b744418265a9607baa970c347eefd0db6a518aaf0cfbd153c0",
+              "url": "https://files.pythonhosted.org/packages/7f/b6/6dc0ddacd20337b4ce6ab0d6b0edc7da3898f85c4f97df7f30267e57509e/wrapt-1.15.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7",
-              "url": "https://files.pythonhosted.org/packages/93/12/b20ae4dbefa94ef5d667ba71324763d870b86064a944c8ec9533042a41fc/wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "e20076a211cd6f9b44a6be58f7eeafa7ab5720eb796975d0c03f05b47d89eb90",
+              "url": "https://files.pythonhosted.org/packages/88/f1/4dfaa1ad111d2a48429dca133e46249922ee2f279e9fdd4ab5b149cd6c71/wrapt-1.15.0-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b",
-              "url": "https://files.pythonhosted.org/packages/94/4b/ff8d58aee32ed91744f1ff4970e590f0c8fdda3fa6d702dc82281e0309bd/wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "7dc0713bf81287a00516ef43137273b23ee414fe41a3c14be10dd95ed98a2df9",
+              "url": "https://files.pythonhosted.org/packages/8a/1c/740c3ad1b7754dd7213f4df09ccdaf6b19e36da5ff3a269444ba9e103f1b/wrapt-1.15.0-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069",
-              "url": "https://files.pythonhosted.org/packages/94/56/fd707fb8e1ea86e72503d823549fb002a0f16cb4909619748996daeb3a82/wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "3bbe623731d03b186b3d6b0d6f51865bf598587c38d6f7b0be2e27414f7f214e",
+              "url": "https://files.pythonhosted.org/packages/8f/87/ba6dc86e8edb28fd1e314446301802751bd3157e9780385c9eef633994b9/wrapt-1.15.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248",
-              "url": "https://files.pythonhosted.org/packages/94/59/60b2fe919ffb190cf8cae0307bafdaf1695eac8655921f59768ce3bf1084/wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "54accd4b8bc202966bafafd16e69da9d5640ff92389d33d28555c5fd4f25ccb7",
+              "url": "https://files.pythonhosted.org/packages/94/55/91dd3a7efbc1db2b07bbfc490d48e8484852c355d55e61e8b1565d7725f6/wrapt-1.15.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68",
-              "url": "https://files.pythonhosted.org/packages/a7/0d/a52a0268c98a687785c5452324e10f9462d289e850066e281aa327505aa7/wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "ce42618f67741d4697684e501ef02f29e758a123aa2d669e2d964ff734ee00ee",
+              "url": "https://files.pythonhosted.org/packages/96/37/a33c1220e8a298ab18eb070b6a59e4ccc3f7344b434a7ac4bd5d4bdccc97/wrapt-1.15.0-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7",
-              "url": "https://files.pythonhosted.org/packages/bb/70/73c54e24ea69a8b06ae9649e61d5e64f2b4bdfc6f202fc7794abeac1ed20/wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "e169e957c33576f47e21864cf3fc9ff47c223a4ebca8960079b8bd36cb014fd0",
+              "url": "https://files.pythonhosted.org/packages/a2/3e/ee671ac60945154dfa3a406b8cb5cef2e3b4fa31c7d04edeb92716342026/wrapt-1.15.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656",
-              "url": "https://files.pythonhosted.org/packages/cd/ec/383d9552df0641e9915454b03139571e0c6e055f5d414d8f3d04f3892f38/wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "c99f4309f5145b93eca6e35ac1a988f0dc0a7ccf9ccdcd78d3c0adf57224e62f",
+              "url": "https://files.pythonhosted.org/packages/af/7f/25913aacbe0c2c68e7354222bdefe4e840489725eb835e311c581396f91f/wrapt-1.15.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383",
-              "url": "https://files.pythonhosted.org/packages/d9/ab/3ba5816dd466ffd7242913708771d258569825ab76fd29d7fd85b9361311/wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "2e51de54d4fb8fb50d6ee8327f9828306a959ae394d3e01a1ba8b2f937747d86",
+              "url": "https://files.pythonhosted.org/packages/b7/3d/9d3cd75f7fc283b6e627c9b0e904189c41ca144185fd8113a1a094dec8ca/wrapt-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57",
-              "url": "https://files.pythonhosted.org/packages/da/f4/7af9e01b6c1126b2daef72d5ba2cbf59a7229fd57c5b23166f694d758a8f/wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "3abbe948c3cbde2689370a262a8d04e32ec2dd4f27103669a45c6929bcdbfe7c",
+              "url": "https://files.pythonhosted.org/packages/b9/40/975fbb1ab03fa987900bacc365645c4cbead22baddd273b4f5db7f9843d2/wrapt-1.15.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3",
-              "url": "https://files.pythonhosted.org/packages/e0/20/9716fb522d17a726364c4d032c8806ffe312268773dd46a394436b2787cc/wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "b130fe77361d6771ecf5a219d8e0817d61b236b7d8b37cc045172e574ed219e6",
+              "url": "https://files.pythonhosted.org/packages/bd/47/57ffe222af59fae1eb56bca7d458b704a9b59380c47f0921efb94dc4786a/wrapt-1.15.0-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b",
-              "url": "https://files.pythonhosted.org/packages/e0/6a/3c660fa34c8106aa9719f2a6636c1c3ea7afd5931ae665eb197fdf4def84/wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "cd525e0e52a5ff16653a3fc9e3dd827981917d34996600bbc34c05d048ca35cc",
+              "url": "https://files.pythonhosted.org/packages/c3/12/5fabf0014a0f30eb3975b7199ac2731215a40bc8273083f6a89bd6cadec6/wrapt-1.15.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0",
-              "url": "https://files.pythonhosted.org/packages/e8/f6/7e30a8c53d27ef8c1ff872dc4fb75247c99eb73d834c91a49a55d046c127/wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "a89ce3fd220ff144bd9d54da333ec0de0399b52c9ac3d2ce34b569cf1a5748fb",
+              "url": "https://files.pythonhosted.org/packages/ca/1c/5caf61431705b3076ca1152abfd6da6304697d7d4fe48bb3448a6decab40/wrapt-1.15.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320",
-              "url": "https://files.pythonhosted.org/packages/f7/92/121147bb2f9ed1aa35a8780c636d5da9c167545f97737f0860b4c6c92086/wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "230ae493696a371f1dbffaad3dafbb742a4d27a0afd2b1aecebe52b740167e7f",
+              "url": "https://files.pythonhosted.org/packages/cd/a0/84b8fe24af8d7f7374d15e0da1cd5502fff59964bbbf34982df0ca2c9047/wrapt-1.15.0-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d",
-              "url": "https://files.pythonhosted.org/packages/f8/c4/3f8130d646bfc89382966adfb3d6428f26d0f752543a7e2fd92c1e493be6/wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "3a8564f283394634a7a7054b7983e47dbf39c07712d7b177b37e03f2467a024e",
+              "url": "https://files.pythonhosted.org/packages/d2/60/9fe25f4cd910ae94e75a1fd4772b058545e107a82629a5ca0f2cd7cc34d5/wrapt-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310",
-              "url": "https://files.pythonhosted.org/packages/fd/70/8a133c88a394394dd57159083b86a564247399440b63f2da0ad727593570/wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "9d37ac69edc5614b90516807de32d08cb8e7b12260a285ee330955604ed9dd29",
+              "url": "https://files.pythonhosted.org/packages/dd/eb/389f9975a6be31ddd19d29128a11f1288d07b624e464598a4b450f8d007e/wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "96177eb5645b1c6985f5c11d03fc2dbda9ad24ec0f3a46dcce91445747e15094",
+              "url": "https://files.pythonhosted.org/packages/de/77/e2ebfa2f46c19094888a364fdb59aeab9d3336a3ad7ccdf542de572d2a35/wrapt-1.15.0-cp38-cp38-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ba1711cda2d30634a7e452fc79eabcadaffedf241ff206db2ee93dd2c89a60e7",
+              "url": "https://files.pythonhosted.org/packages/e8/86/fc38e58843159bdda745258d872b1187ad916087369ec57ef93f5e832fa8/wrapt-1.15.0-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7eebcdbe3677e58dd4c0e03b4f2cfa346ed4049687d839adad68cc38bb559c92",
+              "url": "https://files.pythonhosted.org/packages/ee/25/83f5dcd9f96606521da2d0e7a03a18800264eafb59b569ff109c4d2fea67/wrapt-1.15.0-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2cf56d0e237280baed46f0b5316661da892565ff58309d4d2ed7dba763d984b8",
+              "url": "https://files.pythonhosted.org/packages/f6/89/bf77b063c594795aaa056cac7b467463702f346d124d46d7f06e76e8cd97/wrapt-1.15.0-cp39-cp39-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d6bcbfc99f55655c3d93feb7ef3800bd5bbe963a755687cbf1f490a71fb7794b",
+              "url": "https://files.pythonhosted.org/packages/f8/49/10013abe31f6892ae57c5cc260f71b7e08f1cc00f0d7b2bcfa482ea74349/wrapt-1.15.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d06730c6aed78cee4126234cf2d071e01b44b915e725a6cb439a879ec9754a3a",
+              "url": "https://files.pythonhosted.org/packages/f8/7d/73e4e3cdb2c780e13f9d87dc10488d7566d8fd77f8d68f0e416bfbd144c7/wrapt-1.15.0.tar.gz"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "41d07d029dd4157ae27beab04d22b8e261eddfc6ecd64ff7000b10dc8b3a5727",
+              "url": "https://files.pythonhosted.org/packages/fb/bd/ca7fd05a45e7022f3b780a709bbdb081a6138d828ecdb5b7df113a3ad3be/wrapt-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cdb4f085756c96a3af04e6eca7f08b1345e94b53af8921b25c72f096e704e145",
+              "url": "https://files.pythonhosted.org/packages/fd/8a/db55250ad0b536901173d737781e3b5a7cc7063c46b232c2e3a82a33c032/wrapt-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b02f21c1e2074943312d03d243ac4388319f2456576b2c6023041c4d57cd7019",
+              "url": "https://files.pythonhosted.org/packages/ff/f6/c044dec6bec4ce64fbc92614c5238dd432780b06293d2efbcab1a349629c/wrapt-1.15.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
             }
           ],
           "project_name": "wrapt",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.14.1"
+          "version": "1.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "pylint<2.15,>=2.13.0"
+    "pylint<3,>=2.13.0"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/pylint/rules.py
+++ b/src/python/pants/backend/python/lint/pylint/rules.py
@@ -160,7 +160,12 @@ async def run_pylint(
     # Ensure that the empty report dir exists.
     report_directory_digest_get = Get(Digest, CreateDigest([Directory(REPORT_DIR)]))
 
-    (pylint_pex, requirements_pex, sources, report_directory,) = await MultiGet(
+    (
+        pylint_pex,
+        requirements_pex,
+        sources,
+        report_directory,
+    ) = await MultiGet(
         pylint_pex_get,
         requirements_pex_get,
         sources_get,

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -72,8 +72,9 @@ class Pylint(PythonToolBase):
     name = "Pylint"
     help = "The Pylint linter for Python code (https://www.pylint.org/)."
 
-    default_version = "pylint>=2.13.0,<2.15"
+    default_version = "pylint>=2.13.0,<3"
     default_main = ConsoleScript("pylint")
+    default_requirements = [default_version]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.pylint", "pylint.lock")

--- a/src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock
+++ b/src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "pyupgrade<2.35,>=2.33.0"
-//   ]
+//     "pyupgrade<4,>=2.33.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,13 +31,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "16617805b8d1138f96a1ff9cdb4b302b39b51804b3fc5474dc36c0326387445a",
-              "url": "https://files.pythonhosted.org/packages/47/71/51fcb714ff40146f0af345c138486df6d411d6f626f189e623af327c2a3b/pyupgrade-2.34.0-py2.py3-none-any.whl"
+              "hash": "3b93641963df022d605c78aeae4b5956a5296ea24701eafaef9c487527b77e60",
+              "url": "https://files.pythonhosted.org/packages/31/ee/dda0d7b86c4c0cd02494566243ad14f152e10994f1c345d57e9b9edd0c8a/pyupgrade-3.3.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ed0d9f282fa6282d0ca3bc0596a022aeb95435edab9daf3fc04c2ba118687b68",
-              "url": "https://files.pythonhosted.org/packages/67/23/f973126edfc98be98c821b4e4a12a6821aa1d81bb2e1af4ff8672a9b51a8/pyupgrade-2.34.0.tar.gz"
+              "hash": "f88bce38b0ba92c2a9a5063c8629e456e8d919b67d2d42c7ecab82ff196f9813",
+              "url": "https://files.pythonhosted.org/packages/b4/e8/4c3f29d281a6dcf7ffe19a19a446fd385b34802b3b33d25ebcc5ec03d285/pyupgrade-3.3.1.tar.gz"
             }
           ],
           "project_name": "pyupgrade",
@@ -41,35 +45,36 @@
             "tokenize-rt>=3.2.0"
           ],
           "requires_python": ">=3.7",
-          "version": "2.34"
+          "version": "3.3.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "08a27fa032a81cf45e8858d0ac706004fcd523e8463415ddf1442be38e204ea8",
-              "url": "https://files.pythonhosted.org/packages/2f/e2/654a25ad594df2eb07f76e405f6f261d8fa9b5c06eb1e78549a086245455/tokenize_rt-4.2.1-py2.py3-none-any.whl"
+              "hash": "c67772c662c6b3dc65edf66808577968fb10badfc2042e3027196bed4daf9e5a",
+              "url": "https://files.pythonhosted.org/packages/8d/12/4c7495f25b4c9131706f3aaffb185d4de32c02a6ee49d875e929c5b7c919/tokenize_rt-5.0.0-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d4f69026fed520f8a1e0103aa36c406ef4661417f20ca643f913e33531b3b94",
-              "url": "https://files.pythonhosted.org/packages/2c/9c/d7c5d9e83bf5a2b52f9505ac3ce092c8788d10632ad8341b649a0906852a/tokenize_rt-4.2.1.tar.gz"
+              "hash": "3160bc0c3e8491312d0485171dea861fc160a240f5f5766b72a1165408d10740",
+              "url": "https://files.pythonhosted.org/packages/40/01/fb40ea8c465f680bf7aa3f5bee39c62ba8b7f52c38048c27aa95aff4f779/tokenize_rt-5.0.0.tar.gz"
             }
           ],
           "project_name": "tokenize-rt",
           "requires_dists": [],
-          "requires_python": ">=3.6.1",
-          "version": "4.2.1"
+          "requires_python": ">=3.7",
+          "version": "5.0.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "pyupgrade<2.35,>=2.33.0"
+    "pyupgrade<4,>=2.33.0"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -25,8 +25,9 @@ class PyUpgrade(PythonToolBase):
         "Upgrade syntax for newer versions of the language (https://github.com/asottile/pyupgrade)."
     )
 
-    default_version = "pyupgrade>=2.33.0,<2.35"
+    default_version = "pyupgrade>=2.33.0,<4"
     default_main = ConsoleScript("pyupgrade")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/ruff/ruff.lock
+++ b/src/python/pants/backend/python/lint/ruff/ruff.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "ruff==0.0.213"
+//     "ruff==0.0.254"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -31,90 +31,90 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "0a77a395a085df6e1654f423703ab8ac75f154089686c34a588e6b209c4b4209",
-              "url": "https://files.pythonhosted.org/packages/d2/92/edeef2dc9b30c8ba897c65062de4a35a83e65b606310cdfd499ba2ae5e9c/ruff-0.0.213-py3-none-musllinux_1_2_x86_64.whl"
+              "hash": "d4385cdd30153b7aa1d8f75dfd1ae30d49c918ead7de07e69b7eadf0d5538a1f",
+              "url": "https://files.pythonhosted.org/packages/aa/66/72e8531e8c1478be542097c6e0ca7d4579f0d950c1c081ed2ede082ee7ef/ruff-0.0.254-py3-none-musllinux_1_2_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f9d19762b15854e791e1f3e9ab126e7dd2968d9ced50f05bad14f0162717d1f6",
-              "url": "https://files.pythonhosted.org/packages/09/88/85672b45716120e2cd37ba01e77a5c31a8cd3e4bf1936a14ba74f0c153b6/ruff-0.0.213-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
+              "hash": "688379050ae05394a6f9f9c8471587fd5dcf22149bd4304a4ede233cc4ef89a1",
+              "url": "https://files.pythonhosted.org/packages/10/8a/12c4b8d9a600e3802148f3747cf0d3ef530da8748df0d79f73116f960a61/ruff-0.0.254-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9506861ebb92041a1d56e38d69253919b3c68874d987c3e44c1bd9feafe1e677",
-              "url": "https://files.pythonhosted.org/packages/13/d8/95d835998121ec8bd92930cf0e5640543efa4d697504f1c76b97aa6d4ea5/ruff-0.0.213.tar.gz"
+              "hash": "f70dc93bc9db15cccf2ed2a831938919e3e630993eeea6aba5c84bc274237885",
+              "url": "https://files.pythonhosted.org/packages/14/70/86a68a61322b1a342481e8e33db94e09eac352ca472058f2f691d6fd7b8d/ruff-0.0.254-py3-none-musllinux_1_2_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1b675a46aec572d82194c9418e77be8cbe1f6194ddcb955a371f1afc97373761",
-              "url": "https://files.pythonhosted.org/packages/17/e6/a17636b045826148b80708fb246e6e1dce730808cb20ec3f1b33ced4de99/ruff-0.0.213-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "09c764bc2bd80c974f7ce1f73a46092c286085355a5711126af351b9ae4bea0c",
+              "url": "https://files.pythonhosted.org/packages/29/2f/9d1c05003494c445a1bc6b6fb14baf098ed0e3683d7bc3aaa3333439e908/ruff-0.0.254-py3-none-musllinux_1_2_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "980d2df0085b2002be0e41aa813b36f23d925087c24497f8e36964d7e6590fd5",
-              "url": "https://files.pythonhosted.org/packages/1b/bb/d239e6d0e2aba60bf258e3260f61c3d411dec4e93166a1b41b4db074d74e/ruff-0.0.213-py3-none-macosx_10_7_x86_64.whl"
+              "hash": "ac1429be6d8bd3db0bf5becac3a38bd56f8421447790c50599cd90fd53417ec4",
+              "url": "https://files.pythonhosted.org/packages/40/bf/7fad53f42418f03f254374b3bfd8e73cd2a974ac778677840c4ac1808adc/ruff-0.0.254-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6a9693d991ad4908a901bd92514148151177aa3104fbcb2742aacd19304cb486",
-              "url": "https://files.pythonhosted.org/packages/40/5d/4d1d2f5026d8cc911f8f01c8f401798193eedb18ccf198007e8c14de1af6/ruff-0.0.213-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "8deba44fd563361c488dedec90dc330763ee0c01ba54e17df54ef5820079e7e0",
+              "url": "https://files.pythonhosted.org/packages/5d/1a/3769a1da21236c06fbc300048c0da4157ee7523bbf82ebf53bd73412e3ee/ruff-0.0.254-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "43c70375d32f92d62e0a39e849ac6411c1d11236f4206d83c2de654e00f24e00",
-              "url": "https://files.pythonhosted.org/packages/4c/12/49e046488691a4b0361ef1aa720ecbf21ec2392ddbb8bcd72957c5d42461/ruff-0.0.213-py3-none-musllinux_1_2_aarch64.whl"
+              "hash": "0eb66c9520151d3bd950ea43b3a088618a8e4e10a5014a72687881e6f3606312",
+              "url": "https://files.pythonhosted.org/packages/93/b4/14cb42614daf79be830a922325d982ea31f64c5ade1b312df34b331ed377/ruff-0.0.254.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "01dd64c226058ebe50cf0b8a9b800ca3096043a1f6fadd2c0eb09ca60f3fa083",
-              "url": "https://files.pythonhosted.org/packages/5e/84/3098639afa0e8ebf0b325097d6a92f99a3171a38957b83fb295959fba57d/ruff-0.0.213-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0deb1d7226ea9da9b18881736d2d96accfa7f328c67b7410478cc064ad1fa6aa",
+              "url": "https://files.pythonhosted.org/packages/9c/cb/31358d6e6f53be90d75d5ce9fd9d3c9633827b363aefd5279775d4194c5d/ruff-0.0.254-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "960fd2244f76cb8359444127724f638c61c382b37d4f6cb47c14d272e6db51d2",
-              "url": "https://files.pythonhosted.org/packages/72/44/471a97356bf065f35386d63156ff9e1dfb8ce3b668a74ce629393f1aa1d3/ruff-0.0.213-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+              "hash": "2fc21d060a3197ac463596a97d9b5db2d429395938b270ded61dd60f0e57eb21",
+              "url": "https://files.pythonhosted.org/packages/ae/f9/8c68341ac9f6f612682defcbc51ef1d04180a13cce41f21d92596e7de332/ruff-0.0.254-py3-none-musllinux_1_2_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1bb71b27e2a3d135ba52fce235ab3d8675503be13dfc33c49f7df645df58c4c8",
-              "url": "https://files.pythonhosted.org/packages/8a/50/50825da49894b5e647e988ba89e272ad86c329c6f78853bb8a60652a0e11/ruff-0.0.213-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
+              "hash": "ef20bf798ffe634090ad3dc2e8aa6a055f08c448810a2f800ab716cc18b80107",
+              "url": "https://files.pythonhosted.org/packages/be/35/ee26a0b025d0af84d24cb4a1093e0acdeae1c150d8fc98cec9d7556b4d14/ruff-0.0.254-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fd63e5a41452ce102744f9dc3ca137fae57855b5000f9bde748eaf1c0fd108fa",
-              "url": "https://files.pythonhosted.org/packages/a0/97/414b6ded188e84e6bba26d03a4a2c26d531c3515f5d1c54bcadbe1ffc5cd/ruff-0.0.213-py3-none-musllinux_1_2_armv7l.whl"
+              "hash": "27d39d697fdd7df1f2a32c1063756ee269ad8d5345c471ee3ca450636d56e8c6",
+              "url": "https://files.pythonhosted.org/packages/ce/fe/c834eaa2cd9a8c277f963d8ff5351a4c478d81f6f14c970f1fc8e1e55d05/ruff-0.0.254-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3756d604fb941edb82fe5c7da169aa064f5f163f10e4d842b4ce3b625a917fa9",
-              "url": "https://files.pythonhosted.org/packages/a8/fc/319b3d43604ee96855bdf3f539d610653b6751641c11d529450be0fc0584/ruff-0.0.213-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+              "hash": "b3f15d5d033fd3dcb85d982d6828ddab94134686fac2c02c13a8822aa03e1321",
+              "url": "https://files.pythonhosted.org/packages/d0/4d/d29b94eca79cbb939b86235106a72135aaaed80ac987f90bc9cb52cf1e24/ruff-0.0.254-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ca1987e11636b87f5ff54f037ec4571733373e6214b0c933190c0fb8ccbd44a7",
-              "url": "https://files.pythonhosted.org/packages/de/d0/2a2df646f24e50ebd46e30253cdc5ddcc2b1ca56a868c8dd8b21e66488ba/ruff-0.0.213-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl"
+              "hash": "059a380c08e849b6f312479b18cc63bba2808cff749ad71555f61dd930e3c9a2",
+              "url": "https://files.pythonhosted.org/packages/e9/91/4d367732ff80666bd77c7de0eeebb7677ef33ec225449dae0a597e99d8ba/ruff-0.0.254-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f0cd9df96046bb760c601a5789ec540c2993e72191a2f6b348f127b8e4d29e38",
-              "url": "https://files.pythonhosted.org/packages/f7/81/5ffff7a427cbe0de583dfe3eb0ca06ef920379f1e4dc75d6274f18fd9938/ruff-0.0.213-py3-none-musllinux_1_2_i686.whl"
+              "hash": "dd58c500d039fb381af8d861ef456c3e94fd6855c3d267d6c6718c9a9fe07be0",
+              "url": "https://files.pythonhosted.org/packages/eb/1c/4edb3c205ce3b1b3979bf4913cdba5872283ff013eabb5297c8e65d47535/ruff-0.0.254-py3-none-macosx_10_7_x86_64.whl"
             }
           ],
           "project_name": "ruff",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "0.0.213"
+          "version": "0.0.254"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "ruff==0.0.213"
+    "ruff==0.0.254"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/lint/ruff/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/ruff/rules_integration_test.py
@@ -100,7 +100,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_ruff(rule_runner, [tgt])
-    assert result.stdout == "Found 1 error(s) (1 fixed, 0 remaining).\n"
+    assert result.stdout == "Found 1 error (1 fixed, 0 remaining).\n"
     assert result.stderr == ""
     assert result.did_change
     assert result.output == get_snapshot(rule_runner, {"f.py": GOOD_FILE})

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -56,8 +56,9 @@ class Ruff(PythonToolBase):
     name = "Ruff"
     help = "The Ruff Python formatter (https://github.com/charliermarsh/ruff)."
 
-    default_version = "ruff==0.0.213"
+    default_version = "ruff==0.0.254"
     default_main = ConsoleScript("ruff")
+    default_requirements = ["ruff>=0.0.213,<0.1"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -28,9 +28,10 @@ class Yapf(PythonToolBase):
     name = "yapf"
     help = "A formatter for Python files (https://github.com/google/yapf)."
 
-    default_version = "yapf==0.32.0"
+    default_version = "yapf>=0.32.0,<1"
     default_extra_requirements = ["toml"]
     default_main = ConsoleScript("yapf")
+    default_requirements = [default_version, *default_extra_requirements]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/lint/yapf/yapf.lock
+++ b/src/python/pants/backend/python/lint/yapf/yapf.lock
@@ -4,14 +4,18 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "toml",
-//     "yapf==0.32.0"
-//   ]
+//     "yapf<1,>=0.32.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -58,18 +62,19 @@
           "project_name": "yapf",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.32"
+          "version": "0.32.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "toml",
-    "yapf==0.32.0"
+    "yapf<1,>=0.32.0"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -328,7 +328,6 @@ def parse_single_dependency(
     attributes: str | Mapping[str, str | Sequence] | Sequence[Mapping[str, str | Sequence]],
     pyproject_toml: PyProjectToml,
 ) -> Iterator[PipRequirement]:
-
     if isinstance(attributes, str):
         # E.g. `foo = "~1.1~'.
         yield PipRequirement.parse(

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -108,7 +108,6 @@ def test_handle_str(test, exp) -> None:
 
 
 def test_add_markers() -> None:
-
     attr_mark = PyprojectAttr({"markers": "platform_python_implementation == 'CPython'"})
     assert (
         add_markers("foo==1.0.0", attr_mark, "somepath")

--- a/src/python/pants/backend/python/macros/python_artifact.py
+++ b/src/python/pants/backend/python/macros/python_artifact.py
@@ -57,7 +57,7 @@ def _normalize_entry_points(
 class PythonArtifact:
     """Represents a Python setup.py-based project."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         """
         :param kwargs: Passed to `setuptools.setup
           <https://setuptools.pypa.io/en/latest/setuptools.html>`_.

--- a/src/python/pants/backend/python/packaging/pyoxidizer/pyoxidizer.lock
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/pyoxidizer.lock
@@ -9,12 +9,8 @@
 //     "CPython<4,>=3.8"
 //   ],
 //   "generated_with_requirements": [
-//     "pyoxidizer==0.18.0"
+//     "pyoxidizer<1,>=0.18.0"
 //   ],
-//   "indexes": [
-//     "https://pypi.org/simple/"
-//   ],
-//   "find_links": [],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
 //   "only_binary": [],
@@ -35,49 +31,40 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5ac421ea9d05488d745b0f340d64ed6cbcbea6c2adeca394662e9c582394579a",
-              "url": "https://files.pythonhosted.org/packages/8f/cd/2d865e341856220e8aecf6408808748e498727a7d6afae6522f838a15e37/pyoxidizer-0.18.0-py3-none-manylinux2014_armv7l.whl"
+              "hash": "825d37c8d44971f3e7ca6beed77b560b508c69497f48019428f1aae3fd80c049",
+              "url": "https://files.pythonhosted.org/packages/72/ff/02653151eb66ce7c945ee19aadcbdd5cd6a8e13e201254bb6a787df851dd/pyoxidizer-0.24.0-py3-none-manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "488ccbb2bd78da47a76f4401486a9e29900ce67e601e24180744d548cd12dada",
-              "url": "https://files.pythonhosted.org/packages/3e/b9/40edb7a179953fdcfb8caf09b0fb6802b4c21ae2a9a2f5893bffb77b6c01/pyoxidizer-0.18.0-py3-none-manylinux2010_x86_64.whl"
+              "hash": "ec56f2b99495aa0178e927389a3e151e9669beae4e2bce3f6897fb9891b5502e",
+              "url": "https://files.pythonhosted.org/packages/62/e5/2f5a9cc8fb06aff4fe84299bf7fa9815b1eaee81842137e0e98a45ab1b3e/pyoxidizer-0.24.0-py3-none-manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bb92388a02a11d023bee3d48f8b1343f59a7d2ab1b04489b9bd7df988ed9a1a0",
-              "url": "https://files.pythonhosted.org/packages/51/47/a2d608af0c94be395a1e4a8c10bc9a85263ada76a399b2516f4fcea64c08/pyoxidizer-0.18.0-py3-none-macosx_10_9_x86_64.whl"
+              "hash": "eed0f08a38798f14cf0464272552aef97e534b9a418d2a671b8d85ec7af1a237",
+              "url": "https://files.pythonhosted.org/packages/7a/93/aae15e73855e6e9a327528b506b4ae2e6e0f94d301fed8f27015bbe047e4/pyoxidizer-0.24.0-py3-none-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "db936efed3cca44195c0d08706636220bbb1d426babd8fac7a85f6a99149b803",
-              "url": "https://files.pythonhosted.org/packages/52/00/cc4ab87ffdafdeed4fc2b832a786701924d25536e7c8b804dbc90667e2f9/pyoxidizer-0.18.0-py3-none-manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "3de42fa117fef3cf5f916de2380d2572838936e2215b8cb7eed072e15f04b836",
-              "url": "https://files.pythonhosted.org/packages/6b/1e/242e68bc472c0773f1c2ffb56e46f22d0fc1b18e8edf0c89be63890835f9/pyoxidizer-0.18.0-py3-none-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "23debea5a5dab400edf583ddd3ff2e58b00c1c3ca45a9a37a97f9e300176faa3",
-              "url": "https://files.pythonhosted.org/packages/70/22/a291eb5651ec2d53f5e510635ff5f0cfbff5a1792d4953660e499f099f4f/pyoxidizer-0.18.0-py3-none-manylinux2010_i686.whl"
+              "hash": "1a9940d2bdb6c9e6c6c45eb4de3d4d6e5c9b3a3724dbc7d774d85d4956058447",
+              "url": "https://files.pythonhosted.org/packages/ab/bc/ac789f384f84583a5057b6198553e407e1116375cf1840427bad56d1f97f/pyoxidizer-0.24.0-py3-none-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "pyoxidizer",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.18"
+          "version": "0.24.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.103",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "pyoxidizer==0.18.0"
+    "pyoxidizer<1,>=0.18.0"
   ],
   "requires_python": [
     "<4,>=3.8"

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -226,7 +226,8 @@ async def run_pyoxidizer_binary(field_set: PyOxidizerFieldSet) -> RunRequest:
             return False
 
         artifact_path = PurePath(artifact_relpath)
-        return artifact_path.parent.name == "install"
+        # COPYING.txt is the default name later versions of pyoxidizer use to write an SBOM.
+        return artifact_path.parent.name == "install" and artifact_path.name != "COPYING.txt"
 
     binary = await Get(BuiltPackage, PackageFieldSet, field_set)
     executable_binaries = [

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
@@ -91,6 +91,7 @@ def test_end_to_end() -> None:
             f"{tmpdir}/hellotest:bin",
         ]
         run_result = run_pants(run_args)
+        print(run_result)
         assert run_result.exit_code == 42
         assert run_result.stdout == "Hello world!\n"
 

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -26,8 +26,9 @@ class PyOxidizer(PythonToolBase):
         """
     )
 
-    default_version = "pyoxidizer==0.18.0"
+    default_version = "pyoxidizer>=0.18.0,<1"
     default_main = ConsoleScript("pyoxidizer")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.8,<4"]

--- a/src/python/pants/backend/python/subsystems/coverage_py.lock
+++ b/src/python/pants/backend/python/subsystems/coverage_py.lock
@@ -9,7 +9,7 @@
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "coverage[toml]<6.6,>=6.5"
+//     "coverage[toml]<8,>=6.5"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -31,203 +31,208 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a",
-              "url": "https://files.pythonhosted.org/packages/6e/e6/b31a4b2aa9489da59b35ee0ea4259d6fe9b321a1eaa6492f19342d03d53b/coverage-6.5.0-pp36.pp37.pp38-none-any.whl"
+              "hash": "436313d129db7cf5b4ac355dd2bd3f7c7e5294af077b090b85de75f8458b8616",
+              "url": "https://files.pythonhosted.org/packages/9e/de/989111fbf70f00912513912b3111072680154ec713b3f3d523636832965d/coverage-7.2.1-pp37.pp38.pp39-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398",
-              "url": "https://files.pythonhosted.org/packages/02/7a/a45f3958442d50b9a930a62f0dba9ee502521213ebd016203c2890ea212f/coverage-6.5.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "5d2b9b5e70a21474c105a133ba227c61bc95f2ac3b66861143ce39a5ea4b3f84",
+              "url": "https://files.pythonhosted.org/packages/06/64/cf8b320fcedbca7216e050c0529364241a0746eecff2d521fa31575b997f/coverage-7.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c",
-              "url": "https://files.pythonhosted.org/packages/05/63/a789b462075395d34f8152229dccf92b25ca73eac05b3f6cd75fa5017095/coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "bdd3f2f285ddcf2e75174248b2406189261a79e7fedee2ceeadc76219b6faa0e",
+              "url": "https://files.pythonhosted.org/packages/1c/89/b2f00ae4d1267aeed0026e68b17a6357afe52c1f773dff9c595da4b88977/coverage-7.2.1-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba",
-              "url": "https://files.pythonhosted.org/packages/07/82/79fa21ceca9a9b091eb3c67e27eb648dade27b2c9e1eb23af47232a2a365/coverage-6.5.0-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "80559eaf6c15ce3da10edb7977a1548b393db36cbc6cf417633eca05d84dd1ed",
+              "url": "https://files.pythonhosted.org/packages/24/8d/d9d880cb7319cc06eab02757a0fb3f623c6e7613d16d297cfdf249d4926d/coverage-7.2.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79",
-              "url": "https://files.pythonhosted.org/packages/0d/ef/8735875a8dc09e1c4e484a5436c8b4148731b70daccc6f203c50b05e7505/coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "9e872b082b32065ac2834149dc0adc2a2e6d8203080501e1e3c3c77851b466f9",
+              "url": "https://files.pythonhosted.org/packages/2d/24/06ad2452717337ed45a928107fc5d91601a4a79692012ee86dc06782ab51/coverage-7.2.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae",
-              "url": "https://files.pythonhosted.org/packages/10/9e/68e384940179713640743a010ac7f7c813d1087c8730a9c0bdfa73bdffd7/coverage-6.5.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "834c2172edff5a08d78e2f53cf5e7164aacabeb66b369f76e7bb367ca4e2d993",
+              "url": "https://files.pythonhosted.org/packages/2f/e3/15f85c7527577907ddf354f45ad212c3882012c92186d45baa553cff47e3/coverage-7.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04",
-              "url": "https://files.pythonhosted.org/packages/13/f3/c6025ba30f2ce21d20d5332c3819880fe8afdfc008c2e2f9c075c7b67543/coverage-6.5.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "f29351393eb05e6326f044a7b45ed8e38cb4dcc38570d12791f271399dc41431",
+              "url": "https://files.pythonhosted.org/packages/36/51/e0a33466be7083709db9325167349ffeeedc419bb73864f72c8280e25aae/coverage-7.2.1-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4",
-              "url": "https://files.pythonhosted.org/packages/15/b0/3639d84ee8a900da0cf6450ab46e22517e4688b6cec0ba8ab6f8166103a2/coverage-6.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8dca3c1706670297851bca1acff9618455122246bdae623be31eca744ade05ec",
+              "url": "https://files.pythonhosted.org/packages/3d/f5/97bdecac0c23ec52d2ddf4cae5d6de3c69c4441f1b1e448ff7975f91d37b/coverage-7.2.1-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe",
-              "url": "https://files.pythonhosted.org/packages/18/95/27f80dcd8273171b781a19d109aeaed7f13d78ef6d1e2f7134a5826fd1b4/coverage-6.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "4dd34a935de268a133e4741827ae951283a28c0125ddcdbcbba41c4b98f2dfef",
+              "url": "https://files.pythonhosted.org/packages/44/39/5efa733d0508d31565faf2761998f2e0417bfbb5bf4269b64384c7f5031a/coverage-7.2.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466",
-              "url": "https://files.pythonhosted.org/packages/2f/8b/ca3fe3cfbd66d63181f6e6a06b8b494bb327ba8222d2fa628b392b9ad08a/coverage-6.5.0-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "d9256d4c60c4bbfec92721b51579c50f9e5062c21c12bec56b55292464873508",
+              "url": "https://files.pythonhosted.org/packages/47/83/d5353ffb69cd7cfb32e146475d10b6ebba930d9eb323e508933df0d02434/coverage-7.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75",
-              "url": "https://files.pythonhosted.org/packages/36/f3/5cbd79cf4cd059c80b59104aca33b8d05af4ad5bf5b1547645ecee716378/coverage-6.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "99f4dd81b2bb8fc67c3da68b1f5ee1650aca06faa585cbc6818dbf67893c6d58",
+              "url": "https://files.pythonhosted.org/packages/4a/80/44c734492221b7e065bd8a2856c3f2f4650664abad70aab5e22a9d71a984/coverage-7.2.1-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0",
-              "url": "https://files.pythonhosted.org/packages/3c/7d/d5211ea782b193ab8064b06dc0cc042cf1a4ca9c93a530071459172c550f/coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8649371570551d2fd7dee22cfbf0b61f1747cdfb2b7587bb551e4beaaa44cb97",
+              "url": "https://files.pythonhosted.org/packages/4e/42/eca4b81b6fb43731dba91dbf35af617fe4999ee4270132eb2a9cd90b8566/coverage-7.2.1-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e",
-              "url": "https://files.pythonhosted.org/packages/40/3b/cd68cb278c4966df00158811ec1e357b9a7d132790c240fc65da57e10013/coverage-6.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "fac6343bae03b176e9b58104a9810df3cdccd5cfed19f99adfa807ffbf43cf9b",
+              "url": "https://files.pythonhosted.org/packages/4e/6b/7d9c6c23aa227b91bc2f85f197406b899a4469c6e0d182d499eb2a515e91/coverage-7.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b",
-              "url": "https://files.pythonhosted.org/packages/4b/66/6e588f5dfc93ccedd06d6785c8143f17bb92b89247d50128d8789e9588d0/coverage-6.5.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "7f099da6958ddfa2ed84bddea7515cb248583292e16bb9231d151cd528eab657",
+              "url": "https://files.pythonhosted.org/packages/4f/1a/a3106f807989fa33aa6e378a11cfd4df6873f243c0406122cc2fd03c4c3c/coverage-7.2.1-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795",
-              "url": "https://files.pythonhosted.org/packages/50/cf/455930004231fa87efe8be06d13512f34e070ddfee8b8bf5a050cdc47ab3/coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl"
+              "hash": "3a209d512d157379cc9ab697cbdbb4cfd18daa3e7eebaa84c3d20b6af0037384",
+              "url": "https://files.pythonhosted.org/packages/50/aa/b799631d7c990e777da1a6ba85ccf5194180c79d49f20a1acb1306a18a13/coverage-7.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518",
-              "url": "https://files.pythonhosted.org/packages/58/2c/213861cec1d9f6451d29c0b1838769b558f6a8c6844b001f6e98c37c4b1b/coverage-6.5.0-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "570c21a29493b350f591a4b04c158ce1601e8d18bdcd21db136fbb135d75efa6",
+              "url": "https://files.pythonhosted.org/packages/51/61/2bab4add265c0fcf0a4372ab9e647405f157a9c5cdcbab1e0b7b117f92fa/coverage-7.2.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84",
-              "url": "https://files.pythonhosted.org/packages/5c/66/38d1870cb7cf62da49add1d6803fdbcdef632b2808b5c80bcac35b7634d8/coverage-6.5.0.tar.gz"
+              "hash": "cb5f152fb14857cbe7f3e8c9a5d98979c4c66319a33cad6e617f0067c9accdc4",
+              "url": "https://files.pythonhosted.org/packages/59/7b/250aa653d48f6dccc553dd95739aac5ed7880ee99358b0d5aa0f13d1a338/coverage-7.2.1-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d",
-              "url": "https://files.pythonhosted.org/packages/61/a6/af54588e2091693026df94b09106ee10dcbcdc8c9b2c3989149e6e44a324/coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "a81dbcf6c6c877986083d00b834ac1e84b375220207a059ad45d12f6e518a4e3",
+              "url": "https://files.pythonhosted.org/packages/61/fb/3a9756915a126b138e69f2eef2118b64f126250e6e67d597821eb23dcaf2/coverage-7.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc",
-              "url": "https://files.pythonhosted.org/packages/63/e9/f23e8664ec4032d7802a1cf920853196bcbdce7b56408e3efe1b2da08f3c/coverage-6.5.0-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "5928b85416a388dd557ddc006425b0c37e8468bd1c3dc118c1a3de42f59e2a54",
+              "url": "https://files.pythonhosted.org/packages/6e/1b/3cc2589eae54eee6d5535e5437883fafd9e5b598961a21a6c0459ad97666/coverage-7.2.1-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f",
-              "url": "https://files.pythonhosted.org/packages/64/7f/13f5d58f5ca41182d7020af5257c8fd08ddf33921d2a28cf66753571c278/coverage-6.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "e4d70c853f0546855f027890b77854508bdb4d6a81242a9d804482e667fff6e6",
+              "url": "https://files.pythonhosted.org/packages/7b/36/afdf9ae3cf36ad922599df32b5517f48be389761869907bf89670eecd362/coverage-7.2.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91",
-              "url": "https://files.pythonhosted.org/packages/6a/63/8e82513b7e4a1b8d887b4e85c1c2b6c9b754a581b187c0b084f3330ac479/coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "8d3843ca645f62c426c3d272902b9de90558e9886f15ddf5efe757b12dd376f5",
+              "url": "https://files.pythonhosted.org/packages/7b/f9/5b9e843989ab7461e97f0cba987f78fb043adc8975e65af9eb9bda22c3a2/coverage-7.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef",
-              "url": "https://files.pythonhosted.org/packages/6b/ba/ef67c1e859b8ddd8cafb81199986ff702efcd4ee5d373670a0bc0a293d1f/coverage-6.5.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "0f8318ed0f3c376cfad8d3520f496946977abde080439d6689d7799791457454",
+              "url": "https://files.pythonhosted.org/packages/7c/f6/3c1715c27e3251baa578b469f3c266b48623d3bce4ea08509a636e11447c/coverage-7.2.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5",
-              "url": "https://files.pythonhosted.org/packages/6b/f2/919f0fdc93d3991ca074894402074d847be8ac1e1d78e7e9e1c371b69a6f/coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0339dc3237c0d31c3b574f19c57985fcbe494280153bbcad33f2cdf469f4ac3e",
+              "url": "https://files.pythonhosted.org/packages/85/97/8b13f1afcdef9d8deb65ffb8f70f6d1519dacecf269f80349c3b424eca2e/coverage-7.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c",
-              "url": "https://files.pythonhosted.org/packages/76/44/78c1936c2bd9e7705f170d5e413ed34d9d6d7d0324757786627f88df1514/coverage-6.5.0-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "c77f2a9093ccf329dd523a9b2b3c854c20d2a3d968b6def3b820272ca6732242",
+              "url": "https://files.pythonhosted.org/packages/8d/4a/3518606d4b110df4f3e77bd52c241ae8a84c6dc74fac7c2a8e809449e541/coverage-7.2.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa",
-              "url": "https://files.pythonhosted.org/packages/78/98/253ce0cfcc3b352d3072940940ed44a035614f2abe781477f77038d21d9f/coverage-6.5.0-cp311-cp311-musllinux_1_1_i686.whl"
+              "hash": "e191a63a05851f8bce77bc875e75457f9b01d42843f8bd7feed2fc26bbe60833",
+              "url": "https://files.pythonhosted.org/packages/94/91/c708f837c5550ff5447203e29f5273d9b20959fa48753bcfe58cd522fbef/coverage-7.2.1-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3",
-              "url": "https://files.pythonhosted.org/packages/85/03/9dcc8b7e269cfeaf5519d433d841a7d78f283c5fb016385d4690e1aedfc1/coverage-6.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "f3d07edb912a978915576a776756069dede66d012baa503022d3a0adba1b6afa",
+              "url": "https://files.pythonhosted.org/packages/aa/9f/9d5ffcca635f09cb92e66afb149996889ea8cb7408bec5e908d36686bf8a/coverage-7.2.1-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b",
-              "url": "https://files.pythonhosted.org/packages/89/58/5ec19b43a6511288511f64fc4763d95af8403f5926e7e4556e6b29b03a26/coverage-6.5.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "abacd0a738e71b20e224861bc87e819ef46fedba2fb01bc1af83dfd122e9c319",
+              "url": "https://files.pythonhosted.org/packages/af/ff/bf04eeb95213c25a5ef718e1e70b6e476f4e6f48b00d62860f3a8facd3ef/coverage-7.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660",
-              "url": "https://files.pythonhosted.org/packages/89/a2/cbf599e50bb4be416e0408c4cf523c354c51d7da39935461a9687e039481/coverage-6.5.0-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "ae82c988954722fa07ec5045c57b6d55bc1a0890defb57cf4a712ced65b26ddd",
+              "url": "https://files.pythonhosted.org/packages/bb/2d/0011ba3d37d53a840728390a86120f7316ec059a656afe42386abc67bfaa/coverage-7.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f",
-              "url": "https://files.pythonhosted.org/packages/a1/6b/7efeeffc7559150a705931b2144b936042c561e63ef248f0e0d9f4523d74/coverage-6.5.0-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "b1991a6d64231a3e5bbe3099fb0dd7c9aeaa4275ad0e0aeff4cb9ef885c62ba2",
+              "url": "https://files.pythonhosted.org/packages/bc/d8/a06bc91226ff1940547934af0c514acd17510cf9b9a54b13046e5f2d9538/coverage-7.2.1-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b",
-              "url": "https://files.pythonhosted.org/packages/a3/a0/4c59586df0511b18f7b59593672a4baadacef8f393024052d59c6222477c/coverage-6.5.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "09643fb0df8e29f7417adc3f40aaf379d071ee8f0350ab290517c7004f05360b",
+              "url": "https://files.pythonhosted.org/packages/bf/4e/bb6008789e813f6930179757acdd409f0056e48ef687416bed819464a79c/coverage-7.2.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62",
-              "url": "https://files.pythonhosted.org/packages/a8/d9/b367c52cb1297414ba967e38fe9b5338ee4700a2d1592fc78532dc9f882f/coverage-6.5.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "3004765bca3acd9e015794e5c2f0c9a05587f5e698127ff95e9cfba0d3f29339",
+              "url": "https://files.pythonhosted.org/packages/c8/33/f3cf1fd69b2de5c9d63836c517bd0082fa6db53aa5068ae7df9acf115b9e/coverage-7.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4",
-              "url": "https://files.pythonhosted.org/packages/ac/bc/c9d4fd6b3494d2cc1e26f4b98eb19206b92a59094617ad02d5689ac9d3c4/coverage-6.5.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+              "hash": "87dc37f16fb5e3a28429e094145bf7c1753e32bb50f662722e378c5851f7fdc6",
+              "url": "https://files.pythonhosted.org/packages/d4/94/fb0c114600331faead0abd61d8182fcc67030f0711dd5841d7c9a36cdaf0/coverage-7.2.1-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b",
-              "url": "https://files.pythonhosted.org/packages/bd/a0/e263b115808226fdb2658f1887808c06ac3f1b579ef5dda02309e0d54459/coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "97a3189e019d27e914ecf5c5247ea9f13261d22c3bb0cfcfd2a9b179bb36f8b1",
+              "url": "https://files.pythonhosted.org/packages/d4/e1/c6c41180badec9d558bcbdb989792acd414fd93336b8c0a8d91ffe2e3a4a/coverage-7.2.1-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a",
-              "url": "https://files.pythonhosted.org/packages/c0/18/2a0a9b3c29376ce04ceb7ca2948559dad76409a2c9b3f664756581101e16/coverage-6.5.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "0bd7e628f6c3ec4e7d2d24ec0e50aae4e5ae95ea644e849d92ae4805650b4c4e",
+              "url": "https://files.pythonhosted.org/packages/d9/c5/8a6ad089d9d9a15f94f40957d804e7712767f8ac458eca55b02a73d249d6/coverage-7.2.1-cp311-cp311-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53",
-              "url": "https://files.pythonhosted.org/packages/c4/8d/5ec7d08f4601d2d792563fe31db5e9322c306848fec1e65ec8885927f739/coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "cca7c0b7f5881dfe0291ef09ba7bb1582cb92ab0aeffd8afb00c700bf692415a",
+              "url": "https://files.pythonhosted.org/packages/da/f6/6c8f89d02dd9fda71ec61a5baa4d210017f2eb0bb57d4dd513d98d875867/coverage-7.2.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f",
-              "url": "https://files.pythonhosted.org/packages/c8/e8/e712b61abf1282ce3ac9826473ab4b245a4319303cce2e4115a8de1435f2/coverage-6.5.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "49567ec91fc5e0b15356da07a2feabb421d62f52a9fff4b1ec40e9e19772f5f8",
+              "url": "https://files.pythonhosted.org/packages/e4/ae/489a39a3615a23000f731ddd0a8d397f771b42ab2d0404fd6607f0a38c42/coverage-7.2.1-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d",
-              "url": "https://files.pythonhosted.org/packages/cd/48/65d314e702b4a7095ea96da0a319a5a377e594354a4a6badde483832bb5a/coverage-6.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "8a6450da4c7afc4534305b2b7d8650131e130610cea448ff240b6ab73d7eab63",
+              "url": "https://files.pythonhosted.org/packages/e5/a9/62aabc67971d2fd439474b05cfc25c852b28bb6dfe8082c5b665652899f5/coverage-7.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf",
-              "url": "https://files.pythonhosted.org/packages/d6/0f/012a7370aaf61123a222b34b657dedc63e03ce2af8d064ac5c5afe14f29c/coverage-6.5.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "861cc85dfbf55a7a768443d90a07e0ac5207704a9f97a8eb753292a7fcbdfcfc",
+              "url": "https://files.pythonhosted.org/packages/f2/08/ed8f2266db3f851de17df7a5923157d2444969af283daf99ca572c4c724d/coverage-7.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e",
-              "url": "https://files.pythonhosted.org/packages/e5/fb/11982f5faf2990d4d9159e01a12bbf0a7d7873893d4d2e2acec012ad69ae/coverage-6.5.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "b2167d116309f564af56f9aa5e75ef710ef871c5f9b313a83050035097b56820",
+              "url": "https://files.pythonhosted.org/packages/f3/ff/0bf7a9497dc91e4b0f11656a50c95fd1e641d912a281a0b0921d20fa5760/coverage-7.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745",
-              "url": "https://files.pythonhosted.org/packages/ea/52/c08080405329326a7ff16c0dfdb4feefaa8edd7446413df67386fe1bbfe0/coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "78d2c3dde4c0b9be4b02067185136b7ee4681978228ad5ec1278fa74f5ca3e99",
+              "url": "https://files.pythonhosted.org/packages/f5/70/9400b5c37f43d8e39527f9209cc7b1db96b5f16a6a3da2ccd8f75465d567/coverage-7.2.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2ef6cae70168815ed91388948b5f4fcc69681480a0061114db737f957719f03",
+              "url": "https://files.pythonhosted.org/packages/f9/06/5f6555205d13f8811558b73fa37596519272fb077ad7f9faa4e4162a23a4/coverage-7.2.1-cp310-cp310-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "coverage",
@@ -235,7 +240,7 @@
             "tomli; python_full_version <= \"3.11.0a6\" and extra == \"toml\""
           ],
           "requires_python": ">=3.7",
-          "version": "6.5"
+          "version": "7.2.1"
         },
         {
           "artifacts": [
@@ -260,11 +265,11 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.108",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "coverage[toml]<6.6,>=6.5"
+    "coverage[toml]<8,>=6.5"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/subsystems/debugpy.lock
+++ b/src/python/pants/backend/python/subsystems/debugpy.lock
@@ -9,7 +9,7 @@
 //     "CPython>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "debugpy==1.6.0"
+//     "debugpy<1.7,>=1.6.5"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -31,70 +31,65 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4de7777842da7e08652f2776c552070bbdd758557fdec73a15d7be0e4aab95ce",
-              "url": "https://files.pythonhosted.org/packages/e3/9c/0920139b8ccce7565e1e5ba1ccdeeba281bbab37392689aa00dfb6b55a6d/debugpy-1.6.0-py2.py3-none-any.whl"
+              "hash": "be596b44448aac14eb3614248c91586e2bc1728e020e82ef3197189aae556115",
+              "url": "https://files.pythonhosted.org/packages/f9/35/325e53d2a75b28777c28e790f84ea1ee45e1ecc00ae76550a53872a541f9/debugpy-1.6.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e3513399177dd37af4c1332df52da5da1d0c387e5927dc4c0709e26ee7302e8f",
-              "url": "https://files.pythonhosted.org/packages/03/08/5746cb2c425af840fffe3ff727e7257ee1169c5af19ccf5c225a7e36cd85/debugpy-1.6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "9b5d1b13d7c7bf5d7cf700e33c0b8ddb7baf030fcf502f76fc061ddd9405d16c",
+              "url": "https://files.pythonhosted.org/packages/02/2a/ce810a4aa646a1815da8df938d9a3476b5920059c5b6076c598dce255147/debugpy-1.6.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8ee75844242b4537beb5899f3e60a578454d1f136b99e8d57ac424573797b94a",
-              "url": "https://files.pythonhosted.org/packages/0e/21/eaac4b6ff2503e2ad86b3cdd7fe2875cbcd11af2b648eef8285346290196/debugpy-1.6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "23363e6d2a04d726bbc1400bd4e9898d54419b36b2cdf7020e3e215e1dcd0f8e",
+              "url": "https://files.pythonhosted.org/packages/0e/79/6995198851451c0b6be67244d51e33f032d3c2be0e9d941334d3551e3785/debugpy-1.6.6-cp38-cp38-macosx_10_15_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "132defb585b518955358321d0f42f6aa815aa15b432be27db654807707c70b2f",
-              "url": "https://files.pythonhosted.org/packages/29/14/37d8721384550a40d766634a0aa6ecdcd1967c462f9c1ef38e1ad4d87bb1/debugpy-1.6.0-cp38-cp38-macosx_10_15_x86_64.whl"
+              "hash": "dff595686178b0e75580c24d316aa45a8f4d56e2418063865c114eef651a982e",
+              "url": "https://files.pythonhosted.org/packages/1f/19/345c21f6b62acf556c39e4358a22b0ad868fecb462c1041c13513d229b33/debugpy-1.6.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e3aa2368883e83e7b689ddff3cafb595f7b711f6a065886b46a96a7fef874e7",
-              "url": "https://files.pythonhosted.org/packages/31/c4/7da0696f7f07dc30d474d06cf087c788d1dad12d6fdb39b0ba8cbece1f72/debugpy-1.6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "23c29e40e39ad7d869d408ded414f6d46d82f8a93b5857ac3ac1e915893139ca",
+              "url": "https://files.pythonhosted.org/packages/23/93/e2d0ca3e60ad679d5f258d972cce1403cd0bbbd8be6fa5292ef0d229eb3d/debugpy-1.6.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eb1946efac0c0c3d411cea0b5ac772fbde744109fd9520fb0c5a51979faf05ad",
-              "url": "https://files.pythonhosted.org/packages/36/9e/acfa30a163037b8cabfa2251ad3f722caf4cde887f8e93f97451470e4bbc/debugpy-1.6.0-cp310-cp310-macosx_10_15_x86_64.whl"
+              "hash": "0ea1011e94416e90fb3598cc3ef5e08b0a4dd6ce6b9b33ccd436c1dffc8cd664",
+              "url": "https://files.pythonhosted.org/packages/c6/fe/1b1bb61a51c2dd83660c4f3ac685534a65197354be9abe6862c21f38d846/debugpy-1.6.6-cp310-cp310-macosx_11_0_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "245c7789a012f86210847ec7ee9f38c30a30d4c2223c3e111829a76c9006a5d0",
-              "url": "https://files.pythonhosted.org/packages/45/a7/0bf4729aa497cc8837e9b525f34e6bad69f2191cfc14d63b36214add7a5c/debugpy-1.6.0-cp39-cp39-macosx_10_15_x86_64.whl"
+              "hash": "b9c2130e1c632540fbf9c2c88341493797ddf58016e7cba02e311de9b0a96b67",
+              "url": "https://files.pythonhosted.org/packages/d5/b4/dee6aae40c3ff7a4c3b27f1611f64ab8570a07add5f82321414d9ced4fec/debugpy-1.6.6.zip"
             },
             {
               "algorithm": "sha256",
-              "hash": "7b79c40852991f7b6c3ea65845ed0f5f6b731c37f4f9ad9c61e2ab4bd48a9275",
-              "url": "https://files.pythonhosted.org/packages/9c/45/8e3384e99b8bf79f8ba937aa3e726331789bdfb65ab03aedaedda9e2d30b/debugpy-1.6.0.zip"
+              "hash": "a771739902b1ae22a120dbbb6bd91b2cae6696c0e318b5007c5348519a4211c6",
+              "url": "https://files.pythonhosted.org/packages/ec/6c/5e761f39e804afbe608c4cb62e1cddbfb2496ebca55a5cc916d8abc8bd60/debugpy-1.6.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "1ff853e60e77e1c16f85a31adb8360bb2d98ca588d7ed645b7f0985b240bdb5e",
-              "url": "https://files.pythonhosted.org/packages/9d/70/f05a8ba35d5b75045c7fbbd268fe3b4d721b4013df42c30b00aed5bfda54/debugpy-1.6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0d383b91efee57dbb923ba20801130cf60450a0eda60bce25bccd937de8e323a",
-              "url": "https://files.pythonhosted.org/packages/a2/4f/b194a30eadabe0b578a4e9cf2ac9b1e387f0f5d2d6333d9bca18b69de689/debugpy-1.6.0-cp37-cp37m-macosx_10_15_x86_64.whl"
+              "hash": "78739f77c58048ec006e2b3eb2e0cd5a06d5f48c915e2fc7911a337354508110",
+              "url": "https://files.pythonhosted.org/packages/f4/99/b65528ecd9507241c0f49dad313e711d03277ce923aa2de13a93d106cc29/debugpy-1.6.6-cp37-cp37m-macosx_10_15_x86_64.whl"
             }
           ],
           "project_name": "debugpy",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "1.6.0"
+          "version": "1.6.6"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.116",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "debugpy==1.6.0"
+    "debugpy<1.7,>=1.6.5"
   ],
   "requires_python": [
     ">=3.7"

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -23,8 +23,9 @@ class DebugPy(PythonToolBase):
     name = options_scope
     help = "An implementation of the Debug Adapter Protocol for Python (https://github.com/microsoft/debugpy)."
 
-    default_version = "debugpy==1.6.0"
+    default_version = "debugpy>=1.6.5,<1.7"
     default_main = EntryPoint("debugpy")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7"]

--- a/src/python/pants/backend/python/subsystems/ipython.lock
+++ b/src/python/pants/backend/python/subsystems/ipython.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "ipython<8,>=7.34"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -57,7 +61,7 @@
           "project_name": "backcall",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.2"
+          "version": "0.2.0"
         },
         {
           "artifacts": [
@@ -134,45 +138,71 @@
             "traitlets>=4.2"
           ],
           "requires_python": ">=3.7",
-          "version": "7.34"
+          "version": "7.34.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d",
-              "url": "https://files.pythonhosted.org/packages/b3/0e/836f12ec50075161e365131f13f5758451645af75c2becf61c6351ecec39/jedi-0.18.1-py2.py3-none-any.whl"
+              "hash": "203c1fd9d969ab8f2119ec0a3342e0b49910045abe6af0a3ae83a5764d54639e",
+              "url": "https://files.pythonhosted.org/packages/6d/60/4acda63286ef6023515eb914543ba36496b8929cb7af49ecce63afde09c6/jedi-0.18.2-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab",
-              "url": "https://files.pythonhosted.org/packages/c2/25/273288df952e07e3190446efbbb30b0e4871a0d63b4246475f3019d4f55e/jedi-0.18.1.tar.gz"
+              "hash": "bae794c30d07f6d910d32a7048af09b5a39ed740918da923c6b780790ebac612",
+              "url": "https://files.pythonhosted.org/packages/15/02/afd43c5066de05f6b3188f3aa74136a3289e6c30e7a45f351546cab0928c/jedi-0.18.2.tar.gz"
             }
           ],
           "project_name": "jedi",
           "requires_dists": [
             "Django<3.1; extra == \"testing\"",
+            "Jinja2==2.11.3; extra == \"docs\"",
+            "MarkupSafe==1.1.1; extra == \"docs\"",
+            "Pygments==2.8.1; extra == \"docs\"",
+            "alabaster==0.7.12; extra == \"docs\"",
+            "attrs; extra == \"testing\"",
+            "babel==2.9.1; extra == \"docs\"",
+            "chardet==4.0.0; extra == \"docs\"",
             "colorama; extra == \"testing\"",
+            "commonmark==0.8.1; extra == \"docs\"",
             "docopt; extra == \"testing\"",
+            "docutils==0.17.1; extra == \"docs\"",
             "flake8==3.8.3; extra == \"qa\"",
+            "future==0.18.2; extra == \"docs\"",
+            "idna==2.10; extra == \"docs\"",
+            "imagesize==1.2.0; extra == \"docs\"",
+            "mock==1.0.1; extra == \"docs\"",
             "mypy==0.782; extra == \"qa\"",
+            "packaging==20.9; extra == \"docs\"",
             "parso<0.9.0,>=0.8.0",
-            "pytest<7.0.0; extra == \"testing\""
+            "pyparsing==2.4.7; extra == \"docs\"",
+            "pytest<7.0.0; extra == \"testing\"",
+            "pytz==2021.1; extra == \"docs\"",
+            "readthedocs-sphinx-ext==2.1.4; extra == \"docs\"",
+            "recommonmark==0.5.0; extra == \"docs\"",
+            "requests==2.25.1; extra == \"docs\"",
+            "six==1.15.0; extra == \"docs\"",
+            "snowballstemmer==2.1.0; extra == \"docs\"",
+            "sphinx-rtd-theme==0.4.3; extra == \"docs\"",
+            "sphinx==1.8.5; extra == \"docs\"",
+            "sphinxcontrib-serializinghtml==1.1.4; extra == \"docs\"",
+            "sphinxcontrib-websupport==1.2.4; extra == \"docs\"",
+            "urllib3==1.26.4; extra == \"docs\""
           ],
           "requires_python": ">=3.6",
-          "version": "0.18.1"
+          "version": "0.18.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "aed605ba3b72462d64d475a21a9296f400a19c4f74a31b59103d2a99ffd5aa5c",
-              "url": "https://files.pythonhosted.org/packages/a6/2d/2230afd570c70074e80fd06857ba2bdc5f10c055bd9125665fe276fadb67/matplotlib_inline-0.1.3-py3-none-any.whl"
+              "hash": "f1f41aab5328aa5aaea9b16d083b128102f8712542f819fe7e6a420ff581b311",
+              "url": "https://files.pythonhosted.org/packages/f2/51/c34d7a1d528efaae3d8ddb18ef45a41f284eacf9e514523b191b7d0872cc/matplotlib_inline-0.1.6-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a04bfba22e0d1395479f866853ec1ee28eea1485c1d69a6faf00dc3e24ff34ee",
-              "url": "https://files.pythonhosted.org/packages/0f/98/838f4c57f7b2679eec038ad0abefd1acaeec35e635d4d7af215acd7d1bd2/matplotlib-inline-0.1.3.tar.gz"
+              "hash": "f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304",
+              "url": "https://files.pythonhosted.org/packages/d9/50/3af8c0362f26108e54d58c7f38784a3bdae6b9a450bab48ee8482d737f44/matplotlib-inline-0.1.6.tar.gz"
             }
           ],
           "project_name": "matplotlib-inline",
@@ -180,7 +210,7 @@
             "traitlets"
           ],
           "requires_python": ">=3.5",
-          "version": "0.1.3"
+          "version": "0.1.6"
         },
         {
           "artifacts": [
@@ -223,7 +253,7 @@
             "ptyprocess>=0.5"
           ],
           "requires_python": null,
-          "version": "4.8"
+          "version": "4.8.0"
         },
         {
           "artifacts": [
@@ -249,21 +279,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289",
-              "url": "https://files.pythonhosted.org/packages/b0/8f/09a88160539a1164de562809f8b1d0a36dc1f9d8c6473f4b71ebed17b953/prompt_toolkit-3.0.30-py3-none-any.whl"
+              "hash": "45ea77a2f7c60418850331366c81cf6b5b9cf4c7fd34616f733c5427e6abbb1f",
+              "url": "https://files.pythonhosted.org/packages/87/3f/1f5a0ff475ae6481f4b0d45d4d911824d3218b94ee2a97a8cb84e5569836/prompt_toolkit-3.0.38-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0",
-              "url": "https://files.pythonhosted.org/packages/c5/7e/71693dc21d20464e4cd7c600f2d8fad1159601a42ed55566500272fe69b5/prompt_toolkit-3.0.30.tar.gz"
+              "hash": "23ac5d50538a9a38c8bde05fecb47d0b403ecd0662857a86f886f798563d5b9b",
+              "url": "https://files.pythonhosted.org/packages/4b/bb/75cdcd356f57d17b295aba121494c2333d26bfff1a837e6199b8b83c415a/prompt_toolkit-3.0.38.tar.gz"
             }
           ],
           "project_name": "prompt-toolkit",
           "requires_dists": [
             "wcwidth"
           ],
-          "requires_python": ">=3.6.2",
-          "version": "3.0.30"
+          "requires_python": ">=3.7.0",
+          "version": "3.0.38"
         },
         {
           "artifacts": [
@@ -281,37 +311,39 @@
           "project_name": "ptyprocess",
           "requires_dists": [],
           "requires_python": null,
-          "version": "0.7"
+          "version": "0.7.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519",
-              "url": "https://files.pythonhosted.org/packages/5c/8e/1d9017950034297fffa336c72e693a5b51bbf85141b24a763882cf1977b5/Pygments-2.12.0-py3-none-any.whl"
+              "hash": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
+              "url": "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
-              "url": "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz"
+              "hash": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
+              "url": "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz"
             }
           ],
           "project_name": "pygments",
-          "requires_dists": [],
+          "requires_dists": [
+            "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
+          ],
           "requires_python": ">=3.6",
-          "version": "2.12"
+          "version": "2.14.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -321,6 +353,7 @@
             "filelock>=3.4.0; extra == \"testing\"",
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
@@ -329,7 +362,6 @@
             "jaraco.path>=3.2.0; extra == \"testing\"",
             "jaraco.path>=3.2.0; extra == \"testing-integration\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "mock; extra == \"testing\"",
             "pip-run>=8.8; extra == \"testing\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
@@ -338,18 +370,22 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
+            "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest; extra == \"testing-integration\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
             "tomli; extra == \"testing-integration\"",
@@ -359,40 +395,45 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a",
-              "url": "https://files.pythonhosted.org/packages/83/a9/1059771062cb80901c34a4dea020e76269412e69300b4ba12e3356865ad8/traitlets-5.3.0-py3-none-any.whl"
+              "hash": "9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8",
+              "url": "https://files.pythonhosted.org/packages/77/75/c28e9ef7abec2b7e9ff35aea3e0be6c1aceaf7873c26c95ae1f0d594de71/traitlets-5.9.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2",
-              "url": "https://files.pythonhosted.org/packages/b2/ed/3c842dbe5a8f0f1ebf3f5b74fc1a46601ed2dfe0a2d256c8488d387b14dd/traitlets-5.3.0.tar.gz"
+              "hash": "f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9",
+              "url": "https://files.pythonhosted.org/packages/39/c3/205e88f02959712b62008502952707313640369144a7fded4cbc61f48321/traitlets-5.9.0.tar.gz"
             }
           ],
           "project_name": "traitlets",
           "requires_dists": [
+            "argcomplete>=2.0; extra == \"test\"",
+            "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"test\"",
-            "pytest; extra == \"test\""
+            "pydata-sphinx-theme; extra == \"docs\"",
+            "pytest-mock; extra == \"test\"",
+            "pytest; extra == \"test\"",
+            "sphinx; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "5.3"
+          "version": "5.9.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
-              "url": "https://files.pythonhosted.org/packages/59/7c/e39aca596badaf1b78e8f547c807b04dae603a433d3e7a7e04d67f2ef3e5/wcwidth-0.2.5-py2.py3-none-any.whl"
+              "hash": "795b138f6875577cd91bba52baf9e445cd5118fd32723b460e30a0af30ea230e",
+              "url": "https://files.pythonhosted.org/packages/20/f4/c0584a25144ce20bfcf1aecd041768b8c762c1eb0aa77502a3f0baa83f11/wcwidth-0.2.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83",
-              "url": "https://files.pythonhosted.org/packages/89/38/459b727c381504f361832b9e5ace19966de1a235d73cdbdea91c771a1155/wcwidth-0.2.5.tar.gz"
+              "hash": "a5220780a404dbe3353789870978e472cfe477761f06ee55077256e509b156d0",
+              "url": "https://files.pythonhosted.org/packages/5e/5f/1e4bd82a9cc1f17b2c2361a2d876d4c38973a997003ba5eb400e8a932b6c/wcwidth-0.2.6.tar.gz"
             }
           ],
           "project_name": "wcwidth",
@@ -400,14 +441,15 @@
             "backports.functools-lru-cache>=1.2.1; python_version < \"3.2\""
           ],
           "requires_python": null,
-          "version": "0.2.5"
+          "version": "0.2.6"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "ipython<8,>=7.34"

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -28,6 +28,7 @@ class IPython(PythonToolBase):
 
     default_version = "ipython>=7.34,<8"  # ipython 8 does not support Python 3.7.
     default_main = ConsoleScript("ipython")
+    default_requirements = ["ipython>=7.34,<9"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "ipython.lock")

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -9,7 +9,7 @@
 //     "CPython<3.12,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "lambdex==0.1.9"
+//     "lambdex>=0.1.9"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -79,7 +79,7 @@
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "lambdex==0.1.9"
+    "lambdex>=0.1.9"
   ],
   "requires_python": [
     "<3.12,>=3.7"

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -18,8 +18,9 @@ class Lambdex(PythonToolBase):
     options_scope = "lambdex"
     help = "A tool for turning .pex files into Function-as-a-Service artifacts (https://github.com/pantsbuild/lambdex)."
 
-    default_version = "lambdex==0.1.9"
+    default_version = "lambdex>=0.1.9"
     default_main = ConsoleScript("lambdex")
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.12"]

--- a/src/python/pants/backend/python/subsystems/pytest.lock
+++ b/src/python/pants/backend/python/subsystems/pytest.lock
@@ -4,7 +4,7 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
@@ -12,7 +12,11 @@
 //     "pytest-cov!=2.12.1,<3.1,>=2.12",
 //     "pytest-xdist<3,>=2.5",
 //     "pytest==7.0.1"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -29,218 +33,254 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c",
-              "url": "https://files.pythonhosted.org/packages/f2/bc/d817287d1aa01878af07c19505fafd1165cd6a119e9d0821ca1d1c20312d/attrs-22.1.0-py2.py3-none-any.whl"
+              "hash": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
+              "url": "https://files.pythonhosted.org/packages/fb/6e/6f83bf616d2becdf333a1640f1d463fef3150e2e926b7010cb0f81c95e88/attrs-22.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
-              "url": "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+              "hash": "c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99",
+              "url": "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz"
             }
           ],
           "project_name": "attrs",
           "requires_dists": [
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"dev\"",
-            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests\"",
+            "attrs[docs,tests]; extra == \"dev\"",
+            "attrs[tests-no-zope]; extra == \"tests\"",
+            "attrs[tests]; extra == \"cov\"",
+            "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
             "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
-            "coverage[toml]>=5.0.2; extra == \"dev\"",
-            "coverage[toml]>=5.0.2; extra == \"tests\"",
-            "coverage[toml]>=5.0.2; extra == \"tests_no_zope\"",
-            "furo; extra == \"dev\"",
+            "coverage-enable-subprocess; extra == \"cov\"",
+            "coverage[toml]>=5.3; extra == \"cov\"",
             "furo; extra == \"docs\"",
-            "hypothesis; extra == \"dev\"",
-            "hypothesis; extra == \"tests\"",
+            "hypothesis; extra == \"tests-no-zope\"",
             "hypothesis; extra == \"tests_no_zope\"",
-            "mypy!=0.940,>=0.900; extra == \"dev\"",
-            "mypy!=0.940,>=0.900; extra == \"tests\"",
-            "mypy!=0.940,>=0.900; extra == \"tests_no_zope\"",
-            "pre-commit; extra == \"dev\"",
-            "pympler; extra == \"dev\"",
-            "pympler; extra == \"tests\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
+            "mypy<0.990,>=0.971; platform_python_implementation == \"CPython\" and extra == \"tests_no_zope\"",
+            "myst-parser; extra == \"docs\"",
+            "pympler; extra == \"tests-no-zope\"",
             "pympler; extra == \"tests_no_zope\"",
-            "pytest-mypy-plugins; extra == \"dev\"",
-            "pytest-mypy-plugins; extra == \"tests\"",
-            "pytest-mypy-plugins; extra == \"tests_no_zope\"",
-            "pytest>=4.3.0; extra == \"dev\"",
-            "pytest>=4.3.0; extra == \"tests\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests-no-zope\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version < \"3.11\") and extra == \"tests_no_zope\"",
+            "pytest-xdist[psutil]; extra == \"tests-no-zope\"",
+            "pytest-xdist[psutil]; extra == \"tests_no_zope\"",
+            "pytest>=4.3.0; extra == \"tests-no-zope\"",
             "pytest>=4.3.0; extra == \"tests_no_zope\"",
-            "sphinx-notfound-page; extra == \"dev\"",
             "sphinx-notfound-page; extra == \"docs\"",
-            "sphinx; extra == \"dev\"",
             "sphinx; extra == \"docs\"",
-            "zope.interface; extra == \"dev\"",
+            "sphinxcontrib-towncrier; extra == \"docs\"",
+            "towncrier; extra == \"docs\"",
             "zope.interface; extra == \"docs\"",
             "zope.interface; extra == \"tests\""
           ],
-          "requires_python": ">=3.5",
-          "version": "22.1"
+          "requires_python": ">=3.6",
+          "version": "22.2.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "068d6f2a893af838291b8809c876973d885543411ea460f3e6886ac0ee941732",
-              "url": "https://files.pythonhosted.org/packages/df/83/194a9e576faebbf371338a461af5f5464cf7ec3c80ed616cd7f9f23a5040/coverage-6.4.3-pp36.pp37.pp38-none-any.whl"
+              "hash": "436313d129db7cf5b4ac355dd2bd3f7c7e5294af077b090b85de75f8458b8616",
+              "url": "https://files.pythonhosted.org/packages/9e/de/989111fbf70f00912513912b3111072680154ec713b3f3d523636832965d/coverage-7.2.1-pp37.pp38.pp39-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "adf1a0d272633b21d645dd6e02e3293429c1141c7d65a58e4cbcd592d53b8e01",
-              "url": "https://files.pythonhosted.org/packages/02/98/9fb7c1c92f4436117f345bcbbaaaf37af6730b991383b97353110dcdf1f8/coverage-6.4.3-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "5d2b9b5e70a21474c105a133ba227c61bc95f2ac3b66861143ce39a5ea4b3f84",
+              "url": "https://files.pythonhosted.org/packages/06/64/cf8b320fcedbca7216e050c0529364241a0746eecff2d521fa31575b997f/coverage-7.2.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc698580216050b5f4a34d2cdd2838b429c53314f1c4835fab7338200a8396f2",
-              "url": "https://files.pythonhosted.org/packages/19/52/7056ae02fd4955ba1abe83ac72d33511d5fd2e41c0a906695aa558da6e7b/coverage-6.4.3-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "bdd3f2f285ddcf2e75174248b2406189261a79e7fedee2ceeadc76219b6faa0e",
+              "url": "https://files.pythonhosted.org/packages/1c/89/b2f00ae4d1267aeed0026e68b17a6357afe52c1f773dff9c595da4b88977/coverage-7.2.1-cp39-cp39-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "05de0762c1caed4a162b3e305f36cf20a548ff4da0be6766ad5c870704be3660",
-              "url": "https://files.pythonhosted.org/packages/1e/37/bd2cf47fe1de3b6b0fcbc6c9bbce5266a0d71c02c13244a08881a35cbdce/coverage-6.4.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "80559eaf6c15ce3da10edb7977a1548b393db36cbc6cf417633eca05d84dd1ed",
+              "url": "https://files.pythonhosted.org/packages/24/8d/d9d880cb7319cc06eab02757a0fb3f623c6e7613d16d297cfdf249d4926d/coverage-7.2.1-cp311-cp311-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "fc294de50941d3da66a09dca06e206297709332050973eca17040278cb0918ff",
-              "url": "https://files.pythonhosted.org/packages/25/b2/26c5bf1497eaf14bbd9d9b93bcb4a947a58c2b57233799b2700f415ab7c9/coverage-6.4.3-cp39-cp39-musllinux_1_1_aarch64.whl"
+              "hash": "9e872b082b32065ac2834149dc0adc2a2e6d8203080501e1e3c3c77851b466f9",
+              "url": "https://files.pythonhosted.org/packages/2d/24/06ad2452717337ed45a928107fc5d91601a4a79692012ee86dc06782ab51/coverage-7.2.1-cp311-cp311-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5a559aab40c716de80c7212295d0dc96bc1b6c719371c20dd18c5187c3155518",
-              "url": "https://files.pythonhosted.org/packages/32/c5/5e5833660ae06ecd7713ede0586329a827ed00d8b023513b6cee83713208/coverage-6.4.3-cp37-cp37m-musllinux_1_1_aarch64.whl"
+              "hash": "834c2172edff5a08d78e2f53cf5e7164aacabeb66b369f76e7bb367ca4e2d993",
+              "url": "https://files.pythonhosted.org/packages/2f/e3/15f85c7527577907ddf354f45ad212c3882012c92186d45baa553cff47e3/coverage-7.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "411fdd9f4203afd93b056c0868c8f9e5e16813e765de962f27e4e5798356a052",
-              "url": "https://files.pythonhosted.org/packages/3b/0e/650b185431a2bb03f580ae8fa042c7355468088a904d2000e7ff94c2dfb0/coverage-6.4.3-cp38-cp38-musllinux_1_1_i686.whl"
+              "hash": "f29351393eb05e6326f044a7b45ed8e38cb4dcc38570d12791f271399dc41431",
+              "url": "https://files.pythonhosted.org/packages/36/51/e0a33466be7083709db9325167349ffeeedc419bb73864f72c8280e25aae/coverage-7.2.1-cp39-cp39-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "306788fd019bb90e9cbb83d3f3c6becad1c048dd432af24f8320cf38ac085684",
-              "url": "https://files.pythonhosted.org/packages/43/0e/47365f030698de2da986e4bdfba404a3613cba1db123d55fd3e923be0c00/coverage-6.4.3-cp37-cp37m-musllinux_1_1_i686.whl"
+              "hash": "8dca3c1706670297851bca1acff9618455122246bdae623be31eca744ade05ec",
+              "url": "https://files.pythonhosted.org/packages/3d/f5/97bdecac0c23ec52d2ddf4cae5d6de3c69c4441f1b1e448ff7975f91d37b/coverage-7.2.1-cp38-cp38-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d75314b00825d70e1e34b07396e23f47ed1d4feedc0122748f9f6bd31a544840",
-              "url": "https://files.pythonhosted.org/packages/4d/d4/d4b511312729be53ada212792315f179d721b317053e7d7fa8644c3df005/coverage-6.4.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "4dd34a935de268a133e4741827ae951283a28c0125ddcdbcbba41c4b98f2dfef",
+              "url": "https://files.pythonhosted.org/packages/44/39/5efa733d0508d31565faf2761998f2e0417bfbb5bf4269b64384c7f5031a/coverage-7.2.1-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f50d3a822947572496ea922ee7825becd8e3ae6fbd2400cd8236b7d64b17f285",
-              "url": "https://files.pythonhosted.org/packages/55/23/ec5b740dfe79e9a5972873997d85e3d0b1d08b6d17fe69034a04916ec9d0/coverage-6.4.3-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "d9256d4c60c4bbfec92721b51579c50f9e5062c21c12bec56b55292464873508",
+              "url": "https://files.pythonhosted.org/packages/47/83/d5353ffb69cd7cfb32e146475d10b6ebba930d9eb323e508933df0d02434/coverage-7.2.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "923f9084d7e1d31b5f74c92396b05b18921ed01ee5350402b561a79dce3ea48d",
-              "url": "https://files.pythonhosted.org/packages/5a/1a/d1df308a7d7c8077664a8e70e1a2cbca7d54497aa38f4d35b6178e6134fc/coverage-6.4.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "99f4dd81b2bb8fc67c3da68b1f5ee1650aca06faa585cbc6818dbf67893c6d58",
+              "url": "https://files.pythonhosted.org/packages/4a/80/44c734492221b7e065bd8a2856c3f2f4650664abad70aab5e22a9d71a984/coverage-7.2.1-cp39-cp39-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ec2ae1f398e5aca655b7084392d23e80efb31f7a660d2eecf569fb9f79b3fb94",
-              "url": "https://files.pythonhosted.org/packages/72/bf/3896381becfd8ee66be4d4b65fbf354d91a51a0306b8bc8cddd91a3ae679/coverage-6.4.3.tar.gz"
+              "hash": "8649371570551d2fd7dee22cfbf0b61f1747cdfb2b7587bb551e4beaaa44cb97",
+              "url": "https://files.pythonhosted.org/packages/4e/42/eca4b81b6fb43731dba91dbf35af617fe4999ee4270132eb2a9cd90b8566/coverage-7.2.1-cp37-cp37m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7856ea39059d75f822ff0df3a51ea6d76307c897048bdec3aad1377e4e9dca20",
-              "url": "https://files.pythonhosted.org/packages/7a/26/df8dfdc984e2b528cd93328ac48ee076b595da6c56a24c2fcab152238f07/coverage-6.4.3-cp38-cp38-musllinux_1_1_aarch64.whl"
+              "hash": "fac6343bae03b176e9b58104a9810df3cdccd5cfed19f99adfa807ffbf43cf9b",
+              "url": "https://files.pythonhosted.org/packages/4e/6b/7d9c6c23aa227b91bc2f85f197406b899a4469c6e0d182d499eb2a515e91/coverage-7.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "877ee5478fd78e100362aed56db47ccc5f23f6e7bb035a8896855f4c3e49bc9b",
-              "url": "https://files.pythonhosted.org/packages/7c/2a/de52bb9187885bbf90fd89462d81ab28f9f40d090623491b80a8528a6910/coverage-6.4.3-cp38-cp38-macosx_11_0_arm64.whl"
+              "hash": "7f099da6958ddfa2ed84bddea7515cb248583292e16bb9231d151cd528eab657",
+              "url": "https://files.pythonhosted.org/packages/4f/1a/a3106f807989fa33aa6e378a11cfd4df6873f243c0406122cc2fd03c4c3c/coverage-7.2.1-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f1eda5cae434282712e40b42aaf590b773382afc3642786ac3ed39053973f61f",
-              "url": "https://files.pythonhosted.org/packages/8a/99/6f461039a3d1754604084a535965ad4e6ae6bbad4b191deaac22b5c02cf1/coverage-6.4.3-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "3a209d512d157379cc9ab697cbdbb4cfd18daa3e7eebaa84c3d20b6af0037384",
+              "url": "https://files.pythonhosted.org/packages/50/aa/b799631d7c990e777da1a6ba85ccf5194180c79d49f20a1acb1306a18a13/coverage-7.2.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "555a498999c44f5287cc95500486cd0d4f021af9162982cbe504d4cb388f73b5",
-              "url": "https://files.pythonhosted.org/packages/8d/57/fba4c25b70bdb40c992733d48d3740800dca1b927ec6a2b05d9fc992078f/coverage-6.4.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "570c21a29493b350f591a4b04c158ce1601e8d18bdcd21db136fbb135d75efa6",
+              "url": "https://files.pythonhosted.org/packages/51/61/2bab4add265c0fcf0a4372ab9e647405f157a9c5cdcbab1e0b7b117f92fa/coverage-7.2.1-cp311-cp311-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cdf7b83f04a313a21afb1f8730fe4dd09577fefc53bbdfececf78b2006f4268e",
-              "url": "https://files.pythonhosted.org/packages/8f/d6/ceba88f2eaaeae2df31c54d4fa7faad2e7df54a1fcd6c4b0dddeb90a4ac5/coverage-6.4.3-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "cb5f152fb14857cbe7f3e8c9a5d98979c4c66319a33cad6e617f0067c9accdc4",
+              "url": "https://files.pythonhosted.org/packages/59/7b/250aa653d48f6dccc553dd95739aac5ed7880ee99358b0d5aa0f13d1a338/coverage-7.2.1-cp310-cp310-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a0d2df4227f645a879010461df2cea6b7e3fb5a97d7eafa210f7fb60345af9e8",
-              "url": "https://files.pythonhosted.org/packages/a2/2d/f392e2d59f7ab0d0c6d6a6ced8bc63440c5e2e1b425545df95064fdb53d6/coverage-6.4.3-cp310-cp310-musllinux_1_1_x86_64.whl"
+              "hash": "a81dbcf6c6c877986083d00b834ac1e84b375220207a059ad45d12f6e518a4e3",
+              "url": "https://files.pythonhosted.org/packages/61/fb/3a9756915a126b138e69f2eef2118b64f126250e6e67d597821eb23dcaf2/coverage-7.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e4d64304acf79766e650f7acb81d263a3ea6e2d0d04c5172b7189180ff2c023c",
-              "url": "https://files.pythonhosted.org/packages/a5/6a/5a201c1b85c5c406c5ee5be4d17c223ad71a5f77937fe9a680b02e6a1fb3/coverage-6.4.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "5928b85416a388dd557ddc006425b0c37e8468bd1c3dc118c1a3de42f59e2a54",
+              "url": "https://files.pythonhosted.org/packages/6e/1b/3cc2589eae54eee6d5535e5437883fafd9e5b598961a21a6c0459ad97666/coverage-7.2.1-cp37-cp37m-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0e3a41aad5919613483aad9ebd53336905cab1bd6788afd3995c2a972d89d795",
-              "url": "https://files.pythonhosted.org/packages/a7/be/f8148ab0a34f180851a1751ed72c935a8f32d922037f34c3aa406fd70dc9/coverage-6.4.3-cp310-cp310-musllinux_1_1_aarch64.whl"
+              "hash": "e4d70c853f0546855f027890b77854508bdb4d6a81242a9d804482e667fff6e6",
+              "url": "https://files.pythonhosted.org/packages/7b/36/afdf9ae3cf36ad922599df32b5517f48be389761869907bf89670eecd362/coverage-7.2.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ff9832434a9193fbd716fbe05f9276484e18d26cc4cf850853594bb322807ac3",
-              "url": "https://files.pythonhosted.org/packages/a8/50/ab9f27b02307d11ecb184efedd9e649459d6e17dd86bcf1025c52d5eb095/coverage-6.4.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "8d3843ca645f62c426c3d272902b9de90558e9886f15ddf5efe757b12dd376f5",
+              "url": "https://files.pythonhosted.org/packages/7b/f9/5b9e843989ab7461e97f0cba987f78fb043adc8975e65af9eb9bda22c3a2/coverage-7.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b104b6b1827d6a22483c469e3983a204bcf9c6bf7544bf90362c4654ebc2edf3",
-              "url": "https://files.pythonhosted.org/packages/b0/9b/b80e3fc42f6942077551dbc593227c06354b5db446760e67ec6b61aa503d/coverage-6.4.3-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "0f8318ed0f3c376cfad8d3520f496946977abde080439d6689d7799791457454",
+              "url": "https://files.pythonhosted.org/packages/7c/f6/3c1715c27e3251baa578b469f3c266b48623d3bce4ea08509a636e11447c/coverage-7.2.1-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "04010af3c06ce2bfeb3b1e4e05d136f88d88c25f76cd4faff5d1fd84d11581ea",
-              "url": "https://files.pythonhosted.org/packages/b2/89/e17f519b13d1c62a154485efdf547ca98d4179a4c3d97c5dbae7fb1c5fb5/coverage-6.4.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "0339dc3237c0d31c3b574f19c57985fcbe494280153bbcad33f2cdf469f4ac3e",
+              "url": "https://files.pythonhosted.org/packages/85/97/8b13f1afcdef9d8deb65ffb8f70f6d1519dacecf269f80349c3b424eca2e/coverage-7.2.1-cp37-cp37m-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d5191d53afbe5b6059895fa7f58223d3751c42b8101fb3ce767e1a0b1a1d8f87",
-              "url": "https://files.pythonhosted.org/packages/b9/1f/5704ce67cb66bc22e78e0e071ca1f8d136bb0d5abfc76fecaa24264323fd/coverage-6.4.3-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "c77f2a9093ccf329dd523a9b2b3c854c20d2a3d968b6def3b820272ca6732242",
+              "url": "https://files.pythonhosted.org/packages/8d/4a/3518606d4b110df4f3e77bd52c241ae8a84c6dc74fac7c2a8e809449e541/coverage-7.2.1.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "6630d8d943644ea62132789940ca97d05fac83f73186eaf0930ffa715fbdab6b",
-              "url": "https://files.pythonhosted.org/packages/c5/84/461934c8d3fe5f864ad35402de9fab652a6f6531752fbcb4101ed3985bac/coverage-6.4.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "e191a63a05851f8bce77bc875e75457f9b01d42843f8bd7feed2fc26bbe60833",
+              "url": "https://files.pythonhosted.org/packages/94/91/c708f837c5550ff5447203e29f5273d9b20959fa48753bcfe58cd522fbef/coverage-7.2.1-cp310-cp310-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "eff095a5aac7011fdb51a2c82a8fae9ec5211577f4b764e1e59cfa27ceeb1b59",
-              "url": "https://files.pythonhosted.org/packages/d1/b1/4120b124e57d7da46a180b2065ca0061efa76ea83b1e8cd07989c8f7c401/coverage-6.4.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+              "hash": "f3d07edb912a978915576a776756069dede66d012baa503022d3a0adba1b6afa",
+              "url": "https://files.pythonhosted.org/packages/aa/9f/9d5ffcca635f09cb92e66afb149996889ea8cb7408bec5e908d36686bf8a/coverage-7.2.1-cp38-cp38-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5de1e9335e2569974e20df0ce31493d315a830d7987e71a24a2a335a8d8459d3",
-              "url": "https://files.pythonhosted.org/packages/d3/da/4f32b46ee7dc189aef756bcbf60c3ecdf18128b5c9bccfbde4a10fd38f55/coverage-6.4.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "abacd0a738e71b20e224861bc87e819ef46fedba2fb01bc1af83dfd122e9c319",
+              "url": "https://files.pythonhosted.org/packages/af/ff/bf04eeb95213c25a5ef718e1e70b6e476f4e6f48b00d62860f3a8facd3ef/coverage-7.2.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4822327b35cb032ff16af3bec27f73985448f08e874146b5b101e0e558b613dd",
-              "url": "https://files.pythonhosted.org/packages/da/ab/64dbfdae362c6e2696c07d3ec19d4c00b10ca85a5430d7669e24fd58a6f4/coverage-6.4.3-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "ae82c988954722fa07ec5045c57b6d55bc1a0890defb57cf4a712ced65b26ddd",
+              "url": "https://files.pythonhosted.org/packages/bb/2d/0011ba3d37d53a840728390a86120f7316ec059a656afe42386abc67bfaa/coverage-7.2.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a2738ba1ee544d6f294278cfb6de2dc1f9a737a780469b5366e662a218f806c3",
-              "url": "https://files.pythonhosted.org/packages/e1/32/e4c1970794ff62fdf94182a68ebe9e8a96f4720659c0687122ca57087624/coverage-6.4.3-cp310-cp310-musllinux_1_1_i686.whl"
+              "hash": "b1991a6d64231a3e5bbe3099fb0dd7c9aeaa4275ad0e0aeff4cb9ef885c62ba2",
+              "url": "https://files.pythonhosted.org/packages/bc/d8/a06bc91226ff1940547934af0c514acd17510cf9b9a54b13046e5f2d9538/coverage-7.2.1-cp38-cp38-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "52f8b9fcf3c5e427d51bbab1fb92b575a9a9235d516f175b24712bcd4b5be917",
-              "url": "https://files.pythonhosted.org/packages/e5/a5/f90ebe1d1f30b19fe185c784318e380e34cf6cbb11775f09399efd7bdfda/coverage-6.4.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "09643fb0df8e29f7417adc3f40aaf379d071ee8f0350ab290517c7004f05360b",
+              "url": "https://files.pythonhosted.org/packages/bf/4e/bb6008789e813f6930179757acdd409f0056e48ef687416bed819464a79c/coverage-7.2.1-cp311-cp311-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "920a734fe3d311ca01883b4a19aa386c97b82b69fbc023458899cff0a0d621b9",
-              "url": "https://files.pythonhosted.org/packages/ea/b5/f82e90416eed8bbb705f4ba3a1c5b1c1773060093e545af49e112e110518/coverage-6.4.3-cp37-cp37m-musllinux_1_1_x86_64.whl"
+              "hash": "3004765bca3acd9e015794e5c2f0c9a05587f5e698127ff95e9cfba0d3f29339",
+              "url": "https://files.pythonhosted.org/packages/c8/33/f3cf1fd69b2de5c9d63836c517bd0082fa6db53aa5068ae7df9acf115b9e/coverage-7.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "59fc88bc13e30f25167e807b8cad3c41b7218ef4473a20c86fd98a7968733083",
-              "url": "https://files.pythonhosted.org/packages/ea/ff/bd5f5401d25b53dcf6e4da2e46cfb0e139bf3ddbf3468179af0319774e83/coverage-6.4.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "87dc37f16fb5e3a28429e094145bf7c1753e32bb50f662722e378c5851f7fdc6",
+              "url": "https://files.pythonhosted.org/packages/d4/94/fb0c114600331faead0abd61d8182fcc67030f0711dd5841d7c9a36cdaf0/coverage-7.2.1-cp310-cp310-musllinux_1_1_i686.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a42eaaae772f14a5194f181740a67bfd48e8806394b8c67aa4399e09d0d6b5db",
-              "url": "https://files.pythonhosted.org/packages/ee/1a/ea125bdde30f3d5089eda690de51ee07f1f8851c2e9b50c0ee10e3f1acda/coverage-6.4.3-cp39-cp39-musllinux_1_1_i686.whl"
+              "hash": "97a3189e019d27e914ecf5c5247ea9f13261d22c3bb0cfcfd2a9b179bb36f8b1",
+              "url": "https://files.pythonhosted.org/packages/d4/e1/c6c41180badec9d558bcbdb989792acd414fd93336b8c0a8d91ffe2e3a4a/coverage-7.2.1-cp38-cp38-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0bd7e628f6c3ec4e7d2d24ec0e50aae4e5ae95ea644e849d92ae4805650b4c4e",
+              "url": "https://files.pythonhosted.org/packages/d9/c5/8a6ad089d9d9a15f94f40957d804e7712767f8ac458eca55b02a73d249d6/coverage-7.2.1-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cca7c0b7f5881dfe0291ef09ba7bb1582cb92ab0aeffd8afb00c700bf692415a",
+              "url": "https://files.pythonhosted.org/packages/da/f6/6c8f89d02dd9fda71ec61a5baa4d210017f2eb0bb57d4dd513d98d875867/coverage-7.2.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "49567ec91fc5e0b15356da07a2feabb421d62f52a9fff4b1ec40e9e19772f5f8",
+              "url": "https://files.pythonhosted.org/packages/e4/ae/489a39a3615a23000f731ddd0a8d397f771b42ab2d0404fd6607f0a38c42/coverage-7.2.1-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8a6450da4c7afc4534305b2b7d8650131e130610cea448ff240b6ab73d7eab63",
+              "url": "https://files.pythonhosted.org/packages/e5/a9/62aabc67971d2fd439474b05cfc25c852b28bb6dfe8082c5b665652899f5/coverage-7.2.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "861cc85dfbf55a7a768443d90a07e0ac5207704a9f97a8eb753292a7fcbdfcfc",
+              "url": "https://files.pythonhosted.org/packages/f2/08/ed8f2266db3f851de17df7a5923157d2444969af283daf99ca572c4c724d/coverage-7.2.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b2167d116309f564af56f9aa5e75ef710ef871c5f9b313a83050035097b56820",
+              "url": "https://files.pythonhosted.org/packages/f3/ff/0bf7a9497dc91e4b0f11656a50c95fd1e641d912a281a0b0921d20fa5760/coverage-7.2.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "78d2c3dde4c0b9be4b02067185136b7ee4681978228ad5ec1278fa74f5ca3e99",
+              "url": "https://files.pythonhosted.org/packages/f5/70/9400b5c37f43d8e39527f9209cc7b1db96b5f16a6a3da2ccd8f75465d567/coverage-7.2.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2ef6cae70168815ed91388948b5f4fcc69681480a0061114db737f957719f03",
+              "url": "https://files.pythonhosted.org/packages/f9/06/5f6555205d13f8811558b73fa37596519272fb077ad7f9faa4e4162a23a4/coverage-7.2.1-cp310-cp310-macosx_11_0_arm64.whl"
             }
           ],
           "project_name": "coverage",
@@ -248,7 +288,7 @@
             "tomli; python_full_version <= \"3.11.0a6\" and extra == \"toml\""
           ],
           "requires_python": ">=3.7",
-          "version": "6.4.3"
+          "version": "7.2.1"
         },
         {
           "artifacts": [
@@ -268,82 +308,84 @@
             "pre-commit; extra == \"testing\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.9"
+          "version": "1.9.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
-              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
           "requires_dists": [
+            "flake8<5; extra == \"testing\"",
             "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
             "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
             "ipython; extra == \"perf\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
             "packaging; extra == \"testing\"",
             "pyfakefs; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.12"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-              "url": "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl"
+              "hash": "b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374",
+              "url": "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32",
-              "url": "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz"
+              "hash": "2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3",
+              "url": "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz"
             }
           ],
           "project_name": "iniconfig",
           "requires_dists": [],
-          "requires_python": null,
-          "version": "1.1.1"
+          "requires_python": ">=3.7",
+          "version": "2.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522",
-              "url": "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl"
+              "hash": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+              "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-              "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
+              "hash": "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97",
+              "url": "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz"
             }
           ],
           "project_name": "packaging",
-          "requires_dists": [
-            "pyparsing!=3.0.5,>=2.0.2"
-          ],
-          "requires_python": ">=3.6",
-          "version": "21.3"
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "23.0"
         },
         {
           "artifacts": [
@@ -367,7 +409,7 @@
             "tox; extra == \"dev\""
           ],
           "requires_python": ">=3.6",
-          "version": "1"
+          "version": "1.0.0"
         },
         {
           "artifacts": [
@@ -385,28 +427,7 @@
           "project_name": "py",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "1.11"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
-              "url": "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-              "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz"
-            }
-          ],
-          "project_name": "pyparsing",
-          "requires_dists": [
-            "jinja2; extra == \"diagrams\"",
-            "railroad-diagrams; extra == \"diagrams\""
-          ],
-          "requires_python": ">=3.6.8",
-          "version": "3.0.9"
+          "version": "1.11.0"
         },
         {
           "artifacts": [
@@ -468,19 +489,19 @@
             "virtualenv; extra == \"testing\""
           ],
           "requires_python": ">=3.6",
-          "version": "3"
+          "version": "3.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "bbbb6717efc886b9d64537b41fb1497cfaf3c9601276be8da2cccfea5a3c8ad8",
-              "url": "https://files.pythonhosted.org/packages/0c/36/c56ef2aea73912190cdbcc39aaa860db8c07c1a5ce8566994ec9425453db/pytest_forked-1.4.0-py3-none-any.whl"
+              "hash": "810958f66a91afb1a1e2ae83089d8dc1cd2437ac96b12963042fbb9fb4d16af0",
+              "url": "https://files.pythonhosted.org/packages/f4/af/9c0bda43e486a3c9bf1e0f876d0f241bc3f229d7d65d09331a0868db9629/pytest_forked-1.6.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "8b67587c8f98cbbadfdd804539ed5455b6ed03802203485dd2f53c1422d7440e",
-              "url": "https://files.pythonhosted.org/packages/f1/bc/0121a2e386b261b69f4f5aa48e5304c947451dce70d68628cb28d5cd0d28/pytest-forked-1.4.0.tar.gz"
+              "hash": "4dafd46a9a600f65d822b8f605133ecf5b3e1941ebb3588e943b4e3eb71a5a3f",
+              "url": "https://files.pythonhosted.org/packages/8c/c9/93ad2ba2413057ee694884b88cf7467a46c50c438977720aeac26e73fdb7/pytest-forked-1.6.0.tar.gz"
             }
           ],
           "project_name": "pytest-forked",
@@ -488,8 +509,8 @@
             "py",
             "pytest>=3.10"
           ],
-          "requires_python": ">=3.6",
-          "version": "1.4"
+          "requires_python": ">=3.7",
+          "version": "1.6.0"
         },
         {
           "artifacts": [
@@ -514,7 +535,7 @@
             "setproctitle; extra == \"setproctitle\""
           ],
           "requires_python": ">=3.6",
-          "version": "2.5"
+          "version": "2.5.0"
         },
         {
           "artifacts": [
@@ -538,58 +559,64 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.3"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009",
-              "url": "https://files.pythonhosted.org/packages/f0/36/639d6742bcc3ffdce8b85c31d79fcfae7bb04b95f0e5c4c6f8b206a038cc/zipp-3.8.1-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-              "url": "https://files.pythonhosted.org/packages/3b/e3/fb79a1ea5f3a7e9745f688855d3c673f2ef7921639a380ec76f7d4d83a85/zipp-3.8.1.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
-            "func-timeout; extra == \"testing\"",
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
             "jaraco.packaging>=9; extra == \"docs\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.8.1"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.103",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "pytest-cov!=2.12.1,<3.1,>=2.12",

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -77,6 +77,7 @@ class PyTest(PythonToolBase):
     #  E.g., as default_version = "pytest>=7,<8,!=7.1.0,!=7.1.1"
     default_version = "pytest==7.0.1"
     default_extra_requirements = ["pytest-cov>=2.12,!=2.12.1,<3.1", "pytest-xdist>=2.5,<3"]
+    default_requirements = [default_version, *default_extra_requirements]
 
     default_main = ConsoleScript("pytest")
 

--- a/src/python/pants/backend/python/subsystems/python_native_code.py
+++ b/src/python/pants/backend/python/subsystems/python_native_code.py
@@ -11,7 +11,6 @@ from pants.util.strutil import safe_shlex_join, safe_shlex_split
 
 
 class PythonNativeCodeSubsystem(Subsystem):
-
     options_scope = "python-native-code"
     help = "Options for building native code using Python, e.g. when resolving distributions."
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -83,8 +83,13 @@ class PythonToolRequirementsBase(Subsystem):
         or sorted([cls.default_version, *cls.default_extra_requirements]),
         help=lambda cls: softwrap(
             """\
-            If install_from_resolve is specified, it will install these distribution packages,
-            using the versions from the specified resolve.
+            If install_from_resolve is specified, it will install these requirements,
+            at the versions locked by the specified resolve's lockfile.
+
+            The default version ranges provided here are versions that Pants is expected to be
+            compatible with. If you need a version outside these ranges you can loosen this
+            restriction by setting this option to a wider range, but you may encounter errors
+            if Pants is not compatible with the version you choose.
             """
         ),
     )

--- a/src/python/pants/backend/python/subsystems/setuptools.lock
+++ b/src/python/pants/backend/python/subsystems/setuptools.lock
@@ -4,14 +4,18 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "setuptools<64.0,>=63.1.0",
 //     "wheel<0.38,>=0.35.1"
-//   ]
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -28,13 +32,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
+              "hash": "7f61f7e82647f77d4118eeaf43d64cbcd4d87e38af9611694d4866eb070cd10d",
+              "url": "https://files.pythonhosted.org/packages/2a/a3/49c29680d6118273b992b40ebe881e8e899b8e26a4e951f37f223da8f862/setuptools-63.4.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "521c833d1e5e1ef0869940e7f486a83de7773b9f029010ad0c2fe35453a9dad9",
+              "url": "https://files.pythonhosted.org/packages/5b/ff/69fd395c5237da934753752b71c38e95e137bd0603d5640df70ddaea8038/setuptools-63.4.3.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -44,6 +48,7 @@
             "filelock>=3.4.0; extra == \"testing\"",
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
@@ -70,7 +75,9 @@
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
             "sphinx; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
@@ -82,7 +89,7 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "63.4.3"
         },
         {
           "artifacts": [
@@ -110,7 +117,8 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "setuptools<64.0,>=63.1.0",

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -34,6 +34,7 @@ class Setuptools(PythonToolRequirementsBase):
 
     default_version = "setuptools>=63.1.0,<64.0"
     default_extra_requirements = ["wheel>=0.35.1,<0.38"]
+    default_requirements = [default_version, *default_extra_requirements]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "setuptools.lock")

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.lock
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "setuptools-scm==6.4.2"
-//   ]
+//     "setuptools-scm==7.1.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,54 +31,72 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522",
-              "url": "https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
-              "url": "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
+            }
+          ],
+          "project_name": "importlib-metadata",
+          "requires_dists": [
+            "flake8<5; extra == \"testing\"",
+            "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
+            "ipython; extra == \"perf\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "packaging; extra == \"testing\"",
+            "pyfakefs; extra == \"testing\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-perf>=0.9.2; extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
+            "typing-extensions>=3.6.4; python_version < \"3.8\"",
+            "zipp>=0.5"
+          ],
+          "requires_python": ">=3.7",
+          "version": "6.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+              "url": "https://files.pythonhosted.org/packages/ed/35/a31aed2993e398f6b09a790a181a7927eb14610ee8bbf02dc14d31677f1c/packaging-23.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97",
+              "url": "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz"
             }
           ],
           "project_name": "packaging",
-          "requires_dists": [
-            "pyparsing!=3.0.5,>=2.0.2"
-          ],
-          "requires_python": ">=3.6",
-          "version": "21.3"
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "23.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc",
-              "url": "https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
-              "url": "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz"
-            }
-          ],
-          "project_name": "pyparsing",
-          "requires_dists": [
-            "jinja2; extra == \"diagrams\"",
-            "railroad-diagrams; extra == \"diagrams\""
-          ],
-          "requires_python": ">=3.6.8",
-          "version": "3.0.9"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65",
-              "url": "https://files.pythonhosted.org/packages/ae/7f/6d816941769a7783be4258dd35e28bbf1a64bb36b1b7e0c773eff07fb0a8/setuptools-63.1.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-              "url": "https://files.pythonhosted.org/packages/67/25/42e2d6664c3e106c33ecad8356a55e3ae5d81708c89098061a97fbff7cee/setuptools-63.1.0.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
@@ -84,6 +106,7 @@
             "filelock>=3.4.0; extra == \"testing\"",
             "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
             "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
@@ -92,7 +115,6 @@
             "jaraco.path>=3.2.0; extra == \"testing\"",
             "jaraco.path>=3.2.0; extra == \"testing-integration\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "mock; extra == \"testing\"",
             "pip-run>=8.8; extra == \"testing\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
@@ -101,18 +123,22 @@
             "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-enabler; extra == \"testing-integration\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf; extra == \"testing\"",
+            "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
             "pytest-xdist; extra == \"testing-integration\"",
             "pytest; extra == \"testing-integration\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
             "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
             "sphinx-reredirects; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
             "tomli-w>=1.0.0; extra == \"testing\"",
             "tomli; extra == \"testing-integration\"",
@@ -122,32 +148,34 @@
             "wheel; extra == \"testing-integration\""
           ],
           "requires_python": ">=3.7",
-          "version": "63.1"
+          "version": "67.5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4",
-              "url": "https://files.pythonhosted.org/packages/e3/e5/c28b544051340e63e0d507eb893c9513d3a300e5e9183e2990518acbfe36/setuptools_scm-6.4.2-py3-none-any.whl"
+              "hash": "73988b6d848709e2af142aa48c986ea29592bbcfca5375678064708205253d8e",
+              "url": "https://files.pythonhosted.org/packages/1d/66/8f42c941be949ef2b22fe905d850c794e7c170a526023612aad5f3a121ad/setuptools_scm-7.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30",
-              "url": "https://files.pythonhosted.org/packages/4a/18/477d3d9eb2f88230ff2a41de9d8ffa3554b706352787d289f57f76bfba0b/setuptools_scm-6.4.2.tar.gz"
+              "hash": "6c508345a771aad7d56ebff0e70628bf2b0ec7573762be9960214730de278f27",
+              "url": "https://files.pythonhosted.org/packages/98/12/2c1e579bb968759fc512391473340d0661b1a8c96a59fb7c65b02eec1321/setuptools_scm-7.1.0.tar.gz"
             }
           ],
           "project_name": "setuptools-scm",
           "requires_dists": [
+            "importlib-metadata; python_version < \"3.8\"",
             "packaging>=20.0",
             "pytest>=6.2; extra == \"test\"",
             "setuptools",
             "setuptools>=42; extra == \"toml\"",
-            "tomli>=1.0.0",
+            "tomli>=1.0.0; python_version < \"3.11\"",
+            "typing-extensions",
             "virtualenv>20; extra == \"test\""
           ],
-          "requires_python": ">=3.6",
-          "version": "6.4.2"
+          "requires_python": ">=3.7",
+          "version": "7.1.0"
         },
         {
           "artifacts": [
@@ -166,16 +194,72 @@
           "requires_dists": [],
           "requires_python": ">=3.7",
           "version": "2.0.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
+            }
+          ],
+          "project_name": "typing-extensions",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "4.5.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
+            }
+          ],
+          "project_name": "zipp",
+          "requires_dists": [
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
+            "jaraco.itertools; extra == \"testing\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "setuptools-scm==6.4.2"
+    "setuptools-scm==7.1.0"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -20,9 +20,9 @@ class SetuptoolsSCM(PythonToolBase):
         "A tool for generating versions from VCS metadata (https://github.com/pypa/setuptools_scm)."
     )
 
-    default_version = "setuptools-scm==6.4.2"
+    default_version = "setuptools-scm==7.1.0"
     default_main = EntryPoint("setuptools_scm")
-    default_requirements = ["setuptools-scm"]
+    default_requirements = ["setuptools-scm>=6.4.2,<8"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/subsystems/twine.lock
+++ b/src/python/pants/backend/python/subsystems/twine.lock
@@ -4,14 +4,18 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
 //     "colorama>=0.4.3",
-//     "twine<3.8,>=3.7.1"
-//   ]
+//     "twine<5,>=4"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -28,52 +32,41 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a",
-              "url": "https://files.pythonhosted.org/packages/d4/87/508104336a2bc0c4cfdbdceedc0f44dc72da3abc0460c57e323ddd1b3257/bleach-5.0.1-py3-none-any.whl"
+              "hash": "33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4",
+              "url": "https://files.pythonhosted.org/packages/ac/e2/dfcab68c9b2e7800c8f06b85c76e5f978d05b195a958daa9b1dda54a1db6/bleach-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c",
-              "url": "https://files.pythonhosted.org/packages/c2/5d/d5d45a38163ede3342d6ac1ca01b5d387329daadf534a25718f9a9ba818c/bleach-5.0.1.tar.gz"
+              "hash": "1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+              "url": "https://files.pythonhosted.org/packages/7e/e6/d5f220ca638f6a25557a611860482cb6e54b2d97f0332966b1b005742e1f/bleach-6.0.0.tar.gz"
             }
           ],
           "project_name": "bleach",
           "requires_dists": [
-            "Sphinx==4.3.2; extra == \"dev\"",
-            "black==22.3.0; implementation_name == \"cpython\" and extra == \"dev\"",
-            "build==0.8.0; extra == \"dev\"",
-            "flake8==4.0.1; extra == \"dev\"",
-            "hashin==0.17.0; extra == \"dev\"",
-            "mypy==0.961; implementation_name == \"cpython\" and extra == \"dev\"",
-            "pip-tools==6.6.2; extra == \"dev\"",
-            "pytest==7.1.2; extra == \"dev\"",
             "six>=1.9.0",
             "tinycss2<1.2,>=1.1.0; extra == \"css\"",
-            "tox==3.25.0; extra == \"dev\"",
-            "twine==4.0.1; extra == \"dev\"",
-            "webencodings",
-            "wheel==0.37.1; extra == \"dev\""
+            "webencodings"
           ],
           "requires_python": ">=3.7",
-          "version": "5.0.1"
+          "version": "6.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412",
-              "url": "https://files.pythonhosted.org/packages/e9/06/d3d367b7af6305b16f0d28ae2aaeb86154fa91f144f036c2d5002a5a202b/certifi-2022.6.15-py3-none-any.whl"
+              "hash": "4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18",
+              "url": "https://files.pythonhosted.org/packages/71/4c/3db2b8021bd6f2f0ceb0e088d6b2d49147671f25832fb17970e9b583d742/certifi-2022.12.7-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
-              "url": "https://files.pythonhosted.org/packages/cc/85/319a8a684e8ac6d87a1193090e06b6bbb302717496380e225ee10487c888/certifi-2022.6.15.tar.gz"
+              "hash": "35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+              "url": "https://files.pythonhosted.org/packages/37/f7/2b1b0ec44fdc30a3d31dfebe52226be9ddc40cd6c0f34ffc8923ba423b69/certifi-2022.12.7.tar.gz"
             }
           ],
           "project_name": "certifi",
           "requires_dists": [],
           "requires_python": ">=3.6",
-          "version": "2022.6.15"
+          "version": "2022.12.7"
         },
         {
           "artifacts": [
@@ -284,131 +277,444 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
-              "url": "https://files.pythonhosted.org/packages/94/69/64b11e8c2fb21f08634468caef885112e682b0ebe2908e74d3616eb1c113/charset_normalizer-2.1.0-py3-none-any.whl"
+              "hash": "3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
+              "url": "https://files.pythonhosted.org/packages/ef/81/14b3b8f01ddaddad6cdec97f2f599aa2fa466bd5ee9af99b08b7713ccd29/charset_normalizer-3.1.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413",
-              "url": "https://files.pythonhosted.org/packages/93/1d/d9392056df6670ae2a29fcb04cfa5cee9f6fbde7311a1bb511d4115e9b7a/charset-normalizer-2.1.0.tar.gz"
+              "hash": "3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
+              "url": "https://files.pythonhosted.org/packages/00/47/f14533da238134f5067fb1d951eb03d5c4be895d6afb11c7ebd07d111acb/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
+              "url": "https://files.pythonhosted.org/packages/01/c7/0407de35b70525dba2a58a2724a525cf882ee76c3d2171d834463c5d2881/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
+              "url": "https://files.pythonhosted.org/packages/0a/67/8d3d162ec6641911879651cdef670c3c6136782b711d7f8e82e2fffe06e0/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
+              "url": "https://files.pythonhosted.org/packages/12/12/c5c39f5a149cd6788d2e40cea5618bae37380e2754fcdf53dc9e01bdd33a/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
+              "url": "https://files.pythonhosted.org/packages/12/68/4812f9b05ac0a2b7619ac3dd7d7e3fc52c12006b84617021c615fc2fcf42/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
+              "url": "https://files.pythonhosted.org/packages/13/b7/21729a6d512246aa0bb872b90aea0d9fcd1b293762cdb1d1d33c01140074/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
+              "url": "https://files.pythonhosted.org/packages/16/58/19fd2f62e6ff44ba0db0cd44b584790555e2cde09293149f4409d654811b/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
+              "url": "https://files.pythonhosted.org/packages/18/36/7ae10a3dd7f9117b61180671f8d1e4802080cca88ad40aaabd3dad8bab0e/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
+              "url": "https://files.pythonhosted.org/packages/1c/9b/de2adc43345623da8e7c958719528a42b6d87d2601017ce1187d43b8a2d7/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
+              "url": "https://files.pythonhosted.org/packages/1f/be/c6c76cf8fcf6918922223203c83ba8192eff1c6a709e8cfec7f5ca3e7d2d/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
+              "url": "https://files.pythonhosted.org/packages/21/16/1b0d8fdcb81bbf180976af4f867ce0f2244d303ab10d452fde361dec3b5c/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
+              "url": "https://files.pythonhosted.org/packages/23/13/cf5d7bb5bc95f120df64d6c470581189df51d7f011560b2a06a395b7a120/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
+              "url": "https://files.pythonhosted.org/packages/2c/2f/ec805104098085728b7cb610deede7195c6fa59f51942422f02cc427b6f6/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
+              "url": "https://files.pythonhosted.org/packages/31/8b/81c3515a69d06b501fcce69506af57a7a19bd9f42cabd1a667b1b40f2c55/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
+              "url": "https://files.pythonhosted.org/packages/33/10/c87ba15f779f8251ae55fa147631339cd91e7af51c3c133d2687c6e41800/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
+              "url": "https://files.pythonhosted.org/packages/33/97/9967fb2d364a9da38557e4af323abcd58cc05bdd8f77e9fd5ae4882772cc/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
+              "url": "https://files.pythonhosted.org/packages/45/3d/fa2683f5604f99fba5098a7313e5d4846baaecbee754faf115907f21a85f/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
+              "url": "https://files.pythonhosted.org/packages/4e/11/f7077d78b18aca8ea3186a706c0221aa2bc34c442a3d3bdf3ad401a29052/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
+              "url": "https://files.pythonhosted.org/packages/4f/18/92866f050f7114ba38aba4f4a69f83cc2a25dc2e5a8af4b44fd1bfd6d528/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
+              "url": "https://files.pythonhosted.org/packages/4f/7c/af43743567a7da2a069b4f9fa31874c3c02b963cd1fb84fe1e7568a567e6/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
+              "url": "https://files.pythonhosted.org/packages/4f/a2/9031ba4a008e11a21d7b7aa41751290d2f2035a2f14ecb6e589771a17c47/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
+              "url": "https://files.pythonhosted.org/packages/56/24/5f2dedcf3d0673931b6200c410832ae44b376848bc899dbf1fa6c91c4ebe/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
+              "url": "https://files.pythonhosted.org/packages/5d/2b/4d8c80400c04ae3c8dbc847de092e282b5c7b17f8f9505d68bb3e5815c71/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
+              "url": "https://files.pythonhosted.org/packages/61/e3/ad9ae58b28482d1069eba1edec2be87701f5dd6fd6024a665020d66677a0/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
+              "url": "https://files.pythonhosted.org/packages/67/30/dbab1fe5ab2ce5d3d517ad9936170d896e9687f3860a092519f1fe359812/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
+              "url": "https://files.pythonhosted.org/packages/67/df/660e9665ace7ad711e275194a86cb757fb4d4e513fae5ff3d39573db4984/charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
+              "url": "https://files.pythonhosted.org/packages/68/77/af702eba147ba963b27eb00832cef6b8c4cb9fcf7404a476993876434b93/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
+              "url": "https://files.pythonhosted.org/packages/69/22/66351781e668158feef71c5e3b059a79ecc9efc3ef84a45888b0f3a933d5/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
+              "url": "https://files.pythonhosted.org/packages/6d/59/59a3f4d8a59ee270da77f9e954a0e284c9d6884d39ec69d696d9aa5ff2f2/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
+              "url": "https://files.pythonhosted.org/packages/72/90/667a6bc6abe42fc10adf4cd2c1e1c399d78e653dbac4c8018350843d4ab7/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
+              "url": "https://files.pythonhosted.org/packages/74/5f/361202de730532028458b729781b8435f320e31a622c27f30e25eec80513/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
+              "url": "https://files.pythonhosted.org/packages/74/f1/d0b8385b574f7e086fb6709e104b696707bd3742d54a6caf0cebbb7e975b/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
+              "url": "https://files.pythonhosted.org/packages/82/b9/51b66a647be8685dee75b7807e0f750edf5c1e4f29bc562ad285c501e3c7/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
+              "url": "https://files.pythonhosted.org/packages/84/23/f60cda6c70ae922ad78368982f06e7fef258fba833212f26275fe4727dc4/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
+              "url": "https://files.pythonhosted.org/packages/85/e8/18d408d8fe29a56012c10d6b15960940b83f06620e9d7481581cdc6d9901/charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
+              "url": "https://files.pythonhosted.org/packages/94/70/23981e7bf098efbc4037e7c66d28a10e950d9296c08c6dea8ef290f9c79e/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
+              "url": "https://files.pythonhosted.org/packages/9a/f1/ff81439aa09070fee64173e6ca6ce1342f2b1cca997bcaae89e443812684/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
+              "url": "https://files.pythonhosted.org/packages/9e/62/a1e0a8f8830c92014602c8a88a1a20b8a68d636378077381f671e6e1cec9/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
+              "url": "https://files.pythonhosted.org/packages/a2/6c/5167f08da5298f383036c33cb749ab5b3405fd07853edc8314c6882c01b8/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
+              "url": "https://files.pythonhosted.org/packages/a4/03/355281b62c26712a50c6a9dd75339d8cdd58488fd7bf2556ba1320ebd315/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
+              "url": "https://files.pythonhosted.org/packages/a9/83/138d2624fdbcb62b7e14715eb721d44347e41a1b4c16544661e940793f49/charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
+              "url": "https://files.pythonhosted.org/packages/ac/7f/62d5dff4e9cb993e4b0d4ea78a74cc84d7d92120879529e0ce0965765936/charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
+              "url": "https://files.pythonhosted.org/packages/ac/c5/990bc41a98b7fa2677c665737fdf278bb74ad4b199c56b6b564b3d4cbfc5/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
+              "url": "https://files.pythonhosted.org/packages/b0/55/d8ef4c8c7d2a8b3a16e7d9b03c59475c2ee96a0e0c90b14c99faaac0ee3b/charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
+              "url": "https://files.pythonhosted.org/packages/bb/dc/58fdef3ab85e8e7953a8b89ef1d2c06938b8ad88d9617f22967e1a90e6b8/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
+              "url": "https://files.pythonhosted.org/packages/c2/35/dfb4032f5712747d3dcfdd19d0768f6d8f60910ae24ed066ecbf442be013/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
+              "url": "https://files.pythonhosted.org/packages/c6/ab/43ea052756b2f2dcb6a131897811c0e2704b0288f090336217d3346cd682/charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
+              "url": "https://files.pythonhosted.org/packages/c9/8c/a76dd9f2c8803eb147e1e715727f5c3ba0ef39adaadf66a7b3698c113180/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
+              "url": "https://files.pythonhosted.org/packages/cc/f6/21a66e524658bd1dd7b89ac9d1ee8f7823f2d9701a2fbc458ab9ede53c63/charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
+              "url": "https://files.pythonhosted.org/packages/d5/92/86c0f0e66e897f6818c46dadef328a5b345d061688f9960fc6ca1fd03dbe/charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
+              "url": "https://files.pythonhosted.org/packages/d7/4c/37ad75674e8c6bc22ab01bef673d2d6e46ee44203498c9a26aa23959afe5/charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
+              "url": "https://files.pythonhosted.org/packages/d8/ca/a7ff600781bf1e5f702ba26bb82f2ba1d3a873a3f8ad73cc44c79dfaefa9/charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
+              "url": "https://files.pythonhosted.org/packages/dd/39/6276cf5a395ffd39b77dadf0e2fcbfca8dbfe48c56ada250c40086055143/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
+              "url": "https://files.pythonhosted.org/packages/e1/7c/398600268fc98b7e007f5a716bd60903fff1ecff75e45f5700212df5cd76/charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
+              "url": "https://files.pythonhosted.org/packages/e1/b4/53678b2a14e0496fc167fe9b9e726ad33d670cfd2011031aa5caeee6b784/charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
+              "url": "https://files.pythonhosted.org/packages/e5/aa/9d2d60d6a566423da96c15cd11cbb88a70f9aff9a4db096094ee19179cab/charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
+              "url": "https://files.pythonhosted.org/packages/ea/38/d31c7906c4be13060c1a5034087966774ef33ab57ff2eee76d71265173c3/charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab",
+              "url": "https://files.pythonhosted.org/packages/f2/b7/e21e16c98575616f4ce09dc766dbccdac0ca119c176b184d46105e971a84/charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
+              "url": "https://files.pythonhosted.org/packages/f2/d7/6ee92c11eda3f3c9cac1e059901092bfdf07388be7d2e60ac627527eee62/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
+              "url": "https://files.pythonhosted.org/packages/f4/0a/8c03913ed1eca9d831db0c28759edb6ce87af22bb55dbc005a52525a75b6/charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
+              "url": "https://files.pythonhosted.org/packages/f6/0f/de1c4030fd669e6719277043e3b0f152a83c118dd1020cf85b51d443d04a/charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
+              "url": "https://files.pythonhosted.org/packages/f8/ed/500609cb2457b002242b090c814549997424d72690ef3058cfdfca91f68b/charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
+              "url": "https://files.pythonhosted.org/packages/fa/8e/2e5c742c3082bce3eea2ddd5b331d08050cda458bc362d71c48e07a44719/charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl"
             }
           ],
           "project_name": "charset-normalizer",
-          "requires_dists": [
-            "unicodedata2; extra == \"unicode_backport\""
-          ],
-          "requires_python": ">=3.6.0",
-          "version": "2.1"
+          "requires_dists": [],
+          "requires_python": ">=3.7.0",
+          "version": "3.1.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da",
-              "url": "https://files.pythonhosted.org/packages/77/8b/7550e87b2d308a1b711725dfaddc19c695f8c5fa413c640b2be01662f4e6/colorama-0.4.5-py2.py3-none-any.whl"
+              "hash": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6",
+              "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4",
-              "url": "https://files.pythonhosted.org/packages/2b/65/24d033a9325ce42ccbfa3ca2d0866c7e89cc68e5b9d92ecaba9feef631df/colorama-0.4.5.tar.gz"
+              "hash": "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44",
+              "url": "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
             }
           ],
           "project_name": "colorama",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.4.5"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7",
+          "version": "0.4.6"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "91ce48d35f4e3d3f1d83e29ef4a9267246e6a3be51864a5b7d2247d5086fa99a",
-              "url": "https://files.pythonhosted.org/packages/6a/79/77dc09377aea15ed0238b3cdcac7375f33aa812dea9a26f1af46f7097b6e/cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl"
+              "hash": "fa507318e427169ade4e9eccef39e9011cdc19534f55ca2f36ec3f388c1f70f3",
+              "url": "https://files.pythonhosted.org/packages/b2/54/2b2a610b6eced5a7be96c0d2e214be9cee6824b9494756e6043470ca594f/cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f2dcb0b3b63afb6df7fd94ec6fbddac81b5492513f7b0436210d390c14d46ee8",
-              "url": "https://files.pythonhosted.org/packages/20/8b/66600f5851ec7893ace9b74445d7eaf3499571b347e339d18c76c876b0f9/cryptography-37.0.4-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "e944fe07b6f229f4c1a06a7ef906a19652bdd9fd54c761b0ff87e83ae7a30354",
+              "url": "https://files.pythonhosted.org/packages/06/ea/d998c35ac871396749f14a4b4e82f080422182e1830f02959e893abd3016/cryptography-39.0.2-pp39-pypy39_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f8c0a6e9e1dd3eb0414ba320f85da6b0dcbd543126e30fcc546e7372a7fbf3b9",
-              "url": "https://files.pythonhosted.org/packages/2e/61/1aa189625666814dfaa1a10c338ba1b5a807e861d9f3b73307b492913e24/cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_24_x86_64.whl"
+              "hash": "30b1d1bfd00f6fc80d11300a29f1d8ab2b8d9febb6ed4a38a76880ec564fae84",
+              "url": "https://files.pythonhosted.org/packages/13/40/acfea5abe60f483bfba44a24419fa89d584e1e93dca750b800805ef272b9/cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_24_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6bc95ed67b6741b2607298f9ea4932ff157e570ef456ef7ff0ef4884a134cc4b",
-              "url": "https://files.pythonhosted.org/packages/47/26/0c9eaff097ff4080c2fa6ff6a53074d772fee881d9f0a5d59ea33229512e/cryptography-37.0.4-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "103e8f7155f3ce2ffa0049fe60169878d47a4364b277906386f8de21c9234aa1",
+              "url": "https://files.pythonhosted.org/packages/1e/85/d5b768b45e564a66fc5ba6344145334208f01d64939adcb8c4032545d164/cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3d41b965b3380f10e4611dbae366f6dc3cefc7c9ac4e8842a806b9672ae9add5",
-              "url": "https://files.pythonhosted.org/packages/55/68/17d21988cec2dec825ce7fb965cc44d5f64e9f48f414084510f5836c5cb3/cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
+              "hash": "ffd394c7896ed7821a6d13b24657c6a34b6e2650bd84ae063cf11ccffa4f1a97",
+              "url": "https://files.pythonhosted.org/packages/26/d2/85480f4e754375c6d8e4a18cc8d2f28ef1984cf2843395c4d1ea396331d3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "190f82f3e87033821828f60787cfa42bff98404483577b591429ed99bed39d59",
-              "url": "https://files.pythonhosted.org/packages/6b/c0/4cfdc2fa58f86ccb5dcd017c9aa2125a5132e9b52868ccc5d46d0542d29c/cryptography-37.0.4-cp36-abi3-musllinux_1_1_x86_64.whl"
+              "hash": "23df8ca3f24699167daf3e23e51f7ba7334d504af63a94af468f468b975b7dd7",
+              "url": "https://files.pythonhosted.org/packages/3c/0c/ac188ca210fbc02102d34ad8dba6956fe16fc566e5c5110a7f7bdbd30138/cryptography-39.0.2-cp36-abi3-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b7f8dd0d4c1f21759695c05a5ec8536c12f31611541f8904083f3dc582604280",
-              "url": "https://files.pythonhosted.org/packages/86/82/5e81dbf8a94c011e5240595149626d92e78a110f01311face1ab08431566/cryptography-37.0.4-cp36-abi3-manylinux_2_24_x86_64.whl"
+              "hash": "eb40fe69cfc6f5cdab9a5ebd022131ba21453cf7b8a7fd3631f45bbf52bed612",
+              "url": "https://files.pythonhosted.org/packages/3c/5a/6c180b745336f989e9b298e1790af0ef5b37640edb861fc536b5663726e3/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82",
-              "url": "https://files.pythonhosted.org/packages/89/d9/5fcd312d5cce0b4d7ee8b551a0ea99e4ea9db0fdbf6dd455a19042e3370b/cryptography-37.0.4.tar.gz"
+              "hash": "d15809e0dbdad486f4ad0979753518f47980020b7a34e9fc56e8be4f60702fac",
+              "url": "https://files.pythonhosted.org/packages/6d/5b/516dc11fa0a638cb707293ad44cc1cb93924bb4b5ba03881dfdb819e23b0/cryptography-39.0.2-pp38-pypy38_pp73-macosx_10_12_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d204833f3c8a33bbe11eda63a54b1aad7aa7456ed769a982f21ec599ba5fa282",
-              "url": "https://files.pythonhosted.org/packages/8d/f4/477730b78a6152dafca6f8c47d246979ed95e6d144f27a85bddb845fe894/cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_24_x86_64.whl"
+              "hash": "50cadb9b2f961757e712a9737ef33d89b8190c3ea34d0fb6675e00edbe35d074",
+              "url": "https://files.pythonhosted.org/packages/77/19/47d55b3f609fc03b6f80c63820996671dfccb28e1d07427dd81319d514d5/cryptography-39.0.2-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7099a8d55cd49b737ffc99c17de504f2257e3787e02abe6d1a6d136574873441",
-              "url": "https://files.pythonhosted.org/packages/92/bb/31fe12a6bc8d066621d79345c84a517c2bd6bf9ae18e1c53652a5c4e8790/cryptography-37.0.4-pp39-pypy39_pp73-macosx_10_10_x86_64.whl"
+              "hash": "8f35c17bd4faed2bc7797d2a66cbb4f986242ce2e30340ab832e5d99ae60e011",
+              "url": "https://files.pythonhosted.org/packages/9c/30/e787edf59f35192799d340a0a36976870ce487ba32948f086c29dc5d54ab/cryptography-39.0.2-cp36-abi3-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "2be53f9f5505673eeda5f2736bea736c40f051a739bfae2f92d18aed1eb54596",
-              "url": "https://files.pythonhosted.org/packages/a4/e4/fcabae3e4c903a0c63e0537c6427a710680f10113a61aaadf8fd74896e00/cryptography-37.0.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "2725672bb53bb92dc7b4150d233cd4b8c59615cd8288d495eaa86db00d4e5c06",
+              "url": "https://files.pythonhosted.org/packages/c5/8a/6dcd53c995506d4ff0de3a7da2202715654493fd12d7875f2a43b3a44150/cryptography-39.0.2-cp36-abi3-macosx_10_12_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a958c52505c8adf0d3822703078580d2c0456dd1d27fabfb6f76fe63d2971cd6",
-              "url": "https://files.pythonhosted.org/packages/c5/93/23f1cc4a39cee6ca0dc75550dc204e5af71e8bf3012d23feb1bd5b06edea/cryptography-37.0.4-cp36-abi3-macosx_10_10_x86_64.whl"
+              "hash": "35d658536b0a4117c885728d1a7032bdc9a5974722ae298d6c533755a6ee3915",
+              "url": "https://files.pythonhosted.org/packages/c6/c4/354c78bade0270f951a14db9f8248ab975ca7df050476dc3759831e52a7f/cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "f721d1885ecae9078c3f6bbe8a88bc0786b6e749bf32ccec1ef2b18929a05046",
-              "url": "https://files.pythonhosted.org/packages/ca/44/2384260ffa2fa974894ec5f70896b328cd55a19dc367cf5c7ef32d5b3ba8/cryptography-37.0.4-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
+              "hash": "e029b844c21116564b8b61216befabca4b500e6816fa9f0ba49527653cae2108",
+              "url": "https://files.pythonhosted.org/packages/cb/76/c9fa9cda16ac5b47b5bb29b3e3b8536ca3584458e889a6df82bbee18e693/cryptography-39.0.2-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "30788e070800fec9bbcf9faa71ea6d8068f5136f60029759fd8c3efec3c9dcb3",
-              "url": "https://files.pythonhosted.org/packages/d4/d7/fa8688ca6ba6dbe44a8ecab9b34cbba0a5ab42c5a3609371968ba3e7f44a/cryptography-37.0.4-cp36-abi3-musllinux_1_1_aarch64.whl"
+              "hash": "5f8c682e736513db7d04349b4f6693690170f95aac449c56f97415c6980edef5",
+              "url": "https://files.pythonhosted.org/packages/d3/26/da69282ae3b350ee869536994e6816ac77057a7b5970068fabe56c644624/cryptography-39.0.2-cp36-abi3-musllinux_1_1_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e007f052ed10cc316df59bc90fbb7ff7950d7e2919c9757fd42a2b8ecf8a5f67",
-              "url": "https://files.pythonhosted.org/packages/e8/ae/8ea6a2010ef1b916e3d158e1dcea6236c5660e7db6425eb9e491f69093a6/cryptography-37.0.4-pp38-pypy38_pp73-macosx_10_10_x86_64.whl"
+              "hash": "bc0521cce2c1d541634b19f3ac661d7a64f9555135e9d8af3980965be717fd4a",
+              "url": "https://files.pythonhosted.org/packages/d6/99/12d3b9c8df83b52799f9994da17bb67bb4565c418b3a8284ed1f79b692e1/cryptography-39.0.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "549153378611c0cca1042f20fd9c5030d37a72f634c9326e225c9f666d472884",
-              "url": "https://files.pythonhosted.org/packages/eb/f0/8bc2246a422eb5cd1fe7cfc2ed522e4e3e0fd6f1c828193c0860c7030ca6/cryptography-37.0.4-cp36-abi3-macosx_10_10_universal2.whl"
+              "hash": "d7d84a512a59f4412ca8549b01f94be4161c94efc598bf09d027d67826beddc0",
+              "url": "https://files.pythonhosted.org/packages/e8/5c/9e47aac90fb5923d09c413909af6bf6ad4af2bfeeff707a2485c3f2af8be/cryptography-39.0.2-cp36-abi3-musllinux_1_1_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7bc997818309f56c0038a33b8da5c0bfbb3f1f067f315f9abd6fc07ad359398d",
-              "url": "https://files.pythonhosted.org/packages/f1/a2/691402d66e95b8e85e2a96c670038ce2d9fc934e5a40152ac68d3c7fe486/cryptography-37.0.4-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b49a88ff802e1993b7f749b1eeb31134f03c8d5c956e3c125c75558955cda536",
+              "url": "https://files.pythonhosted.org/packages/f4/6d/1afb19efbe093f0b1af7a788bb8a693e495dc6c1d2139316b05b40f5e1dd/cryptography-39.0.2-cp36-abi3-manylinux_2_28_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "80f49023dd13ba35f7c34072fa17f604d2f19bf0989f292cedf7ab5770b87a0b",
-              "url": "https://files.pythonhosted.org/packages/fd/5a/f47456f062b0c5bd828198992fca1f78bcc7aeadd216d9ce6c3348188b92/cryptography-37.0.4-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
+              "hash": "e8a0772016feeb106efd28d4a328e77dc2edae84dfbac06061319fdb669ff828",
+              "url": "https://files.pythonhosted.org/packages/f7/c0/daaeedc40e3385f01bb1af8c001ac214dcea6716b61efebabf9066b6f619/cryptography-39.0.2-cp36-abi3-manylinux_2_24_x86_64.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bc5b871e977c8ee5a1bbc42fa8d19bcc08baf0c51cbf1586b0e87a2694dde42f",
+              "url": "https://files.pythonhosted.org/packages/fa/f3/f4b8c175ea9a1de650b0085858059050b7953a93d66c97ed89b93b232996/cryptography-39.0.2.tar.gz"
             }
           ],
           "project_name": "cryptography",
@@ -416,27 +722,32 @@
             "bcrypt>=3.1.5; extra == \"ssh\"",
             "black; extra == \"pep8test\"",
             "cffi>=1.12",
-            "flake8-import-order; extra == \"pep8test\"",
-            "flake8; extra == \"pep8test\"",
+            "check-manifest; extra == \"pep8test\"",
             "hypothesis!=3.79.2,>=1.11.4; extra == \"test\"",
             "iso8601; extra == \"test\"",
-            "pep8-naming; extra == \"pep8test\"",
+            "mypy; extra == \"pep8test\"",
             "pretend; extra == \"test\"",
             "pyenchant>=1.6.11; extra == \"docstest\"",
             "pytest-benchmark; extra == \"test\"",
             "pytest-cov; extra == \"test\"",
+            "pytest-randomly; extra == \"test-randomorder\"",
+            "pytest-shard>=0.1.2; extra == \"test\"",
             "pytest-subtests; extra == \"test\"",
             "pytest-xdist; extra == \"test\"",
             "pytest>=6.2.0; extra == \"test\"",
             "pytz; extra == \"test\"",
+            "ruff; extra == \"pep8test\"",
             "setuptools-rust>=0.11.4; extra == \"sdist\"",
-            "sphinx!=1.8.0,!=3.1.0,!=3.1.1,>=1.6.5; extra == \"docs\"",
-            "sphinx-rtd-theme; extra == \"docs\"",
+            "sphinx-rtd-theme>=1.1.1; extra == \"docs\"",
+            "sphinx>=5.3.0; extra == \"docs\"",
             "sphinxcontrib-spelling>=4.0.1; extra == \"docstest\"",
-            "twine>=1.12.0; extra == \"docstest\""
+            "tox; extra == \"tox\"",
+            "twine>=1.12.0; extra == \"docstest\"",
+            "types-pytz; extra == \"pep8test\"",
+            "types-requests; extra == \"pep8test\""
           ],
           "requires_python": ">=3.6",
-          "version": "37.0.4"
+          "version": "39.0.2"
         },
         {
           "artifacts": [
@@ -460,56 +771,126 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-              "url": "https://files.pythonhosted.org/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl"
+              "hash": "90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2",
+              "url": "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d",
-              "url": "https://files.pythonhosted.org/packages/62/08/e3fc7c8161090f742f504f40b1bccbfc544d4a4e09eb774bf40aafce5436/idna-3.3.tar.gz"
+              "hash": "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+              "url": "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
             }
           ],
           "project_name": "idna",
           "requires_dists": [],
           "requires_python": ">=3.5",
-          "version": "3.3"
+          "version": "3.4"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23",
-              "url": "https://files.pythonhosted.org/packages/d2/a2/8c239dc898138f208dd14b441b196e7b3032b94d3137d9d8453e186967fc/importlib_metadata-4.12.0-py3-none-any.whl"
+              "hash": "7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+              "url": "https://files.pythonhosted.org/packages/26/a7/9da7d5b23fc98ab3d424ac2c65613d63c1f401efb84ad50f2fa27b2caab4/importlib_metadata-6.0.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-              "url": "https://files.pythonhosted.org/packages/1a/16/441080c907df829016729e71d8bdd42d99b9bdde48b01492ed08912c0aa9/importlib_metadata-4.12.0.tar.gz"
+              "hash": "e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d",
+              "url": "https://files.pythonhosted.org/packages/90/07/6397ad02d31bddf1841c9ad3ec30a693a3ff208e09c2ef45c9a8a5f85156/importlib_metadata-6.0.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
           "requires_dists": [
+            "flake8<5; extra == \"testing\"",
             "flufl.flake8; extra == \"testing\"",
+            "furo; extra == \"docs\"",
             "importlib-resources>=1.3; python_version < \"3.9\" and extra == \"testing\"",
             "ipython; extra == \"perf\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
             "packaging; extra == \"testing\"",
             "pyfakefs; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
             "pytest-enabler>=1.3; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-perf>=0.9.2; extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "typing-extensions>=3.6.4; python_version < \"3.8\"",
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "4.12"
+          "version": "6.0.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a",
+              "url": "https://files.pythonhosted.org/packages/38/71/c13ea695a4393639830bf96baea956538ba7a9d06fcce7cef10bfff20f72/importlib_resources-5.12.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6",
+              "url": "https://files.pythonhosted.org/packages/4e/a2/3cab1de83f95dd15297c15bdc04d50902391d707247cada1f021bbfe2149/importlib_resources-5.12.0.tar.gz"
+            }
+          ],
+          "project_name": "importlib-resources",
+          "requires_dists": [
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
+            "zipp>=3.1.0; python_version < \"3.10\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "5.12.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
+              "url": "https://files.pythonhosted.org/packages/60/28/220d3ae0829171c11e50dded4355d17824d60895285631d7eb9dee0ab5e5/jaraco.classes-3.2.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a",
+              "url": "https://files.pythonhosted.org/packages/bf/02/a956c9bfd2dfe60b30c065ed8e28df7fcf72b292b861dca97e951c145ef6/jaraco.classes-3.2.3.tar.gz"
+            }
+          ],
+          "project_name": "jaraco-classes",
+          "requires_dists": [
+            "flake8<5; extra == \"testing\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools",
+            "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-checkdocs>=2.4; extra == \"testing\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest>=6; extra == \"testing\"",
+            "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "3.2.3"
         },
         {
           "artifacts": [
@@ -536,62 +917,147 @@
             "trio; extra == \"trio\""
           ],
           "requires_python": ">=3.7",
-          "version": "0.8"
+          "version": "0.8.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "372ff2fc43ab779e3f87911c26e6c7acc8bb440cbd82683e383ca37594cb0617",
-              "url": "https://files.pythonhosted.org/packages/53/84/1a3287c12f4e19c673ba33304a917c28414fca4ecb56d156a11779bfd668/keyring-23.6.0-py3-none-any.whl"
+              "hash": "771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
+              "url": "https://files.pythonhosted.org/packages/62/db/0e9a09b2b95986dcd73ac78be6ed2bd73ebe8bac65cba7add5b83eb9d899/keyring-23.13.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "3ac00c26e4c93739e19103091a9986a9f79665a78cf15a4df1dba7ea9ac8da2f",
-              "url": "https://files.pythonhosted.org/packages/a4/9e/9d9eb6a6dc4f347bae8200a2e1dd65a7b96ae99e29ef8f7452ccc4ef9eea/keyring-23.6.0.tar.gz"
+              "hash": "ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678",
+              "url": "https://files.pythonhosted.org/packages/55/fe/282f4c205add8e8bb3a1635cbbac59d6def2e0891b145aa553a0e40dd2d0/keyring-23.13.1.tar.gz"
             }
           ],
           "project_name": "keyring",
           "requires_dists": [
             "SecretStorage>=3.2; sys_platform == \"linux\"",
-            "importlib-metadata>=3.6; python_version < \"3.10\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "importlib-metadata>=4.11.4; python_version < \"3.12\"",
+            "importlib-resources; python_version < \"3.9\"",
+            "jaraco.classes",
             "jaraco.packaging>=9; extra == \"docs\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
             "jeepney>=0.4.2; sys_platform == \"linux\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
-            "pywin32-ctypes!=0.1.0,!=0.1.1; sys_platform == \"win32\"",
+            "pywin32-ctypes>=0.2.0; sys_platform == \"win32\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
+            "shtab; extra == \"completion\"",
+            "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "23.6"
+          "version": "23.13.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "848865108ec99d4901b2f7e84058b6e7660aae8ae10164e015a6dcf5b242a594",
-              "url": "https://files.pythonhosted.org/packages/f3/28/ded592460bc65d39a48fe51d7678c408ae895ee3694d4cd404a131a73271/pkginfo-1.8.3-py2.py3-none-any.whl"
+              "hash": "5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
+              "url": "https://files.pythonhosted.org/packages/bf/25/2d88e8feee8e055d015343f9b86e370a1ccbec546f2865c98397aaef24af/markdown_it_py-2.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a84da4318dd86f870a9447a8c98340aa06216bfc6f2b7bdc4b8766984ae1867c",
-              "url": "https://files.pythonhosted.org/packages/00/91/fe0806e3ebded8c4e52f93ab4d963eef34bb33595c7aa7b5591d32ab5b92/pkginfo-1.8.3.tar.gz"
+              "hash": "7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1",
+              "url": "https://files.pythonhosted.org/packages/e4/c0/59bd6d0571986f72899288a95d9d6178d0eebd70b6650f1bb3f0da90f8f7/markdown-it-py-2.2.0.tar.gz"
+            }
+          ],
+          "project_name": "markdown-it-py",
+          "requires_dists": [
+            "attrs; extra == \"rtd\"",
+            "commonmark~=0.9; extra == \"compare\"",
+            "coverage; extra == \"testing\"",
+            "gprof2dot; extra == \"profiling\"",
+            "linkify-it-py<3,>=1; extra == \"linkify\"",
+            "markdown~=3.4; extra == \"compare\"",
+            "mdit-py-plugins; extra == \"plugins\"",
+            "mdurl~=0.1",
+            "mistletoe~=1.0; extra == \"compare\"",
+            "mistune~=2.0; extra == \"compare\"",
+            "myst-parser; extra == \"rtd\"",
+            "panflute~=2.3; extra == \"compare\"",
+            "pre-commit~=3.0; extra == \"code_style\"",
+            "psutil; extra == \"benchmarking\"",
+            "pytest-benchmark; extra == \"benchmarking\"",
+            "pytest-cov; extra == \"testing\"",
+            "pytest-regressions; extra == \"testing\"",
+            "pytest; extra == \"benchmarking\"",
+            "pytest; extra == \"testing\"",
+            "pyyaml; extra == \"rtd\"",
+            "sphinx-copybutton; extra == \"rtd\"",
+            "sphinx-design; extra == \"rtd\"",
+            "sphinx; extra == \"rtd\"",
+            "sphinx_book_theme; extra == \"rtd\"",
+            "typing_extensions>=3.7.4; python_version < \"3.8\""
+          ],
+          "requires_python": ">=3.7",
+          "version": "2.2.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+              "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba",
+              "url": "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+            }
+          ],
+          "project_name": "mdurl",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "0.1.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3",
+              "url": "https://files.pythonhosted.org/packages/85/01/e2678ee4e0d7eed4fd6be9e5b043fff9d22d245d06c8c91def8ced664189/more_itertools-9.1.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d",
+              "url": "https://files.pythonhosted.org/packages/2e/d0/bea165535891bd1dcb5152263603e902c0ec1f4c9a2e152cc4adff6b3a38/more-itertools-9.1.0.tar.gz"
+            }
+          ],
+          "project_name": "more-itertools",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "9.1.0"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+              "url": "https://files.pythonhosted.org/packages/b3/f2/6e95c86a23a30fa205ea6303a524b20cbae27fbee69216377e3d95266406/pkginfo-1.9.6-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046",
+              "url": "https://files.pythonhosted.org/packages/b4/1c/89b38e431c20d6b2389ed8b3926c2ab72f58944733ba029354c6d9f69129/pkginfo-1.9.6.tar.gz"
             }
           ],
           "project_name": "pkginfo",
           "requires_dists": [
-            "coverage; extra == \"testing\"",
-            "nose; extra == \"testing\""
+            "pytest-cov; extra == \"testing\"",
+            "pytest; extra == \"testing\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
-          "version": "1.8.3"
+          "requires_python": ">=3.6",
+          "version": "1.9.6"
         },
         {
           "artifacts": [
@@ -615,31 +1081,33 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519",
-              "url": "https://files.pythonhosted.org/packages/5c/8e/1d9017950034297fffa336c72e693a5b51bbf85141b24a763882cf1977b5/Pygments-2.12.0-py3-none-any.whl"
+              "hash": "fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717",
+              "url": "https://files.pythonhosted.org/packages/0b/42/d9d95cc461f098f204cd20c85642ae40fbff81f74c300341b8d0e0df14e0/Pygments-2.14.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
-              "url": "https://files.pythonhosted.org/packages/59/0f/eb10576eb73b5857bc22610cdfc59e424ced4004fe7132c8f2af2cc168d3/Pygments-2.12.0.tar.gz"
+              "hash": "b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
+              "url": "https://files.pythonhosted.org/packages/da/6a/c427c06913204e24de28de5300d3f0e809933f376e0b7df95194b2bb3f71/Pygments-2.14.0.tar.gz"
             }
           ],
           "project_name": "pygments",
-          "requires_dists": [],
+          "requires_dists": [
+            "importlib-metadata; python_version < \"3.8\" and extra == \"plugins\""
+          ],
           "requires_python": ">=3.6",
-          "version": "2.12"
+          "version": "2.14.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "73b84905d091c31f36e50b4ae05ae2acead661f6a09a9abb4df7d2ddcdb6a698",
-              "url": "https://files.pythonhosted.org/packages/b0/c3/63b1bb5f406a7b223c254a5b34079f205b4f4b365143620fbc1415c98367/readme_renderer-35.0-py3-none-any.whl"
+              "hash": "f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343",
+              "url": "https://files.pythonhosted.org/packages/97/52/fd8a77d6f0a9ddeb26ed8fb334e01ac546106bf0c5b8e40dc826c5bd160f/readme_renderer-37.3-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "a727999acfc222fc21d82a12ed48c957c4989785e5865807c65a487d21677497",
-              "url": "https://files.pythonhosted.org/packages/3f/e8/8a6fe77582ae0f2617a57ec239eda638f7b1939b78e303a81b9c91fb0b96/readme_renderer-35.0.tar.gz"
+              "hash": "cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
+              "url": "https://files.pythonhosted.org/packages/81/c3/d20152fcd1986117b898f66928938f329d0c91ddc47f081c58e64e0f51dc/readme_renderer-37.3.tar.gz"
             }
           ],
           "project_name": "readme-renderer",
@@ -650,19 +1118,19 @@
             "docutils>=0.13.1"
           ],
           "requires_python": ">=3.7",
-          "version": "35"
+          "version": "37.3"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349",
-              "url": "https://files.pythonhosted.org/packages/ca/91/6d9b8ccacd0412c08820f72cebaa4f0c0441b5cda699c90f618b6f8a1b42/requests-2.28.1-py3-none-any.whl"
+              "hash": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+              "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
-              "url": "https://files.pythonhosted.org/packages/a5/61/a867851fd5ab77277495a8709ddda0861b28163c4613b011bc00228cc724/requests-2.28.1.tar.gz"
+              "hash": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
+              "url": "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -670,32 +1138,32 @@
             "PySocks!=1.5.7,>=1.5.6; extra == \"socks\"",
             "certifi>=2017.4.17",
             "chardet<6,>=3.0.2; extra == \"use_chardet_on_py3\"",
-            "charset-normalizer<3,>=2",
+            "charset-normalizer<4,>=2",
             "idna<4,>=2.5",
             "urllib3<1.27,>=1.21.1"
           ],
           "requires_python": "<4,>=3.7",
-          "version": "2.28.1"
+          "version": "2.28.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
-              "url": "https://files.pythonhosted.org/packages/60/ef/7681134338fc097acef8d9b2f8abe0458e4d87559c689a8c306d0957ece5/requests_toolbelt-0.9.1-py2.py3-none-any.whl"
+              "hash": "18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+              "url": "https://files.pythonhosted.org/packages/05/d3/bf87a36bff1cb88fd30a509fd366c70ec30676517ee791b2f77e0e29817a/requests_toolbelt-0.10.1-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0",
-              "url": "https://files.pythonhosted.org/packages/28/30/7bf7e5071081f761766d46820e52f4b16c8a08fef02d2eb4682ca7534310/requests-toolbelt-0.9.1.tar.gz"
+              "hash": "62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d",
+              "url": "https://files.pythonhosted.org/packages/0c/4c/07f01c6ac44f7784fa399137fbc8d0cdc1b5d35304e8c0f278ad82105b58/requests-toolbelt-0.10.1.tar.gz"
             }
           ],
           "project_name": "requests-toolbelt",
           "requires_dists": [
             "requests<3.0.0,>=2.0.1"
           ],
-          "requires_python": null,
-          "version": "0.9.1"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
+          "version": "0.10.1"
         },
         {
           "artifacts": [
@@ -715,19 +1183,42 @@
             "idna; extra == \"idna2008\""
           ],
           "requires_python": ">=3.7",
-          "version": "2"
+          "version": "2.0.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "755dc845b6ad76dcbcbc07ea3da75ae54bb1ea529eb72d15f83d26499a5df319",
-              "url": "https://files.pythonhosted.org/packages/54/42/7cf083c31a9739b40ed683fad17460d1db97ecd23c344df25e41fa9e85e2/SecretStorage-3.3.2-py3-none-any.whl"
+              "hash": "a104f37270bf677148d8acb07d33be1569eeee87e2d1beb286a4e9113caf6f2f",
+              "url": "https://files.pythonhosted.org/packages/6b/f0/79df8eaa345ece1d33d8dfeec46ea166028da37b314dc44ead18c058a126/rich-13.3.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "0a8eb9645b320881c222e827c26f4cfcf55363e8b374a021981ef886657a912f",
-              "url": "https://files.pythonhosted.org/packages/bc/3b/6e294fcaa5aed4059f2aa01a1ee7d343953521f8e0f6965ebcf63c950269/SecretStorage-3.3.2.tar.gz"
+              "hash": "91954fe80cfb7985727a467ca98a7618e5dd15178cc2da10f553b36a93859001",
+              "url": "https://files.pythonhosted.org/packages/5e/0e/ef0a49be56dbc4052a086888cd2490e15fcc95b0eda79e9d0e737b1ab93d/rich-13.3.2.tar.gz"
+            }
+          ],
+          "project_name": "rich",
+          "requires_dists": [
+            "ipywidgets<9,>=7.5.1; extra == \"jupyter\"",
+            "markdown-it-py<3.0.0,>=2.2.0",
+            "pygments<3.0.0,>=2.13.0",
+            "typing-extensions<5.0,>=4.0.0; python_version < \"3.9\""
+          ],
+          "requires_python": ">=3.7.0",
+          "version": "13.3.2"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99",
+              "url": "https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+              "url": "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
             }
           ],
           "project_name": "secretstorage",
@@ -736,7 +1227,7 @@
             "jeepney>=0.6"
           ],
           "requires_python": ">=3.6",
-          "version": "3.3.2"
+          "version": "3.3.3"
         },
         {
           "artifacts": [
@@ -754,92 +1245,65 @@
           "project_name": "six",
           "requires_dists": [],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7",
-          "version": "1.16"
+          "version": "1.16.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "74a2cdefe14d11442cedf3ba4e21a3b84ff9a2dbdc6cfae2c34addb2a14a5ea6",
-              "url": "https://files.pythonhosted.org/packages/8a/c4/d15f1e627fff25443ded77ea70a7b5532d6371498f9285d44d62587e209c/tqdm-4.64.0-py2.py3-none-any.whl"
+              "hash": "929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
+              "url": "https://files.pythonhosted.org/packages/3a/38/a3f27a9e8ce45523d7d1e28c09e9085b61a98dab15d35ec086f36a44b37c/twine-4.0.2-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "40be55d30e200777a307a7585aee69e4eabb46b4ec6a4b4a5f2d9f11e7d5408d",
-              "url": "https://files.pythonhosted.org/packages/98/2a/838de32e09bd511cf69fe4ae13ffc748ac143449bfc24bb3fd172d53a84f/tqdm-4.64.0.tar.gz"
-            }
-          ],
-          "project_name": "tqdm",
-          "requires_dists": [
-            "colorama; platform_system == \"Windows\"",
-            "importlib-resources; python_version < \"3.7\"",
-            "ipywidgets>=6; extra == \"notebook\"",
-            "py-make>=0.1.0; extra == \"dev\"",
-            "requests; extra == \"telegram\"",
-            "slack-sdk; extra == \"slack\"",
-            "twine; extra == \"dev\"",
-            "wheel; extra == \"dev\""
-          ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7",
-          "version": "4.64"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "8c120845fc05270f9ee3e9d7ebbed29ea840e41f48cd059e04733f7e1d401345",
-              "url": "https://files.pythonhosted.org/packages/24/aa/636b8eb9637944d2d94b766997d0420d1911abfd6392a6e3e2a75347949a/twine-3.7.1-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "28460a3db6b4532bde6a5db6755cf2dce6c5020bada8a641bb2c5c7a9b1f35b8",
-              "url": "https://files.pythonhosted.org/packages/9d/12/0e4c8df764d87c15b8256444d0b8b433c183ce3a986ffae3086df3f876ef/twine-3.7.1.tar.gz"
+              "hash": "9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8",
+              "url": "https://files.pythonhosted.org/packages/b7/1a/a7884359429d801cd63c2c5512ad0a337a509994b0e42d9696d4778d71f6/twine-4.0.2.tar.gz"
             }
           ],
           "project_name": "twine",
           "requires_dists": [
-            "colorama>=0.4.3",
             "importlib-metadata>=3.6",
             "keyring>=15.1",
             "pkginfo>=1.8.1",
-            "readme-renderer>=21.0",
+            "readme-renderer>=35.0",
             "requests-toolbelt!=0.9.0,>=0.8.0",
             "requests>=2.20",
             "rfc3986>=1.4.0",
-            "tqdm>=4.14"
+            "rich>=12.0.0",
+            "urllib3>=1.26.0"
           ],
-          "requires_python": ">=3.6",
-          "version": "3.7.1"
+          "requires_python": ">=3.7",
+          "version": "4.0.2"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
+              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
+              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
-              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
+              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.3"
+          "version": "4.5.0"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
-              "url": "https://files.pythonhosted.org/packages/68/47/93d3d28e97c7577f563903907912f4b3804054e4877a5ba6651f7182c53b/urllib3-1.26.10-py2.py3-none-any.whl"
+              "hash": "75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1",
+              "url": "https://files.pythonhosted.org/packages/fe/ca/466766e20b767ddb9b951202542310cba37ea5f2d792dae7589f1741af58/urllib3-1.26.14-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6",
-              "url": "https://files.pythonhosted.org/packages/25/36/f056e5f1389004cf886bb7a8514077f24224238a7534497c014a6b9ac770/urllib3-1.26.10.tar.gz"
+              "hash": "076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+              "url": "https://files.pythonhosted.org/packages/c5/52/fe421fb7364aa738b3506a2d99e4f3a56e079c0a798e9f4fa5e14c60922f/urllib3-1.26.14.tar.gz"
             }
           ],
           "project_name": "urllib3",
@@ -852,10 +1316,11 @@
             "cryptography>=1.3.4; extra == \"secure\"",
             "idna>=2.0.0; extra == \"secure\"",
             "ipaddress; python_version == \"2.7\" and extra == \"secure\"",
-            "pyOpenSSL>=0.14; extra == \"secure\""
+            "pyOpenSSL>=0.14; extra == \"secure\"",
+            "urllib3-secure-extra; extra == \"secure\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,<4,>=2.7",
-          "version": "1.26.10"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7",
+          "version": "1.26.14"
         },
         {
           "artifacts": [
@@ -879,43 +1344,50 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099",
-              "url": "https://files.pythonhosted.org/packages/80/0e/16a7ee38617aab6a624e95948d314097cc2669edae9b02ded53309941cfc/zipp-3.8.0-py3-none-any.whl"
+              "hash": "48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556",
+              "url": "https://files.pythonhosted.org/packages/5b/fa/c9e82bbe1af6266adf08afb563905eb87cab83fde00a0a08963510621047/zipp-3.15.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
-              "url": "https://files.pythonhosted.org/packages/cc/3c/3e8c69cd493297003da83f26ccf1faea5dd7da7892a0a7c965ac3bcba7bf/zipp-3.8.0.tar.gz"
+              "hash": "112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+              "url": "https://files.pythonhosted.org/packages/00/27/f0ac6b846684cecce1ee93d32450c45ab607f65c2e0255f0092032d91f07/zipp-3.15.0.tar.gz"
             }
           ],
           "project_name": "zipp",
           "requires_dists": [
-            "func-timeout; extra == \"testing\"",
+            "big-O; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
+            "furo; extra == \"docs\"",
+            "jaraco.functools; extra == \"testing\"",
             "jaraco.itertools; extra == \"testing\"",
             "jaraco.packaging>=9; extra == \"docs\"",
+            "jaraco.tidelift>=1.4; extra == \"docs\"",
+            "more-itertools; extra == \"testing\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
             "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
             "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
-            "sphinx; extra == \"docs\""
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\""
           ],
           "requires_python": ">=3.7",
-          "version": "3.8"
+          "version": "3.15.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
     "colorama>=0.4.3",
-    "twine<3.8,>=3.7.1"
+    "twine<5,>=4"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -26,7 +26,7 @@ class TwineSubsystem(PythonToolBase):
     name = "Twine"
     help = "The utility for publishing Python distributions to PyPI and other Python repositories."
 
-    default_version = "twine>=3.7.1,<3.8"
+    default_version = "twine>=4,<5"
     default_main = ConsoleScript("twine")
 
     # This explicit dependency resolves a weird behavior in poetry, where it would include a sys
@@ -34,6 +34,7 @@ class TwineSubsystem(PythonToolBase):
     # requirements.
     # See: https://github.com/pantsbuild/pants/pull/13594#issuecomment-968154931
     default_extra_requirements = ["colorama>=0.4.3"]
+    default_requirements = ["twine>=3.7.1,<5", *default_extra_requirements]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -192,6 +192,7 @@ class PythonFilesGeneratorSettingsRequest(TargetFilesGeneratorSettingsRequest):
 # `pex_binary` and `pex_binaries` target
 # -----------------------------------------------------------------------------------------------
 
+
 # See `target_types_rules.py` for a dependency injection rule.
 class PexBinaryDependenciesField(Dependencies):
     supports_transitive_excludes = True

--- a/src/python/pants/backend/python/typecheck/mypy/BUILD
+++ b/src/python/pants/backend/python/typecheck/mypy/BUILD
@@ -3,6 +3,8 @@
 
 resource(name="lockfile", source="mypy.lock")
 
+resource(name="older_lockfile_for_testing", source="older_mypy_for_testing.lock")
+
 python_sources(
     overrides={"subsystem.py": {"dependencies": [":lockfile"]}},
 )
@@ -17,6 +19,7 @@ python_tests(
         },
         "subsystem_test.py": {"timeout": 180},
         "rules_integration_test.py": {
+            "dependencies": [":older_lockfile_for_testing"],
             "tags": ["platform_specific_behavior"],
             "timeout": 480,
         },

--- a/src/python/pants/backend/python/typecheck/mypy/older_mypy_for_testing.lock
+++ b/src/python/pants/backend/python/typecheck/mypy/older_mypy_for_testing.lock
@@ -4,17 +4,13 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 3,
+//   "version": 2,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "mypy==1.1.1"
-//   ],
-//   "manylinux": "manylinux2014",
-//   "requirement_constraints": [],
-//   "only_binary": [],
-//   "no_binary": []
+//     "mypy==0.961"
+//   ]
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -31,141 +27,117 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4e4e8b362cdf99ba00c2b218036002bdcdf1e0de085cdb296a49df03fb31dfc4",
-              "url": "https://files.pythonhosted.org/packages/a4/0b/3a30f50287e42a4230320fa2eac25eb3017d38a7c31f083d407ab627607c/mypy-1.1.1-py3-none-any.whl"
+              "hash": "03c6cc893e7563e7b2949b969e63f02c000b32502a1b4d1314cabe391aa87d66",
+              "url": "https://files.pythonhosted.org/packages/cb/30/03a46a37902348b309aa5fe8a92636b9417fdcea77e20dfc1455581a0ae7/mypy-0.961-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ce61663faf7a8e5ec6f456857bfbcec2901fbdb3ad958b778403f63b9e606a1b",
-              "url": "https://files.pythonhosted.org/packages/2a/28/8485aad67750b3374443d28bad3eed947737cf425a640ea4be4ac70a7827/mypy-1.1.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "5f1332964963d4832a94bebc10f13d3279be3ce8f6c64da563d6ee6e2eeda932",
+              "url": "https://files.pythonhosted.org/packages/31/73/71ae84ece879f7c6fd5fbbe7c750c4663dcbd53fa5c7fa7023be59af27f5/mypy-0.961-cp39-cp39-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9401e33814cec6aec8c03a9548e9385e0e228fc1b8b0a37b9ea21038e64cdd8a",
-              "url": "https://files.pythonhosted.org/packages/30/da/808ceaf2bcf23a9e90156c7b11b41add8dd5a009ee48159ec820d04d97bd/mypy-1.1.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "b117650592e1782819829605a193360a08aa99f1fc23d1d71e1a75a142dc7e15",
+              "url": "https://files.pythonhosted.org/packages/46/d7/3cf7605655f78daded7a23e66f632b50a3b3a8b4262739782f558f8949cf/mypy-0.961-cp310-cp310-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "39c7119335be05630611ee798cc982623b9e8f0cff04a0b48dfc26100e0b97af",
-              "url": "https://files.pythonhosted.org/packages/44/9d/d23fa5d12bacbe7beea5fb6315b3325beabbe438e7e14d38c82b71609818/mypy-1.1.1-cp310-cp310-macosx_10_9_x86_64.whl"
+              "hash": "006be38474216b833eca29ff6b73e143386f352e10e9c2fbe76aa8549e5554f5",
+              "url": "https://files.pythonhosted.org/packages/5e/5a/1b46c161aacdff572632695a483e64ea908089b5c1b6bb92c7e59685c889/mypy-0.961-cp39-cp39-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "59bbd71e5c58eed2e992ce6523180e03c221dcd92b52f0e792f291d67b15a71c",
-              "url": "https://files.pythonhosted.org/packages/47/9f/34f6a2254f7d39b8c4349b8ac480c233d37c377faf2c67c6ef925b3af0ab/mypy-1.1.1-cp39-cp39-macosx_11_0_arm64.whl"
+              "hash": "f730d56cb924d371c26b8eaddeea3cc07d78ff51c521c6d04899ac6904b75492",
+              "url": "https://files.pythonhosted.org/packages/67/48/e73045183ce9824d98365f18255a79d0b01638f40a0a68f898dc8f3cebcc/mypy-0.961.tar.gz"
             },
             {
               "algorithm": "sha256",
-              "hash": "dbb19c9f662e41e474e0cff502b7064a7edc6764f5262b6cd91d698163196799",
-              "url": "https://files.pythonhosted.org/packages/61/99/4a844dcacbc4990a8312236bf74a55910ee9a05db69dee7d6fb7a7ffe6c2/mypy-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "64759a273d590040a592e0f4186539858c948302c653c2eac840c7a3cd29e51b",
+              "url": "https://files.pythonhosted.org/packages/7e/10/617b3a85123226906353fa8c5d574390ee1899fae2fe3e62109f87f48f4e/mypy-0.961-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "ae9ceae0f5b9059f33dbc62dea087e942c0ccab4b7a003719cb70f9b8abfa32f",
-              "url": "https://files.pythonhosted.org/packages/62/54/be80f8d01f5cf72f774a77f9f750527a6fa733f09f78b1da30e8fa3914e6/mypy-1.1.1.tar.gz"
+              "hash": "9f5f5a74085d9a81a1f9c78081d60a0040c3efb3f28e5c9912b900adf59a16e6",
+              "url": "https://files.pythonhosted.org/packages/83/ac/29e343bc9423c7061d55ba061ad58af2143f26fbf4ab57c9817286ab10ce/mypy-0.961-cp38-cp38-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d809f88734f44a0d44959d795b1e6f64b2bbe0ea4d9cc4776aa588bb4229fc1c",
-              "url": "https://files.pythonhosted.org/packages/64/63/6a04ca7a8b7f34811cada43ed6119736a7f4a07c5e1cbd8eec0e0f4962d5/mypy-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl"
+              "hash": "697540876638ce349b01b6786bc6094ccdaba88af446a9abb967293ce6eaa2b0",
+              "url": "https://files.pythonhosted.org/packages/86/df/16748348d0119a6f2528f370e20f644a15ffb8a335a79e91023babc34d0b/mypy-0.961-cp310-cp310-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b7c7b708fe9a871a96626d61912e3f4ddd365bf7f39128362bc50cbd74a634d5",
-              "url": "https://files.pythonhosted.org/packages/7e/32/1b161731d19580c55d3d7c04b8ace80dc7cf42d852adf750f348a485068f/mypy-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl"
+              "hash": "f4b794db44168a4fc886e3450201365c9526a522c46ba089b55e1f11c163750d",
+              "url": "https://files.pythonhosted.org/packages/99/99/c1d2e6d00b7336b67b033beec51c346017f33c3d5e36e1cf62239310b950/mypy-0.961-cp38-cp38-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "61bf08362e93b6b12fad3eab68c4ea903a077b87c90ac06c11e3d7a09b56b9c1",
-              "url": "https://files.pythonhosted.org/packages/8a/fd/b610256224e01da4c4f315d11f62d39d815e97439a58d49d60aa4f55a60b/mypy-1.1.1-cp310-cp310-macosx_11_0_arm64.whl"
+              "hash": "3e09f1f983a71d0672bbc97ae33ee3709d10c779beb613febc36805a6e28bb4e",
+              "url": "https://files.pythonhosted.org/packages/9c/4b/37c32ab752c1a16cd528bfa239553207108ae33c7b617f9cfea3bb6e2f00/mypy-0.961-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c1c10fa12df1232c936830839e2e935d090fc9ee315744ac33b8a32216b93707",
-              "url": "https://files.pythonhosted.org/packages/8c/3d/a8d518bb06952484ada20897878a7a14741536f43514dcfecfac0676aa01/mypy-1.1.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
+              "hash": "0e9f70df36405c25cc530a86eeda1e0867863d9471fe76d1273c783df3d35c2e",
+              "url": "https://files.pythonhosted.org/packages/a0/dc/8356726d7964f4418a9cc197395b220921c55259ba55d9d20f07c001a8e3/mypy-0.961-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "d64c28e03ce40d5303450f547e07418c64c241669ab20610f273c9e6290b4b0b",
-              "url": "https://files.pythonhosted.org/packages/b8/06/3d72d1b316ceec347874c4285fad8bf17e3fb21bb7848c1a942df239e44a/mypy-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl"
+              "hash": "a5ea0875a049de1b63b972456542f04643daf320d27dc592d7c3d9cd5d9bf950",
+              "url": "https://files.pythonhosted.org/packages/b4/5f/6f116003e4ddb472912c13f999127d658e56a210177e23c9d6b1538a5184/mypy-0.961-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "19ba15f9627a5723e522d007fe708007bae52b93faab00f95d72f03e1afa9598",
-              "url": "https://files.pythonhosted.org/packages/b8/72/385f3aeaaf262325454ac7f569eb81ac623464871df23d9778c864d04c6c/mypy-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl"
+              "hash": "bdd5ca340beffb8c44cb9dc26697628d1b88c6bddf5c2f6eb308c46f269bb6f3",
+              "url": "https://files.pythonhosted.org/packages/ba/85/d59bd3b0c84a59d862d2494a3461710ad4a2a1616312414ecc95b2393310/mypy-0.961-cp310-cp310-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5b5f81b40d94c785f288948c16e1f2da37203c6006546c5d947aab6f90aefef2",
-              "url": "https://files.pythonhosted.org/packages/b9/e5/71eef5239219ee2f4d85e2ca6368d736705a3b874023b57f7237b977839c/mypy-1.1.1-cp311-cp311-macosx_11_0_arm64.whl"
+              "hash": "d5aaf1edaa7692490f72bdb9fbd941fbf2e201713523bdb3f4038be0af8846c6",
+              "url": "https://files.pythonhosted.org/packages/d3/c1/044316d783ce5ff2df602cc7562c6a6a2c1f8500d1449e1e0d06a36a8ae1/mypy-0.961-cp38-cp38-macosx_10_9_universal2.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "4b398d8b1f4fba0e3c6463e02f8ad3346f71956b92287af22c9b12c3ec965a9f",
-              "url": "https://files.pythonhosted.org/packages/be/d5/5588a2ee0d77189626a57b555b6b006dda6d5b0083f16c6be0c2d761cd7b/mypy-1.1.1-cp39-cp39-musllinux_1_1_x86_64.whl"
+              "hash": "9940e6916ed9371809b35b2154baf1f684acba935cd09928952310fbddaba648",
+              "url": "https://files.pythonhosted.org/packages/e3/66/9942860fc360e529dbd695b1da3dd80336095d0d3c956e416eb656fba7dd/mypy-0.961-cp39-cp39-macosx_11_0_arm64.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "21b437be1c02712a605591e1ed1d858aba681757a1e55fe678a15c2244cd68a5",
-              "url": "https://files.pythonhosted.org/packages/bf/2d/45a526f248719ee32ecf1261564247a2e717a9c6167de5eb67d53599c4df/mypy-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "315ac73cc1cce4771c27d426b7ea558fb4e2836f89cb0296cbe056894e3a1f78",
-              "url": "https://files.pythonhosted.org/packages/c0/d6/17ba6f8749722b8f61c6ab680769658f0bc63c293556149e2bf400b1f1a2/mypy-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "0a28a76785bf57655a8ea5eb0540a15b0e781c807b5aa798bd463779988fa1d5",
-              "url": "https://files.pythonhosted.org/packages/d3/35/a0892864f1c128dc6449ee69897f9db7a64de2c16f41c14640dd22251b1b/mypy-1.1.1-cp37-cp37m-musllinux_1_1_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "26cdd6a22b9b40b2fd71881a8a4f34b4d7914c679f154f43385ca878a8297389",
-              "url": "https://files.pythonhosted.org/packages/d9/ab/d6d3884c3f432898458e2ade712988a7d1da562c1a363f2003b31677acd8/mypy-1.1.1-cp311-cp311-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "64cc3afb3e9e71a79d06e3ed24bb508a6d66f782aff7e56f628bf35ba2e0ba51",
-              "url": "https://files.pythonhosted.org/packages/e1/a6/331cff5f7476904a2ebe6ed7cee2310b6be583ff6d45609ea0e0d67fd39d/mypy-1.1.1-cp38-cp38-macosx_11_0_arm64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "2b0c373d071593deefbcdd87ec8db91ea13bd8f1328d44947e88beae21e8d5e9",
-              "url": "https://files.pythonhosted.org/packages/f6/57/93e676773f91141127329a56e2238eac506a78f6fb0ae0650a53fcc1355d/mypy-1.1.1-cp38-cp38-musllinux_1_1_x86_64.whl"
+              "hash": "5a0b53747f713f490affdceef835d8f0cb7285187a6a44c33821b6d1f46ed813",
+              "url": "https://files.pythonhosted.org/packages/f6/fa/fc6a127fd06f266f2e615b2ee8cd4ab8a49adecc740965ceec072569427c/mypy-0.961-cp37-cp37m-macosx_10_9_x86_64.whl"
             }
           ],
           "project_name": "mypy",
           "requires_dists": [
             "lxml; extra == \"reports\"",
-            "mypy-extensions>=1.0.0",
-            "pip; extra == \"install-types\"",
+            "mypy-extensions>=0.4.3",
             "psutil>=4.0; extra == \"dmypy\"",
             "tomli>=1.1.0; python_version < \"3.11\"",
             "typed-ast<2,>=1.4.0; extra == \"python2\"",
             "typed-ast<2,>=1.4.0; python_version < \"3.8\"",
             "typing-extensions>=3.10"
           ],
-          "requires_python": ">=3.7",
-          "version": "1.1.1"
+          "requires_python": ">=3.6",
+          "version": "0.961"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
-              "url": "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl"
+              "hash": "090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+              "url": "https://files.pythonhosted.org/packages/5c/eb/975c7c080f3223a5cdaff09612f3a5221e4ba534f7039db34c35d95fa6a5/mypy_extensions-0.4.3-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782",
-              "url": "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz"
+              "hash": "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8",
+              "url": "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz"
             }
           ],
           "project_name": "mypy-extensions",
-          "requires_dists": [],
-          "requires_python": ">=3.5",
-          "version": "1.0.0"
+          "requires_dists": [
+            "typing>=3.5.3; python_version < \"3.5\""
+          ],
+          "requires_python": null,
+          "version": "0.4.3"
         },
         {
           "artifacts": [
@@ -277,30 +249,29 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4",
-              "url": "https://files.pythonhosted.org/packages/31/25/5abcd82372d3d4a3932e1fa8c3dbf9efac10cc7c0d16e78467460571b404/typing_extensions-4.5.0-py3-none-any.whl"
+              "hash": "25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+              "url": "https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
-              "url": "https://files.pythonhosted.org/packages/d3/20/06270dac7316220643c32ae61694e451c98f8caf4c8eab3aa80a2bedf0df/typing_extensions-4.5.0.tar.gz"
+              "hash": "e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6",
+              "url": "https://files.pythonhosted.org/packages/9e/1d/d128169ff58c501059330f1ad96ed62b79114a2eb30b8238af63a2e27f70/typing_extensions-4.3.0.tar.gz"
             }
           ],
           "project_name": "typing-extensions",
           "requires_dists": [],
           "requires_python": ">=3.7",
-          "version": "4.5.0"
+          "version": "4.3"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.127",
-  "pip_version": "23.0.1",
+  "pex_version": "2.1.96",
   "prefer_older_binary": false,
   "requirements": [
-    "mypy==1.1.1"
+    "mypy==0.961"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -137,7 +137,6 @@ async def mypy_typecheck_partition(
     mv: MvBinary,
     global_options: GlobalOptions,
 ) -> CheckResult:
-
     # MyPy requires 3.5+ to run, but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6,
     # and 3.7. However, typed-ast does not understand 3.8+, so instead we must run MyPy with
     # Python 3.8+ when relevant. We only do this if <3.8 can't be used, as we don't want a
@@ -180,7 +179,12 @@ async def mypy_typecheck_partition(
         ),
     )
 
-    (roots_sources, mypy_pex, extra_type_stubs_pex, requirements_pex,) = await MultiGet(
+    (
+        roots_sources,
+        mypy_pex,
+        extra_type_stubs_pex,
+        requirements_pex,
+    ) = await MultiGet(
         roots_sources_get,
         mypy_pex_get,
         extra_type_stubs_pex_get,

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -94,8 +94,9 @@ class MyPy(PythonToolBase):
     name = "MyPy"
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
-    default_version = "mypy==0.961"
+    default_version = "mypy==1.1.1"
     default_main = ConsoleScript("mypy")
+    default_requirements = ["mypy>=0.961,<2"]
 
     # See `mypy/rules.py`. We only use these default constraints in some situations.
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/typecheck/pyright/rules.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules.py
@@ -148,7 +148,6 @@ async def pyright_typecheck_partition(
     pyright: Pyright,
     pex_environment: PexEnvironment,
 ) -> CheckResult:
-
     root_sources_get = Get(
         SourceFiles,
         SourceFilesRequest(fs.sources for fs in partition.field_sets),
@@ -241,7 +240,6 @@ async def pyright_determine_partitions(
     pyright: Pyright,
     python_setup: PythonSetup,
 ) -> PyrightPartitions:
-
     resolve_and_interpreter_constraints_to_field_sets = (
         _partition_by_interpreter_constraints_and_resolve(request.field_sets, python_setup)
     )

--- a/src/python/pants/backend/python/util_rules/lockfile_metadata.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_metadata.py
@@ -32,7 +32,6 @@ class InvalidPythonLockfileReason(Enum):
 
 @dataclass(frozen=True)
 class PythonLockfileMetadata(LockfileMetadata):
-
     scope = LockfileScope.PYTHON
 
     valid_for_interpreter_constraints: InterpreterConstraints
@@ -94,7 +93,6 @@ class PythonLockfileMetadata(LockfileMetadata):
 @_python_lockfile_metadata(1)
 @dataclass(frozen=True)
 class PythonLockfileMetadataV1(PythonLockfileMetadata):
-
     requirements_invalidation_digest: str
 
     @classmethod

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -213,7 +213,10 @@ async def bsp_resolve_scala_metadata(
     jdk_requests = [JdkRequest.from_field(version) for version in jdk_versions]
     jdk_request = max(jdk_requests, key=_jdk_request_sort_key(jvm))
 
-    jdk, readlink, = await MultiGet(
+    (
+        jdk,
+        readlink,
+    ) = await MultiGet(
         Get(JdkEnvironment, JdkRequest, jdk_request),
         Get(ReadlinkBinary, ReadlinkBinaryRequest()),
     )

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -72,7 +72,6 @@ async def compile_scala_source(
     scalac: Scalac,
     request: CompileScalaSourceRequest,
 ) -> FallibleClasspathEntry:
-
     # Request classpath entries for our direct dependencies.
     dependency_cpers = await Get(FallibleClasspathEntries, ClasspathDependenciesRequest(request))
     direct_dependency_classpath_entries = dependency_cpers.if_all_succeeded()

--- a/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
+++ b/src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt
@@ -14,15 +14,9 @@
 [[entries]]
 file_name = "com.geirsson_metaconfig-core_2.13_0.9.15.jar"
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
+group = "com.lihaoyi"
+artifact = "pprint_2.13"
+version = "0.6.6"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -32,9 +26,9 @@ version = "2.5.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "com.lihaoyi"
-artifact = "pprint_2.13"
-version = "0.6.6"
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -43,10 +37,10 @@ artifact = "scala-reflect"
 version = "2.13.7"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
+[[entries.directDependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -56,15 +50,9 @@ version = "0.2.14"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
+group = "com.lihaoyi"
+artifact = "pprint_2.13"
+version = "0.6.6"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -74,15 +62,27 @@ version = "0.2.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "pprint_2.13"
-version = "0.6.6"
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-reflect"
 version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 
@@ -115,18 +115,6 @@ version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.typesafe"
-artifact = "config"
-version = "1.4.1"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.geirsson"
 artifact = "metaconfig-core_2.13"
 version = "0.9.15"
@@ -139,15 +127,9 @@ version = "0.2.14"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
+group = "com.lihaoyi"
+artifact = "pprint_2.13"
+version = "0.6.6"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -157,15 +139,33 @@ version = "0.2.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "pprint_2.13"
-version = "0.6.6"
+group = "com.typesafe"
+artifact = "config"
+version = "1.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-reflect"
 version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 
@@ -535,18 +535,6 @@ version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-compiler"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "net.java.dev.jna"
 artifact = "jna"
 version = "5.8.0"
@@ -556,6 +544,18 @@ packaging = "jar"
 group = "org.jline"
 artifact = "jline"
 version = "3.20.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-compiler"
+version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -658,21 +658,9 @@ version = "4.4.30"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "trees_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "common_2.13"
-version = "4.4.30"
+group = "com.lihaoyi"
+artifact = "geny_2.13"
+version = "0.6.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -682,15 +670,27 @@ version = "0.2.7"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "common_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.scalameta"
 artifact = "fastparse-v2_2.13"
 version = "2.3.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "geny_2.13"
-version = "0.6.5"
+group = "org.scalameta"
+artifact = "trees_2.13"
+version = "4.4.30"
 packaging = "jar"
 
 
@@ -705,42 +705,6 @@ serialized_bytes_length = 1364598
 [[entries]]
 file_name = "org.scalameta_scalafmt-cli_2.13_3.2.1.jar"
 [[entries.directDependencies]]
-group = "org.scalameta"
-artifact = "svm-subs"
-version = "101.0.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-dynamic_2.13"
-version = "3.2.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "com.martiansoftware"
-artifact = "nailgun-server"
-version = "0.9.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-core_2.13"
-version = "3.2.1"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
 group = "com.github.scopt"
 artifact = "scopt_2.13"
 version = "4.0.1"
@@ -752,34 +716,40 @@ artifact = "diffutils"
 version = "1.3.0"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "svm-subs"
-version = "101.0.0"
+[[entries.directDependencies]]
+group = "com.martiansoftware"
+artifact = "nailgun-server"
+version = "0.9.1"
 packaging = "jar"
 
-[[entries.dependencies]]
+[[entries.directDependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
+packaging = "jar"
+
+[[entries.directDependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.7"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "com.typesafe"
-artifact = "config"
-version = "1.4.1"
+[[entries.directDependencies]]
+group = "org.scalameta"
+artifact = "scalafmt-core_2.13"
+version = "3.2.1"
 packaging = "jar"
 
-[[entries.dependencies]]
+[[entries.directDependencies]]
 group = "org.scalameta"
 artifact = "scalafmt-dynamic_2.13"
 version = "3.2.1"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-parallel-collections_2.13"
-version = "1.0.4"
+[[entries.directDependencies]]
+group = "org.scalameta"
+artifact = "svm-subs"
+version = "101.0.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -789,45 +759,57 @@ version = "0.9.15"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.martiansoftware"
-artifact = "nailgun-server"
-version = "0.9.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-core_2.13"
-version = "3.2.1"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.geirsson"
 artifact = "metaconfig-typesafe-config_2.13"
 version = "0.9.15"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-config_2.13"
-version = "3.2.1"
+group = "com.github.scopt"
+artifact = "scopt_2.13"
+version = "4.0.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
+group = "com.googlecode.java-diff-utils"
+artifact = "diffutils"
 version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "parsers_2.13"
-version = "4.4.30"
+group = "com.lihaoyi"
+artifact = "fansi_2.13"
+version = "0.2.14"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-compiler"
-version = "2.13.7"
+group = "com.lihaoyi"
+artifact = "geny_2.13"
+version = "0.6.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.lihaoyi"
+artifact = "pprint_2.13"
+version = "0.6.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.lihaoyi"
+artifact = "sourcecode_2.13"
+version = "0.2.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.martiansoftware"
+artifact = "nailgun-server"
+version = "0.9.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.typesafe"
+artifact = "config"
+version = "1.4.1"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -843,33 +825,9 @@ version = "5.8.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "trees_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "fansi_2.13"
-version = "0.2.14"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.github.scopt"
-artifact = "scopt_2.13"
-version = "4.0.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "common_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
+group = "org.jline"
+artifact = "jline"
+version = "3.20.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -879,39 +837,33 @@ version = "2.5.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "sourcecode_2.13"
-version = "0.2.7"
+group = "org.scala-lang.modules"
+artifact = "scala-parallel-collections_2.13"
+version = "1.0.4"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.jline"
-artifact = "jline"
-version = "3.20.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.googlecode.java-diff-utils"
-artifact = "diffutils"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
 version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "fastparse-v2_2.13"
-version = "2.3.1"
+group = "org.scala-lang"
+artifact = "scala-compiler"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "pprint_2.13"
-version = "0.6.6"
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "scalameta_2.13"
-version = "4.4.30"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -922,7 +874,37 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalameta"
-artifact = "scalafmt-sysops_2.13"
+artifact = "common_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "fastparse-v2_2.13"
+version = "2.3.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "parsers_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "scalafmt-config_2.13"
+version = "3.2.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "scalafmt-core_2.13"
+version = "3.2.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "scalafmt-dynamic_2.13"
 version = "3.2.1"
 packaging = "jar"
 
@@ -933,15 +915,33 @@ version = "3.2.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.7"
+group = "org.scalameta"
+artifact = "scalafmt-sysops_2.13"
+version = "3.2.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "geny_2.13"
-version = "0.6.5"
+group = "org.scalameta"
+artifact = "scalameta_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "svm-subs"
+version = "101.0.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "trees_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 
@@ -974,18 +974,6 @@ version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.typesafe"
-artifact = "config"
-version = "1.4.1"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.geirsson"
 artifact = "metaconfig-core_2.13"
 version = "0.9.15"
@@ -1004,15 +992,9 @@ version = "0.2.14"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
+group = "com.lihaoyi"
+artifact = "pprint_2.13"
+version = "0.6.6"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1022,15 +1004,33 @@ version = "0.2.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "pprint_2.13"
-version = "0.6.6"
+group = "com.typesafe"
+artifact = "config"
+version = "1.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-reflect"
 version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 
@@ -1051,15 +1051,15 @@ version = "2.13.7"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-config_2.13"
-version = "3.2.1"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.scalameta"
-artifact = "scalameta_2.13"
-version = "4.4.30"
+artifact = "scalafmt-config_2.13"
+version = "3.2.1"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -1069,27 +1069,9 @@ version = "3.2.1"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.typesafe"
-artifact = "config"
-version = "1.4.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-parallel-collections_2.13"
-version = "1.0.4"
+group = "org.scalameta"
+artifact = "scalameta_2.13"
+version = "4.4.30"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1105,75 +1087,15 @@ version = "0.9.15"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "scalafmt-config_2.13"
-version = "3.2.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "parsers_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-compiler"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "net.java.dev.jna"
-artifact = "jna"
-version = "5.8.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "trees_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.lihaoyi"
 artifact = "fansi_2.13"
 version = "0.2.14"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "common_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.typelevel"
-artifact = "paiges-core_2.13"
-version = "0.4.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-collection-compat_2.13"
-version = "2.5.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "com.lihaoyi"
-artifact = "sourcecode_2.13"
-version = "0.2.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.jline"
-artifact = "jline"
-version = "3.20.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "fastparse-v2_2.13"
-version = "2.3.1"
+artifact = "geny_2.13"
+version = "0.6.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1183,9 +1105,57 @@ version = "0.6.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "scalameta_2.13"
-version = "4.4.30"
+group = "com.lihaoyi"
+artifact = "sourcecode_2.13"
+version = "0.2.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.typesafe"
+artifact = "config"
+version = "1.4.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "net.java.dev.jna"
+artifact = "jna"
+version = "5.8.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.jline"
+artifact = "jline"
+version = "3.20.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-collection-compat_2.13"
+version = "2.5.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang.modules"
+artifact = "scala-parallel-collections_2.13"
+version = "1.0.4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-compiler"
+version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1196,20 +1166,50 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalameta"
+artifact = "common_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "fastparse-v2_2.13"
+version = "2.3.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "parsers_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "scalafmt-config_2.13"
+version = "3.2.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
 artifact = "scalafmt-sysops_2.13"
 version = "3.2.1"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.7"
+group = "org.scalameta"
+artifact = "scalameta_2.13"
+version = "4.4.30"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "geny_2.13"
-version = "0.6.5"
+group = "org.scalameta"
+artifact = "trees_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.typelevel"
+artifact = "paiges-core_2.13"
+version = "0.4.2"
 packaging = "jar"
 
 
@@ -1296,18 +1296,12 @@ serialized_bytes_length = 5371
 [[entries]]
 file_name = "org.scalameta_scalafmt-sysops_2.13_3.2.1.jar"
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
+group = "org.scala-lang.modules"
+artifact = "scala-parallel-collections_2.13"
+version = "1.0.4"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-parallel-collections_2.13"
-version = "1.0.4"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.7"
@@ -1317,6 +1311,12 @@ packaging = "jar"
 group = "org.scala-lang.modules"
 artifact = "scala-parallel-collections_2.13"
 version = "1.0.4"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.7"
 packaging = "jar"
 
 
@@ -1349,39 +1349,9 @@ version = "4.4.30"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "parsers_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-compiler"
-version = "2.13.7"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "net.java.dev.jna"
-artifact = "jna"
-version = "5.8.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "trees_2.13"
-version = "4.4.30"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalameta"
-artifact = "common_2.13"
-version = "4.4.30"
+group = "com.lihaoyi"
+artifact = "geny_2.13"
+version = "0.6.5"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -1391,20 +1361,26 @@ version = "0.2.7"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "net.java.dev.jna"
+artifact = "jna"
+version = "5.8.0"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.jline"
 artifact = "jline"
 version = "3.20.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalameta"
-artifact = "fastparse-v2_2.13"
-version = "2.3.1"
+group = "org.scala-lang"
+artifact = "scala-compiler"
+version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scala-lang"
-artifact = "scalap"
+artifact = "scala-library"
 version = "2.13.7"
 packaging = "jar"
 
@@ -1415,9 +1391,33 @@ version = "2.13.7"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "geny_2.13"
-version = "0.6.5"
+group = "org.scala-lang"
+artifact = "scalap"
+version = "2.13.7"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "common_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "fastparse-v2_2.13"
+version = "2.3.1"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "parsers_2.13"
+version = "4.4.30"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalameta"
+artifact = "trees_2.13"
+version = "4.4.30"
 packaging = "jar"
 
 
@@ -1473,6 +1473,18 @@ version = "2.3.1"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "com.lihaoyi"
+artifact = "geny_2.13"
+version = "0.6.5"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "com.lihaoyi"
+artifact = "sourcecode_2.13"
+version = "0.2.7"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.scala-lang"
 artifact = "scala-library"
 version = "2.13.7"
@@ -1485,21 +1497,9 @@ version = "4.4.30"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "sourcecode_2.13"
-version = "0.2.7"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.scalameta"
 artifact = "fastparse-v2_2.13"
 version = "2.3.1"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "com.lihaoyi"
-artifact = "geny_2.13"
-version = "0.6.5"
 packaging = "jar"
 
 

--- a/src/python/pants/backend/scala/subsystems/scalatest.default.lockfile.txt
+++ b/src/python/pants/backend/scala/subsystems/scalatest.default.lockfile.txt
@@ -121,9 +121,9 @@ serialized_bytes_length = 1413
 [[entries]]
 file_name = "org.scalatest_scalatest-core_2.13_3.2.10.jar"
 [[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -133,15 +133,9 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.directDependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-compatible"
-version = "3.2.10"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
 packaging = "jar"
 
 [[entries.directDependencies]]
@@ -150,10 +144,16 @@ artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
+[[entries.directDependencies]]
+group = "org.scalatest"
+artifact = "scalatest-compatible"
+version = "3.2.10"
+packaging = "jar"
+
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -163,20 +163,20 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalatest"
-artifact = "scalatest-compatible"
-version = "3.2.10"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalactic"
 artifact = "scalactic_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-compatible"
 version = "3.2.10"
 packaging = "jar"
 
@@ -210,9 +210,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -222,9 +222,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -236,12 +242,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -275,9 +275,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -287,9 +287,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -301,12 +307,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -340,9 +340,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -352,9 +352,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -366,12 +372,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -405,9 +405,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -417,9 +417,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -431,12 +437,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -470,9 +470,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -482,9 +482,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -496,12 +502,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -535,9 +535,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -547,9 +547,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -561,12 +567,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -600,9 +600,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -612,9 +612,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -626,12 +632,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -665,9 +665,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -677,9 +677,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -691,12 +697,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -736,9 +736,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -748,9 +748,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -762,12 +768,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -801,9 +801,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -813,9 +813,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -827,12 +833,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -866,9 +866,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -878,9 +878,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -892,12 +898,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -937,9 +937,9 @@ version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
+group = "org.scala-lang.modules"
+artifact = "scala-xml_2.13"
+version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -949,9 +949,15 @@ version = "2.13.6"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scala-lang.modules"
-artifact = "scala-xml_2.13"
-version = "1.3.0"
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
+version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -963,12 +969,6 @@ packaging = "jar"
 [[entries.dependencies]]
 group = "org.scalatest"
 artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -984,8 +984,32 @@ serialized_bytes_length = 134857
 [[entries]]
 file_name = "org.scalatest_scalatest_2.13_3.2.10.jar"
 [[entries.directDependencies]]
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.scalatest"
+artifact = "scalatest-core_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.directDependencies]]
 group = "org.scalatest"
 artifact = "scalatest-diagrams_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.scalatest"
+artifact = "scalatest-featurespec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -997,61 +1021,13 @@ packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.scalatest"
-artifact = "scalatest-funspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-refspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-wordspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-propspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-shouldmatchers_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-core_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
-artifact = "scalatest-mustmatchers_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.directDependencies]]
-group = "org.scalatest"
 artifact = "scalatest-freespec_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.directDependencies]]
+group = "org.scalatest"
+artifact = "scalatest-funspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -1069,47 +1045,29 @@ packaging = "jar"
 
 [[entries.directDependencies]]
 group = "org.scalatest"
-artifact = "scalatest-featurespec_2.13"
+artifact = "scalatest-mustmatchers_2.13"
 version = "3.2.10"
 packaging = "jar"
 
-[[entries.dependencies]]
+[[entries.directDependencies]]
 group = "org.scalatest"
-artifact = "scalatest-diagrams_2.13"
+artifact = "scalatest-propspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
-[[entries.dependencies]]
-group = "org.scalatest"
-artifact = "scalatest-flatspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalatest"
-artifact = "scalatest-funspec_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-reflect"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scala-lang"
-artifact = "scala-library"
-version = "2.13.6"
-packaging = "jar"
-
-[[entries.dependencies]]
+[[entries.directDependencies]]
 group = "org.scalatest"
 artifact = "scalatest-refspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
-[[entries.dependencies]]
+[[entries.directDependencies]]
+group = "org.scalatest"
+artifact = "scalatest-shouldmatchers_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.directDependencies]]
 group = "org.scalatest"
 artifact = "scalatest-wordspec_2.13"
 version = "3.2.10"
@@ -1122,8 +1080,20 @@ version = "1.3.0"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalatest"
-artifact = "scalatest-propspec_2.13"
+group = "org.scala-lang"
+artifact = "scala-library"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scala-lang"
+artifact = "scala-reflect"
+version = "2.13.6"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalactic"
+artifact = "scalactic_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -1135,19 +1105,25 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalatest"
-artifact = "scalatest-shouldmatchers_2.13"
-version = "3.2.10"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.scalatest"
 artifact = "scalatest-core_2.13"
 version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalatest"
-artifact = "scalatest-mustmatchers_2.13"
+artifact = "scalatest-diagrams_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-featurespec_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-flatspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -1159,13 +1135,13 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalatest"
-artifact = "scalatest-funsuite_2.13"
+artifact = "scalatest-funspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.scalactic"
-artifact = "scalactic_2.13"
+group = "org.scalatest"
+artifact = "scalatest-funsuite_2.13"
 version = "3.2.10"
 packaging = "jar"
 
@@ -1177,7 +1153,31 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.scalatest"
-artifact = "scalatest-featurespec_2.13"
+artifact = "scalatest-mustmatchers_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-propspec_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-refspec_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-shouldmatchers_2.13"
+version = "3.2.10"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.scalatest"
+artifact = "scalatest-wordspec_2.13"
 version = "3.2.10"
 packaging = "jar"
 

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -91,7 +91,6 @@ async def setup_scalatest_for_target(
     test_subsystem: TestSubsystem,
     test_extra_env: TestExtraEnv,
 ) -> TestSetup:
-
     jdk, transitive_tgts = await MultiGet(
         Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(request.field_set.jdk_version)),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -236,7 +236,6 @@ async def _interactive_shell_command(
     shell_command: Target,
     bash: BashBinary,
 ) -> Process:
-
     description = f"the `{shell_command.alias}` at `{shell_command.address}`"
     shell_name = shell_command.address.spec
     working_directory = shell_command[RunShellCommandWorkdirField].value

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -41,7 +41,8 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
     options_scope = "terraform-hcl2-parser"
     help = "Used to parse Terraform modules to infer their dependencies."
 
-    default_version = "python-hcl2==3.0.5"
+    default_version = "python-hcl2==4.3.0"
+    default_requirements = ["python-hcl2>=3.0.5,<5"]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/terraform/hcl2.lock
+++ b/src/python/pants/backend/terraform/hcl2.lock
@@ -4,13 +4,17 @@
 //
 // --- BEGIN PANTS LOCKFILE METADATA: DO NOT EDIT OR REMOVE ---
 // {
-//   "version": 2,
+//   "version": 3,
 //   "valid_for_interpreter_constraints": [
 //     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "python-hcl2==3.0.5"
-//   ]
+//     "python-hcl2==4.3.0"
+//   ],
+//   "manylinux": "manylinux2014",
+//   "requirement_constraints": [],
+//   "only_binary": [],
+//   "no_binary": []
 // }
 // --- END PANTS LOCKFILE METADATA ---
 
@@ -27,42 +31,54 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "42f367612a1bbc4cf9d8c8eb1b209d8a9b397d55af75620c9e6f53e502235996",
-              "url": "https://files.pythonhosted.org/packages/0d/a5/60580c84bbc28f3952aec8f718e7311eb679a825f9c1d424d98a5542d7c0/lark-parser-0.10.1.tar.gz"
+              "hash": "8476f9903e93fbde4f6c327f74d79e9b4bd0ed9294c5dfa3164ab8c581b5de2a",
+              "url": "https://files.pythonhosted.org/packages/ac/c7/25e678cb94ac2b7be741272d5b2ae099e32e23f36d820e6feb8931b12382/lark-1.1.5-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "4b534eae1f9af5b4ea000bea95776350befe1981658eea3820a01c37e504bb4d",
+              "url": "https://files.pythonhosted.org/packages/a2/25/8e16de418fc83bb00dabaf8c7110bc45a90bf5481a70aa5f1668fcea73bc/lark-1.1.5.tar.gz"
             }
           ],
-          "project_name": "lark-parser",
+          "project_name": "lark",
           "requires_dists": [
+            "atomicwrites; extra == \"atomic_cache\"",
             "js2py; extra == \"nearley\"",
             "regex; extra == \"regex\""
           ],
           "requires_python": null,
-          "version": "0.10.1"
+          "version": "1.1.5"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "f8beff86346c6f42ccad75d6d2af4a33981802b6a000de881cc93b649f49ed1c",
-              "url": "https://files.pythonhosted.org/packages/fb/a6/bd6f186bc3c462337a91f4d35daa49423788733f48e8e58793ab516227de/python-hcl2-3.0.5.tar.gz"
+              "hash": "6c76d1d523b6fb8ca6d1f70308459f310853e124c4bbfe9fcc018bcacdc78a40",
+              "url": "https://files.pythonhosted.org/packages/0d/58/32f70aa0d776a467472ee0077929e03d4febb681f6b564cec1d58c09d95b/python_hcl2-4.3.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "41e37e2a9b3d223da5e8ebc99e72b40d2315087e966f458f7eac13c7831d9b9e",
+              "url": "https://files.pythonhosted.org/packages/0b/8c/9c7858604212b25e040652fba3eb06514b363b857544f7321ca97185f001/python-hcl2-4.3.0.tar.gz"
             }
           ],
           "project_name": "python-hcl2",
           "requires_dists": [
-            "lark-parser<0.11.0,>=0.10.0"
+            "lark<2,>=1"
           ],
-          "requires_python": ">=3.6.0",
-          "version": "3.0.5"
+          "requires_python": ">=3.7.0",
+          "version": "4.3.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.96",
+  "pex_version": "2.1.126",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "python-hcl2==3.0.5"
+    "python-hcl2==4.3.0"
   ],
   "requires_python": [
     "<4,>=3.7"

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -24,11 +24,12 @@ class Yamllint(PythonToolBase):
     options_scope = "yamllint"
     help = "A linter for YAML files (https://yamllint.readthedocs.io)"
 
-    default_version = "yamllint==1.28.0"
+    default_version = "yamllint==1.29.0"
     default_main = ConsoleScript("yamllint")
+    default_requirements = ["yamllint>=1.28.0,<2"]
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.6,<4"]
+    default_interpreter_constraints = ["CPython>=3.7,<4"]
 
     register_lockfile = True
     default_lockfile_resource = ("pants.backend.tools.yamllint", "yamllint.lock")

--- a/src/python/pants/backend/tools/yamllint/yamllint.lock
+++ b/src/python/pants/backend/tools/yamllint/yamllint.lock
@@ -6,10 +6,10 @@
 // {
 //   "version": 3,
 //   "valid_for_interpreter_constraints": [
-//     "CPython<4,>=3.6"
+//     "CPython<4,>=3.7"
 //   ],
 //   "generated_with_requirements": [
-//     "yamllint==1.28.0"
+//     "yamllint==1.29.0"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -31,19 +31,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
-              "url": "https://files.pythonhosted.org/packages/42/ba/a9d64c7bcbc7e3e8e5f93a52721b377e994c22d16196e2b0f1236774353a/pathspec-0.9.0-py2.py3-none-any.whl"
+              "hash": "3a66eb970cbac598f9e5ccb5b2cf58930cd8e3ed86d393d541eaf2d8b1705229",
+              "url": "https://files.pythonhosted.org/packages/e6/be/1a973593d7ce7ac9d1a793b81eb265c152a62f34825169fbd7c4e4548e34/pathspec-0.11.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1",
-              "url": "https://files.pythonhosted.org/packages/f6/33/436c5cb94e9f8902e59d1d544eb298b83c84b9ec37b5b769c5a0ad6edb19/pathspec-0.9.0.tar.gz"
+              "hash": "64d338d4e0914e91c1792321e6907b5a593f1ab1851de7fc269557a21b30ebbc",
+              "url": "https://files.pythonhosted.org/packages/f4/8e/f91cffb32740b251cff04cad1e7cdd2c710582c735a01f56307316c148f2/pathspec-0.11.0.tar.gz"
             }
           ],
           "project_name": "pathspec",
           "requires_dists": [],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7",
-          "version": "0.9.0"
+          "requires_python": ">=3.7",
+          "version": "0.11.0"
         },
         {
           "artifacts": [
@@ -71,11 +71,6 @@
               "algorithm": "sha256",
               "hash": "d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
               "url": "https://files.pythonhosted.org/packages/44/e5/4fea13230bcebf24b28c0efd774a2dd65a0937a2d39e94a4503438b078ed/PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
-              "url": "https://files.pythonhosted.org/packages/55/e3/507a92589994a5b3c3d7f2a7a066339d6ff61c5c839bae56f7eff03d9c7b/PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -109,11 +104,6 @@
             },
             {
               "algorithm": "sha256",
-              "hash": "48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
-              "url": "https://files.pythonhosted.org/packages/74/68/3c13deaa496c14a030c431b7b828d6b343f79eb241b4848c7918091a64a2/PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl"
-            },
-            {
-              "algorithm": "sha256",
               "hash": "cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
               "url": "https://files.pythonhosted.org/packages/77/da/e845437ffe0dffae4e7562faf23a4f264d886431c5d2a2816c853288dc8e/PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl"
             },
@@ -136,16 +126,6 @@
               "algorithm": "sha256",
               "hash": "819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
               "url": "https://files.pythonhosted.org/packages/9d/f6/7e91fbb58c9ee528759aea5892e062cccb426720c5830ddcce92eba00ff1/PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
-              "url": "https://files.pythonhosted.org/packages/a8/32/1bbe38477fb23f1d83041fefeabf93ef1cd6f0efcf44c221519507315d92/PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
-              "url": "https://files.pythonhosted.org/packages/b3/85/79b9e5b4e8d3c0ac657f4e8617713cca8408f6cdc65d2ee6554217cedff1/PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl"
             },
             {
               "algorithm": "sha256",
@@ -197,58 +177,77 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "4ce92f1e1f8f01233ee9952c04f6b81d1e02939d6e1b488428154974a4d0783e",
-              "url": "https://files.pythonhosted.org/packages/b0/3a/88b210db68e56854d0bcf4b38e165e03be377e13907746f825790f3df5bf/setuptools-59.6.0-py3-none-any.whl"
+              "hash": "1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242",
+              "url": "https://files.pythonhosted.org/packages/99/02/d6ac140d446e939959e80b7e0c55774fa7a22376847ff5fe191674fd1862/setuptools-67.5.1-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "22c7348c6d2976a52632c67f7ab0cdf40147db7789f9aed18734643fe9cf3373",
-              "url": "https://files.pythonhosted.org/packages/6a/fa/5ec0fa9095c9b72cb1c31a8175c4c6745bf5927d1045d7a70df35d54944f/setuptools-59.6.0.tar.gz"
+              "hash": "15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535",
+              "url": "https://files.pythonhosted.org/packages/a4/3a/d60ed296ff8bbc6157ce818765c4c02df8b02fe70c310b7d29127962c5ae/setuptools-67.5.1.tar.gz"
             }
           ],
           "project_name": "setuptools",
           "requires_dists": [
+            "build[virtualenv]; extra == \"testing\"",
+            "build[virtualenv]; extra == \"testing-integration\"",
+            "filelock>=3.4.0; extra == \"testing\"",
+            "filelock>=3.4.0; extra == \"testing-integration\"",
             "flake8-2020; extra == \"testing\"",
+            "flake8<5; extra == \"testing\"",
             "furo; extra == \"docs\"",
+            "ini2toml[lite]>=0.9; extra == \"testing\"",
             "jaraco.envs>=2.2; extra == \"testing\"",
-            "jaraco.packaging>=8.2; extra == \"docs\"",
+            "jaraco.envs>=2.2; extra == \"testing-integration\"",
+            "jaraco.packaging>=9; extra == \"docs\"",
             "jaraco.path>=3.2.0; extra == \"testing\"",
+            "jaraco.path>=3.2.0; extra == \"testing-integration\"",
             "jaraco.tidelift>=1.4; extra == \"docs\"",
-            "mock; extra == \"testing\"",
-            "paver; extra == \"testing\"",
+            "pip-run>=8.8; extra == \"testing\"",
             "pip>=19.1; extra == \"testing\"",
             "pygments-github-lexers==0.0.5; extra == \"docs\"",
             "pytest-black>=0.3.7; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
             "pytest-checkdocs>=2.4; extra == \"testing\"",
-            "pytest-cov; extra == \"testing\"",
-            "pytest-enabler>=1.0.1; extra == \"testing\"",
-            "pytest-flake8; extra == \"testing\"",
-            "pytest-mypy; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
-            "pytest-virtualenv>=1.2.7; extra == \"testing\"",
+            "pytest-cov; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-enabler; extra == \"testing-integration\"",
+            "pytest-enabler>=1.3; extra == \"testing\"",
+            "pytest-flake8; python_version < \"3.12\" and extra == \"testing\"",
+            "pytest-mypy>=0.9.1; platform_python_implementation != \"PyPy\" and extra == \"testing\"",
+            "pytest-perf; extra == \"testing\"",
+            "pytest-timeout; extra == \"testing\"",
             "pytest-xdist; extra == \"testing\"",
+            "pytest-xdist; extra == \"testing-integration\"",
+            "pytest; extra == \"testing-integration\"",
             "pytest>=6; extra == \"testing\"",
             "rst.linker>=1.9; extra == \"docs\"",
+            "sphinx-favicon; extra == \"docs\"",
+            "sphinx-hoverxref<2; extra == \"docs\"",
             "sphinx-inline-tabs; extra == \"docs\"",
-            "sphinx; extra == \"docs\"",
-            "sphinx; extra == \"testing\"",
+            "sphinx-lint; extra == \"docs\"",
+            "sphinx-notfound-page==0.8.3; extra == \"docs\"",
+            "sphinx-reredirects; extra == \"docs\"",
+            "sphinx>=3.5; extra == \"docs\"",
             "sphinxcontrib-towncrier; extra == \"docs\"",
+            "tomli-w>=1.0.0; extra == \"testing\"",
+            "tomli; extra == \"testing-integration\"",
             "virtualenv>=13.0.0; extra == \"testing\"",
-            "wheel; extra == \"testing\""
+            "virtualenv>=13.0.0; extra == \"testing-integration\"",
+            "wheel; extra == \"testing\"",
+            "wheel; extra == \"testing-integration\""
           ],
-          "requires_python": ">=3.6",
-          "version": "59.6.0"
+          "requires_python": ">=3.7",
+          "version": "67.5.1"
         },
         {
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "89bb5b5ac33b1ade059743cf227de73daa34d5e5a474b06a5e17fc16583b0cf2",
-              "url": "https://files.pythonhosted.org/packages/40/f9/882281af7c40a99bfa5b14585071c5aa13f48961582ebe067ae38221d0d9/yamllint-1.28.0-py2.py3-none-any.whl"
+              "hash": "5153bf9f8205aa9dc6af6217e38bd4f5baf09d9a7c6f4ae1e23f90d9c00c49c5",
+              "url": "https://files.pythonhosted.org/packages/32/cf/f8d999a3359f0873b35c064f6a9ba63e0410526e54b65ab54d66995faad2/yamllint-1.29.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "9e3d8ddd16d0583214c5fdffe806c9344086721f107435f68bad990e5a88826b",
-              "url": "https://files.pythonhosted.org/packages/c8/82/4cd3ec8f98d821e7cc7ef504add450623d5c86b656faf65e9b0cc46f4be6/yamllint-1.28.0.tar.gz"
+              "hash": "66a755d5fbcbb8831f1a9568676329b5bac82c37995bcc9afd048b6459f9fa48",
+              "url": "https://files.pythonhosted.org/packages/a5/ae/2622262d7a5c6af2af85e5edd86f4cf183628e88407942aa0be487b582b6/yamllint-1.29.0.tar.gz"
             }
           ],
           "project_name": "yamllint",
@@ -257,22 +256,22 @@
             "pyyaml",
             "setuptools"
           ],
-          "requires_python": ">=3.6",
-          "version": "1.28.0"
+          "requires_python": ">=3.7",
+          "version": "1.29.0"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.120",
-  "pip_version": "20.3.4-patched",
+  "pex_version": "2.1.127",
+  "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [
-    "yamllint==1.28.0"
+    "yamllint==1.29.0"
   ],
   "requires_python": [
-    "<4,>=3.6"
+    "<4,>=3.7"
   ],
   "resolver_version": "pip-2020-resolver",
   "style": "universal",

--- a/src/python/pants/base/deprecated_test.py
+++ b/src/python/pants/base/deprecated_test.py
@@ -37,7 +37,7 @@ def test_deprecated_function(caplog) -> None:
         def deprecated_method(self):
             return "some val"
 
-        @property  # type: ignore[misc]
+        @property
         @deprecated(FUTURE_VERSION)
         def deprecated_property(self):
             return "some val"

--- a/src/python/pants/base/exception_sink_integration_test.py
+++ b/src/python/pants/base/exception_sink_integration_test.py
@@ -102,7 +102,7 @@ class ExceptionSinkIntegrationTest(PantsDaemonIntegrationTestBase):
             signal.SIGQUIT: "SIGQUIT",
             signal.SIGTERM: "SIGTERM",
         }
-        for (signum, signame) in signal_names.items():
+        for signum, signame in signal_names.items():
             with self.pantsd_successful_run_context() as ctx:
                 ctx.runner(["help"])
                 pid = ctx.checker.assert_started()

--- a/src/python/pants/base/exiter_integration_test.py
+++ b/src/python/pants/base/exiter_integration_test.py
@@ -20,7 +20,6 @@ dir_layout = {
 
 @ensure_daemon
 def test_unicode_containing_exception(use_pantsd: bool) -> None:
-
     with setup_tmpdir(dir_layout) as tmpdir:
         pants_run = run_pants(
             [

--- a/src/python/pants/bin/loader_integration_test.py
+++ b/src/python/pants/bin/loader_integration_test.py
@@ -60,7 +60,6 @@ def exercise_alternate_entrypoint_scrubbing():
 
 
 def test_alternate_entrypoint_scrubbing() -> None:
-
     pants_run = run_pants(
         command=["help"],
         extra_env={

--- a/src/python/pants/build_graph/build_configuration_test.py
+++ b/src/python/pants/build_graph/build_configuration_test.py
@@ -88,7 +88,7 @@ def test_validation(caplog, bc_builder: BuildConfiguration.Builder) -> None:
     def mk_dummy_tgt(_alias: str) -> Type[Target]:
         class DummyTarget(Target):
             alias = _alias
-            core_fields = tuple()  # type: ignore[var-annotated]
+            core_fields = tuple()
 
         return DummyTarget
 
@@ -150,7 +150,7 @@ def test_register_target_types(bc_builder: BuildConfiguration.Builder) -> None:
     def mk_dummy_tgt(_alias: str) -> Type[Target]:
         class DummyTarget(Target):
             alias = _alias
-            core_fields = tuple()  # type: ignore[var-annotated]
+            core_fields = tuple()
 
         return DummyTarget
 

--- a/src/python/pants/build_graph/build_file_aliases.py
+++ b/src/python/pants/build_graph/build_file_aliases.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 from pants.base.parse_context import ParseContext
 from pants.util.frozendict import FrozenDict
@@ -109,14 +109,14 @@ class BuildFileAliases:
         if not isinstance(other, BuildFileAliases):
             raise TypeError(f"Can only merge other BuildFileAliases, given {other}")
 
-        def merge(*items):
-            merged: dict = {}
-            for item in items:
-                merged.update(item)
+        def _merge(item1: Mapping[str, Any], item2: Mapping[str, Any]) -> dict[str, Any]:
+            merged: dict[str, Any] = {}
+            merged.update(item1)
+            merged.update(item2)
             return merged
 
-        objects = merge(self.objects, other.objects)
-        context_aware_object_factories = merge(
+        objects = _merge(self.objects, other.objects)
+        context_aware_object_factories = _merge(
             self.context_aware_object_factories, other.context_aware_object_factories
         )
         return BuildFileAliases(

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -209,7 +209,6 @@ _e = lambda path, env: make_target(path, path, env)
 def test_warnings_for_non_local_target_environments(
     targets: Iterable[Target], err_present: Iterable[str], err_absent: Iterable[str]
 ) -> None:
-
     rule_runner = RuleRunner(
         rules=[
             UnionRule(ExportRequest, MockExportRequest),

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -628,7 +628,6 @@ async def generate_lockfiles_goal(
 
 
 def _preferred_environment(request: GenerateLockfile, default: EnvironmentName) -> EnvironmentName:
-
     if not isinstance(request, GenerateLockfileWithEnvironments):
         return default  # This request has not been migrated to use environments.
 

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -303,7 +303,6 @@ def test_preferred_environment(
     not_in_output: str | None,
     caplog,
 ):
-
     resolve_name = "boop"
     resolve_dest = "beep"
     if not env_names:

--- a/src/python/pants/core/goals/repl.py
+++ b/src/python/pants/core/goals/repl.py
@@ -104,7 +104,6 @@ async def run_repl(
     union_membership: UnionMembership,
     complete_env: CompleteEnvironmentVars,
 ) -> Repl:
-
     await _warn_on_non_local_environments(specified_targets, "the `repl` goal")
 
     # TODO: When we support multiple languages, detect the default repl to use based

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -208,6 +208,7 @@ class SecondaryOwnerField(SecondaryOwnerMixin, Field):
     alias = "borrowed"
     default = None
 
+    @property
     def filespec(self) -> Filespec:
         return Filespec(includes=[])
 

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -113,7 +113,6 @@ class _SearchPaths:
 async def _expand_interpreter_search_paths(
     request: _ExpandInterpreterSearchPathsRequest,
 ) -> _SearchPaths:
-
     interpreter_search_paths, env_tgt = (request.interpreter_search_paths, request.env_tgt)
 
     env = await Get(EnvironmentVars, EnvironmentVarsRequest(("PATH",)))
@@ -327,7 +326,6 @@ def _preprocessed_interpreter_search_paths(
 async def python_bootstrap(
     python_bootstrap_subsystem: PythonBootstrapSubsystem.EnvironmentAware,
 ) -> PythonBootstrap:
-
     interpreter_search_paths = _preprocessed_interpreter_search_paths(
         python_bootstrap_subsystem.env_tgt,
         python_bootstrap_subsystem.search_path,

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -178,7 +178,6 @@ def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
             expected_pyenv_paths,
             expected_pyenv_local_paths,
         ):
-
             rule_runner.set_session_values(
                 {
                     CompleteEnvironmentVars: CompleteEnvironmentVars(
@@ -290,7 +289,6 @@ def test_preprocessed_interpreter_search_paths(
     is_default: bool,
     expected: tuple[str] | type[ValueError],
 ):
-
     extra_kwargs: dict = {}
     if env_tgt_type is DockerEnvironmentTarget:
         extra_kwargs = {

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -686,7 +686,6 @@ class AllAssetTargetsByPath:
 def map_assets_by_path(
     all_asset_targets: AllAssetTargets,
 ) -> AllAssetTargetsByPath:
-
     resources_by_path: defaultdict[PurePath, set[Target]] = defaultdict(set)
     for resource_tgt in all_asset_targets.resources:
         resources_by_path[PurePath(resource_tgt[ResourceSourceField].file_path)].add(resource_tgt)

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -148,7 +148,6 @@ async def merge_extra_sandbox_contents(request: MergeExtraSandboxContents) -> Ex
 
 @rule
 async def add_extra_contents_to_prcess(request: AddExtraSandboxContentsToProcess) -> Process:
-
     proc = request.process
     extras = request.contents
     new_digest = await Get(
@@ -182,7 +181,6 @@ async def add_extra_contents_to_prcess(request: AddExtraSandboxContentsToProcess
 async def _resolve_runnable_dependencies(
     bash: BashBinary, deps: tuple[str, ...] | None, owning: Address, origin: str
 ) -> tuple[Digest, RunnableDependencies | None]:
-
     if not deps:
         return EMPTY_DIGEST, None
 
@@ -263,7 +261,6 @@ async def resolve_execution_environment(
     request: ResolveExecutionDependenciesRequest,
     bash: BashBinary,
 ) -> ResolvedExecutionDependencies:
-
     target_address = request.address
     raw_execution_dependencies = request.execution_dependencies
     raw_regular_dependencies = request.dependencies
@@ -472,7 +469,6 @@ async def prepare_adhoc_process(
 
 
 def _output_at_build_root(process: Process, bash: BashBinary) -> Process:
-
     working_directory = process.working_directory or ""
 
     output_directories = process.output_directories

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -55,7 +55,6 @@ class CreateArchive:
 
 @rule(desc="Creating an archive file", level=LogLevel.DEBUG)
 async def create_archive(request: CreateArchive) -> Digest:
-
     # #16091 -- if an arg list is really long, archive utilities tend to get upset.
     # passing a list of filenames into the utilities fixes this.
     FILE_LIST_FILENAME = "__pants_archive_filelist__"

--- a/src/python/pants/core/util_rules/asdf.py
+++ b/src/python/pants/core/util_rules/asdf.py
@@ -47,7 +47,6 @@ async def _resolve_asdf_tool_paths(
     env: EnvironmentVars,
     local: bool,
 ) -> tuple[str, ...]:
-
     if not (isinstance(env_tgt.val, LocalEnvironmentTarget) or env_tgt.val is None):
         return ()
 

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -39,7 +39,6 @@ def fake_asdf_root(
     tool_name: str,
 ):
     with temporary_dir() as home_dir, temporary_dir() as asdf_dir:
-
         fake_dirs: list[Path] = []
         fake_version_dirs: list[str] = []
 
@@ -167,7 +166,6 @@ def test_get_asdf_paths(
         expected_asdf_home_paths,
         expected_asdf_local_paths,
     ):
-
         extra_kwargs: dict = {}
         if env_tgt_type is DockerEnvironmentTarget:
             extra_kwargs = {

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -414,7 +414,7 @@ async def _warn_on_non_local_environments(specified_targets: Iterable[Target], s
         if env_tgt.val is not None and not isinstance(env_tgt.val, LocalEnvironmentTarget)
     ]
 
-    for (env_name, tgts, env_tgt) in error_cases:
+    for env_name, tgts, env_tgt in error_cases:
         # "Blah was called with target `//foo` which specifies…"
         # "Blah was called with targets `//foo`, `//bar` which specify…"
         # "Blah was called with targets including `//foo`, `//bar`, `//baz` (and others) which specify…"

--- a/src/python/pants/core/util_rules/lockfile_metadata.py
+++ b/src/python/pants/core/util_rules/lockfile_metadata.py
@@ -44,7 +44,6 @@ def lockfile_metadata_registrar(scope: LockfileScope) -> Callable[[int], Registe
         """
 
         def _dec(cls: Type[LockfileMetadata]) -> Type[LockfileMetadata]:
-
             # Only frozen dataclasses may be registered as lockfile metadata:
             cls_dataclass_params = getattr(cls, "__dataclass_params__", None)
             if not cls_dataclass_params or not cls_dataclass_params.frozen:

--- a/src/python/pants/core/util_rules/wrap_source.py
+++ b/src/python/pants/core/util_rules/wrap_source.py
@@ -101,7 +101,6 @@ async def _wrap_source(wrapper: GenerateSourcesRequest) -> GeneratedSources:
 def wrap_source_rule_and_target(
     source_field_type: type[SourcesField], target_name_suffix: str
 ) -> WrapSource:
-
     if source_field_type.expected_file_extensions:
         outputs_help = (
             "If `outputs` is not specified, all files with the following extensions will be "

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -247,7 +247,7 @@ def test_set_defaults(
     registered_target_types: RegisteredTargetTypes,
     union_membership: UnionMembership,
 ) -> None:
-    with (scenario.expected_error or no_exception()):
+    with scenario.expected_error or no_exception():
         defaults = BuildFileDefaultsParserState.create(
             scenario.path,
             BuildFileDefaults(

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -669,7 +669,6 @@ def coarsened_targets_request(addresses: Addresses) -> CoarsenedTargetsRequest:
 async def coarsened_targets(
     request: CoarsenedTargetsRequest, local_environment_name: ChosenLocalEnvironmentName
 ) -> CoarsenedTargets:
-
     dependency_mapping = await Get(
         _DependencyMapping,
         _DependencyMappingRequest(
@@ -867,7 +866,7 @@ async def find_owners(
             # primary ownership, but the target still should match the file. We can't use
             # `tgt.get()` because this is a mixin, and there technically may be >1 field.
             secondary_owner_fields = tuple(
-                field
+                field  # type: ignore[misc]
                 for field in candidate_tgt.field_values.values()
                 if isinstance(field, SecondaryOwnerMixin)
             )

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -97,7 +97,7 @@ class UnaddressableObjectError(MappingError):
 
 
 class ParseState(threading.local):
-    def __init__(self):
+    def __init__(self) -> None:
         self._defaults: BuildFileDefaultsParserState | None = None
         self._dependents_rules: BuildFileDependencyRulesParserState | None = None
         self._dependencies_rules: BuildFileDependencyRulesParserState | None = None

--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -115,7 +115,7 @@ def test_attribute_lookup() -> None:
 
 
 def test_get_no_index_call_no_subject_call_allowed() -> None:
-    async def rule():
+    async def rule() -> None:
         get_type: type = Get  # noqa: F841
 
     assert_awaitables(rule, [])

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -43,10 +43,10 @@ class GetParseError(ValueError):
             if isinstance(expr, ast.Call):
                 # Check if it's a top-level function call.
                 if hasattr(expr.func, "id"):
-                    return f"{expr.func.id}()"  # type: ignore[attr-defined]
+                    return f"{expr.func.id}()"
                 # Check if it's a method call.
                 if hasattr(expr.func, "attr") and hasattr(expr.func, "value"):
-                    return f"{expr.func.value.id}.{expr.func.attr}()"  # type: ignore[attr-defined]
+                    return f"{expr.func.value.id}.{expr.func.attr}()"
 
             # Fall back to the name of the ast node's class.
             return str(type(expr))

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -363,7 +363,7 @@ def _rule_helper_decorator(func: Callable[P, R], _public: bool = False) -> Calla
         raise ValueError("@rule_helpers must be async.")
 
     setattr(func, "rule_helper", func)
-    return func
+    return func  # type: ignore[return-value]
 
 
 @overload

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -419,11 +419,11 @@ class TestRuleGraph:
     def test_ruleset_with_ambiguity(self) -> None:
         @rule
         def a_from_b_and_c(b: B, c: C) -> A:
-            pass
+            return A()
 
         @rule
         def a_from_c_and_b(c: C, b: B) -> A:
-            pass
+            return A()
 
         rules = [a_from_b_and_c, a_from_c_and_b, QueryRule(A, (B, C))]
         with pytest.raises(Exception) as cm:
@@ -445,7 +445,7 @@ class TestRuleGraph:
     def test_ruleset_with_valid_root(self) -> None:
         @rule
         def a_from_b(b: B) -> A:
-            pass
+            return A()
 
         rules = [a_from_b, QueryRule(A, (B,))]
         create_scheduler(rules)
@@ -453,7 +453,7 @@ class TestRuleGraph:
     def test_ruleset_with_unreachable_root(self) -> None:
         @rule
         def a_from_b(b: B) -> A:
-            pass
+            return A()
 
         rules = [a_from_b, QueryRule(A, ())]
         with pytest.raises(Exception) as cm:
@@ -478,11 +478,11 @@ class TestRuleGraph:
 
         @rule
         def a_from_c(c: C) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_d(d: D) -> B:
-            pass
+            return B()
 
         @rule
         async def d_from_a_and_suba(a: A, suba: SubA) -> D:  # type: ignore[return]
@@ -547,7 +547,7 @@ class TestRuleGraph:
     def test_smallest_full_test(self) -> None:
         @rule
         def a_from_suba(suba: SubA) -> A:
-            pass
+            return A()
 
         rules = [a_from_suba, QueryRule(A, (SubA,))]
         fullgraph = self.create_full_graph(rules)
@@ -569,11 +569,11 @@ class TestRuleGraph:
     def test_smallest_full_test_multiple_root_subject_types(self) -> None:
         @rule
         def a_from_suba(suba: SubA) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_a(a: A) -> B:
-            pass
+            return B()
 
         rules = [a_from_suba, QueryRule(A, (SubA,)), b_from_a, QueryRule(B, (A,))]
         fullgraph = self.create_full_graph(rules)
@@ -598,7 +598,7 @@ class TestRuleGraph:
     def test_single_rule_depending_on_subject_selection(self) -> None:
         @rule
         def a_from_suba(suba: SubA) -> A:
-            pass
+            return A()
 
         rules = [a_from_suba, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(A, rules, SubA())
@@ -620,11 +620,11 @@ class TestRuleGraph:
     def test_multiple_selects(self) -> None:
         @rule
         def a_from_suba_and_b(suba: SubA, b: B) -> A:
-            pass
+            return A()
 
         @rule
         def b() -> B:
-            pass
+            return B()
 
         rules = [a_from_suba_and_b, b, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(A, rules, SubA())
@@ -659,11 +659,11 @@ class TestRuleGraph:
 
         @rule
         def b_from_suba(suba: SubA) -> B:
-            pass
+            return B()
 
         @rule
         def suba_from_c(c: C) -> SubA:
-            pass
+            return SubA()
 
         rules = [a, b_from_suba, suba_from_c, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(A, rules, SubA())
@@ -688,11 +688,11 @@ class TestRuleGraph:
     def test_one_level_of_recursion(self) -> None:
         @rule
         def a_from_b(b: B) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_suba(suba: SubA) -> B:
-            pass
+            return B()
 
         rules = [a_from_b, b_from_suba, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(A, rules, SubA())
@@ -717,11 +717,11 @@ class TestRuleGraph:
     def test_noop_removal_in_subgraph(self) -> None:
         @rule
         def a_from_c(c: C) -> A:
-            pass
+            return A()
 
         @rule
         def a() -> A:
-            pass
+            return A()
 
         @rule
         def b_singleton() -> B:
@@ -750,11 +750,11 @@ class TestRuleGraph:
     def test_noop_removal_full_single_subject_type(self) -> None:
         @rule
         def a_from_c(c: C) -> A:
-            pass
+            return A()
 
         @rule
         def a() -> A:
-            pass
+            return A()
 
         rules = [a_from_c, a, QueryRule(A, (SubA,))]
         fullgraph = self.create_full_graph(rules, validate=False)
@@ -779,11 +779,11 @@ class TestRuleGraph:
     def test_root_tuple_removed_when_no_matches(self) -> None:
         @rule
         def a_from_c(c: C) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_d_and_a(d: D, a: A) -> B:
-            pass
+            return B()
 
         rules = [
             a_from_c,
@@ -818,15 +818,15 @@ class TestRuleGraph:
 
         @rule
         def b_from_c(c: C) -> B:
-            pass
+            return B()
 
         @rule
         def a_from_b(b: B) -> A:
-            pass
+            return A()
 
         @rule
         def a() -> A:
-            pass
+            return A()
 
         rules = [
             b_from_c,
@@ -884,15 +884,15 @@ class TestRuleGraph:
     def test_depends_on_multiple_one_noop(self) -> None:
         @rule
         def a_from_c(c: C) -> A:
-            pass
+            return A()
 
         @rule
         def a_from_suba(suba: SubA) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_a(a: A) -> B:
-            pass
+            return B()
 
         rules = [a_from_c, a_from_suba, b_from_a, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(B, rules, SubA(), validate=False)
@@ -915,15 +915,15 @@ class TestRuleGraph:
     def test_multiple_depend_on_same_rule(self) -> None:
         @rule
         def a_from_suba(suba: SubA) -> A:
-            pass
+            return A()
 
         @rule
         def b_from_a(a: A) -> B:
-            pass
+            return B()
 
         @rule
         def c_from_a(a: A) -> C:
-            pass
+            return C()
 
         rules = [
             a_from_suba,
@@ -964,7 +964,7 @@ class TestRuleGraph:
 
         @rule
         async def b_from_d(d: D) -> B:
-            pass
+            return B()
 
         rules = [a, b_from_d, QueryRule(A, (SubA,))]
         subgraph = self.create_subgraph(A, rules, SubA())
@@ -1039,11 +1039,11 @@ def test_invalid_rule_helper_name() -> None:
 
         @rule_helper
         async def foo() -> A:
-            pass
+            return A()
 
     @rule_helper(_public=True)
     async def bar() -> A:
-        pass
+        return A()
 
 
 def test_cant_be_both_rule_and_rule_helper() -> None:
@@ -1052,14 +1052,14 @@ def test_cant_be_both_rule_and_rule_helper() -> None:
         @rule_helper
         @rule
         async def _func1() -> A:
-            pass
+            return A()
 
     with pytest.raises(ValueError, match="Cannot use both @rule and @rule_helper"):
 
         @rule
         @rule_helper
         async def _func2() -> A:
-            pass
+            return A()
 
 
 def test_synchronous_rule_helper() -> None:
@@ -1067,4 +1067,4 @@ def test_synchronous_rule_helper() -> None:
 
         @rule_helper
         def _foo() -> A:
-            pass
+            return A()

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -735,15 +735,15 @@ def test_string_field_valid_choices() -> None:
 
 @pytest.mark.parametrize("field_cls", [IntField, FloatField])
 def test_int_float_fields_valid_numbers(field_cls: type) -> None:
-    class AllNums(field_cls):  # type: ignore[valid-type,misc]
+    class AllNums(field_cls):
         alias = "all_nums"
         valid_numbers = ValidNumbers.all
 
-    class PositiveAndZero(field_cls):  # type: ignore[valid-type,misc]
+    class PositiveAndZero(field_cls):
         alias = "positive_and_zero"
         valid_numbers = ValidNumbers.positive_and_zero
 
-    class PositiveOnly(field_cls):  # type: ignore[valid-type,misc]
+    class PositiveOnly(field_cls):
         alias = "positive_only"
         valid_numbers = ValidNumbers.positive_only
 

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -281,8 +281,9 @@ def test_get_all_help_info():
     Bar.register_options_on_scope(options, UnionMembership({}))
 
     @rule
-    def rule_info_test(foo: Foo) -> Target:
+    def rule_info_test(foo: Foo) -> Target:  # type: ignore[empty-body]
         """This rule is for testing info extraction only."""
+        ...
 
     def fake_consumed_scopes_mapper(scope: str) -> Tuple[str, ...]:
         return ("somescope", f"used_by_{scope or 'GLOBAL_SCOPE'}")

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -216,7 +216,7 @@ def initialize_stdio_raw(
             encoding=locale.getpreferredencoding(False),
         )
 
-        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[assignment]
+        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[misc,assignment]
         # Install a Python logger that will route through the Rust logger.
         with _python_logging_setup(
             global_level, log_levels_by_target, print_stacktrace=print_stacktrace
@@ -224,7 +224,7 @@ def initialize_stdio_raw(
             yield
     finally:
         sys.stdin, sys.stdout, sys.stderr = original_stdin, original_stdout, original_stderr
-        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[assignment]
+        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[misc,assignment]
 
 
 def pants_log_path(workdir: PurePath) -> PurePath:

--- a/src/python/pants/jvm/compile_test.py
+++ b/src/python/pants/jvm/compile_test.py
@@ -221,7 +221,6 @@ def test_request_classification(
         members: Sequence[type[ClasspathEntryRequest]],
         generators: FrozenDict[type[ClasspathEntryRequest], frozenset[type[SourcesField]]],
     ) -> tuple[type[ClasspathEntryRequest], type[ClasspathEntryRequest] | None]:
-
         factory = ClasspathEntryRequestFactory(tuple(members), generators)
 
         req = factory.for_targets(

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -67,7 +67,7 @@ class MutableTrieNode:
         "first_party",
     ]  # don't use a `dict` to store attrs
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.children: dict[str, MutableTrieNode] = {}
         self.recursive: bool = False
         self.addresses: dict[SymbolNamespace, OrderedSet[Address]] = defaultdict(OrderedSet)

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -386,7 +386,6 @@ _JVM_HEAP_SIZE_UNITS = ["", "k", "m", "g"]
 async def jvm_process(
     bash: BashBinary, request: JvmProcess, jvm: JvmSubsystem, global_options: GlobalOptions
 ) -> Process:
-
     jdk = request.jdk
 
     immutable_input_digests = {

--- a/src/python/pants/jvm/non_jvm_dependencies.py
+++ b/src/python/pants/jvm/non_jvm_dependencies.py
@@ -46,7 +46,6 @@ class NoopClasspathEntryRequest(ClasspathEntryRequest):
 async def noop_classpath_entry(
     request: NoopClasspathEntryRequest,
 ) -> FallibleClasspathEntry:
-
     return FallibleClasspathEntry(
         f"Empty classpath for no-op classpath target {request.component}",
         CompileResult.SUCCEEDED,

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -39,7 +39,6 @@ direct: dict[Coordinate, set[Coordinate]] = {
 
 @pytest.fixture
 def lockfile() -> CoursierResolvedLockfile:
-
     # Calculate transitive deps
     transitive_ = {(i, k) for i, j in direct.items() for k in j}
     while True:
@@ -48,7 +47,7 @@ def lockfile() -> CoursierResolvedLockfile:
         if old_len == len(transitive_):
             break
     transitive = DefaultDict(set)
-    for (i, j) in transitive_:
+    for i, j in transitive_:
         transitive[i].add(j)
 
     entries = (

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -251,7 +251,6 @@ def test_resolve_with_packaging(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
-
     coordinate = ArtifactRequirement(
         coordinate=Coordinate(
             group="org.hamcrest",
@@ -272,7 +271,6 @@ def test_resolve_with_broken_url(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_resolve_with_working_url(rule_runner: RuleRunner) -> None:
-
     requirement = ArtifactRequirement(
         coordinate=Coordinate(
             group="apache-commons-local",
@@ -311,7 +309,6 @@ def test_resolve_with_working_url(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_resolve_with_a_jar(rule_runner: RuleRunner) -> None:
-
     rule_runner.write_files(
         {
             "BUILD": textwrap.dedent(
@@ -420,7 +417,6 @@ def test_fetch_one_coord_with_jar(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_fetch_one_coord_with_no_deps(rule_runner: RuleRunner) -> None:
-
     classpath_entry = rule_runner.request(
         ClasspathEntry,
         [

--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -209,7 +209,6 @@ class Coursier:
 
 @dataclass(frozen=True)
 class CoursierFetchProcess:
-
     args: Tuple[str, ...]
     input_digest: Digest
     output_directories: Tuple[str, ...]
@@ -223,7 +222,6 @@ async def invoke_coursier_wrapper(
     coursier: Coursier,
     request: CoursierFetchProcess,
 ) -> Process:
-
     return Process(
         argv=coursier.args(
             request.args,

--- a/src/python/pants/jvm/resolve/lockfile_metadata.py
+++ b/src/python/pants/jvm/resolve/lockfile_metadata.py
@@ -31,7 +31,6 @@ class LockfileContext(Enum):
 
 @dataclass(frozen=True)
 class JVMLockfileMetadata(LockfileMetadata):
-
     scope = LockfileScope.JVM
 
     @staticmethod

--- a/src/python/pants/jvm/run.py
+++ b/src/python/pants/jvm/run.py
@@ -133,7 +133,6 @@ async def create_run_request(
     request: GenericJvmRunRequest,
     unzip: UnzipBinary,
 ) -> RunRequest:
-
     field_set = request.field_set
 
     jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(field_set.jdk_version))

--- a/src/python/pants/jvm/run_deploy_jar.py
+++ b/src/python/pants/jvm/run_deploy_jar.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 async def create_deploy_jar_run_request(
     field_set: DeployJarFieldSet,
 ) -> RunRequest:
-
     jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(field_set.jdk_version))
 
     main_class = field_set.main_class.value

--- a/src/python/pants/jvm/strip_jar/strip_jar.py
+++ b/src/python/pants/jvm/strip_jar/strip_jar.py
@@ -48,7 +48,6 @@ async def strip_jar(
     jdk: InternalJdk,
     request: StripJarRequest,
 ) -> Digest:
-
     filenames = list(request.filenames)
 
     if len(filenames) == 0:

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -303,7 +303,6 @@ class JvmArtifactResolveField(JvmResolveField):
 
 @dataclass(frozen=True)
 class JvmArtifactFieldSet(JvmRunnableSourceFieldSet):
-
     group: JvmArtifactGroupField
     artifact: JvmArtifactArtifactField
     version: JvmArtifactVersionField
@@ -414,7 +413,7 @@ class JvmShadingRule(ABC):
         return set(errors)
 
     def __repr__(self) -> str:
-        fields = [f"{fld.name}={repr(getattr(self, fld.name))}" for fld in dataclasses.fields(self)]
+        fields = [f"{fld.name}={repr(getattr(self, fld.name))}" for fld in dataclasses.fields(self)]  # type: ignore[arg-type]
         return f"{self.alias}({', '.join(fields)})"
 
 

--- a/src/python/pants/jvm/test/junit.default.lockfile.txt
+++ b/src/python/pants/jvm/test/junit.default.lockfile.txt
@@ -130,9 +130,9 @@ version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.junit.platform"
-artifact = "junit-platform-commons"
-version = "1.7.2"
+group = "org.apiguardian"
+artifact = "apiguardian-api"
+version = "1.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -142,21 +142,21 @@ version = "5.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.opentest4j"
-artifact = "opentest4j"
-version = "1.2.0"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.apiguardian"
-artifact = "apiguardian-api"
-version = "1.1.0"
+group = "org.junit.platform"
+artifact = "junit-platform-commons"
+version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.junit.platform"
 artifact = "junit-platform-engine"
 version = "1.7.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.opentest4j"
+artifact = "opentest4j"
+version = "1.2.0"
 packaging = "jar"
 
 
@@ -206,21 +206,15 @@ version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.junit.platform"
-artifact = "junit-platform-commons"
-version = "1.7.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.opentest4j"
-artifact = "opentest4j"
-version = "1.2.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.apiguardian"
 artifact = "apiguardian-api"
 version = "1.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.junit.platform"
+artifact = "junit-platform-commons"
+version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -239,6 +233,12 @@ packaging = "jar"
 group = "org.junit.platform"
 artifact = "junit-platform-reporting"
 version = "1.7.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.opentest4j"
+artifact = "opentest4j"
+version = "1.2.0"
 packaging = "jar"
 
 
@@ -319,13 +319,13 @@ packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.junit.platform"
-artifact = "junit-platform-engine"
+artifact = "junit-platform-commons"
 version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
 group = "org.junit.platform"
-artifact = "junit-platform-commons"
+artifact = "junit-platform-engine"
 version = "1.7.2"
 packaging = "jar"
 
@@ -359,21 +359,15 @@ version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.junit.platform"
-artifact = "junit-platform-commons"
-version = "1.7.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.opentest4j"
-artifact = "opentest4j"
-version = "1.2.0"
-packaging = "jar"
-
-[[entries.dependencies]]
 group = "org.apiguardian"
 artifact = "apiguardian-api"
 version = "1.1.0"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.junit.platform"
+artifact = "junit-platform-commons"
+version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -386,6 +380,12 @@ packaging = "jar"
 group = "org.junit.platform"
 artifact = "junit-platform-launcher"
 version = "1.7.2"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.opentest4j"
+artifact = "opentest4j"
+version = "1.2.0"
 packaging = "jar"
 
 
@@ -418,21 +418,9 @@ version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "org.junit.platform"
-artifact = "junit-platform-commons"
-version = "1.7.2"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.hamcrest"
-artifact = "hamcrest-core"
-version = "1.3"
-packaging = "jar"
-
-[[entries.dependencies]]
-group = "org.opentest4j"
-artifact = "opentest4j"
-version = "1.2.0"
+group = "junit"
+artifact = "junit"
+version = "4.13"
 packaging = "jar"
 
 [[entries.dependencies]]
@@ -442,15 +430,27 @@ version = "1.1.0"
 packaging = "jar"
 
 [[entries.dependencies]]
+group = "org.hamcrest"
+artifact = "hamcrest-core"
+version = "1.3"
+packaging = "jar"
+
+[[entries.dependencies]]
+group = "org.junit.platform"
+artifact = "junit-platform-commons"
+version = "1.7.2"
+packaging = "jar"
+
+[[entries.dependencies]]
 group = "org.junit.platform"
 artifact = "junit-platform-engine"
 version = "1.7.2"
 packaging = "jar"
 
 [[entries.dependencies]]
-group = "junit"
-artifact = "junit"
-version = "4.13"
+group = "org.opentest4j"
+artifact = "opentest4j"
+version = "1.2.0"
 packaging = "jar"
 
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -93,7 +93,6 @@ async def setup_junit_for_target(
     test_subsystem: TestSubsystem,
     test_extra_env: TestExtraEnv,
 ) -> TestSetup:
-
     jdk, transitive_tgts = await MultiGet(
         Get(JdkEnvironment, JdkRequest, JdkRequest.from_field(request.field_set.jdk_version)),
         Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -137,7 +137,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         self._flag_names = (flag_name,) if flag_name else None
         self._default = default
         self._help = help
-        self._register_if = register_if or (lambda cls: True)  # type: ignore[assignment]
+        self._register_if = register_if or (lambda cls: True)
         self._extra_kwargs = {
             k: v
             for k, v in {

--- a/src/python/pants/option/options.py
+++ b/src/python/pants/option/options.py
@@ -376,7 +376,7 @@ class Options:
         pairs = []
         parser = self.get_parser(scope)
         # Sort the arguments, so that the fingerprint is consistent.
-        for (_, kwargs) in sorted(parser.option_registrations_iter()):
+        for _, kwargs in sorted(parser.option_registrations_iter()):
             if not kwargs.get("fingerprint", True):
                 continue
             if daemon_only and not kwargs.get("daemon", False):

--- a/src/python/pants/option/options_fingerprinter.py
+++ b/src/python/pants/option/options_fingerprinter.py
@@ -41,7 +41,7 @@ class OptionsFingerprinter:
         fingerprinter = cls()
         hasher = sha1()
         pairs = options.get_fingerprintable_for_scope(scope, daemon_only)
-        for (option_type, option_value) in pairs:
+        for option_type, option_value in pairs:
             fingerprint = fingerprinter.fingerprint(option_type, option_value)
             if fingerprint is None:
                 # This isn't necessarily a good value to be using here, but it preserves behavior from

--- a/src/python/pants/option/options_integration_test.py
+++ b/src/python/pants/option/options_integration_test.py
@@ -98,7 +98,6 @@ def test_deprecation_and_ignore_warnings(use_pantsd: bool) -> None:
 
 
 def test_pants_symlink_workdirs(tmp_path: Path) -> None:
-
     symlink_workdir = tmp_path / ".pants.d"
     physical_workdir_base = tmp_path / "workdirs"
     physical_workdir = physical_workdir_base / safe_filename_from_path(symlink_workdir.as_posix())

--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -152,7 +152,7 @@ class PantsDaemon(PantsDaemonProcessManager):
             temp_fd = safe_open(log_path, "a") if writable else open(os.devnull)
             os.dup2(temp_fd.fileno(), fileno)
             setattr(sys, attr, os.fdopen(fileno, mode=("w" if writable else "r")))
-        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[assignment]
+        sys.__stdin__, sys.__stdout__, sys.__stderr__ = sys.stdin, sys.stdout, sys.stderr  # type: ignore[assignment,misc]
 
     def _initialize_metadata(self) -> None:
         """Writes out our pid and other metadata.

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -265,7 +265,6 @@ class RuleRunner:
         inherent_environment: EnvironmentName | None = EnvironmentName(None),
         is_bootstrap: bool = False,
     ) -> None:
-
         bootstrap_args = [*bootstrap_args]
 
         root_dir: Path | None = None
@@ -691,7 +690,7 @@ def run_rule_with_mocks(
 
     res = rule(*(rule_args or ()))
     if not isinstance(res, (CoroutineType, GeneratorType)):
-        return res  # type: ignore[return-value]
+        return res  # type: ignore[misc,return-value]
 
     def get(res: Get | Effect):
         provider = next(
@@ -728,7 +727,7 @@ def run_rule_with_mocks(
             elif type(res) in (tuple, list):
                 rule_input = [get(g) for g in res]  # type: ignore[attr-defined]
             else:
-                return res  # type: ignore[return-value]
+                return res  # type: ignore[misc,return-value]
         except StopIteration as e:
             return e.value  # type: ignore[no-any-return]
 

--- a/src/python/pants/util/dirutil_test.py
+++ b/src/python/pants/util/dirutil_test.py
@@ -172,9 +172,9 @@ class TestDirutilTest:
         path: str
 
     def assert_tree(self, root: str, *expected: Dir | File | Symlink):
-        def collect_tree() -> Iterator[
-            TestDirutilTest.Dir | TestDirutilTest.File | TestDirutilTest.Symlink
-        ]:
+        def collect_tree() -> (
+            Iterator[TestDirutilTest.Dir | TestDirutilTest.File | TestDirutilTest.Symlink]
+        ):
             for path, dirnames, filenames in os.walk(root, followlinks=False):
                 relpath = os.path.relpath(path, root)
                 if relpath == os.curdir:

--- a/src/python/pants/util/meta_test.py
+++ b/src/python/pants/util/meta_test.py
@@ -73,7 +73,6 @@ class WithShadowingInstanceMethod(OverridingValueInit):
 
 
 class OverridingMethodDefSuper(WithProp):
-
     _other_value = "o0"
 
     @classproperty

--- a/src/python/pants/util/ordered_set.py
+++ b/src/python/pants/util/ordered_set.py
@@ -29,9 +29,7 @@ class _AbstractOrderedSet(AbstractSet[T]):
         # Using a dictionary, rather than using the recipe's original `self |= iterable`, results
         # in a ~20% performance increase for the constructor.
         #
-        # NB: Dictionaries are ordered in Python 3.6+. While this was not formalized until Python
-        # 3.7, Python 3.6 uses this behavior; Pants requires CPython 3.6+ to run, so this
-        # assumption is safe for us to rely on.
+        # NB: Dictionaries are ordered in Python 3.7+.
         self._items: dict[T, None] = {v: None for v in iterable or ()}
 
     def __len__(self) -> int:
@@ -198,7 +196,7 @@ class OrderedSet(_AbstractOrderedSet[T], MutableSet[T]):
             self._items[item] = None
 
 
-class FrozenOrderedSet(_AbstractOrderedSet[T_co], Hashable):
+class FrozenOrderedSet(_AbstractOrderedSet[T_co], Hashable):  # type: ignore[type-var]
     """A frozen (i.e. immutable) set that retains its order.
 
     This is safe to use with the V2 engine.

--- a/tests/python/pants_test/init/test_extension_loader.py
+++ b/tests/python/pants_test/init/test_extension_loader.py
@@ -110,7 +110,6 @@ class LoaderTest(unittest.TestCase):
         target_types=None,
         module_name="register",
     ):
-
         package_name = f"__test_package_{uuid.uuid4().hex}"
         self.assertFalse(package_name in sys.modules)
 

--- a/tests/python/pants_test/init/test_plugin_resolver.py
+++ b/tests/python/pants_test/init/test_plugin_resolver.py
@@ -258,7 +258,6 @@ def _do_test_exact_requirements(rule_runner: RuleRunner, sdist: bool) -> None:
         with plugin_resolution(
             rule_runner, chroot=chroot, plugins=[Plugin("jake", "1.2.3"), Plugin("jane", "3.4.5")]
         ) as results2:
-
             working_set2, _, _ = results2
 
             assert list(working_set) == list(working_set2)
@@ -302,7 +301,6 @@ def _do_test_exact_requirements_interpreter_change(rule_runner: RuleRunner, sdis
         plugins=[Plugin("jake", "1.2.3"), Plugin("jane", "3.4.5")],
         sdist=sdist,
     ) as results:
-
         working_set, chroot, repo_dir = results
 
         safe_rmtree(repo_dir)
@@ -330,6 +328,5 @@ def _do_test_exact_requirements_interpreter_change(rule_runner: RuleRunner, sdis
             chroot=chroot,
             plugins=[Plugin("jake", "1.2.3"), Plugin("jane", "3.4.5")],
         ) as results2:
-
             working_set2, _, _ = results2
             assert list(working_set) == list(working_set2)

--- a/tests/python/pants_test/integration/pep561_integration_test.py
+++ b/tests/python/pants_test/integration/pep561_integration_test.py
@@ -9,7 +9,6 @@ from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_
 
 
 def typecheck_file(path: str, filename: str) -> PantsResult:
-
     return run_pants(
         [
             "--backend-packages=pants.backend.python",


### PR DESCRIPTION
Specifically, it added a `requirements` option for each tool that is
expected to contain very loose requirements that we expect
Pants to support.

We initialized the default value for that option from the existing
`version` and`extra_requirements` fields. However those were often
overly-constrained, sometimes to a single version.

This PR audits all the tools' defaults and in various cases does one or
both of:
    
1. Update `default_version` to a newer version so we can regen more
up-to-date lockfiles.
2. Explicitly set `default_requirements` to something loose but likely
 compatible.
    
Of course it's hard to know which currently available tool versions
Pants is compatible with, unless we test against them. And it's impossible
to know which future versions Pants will remain compatible with.

So we assume that tools are semver-adherent, so that floating up in the
same major version is safe. Updating to newer versions lets us at least start
to test against some newer versions, and is also overdue, since many of
our default tool versions are quite old. The proof that these upgrades
are compatible is in the passing tests.

At some point soon we will `deprecate` `version` and `extra_requirements`
in favor of using user lockfiles for custom tool versions.
