### PR TITLE
Preserve environment variables in `pantsd` to allow Docker auth. (Cherry-pick of #18465)

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -36,6 +36,16 @@ from pants.version import VERSION
 
 _SHUTDOWN_TIMEOUT_SECS = 3
 
+_PRESERVED_ENV_VARS = [
+    # Controls backtrace behavior for rust code.
+    "RUST_BACKTRACE",
+    # The environment variables consumed by the `bollard` crate as of
+    # https://github.com/fussybeaver/bollard/commit/a12c6b21b737e5ea9e6efe5f0128d02dc594f9aa
+    "DOCKER_HOST",
+    "DOCKER_CONFIG",
+    "DOCKER_CERT_PATH",
+]
+
 
 class PantsDaemon(PantsDaemonProcessManager):
     """A daemon that manages PantsService instances."""
@@ -180,9 +190,9 @@ class PantsDaemon(PantsDaemonProcessManager):
         # Switch log output to the daemon's log stream, and empty `env` and `argv` to encourage all
         # further usage of those variables to happen via engine APIs and options.
         self._close_stdio(pants_log_path(PurePath(global_bootstrap_options.pants_workdir)))
-        with initialize_stdio(global_bootstrap_options), argv_as(
-            tuple()
-        ), hermetic_environment_as():
+        with initialize_stdio(global_bootstrap_options), argv_as(tuple()), hermetic_environment_as(
+            *_PRESERVED_ENV_VARS
+        ):
             # Install signal and panic handling.
             ExceptionSink.install(
                 log_location=init_workdir(global_bootstrap_options), pantsd_instance=True

--- a/src/python/pants/util/contextutil.py
+++ b/src/python/pants/util/contextutil.py
@@ -68,12 +68,22 @@ def _restore_env(env: Mapping[str, str]) -> None:
 
 
 @contextmanager
-def hermetic_environment_as(**kwargs: str | None) -> Iterator[None]:
-    """Set the environment to the supplied values from an empty state."""
+def hermetic_environment_as(*preserve: str, **override: str | None) -> Iterator[None]:
+    """Mutate the environment of this process, restoring it on exit.
+
+    The given `preserve` environment variable names will have their current values preserved, while
+    the given `override` environment variables will override any values which are already set.
+    """
     old_environment = os.environ.copy()
+    preserve_set = set(preserve)
+    new_environment: dict[str, str | None] = {
+        k: v for k, v in old_environment.items() if k in preserve_set
+    }
+    new_environment.update(override)
+
     _purge_env()
     try:
-        with environment_as(**kwargs):
+        with environment_as(**new_environment):
             yield
     finally:
         _purge_env()

--- a/src/python/pants/util/contextutil_test.py
+++ b/src/python/pants/util/contextutil_test.py
@@ -74,6 +74,9 @@ class TestContextutilTest:
         with self.ensure_user_defined_in_environment():
             with hermetic_environment_as():
                 assert "USER" not in os.environ
+        with self.ensure_user_defined_in_environment():
+            with hermetic_environment_as("USER"):
+                assert "USER" in os.environ
 
     def test_hermetic_environment_subprocesses(self) -> None:
         with self.ensure_user_defined_in_environment():


### PR DESCRIPTION
As reported in #18187, the environment variables used by the `bollard` crate to connect to non-standard Docker setups were being filtered out when `pantsd` was in use. Users confirmed that disabling `pantsd` resolved #18187.

This change preserves those environment variables when `pantsd` starts.

Fixes #18187.
