### PR TITLE
Support dynamic removal_hint messages. (Cherry-pick of #18478)

### DIFF
--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -92,7 +92,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -170,11 +170,19 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         return cast("_OptT", val)
 
     def get_flag_options(self, subsystem_cls) -> dict:
+        rh = "removal_hint"
+        if rh in self._extra_kwargs:
+            extra_kwargs: dict[str, Any] = {
+                **self._extra_kwargs,
+                rh: _eval_maybe_dynamic(self._extra_kwargs[rh], subsystem_cls),
+            }
+        else:
+            extra_kwargs = self._extra_kwargs
         return dict(
             help=_eval_maybe_dynamic(self._help, subsystem_cls),
             default=_eval_maybe_dynamic(self._default, subsystem_cls),
             type=self.get_option_type(subsystem_cls),
-            **self._extra_kwargs,
+            **extra_kwargs,
         )
 
     @overload
@@ -231,7 +239,7 @@ class _ListOptionBase(
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -448,7 +456,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -473,7 +481,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -498,7 +506,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -591,7 +599,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -616,7 +624,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -640,7 +648,7 @@ class EnumListOption(_ListOptionBase[_OptT], Generic[_OptT]):
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
@@ -750,7 +758,7 @@ class DictOption(_OptionBase["dict[str, _ValueT]", "dict[str, _ValueT]"], Generi
         metavar: str | None = None,
         mutually_exclusive_group: str | None = None,
         removal_version: str | None = None,
-        removal_hint: str | None = None,
+        removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -268,7 +268,7 @@ def test_advanced_params():
             fromfile=True,
             metavar="META",
             mutually_exclusive_group="group",
-            removal_hint="it's purple",
+            removal_hint=lambda cls: f"{cls.__name__} is purple",
             removal_version="99.9.9",
         )
 
@@ -279,7 +279,7 @@ def test_advanced_params():
     assert flag_options["mutually_exclusive_group"] == "group"
     assert flag_options["default_help_repr"] == "Help!"
     assert flag_options["removal_version"] == "99.9.9"
-    assert flag_options["removal_hint"] == "it's purple"
+    assert flag_options["removal_hint"] == "MySubsystem is purple"
     assert flag_options["daemon"]
     assert not flag_options["fingerprint"]
 


### PR DESCRIPTION
Similar to the existing capability for help=, this change adds the ability to set removal_hint to a lambda that takes the registering subsystem cls and returns a string.

This allows the removal_hint messages to access the options_scope, for more useful messaging.
