### PR TITLE
Add support for Docker registry auth (Cherry-pick of #18541)

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -44,6 +44,10 @@ _PRESERVED_ENV_VARS = [
     "DOCKER_HOST",
     "DOCKER_CONFIG",
     "DOCKER_CERT_PATH",
+    # Environment variables consumed (indirectly) by the `docker_credential` crate as of
+    # https://github.com/keirlawson/docker_credential/commit/0c42d0f3c76a7d5f699d4d1e8b9747f799cf6116
+    "HOME",
+    "PATH",
 ]
 
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -162,6 +162,15 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -195,7 +204,7 @@ name = "bollard"
 version = "0.13.0"
 source = "git+https://github.com/fussybeaver/bollard.git?rev=2d66d11b44aeff0373ece3d64a44b243e5152973#2d66d11b44aeff0373ece3d64a44b243e5152973"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -821,6 +830,7 @@ dependencies = [
  "bollard",
  "bollard-stubs",
  "bytes",
+ "docker_credential",
  "env_logger",
  "fs",
  "futures",
@@ -842,6 +852,17 @@ dependencies = [
  "tokio-rustls 0.23.4",
  "tokio-util 0.7.4",
  "workunit_store",
+]
+
+[[package]]
+name = "docker_credential"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2b7a539236f31eb8bcfa784affc137400cedbf1a73e0607acbb2f6306584e5"
+dependencies = [
+ "base64 0.10.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1361,7 +1382,7 @@ version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f19b9f54f7c7f55e31401bb647626ce0cf0f67b0004982ce815b3ee72a02aa8"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "byteorder",
  "crossbeam-channel",
  "flate2",
@@ -2854,7 +2875,7 @@ version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2938,7 +2959,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct 0.6.1",
@@ -2975,7 +2996,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -2984,7 +3005,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7522c9de787ff061458fe9a829dc790a3f5b22dc571694fc5883f448b94d9a9"
 dependencies = [
- "base64",
+ "base64 0.13.0",
 ]
 
 [[package]]
@@ -3657,7 +3678,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "futures-core",
  "futures-util",

--- a/src/rust/engine/process_execution/docker/Cargo.toml
+++ b/src/rust/engine/process_execution/docker/Cargo.toml
@@ -11,6 +11,7 @@ async-trait = "0.1"
 async-lock = "2.5"
 bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
 bollard-stubs = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
+docker_credential = "1.1"
 fs = { path = "../../fs" }
 futures = "0.3"
 log = "0.4"

--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -3,11 +3,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsStr;
 use std::fmt;
+use std::net::ToSocketAddrs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_oncecell::OnceCell;
 use async_trait::async_trait;
+use bollard::auth::DockerCredentials;
 use bollard::container::{CreateContainerOptions, LogOutput, RemoveContainerOptions};
 use bollard::exec::StartExecResults;
 use bollard::image::CreateImageOptions;
@@ -148,6 +150,7 @@ impl ImagePullCache {
   pub async fn pull_image(
     &self,
     docker: &Docker,
+    executor: &Executor,
     image: &str,
     platform: &Platform,
     image_pull_scope: ImagePullScope,
@@ -169,7 +172,13 @@ impl ImagePullCache {
     };
 
     image_cell
-      .get_or_try_init(pull_image(docker, image, platform, image_pull_policy))
+      .get_or_try_init(pull_image(
+        docker,
+        executor,
+        image,
+        platform,
+        image_pull_policy,
+      ))
       .await?;
 
     Ok(())
@@ -184,10 +193,60 @@ pub enum ImagePullPolicy {
   OnlyIfLatestOrMissing,
 }
 
+async fn credentials_for_image(
+  executor: &Executor,
+  image: &str,
+) -> Result<Option<DockerCredentials>, String> {
+  // An image name has an optional domain component before the first `/`. While the grammar (linked
+  // below) seems to imply that the domain can be statically differentiated from the path, it's not
+  // clear how. So to confirm that it is a domain, we attempt to DNS resolve it.
+  //
+  // https://github.com/distribution/distribution/blob/e5d5810851d1f17a5070e9b6f940d8af98ea3c29/reference/reference.go#L4-L26
+  let Some((server, _)) = image.split_once('/') else {
+    return Ok(None)
+  };
+  let server = server.to_owned();
+
+  executor
+    .spawn_blocking(
+      move || {
+        // Resolve the server as a DNS name to confirm that it is actually a registry.
+        let Ok(_) = (server.as_ref(), 80).to_socket_addrs().or_else(|_| server.to_socket_addrs()) else {
+          return Ok(None)
+        };
+
+        // TODO: https://github.com/keirlawson/docker_credential/issues/7 means that this will only
+        // work for credential helpers and credentials encoded directly in the docker config,
+        // rather than for general credStore implementations.
+        let credential = docker_credential::get_credential(&server)
+          .map_err(|e| format!("Failed to retrieve credentials for server `{server}`: {e}"))?;
+
+        let bollard_credentials = match credential {
+          docker_credential::DockerCredential::IdentityToken(token) => DockerCredentials {
+            identitytoken: Some(token),
+            ..DockerCredentials::default()
+          },
+          docker_credential::DockerCredential::UsernamePassword(username, password) => {
+            DockerCredentials {
+              username: Some(username),
+              password: Some(password),
+              ..DockerCredentials::default()
+            }
+          }
+        };
+
+        Ok(Some(bollard_credentials))
+      },
+      |e| Err(format!("Credentials task failed: {e}")),
+    )
+    .await
+}
+
 /// Pull an image given its name and the image pull policy. This method is debounced by
 /// the "image pull cache" in the `CommandRunner`.
 async fn pull_image(
   docker: &Docker,
+  executor: &Executor,
   image: &str,
   platform: &Platform,
   policy: ImagePullPolicy,
@@ -239,13 +298,17 @@ async fn pull_image(
         "Pulling Docker image `{image}` because {pull_reason}."
       )),
       |_workunit| async move {
+        let credentials = credentials_for_image(executor, image)
+          .await
+          .map_err(|e| format!("Failed to pull Docker image `{image}`: {e}"))?;
+
         let create_image_options = CreateImageOptions::<String> {
           from_image: image.to_string(),
           platform: docker_platform_identifier(platform).to_string(),
           ..CreateImageOptions::default()
         };
 
-        let mut result_stream = docker.create_image(Some(create_image_options), None, None);
+        let mut result_stream = docker.create_image(Some(create_image_options), None, credentials);
         while let Some(msg) = result_stream.next().await {
           log::trace!("pull {}: {:?}", image, msg);
           match msg {
@@ -253,9 +316,7 @@ async fn pull_image(
               CreateImageInfo {
                 error: Some(error), ..
               } => {
-                let error_msg = format!("Failed to pull Docker image `{image}`: {error}");
-                log::error!("{error_msg}");
-                return Err(error_msg);
+                return Err(format!("Failed to pull Docker image `{image}`: {error}"));
               }
               CreateImageInfo {
                 status: Some(status),
@@ -289,8 +350,13 @@ impl<'a> CommandRunner<'a> {
     immutable_inputs: ImmutableInputs,
     keep_sandboxes: KeepSandboxes,
   ) -> Result<Self, String> {
-    let container_cache =
-      ContainerCache::new(docker, image_pull_cache, &work_dir_base, &immutable_inputs)?;
+    let container_cache = ContainerCache::new(
+      docker,
+      image_pull_cache,
+      executor.clone(),
+      &work_dir_base,
+      &immutable_inputs,
+    )?;
 
     Ok(CommandRunner {
       store,
@@ -666,6 +732,7 @@ type CachedContainer = Arc<OnceCell<(String, NamedCaches)>>;
 pub(crate) struct ContainerCache<'a> {
   docker: &'a DockerOnceCell,
   image_pull_cache: &'a ImagePullCache,
+  executor: Executor,
   work_dir_base: String,
   immutable_inputs_base_dir: String,
   /// Cache that maps image name / platform to a cached container.
@@ -676,6 +743,7 @@ impl<'a> ContainerCache<'a> {
   pub fn new(
     docker: &'a DockerOnceCell,
     image_pull_cache: &'a ImagePullCache,
+    executor: Executor,
     work_dir_base: &Path,
     immutable_inputs: &ImmutableInputs,
   ) -> Result<Self, String> {
@@ -697,6 +765,7 @@ impl<'a> ContainerCache<'a> {
     Ok(Self {
       docker,
       image_pull_cache,
+      executor,
       work_dir_base,
       immutable_inputs_base_dir,
       containers: Mutex::default(),
@@ -707,6 +776,7 @@ impl<'a> ContainerCache<'a> {
   /// (named) caches.
   async fn make_container(
     docker: Docker,
+    executor: Executor,
     image_name: String,
     platform: Platform,
     image_pull_scope: ImagePullScope,
@@ -718,6 +788,7 @@ impl<'a> ContainerCache<'a> {
     image_pull_cache
       .pull_image(
         &docker,
+        &executor,
         &image_name,
         &platform,
         image_pull_scope,
@@ -854,8 +925,8 @@ impl<'a> ContainerCache<'a> {
     platform: &Platform,
     build_generation: &str,
   ) -> Result<(String, NamedCaches), String> {
-    let docker = self.docker.get().await?;
-    let docker = docker.clone();
+    let docker = self.docker.get().await?.clone();
+    let executor = self.executor.clone();
 
     let container_id_cell = {
       let mut containers = self.containers.lock();
@@ -873,6 +944,7 @@ impl<'a> ContainerCache<'a> {
       .get_or_try_init(async move {
         let container_id = Self::make_container(
           docker.clone(),
+          executor,
           image_name.to_string(),
           *platform,
           image_pull_scope,

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -700,6 +700,7 @@ fn docker_resolve_image(
     IMAGE_PULL_CACHE
       .pull_image(
         docker,
+        &context.core.executor,
         &image_name,
         &platform,
         image_pull_scope,


### PR DESCRIPTION
As reported in #18533, the `bollard` crate does not implement Docker registry auth. The `docker_credential` crate does though (including invoking [credential helpers](https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol) if necessary).

This change was tested to suffice for auth against AWS ECR registries (which use the `docker-credential-ecr-login` helper).

Fixes #18533.
