### PR TITLE
Fail fast for attempts to use `test --debug` with a docker environment (Cherry-pick of #18560)

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -9,7 +9,7 @@ from abc import ABC, ABCMeta
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, ClassVar, Iterable, Optional, TypeVar, cast
+from typing import Any, ClassVar, Iterable, Optional, Sequence, TypeVar, cast
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
@@ -732,28 +732,26 @@ async def _get_test_batches(
 
 async def _run_debug_tests(
     batches: Iterable[TestRequest.Batch],
+    environment_names: Sequence[EnvironmentName],
     test_subsystem: TestSubsystem,
     debug_adapter: DebugAdapterSubsystem,
-    local_environment_name: ChosenLocalEnvironmentName,
 ) -> Test:
-    # TODO: Because these are interactive, they are always pinned to the local environment.
-    # See https://github.com/pantsbuild/pants/issues/17182
     debug_requests = await MultiGet(
         (
             Get(
                 TestDebugRequest,
-                {batch: TestRequest.Batch, local_environment_name.val: EnvironmentName},
+                {batch: TestRequest.Batch, environment_name: EnvironmentName},
             )
             if not test_subsystem.debug_adapter
             else Get(
                 TestDebugAdapterRequest,
-                {batch: TestRequest.Batch, local_environment_name.val: EnvironmentName},
+                {batch: TestRequest.Batch, environment_name: EnvironmentName},
             )
         )
-        for batch in batches
+        for batch, environment_name in zip(batches, environment_names)
     )
     exit_code = 0
-    for debug_request in debug_requests:
+    for debug_request, environment_name in zip(debug_requests, environment_names):
         if test_subsystem.debug_adapter:
             logger.info(
                 softwrap(
@@ -768,7 +766,7 @@ async def _run_debug_tests(
             InteractiveProcessResult,
             {
                 debug_request.process: InteractiveProcess,
-                local_environment_name.val: EnvironmentName,
+                environment_name: EnvironmentName,
             },
         )
         if debug_result.exit_code != 0:
@@ -817,11 +815,6 @@ async def run_tests(
         test_subsystem,
     )
 
-    if test_subsystem.debug or test_subsystem.debug_adapter:
-        return await _run_debug_tests(
-            test_batches, test_subsystem, debug_adapter, local_environment_name
-        )
-
     environment_names = await MultiGet(
         Get(
             EnvironmentName,
@@ -830,6 +823,11 @@ async def run_tests(
         )
         for batch in test_batches
     )
+
+    if test_subsystem.debug or test_subsystem.debug_adapter:
+        return await _run_debug_tests(
+            test_batches, environment_names, test_subsystem, debug_adapter
+        )
 
     results = await MultiGet(
         Get(TestResult, {batch: TestRequest.Batch, environment_name: EnvironmentName})

--- a/src/python/pants/core/goals/test_integration_test.py
+++ b/src/python/pants/core/goals/test_integration_test.py
@@ -1,0 +1,49 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import PantsResult, run_pants, setup_tmpdir
+
+
+def test_environment_usage() -> None:
+    files = {
+        "project/tests.py": dedent(
+            """\
+            def test_thing():
+                pass
+            """
+        ),
+        "project/BUILD": "python_tests(environment='python_38')",
+        "BUILD": dedent(
+            """\
+            docker_environment(
+                name="python_38",
+                image="python:3.8",
+                python_bootstrap_search_path=["<PATH>"],
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(files) as dirname:
+
+        def run(*extra_test_args: str) -> PantsResult:
+            return run_pants(
+                [
+                    "--backend-packages=['pants.backend.python']",
+                    "--python-interpreter-constraints=['==3.8.*']",
+                    f"--environments-preview-names={{'python_38': '{dirname}:python_38'}}",
+                    "test",
+                    *extra_test_args,
+                    f"{dirname}/project:",
+                ],
+            )
+
+        # A normal run should succeed.
+        run().assert_success()
+
+        # A debug run should fail (TODO: currently, see #17182).
+        debug_run = run("--debug")
+        debug_run.assert_failure()
+        assert "Only local environments support running processes interactively" in debug_run.stderr

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -535,7 +535,16 @@ fn interactive_process(
         (py_interactive_process.extract().unwrap(), py_process, process_config)
       });
       match process_config.environment.strategy {
-        ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => Err("InteractiveProcess should not set docker_image or remote_execution".to_owned()),
+        ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => {
+          // TODO: #17182 covers adding support for running processes interactively in Docker.
+          Err(
+            format!(
+              "Only local environments support running processes \
+               interactively, but a {} environment was used.",
+              process_config.environment.strategy.strategy_type(),
+            )
+          )
+        },
         _ => Ok(())
       }?;
       let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config).await?.process;


### PR DESCRIPTION
As described in #18212, `test --debug` currently silently uses the local environment to attempt to debug a target, which can cause a lot of confusion. Other goals like `run` at least render a warning.

Until #17182 is fixed, we should ensure that we fail fast for the case of `test --debug` instead.

Fixes #18212.
