### PR TITLE
javascript: Do not read none mapped package.json files in javascript rules

### DIFF
--- a/src/python/pants/backend/javascript/nodejs_project_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_test.py
@@ -66,6 +66,7 @@ def test_parses_project_with_workspaces(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/js/package.json": given_package_with_workspaces("egg", "1.0.0", "foo", "bar"),
+            "src/js/BUILD": "package_json()",
             "src/js/foo/BUILD": "package_json()",
             "src/js/foo/package.json": given_package("ham", "0.0.1"),
             "src/js/bar/BUILD": "package_json()",
@@ -81,6 +82,7 @@ def test_parses_project_with_nested_workspaces(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/js/package.json": given_package_with_workspaces("egg", "1.0.0", "foo"),
+            "src/js/BUILD": "package_json()",
             "src/js/foo/BUILD": "package_json()",
             "src/js/foo/package.json": given_package_with_workspaces("ham", "0.0.1", "bar"),
             "src/js/foo/bar/BUILD": "package_json()",
@@ -96,6 +98,7 @@ def test_workspaces_with_multiple_owners_is_an_error(rule_runner: RuleRunner) ->
     rule_runner.write_files(
         {
             "src/js/package.json": given_package_with_workspaces("egg", "1.0.0", "foo/bar"),
+            "src/js/BUILD": "package_json()",
             "src/js/foo/BUILD": "package_json()",
             "src/js/foo/package.json": given_package_with_workspaces("ham", "0.0.1", "bar"),
             "src/js/foo/bar/BUILD": "package_json()",

--- a/src/python/pants/backend/javascript/package/rules_test.py
+++ b/src/python/pants/backend/javascript/package/rules_test.py
@@ -145,6 +145,7 @@ def test_packages_files_as_resource_in_workspace(rule_runner: RuleRunner) -> Non
             "src/js/package.json": json.dumps(
                 {"name": "spam", "version": "0.0.1", "workspaces": ["a"]}
             ),
+            "src/js/BUILD": "package_json()",
             "src/js/a/BUILD": dedent(
                 """\
                 package_json(

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -625,6 +625,9 @@ async def read_package_jsons(globs: PathGlobs) -> PackageJsonForGlobs:
 
 @rule
 async def all_package_json() -> AllPackageJson:
+    # Avoids using `AllTargets` due to a circular rule dependency.
+    # `generate_node_package_targets` requires knowledge of all
+    # first party package names.
     description_of_origin = "The `AllPackageJson` rule"
     requests = await Get(
         ResolvedTargetGeneratorRequests,

--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -121,6 +121,25 @@ def test_does_not_generate_third_party_node_package_target_for_first_party_packa
     ]
 
 
+def test_does_not_consider_package_json_without_a_target(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/a/BUILD": "package_json()",
+            "src/js/a/package.json": json.dumps(
+                {"name": "ham", "version": "0.0.1", "dependencies": {"chalk": "^5.2.0"}}
+            ),
+            "src/js/b/package.json": json.dumps(
+                {"name": "spam", "version": "0.0.1", "dependencies": {"ham": "0.0.1"}}
+            ),
+        }
+    )
+    all_packages = rule_runner.request(AllPackageJson, ())
+    assert len(all_packages) == 1
+    assert all_packages[0].name == "ham"
+
+
 def test_generates_build_script_targets(
     rule_runner: RuleRunner,
 ) -> None:

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -236,37 +236,37 @@ async def resolve_generator_target_requests(
     target_adaptor = adaptor_and_type.adaptor
     target_type = req.target_type
     generate_request = target_types_to_generate_requests.request_for(req.target_type)
-    if generate_request:
-        generator_fields = dict(target_adaptor.kwargs)
-        generators = _parametrized_target_generators_with_templates(
-            req.address,
-            target_adaptor,
-            req.target_type,
-            generator_fields,
-            union_membership,
-        )
-        base_generator = target_type(
-            generator_fields,
-            req.address,
-            name_explicitly_set=target_adaptor.name_explicitly_set,
-            union_membership=union_membership,
-        )
-        overrides = await Get(_Overrides, _TargetGeneratorOverridesRequest(base_generator))
-        return ResolvedTargetGeneratorRequests(
-            requests=tuple(
-                generate_request(
-                    generator,
-                    template_address=generator.address,
-                    template=template,
-                    overrides={
-                        name: dict(Parametrize.expand(generator.address, override))
-                        for name, override in overrides.overrides.items()
-                    },
-                )
-                for generator, template in generators
+    if not generate_request:
+        return ResolvedTargetGeneratorRequests()
+    generator_fields = dict(target_adaptor.kwargs)
+    generators = _parametrized_target_generators_with_templates(
+        req.address,
+        target_adaptor,
+        req.target_type,
+        generator_fields,
+        union_membership,
+    )
+    base_generator = target_type(
+        generator_fields,
+        req.address,
+        name_explicitly_set=target_adaptor.name_explicitly_set,
+        union_membership=union_membership,
+    )
+    overrides = await Get(_Overrides, _TargetGeneratorOverridesRequest(base_generator))
+    return ResolvedTargetGeneratorRequests(
+        requests=tuple(
+            generate_request(
+                generator,
+                template_address=generator.address,
+                template=template,
+                overrides={
+                    name: dict(Parametrize.expand(generator.address, override))
+                    for name, override in overrides.overrides.items()
+                },
             )
+            for generator, template in generators
         )
-    return ResolvedTargetGeneratorRequests()
+    )
 
 
 @rule

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -10,6 +10,8 @@ from typing import Iterable, Mapping, TypeVar
 from pants.backend.project_info.filter_targets import FilterSubsystem
 from pants.base.exceptions import MappingError
 from pants.build_graph.address import Address, BuildFileAddress
+from pants.engine.addresses import Addresses
+from pants.engine.collection import Collection
 from pants.engine.env_vars import EnvironmentVars
 from pants.engine.internals.defaults import BuildFileDefaults, BuildFileDefaultsParserState
 from pants.engine.internals.dep_rules import (
@@ -232,3 +234,12 @@ class SpecsFilter:
         """Check that the target matches the provided `--tag` and `--exclude-target-regexp`
         options."""
         return self.tags_filter(target) and self.filter_subsystem_filter(target)
+
+
+class AddressFamilies(Collection[AddressFamily]):
+    def addresses(self) -> Addresses:
+        return Addresses(self._base_addresses())
+
+    def _base_addresses(self) -> Iterable[Address]:
+        for family in self:
+            yield from family.addresses_to_target_adaptors

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -27,7 +27,7 @@ from pants.engine.environment import ChosenLocalEnvironmentName, EnvironmentName
 from pants.engine.fs import PathGlobs, Paths, SpecsPaths
 from pants.engine.internals.build_files import AddressFamilyDir, BuildFileOptions
 from pants.engine.internals.graph import Owners, OwnersRequest
-from pants.engine.internals.mapper import AddressFamily, SpecsFilter
+from pants.engine.internals.mapper import AddressFamilies, AddressFamily, SpecsFilter
 from pants.engine.internals.parametrize import (
     _TargetParametrizations,
     _TargetParametrizationsRequest,
@@ -127,29 +127,12 @@ async def _determine_literal_addresses_from_raw_specs(
 
 
 @rule(_masked_types=[EnvironmentName])
-async def addresses_from_raw_specs_without_file_owners(
+async def address_families_from_raw_specs_without_file_owners(
     specs: RawSpecsWithoutFileOwners,
     build_file_options: BuildFileOptions,
-    specs_filter: SpecsFilter,
-    local_environment_name: ChosenLocalEnvironmentName,
-    union_membership: UnionMembership,
-) -> Addresses:
-    matched_addresses: OrderedSet[Address] = OrderedSet()
-    filtering_disabled = specs.filter_by_global_options is False
-
-    literal_wrapped_targets = await _determine_literal_addresses_from_raw_specs(
-        specs.address_literals,
-        local_environment_name,
-        description_of_origin=specs.description_of_origin,
-    )
-    matched_addresses.update(
-        wrapped_tgt.target.address
-        for wrapped_tgt in literal_wrapped_targets
-        if filtering_disabled or specs_filter.matches(wrapped_tgt.target)
-    )
+) -> AddressFamilies:
     if not (specs.dir_literals or specs.dir_globs or specs.recursive_globs or specs.ancestor_globs):
-        return Addresses(matched_addresses)
-
+        return AddressFamilies()
     # Resolve all globs.
     build_file_globs, validation_globs = specs.to_build_file_path_globs_tuple(
         build_patterns=build_file_options.patterns,
@@ -165,12 +148,36 @@ async def addresses_from_raw_specs_without_file_owners(
         )
     )
     dirnames.update(os.path.dirname(f) for f in build_file_paths.files)
-    address_families = await MultiGet(Get(AddressFamily, AddressFamilyDir(d)) for d in dirnames)
-    base_addresses = Addresses(
-        itertools.chain.from_iterable(
-            address_family.addresses_to_target_adaptors for address_family in address_families
-        )
+    return AddressFamilies(
+        await MultiGet(Get(AddressFamily, AddressFamilyDir(d)) for d in dirnames)
     )
+
+
+@rule(_masked_types=[EnvironmentName])
+async def addresses_from_raw_specs_without_file_owners(
+    specs: RawSpecsWithoutFileOwners,
+    specs_filter: SpecsFilter,
+    local_environment_name: ChosenLocalEnvironmentName,
+) -> Addresses:
+    matched_addresses: OrderedSet[Address] = OrderedSet()
+    filtering_disabled = specs.filter_by_global_options is False
+
+    literal_wrapped_targets = await _determine_literal_addresses_from_raw_specs(
+        specs.address_literals,
+        local_environment_name,
+        description_of_origin=specs.description_of_origin,
+    )
+    matched_addresses.update(
+        wrapped_tgt.target.address
+        for wrapped_tgt in literal_wrapped_targets
+        if filtering_disabled or specs_filter.matches(wrapped_tgt.target)
+    )
+
+    address_families = await Get(AddressFamilies, RawSpecsWithoutFileOwners, specs)
+    if not address_families:
+        return Addresses(matched_addresses)
+
+    base_addresses = address_families.addresses()
 
     target_parametrizations_list = await MultiGet(
         Get(


### PR DESCRIPTION
Consider the to-be-parsed `TargetGeneratorRequests` and read the associated `package.json` from globs _before_ `GenerateNodePackageTargets` is consumed to produce `GeneratedTargets`. It needs to be done like this to avoid a circular rule dependency that stems from `WrappedTarget` being used to validate addresses, and `_TargetParametrizations` being an integral part of this validation (I think?).

This is an attempt at fixing point 1. of the weirdness observed in https://github.com/pantsbuild/pants/pull/18326#discussion_r1139210901.

I also took some liberties in refactoring `resolve_target_parametrizations`, because I struggled to navigate it. It does mean more `@rule`s in the `graph` module though, I dont know if that is a metric to be weary of?