### PR TITLE
Adds `adhoc` to list of enabled backends

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -242,6 +242,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.codegen.thrift.apache.python",
         "pants.backend.docker",
         "pants.backend.docker.lint.hadolint",
+        "pants.backend.experimental.adhoc",
         "pants.backend.experimental.codegen.protobuf.go",
         "pants.backend.experimental.codegen.protobuf.java",
         "pants.backend.experimental.codegen.protobuf.scala",

--- a/pants.toml
+++ b/pants.toml
@@ -7,6 +7,7 @@ backend_packages.add = [
   "pants.backend.build_files.fix.deprecations",
   "pants.backend.build_files.fmt.black",
   "pants.backend.python",
+  "pants.backend.experimental.adhoc",
   "pants.backend.experimental.python.packaging.pyoxidizer",
   "pants.backend.python.lint.autoflake",
   "pants.backend.python.lint.black",

--- a/pants.toml
+++ b/pants.toml
@@ -7,7 +7,6 @@ backend_packages.add = [
   "pants.backend.build_files.fix.deprecations",
   "pants.backend.build_files.fmt.black",
   "pants.backend.python",
-  "pants.backend.experimental.adhoc",
   "pants.backend.experimental.python.packaging.pyoxidizer",
   "pants.backend.python.lint.autoflake",
   "pants.backend.python.lint.black",


### PR DESCRIPTION
This will let `adhoc_tool` etc appear in our reference docs.

Will need to be cherry-picked to 2.16.