### PR TITLE
Tweak version ranges for python tools

### DIFF
--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -50,7 +50,7 @@ class Bandit(PythonToolBase):
 
     # When upgrading, check if Bandit has started using PEP 517 (a `pyproject.toml` file). If so,
     # remove `setuptools` from `default_extra_requirements`.
-    default_version = "bandit>=1.7.0,<1.8"
+    default_version = "bandit>=1.7.0,<2"
     default_extra_requirements = [
         "setuptools",
         # GitPython 3.1.20 was yanked because it breaks Python 3.8+, but Poetry's lockfile

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -54,9 +54,9 @@ class Ruff(PythonToolBase):
     name = "Ruff"
     help = "The Ruff Python formatter (https://github.com/charliermarsh/ruff)."
 
-    default_version = "ruff==0.0.254"
+    default_version = "ruff>=0.0.213,<1"
     default_main = ConsoleScript("ruff")
-    default_requirements = ["ruff>=0.0.213,<0.1"]
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -13,9 +13,9 @@ class SetuptoolsSCM(PythonToolBase):
         "A tool for generating versions from VCS metadata (https://github.com/pypa/setuptools_scm)."
     )
 
-    default_version = "setuptools-scm==7.1.0"
+    default_version = "setuptools-scm>=6.4.2,<8"
     default_main = EntryPoint("setuptools_scm")
-    default_requirements = ["setuptools-scm>=6.4.2,<8"]
+    default_requirements = [default_version]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -27,7 +27,7 @@ class TwineSubsystem(PythonToolBase):
     # requirements.
     # See: https://github.com/pantsbuild/pants/pull/13594#issuecomment-968154931
     default_extra_requirements = ["colorama>=0.4.3"]
-    default_requirements = ["twine>=3.7.1,<5", *default_extra_requirements]
+    default_requirements = [default_version, *default_extra_requirements]
 
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -93,9 +93,9 @@ class MyPy(PythonToolBase):
     name = "MyPy"
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
-    default_version = "mypy>=1.1.1,<2"
+    default_version = "mypy==1.1.1"
     default_main = ConsoleScript("mypy")
-    default_requirements = [default_version]
+    default_requirements = ["mypy>=0.961,<2"]
 
     # See `mypy/rules.py`. We only use these default constraints in some situations.
     register_interpreter_constraints = True

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -93,9 +93,9 @@ class MyPy(PythonToolBase):
     name = "MyPy"
     help = "The MyPy Python type checker (http://mypy-lang.org/)."
 
-    default_version = "mypy==1.1.1"
+    default_version = "mypy>=1.1.1,<2"
     default_main = ConsoleScript("mypy")
-    default_requirements = ["mypy>=0.961,<2"]
+    default_requirements = [default_version]
 
     # See `mypy/rules.py`. We only use these default constraints in some situations.
     register_interpreter_constraints = True


### PR DESCRIPTION
this will allow pants users to upgrade those tools when using the new install_from_resolve feature. At least upgrade between minor versions, which for the most part should be safe. instead of https://github.com/pantsbuild/pants/pull/18680
this also reduces repetition in some places by reusing the `default_version` when setting the value for `default_requirements`