### PR TITLE
Add chat archive; deprecate GH Discussions

### DIFF
--- a/docs/markdown/Getting Help/getting-help.md
+++ b/docs/markdown/Getting Help/getting-help.md
@@ -7,20 +7,12 @@ createdAt: "2020-03-23T21:37:03.235Z"
 ---
 The [Pants community](doc:the-pants-community) is friendly, welcoming, and passionate about improving the craft of software engineering. If you need help with anything Pants-related, you've come to the right place.  We'd love to hear from you!
 
-Discussions
-----
-
-The best place to ask technical questions or hold design discussions is via the project's [GitHub Discussions](https://github.com/pantsbuild/pants). While questions, feedback, and design discussions are equally welcome on Slack, *we encourage you to choose Discussions whenever it's likely other users would benefit from persistent access to the conversation*. GitHub Discussions is indexed by search engines, and its content is retained long-term, so this is opportunity to help your fellow Pants users by making it easier for folks to discover supplementary technical information beyond the [docs](https://pantsbuild.org/docs).
-
-We encourage you to introduce yourself in the [`"welcome"`](https://github.com/pantsbuild/pants/discussions/categories/-welcome) category!
-
-
 Community Chat
 -----
 
-The best place to become acquainted with Pants community members and exchange informal chat is at the project's Slack. You can join using [this link](https://docs.google.com/forms/d/e/1FAIpQLSf9zgf-MXRnVDJbrVEST3urqneq7LCcy0zw8qU-GH4hPMn52A/viewform?usp=sf_link). *We use Slack's basic tier, which expires messages after a couple months, so usage is best suited to the more ephemeral or informal conversations that are unlikely to have long-term archival value.*
+The best place to become acquainted with Pants community members and exchange informal chat is at the project's Slack. You can join using [this link](https://docs.google.com/forms/d/e/1FAIpQLSf9zgf-MXRnVDJbrVEST3urqneq7LCcy0zw8qU-GH4hPMn52A/viewform?usp=sf_link). We encourage you to introduce yourself in the `#welcome` channel!
 
-We encourage you to introduce yourself in the `#welcome` channel!
+The primary public channels of community chat also have a [searchable public archive](https://chat.pantsbuild.org/). If you suspect your question has been asked before, the archive is the fastest way to find an answer. No login is required.
 
 
 Blog


### PR DESCRIPTION
The rationale for splitting conversations between Slack and Discussions had been to make certain types of conversations (design, technical questions) more visible to the general public and to search engines given that our Slack archives were behind a login, and disappeared quickly due to being on Slack's free tier. Now that we are on Slack's Pro tier, and Linen will be making Slack public channels visible to the general public and search engines, that rationale is moot. 

Whether to continue using GH Discussions or not is a separate decision (TBD); this is just removing the request to prefer GH Discussions for certain types of conversations.