### PR TITLE
javascript: Use binary shims in nodejs sandboxes

### DIFF
--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -33,7 +33,6 @@ class DockerOptions(Subsystem):
     help = "Options for interacting with Docker."
 
     class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
-        env_vars_used_by_options = ("PATH",)
         _env_vars = ShellStrListOption(
             help=softwrap(
                 """

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -3,12 +3,11 @@
 
 from __future__ import annotations
 
-import os
 import sys
 from typing import Any
 
 from pants.backend.docker.registries import DockerRegistries
-from pants.engine.env_vars import EnvironmentVars
+from pants.core.util_rules.search_paths import ExecutableSearchPathsOptionMixin
 from pants.option.option_types import (
     BoolOption,
     DictOption,
@@ -20,7 +19,6 @@ from pants.option.option_types import (
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import bin_name
 from pants.util.memo import memoized_method
-from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import bullet_list, softwrap
 
 doc_links = {
@@ -34,7 +32,8 @@ class DockerOptions(Subsystem):
     options_scope = "docker"
     help = "Options for interacting with Docker."
 
-    class EnvironmentAware:
+    class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
+        env_vars_used_by_options = ("PATH",)
         _env_vars = ShellStrListOption(
             help=softwrap(
                 """
@@ -46,35 +45,15 @@ class DockerOptions(Subsystem):
             ),
             advanced=True,
         )
