### PR TITLE
Fix Poetry req synthesis for URLs with markers. (Cherry-pick of #18535)

### DIFF
--- a/src/python/pants/backend/python/macros/poetry_requirements.py
+++ b/src/python/pants/backend/python/macros/poetry_requirements.py
@@ -266,7 +266,7 @@ def add_markers(base: str, attributes: PyprojectAttr, fp) -> str:
     if not markers_lookup and not python_lookup:
         return base
 
-    result = f"{base};("
+    result = f"{base} ;("
 
     if markers_lookup:
         result += f"{markers_lookup})"


### PR DESCRIPTION
Previously the PEP-508 direct reference URL requirement synthesis ran afoul of creating ambiguous requirement strings as detailed here: https://github.com/pypa/packaging/issues/456#issuecomment-931030769

Fixes #18530

(cherry picked from commit 54fb80b303872ecbf8e0722a8ebb12e99a83cce1)

[ci skip-rust]
[ci skip-build-wheels]