### PR TITLE
Set the entire env in __run.sh

### DIFF
--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -876,7 +876,7 @@ pub fn setup_run_sh_script(
 
   let stringified_command_line: String = full_command_line.join(" ");
   let full_script = format!(
-    "#!/bin/bash
+    "#!/usr/bin/env bash
 # This command line should execute the same process as pants did internally.
 cd {stringified_cwd}
 env -i {stringified_env_vars} {stringified_command_line}

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -850,7 +850,11 @@ pub fn setup_run_sh_script(
     let formatted_assignment = format!("{key}={arg_str}");
     env_var_strings.push(formatted_assignment);
   }
-  let stringified_env_vars: String = env_var_strings.join(" ");
+  let stringified_env_var_export: String = if env_var_strings.is_empty() {
+    "".to_owned()
+  } else {
+    "export ".to_owned() + &env_var_strings.join(" ")
+  };
 
   // Shell-quote every command-line argument, as necessary.
   let mut full_command_line: Vec<String> = vec![];
@@ -878,7 +882,7 @@ pub fn setup_run_sh_script(
   let full_script = format!(
     "#!/bin/bash
 # This command line should execute the same process as pants did internally.
-export {stringified_env_vars}
+{stringified_env_var_export}
 cd {stringified_cwd}
 {stringified_command_line}
 ",

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -850,11 +850,7 @@ pub fn setup_run_sh_script(
     let formatted_assignment = format!("{key}={arg_str}");
     env_var_strings.push(formatted_assignment);
   }
-  let stringified_env_var_export: String = if env_var_strings.is_empty() {
-    "".to_owned()
-  } else {
-    "export ".to_owned() + &env_var_strings.join(" ")
-  };
+  let stringified_env_vars: String = env_var_strings.join(" ");
 
   // Shell-quote every command-line argument, as necessary.
   let mut full_command_line: Vec<String> = vec![];
@@ -882,9 +878,8 @@ pub fn setup_run_sh_script(
   let full_script = format!(
     "#!/bin/bash
 # This command line should execute the same process as pants did internally.
-{stringified_env_var_export}
 cd {stringified_cwd}
-{stringified_command_line}
+env -i {stringified_env_vars} {stringified_command_line}
 ",
   );
 


### PR DESCRIPTION
Previously we set the explicit env vars passed to the Process on top of the existing env. 
Now we use `env -i` to force the process to run with exactly the same env as it did
in the engine. This will create a much more faithful debugging setup when you poke
around in the sandbox and run `__run.sh`. 