### PR TITLE
Deprecate some `Request` types in favor of `Get()` with only one arg

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-upgrade-guide.md
@@ -6,6 +6,35 @@ hidden: false
 createdAt: "2020-10-12T16:19:01.543Z"
 ---
 
+2.17
+----
+
+### Deprecated some `Request` types in favor of `Get` with only one arg
+
+For several APIs like `pants.core.util_rules.system_binaries`, we had an eager and lazy version of the same API. You could do either of these two:
+
+```python
+from pants.core.util_rules.system_binaries import ZipBinary, ZipBinaryRequest
+from pants.engine.rules import Get, rule
+
+class MyOutput:
+    pass
+
+@rule
+def my_rule(zip_binary: ZipBinary) -> MyOutput:
+    return MyOutput()
+
+@rule
+async def my_rule_lazy() -> MyOutput:
+    zip_binary = await Get(ZipBinary, ZipBinaryRequest())
+    return MyOutput()
+```
+
+The lazy API is useful, for example, when you only want to `Get` that output type inside an `if` branch.
+
+We added syntax in 2.17 to now use `Get(OutputType)`, whereas before you had to do `Get(OutputType, OutputTypeRequest)` or (as of 2.15) `Get(OutputType, {})`. So, these `OutputTypeRequest` types are now redudent and deprecated in favor of simply using `Get(OutputType)`.
+
+
 2.16
 ----
 

