### PR TITLE
Fix JVM resource JAR creation on older Mac OSes

### DIFF
--- a/src/python/pants/jvm/resources.py
+++ b/src/python/pants/jvm/resources.py
@@ -98,8 +98,9 @@ async def assemble_resources_jar(
                 "-c",
                 " ".join(
                     [
+                        "TZ=UTC",
                         touch.path,
-                        "-d 1980-01-01T00:00:00Z",
+                        "-t 198001010000.00",
                         input_filenames,
                         "&&",
                         "TZ=UTC",


### PR DESCRIPTION
This uses an obsolescent invocation of `touch` (that does not support timezone specs) to support older Mac OSes/systems with older BSD `touch` binaries.

Fixes #18671