### PR TITLE
Plumb entire lockfile/internal only code through `create_pex_from_targets` (cherry-pick of #18622)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -19,6 +19,7 @@ from pants.backend.python.subsystems import setuptools
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.subsystems.setuptools import Setuptools
 from pants.backend.python.target_types import (
+    EntryPoint,
     PexLayout,
     PythonRequirementTarget,
     PythonSourcesGeneratorTarget,
@@ -180,7 +181,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         platforms: bool,
         include_requirements: bool = True,
         run_against_entire_lockfile: bool = False,
-        expected: PexRequirements | PexRequest,
+        expected_reqs: PexRequirements = PexRequirements(),
+        expected_pexes: Iterable[Pex] = (),
     ) -> None:
         lockfile_used = mode in (RequirementMode.PEX_LOCKFILE, RequirementMode.NON_PEX_LOCKFILE)
         requirement_constraints_used = mode in (
@@ -224,7 +226,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             mock_repository_pex_request = OptionalPexRequest(maybe_pex_request=None)
             mock_repository_pex = OptionalPex(maybe_pex=None)
 
-        requirements_or_pex_request = run_rule_with_mocks(
+        reqs, pexes = run_rule_with_mocks(
             _determine_requirements_for_pex_from_targets,
             rule_args=[pex_from_targets_request, python_setup],
             mock_gets=[
@@ -259,8 +261,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
                 ),
             ],
         )
-        if expected:
-            assert requirements_or_pex_request == expected
+        assert expected_reqs == reqs
+        assert expected_pexes == pexes
 
     # If include_requirements is False, no matter what, early return.
     for mode in RequirementMode:
@@ -269,7 +271,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             include_requirements=False,
             internal_only=False,
             platforms=False,
-            expected=PexRequirements(),
+            # Nothing is expected
         )
 
     # Pex lockfiles: usually, return PexRequirements with from_superset as the LoadedLockfile.
@@ -280,13 +282,14 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.PEX_LOCKFILE,
             internal_only=internal_only,
             platforms=False,
-            expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
+            expected_reqs=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
         )
+
     assert_setup(
         RequirementMode.PEX_LOCKFILE,
         internal_only=False,
         platforms=True,
-        expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
+        expected_reqs=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
     )
     for platforms in (True, False):
         assert_setup(
@@ -294,14 +297,15 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             internal_only=False,
             run_against_entire_lockfile=True,
             platforms=platforms,
-            expected=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
+            expected_reqs=PexRequirements(req_strings, from_superset=loaded_lockfile__pex),
         )
     assert_setup(
         RequirementMode.PEX_LOCKFILE,
         internal_only=True,
         run_against_entire_lockfile=True,
         platforms=False,
-        expected=repository_pex_request__lockfile,
+        expected_reqs=repository_pex_request__lockfile.requirements,
+        expected_pexes=[repository_pex__lockfile],
     )
 
     # Non-Pex lockfiles: except for when run_against_entire_lockfile is applicable, return
@@ -312,7 +316,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.NON_PEX_LOCKFILE,
             internal_only=internal_only,
             platforms=False,
-            expected=PexRequirements(
+            expected_reqs=PexRequirements(
                 req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
             ),
         )
@@ -320,14 +324,16 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         RequirementMode.NON_PEX_LOCKFILE,
         internal_only=False,
         platforms=True,
-        expected=PexRequirements(req_strings, constraints_strings=req_strings, from_superset=None),
+        expected_reqs=PexRequirements(
+            req_strings, constraints_strings=req_strings, from_superset=None
+        ),
     )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
         internal_only=False,
         run_against_entire_lockfile=True,
         platforms=False,
-        expected=PexRequirements(
+        expected_reqs=PexRequirements(
             req_strings, constraints_strings=req_strings, from_superset=repository_pex__lockfile
         ),
     )
@@ -336,14 +342,17 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         internal_only=False,
         run_against_entire_lockfile=True,
         platforms=True,
