### PR TITLE
Fail fast for attempts to use `test --debug` with a docker environment (Cherry-pick of #18560)

### DIFF
--- a/src/python/pants/core/goals/test_integration_test.py
+++ b/src/python/pants/core/goals/test_integration_test.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
+
+
+def test_environment_usage() -> None:
+    files = {
+        "project/tests.py": dedent(
+            """\
+            def test_thing():
+                pass
+            """
+        ),
+        "project/BUILD": "python_tests(environment='python_38')",
+        "BUILD": dedent(
+            """\
+            docker_environment(
+                name="python_38",
+                image="python:3.8",
+                python_bootstrap_search_path=["<PATH>"],
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(files) as dirname:
+
+        def run(*extra_test_args: str) -> PantsResult:
+            return run_pants(
+                [
+                    "--backend-packages=['pants.backend.python']",
+                    "--python-interpreter-constraints=['==3.8.*']",
+                    f"--environments-preview-names={{'python_38': '{dirname}:python_38'}}",
+                    "test",
+                    *extra_test_args,
+                    f"{dirname}/project:",
+                ],
+            )
+
+        # A normal run should succeed.
+        run().assert_success()
+
+        # A debug run should fail (TODO: currently, see #17182).
+        debug_run = run("--debug")
+        debug_run.assert_failure()
+        assert "Only local environments support running processes interactively" in debug_run.stderr

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -531,7 +531,16 @@ fn interactive_process(
         (py_interactive_process.extract().unwrap(), py_process, process_config)
       });
       match process_config.execution_strategy {
-        ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => Err("InteractiveProcess should not set docker_image or remote_execution".to_owned()),
+        ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => {
+          // TODO: #17182 covers adding support for running processes interactively in Docker.
+          Err(
+            format!(
+              "Only local environments support running processes \
+               interactively, but {} was used.",
+              process_config.execution_strategy.cache_value(),
+            )
+          )
+        },
         _ => Ok(())
       }?;
       let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;


### PR DESCRIPTION
As described in #18212, `test --debug` currently silently uses the local environment to attempt to debug a target, which can cause a lot of confusion. Other goals like `run` at least render a warning.

Until #17182 is fixed, we should ensure that we fail fast for the case of `test --debug` instead.

Fixes #18212.