-        _executable_search_paths = StrListOption(
-            default=["<PATH>"],
-            help=softwrap(
-                """
-            The PATH value that will be used to find the Docker client and any tools required.
-
-            The special string `"<PATH>"` will expand to the contents of the PATH env var.
+        executable_search_paths_help = softwrap(
             """
-            ),
-            advanced=True,
-            metavar="<binary-paths>",
+            The PATH value that will be used to find the Docker client and any tools required.
+            """
         )
 
         @property
         def env_vars(self) -> tuple[str, ...]:
             return tuple(sorted(set(self._env_vars)))
-
-        @memoized_method
-        def executable_search_path(self, env: EnvironmentVars) -> tuple[str, ...]:
-            def iter_path_entries():
-                for entry in self._executable_search_paths:
-                    if entry == "<PATH>":
-                        path = env.get("PATH")
-                        if path:
-                            yield from path.split(os.pathsep)
-                    else:
-                        yield entry
-
-            return tuple(OrderedSet(iter_path_entries()))
 
     _registries = DictOption[Any](
         help=softwrap(

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -17,7 +17,6 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
@@ -129,8 +128,7 @@ async def find_docker(
     docker_options: DockerOptions,
     docker_options_env_aware: DockerOptions.EnvironmentAware,
 ) -> DockerBinary:
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(["PATH"]))
-    search_path = docker_options_env_aware.executable_search_path(env)
+    search_path = docker_options_env_aware.executable_search_path
     request = BinaryPathRequest(
         binary_name="docker",
         search_path=search_path,

--- a/src/python/pants/backend/javascript/dependency_inference/import_parser/rules_test.py
+++ b/src/python/pants/backend/javascript/dependency_inference/import_parser/rules_test.py
@@ -25,7 +25,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *import_parser_rules(),
             QueryRule(JSImportStrings, (ParseJsImportStrings,)),
@@ -33,6 +33,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JSSourceTarget, JSSourcesGeneratorTarget],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def test_installs_parser_modules(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules_test.py
@@ -27,7 +27,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *package_json.rules(),
             *dependency_inference_rules(),
@@ -38,6 +38,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[*package_json.target_types(), JSSourceTarget, JSSourcesGeneratorTarget],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def given_package(name: str, version: str, **kwargs: str | dict[str, str]) -> str:

--- a/src/python/pants/backend/javascript/goals/lockfile_test.py
+++ b/src/python/pants/backend/javascript/goals/lockfile_test.py
@@ -32,7 +32,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *lockfile.rules(),
             QueryRule(
@@ -53,6 +53,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[PackageJsonTarget],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def given_package_with_name(name: str) -> str:

--- a/src/python/pants/backend/javascript/goals/test_integration_test.py
+++ b/src/python/pants/backend/javascript/goals/test_integration_test.py
@@ -40,6 +40,7 @@ def rule_runner() -> RuleRunner:
         ],
         objects=dict(package_json.build_file_aliases().objects),
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
 
 
@@ -157,7 +158,7 @@ def test_mocha_tests_are_successful(rule_runner: RuleRunner) -> None:
 
 
 def test_jest_test_with_coverage_reporting(rule_runner: RuleRunner) -> None:
-    rule_runner.set_options(args=["--test-use-coverage", "True"])
+    rule_runner.set_options(args=["--test-use-coverage", "True"], env_inherit={"PATH"})
     rule_runner.write_files(
         {
             "foo/BUILD": textwrap.dedent(

--- a/src/python/pants/backend/javascript/package/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/package/rules_integration_test.py
@@ -26,7 +26,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *package_rules(),
             QueryRule(BuiltPackage, (NodePackageTarFieldSet,)),
@@ -41,6 +41,8 @@ def rule_runner() -> RuleRunner:
         ],
         objects=dict(package_json.build_file_aliases().objects),
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def test_packages_sources_as_resource_using_build_tool(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/package/rules_test.py
+++ b/src/python/pants/backend/javascript/package/rules_test.py
@@ -27,7 +27,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *package_rules(),
             QueryRule(BuiltPackage, (NodePackageTarFieldSet,)),
@@ -42,6 +42,8 @@ def rule_runner() -> RuleRunner:
         ],
         objects=dict(package_json.build_file_aliases().objects),
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def test_creates_tar_for_package_json(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/run/rules_test.py
+++ b/src/python/pants/backend/javascript/run/rules_test.py
@@ -19,7 +19,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *run_rules(),
             QueryRule(RunRequest, (RunNodeBuildScriptFieldSet,)),
@@ -31,6 +31,8 @@ def rule_runner() -> RuleRunner:
         ],
         objects=dict(package_json.build_file_aliases().objects),
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def test_creates_run_requests_package_json_scripts(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -23,6 +23,7 @@ from pants.core.util_rules.external_tool import (
 )
 from pants.core.util_rules.external_tool import rules as external_tool_rules
 from pants.core.util_rules.search_paths import (
+    ExecutableSearchPathsOptionMixin,
     ValidatedSearchPaths,
     ValidateSearchPathsRequest,
     VersionManagerSearchPaths,
@@ -34,6 +35,8 @@ from pants.core.util_rules.system_binaries import (
     BinaryPathRequest,
     BinaryPaths,
     BinaryPathTest,
+    BinaryShims,
+    BinaryShimsRequest,
 )
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest, PathEnvironmentVariable
 from pants.engine.fs import EMPTY_DIGEST, Digest, DownloadFile
@@ -117,7 +120,7 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
         download_file = DownloadFile(url, FileDigest(known_version.sha256, known_version.filesize))
         return await Get(DownloadedExternalTool, ExternalToolRequest(download_file, exe))
 
-    class EnvironmentAware(Subsystem.EnvironmentAware):
+    class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
         env_vars_used_by_options = ("PATH",)
 
         search_path = StrListOption(
@@ -152,6 +155,12 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
             ),
             advanced=True,
             metavar="<binary-paths>",
+        )
+
+        executable_search_paths_help = softwrap(
+            """
+            The PATH value that will be used to find any tools required to run nodejs processes.
+            """
         )
 
 
@@ -235,12 +244,13 @@ class NodeJSBinaries:
 class NodeJSProcessEnvironment:
     binaries: NodeJSBinaries
     npm_config_cache: str
+    tool_binaries: BinaryShims
 
     base_bin_dir: ClassVar[str] = "__node"
 
     def to_env_dict(self) -> dict[str, str]:
         return {
-            "PATH": f"/bin:{self.binary_directory}",
+            "PATH": f"{self.tool_binaries.path_component}:{self.binary_directory}",
             "npm_config_cache": self.npm_config_cache,  # Normally stored at ~/.npm
         }
 
@@ -253,12 +263,32 @@ class NodeJSProcessEnvironment:
         return self.binaries.binary_dir
 
     def immutable_digest(self) -> dict[str, Digest]:
-        return {self.base_bin_dir: self.binaries.digest} if self.binaries.digest else {}
+        return (
+            {self.base_bin_dir: self.binaries.digest, **self.tool_binaries.immutable_input_digests}
+            if self.binaries.digest
+            else {**self.tool_binaries.immutable_input_digests}
+        )
 
 
 @rule(level=LogLevel.DEBUG)
-async def node_process_environment(binaries: NodeJSBinaries) -> NodeJSProcessEnvironment:
-    return NodeJSProcessEnvironment(binaries=binaries, npm_config_cache="._npm")
+async def node_process_environment(
+    binaries: NodeJSBinaries, nodejs: NodeJS.EnvironmentAware
+) -> NodeJSProcessEnvironment:
+    binary_shims = await Get(
+        BinaryShims,
+        BinaryShimsRequest.for_binaries(
+            "sh",
+            "bash",
+            "mkdir",  # Some default scripts are generated using mkdir, rm & touch.
+            "rm",
+            "touch",
+            rationale="execute a nodejs process",
+            search_path=nodejs.executable_search_path,
+        ),
+    )
+    return NodeJSProcessEnvironment(
+        binaries=binaries, npm_config_cache="._npm", tool_binaries=binary_shims
+    )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -121,8 +121,6 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
         return await Get(DownloadedExternalTool, ExternalToolRequest(download_file, exe))
 
     class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
-        env_vars_used_by_options = ("PATH",)
-
         search_path = StrListOption(
             default=["<PATH>"],
             help=lambda cls: help_text(

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -43,7 +43,7 @@ from pants.util.contextutil import temporary_dir
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(
+    rule_runner = RuleRunner(
         rules=[
             *nodejs.rules(),
             *source_files.rules(),
@@ -55,6 +55,8 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[JSSourcesGeneratorTarget],
     )
+    rule_runner.set_options([], env_inherit={"PATH"})
+    return rule_runner
 
 
 def test_npx_process(rule_runner: RuleRunner):

--- a/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/npx_tool_test.py
@@ -30,7 +30,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_version_option_overrides_default(rule_runner: RuleRunner):
-    rule_runner.set_options(["--cowsay-version=cowsay@1.5.0"])
+    rule_runner.set_options(["--cowsay-version=cowsay@1.5.0"], env_inherit={"PATH"})
     tool = rule_runner.request(CowsayTool, [])
     assert tool.default_version == "cowsay@1.4.0"
     assert tool.version == "cowsay@1.5.0"

--- a/src/python/pants/backend/shell/subsystems/shell_setup.py
+++ b/src/python/pants/backend/shell/subsystems/shell_setup.py
@@ -3,12 +3,9 @@
 
 from __future__ import annotations
 
-import os
-
-from pants.option.option_types import BoolOption, StrListOption
+from pants.core.util_rules.search_paths import ExecutableSearchPathsOptionMixin
+from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
-from pants.util.memo import memoized_property
-from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import softwrap
 
 
@@ -31,32 +28,12 @@ class ShellSetup(Subsystem):
         advanced=True,
     )
 
-    class EnvironmentAware(Subsystem.EnvironmentAware):
+    class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
         env_vars_used_by_options = ("PATH",)
 
-        _executable_search_path = StrListOption(
-            default=["<PATH>"],
-            help=softwrap(
-                """
-                The PATH value that will be used to find shells and to run certain processes
-                like the shunit2 test runner.
-
-                The special string `"<PATH>"` will expand to the contents of the PATH env var.
-                """
-            ),
-            advanced=True,
-            metavar="<binary-paths>",
+        executable_search_paths_help = softwrap(
+            """
+            The PATH value that will be used to find shells
+            and to run certain processes like the shunit2 test runner.
+            """
         )
-
-        @memoized_property
-        def executable_search_path(self) -> tuple[str, ...]:
-            def iter_path_entries():
-                for entry in self._executable_search_path:
-                    if entry == "<PATH>":
-                        path = self._options_env.get("PATH")
-                        if path:
-                            yield from path.split(os.pathsep)
-                    else:
-                        yield entry
-
-            return tuple(OrderedSet(iter_path_entries()))

--- a/src/python/pants/backend/shell/subsystems/shell_setup.py
+++ b/src/python/pants/backend/shell/subsystems/shell_setup.py
@@ -29,8 +29,6 @@ class ShellSetup(Subsystem):
     )
 
     class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
-        env_vars_used_by_options = ("PATH",)
-
         executable_search_paths_help = softwrap(
             """
             The PATH value that will be used to find shells

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -10,10 +11,13 @@ from typing import Iterable
 from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
 from pants.engine.collection import DeduplicatedCollection
+from pants.engine.env_vars import EnvironmentVars
 from pants.engine.rules import Rule, _uncacheable_rule, collect_rules, rule
+from pants.option.option_types import StrListOption
 from pants.util.logging import LogLevel
-from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import softwrap
+from pants.util.memo import memoized_property
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.strutil import help_text, softwrap
 
 _logger = logging.getLogger(__name__)
 
@@ -140,6 +144,36 @@ async def validate_search_paths(request: ValidateSearchPathsRequest) -> Validate
         )
 
     return ValidatedSearchPaths(search_paths)
