### PR TITLE
Remove deprecations from `adhoc_tool`/`shell_command` stablisation process

### DIFF
--- a/docs/markdown/Shell/run-shell-commands.md
+++ b/docs/markdown/Shell/run-shell-commands.md
@@ -11,7 +11,7 @@ The [`shell_command`](doc:reference-shell_command) target allows you to run any 
 shell_command(
     command="./my-script.sh download some-archive.tar.gz",
     tools=["curl", "env", "bash", "mkdir", "tar"],
-    outputs=["files/"],
+    output_directories=["files"],
     dependencies=[":shell-scripts", ":images"]
 )
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -8,7 +8,6 @@ from pants.backend.adhoc.target_types import (
     AdhocToolArgumentsField,
     AdhocToolExecutionDependenciesField,
     AdhocToolLogOutputField,
-    AdhocToolOutputDependenciesField,
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
@@ -103,7 +102,6 @@ async def run_in_sandbox_request(
         ResolveExecutionDependenciesRequest(
             target.address,
             target.get(AdhocToolExecutionDependenciesField).value,
-            target.get(AdhocToolOutputDependenciesField).value,
             target.get(AdhocToolRunnableDependenciesField).value,
         ),
     )

--- a/src/python/pants/backend/adhoc/run_system_binary.py
+++ b/src/python/pants/backend/adhoc/run_system_binary.py
@@ -77,7 +77,7 @@ async def _find_binary(
 
     deps = await Get(
         ResolvedExecutionDependencies,
-        ResolveExecutionDependenciesRequest(address, (), None, fingerprint_dependencies),
+        ResolveExecutionDependenciesRequest(address, (), fingerprint_dependencies),
     )
     rds = deps.runnable_dependencies
     env: dict[str, str] = {}

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -80,16 +80,11 @@ class AdhocToolOutputDirectoriesField(StringSequenceField):
 class AdhocToolOutputDependenciesField(AdhocToolDependenciesField):
     supports_transitive_excludes = True
     alias: ClassVar[str] = "output_dependencies"
-    deprecated_alias = "dependencies"
-    deprecated_alias_removal_version = "2.17.0.dev1"
 
     help = help_text(
         lambda: f"""
-        Any dependencies that the output artifacts require in order to be effectively consumed.
-
-        To enable legacy use cases, if `{AdhocToolExecutionDependenciesField.alias}` is `None`,
-        these dependencies will be materialized in the execution sandbox. This behavior is
-        deprecated, and will be removed in version 2.17.0.dev1.
+        Any dependencies that need to be present as transitive dependencies whenever the outputs
+        of this target are consumed as dependencies.
         """
     )
 
@@ -231,8 +226,6 @@ class AdhocToolOutputRootDirField(StringField):
 
 class AdhocToolTarget(Target):
     alias: ClassVar[str] = "adhoc_tool"
-    deprecated_alias = "experimental_run_in_sandbox"
-    deprecated_alias_removal_version = "2.17.0.dev1"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         AdhocToolRunnableField,

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -82,9 +82,9 @@ class AdhocToolOutputDependenciesField(AdhocToolDependenciesField):
     alias: ClassVar[str] = "output_dependencies"
 
     help = help_text(
-        lambda: f"""
-        Any dependencies that need to be present as transitive dependencies whenever the outputs
-        of this target are consumed as dependencies.
+        lambda: """
+        Any dependencies that need to be present (as transitive dependencies) whenever the outputs
+        of this target are consumed (including as dependencies).
         """
     )
 
@@ -100,7 +100,7 @@ class AdhocToolExecutionDependenciesField(SpecialCasedDependencies):
 
         Dependencies specified here are those required to make the command complete successfully
         (e.g. file inputs, packages compiled from other targets, etc), but NOT required to make
-        the output side-effects useful. Dependencies that are required to use the side-effects
+        the outputs of the command useful. Dependencies that are required to use the outputs
         produced by this command should be specified using the
         `{AdhocToolOutputDependenciesField.alias}` field.
 

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -56,7 +56,7 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
                   name="msg-gen",
                   command="echo message > msg.txt",
                   tools=["echo"],
-                  outputs=["msg.txt"],
+                  output_files=["msg.txt"],
                 )
 
                 experimental_test_shell_command(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -269,22 +269,6 @@ class ShellCommandCommandField(StringField):
     help = "Shell command to execute.\n\nThe command is executed as 'bash -c <command>' by default."
 
 
-class ShellCommandOutputsField(StringSequenceField):
-    alias = "outputs"
-    help = help_text(
-        """
-        Specify the shell command output files and directories, relative to the value of `workdir`.
-
-        Use a trailing slash on directory names, i.e. `my_dir/`.
-
-        Relative paths (including `..`) may be used, as long as the path does not ascend further
-        than the build root.
-        """
-    )
-    removal_hint = "To fix, use `output_files` and `output_directories` instead."
-    removal_version = "2.17.0.dev1"
-
-
 class ShellCommandOutputFilesField(AdhocToolOutputFilesField):
     pass
 
@@ -377,7 +361,6 @@ class ShellCommandTarget(Target):
         ShellCommandRunnableDependenciesField,
         ShellCommandCommandField,
         ShellCommandLogOutputField,
-        ShellCommandOutputsField,
         ShellCommandOutputFilesField,
         ShellCommandOutputDirectoriesField,
         ShellCommandSourcesField,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -19,7 +19,6 @@ from pants.backend.shell.target_types import (
     ShellCommandOutputDirectoriesField,
     ShellCommandOutputFilesField,
     ShellCommandOutputRootDirField,
-    ShellCommandOutputsField,
     ShellCommandRunnableDependenciesField,
     ShellCommandSourcesField,
     ShellCommandTarget,
@@ -97,7 +96,8 @@ async def _prepare_process_request_from_target(
     )
     dependencies_digest = execution_environment.digest
 
-    output_files, output_directories = _parse_outputs_from_command(shell_command, description)
+    output_files = shell_command.get(ShellCommandOutputFilesField).value or ()
+    output_directories = shell_command.get(ShellCommandOutputDirectoriesField).value or ()
 
     # Resolve the `tools` field into a digest
     tools = shell_command.get(ShellCommandToolsField, default_raw_value=()).value or ()
@@ -160,24 +160,6 @@ async def _prepare_process_request_from_target(
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,
         log_output=shell_command[ShellCommandLogOutputField].value,
     )
-
-
-def _parse_outputs_from_command(
-    adhoc_process_target: Target, description: str
-) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    outputs = adhoc_process_target.get(ShellCommandOutputsField).value or ()
-    output_files = adhoc_process_target.get(ShellCommandOutputFilesField).value or ()
-    output_directories = adhoc_process_target.get(ShellCommandOutputDirectoriesField).value or ()
-    if outputs and (output_files or output_directories):
-        raise ValueError(
-            "Both new-style `output_files` or `output_directories` and old-style `outputs` were "
-            f"specified in {description}. To fix, move all values from `outputs` to "
-            "`output_files` or `output_directories`."
-        )
-    elif outputs:
-        output_files = tuple(f for f in outputs if not f.endswith("/"))
-        output_directories = tuple(d for d in outputs if d.endswith("/"))
-    return output_files, output_directories
 
 
 @rule

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -15,7 +15,6 @@ from pants.backend.shell.target_types import (
     ShellCommandExecutionDependenciesField,
     ShellCommandExtraEnvVarsField,
     ShellCommandLogOutputField,
-    ShellCommandOutputDependenciesField,
     ShellCommandOutputDirectoriesField,
     ShellCommandOutputFilesField,
     ShellCommandOutputRootDirField,
@@ -90,7 +89,6 @@ async def _prepare_process_request_from_target(
         ResolveExecutionDependenciesRequest(
             shell_command.address,
             shell_command.get(ShellCommandExecutionDependenciesField).value,
-            shell_command.get(ShellCommandOutputDependenciesField).value,
             shell_command.get(ShellCommandRunnableDependenciesField).value,
         ),
     )
@@ -238,7 +236,6 @@ async def _interactive_shell_command(
         ResolveExecutionDependenciesRequest(
             shell_command.address,
             shell_command.get(ShellCommandExecutionDependenciesField).value,
-            shell_command.get(ShellCommandOutputDependenciesField).value,
             shell_command.get(ShellCommandRunnableDependenciesField).value,
         ),
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -439,10 +439,20 @@ def test_execution_dependencies(caplog, rule_runner: RuleRunner) -> None:
                     workdir="/",
                 )
 
-                # Fails because runtime dependencies are not fetched transitively
-                # even if the root is requested through `output_dependencies`
+                # Fails because `output_dependencies` are not available at runtime
                 shell_command(
                     name="expect_fail_3",
+                    tools=["cat"],
+                    command="cat msg.txt",
+                    output_dependencies=[":a1"],
+                    workdir="/",
+                )
+
+
+                # Fails because execution dependencies are not fetched transitively
+                # even if the root is requested through `output_dependencies`
+                shell_command(
+                    name="expect_fail_4",
                     tools=["cat"],
                     command="cat msg.txt",
                     output_dependencies=[":a2"],
@@ -465,6 +475,7 @@ def test_execution_dependencies(caplog, rule_runner: RuleRunner) -> None:
                     name="expect_success_2",
                     tools=["cat"],
                     command="cat msg.txt msg2.txt > output.txt",
+                    execution_dependencies=[":a1", ":a2",],
                     output_dependencies=[":a1", ":a2",],
                     output_files=["output.txt"],
                     workdir="/",
@@ -474,18 +485,11 @@ def test_execution_dependencies(caplog, rule_runner: RuleRunner) -> None:
         }
     )
 
-    with engine_error(ProcessExecutionFailure):
-        assert_shell_command_result(
-            rule_runner, Address("src", target_name="expect_fail_1"), expected_contents={}
-        )
-    with engine_error(ProcessExecutionFailure):
-        assert_shell_command_result(
-            rule_runner, Address("src", target_name="expect_fail_2"), expected_contents={}
-        )
-    with engine_error(ProcessExecutionFailure):
-        assert_shell_command_result(
-            rule_runner, Address("src", target_name="expect_fail_3"), expected_contents={}
-        )
+    for i in range(1, 5):
+        with engine_error(ProcessExecutionFailure):
+            assert_shell_command_result(
+                rule_runner, Address("src", target_name=f"expect_fail_{i}"), expected_contents={}
+            )
     assert_shell_command_result(
         rule_runner,
         Address("src", target_name="expect_success_1"),
@@ -494,50 +498,6 @@ def test_execution_dependencies(caplog, rule_runner: RuleRunner) -> None:
     assert_shell_command_result(
         rule_runner,
         Address("src", target_name="expect_success_2"),
-        expected_contents={"output.txt": "message\nmessage\n"},
-    )
-
-
-def test_old_style_dependencies(caplog, rule_runner: RuleRunner) -> None:
-    caplog.set_level(logging.INFO)
-    caplog.clear()
-
-    rule_runner.write_files(
-        {
-            "src/BUILD": dedent(
-                """\
-                shell_command(
-                  name="a1",
-                  command="echo message > msg.txt",
-                  outputs=["msg.txt"],
-                  workdir="/",\
-                )
-
-                shell_command(
-                    name="a2",
-                    tools=["cat"],
-                    command="cat msg.txt > msg2.txt",
-                    dependencies=[":a1",],
-                    outputs=["msg2.txt",],
-                    workdir="/",
-                )
-
-                shell_command(
-                    name="expect_success",
-                    tools=["cat"],
-                    command="cat msg.txt msg2.txt > output.txt",
-                    dependencies=[":a1", ":a2",],
-                    outputs=["output.txt"],
-                    workdir="/",
-                )
-                """
-            ),
-        }
-    )
-
-    assert_shell_command_result(
-        rule_runner,
-        Address("src", target_name="expect_success"),
         expected_contents={"output.txt": "message\nmessage\n"},
     )
 


### PR DESCRIPTION
This removes:

* `outputs` as a field on `shell_command`
* `dependencies` as a field name on `shell_command`, `adhoc_tool`, etc
* Behaviour that allows `output_dependencies`/`dependencies` values to be manifest in the sandbox when `execution_dependencies` is not supplied

and adds some minor docs improvements