### PR TITLE
javascript: NodeJS bootstrapping via binary paths, PATH, asdf or nvm

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -6,6 +6,7 @@ python_requirements(
         "strawberry-graphql": ["strawberry"],
         "beautifulsoup4": ["bs4"],
         "python-gnupg": ["gnupg"],
+        "node-semver": ["nodesemver"],
     },
     overrides={
         "humbug": {"dependencies": ["#setuptools"]},

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -38,6 +38,7 @@ types-setuptools==62.6.1
 types-toml==0.10.8
 typing-extensions==4.3.0
 mypy-typing-asserts==0.1.1
+node-semver==0.9.0
 
 
 # This dependency is only for debugging Pants itself, and should never be imported

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -21,6 +21,7 @@
 //     "ijson==3.1.4",
 //     "importlib_resources==5.0.*",
 //     "mypy-typing-asserts==0.1.1",
+//     "node-semver==0.9.0",
 //     "packaging==21.3",
 //     "pex==2.1.129",
 //     "psutil==5.9.0",
@@ -1047,6 +1048,26 @@
           "requires_dists": [],
           "requires_python": "<4.0,>=3.7",
           "version": "0.1.1"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "8153270903772b1e59500ced6f0aca0f7bdb021651c27584e9283b7077b4916b",
+              "url": "https://files.pythonhosted.org/packages/1a/4b/180481021692a76dc91f46fa6a49cdef4c3e630c77a83b7fda3f4eb7aa04/node_semver-0.9.0-py3-none-any.whl"
+            },
+            {
+              "algorithm": "sha256",
+              "hash": "04aa0b0016dbc06748d6378c42d8cf82a343415bd9fca6284f488041d08b33bb",
+              "url": "https://files.pythonhosted.org/packages/eb/c5/e823658f716b17ab1c52d68ed13a0e09c0130af052401a26b5738e4290cc/node-semver-0.9.0.tar.gz"
+            }
+          ],
+          "project_name": "node-semver",
+          "requires_dists": [
+            "pytest; extra == \"testing\""
+          ],
+          "requires_python": null,
+          "version": "0.9.0"
         },
         {
           "artifacts": [
@@ -2787,6 +2808,7 @@
     "ijson==3.1.4",
     "importlib_resources==5.0.*",
     "mypy-typing-asserts==0.1.1",
+    "node-semver==0.9.0",
     "packaging==21.3",
     "pex==2.1.129",
     "psutil==5.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ module = [
     "hdrh",
     "hdrh.histogram",
     "ijson.*",
+    "nodesemver",
     "pex.*",
     "psutil",
 ]

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -3,14 +3,28 @@
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import pytest
 
 from pants.backend.javascript.subsystems import nodejs
+from pants.backend.javascript.subsystems.nodejs import (
+    NodeJS,
+    NodeJsBootstrap,
+    determine_nodejs_binaries,
+)
 from pants.backend.javascript.target_types import JSSourcesGeneratorTarget
 from pants.backend.python import target_types_rules
 from pants.core.util_rules import config_files, source_files
+from pants.core.util_rules.external_tool import (
+    DownloadedExternalTool,
+    ExternalToolRequest,
+    ExternalToolVersion,
+)
+from pants.engine.internals.native_engine import EMPTY_DIGEST
+from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -54,3 +68,56 @@ def test_npm_process(rule_runner: RuleRunner):
     )
 
     assert result.stdout.strip() == b"8.5.5"
+
+
+def given_known_version(version: str) -> str:
+    return f"{version}|linux_x86_64|1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd|333333"
+
+
+_SEMVER_1_1_0 = given_known_version("1.1.0")
+_SEMVER_2_1_0 = given_known_version("2.1.0")
+_SEMVER_2_2_0 = given_known_version("2.2.0")
+_SEMVER_2_2_2 = given_known_version("2.2.2")
+_SEMVER_3_0_0 = given_known_version("3.0.0")
+
+
+@pytest.mark.parametrize(
+    ("semver_range", "expected"),
+    [
+        pytest.param("1.x", _SEMVER_1_1_0, id="x_range"),
+        pytest.param("2.0 - 3.0", _SEMVER_2_1_0, id="hyphen"),
+        pytest.param(">2.2.0", _SEMVER_2_2_2, id="gt"),
+        pytest.param("2.2.x", _SEMVER_2_2_0, id="x_range_patch"),
+        pytest.param("~2.2.0", _SEMVER_2_2_0, id="thilde"),
+        pytest.param("^2.2.0", _SEMVER_2_2_0, id="caret"),
+        pytest.param("3.0.0", _SEMVER_3_0_0, id="exact"),
+        pytest.param("=3.0.0", _SEMVER_3_0_0, id="exact_equals"),
+        pytest.param("<3.0.0 >2.1", _SEMVER_2_2_0, id="and_range"),
+        pytest.param(">2.1 || <2.1", _SEMVER_1_1_0, id="or_range"),
+    ],
+)
+def test_node_version_from_semver(semver_range: str, expected: str):
+    nodejs_subsystem = Mock(spec_set=NodeJS)
+    nodejs_subsystem.version = semver_range
+    nodejs_subsystem.known_versions = [
+        _SEMVER_1_1_0,
+        _SEMVER_2_1_0,
+        _SEMVER_2_2_0,
+        _SEMVER_2_2_2,
+        _SEMVER_3_0_0,
+    ]
+    run_rule_with_mocks(
+        determine_nodejs_binaries,
+        rule_args=(nodejs_subsystem, NodeJsBootstrap(()), Platform.linux_x86_64),
+        mock_gets=[
+            MockGet(
+                DownloadedExternalTool,
+                (ExternalToolRequest,),
+                mock=lambda *_: DownloadedExternalTool(EMPTY_DIGEST, "myexe"),
+            )
+        ],
+    )
+
+    nodejs_subsystem.download_known_version.assert_called_once_with(
+        ExternalToolVersion.decode(expected), Platform.linux_x86_64
+    )

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -112,50 +112,6 @@ def test_get_pyenv_root(env: dict[str, str], expected: str | None) -> None:
     assert result == expected
 
 