-        expected=PexRequirements(req_strings, constraints_strings=req_strings, from_superset=None),
+        expected_reqs=PexRequirements(
+            req_strings, constraints_strings=req_strings, from_superset=None
+        ),
     )
     assert_setup(
         RequirementMode.NON_PEX_LOCKFILE,
         internal_only=True,
         run_against_entire_lockfile=True,
         platforms=False,
-        expected=repository_pex_request__lockfile,
+        expected_reqs=repository_pex_request__lockfile.requirements,
+        expected_pexes=[repository_pex__lockfile],
     )
 
     # Constraints file with resolve_all_constraints: except for when run_against_entire_lockfile
@@ -354,7 +363,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.CONSTRAINTS_RESOLVE_ALL,
             internal_only=internal_only,
             platforms=False,
-            expected=PexRequirements(
+            expected_reqs=PexRequirements(
                 req_strings,
                 constraints_strings=global_requirement_constraints,
                 from_superset=repository_pex__constraints,
@@ -364,7 +373,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         RequirementMode.CONSTRAINTS_RESOLVE_ALL,
         internal_only=False,
         platforms=True,
-        expected=PexRequirements(
+        expected_reqs=PexRequirements(
             req_strings, constraints_strings=global_requirement_constraints, from_superset=None
         ),
     )
@@ -373,7 +382,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         internal_only=False,
         run_against_entire_lockfile=True,
         platforms=False,
-        expected=PexRequirements(
+        expected_reqs=PexRequirements(
             req_strings,
             constraints_strings=global_requirement_constraints,
             from_superset=repository_pex__constraints,
@@ -384,7 +393,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         internal_only=False,
         run_against_entire_lockfile=True,
         platforms=True,
-        expected=PexRequirements(
+        expected_reqs=PexRequirements(
             req_strings, constraints_strings=global_requirement_constraints, from_superset=None
         ),
     )
@@ -393,7 +402,8 @@ def test_determine_requirements_for_pex_from_targets() -> None:
         internal_only=True,
         run_against_entire_lockfile=True,
         platforms=False,
-        expected=repository_pex_request__constraints,
+        expected_reqs=repository_pex_request__constraints.requirements,
+        expected_pexes=[repository_pex__constraints],
     )
 
     # Constraints file without resolve_all_constraints: always PexRequirements with
@@ -403,7 +413,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
             internal_only=internal_only,
             platforms=platforms,
-            expected=PexRequirements(
+            expected_reqs=PexRequirements(
                 req_strings, constraints_strings=global_requirement_constraints
             ),
         )
@@ -412,7 +422,7 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.CONSTRAINTS_NO_RESOLVE_ALL,
             internal_only=False,
             platforms=platforms,
-            expected=PexRequirements(
+            expected_reqs=PexRequirements(
                 req_strings, constraints_strings=global_requirement_constraints
             ),
         )
@@ -423,13 +433,13 @@ def test_determine_requirements_for_pex_from_targets() -> None:
             RequirementMode.NO_LOCKS,
             internal_only=internal_only,
             platforms=False,
-            expected=PexRequirements(req_strings),
+            expected_reqs=PexRequirements(req_strings),
         )
     assert_setup(
         RequirementMode.NO_LOCKS,
         internal_only=False,
         platforms=True,
-        expected=PexRequirements(req_strings),
+        expected_reqs=PexRequirements(req_strings),
     )
 
 
@@ -834,10 +844,12 @@ def test_lockfile_requirements_selection(
         [Address("", target_name="lib")],
         output_filename="demo.pex",
         internal_only=internal_only,
+        main=EntryPoint("a"),
     )
     rule_runner.set_options(options, env_inherit={"PATH"})
     result = rule_runner.request(PexRequest, [request])
     assert result.layout == (PexLayout.PACKED if internal_only else PexLayout.ZIPAPP)
+    assert result.main == EntryPoint("a")
 
     if run_against_entire_lockfile and internal_only:
         # With `run_against_entire_lockfile`, all internal requests result in the full set


### PR DESCRIPTION
Previously if `_determine_requirements_for_pex_from_targets` returns a `PexRequest` we'd short-circuit the rest of of the code resulting in `main` not being set on the PEX that we run (most likely in addition to other bugs like local dists not existing either).

Refactored so that in this very specific case, we'd still make it through the rest of the code, leveraging `pex_path` for the repo PEX.

Fixes #18552