--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/rules.py
@@ -58,16 +58,10 @@ class RenderedJVMLockfileFixtures(DeduplicatedCollection[RenderedJVMLockfileFixt
     pass
 
 
-@dataclass(frozen=True)
-class CollectFixtureConfigsRequest:
-    pass
-
-
 # TODO: This rule was mostly copied from the rule `setup_pytest_for_target` in
 # `src/python/pants/backend/python/goals/pytest_runner.py`. Some refactoring should be done.
 @rule
 async def collect_fixture_configs(
-    _request: CollectFixtureConfigsRequest,
     pytest: PyTest,
     python_setup: PythonSetup,
     test_extra_env: TestExtraEnv,
@@ -177,8 +171,9 @@ async def collect_fixture_configs(
 
 
 @rule
-async def gather_lockfile_fixtures() -> RenderedJVMLockfileFixtures:
-    configs = await Get(CollectedJVMLockfileFixtureConfigs, CollectFixtureConfigsRequest())
+async def gather_lockfile_fixtures(
+    configs: CollectedJVMLockfileFixtureConfigs,
+) -> RenderedJVMLockfileFixtures:
     rendered_fixtures = []
     for config in configs:
         artifact_reqs = ArtifactRequirements(

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -10,12 +10,7 @@ from pants.backend.codegen.protobuf.target_types import (
 )
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest, Partitions
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.core.util_rules.system_binaries import (
-    BinaryShims,
-    BinaryShimsRequest,
-    DiffBinary,
-    DiffBinaryRequest,
-)
+from pants.core.util_rules.system_binaries import BinaryShims, BinaryShimsRequest, DiffBinary
 from pants.engine.fs import Digest, MergeDigests
 from pants.engine.platform import Platform
 from pants.engine.process import Process, ProcessResult
@@ -62,9 +57,8 @@ async def partition_buf(
 
 @rule(desc="Format with buf format", level=LogLevel.DEBUG)
 async def run_buf_format(
-    request: BufFormatRequest.Batch, buf: BufSubsystem, platform: Platform
+    request: BufFormatRequest.Batch, buf: BufSubsystem, diff_binary: DiffBinary, platform: Platform
 ) -> FmtResult:
-    diff_binary = await Get(DiffBinary, DiffBinaryRequest())
     download_buf_get = Get(DownloadedExternalTool, ExternalToolRequest, buf.get_request(platform))
     binary_shims_get = Get(
         BinaryShims,

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -329,7 +329,7 @@ async def make_cgo_compile_wrapper_script() -> CGoCompilerWrapperScript:
 
 
 @rule
-def cgo_wrapper_compile_script_requesut(
+def cgo_wrapper_compile_script_request(
     _: CGoCompilerWrapperScriptRequest, script: CGoCompilerWrapperScript
 ) -> CGoCompilerWrapperScript:
     return script

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -22,13 +22,9 @@ from pants.backend.go.util_rules.cgo_pkgconfig import (
 from pants.backend.go.util_rules.cgo_security import check_linker_flags
 from pants.backend.go.util_rules.goroot import GoRoot
 from pants.backend.go.util_rules.sdk import GoSdkProcess
+from pants.base.deprecated import warn_or_error
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
-from pants.core.util_rules.system_binaries import (
-    BashBinary,
-    BashBinaryRequest,
-    BinaryPath,
-    BinaryPathTest,
-)
+from pants.core.util_rules.system_binaries import BashBinary, BinaryPath, BinaryPathTest
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import (
@@ -293,7 +289,15 @@ async def setup_compiler_cmd(
 
 @dataclass(frozen=True)
 class CGoCompilerWrapperScriptRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(CGoCompilerWrapperScript, CGoCompilerWrapperScriptRequest)",
+            (
+                "Instead, simply use `Get(CGoCompilerWrapperScript)` or put "
+                + "`CGoCompilerWrapperScript` in the rule signature"
+            ),
+        )
 
 
 @dataclass(frozen=True)
@@ -302,9 +306,7 @@ class CGoCompilerWrapperScript:
 
 
 @rule
-async def make_cgo_compile_wrapper_script(
-    _: CGoCompilerWrapperScriptRequest,
-) -> CGoCompilerWrapperScript:
+async def make_cgo_compile_wrapper_script() -> CGoCompilerWrapperScript:
     digest = await Get(
         Digest,
         CreateDigest(
@@ -326,6 +328,13 @@ async def make_cgo_compile_wrapper_script(
     return CGoCompilerWrapperScript(digest=digest)
 
 
+@rule
+def cgo_wrapper_compile_script_requesut(
+    _: CGoCompilerWrapperScriptRequest, script: CGoCompilerWrapperScript
+) -> CGoCompilerWrapperScript:
+    return script
+
+
 async def _cc(
     binary_name: str,
     input_digest: Digest,
@@ -336,15 +345,17 @@ async def _cc(
     description: str,
     golang_env_aware: GolangSubsystem.EnvironmentAware,
 ) -> Process:
-    compiler_path = await Get(
-        BinaryPath,
-        CGoBinaryPathRequest(
-            binary_name=binary_name,
-            binary_path_test=BinaryPathTest(["--version"]),
+    compiler_path, bash, wrapper_script = await MultiGet(
+        Get(
+            BinaryPath,
+            CGoBinaryPathRequest(
+                binary_name=binary_name,
+                binary_path_test=BinaryPathTest(["--version"]),
+            ),
         ),
+        Get(BashBinary),
+        Get(CGoCompilerWrapperScript),
     )
-    bash = await Get(BashBinary, BashBinaryRequest())
-    wrapper_script = await Get(CGoCompilerWrapperScript, CGoCompilerWrapperScriptRequest())
     compiler_args_result, env, input_digest = await MultiGet(
         Get(SetupCompilerCmdResult, SetupCompilerCmdRequest((compiler_path.path,), dir_path)),
         Get(
@@ -383,17 +394,16 @@ async def _gccld(
     objs: Iterable[str],
     description: str,
 ) -> FallibleProcessResult:
-    compiler_path = await Get(
-        BinaryPath,
-        CGoBinaryPathRequest(
-            binary_name=binary_name,
-            binary_path_test=BinaryPathTest(["--version"]),
+    compiler_path, bash, wrapper_script = await MultiGet(
+        Get(
+            BinaryPath,
+            CGoBinaryPathRequest(
+                binary_name=binary_name,
+                binary_path_test=BinaryPathTest(["--version"]),
+            ),
         ),
-    )
-
-    bash, wrapper_script = await MultiGet(
-        Get(BashBinary, BashBinaryRequest()),
-        Get(CGoCompilerWrapperScript, CGoCompilerWrapperScriptRequest()),
+        Get(BashBinary),
+        Get(CGoCompilerWrapperScript),
     )
 
     compiler_args_result, env, input_digest = await MultiGet(

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -44,7 +44,7 @@ from pants.backend.python.util_rules.ancestor_files import AncestorFiles, Ancest
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core import target_types
-from pants.core.target_types import AllAssetTargets, AllAssetTargetsByPath, AllAssetTargetsRequest
+from pants.core.target_types import AllAssetTargetsByPath
 from pants.core.util_rules import stripped_source_files
 from pants.engine.addresses import Address, Addresses
 from pants.engine.internals.graph import Owners, OwnersRequest
@@ -430,8 +430,7 @@ async def resolve_parsed_dependencies(
         resolve_results = {}
 
     if parsed_assets:
-        all_asset_targets = await Get(AllAssetTargets, AllAssetTargetsRequest())
-        assets_by_path = await Get(AllAssetTargetsByPath, AllAssetTargets, all_asset_targets)
+        assets_by_path = await Get(AllAssetTargetsByPath)
         asset_deps = _get_inferred_asset_deps(
             request.field_set.address,
             request.field_set.source.file_path,

--- a/src/python/pants/backend/python/framework/django/dependency_inference.py
+++ b/src/python/pants/backend/python/framework/django/dependency_inference.py
@@ -8,7 +8,7 @@ from pants.backend.python.dependency_inference.parse_python_dependencies import 
     PythonDependencyVisitorRequest,
     get_scripts_digest,
 )
-from pants.backend.python.framework.django.detect_apps import DjangoApps, DjangoAppsRequest
+from pants.backend.python.framework.django.detect_apps import DjangoApps
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get
@@ -28,8 +28,8 @@ _scripts_package = "pants.backend.python.framework.django.scripts"
 @rule
 async def django_parser_script(
     _: DjangoDependencyVisitorRequest,
+    django_apps: DjangoApps,
 ) -> PythonDependencyVisitor:
-    django_apps = await Get(DjangoApps, DjangoAppsRequest())
     django_apps_digest = await Get(
         Digest, CreateDigest([FileContent("apps.json", django_apps.to_json())])
     )

--- a/src/python/pants/backend/python/framework/django/detect_apps_test.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.backend.python.dependency_inference import parse_python_dependencies
 from pants.backend.python.framework.django import dependency_inference, detect_apps
-from pants.backend.python.framework.django.detect_apps import DjangoApps, DjangoAppsRequest
+from pants.backend.python.framework.django.detect_apps import DjangoApps
 from pants.backend.python.target_types import PythonSourceTarget
 from pants.backend.python.util_rules import pex
 from pants.core.util_rules import stripped_source_files
@@ -35,7 +35,7 @@ def rule_runner() -> RuleRunner:
             *pex.rules(),
             *dependency_inference.rules(),
             *detect_apps.rules(),
-            QueryRule(DjangoApps, [DjangoAppsRequest, EnvironmentName]),
+            QueryRule(DjangoApps, [EnvironmentName]),
         ],
         target_types=[PythonSourceTarget],
     )
@@ -112,7 +112,7 @@ def assert_apps_detected(
     )
     result = rule_runner.request(
         DjangoApps,
-        [DjangoAppsRequest()],
+        [],
     )
     assert result == DjangoApps(
         FrozenDict({"app1": "path.to.app1", "app2_label": "another.path.app2", "app3": "some.app3"})

--- a/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
+++ b/src/python/pants/backend/python/mixed_interpreter_constraints/py_constraints.py
@@ -16,7 +16,6 @@ from pants.engine.goal import Goal, GoalSubsystem, Outputting
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
     AllTargets,
-    AllTargetsRequest,
     RegisteredTargetTypes,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -80,7 +79,7 @@ async def py_constraints(
             )
             return PyConstraintsGoal(exit_code=1)
 
-        all_targets = await Get(AllTargets, AllTargetsRequest())
+        all_targets = await Get(AllTargets)
         all_python_targets = tuple(
             t for t in all_targets if t.has_field(InterpreterConstraintsField)
         )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -47,7 +47,6 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
-    AllTargetsRequest,
     FieldSet,
     Target,
     TransitiveTargets,
@@ -415,7 +414,7 @@ async def setup_mypy_extra_type_stubs_lockfile(
     #
     # This first finds the ICs of each partition. Then, it ORs all unique resulting interpreter
     # constraints. The net effect is that every possible Python interpreter used will be covered.
-    all_tgts = await Get(AllTargets, AllTargetsRequest())
+    all_tgts = await Get(AllTargets)
     all_field_sets = [
         MyPyFieldSet.create(tgt) for tgt in all_tgts if MyPyFieldSet.is_applicable(tgt)
     ]

--- a/src/python/pants/backend/python/util_rules/partition.py
+++ b/src/python/pants/backend/python/util_rules/partition.py
@@ -13,7 +13,7 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField, PythonResolveField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.engine.rules import Get
-from pants.engine.target import AllTargets, AllTargetsRequest, FieldSet
+from pants.engine.target import AllTargets, FieldSet
 from pants.util.ordered_set import OrderedSet
 
 ResolveName = str
@@ -67,7 +67,7 @@ async def _find_all_unique_interpreter_constraints(
 
     Returns the global interpreter constraints if no relevant targets were matched.
     """
-    all_tgts = await Get(AllTargets, AllTargetsRequest())
+    all_tgts = await Get(AllTargets)
     unique_constraints = {
         InterpreterConstraints.create_from_compatibility_fields(
             [tgt[InterpreterConstraintsField], *extra_constraints_per_tgt], python_setup

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -36,7 +36,7 @@ from pants.bsp.util_rules.targets import (
     BSPResourcesRequest,
     BSPResourcesResult,
 )
-from pants.core.util_rules.system_binaries import BashBinary, ReadlinkBinary, ReadlinkBinaryRequest
+from pants.core.util_rules.system_binaries import BashBinary, ReadlinkBinary
 from pants.engine.addresses import Addresses
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
 from pants.engine.internals.native_engine import Snapshot
@@ -181,6 +181,7 @@ async def bsp_resolve_scala_metadata(
     jvm: JvmSubsystem,
     scala: ScalaSubsystem,
     build_root: BuildRoot,
+    readlink: ReadlinkBinary,
 ) -> BSPBuildTargetsMetadataResult:
     resolves = {fs.resolve.normalized_value(jvm) for fs in request.field_sets}
     jdk_versions = {fs.jdk for fs in request.field_sets}
@@ -212,14 +213,7 @@ async def bsp_resolve_scala_metadata(
     # The maximum JDK version will be compatible with all the specified targets
     jdk_requests = [JdkRequest.from_field(version) for version in jdk_versions]
     jdk_request = max(jdk_requests, key=_jdk_request_sort_key(jvm))
-
-    (
-        jdk,
-        readlink,
-    ) = await MultiGet(
-        Get(JdkEnvironment, JdkRequest, jdk_request),
-        Get(ReadlinkBinary, ReadlinkBinaryRequest()),
-    )
+    jdk = await Get(JdkEnvironment, JdkRequest, jdk_request)
 
     if any(i.version == DefaultJdk.SYSTEM for i in jdk_requests):
         system_jdk = await Get(JdkEnvironment, JdkRequest, JdkRequest.SYSTEM)

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from pathlib import PurePath
 from typing import Generic, Optional, Sequence, TypeVar, Union, cast
 
+from pants.base.deprecated import warn_or_error
 from pants.core.goals import package
 from pants.core.goals.package import (
     BuiltPackage,
@@ -652,7 +653,12 @@ class GenericTarget(Target):
 
 @dataclass(frozen=True)
 class AllAssetTargetsRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(AllAssetTargets, AllAssetTargetsRequest)",
+            "Instead, simply use `Get(AllAssetTargets)` or put `AllAssetTargets` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
@@ -662,10 +668,7 @@ class AllAssetTargets:
 
 
 @rule(desc="Find all assets in project")
-def find_all_assets(
-    all_targets: AllTargets,
-    _: AllAssetTargetsRequest,
-) -> AllAssetTargets:
+def find_all_assets(all_targets: AllTargets) -> AllAssetTargets:
     resources = []
     files = []
     for tgt in all_targets:
@@ -674,6 +677,13 @@ def find_all_assets(
         if tgt.has_field(FileSourceField):
             files.append(tgt)
     return AllAssetTargets(tuple(resources), tuple(files))
+
+
+@rule
+def find_all_assets_request(
+    _: AllAssetTargetsRequest, all_asset_targets: AllAssetTargets
+) -> AllAssetTargets:
+    return all_asset_targets
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/archive.py
+++ b/src/python/pants/core/util_rules/archive.py
@@ -10,19 +10,10 @@ from dataclasses import dataclass
 from pathlib import PurePath
 
 from pants.core.util_rules import system_binaries
-from pants.core.util_rules.adhoc_binaries import GunzipBinary, GunzipBinaryRequest
+from pants.core.util_rules.adhoc_binaries import GunzipBinary
 from pants.core.util_rules.system_binaries import SEARCH_PATHS
 from pants.core.util_rules.system_binaries import ArchiveFormat as ArchiveFormat
-from pants.core.util_rules.system_binaries import (
-    BashBinary,
-    BashBinaryRequest,
-    TarBinary,
-    TarBinaryRequest,
-    UnzipBinary,
-    UnzipBinaryRequest,
-    ZipBinary,
-    ZipBinaryRequest,
-)
+from pants.core.util_rules.system_binaries import BashBinary, TarBinary, UnzipBinary, ZipBinary
 from pants.engine.fs import (
     CreateDigest,
     Digest,
@@ -66,10 +57,7 @@ async def create_archive(request: CreateArchive) -> Digest:
     input_digests = []
 
     if request.format == ArchiveFormat.ZIP:
-        zip_binary, bash_binary = await MultiGet(
-            Get(ZipBinary, ZipBinaryRequest()),
-            Get(BashBinary, BashBinaryRequest()),
-        )
+        zip_binary, bash_binary = await MultiGet(Get(ZipBinary), Get(BashBinary))
         env = {}
         argv: tuple[str, ...] = (
             bash_binary.path,
@@ -82,7 +70,7 @@ async def create_archive(request: CreateArchive) -> Digest:
             ),
         )
     else:
-        tar_binary = await Get(TarBinary, TarBinaryRequest())
+        tar_binary = await Get(TarBinary)
         argv = tar_binary.create_archive_argv(
             request.output_filename,
             request.format,
@@ -171,26 +159,17 @@ async def maybe_extract_archive(request: MaybeExtractArchiveRequest) -> Extracte
     env = {}
     immutable_input_digests: FrozenDict[str, Digest] = FrozenDict({})
     if is_zip:
-        input_digest, unzip_binary = await MultiGet(
-            merge_digest_get,
-            Get(UnzipBinary, UnzipBinaryRequest()),
-        )
+        input_digest, unzip_binary = await MultiGet(merge_digest_get, Get(UnzipBinary))
         argv = unzip_binary.extract_archive_argv(archive_path, extract_archive_dir)
     elif is_tar:
-        input_digest, tar_binary = await MultiGet(
-            merge_digest_get,
-            Get(TarBinary, TarBinaryRequest()),
-        )
+        input_digest, tar_binary = await MultiGet(merge_digest_get, Get(TarBinary))
         argv = tar_binary.extract_archive_argv(
             archive_path, extract_archive_dir, archive_suffix=archive_suffix
         )
         # `tar` expects to find a couple binaries like `gzip` and `xz` by looking on the PATH.
         env = {"PATH": os.pathsep.join(SEARCH_PATHS)}
     else:
-        input_digest, gunzip = await MultiGet(
-            merge_digest_get,
-            Get(GunzipBinary, GunzipBinaryRequest()),
-        )
+        input_digest, gunzip = await MultiGet(merge_digest_get, Get(GunzipBinary))
         argv = gunzip.extract_archive_argv(archive_path, extract_archive_dir)
         immutable_input_digests = gunzip.python_binary.immutable_input_digests
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -13,6 +13,7 @@ from enum import Enum
 from textwrap import dedent  # noqa: PNT20
 from typing import Iterable, Mapping, Sequence
 
+from pants.base.deprecated import warn_or_error
 from pants.core.subsystems import python_bootstrap
 from pants.core.subsystems.python_bootstrap import PythonBootstrap
 from pants.core.util_rules.environments import EnvironmentTarget
@@ -251,6 +252,13 @@ class BashBinary(BinaryPath):
 class BashBinaryRequest:
     search_path: SearchPath = BashBinary.DEFAULT_SEARCH_PATH
 
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(BashBinary, BashBinaryRequest)",
+            "Instead, simply use `Get(BashBinary)` or put `BashBinary` in the rule signature.",
+        )
+
 
 class PythonBinary(BinaryPath):
     """A Python3 interpreter for use by `@rule` code as an alternative to BashBinary scripts.
@@ -466,10 +474,15 @@ def _create_shim(bash: str, binary: str) -> bytes:
 
 
 @rule(desc="Finding the `bash` binary", level=LogLevel.DEBUG)
-async def find_bash(bash_request: BashBinaryRequest) -> BashBinary:
+async def find_bash(_: BashBinaryRequest, bash_binary: BashBinary) -> BashBinary:
+    return bash_binary
+
+
+@rule(desc="Finding the `bash` binary", level=LogLevel.DEBUG)
+async def get_bash() -> BashBinary:
     request = BinaryPathRequest(
         binary_name="bash",
-        search_path=bash_request.search_path,
+        search_path=BashBinary.DEFAULT_SEARCH_PATH,
         test=BinaryPathTest(args=["--version"]),
     )
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
@@ -477,12 +490,6 @@ async def find_bash(bash_request: BashBinaryRequest) -> BashBinary:
     if not first_path:
         raise BinaryNotFoundError.from_request(request)
     return BashBinary(first_path.path, first_path.fingerprint)
-
-
-@rule
-async def get_bash() -> BashBinary:
-    # Expose bash to external consumers.
-    return await Get(BashBinary, BashBinaryRequest())
 
 
 @rule
@@ -495,7 +502,7 @@ async def find_binary(request: BinaryPathRequest, env_target: EnvironmentTarget)
     if request.binary_name == "bash":
         shebang = "#!/usr/bin/env bash"
     else:
-        bash = await Get(BashBinary, BashBinaryRequest())
+        bash = await Get(BashBinary)
         shebang = f"#!{bash.path}"
 
     script_path = "./find_binary.sh"
@@ -781,57 +788,106 @@ async def find_git() -> GitBinary:
 
 
 # -------------------------------------------------------------------------------------------
-# Rules for lazy requests
-# TODO(#12946): Get rid of this when it becomes possible to use `Get()` with only one arg.
+# (Deprecated). Rules for lazy requests
 # -------------------------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
 class ZipBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(ZipBinary, ZipBinaryRequest)",
+            "Instead, simply use `Get(ZipBinary)` or put `ZipBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class UnzipBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(UnzipBinary, UnzipBinaryRequest)",
+            "Instead, simply use `Get(UnipBinary)` or put `UnzipBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class GunzipBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(GunzipBinary, GunzipBinaryRequest)",
+            "Instead, simply use `Get(GunzipBinary)` or put `GunzipBinary` in the rule signature",
+        )
 
 
 class CatBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(CatBinary, CatBinaryRequest)",
+            "Instead, simply use `Get(CatBinary)` or put `CatBinary` in the rule signature",
+        )
 
 
 class TarBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(TarBinary, TarBinaryRequest)",
+            "Instead, simply use `Get(TarBinary)` or put `TarBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class MkdirBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(MkdirBinary, MkdirBinaryRequest)",
+            "Instead, simply use `Get(MkdirBinary)` or put `MkdirBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class ChmodBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(ChmodBinary, ChmodBinaryRequest)",
+            "Instead, simply use `Get(ChmodBinary)` or put `ChmodBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class DiffBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(DiffBinary, DiffBinaryRequest)",
+            "Instead, simply use `Get(DiffBinary)` or put `DiffBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class ReadlinkBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(ReadlinkBinary, ReadlinkBinaryRequest)",
+            "Instead, simply use `Get(ReadlinkBinary)` or put `ReadlinkBinary` in the rule signature",
+        )
 
 
 @dataclass(frozen=True)
 class GitBinaryRequest:
-    pass
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(GitBinary, GitBinaryRequest)",
+            "Instead, simply use `Get(GitBinary)` or put `GitBinary` in the rule signature",
+        )
 
 
 @rule

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -450,8 +450,20 @@ async def resolve_targets(
     return Targets(expanded_targets)
 
 
+@rule(_masked_types=[EnvironmentName])
+def find_all_targets_deprecated(_: AllTargetsRequest, all_targets: AllTargets) -> AllTargets:
+    return all_targets
+
+
+@rule(_masked_types=[EnvironmentName])
+def find_all_unexpanded_targets_deprecated(
+    _: AllTargetsRequest, all_targets: AllUnexpandedTargets
+) -> AllUnexpandedTargets:
+    return all_targets
+
+
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG, _masked_types=[EnvironmentName])
-async def find_all_targets(_: AllTargetsRequest) -> AllTargets:
+async def find_all_targets() -> AllTargets:
     tgts = await Get(
         Targets,
         RawSpecsWithoutFileOwners(
@@ -461,8 +473,12 @@ async def find_all_targets(_: AllTargetsRequest) -> AllTargets:
     return AllTargets(tgts)
 
 
-@rule(desc="Find all targets in the project", level=LogLevel.DEBUG, _masked_types=[EnvironmentName])
-async def find_all_unexpanded_targets(_: AllTargetsRequest) -> AllUnexpandedTargets:
+@rule(
+    desc="Find all (unexpanded) targets in the project",
+    level=LogLevel.DEBUG,
+    _masked_types=[EnvironmentName],
+)
+async def find_all_unexpanded_targets() -> AllUnexpandedTargets:
     tgts = await Get(
         UnexpandedTargets,
         RawSpecsWithoutFileOwners(
@@ -470,16 +486,6 @@ async def find_all_unexpanded_targets(_: AllTargetsRequest) -> AllUnexpandedTarg
         ),
     )
     return AllUnexpandedTargets(tgts)
-
-
-@rule(_masked_types=[EnvironmentName])
-async def find_all_targets_singleton() -> AllTargets:
-    return await Get(AllTargets, AllTargetsRequest())
-
-
-@rule(_masked_types=[EnvironmentName])
-async def find_all_unexpanded_targets_singleton() -> AllUnexpandedTargets:
-    return await Get(AllUnexpandedTargets, AllTargetsRequest())
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1021,6 +1021,13 @@ class AllTargetsRequest:
     Use with either `AllUnexpandedTargets` or `AllTargets`.
     """
 
+    def __post_init__(self) -> None:
+        warn_or_error(
+            "2.18.0.dev0",
+            "using `Get(AllTargets, AllTargetsRequest)",
+            "Instead, simply use `Get(AllTargets)` or put `AllTargets` in the rule signature",
+        )
+
 
 # -----------------------------------------------------------------------------------------------
 # Target generation

--- a/src/python/pants/init/specs_calculator.py
+++ b/src/python/pants/init/specs_calculator.py
@@ -7,7 +7,7 @@ from typing import cast
 from pants.base.specs import AddressLiteralSpec, FileLiteralSpec, RawSpecs, Specs
 from pants.base.specs_parser import SpecsParser
 from pants.core.util_rules.environments import determine_bootstrap_environment
-from pants.core.util_rules.system_binaries import GitBinary, GitBinaryRequest
+from pants.core.util_rules.system_binaries import GitBinary
 from pants.engine.addresses import AddressInput
 from pants.engine.environment import EnvironmentName
 from pants.engine.internals.scheduler import SchedulerSession
@@ -58,9 +58,7 @@ def calculate_specs(
 
     bootstrap_environment = determine_bootstrap_environment(session)
 
-    (git_binary,) = session.product_request(
-        GitBinary, [Params(GitBinaryRequest(), bootstrap_environment)]
-    )
+    (git_binary,) = session.product_request(GitBinary, [Params(bootstrap_environment)])
     (maybe_git_worktree,) = session.product_request(
         MaybeGitWorktree, [Params(GitWorktreeRequest(), git_binary, bootstrap_environment)]
     )
@@ -109,6 +107,6 @@ def calculate_specs(
 def rules():
     return [
         QueryRule(ChangedAddresses, [ChangedRequest, EnvironmentName]),
-        QueryRule(GitBinary, [GitBinaryRequest, EnvironmentName]),
+        QueryRule(GitBinary, [EnvironmentName]),
         QueryRule(MaybeGitWorktree, [GitWorktreeRequest, GitBinary, EnvironmentName]),
     ]


### PR DESCRIPTION
Closes https://github.com/pantsbuild/pants/issues/17342.

I found the stale APIs based on my memory and using this regex: `rg '\bGet\(([A-Za-z0-9]+),\s*((?![A-Za-z0-9]*Sentinel\(\))[A-Za-z0-9]+)\(\)\)' --pcre2` (thanks ChatGPT4 🙇)