-def test_get_pyenv_paths(rule_runner: RuleRunner) -> None:
-    local_pyenv_version = "3.5.5"
-    all_pyenv_versions = ["2.7.14", local_pyenv_version]
-    rule_runner.write_files({".python-version": f"{local_pyenv_version}\n"})
-    with fake_pyenv_root(all_pyenv_versions, local_pyenv_version) as (
-        pyenv_root,
-        expected_paths,
-        expected_local_paths,
-    ):
-        rule_runner.set_session_values(
-            {CompleteEnvironmentVars: CompleteEnvironmentVars({"PYENV_ROOT": pyenv_root})}
-        )
-        env_name = "name"
-        tgt = EnvironmentTarget(env_name, LocalEnvironmentTarget({}, Address("flem")))
-        paths = rule_runner.request(
-            VersionManagerSearchPaths,
-            [
-                VersionManagerSearchPathsRequest(
-                    tgt,
-                    pyenv_root,
-                    "versions",
-                    "[python-bootstrap].search_path",
-                    (".python-version",),
-                    None,
-                )
-            ],
-        )
-        local_paths = rule_runner.request(
-            VersionManagerSearchPaths,
-            [
-                VersionManagerSearchPathsRequest(
-                    tgt,
-                    pyenv_root,
-                    "versions",
-                    "[python-bootstrap].search_path",
-                    (".python-version",),
-                    "<PYENV_LOCAL>",
-                )
-            ],
-        )
-    assert set(expected_paths) == set(paths)
-    assert set(expected_local_paths) == set(local_paths)
-
-
 def test_expand_interpreter_search_paths(rule_runner: RuleRunner) -> None:
     local_pyenv_version = "3.5.5"
     all_python_versions = ["2.7.14", local_pyenv_version, "3.7.10", "3.9.4", "3.9.5"]

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -2,14 +2,20 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
+from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
-from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.collection import DeduplicatedCollection
+from pants.engine.rules import Rule, _uncacheable_rule, collect_rules, rule
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -20,6 +26,74 @@ class ValidateSearchPathsRequest:
     environment_key: str
     is_default: bool
     local_only: FrozenOrderedSet[str]
+
+
+@dataclass(frozen=True)
+class VersionManagerSearchPathsRequest:
+    env_tgt: EnvironmentTarget
+    root_dir: str | None
+    tool_path: str
+    option: str
+    version_files: tuple[str, ...] = tuple()
+    local_token: str | None = None
+
+
+class VersionManagerSearchPaths(DeduplicatedCollection[str]):
+    pass
+
+
+@_uncacheable_rule
+async def get_un_cachable_version_manager_paths(
+    request: VersionManagerSearchPathsRequest,
+) -> VersionManagerSearchPaths:
+    """Inspects the directory of a version manager tool to find installations."""
+    if not (request.env_tgt.val is None or isinstance(request.env_tgt.val, LocalEnvironmentTarget)):
+        return VersionManagerSearchPaths()
+
+    manager_root_dir = request.root_dir
+    if not manager_root_dir:
+        return VersionManagerSearchPaths()
+    root_path = Path(manager_root_dir)
+    if not root_path.exists():
+        return VersionManagerSearchPaths()
+
+    tool_versions_path = root_path / request.tool_path
+    if not tool_versions_path.is_dir():
+        return VersionManagerSearchPaths()
+
+    if request.local_token and request.version_files:
+        local_version_files = [Path(get_buildroot(), file) for file in request.version_files]
+        first_version_file = next((file for file in local_version_files if file.exists()), None)
+        if not first_version_file:
+            file_string = ", ".join(f"`{file}`" for file in local_version_files)
+            no_file = (
+                f"No {file_string}" if len(local_version_files) == 1 else f"None of {file_string}"
+            )
+            _logger.warning(
+                softwrap(
+                    f"""
+                    {no_file} found in the build root,
+                    but {request.local_token} was set in `{request.option}`.
+                    """
+                )
+            )
+            return VersionManagerSearchPaths()
+
+        _logger.info(
+            f"Reading {first_version_file} to determine desired version for {request.option}."
+        )
+        local_version = first_version_file.read_text().strip()
+        path = Path(tool_versions_path, local_version, "bin")
+        if path.is_dir():
+            return VersionManagerSearchPaths([str(path)])
+        return VersionManagerSearchPaths()
+
+    versions_in_dir = (
+        tool_versions_path / version / "bin" for version in sorted(tool_versions_path.iterdir())
+    )
+    return VersionManagerSearchPaths(
+        str(version) for version in versions_in_dir if version.is_dir()
+    )
 
 
 class ValidatedSearchPaths(FrozenOrderedSet):


### PR DESCRIPTION
Enables (nodejs dialect) semver version specification for NodeJs in the `nodejs` subsystem.

Also enables support for `asdf` and `nvm` binary installation discovery.