### PR TITLE
Add support for Docker registry auth

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -44,6 +44,10 @@ _PRESERVED_ENV_VARS = [
     "DOCKER_HOST",
     "DOCKER_CONFIG",
     "DOCKER_CERT_PATH",
+    # Environment variables consumed (indirectly) by the `docker_credential` crate as of
+    # https://github.com/keirlawson/docker_credential/commit/0c42d0f3c76a7d5f699d4d1e8b9747f799cf6116
+    "HOME",
+    "PATH",
 ]
 
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -162,6 +162,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -195,7 +204,7 @@ name = "bollard"
 version = "0.13.0"
 source = "git+https://github.com/fussybeaver/bollard.git?rev=2d66d11b44aeff0373ece3d64a44b243e5152973#2d66d11b44aeff0373ece3d64a44b243e5152973"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -812,6 +821,7 @@ dependencies = [
  "bollard",
  "bollard-stubs",
  "bytes",
+ "docker_credential",
  "env_logger",
  "fs",
  "futures",
@@ -833,6 +843,17 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.4",
  "workunit_store",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2b7a539236f31eb8bcfa784affc137400cedbf1a73e0607acbb2f6306584e5"
+dependencies = [
+ "base64 0.10.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1352,7 +1373,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -2879,7 +2900,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2977,7 +2998,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct 0.6.1",
@@ -3014,7 +3035,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3023,7 +3044,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3696,7 +3717,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "futures-core",
  "futures-util",

--- a/src/rust/engine/process_execution/docker/Cargo.toml
+++ b/src/rust/engine/process_execution/docker/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 async-lock = "2.5"
 bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
 bollard-stubs = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
+docker_credential = "1.1"
 fs = { path = "../../fs" }
 futures = "0.3"
 log = "0.4"

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -699,6 +699,7 @@ fn docker_resolve_image(
     IMAGE_PULL_CACHE
       .pull_image(
         docker,
+        &context.core.executor,
         &image_name,
         &platform,
         image_pull_scope,


### PR DESCRIPTION
As reported in #18533, the `bollard` crate does not implement Docker registry auth. The `docker_credential` crate does though (including invoking [credential helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol) if necessary).

This change was tested to suffice for auth against AWS ECR registries (which use the `docker-credential-ecr-login` helper).

Fixes #18533.