### PR TITLE
Let a user resolve shadow a tool lockfile of the same name

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -259,6 +259,10 @@ class PythonSyntheticLockfileTargetsRequest(SyntheticTargetsRequest):
     path: str = SyntheticTargetsRequest.SINGLE_REQUEST_FOR_ALL_TARGETS
 
 
+def synthetic_lockfile_target_name(resolve: str) -> str:
+    return f"_{resolve}_lockfile"
+
+
 @rule
 async def python_lockfile_synthetic_targets(
     request: PythonSyntheticLockfileTargetsRequest,
@@ -277,7 +281,9 @@ async def python_lockfile_synthetic_targets(
             (
                 os.path.join(spec_path, "BUILD.python-lockfiles"),
                 tuple(
-                    TargetAdaptor("_lockfiles", name=name, sources=[lockfile])
+                    TargetAdaptor(
+                        "_lockfiles", name=synthetic_lockfile_target_name(name), sources=[lockfile]
+                    )
                     for _, lockfile, name in lockfiles
                 ),
             )

--- a/src/python/pants/backend/python/macros/common_requirements_rule.py
+++ b/src/python/pants/backend/python/macros/common_requirements_rule.py
@@ -10,6 +10,7 @@ from typing import Callable, Iterable, cast
 
 from packaging.utils import canonicalize_name as canonicalize_project_name
 
+from pants.backend.python.goals.lockfile import synthetic_lockfile_target_name
 from pants.backend.python.macros.common_fields import (
     ModuleMappingField,
     TypeStubsModuleMappingField,
@@ -83,7 +84,7 @@ async def _generate_requirements(
     if lockfile:
         lockfile_address = Address(
             os.path.dirname(lockfile),
-            target_name=resolve,
+            target_name=synthetic_lockfile_target_name(resolve),
         )
         target_adaptor = await Get(
             TargetAdaptor,
@@ -93,7 +94,7 @@ async def _generate_requirements(
             ),
         )
         if target_adaptor.type_alias == "_lockfiles":
-            req_deps.append(f"{lockfile}:{resolve}")
+            req_deps.append(f"{lockfile}:{synthetic_lockfile_target_name(resolve)}")
         else:
             logger.warning(
                 softwrap(

--- a/src/python/pants/backend/python/macros/pipenv_requirements_test.py
+++ b/src/python/pants/backend/python/macros/pipenv_requirements_test.py
@@ -99,7 +99,7 @@ def test_pipfile_lockfile_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--python-enable-resolves"])
     file_addr = Address("", target_name="reqs", relative_file_path="Pipfile.lock")
     lock_addr = Address(
-        "3rdparty/python", target_name="python-default", relative_file_path="default.lock"
+        "3rdparty/python", target_name="_python-default_lockfile", relative_file_path="default.lock"
     )
     assert_pipenv_requirements(
         rule_runner,

--- a/src/python/pants/backend/python/macros/poetry_requirements_test.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements_test.py
@@ -560,7 +560,7 @@ def test_lockfile_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--python-enable-resolves"])
     file_addr = Address("", target_name="reqs", relative_file_path="pyproject.toml")
     lock_addr = Address(
-        "3rdparty/python", target_name="python-default", relative_file_path="default.lock"
+        "3rdparty/python", target_name="_python-default_lockfile", relative_file_path="default.lock"
     )
     assert_poetry_requirements(
         rule_runner,

--- a/src/python/pants/backend/python/macros/python_requirements_test.py
+++ b/src/python/pants/backend/python/macros/python_requirements_test.py
@@ -199,7 +199,7 @@ def test_lockfile_dependency(rule_runner: RuleRunner) -> None:
     rule_runner.set_options(["--python-enable-resolves"])
     reqs_addr = Address("", target_name="reqs", relative_file_path="requirements.txt")
     lock_addr = Address(
-        "3rdparty/python", target_name="python-default", relative_file_path="default.lock"
+        "3rdparty/python", target_name="_python-default_lockfile", relative_file_path="default.lock"
     )
     assert_python_requirements(
         rule_runner,

--- a/src/python/pants/core/goals/generate_lockfiles_test.py
+++ b/src/python/pants/core/goals/generate_lockfiles_test.py
@@ -101,22 +101,23 @@ def test_determine_tool_sentinels_to_generate() -> None:
     with pytest.raises(UnrecognizedResolveNamesError):
         assert_chosen({"fake"}, expected_user_resolves=[], expected_tools=[])
 
-    # Error if same resolve name used for tool lockfiles and user lockfiles.
     class AmbiguousTool(GenerateToolLockfileSentinel):
         resolve_name = "ambiguous"
 
-    with pytest.raises(AmbiguousResolveNamesError):
-        determine_resolves_to_generate(
-            [
-                KnownUserResolveNames(
-                    ("ambiguous",),
-                    "[lang].resolves",
-                    requested_resolve_names_cls=Lang1Requested,
-                )
-            ],
-            [AmbiguousTool],
-            set(),
-        )
+    # Let a user resolve shadow a tool resolve with the same name.
+    assert determine_resolves_to_generate(
+        [
+            KnownUserResolveNames(
+                ("ambiguous",),
+                "[lang].resolves",
+                requested_resolve_names_cls=Lang1Requested,
+            )
+        ],
+        [AmbiguousTool],
+        set(),
+    ) == ([Lang1Requested(["ambiguous"])], [])
+
+    # Error if same resolve name used for multiple user lockfiles.
     with pytest.raises(AmbiguousResolveNamesError):
         determine_resolves_to_generate(
             [

--- a/src/python/pants/engine/internals/synthetic_targets_test.py
+++ b/src/python/pants/engine/internals/synthetic_targets_test.py
@@ -309,10 +309,10 @@ def test_target_name_collision_issue_17343(rule_runner: RuleRunner) -> None:
             "src/issues/17343/BUILD": softwrap(
                 """
                 python_requirements(
-                  name="python-default",
+                  name="_python-default_lockfile",
                   overrides={
                     "humbug": {
-                      "dependencies": ["python-default#setuptools"],
+                      "dependencies": ["_python-default_lockfile#setuptools"],
                     },
                   },
                 )
@@ -330,7 +330,9 @@ def test_target_name_collision_issue_17343(rule_runner: RuleRunner) -> None:
 
     tgt = assert_target(
         rule_runner,
-        Address("src/issues/17343", target_name="python-default", generated_name="setuptools"),
+        Address(
+            "src/issues/17343", target_name="_python-default_lockfile", generated_name="setuptools"
+        ),
         alias="python_requirement",
     )
 


### PR DESCRIPTION
This is necessary for the transition to named resolves - as the tool name will be an obvious choice for many people for the user resolve.

Also, change the name of the synthetic target used for the lockfile. Currently it's squatting on the resolve name, meaning you can't name your python_requirements target for your tool by that name. Now we use a less obtrusive name, that is unlkely to collide with a user-selected one.