### PR TITLE
Clarify that experimental_ shell functions are deprecated and replaced

### DIFF
--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -45,7 +45,7 @@ The Shell backend along with the new `pants.backend.experimental.adhoc` backend 
 Pants is able to invoke workflows that include tools for which Pants does not yet have a
 dedicated backend.
 
-In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` targettypes have 
+In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target types have 
 graduated to no longer have the `experimental_` prefix; deprecating the prefixed variants with removal in 2.17. Upgrade to use 
 `shell_command` and `run_shell_command` respectively instead.
 

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -45,9 +45,9 @@ The Shell backend along with the new `pants.backend.experimental.adhoc` backend 
 Pants is able to invoke workflows that include tools for which Pants does not yet have a
 dedicated backend.
 
-In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` target
-types have graduated to no longer have the `experimental_` prefix; use `shell_command` and `run_shell_command`
-respectively instead.
+In recognition of these improvements, the `experimental_shell_command` and `experimental_run_shell_command` targettypes have 
+graduated to no longer have the `experimental_` prefix; deprecating the prefixed variants with removal in 2.17. Upgrade to use 
+`shell_command` and `run_shell_command` respectively instead.
 
 The improvements include:
 


### PR DESCRIPTION
This is clearer in the actual change listing further down in the file, where they are mentioned as deprecated. When I read this the first time it sounded like the old ones were gone immediately, so figure it can be clarified.

(From this message and further in the thread: https://pantsbuild.slack.com/archives/C046T6T9U/p1679240812207749?thread_ts=1679234208.316439&cid=C046T6T9U)