### PR TITLE
Fix PexPEX invocations

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -10,11 +10,7 @@ from typing import Iterable, List, Mapping, Optional, Tuple
 from pants.backend.python.subsystems.python_native_code import PythonNativeCodeSubsystem
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.util_rules import pex_environment
-from pants.backend.python.util_rules.pex_environment import (
-    PexEnvironment,
-    PexSubsystem,
-    PythonExecutable,
-)
+from pants.backend.python.util_rules.pex_environment import PexEnvironment, PexSubsystem
 from pants.core.util_rules import adhoc_binaries, external_tool
 from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
@@ -67,7 +63,6 @@ class PexCliProcess:
     extra_env: Optional[FrozenDict[str, str]]
     output_files: Optional[Tuple[str, ...]]
     output_directories: Optional[Tuple[str, ...]]
-    python: Optional[PythonExecutable]
     level: LogLevel
     concurrency_available: int
     cache_scope: ProcessCacheScope
@@ -82,7 +77,6 @@ class PexCliProcess:
         extra_env: Optional[Mapping[str, str]] = None,
         output_files: Optional[Iterable[str]] = None,
         output_directories: Optional[Iterable[str]] = None,
-        python: Optional[PythonExecutable] = None,
         level: LogLevel = LogLevel.INFO,
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
@@ -96,7 +90,6 @@ class PexCliProcess:
         object.__setattr__(
             self, "output_directories", tuple(output_directories) if output_directories else None
         )
-        object.__setattr__(self, "python", python)
         object.__setattr__(self, "level", level)
         object.__setattr__(self, "concurrency_available", concurrency_available)
         object.__setattr__(self, "cache_scope", cache_scope)
@@ -190,7 +183,7 @@ async def setup_pex_cli_process(
     complete_pex_env = pex_env.in_sandbox(working_directory=None)
     normalized_argv = complete_pex_env.create_argv(pex_pex.exe, *args)
     env = {
-        **complete_pex_env.environment_dict(python=request.python),
+        **complete_pex_env.environment_dict(python=bootstrap_python),
         **python_native_code.subprocess_env_vars,
         **(request.extra_env or {}),
         # If a subcommand is used, we need to use the `pex3` console script.

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -203,9 +203,7 @@ class CompletePexEnvironment:
     def interpreter_search_paths(self) -> tuple[str, ...]:
         return self._pex_environment.interpreter_search_paths
 
-    def create_argv(
-        self, pex_filepath: str, *args: str, python: PythonExecutable | None = None
-    ) -> tuple[str, ...]:
+    def create_argv(self, pex_filepath: str, *args: str) -> tuple[str, ...]:
         pex_relpath = (
             os.path.relpath(pex_filepath, self._working_directory)
             if self._working_directory
@@ -213,7 +211,9 @@ class CompletePexEnvironment:
         )
         return (self._pex_environment.bootstrap_python.path, pex_relpath, *args)
 
-    def environment_dict(self, *, python: PythonExecutable | None = None) -> Mapping[str, str]:
+    def environment_dict(
+        self, *, python: PythonExecutable | PythonBuildStandaloneBinary | None = None
+    ) -> Mapping[str, str]:
         """The environment to use for running anything with PEX.
 
         If the Process is run with a pre-selected Python interpreter, set `python_configured=True`


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/18601 (among likely other issues) by ensuring we always run the pex PEX with a `--python` set to the bootstrap Python.

Note that none of the callers were passing `python` so I removed the parameter.