### PR TITLE
upgrade Rust to v1.68.0

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -134,7 +134,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -247,7 +247,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -137,7 +137,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -249,7 +249,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -474,7 +474,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 
@@ -542,7 +542,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.67.1-*
+        path: '~/.rustup/toolchains/1.68.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.68.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -163,7 +163,7 @@ impl Scheduler {
       let mut entry = sizes.entry(k.workunit_name()).or_insert_with(|| (0, 0));
       entry.0 += 1;
       entry.1 += {
-        std::mem::size_of_val(&k)
+        std::mem::size_of_val(k)
           + k.deep_size_of_children(&mut deep_context)
           + std::mem::size_of_val(&v)
           + v.deep_size_of_children(&mut deep_context)


### PR DESCRIPTION
Upgrade Rust to [v1.68.0](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html).

A major change in this release is [the stabilization of the Cargo spare index protocol](https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol). In a future PR, we should be able to enable this to speed up any downloads of the crate index.