### PR TITLE
enable cargo sparse protocol for index downloads

### DIFF
--- a/src/rust/engine/.cargo/config
+++ b/src/rust/engine/.cargo/config
@@ -2,3 +2,8 @@
 # See https://docs.rs/tokio/1.21.1/tokio/task/struct.JoinSet.html#method.join_next_with_id.
 [build]
 rustflags = ["--cfg", "tokio_unstable"]
+
+# Opt-in to the Cargo "sparse" protocol for index downloads.
+# Note: Remove once this becomes the default in Rust v1.70.0
+[registries.crates-io]
+protocol = "sparse"


### PR DESCRIPTION
Opt-in to the Cargo sparse protocol for index downloads. The should improve CI performance (and regular build performance) in cases where the crates index is being downloaded

- https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html#cargos-sparse-protocol
- https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html