### PR TITLE
expose PANTS_VERSION and make it string-comparable

### DIFF
--- a/src/python/pants/core/aliases_test.py
+++ b/src/python/pants/core/aliases_test.py
@@ -4,10 +4,9 @@ from textwrap import dedent
 
 import pytest
 
-from pants.build_graph.address import Address, AddressInput, ResolveError
+from pants.build_graph.address import Address, ResolveError
 from pants.core import register
 from pants.core.target_types import GenericTarget
-from pants.engine.addresses import Address
 from pants.testutil.rule_runner import RuleRunner, engine_error
 from pants.version import PANTS_SEMVER
 
@@ -29,13 +28,16 @@ def test_get_with_version():
     assert tgt is not None
 
 
+# NOTE: We Stringify PANTS_SEMVER in parametrize to ensure the generated test name is understandable.
+
+
 @pytest.mark.parametrize(
     "comparator,comparand",
     [
         (">", "2.0"),
-        (">=", PANTS_SEMVER),
-        ("==", PANTS_SEMVER),
-        ("<=", PANTS_SEMVER),
+        (">=", str(PANTS_SEMVER)),
+        ("==", str(PANTS_SEMVER)),
+        ("<=", str(PANTS_SEMVER)),
         ("<", "3.0"),
         ("!=", "1.0"),
     ],
@@ -61,12 +63,12 @@ def test_get_version_comparable(comparator, comparand):
 @pytest.mark.parametrize(
     "comparator,comparand",
     [
-        (">", "2.0"),
-        (">=", PANTS_SEMVER),
-        ("==", PANTS_SEMVER),
-        ("<=", PANTS_SEMVER),
-        ("<", "3.0"),
-        ("!=", "1.0"),
+        (">", "3.0"),
+        (">=", "3.0"),
+        ("==", "3.0"),
+        ("<=", "1.0"),
+        ("<", "1.0"),
+        ("!=", str(PANTS_SEMVER)),
     ],
 )
 def test_get_version_not_comparable(comparator, comparand):
@@ -76,8 +78,7 @@ def test_get_version_not_comparable(comparator, comparand):
         {
             "BUILD": dedent(
                 f"""\
-                condition = PANTS_VERSION {comparator} "{comparand}"
-                if not condition:
+                if PANTS_VERSION {comparator} "{comparand}":
                     target(name=f'test{{PANTS_VERSION}}')
                 """
             ),

--- a/src/python/pants/core/aliases_test.py
+++ b/src/python/pants/core/aliases_test.py
@@ -1,0 +1,88 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from textwrap import dedent
+
+import pytest
+
+from pants.build_graph.address import Address, AddressInput, ResolveError
+from pants.core import register
+from pants.core.target_types import GenericTarget
+from pants.engine.addresses import Address
+from pants.testutil.rule_runner import RuleRunner, engine_error
+from pants.version import PANTS_SEMVER
+
+
+def test_get_with_version():
+    rule_runner = RuleRunner(aliases=[register.build_file_aliases()], target_types=[GenericTarget])
+
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                target(name=f'test{PANTS_VERSION}')
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("", target_name=f"test{PANTS_SEMVER}"))
+    assert tgt is not None
+
+
+@pytest.mark.parametrize(
+    "comparator,comparand",
+    [
+        (">", "2.0"),
+        (">=", PANTS_SEMVER),
+        ("==", PANTS_SEMVER),
+        ("<=", PANTS_SEMVER),
+        ("<", "3.0"),
+        ("!=", "1.0"),
+    ],
+)
+def test_get_version_comparable(comparator, comparand):
+    rule_runner = RuleRunner(aliases=[register.build_file_aliases()], target_types=[GenericTarget])
+
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                f"""\
+                if PANTS_VERSION {comparator} "{comparand}":
+                    target(name=f'test{{PANTS_VERSION}}')
+                """
+            ),
+        }
+    )
+
+    tgt = rule_runner.get_target(Address("", target_name=f"test{PANTS_SEMVER}"))
+    assert tgt is not None
+
+
+@pytest.mark.parametrize(
+    "comparator,comparand",
+    [
+        (">", "2.0"),
+        (">=", PANTS_SEMVER),
+        ("==", PANTS_SEMVER),
+        ("<=", PANTS_SEMVER),
+        ("<", "3.0"),
+        ("!=", "1.0"),
+    ],
+)
+def test_get_version_not_comparable(comparator, comparand):
+    rule_runner = RuleRunner(aliases=[register.build_file_aliases()], target_types=[GenericTarget])
+
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                f"""\
+                condition = PANTS_VERSION {comparator} "{comparand}"
+                if not condition:
+                    target(name=f'test{{PANTS_VERSION}}')
+                """
+            ),
+        }
+    )
+
+    with engine_error(ResolveError):
+        rule_runner.get_target(Address("", target_name=f"test{PANTS_SEMVER}"))

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -59,6 +59,7 @@ from pants.engine.internals.parametrize import Parametrize
 from pants.goal import anonymous_telemetry, stats_aggregator
 from pants.source import source_root
 from pants.vcs import git
