### PR TITLE
Helm: Add support for DNS lookups in Chart templates

### DIFF
--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -88,8 +88,12 @@ class HelmSubsystem(TemplatedExternalTool):
     options_scope = "helm"
     help = "The Helm command line (https://helm.sh)"
 
-    default_version = "3.10.0"
+    default_version = "3.11.1"
     default_known_versions = [
+        "3.11.1|linux_arm64 |919173e8fb7a3b54d76af9feb92e49e86d5a80c5185020bae8c393fa0f0de1e8|13484900",
+        "3.11.1|linux_x86_64|0b1be96b66fab4770526f136f5f1a385a47c41923d33aab0dcb500e0f6c1bf7c|15023104",
+        "3.11.1|macos_arm64 |43d0198a7a2ea2639caafa81bb0596c97bee2d4e40df50b36202343eb4d5c46b|14934852",
+        "3.11.1|macos_x86_64|2548a90e5cc957ccc5016b47060665a9d2cd4d5b4d61dcc32f5de3144d103826|15757902",
         "3.10.0|linux_arm64 |3b72f5f8a60772fb156d0a4ab93272e8da7ef4d18e6421a7020d7c019f521fc1|13055719",
         "3.10.0|linux_x86_64|bf56beb418bb529b5e0d6d43d56654c5a03f89c98400b409d1013a33d9586474|14530566",
         "3.10.0|macos_arm64 |f7f6558ebc8211824032a7fdcf0d55ad064cb33ec1eeec3d18057b9fe2e04dbe|14446277",

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -479,6 +479,12 @@ class HelmDeploymentPostRenderersField(SpecialCasedDependencies):
     )
 
 
+class HelmDeploymentEnableDNSField(BoolField):
+    alias = "enable_dns"
+    default = False
+    help = "Enables DNS lookups when using the `getHostByName` template function."
+
+
 class HelmDeploymentTarget(Target):
     alias = "helm_deployment"
     core_fields = (
@@ -493,6 +499,7 @@ class HelmDeploymentTarget(Target):
         HelmDeploymentNoHooksField,
         HelmDeploymentTimeoutField,
         HelmDeploymentPostRenderersField,
+        HelmDeploymentEnableDNSField,
     )
     help = "A Helm chart deployment."
 
@@ -514,6 +521,7 @@ class HelmDeploymentFieldSet(FieldSet):
     dependencies: HelmDeploymentDependenciesField
     values: HelmDeploymentValuesField
     post_renderers: HelmDeploymentPostRenderersField
+    enable_dns: HelmDeploymentEnableDNSField
 
     def format_values(
         self, interpolation_context: InterpolationContext, *, ignore_missing: bool = False

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -347,6 +347,7 @@ async def setup_render_helm_deployment_process(
             *(("--skip-crds",) if request.field_set.skip_crds.value else ()),
             *(("--no-hooks",) if request.field_set.no_hooks.value else ()),
             *(("--output-dir", output_dir) if output_dir else ()),
+            *(("--enable-dns",) if request.field_set.enable_dns.value else ()),
             *(
                 ("--post-renderer", os.path.join(".", request.post_renderer.exe))
                 if request.post_renderer


### PR DESCRIPTION
Helm 3.11.x added a new template function (`getHostByName`) to perform DNS lookups when rendering or deploying a Helm chart.

The feature is protected by a feature flag and, since this alters the result of a chart render action, it has been added as a field in the `helm_deployment` target (instead of a valid pass-through arg) to enforce repeatability.