### PR TITLE
No need to use lambda when setting help text for ruff

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -73,12 +73,12 @@ class Ruff(PythonToolBase):
     config = FileOption(
         default=None,
         advanced=True,
-        help=lambda cls: softwrap(
+        help=softwrap(
             f"""
             Path to the `pyproject.toml` or `ruff.toml` file to use for configuration
             (https://github.com/charliermarsh/ruff#configuration).
 
-            Setting this option will disable `[{cls.options_scope}].config_discovery`. Use
+            Setting this option will disable `[{options_scope}].config_discovery`. Use
             this option if the config is located in a non-standard location.
             """
         ),
@@ -86,12 +86,12 @@ class Ruff(PythonToolBase):
     config_discovery = BoolOption(
         default=True,
         advanced=True,
-        help=lambda cls: softwrap(
+        help=softwrap(
             f"""
             If true, Pants will include any relevant config files during
             runs (`pyproject.toml`, and `ruff.toml`).
 
-            Use `[{cls.options_scope}].config` instead if your config is in a
+            Use `[{options_scope}].config` instead if your config is in a
             non-standard location.
             """
         ),


### PR DESCRIPTION
not sure why a lambda function was used here... it works just fine w/o it (and dropping the `cls.` when using the option scope)..
![Screenshot 2023-04-06 at 10 27 12 AM](https://user-images.githubusercontent.com/1268088/230408424-fb124d86-018d-48c5-9443-1b080e83aa20.png)

Am I missing something ?