+from pants.version import PANTS_SEMVER
 
 wrap_as_resources = wrap_source_rule_and_target(ResourceSourceField, "resources")
 
@@ -121,6 +122,7 @@ def target_types():
 def build_file_aliases():
     return BuildFileAliases(
         objects={
+            "PANTS_VERSION": PANTS_SEMVER,
             "http_source": http_source,
             "per_platform": per_platform,
             "parametrize": Parametrize,

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -256,6 +256,7 @@ class RuleRunner:
         rules: Iterable | None = None,
         target_types: Iterable[type[Target]] | None = None,
         objects: dict[str, Any] | None = None,
+        aliases: Iterable[BuildFileAliases] | None = None,
         context_aware_object_factories: dict[str, Any] | None = None,
         isolated_local_store: bool = False,
         preserve_tmpdirs: bool = False,
@@ -306,6 +307,10 @@ class RuleRunner:
                 objects=objects, context_aware_object_factories=context_aware_object_factories
             )
         )
+        aliases = aliases or ()
+        for build_file_aliases in aliases:
+            build_config_builder.register_aliases(build_file_aliases)
+
         build_config_builder.register_rules("_dummy_for_test_", all_rules)
         build_config_builder.register_target_types("_dummy_for_test_", target_types or ())
         self.build_config = build_config_builder.create()

--- a/src/python/pants/version.py
+++ b/src/python/pants/version.py
@@ -2,13 +2,54 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
+from typing import Any
 
-from packaging.version import Version
+from packaging.version import Version as _Version
 
 import pants._version
 
 # Generate a inferrable dependency on the `pants._version` package and its associated resources.
 from pants.util.resources import read_resource
+
+
+# Simple derived class to enable comparison with strings in BUILD files.
+class Version(_Version):
+    def __hash__(self):
+        # This is required to be directly implemented because we implement __eq__,
+        # see the docs for object.__hash__:
+        # https://docs.python.org/3/reference/datamodel.html#object.__hash__
+        return super().__hash__()
+
+    def __eq__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__eq__(other)
+
+    def __ne__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__ne__(other)
+
+    def __lt__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__lt__(other)
+
+    def __le__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__le__(other)
+
+    def __gt__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__gt__(other)
+
+    def __ge__(self, other: Any):
+        if isinstance(other, str):
+            other = Version(other)
+        return super().__ge__(other)
+
 
 # Set this env var to override the version pants reports. Useful for testing.
 # Do not change. (see below)


### PR DESCRIPTION
Proposed fix for #18528.

Very "dumb" implementation exposing it as a constant to all BUILD files. Unfortunately `packaging.version.Version` cannot be compared to strings, so I'm shimming it with a local Version class that allows this. I could do this in a more localized manner as this'll *affect* all uses of PANTS_SEMVER - but it seems like it'll reduce boilerplate in a lot of places. Happy to change based on opinion! 

We could also use an explicit comparator, or expose `Version` as well:

```py3 
if pants_version_after("2.13"):
```
or
```py3
if PANTS_VERSION >= Version("2.13")
```