### PR TITLE
Bump minimum supported version of Pex to v2.1.129.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,7 +37,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = "v2.1.131"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.124,<3.0"
+    version_constraints = ">=2.1.129,<3.0"
 
     @classproperty
     def default_known_versions(cls):


### PR DESCRIPTION
e8d387ba6b4d4502e3b6db5ae68ffe7beeeb10a7 made it so the "ambient" Python interpreter used to run Pex is always the scie-provided interpreter (currently Python 3.9). This increases the chances that the interpreter used to run Pex won't match the interpreter constraints configured for user code in Pants. Until Pex v2.1.129, this mismatch would cause errors when resolving / building VCS and local project requirements (see https://github.com/pantsbuild/pex/issues/2092). Bump the minimum supported version of Pex to the first with a fix for that issue, to prevent users pinning `[pex-cli].version` from silently breaking their setups by upgrading Pants without also upgrading Pex.

Resolves #18662