### PR TITLE
Adds `adhoc` to list of enabled backends (Cherry-pick of #18572)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -242,6 +242,7 @@ def run_pants_help_all() -> dict[str, Any]:
         "pants.backend.codegen.thrift.apache.python",
         "pants.backend.docker",
         "pants.backend.docker.lint.hadolint",
+        "pants.backend.experimental.adhoc",
         "pants.backend.experimental.codegen.protobuf.go",
         "pants.backend.experimental.codegen.protobuf.java",
         "pants.backend.experimental.codegen.protobuf.scala",


### PR DESCRIPTION
This will let `adhoc_tool` etc appear in our reference docs.