### PR TITLE
docs: fix an f-string in help

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2967,7 +2967,7 @@ def generate_file_based_overrides_field_help_message(
     return "\n".join(
         [
             softwrap(
-                """
+                f"""
                 Override the field values for generated `{generated_target_name}` targets.
 
                 Expects a dictionary of relative file paths and globs to a dictionary for the


### PR DESCRIPTION
Fixing a missing f-string notation:

![image](https://user-images.githubusercontent.com/50622389/226632956-644532a7-5681-407e-8c81-e704e7bc721d.png)
