### PR TITLE
A RuleRunner subclass to set ICs in Python-related tests.

### DIFF
--- a/src/python/pants/testutil/python_rule_runner.py
+++ b/src/python/pants/testutil/python_rule_runner.py
@@ -12,10 +12,6 @@ from pants.testutil.rule_runner import RuleRunner
 class PythonRuleRunner(RuleRunner):
     """Set common python rule-specific options."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.set_options([])
-
     def create_options_bootstrapper(
         self, args: Iterable[str], env: Mapping[str, str] | None
     ) -> OptionsBootstrapper:

--- a/src/python/pants/testutil/python_rule_runner.py
+++ b/src/python/pants/testutil/python_rule_runner.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from pants.testutil.rule_runner import RuleRunner
+
+
+class PythonRuleRunner(RuleRunner):
+    """Set common python rule-specific options."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.set_options([])
+
+    def set_options(
+        self,
+        args: Iterable[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        env_inherit: set[str] | None = None,
+    ) -> None:
+        env = dict(env) if env else {}
+        if (
+            not any("--python-interpreter-constraints=" in arg for arg in args)
+            and "PANTS_PYTHON_INTERPRETER_CONSTRAINTS" not in env
+        ):
+            # We inject the test ICs via env and not args, because in a handful of cases
+            # we have different behavior when the option is set via flag.
+            env["PANTS_PYTHON_INTERPRETER_CONSTRAINTS"] = "['>=3.7,<3.10',]"
+        super().set_options(args, env=env, env_inherit=env_inherit)

--- a/src/python/pants/testutil/python_rule_runner.py
+++ b/src/python/pants/testutil/python_rule_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping
 
+from pants.option.options_bootstrapper import OptionsBootstrapper
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -15,13 +16,9 @@ class PythonRuleRunner(RuleRunner):
         super().__init__(*args, **kwargs)
         self.set_options([])
 
-    def set_options(
-        self,
-        args: Iterable[str],
-        *,
-        env: Mapping[str, str] | None = None,
-        env_inherit: set[str] | None = None,
-    ) -> None:
+    def create_options_bootstrapper(
+        self, args: Iterable[str], env: Mapping[str, str] | None
+    ) -> OptionsBootstrapper:
         env = dict(env) if env else {}
         if (
             not any("--python-interpreter-constraints=" in arg for arg in args)
@@ -30,4 +27,4 @@ class PythonRuleRunner(RuleRunner):
             # We inject the test ICs via env and not args, because in a handful of cases
             # we have different behavior when the option is set via flag.
             env["PANTS_PYTHON_INTERPRETER_CONSTRAINTS"] = "['>=3.7,<3.10',]"
-        super().set_options(args, env=env, env_inherit=env_inherit)
+        return super().create_options_bootstrapper(args=args, env=env)

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -316,7 +316,7 @@ class RuleRunner:
         self.build_config = build_config_builder.create()
 
         self.environment = CompleteEnvironmentVars({})
-        self.options_bootstrapper = create_options_bootstrapper(args=bootstrap_args)
+        self.options_bootstrapper = self.create_options_bootstrapper(args=bootstrap_args, env=None)
         self.extra_session_values = extra_session_values or {}
         self.inherent_environment = inherent_environment
         self.max_workunit_verbosity = max_workunit_verbosity
@@ -442,6 +442,11 @@ class RuleRunner:
         console.flush()
         return GoalRuleResult(exit_code, stdout.getvalue(), stderr.getvalue())
 
+    def create_options_bootstrapper(
+        self, args: Iterable[str], env: Mapping[str, str] | None
+    ) -> OptionsBootstrapper:
+        return create_options_bootstrapper(args=args, env=env)
+
     def set_options(
         self,
         args: Iterable[str],
@@ -465,7 +470,7 @@ class RuleRunner:
             **{k: os.environ[k] for k in (env_inherit or set()) if k in os.environ},
             **(env or {}),
         }
-        self.options_bootstrapper = create_options_bootstrapper(args=args, env=env)
+        self.options_bootstrapper = self.create_options_bootstrapper(args=args, env=env)
         self.environment = CompleteEnvironmentVars(env)
         self._set_new_session(self.scheduler.scheduler)
 


### PR DESCRIPTION
Subsequent PRs will apply this in relevant tests, so we can remove
one of the hacks introduced in #18627.

I have applied this to several tests and verified that it works.