### PR TITLE
Improve debug information for docker auth, and expose an environment variable. (Cherry-pick of #18599)

### DIFF
--- a/src/python/pants/pantsd/pants_daemon.py
+++ b/src/python/pants/pantsd/pants_daemon.py
@@ -48,6 +48,7 @@ _PRESERVED_ENV_VARS = [
     # https://github.com/keirlawson/docker_credential/commit/0c42d0f3c76a7d5f699d4d1e8b9747f799cf6116
     "HOME",
     "PATH",
+    "USER",
 ]
 
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "docker_credential"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf2b7a539236f31eb8bcfa784affc137400cedbf1a73e0607acbb2f6306584e5"
+checksum = "9f2821ba7f89de240e70f4af347ba5260512d0799a53556c10750805bad7c7fc"
 dependencies = [
  "base64 0.10.1",
  "serde",

--- a/src/rust/engine/process_execution/docker/Cargo.toml
+++ b/src/rust/engine/process_execution/docker/Cargo.toml
@@ -11,7 +11,7 @@ async-trait = "0.1"
 async-lock = "2.5"
 bollard = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
 bollard-stubs = { git = "https://github.com/fussybeaver/bollard.git", rev = "2d66d11b44aeff0373ece3d64a44b243e5152973" }
-docker_credential = "1.1"
+docker_credential = "1.2"
 fs = { path = "../../fs" }
 futures = "0.3"
 log = "0.4"


### PR DESCRIPTION
Improve debug information for docker auth, and expose one additional fundamental environment variable.

Although we could potentially create an option to allow for exposing additional environment variables to `pantsd`, the ones which have been required so far are fundamental, and don't imply the need for an option. Time will tell though.
