### PR TITLE
Add a few more packages/modules to default_module_mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -117,6 +117,7 @@ DEFAULT_MODULE_MAPPING = {
     "opensearch-py": ("opensearchpy",),
     # opentelemetry
     "opentelemetry-api": ("opentelemetry",),
+    "opentelemetry-exporter-otlp": ("opentelemetry.exporter",),
     "opentelemetry-exporter-otlp-proto-grpc": ("opentelemetry.exporter.otlp.proto.grpc",),
     "opentelemetry-exporter-otlp-proto-http": ("opentelemetry.exporter.otlp.proto.http",),
     "opentelemetry-instrumentation-aiohttp-client": (
@@ -200,6 +201,7 @@ DEFAULT_MODULE_MAPPING = {
     "snowflake-connector-python": ("snowflake.connector",),
     "strawberry-graphql": ("strawberry",),
     "streamlit-aggrid": ("st_aggrid",),
+    "tensorboard": ("torch.utils.tensorboard",),
     "websocket-client": ("websocket",),
 }
 

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -114,6 +114,7 @@ DEFAULT_MODULE_MAPPING = {
     "mail-parser": ("mailparser",),
     "mysql-connector-python": ("mysql.connector",),
     "opencv-python": ("cv2",),
+    "opensearch-py": ("opensearchpy",),
     # opentelemetry
     "opentelemetry-api": ("opentelemetry",),
     "opentelemetry-exporter-otlp-proto-grpc": ("opentelemetry.exporter.otlp.proto.grpc",),
@@ -199,7 +200,7 @@ DEFAULT_MODULE_MAPPING = {
     "snowflake-connector-python": ("snowflake.connector",),
     "strawberry-graphql": ("strawberry",),
     "streamlit-aggrid": ("st_aggrid",),
-    "opensearch-py": ("opensearchpy",),
+    "websocket-client": ("websocket",),
 }
 
 DEFAULT_TYPE_STUB_MODULE_MAPPING = {


### PR DESCRIPTION
Add a default module mapping for `websocket-client`, which exposes the `websocket` module.