### PR TITLE
Re-enable hardlinking using `fclonefileat` on macOS.

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -67,7 +67,7 @@ use serde_derive::Serialize;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
 #[cfg(target_os = "macos")]
 use tokio::fs::copy;
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "macos"))]
 use tokio::fs::hard_link;
 use tokio::fs::symlink;
 use tryfuture::try_future;
@@ -1450,7 +1450,7 @@ impl Store {
     // #18162.
     #[cfg(target_os = "macos")]
     copy(target, destination).await?;
-    #[cfg(target_os = "linux")]
+    #[cfg(not(target_os = "macos"))]
     hard_link(target, destination).await?;
     Ok(())
   }


### PR DESCRIPTION
On macOS (and on the same filesystem), Rust's `std::fs::copy` implementation [uses `fclonefileat`](https://doc.rust-lang.org/std/fs/fn.copy.html#platform-specific-behavior), which is as performant as a hardlink, but more defensive (since the clones are completely independently of one another).

It also has the important benefit of playing nicely with Docker for macOS: so this change fixes #18162.