### PR TITLE
Adds a fully-qualified path to a Python interpreter for `pex_binary` `RunRequest`s (Cherry-pick of #18699)

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool_integration_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_integration_test.py
@@ -1,0 +1,41 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from textwrap import dedent
+
+from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
+
+
+def test_pex_binary() -> None:
+    sources = {
+        "src/hello.py": dedent(
+            """\
+            print("Hello, World!")
+            """
+        ),
+        "src/BUILD": dedent(
+            """\
+            python_sources()
+
+            pex_binary(
+                name="pex",
+                entry_point="hello.py",
+            )
+
+            adhoc_tool(
+                name="adhoc",
+                runnable=":pex",
+            )
+            """
+        ),
+    }
+
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=['pants.backend.experimental.adhoc', 'pants.backend.python',]",
+            f"--source-root-patterns=['{tmpdir}/src']",
+            "export-codegen",
+            f"{tmpdir}/src:adhoc",
+        ]
+        result = run_pants(args)
+        assert result.exit_code == 0

--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -115,12 +115,24 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
         return tuple(args)
 
 
+@dataclass(frozen=True)
+class PexFromTargetsRequestForBuiltPackage:
+    """An intermediate class that gives consumers access to the data used to create a
+    `PexFromTargetsRequest` to fulfil a `BuiltPackage` request.
+
+    This class is used directly by `run_pex_binary`, but should be handled transparently by direct
+    `BuiltPackage` requests.
+    """
+
+    request: PexFromTargetsRequest
+
+
 @rule(level=LogLevel.DEBUG)
 async def package_pex_binary(
     field_set: PexBinaryFieldSet,
     pex_binary_defaults: PexBinaryDefaults,
     union_membership: UnionMembership,
-) -> BuiltPackage:
+) -> PexFromTargetsRequestForBuiltPackage:
     resolved_pex_entry_point_get = Get(
         ResolvedPexEntryPoint, ResolvePexEntryPointRequest(field_set.entry_point)
     )
@@ -163,25 +175,32 @@ async def package_pex_binary(
         CompletePlatforms, PexCompletePlatformsField, field_set.complete_platforms
     )
 
-    pex = await Get(
-        Pex,
-        PexFromTargetsRequest(
-            addresses=[field_set.address],
-            internal_only=False,
-            main=resolved_entry_point.val or field_set.script.value,
-            inject_args=field_set.args.value or [],
-            inject_env=field_set.env.value or FrozenDict[str, str](),
-            platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
-            complete_platforms=complete_platforms,
-            output_filename=output_filename,
-            layout=PexLayout(field_set.layout.value),
-            additional_args=field_set.generate_additional_args(pex_binary_defaults),
-            include_requirements=field_set.include_requirements.value,
-            include_source_files=field_set.include_sources.value,
-            include_local_dists=True,
-        ),
+    request = PexFromTargetsRequest(
+        addresses=[field_set.address],
+        internal_only=False,
+        main=resolved_entry_point.val or field_set.script.value,
+        inject_args=field_set.args.value or [],
+        inject_env=field_set.env.value or FrozenDict[str, str](),
+        platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
+        complete_platforms=complete_platforms,
+        output_filename=output_filename,
+        layout=PexLayout(field_set.layout.value),
+        additional_args=field_set.generate_additional_args(pex_binary_defaults),
+        include_requirements=field_set.include_requirements.value,
+        include_source_files=field_set.include_sources.value,
+        include_local_dists=True,
     )
-    return BuiltPackage(pex.digest, (BuiltPackageArtifact(output_filename),))
+
+    return PexFromTargetsRequestForBuiltPackage(request)
+
+
+@rule
+async def built_pacakge_for_pex_from_targets_request(
+    request: PexFromTargetsRequestForBuiltPackage,
+) -> BuiltPackage:
+    pft_request = request.request
+    pex = await Get(Pex, PexFromTargetsRequest, pft_request)
+    return BuiltPackage(pex.digest, (BuiltPackageArtifact(pft_request.output_filename),))
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/run_pex_binary.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary.py
@@ -3,8 +3,13 @@
 
 import os
 
-from pants.backend.python.goals.package_pex_binary import PexBinaryFieldSet
+from pants.backend.python.goals.package_pex_binary import (
+    PexBinaryFieldSet,
+    PexFromTargetsRequestForBuiltPackage,
+)
 from pants.backend.python.target_types import PexLayout
+from pants.backend.python.util_rules.pex_environment import PythonExecutable
+from pants.backend.python.util_rules.pex_from_targets import InterpreterConstraintsRequest
 from pants.core.goals.package import BuiltPackage
 from pants.core.goals.run import RunRequest
 from pants.engine.rules import Get, collect_rules, rule
@@ -13,7 +18,17 @@ from pants.util.logging import LogLevel
 
 @rule(level=LogLevel.DEBUG)
 async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequest:
-    built_pex = await Get(BuiltPackage, PexBinaryFieldSet, field_set)
+    pex_request = await Get(PexFromTargetsRequestForBuiltPackage, PexBinaryFieldSet, field_set)
+    built_pex = await Get(BuiltPackage, PexFromTargetsRequestForBuiltPackage, pex_request)
+
+    # We need a Python executable to fulfil `adhoc_tool`/`runnable_dependency` requests
+    # as sandboxed processes will not have a `python` available on the `PATH`.
+    python = await Get(
+        PythonExecutable,
+        InterpreterConstraintsRequest,
+        pex_request.request.to_interpreter_constraints_request(),
+    )
+
     relpath = built_pex.artifacts[0].relpath
     assert relpath is not None
     if field_set.layout.value != PexLayout.ZIPAPP.value:
@@ -21,7 +36,7 @@ async def create_pex_binary_run_request(field_set: PexBinaryFieldSet) -> RunRequ
 
     return RunRequest(
         digest=built_pex.digest,
-        args=[os.path.join("{chroot}", relpath)],
+        args=[python.path, os.path.join("{chroot}", relpath)],
     )
 
 


### PR DESCRIPTION
Fixes #18683 by adding a rule that extracts the `PexFromTargetsRequest` from our `BuiltPackage` rule for `pex_binary` targets. This allows us to construct an `InterpreterConstraints` and hence a `PythonExecutable` identical to that which was used to request the PEX itself.

Adding the indirection to the `BuiltPackage` rule does not have any apparent impact on `pants package` requests for `pex_binary` targets.
