### PR TITLE
Adds a fully-qualified path to a Python interpreter for `pex_binary` `RunRequest`s

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool_integration_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_integration_test.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+
+
+def test_pex_binary() -> None:
+    sources = {
+        "src/hello.py": dedent(
+            """\
+            print("Hello, World!")
+            """
+        ),
+        "src/BUILD": dedent(
+            """\
+            python_sources()
+
+            pex_binary(
+                name="pex",
+                entry_point="hello.py",
+            )
+
+            adhoc_tool(
+                name="adhoc",
+                runnable=":pex",
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python',]",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        assert result.exit_code == 0

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -118,8 +118,11 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
 @dataclass(frozen=True)
 class PexFromTargetsRequestForBuiltPackage:
     """An intermediate class that gives consumers access to the data used to create a
-    `PexFromTargetsRequest` to fulfil a `BuiltPackage` request. This class is used directly by
-    `run_pex_binary`, but should be handled transparently by direct `BuiltPackage` requests."""
+    `PexFromTargetsRequest` to fulfil a `BuiltPackage` request.
+
+    This class is used directly by `run_pex_binary`, but should be handled transparently by direct
+    `BuiltPackage` requests.
+    """
 
     request: PexFromTargetsRequest
 

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -8,7 +8,6 @@ from pants.backend.python.goals.package_pex_binary import (
     PexFromTargetsRequestForBuiltPackage,
 )
 from pants.backend.python.target_types import PexLayout
-from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.backend.python.util_rules.pex_from_targets import InterpreterConstraintsRequest
 from pants.core.goals.package import BuiltPackage
@@ -24,12 +23,11 @@ async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequ
 
     # We need a Python executable to fulfil `adhoc_tool`/`runnable_dependency` requests
     # as sandboxed processes will not have a `python` available on the `PATH`.
-    interpreter_constraints = await Get(
-        InterpreterConstraints,
+    python = await Get(
+        PythonExecutable,
         InterpreterConstraintsRequest,
         pex_request.request.to_interpreter_constraints_request(),
     )
-    python = await Get(PythonExecutable, InterpreterConstraints, interpreter_constraints)
 
     relpath = built_pex.artifacts[0].relpath
     assert relpath is not None


### PR DESCRIPTION
Fixes #18683 by adding a rule that extracts the `PexFromTargetsRequest` from our `BuiltPackage` rule for `pex_binary` targets. This allows us to construct an `InterpreterConstraints` and hence a `PythonExecutable` identical to that which was used to request the PEX itself.

Adding the indirection to the `BuiltPackage` rule does not have any apparent impact on `pants package` requests for `pex_binary` targets.