### PR TITLE
Ensure that a symlinked exported venv exists and is valid. (Cherry-pick of #18575)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -164,6 +164,7 @@ class PexRequest(EngineAwareParameter):
     additional_args: tuple[str, ...]
     pex_path: tuple[Pex, ...]
     description: str | None = dataclasses.field(compare=False)
+    cache_scope: ProcessCacheScope
 
     def __init__(
         self,
@@ -184,6 +185,7 @@ class PexRequest(EngineAwareParameter):
         additional_args: Iterable[str] = (),
         pex_path: Iterable[Pex] = (),
         description: str | None = None,
+        cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
     ) -> None:
         """A request to create a PEX from its inputs.
 
@@ -220,6 +222,7 @@ class PexRequest(EngineAwareParameter):
         :param pex_path: Pex files to add to the PEX_PATH.
         :param description: A human-readable description to render in the dynamic UI when building
             the Pex.
+        :param cache_scope: The cache scope for the underlying pex cli invocation process.
         """
         object.__setattr__(self, "output_filename", output_filename)
         object.__setattr__(self, "internal_only", internal_only)
@@ -241,6 +244,7 @@ class PexRequest(EngineAwareParameter):
         object.__setattr__(self, "additional_args", tuple(additional_args))
         object.__setattr__(self, "pex_path", tuple(pex_path))
         object.__setattr__(self, "description", description)
+        object.__setattr__(self, "cache_scope", cache_scope)
 
         self.__post_init__()
 
@@ -629,6 +633,7 @@ async def build_pex(
             output_files=output_files,
             output_directories=output_directories,
             concurrency_available=requirements_setup.concurrency_available,
+            cache_scope=request.cache_scope,
         ),
     )
 


### PR DESCRIPTION
Now, if users delete or corrupt the pex_root named cache, rerunning the export 
command will fix things.

Also updates the IT to use the non-deprecated pants cli invocation for export, 
i.e., enumerating the resolves you want with `--resolve=` rather than passing specs.

This test was slow, so I also removed some redundancy - we didn't need to laboriously
test that many tools can export. A sampling was enough. Now even with the added test
the test file as a whole runs in about the same time as previously (~100 seconds).
This will be sped up further once we remove the old-style, deprecated tool lockfiles.