+
+
+class ExecutableSearchPathsOptionMixin:
+    executable_search_paths_help: str
+    _options_env: EnvironmentVars
+
+    executable_search_paths = StrListOption(
+        default=["<PATH>"],
+        help=lambda cls: help_text(
+            f"""
+            {cls.executable_search_paths_help}
+            The special string `"<PATH>"` will expand to the contents of the PATH env var.
+            """
+        ),
+        advanced=True,
+        metavar="<binary-paths>",
+    )
+
+    @memoized_property
+    def executable_search_path(self) -> tuple[str, ...]:
+        def iter_path_entries():
+            for entry in self.executable_search_paths:
+                if entry == "<PATH>":
+                    path = self._options_env.get("PATH")
+                    if path:
+                        yield from path.split(os.pathsep)
+                else:
+                    yield entry
+
+        return tuple(OrderedSet(iter_path_entries()))
 
 
 def rules() -> Iterable[Rule]:

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -6,7 +6,7 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
+from typing import Any, ClassVar, Iterable
 
 from pants.base.build_environment import get_buildroot
 from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
@@ -147,6 +147,20 @@ async def validate_search_paths(request: ValidateSearchPathsRequest) -> Validate
 
 
 class ExecutableSearchPathsOptionMixin:
+    env_vars_used_by_options: ClassVar[tuple[str, ...]] = ("PATH",)
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        if "PATH" not in cls.env_vars_used_by_options:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    {ExecutableSearchPathsOptionMixin.__name__} depends on the PATH environment variable.
+
+                    Please add it to the {cls.__name__}.env_vars_used_by_options.
+                    """
+                )
+            )
+
     executable_search_paths_help: str
     _options_env: EnvironmentVars
 

--- a/src/python/pants/core/util_rules/search_paths.py
+++ b/src/python/pants/core/util_rules/search_paths.py
@@ -150,7 +150,7 @@ class ExecutableSearchPathsOptionMixin:
     executable_search_paths_help: str
     _options_env: EnvironmentVars
 
-    executable_search_paths = StrListOption(
+    _executable_search_paths = StrListOption(
         default=["<PATH>"],
         help=lambda cls: help_text(
             f"""
@@ -165,7 +165,7 @@ class ExecutableSearchPathsOptionMixin:
     @memoized_property
     def executable_search_path(self) -> tuple[str, ...]:
         def iter_path_entries():
-            for entry in self.executable_search_paths:
+            for entry in self._executable_search_paths:
                 if entry == "<PATH>":
                     path = self._options_env.get("PATH")
                     if path:


### PR DESCRIPTION
Use `BinaryShims` instead of adding "/bin" to PATH in the nodejs sandbox.

Addresses https://github.com/pantsbuild/pants/issues/18609, https://github.com/pantsbuild/pants/issues/18597