### PR TITLE
Use wheel build images from GitHub Packages. (#18518)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -322,7 +322,7 @@ jobs:
     timeout-minutes: 60
   build_wheels_linux_arm64:
     container:
-      image: registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v3-8384c5cf
+      image: ghcr.io/pantsbuild/wheel_build_aarch64:v3-8384c5cf
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -717,7 +717,7 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
         # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
         # generously given by the Runs on ARM program. Se we have to build in this image.
         container = {
-            "image": "registry.hub.docker.com/pantsbuild/wheel_build_aarch64:v3-8384c5cf",
+            "image": "ghcr.io/pantsbuild/wheel_build_aarch64:v3-8384c5cf",
         }
     else:
         container = None


### PR DESCRIPTION
Since the Docker Hub free tier is going away.

Also cherrypicks the comment removal in #18521