### PR TITLE
Add `tool_id` `classproperty` to `LintRequest`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -41,6 +41,10 @@ class BufFormatRequest(FmtTargetsRequest):
     def tool_name(cls) -> str:
         return "buf-format"
 
+    @classproperty
+    def tool_id(cls) -> str:
+        return "buf format"
+
 
 @rule
 async def partition_buf(

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules.py
@@ -39,11 +39,11 @@ class BufFormatRequest(FmtTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "buf-format"
+        return "buf format"
 
     @classproperty
     def tool_id(cls) -> str:
-        return "buf format"
+        return "buf-format"
 
 
 @rule

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -42,6 +42,10 @@ class BufLintRequest(LintTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
+        return "buf lint"
+
+    @classproperty
+    def tool_id(cls) -> str:
         return "buf-lint"
 
 

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -13,7 +13,7 @@ import colors
 from pants.core.goals.lint import REPORT_DIR as REPORT_DIR  # noqa: F401
 from pants.core.goals.multi_tool_goal_helper import (
     OnlyOption,
-    determine_specified_tool_slugs,
+    determine_specified_tool_ids,
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -186,14 +186,14 @@ async def check(
     check_subsystem: CheckSubsystem,
 ) -> Check:
     request_types = cast("Iterable[type[CheckRequest]]", union_membership[CheckRequest])
-    specified_slugs = determine_specified_tool_slugs("check", check_subsystem.only, request_types)
+    specified_slugs = determine_specified_tool_ids("check", check_subsystem.only, request_types)
 
     requests = tuple(
         request_type(
             request_type.field_set_type.create(target)
             for target in targets
             if (
-                request_type.tool_slug in specified_slugs
+                request_type.tool_id in specified_slugs
                 and request_type.field_set_type.is_applicable(target)
             )
         )

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -30,6 +30,7 @@ from pants.engine.target import FieldSet, FilteredTargets
 from pants.engine.unions import UnionMembership, union
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
+from pants.util.meta import classproperty
 from pants.util.strutil import strip_v2_chroot_path
 
 logger = logging.getLogger(__name__)
@@ -147,6 +148,11 @@ class CheckRequest(Generic[_FS], EngineAwareParameter):
 
     field_set_type: ClassVar[type[_FS]]  # type: ignore[misc]
     tool_name: ClassVar[str]
+
+    @classproperty
+    def tool_id(cls) -> str:
+        """The "id" of the tool, used in tool selection (Eg --only=<id>)."""
+        return cls.tool_name
 
     field_sets: Collection[_FS]
 

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -13,7 +13,7 @@ import colors
 from pants.core.goals.lint import REPORT_DIR as REPORT_DIR  # noqa: F401
 from pants.core.goals.multi_tool_goal_helper import (
     OnlyOption,
-    determine_specified_tool_names,
+    determine_specified_tool_slugs,
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -186,14 +186,14 @@ async def check(
     check_subsystem: CheckSubsystem,
 ) -> Check:
     request_types = cast("Iterable[type[CheckRequest]]", union_membership[CheckRequest])
-    specified_names = determine_specified_tool_names("check", check_subsystem.only, request_types)
+    specified_slugs = determine_specified_tool_slugs("check", check_subsystem.only, request_types)
 
     requests = tuple(
         request_type(
             request_type.field_set_type.create(target)
             for target in targets
             if (
-                request_type.tool_name in specified_names
+                request_type.tool_slug in specified_slugs
                 and request_type.field_set_type.is_applicable(target)
             )
         )

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -186,14 +186,14 @@ async def check(
     check_subsystem: CheckSubsystem,
 ) -> Check:
     request_types = cast("Iterable[type[CheckRequest]]", union_membership[CheckRequest])
-    specified_slugs = determine_specified_tool_ids("check", check_subsystem.only, request_types)
+    specified_ids = determine_specified_tool_ids("check", check_subsystem.only, request_types)
 
     requests = tuple(
         request_type(
             request_type.field_set_type.create(target)
             for target in targets
             if (
-                request_type.tool_id in specified_slugs
+                request_type.tool_id in specified_ids
                 and request_type.field_set_type.is_applicable(target)
             )
         )

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -67,7 +67,8 @@ class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
 
 
 class SuccessfulRequest(MockCheckRequest):
-    tool_name = "SuccessfulChecker"
+    tool_name = "Successful Checker"
+    tool_id = "successfulchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -75,7 +76,8 @@ class SuccessfulRequest(MockCheckRequest):
 
 
 class FailingRequest(MockCheckRequest):
-    tool_name = "FailingChecker"
+    tool_name = "Failing Checker"
+    tool_id = "failingchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -83,7 +85,8 @@ class FailingRequest(MockCheckRequest):
 
 
 class ConditionallySucceedsRequest(MockCheckRequest):
-    tool_name = "ConditionallySucceedsChecker"
+    tool_name = "Conditionally Succeeds Checker"
+    tool_id = "conditionallysucceedschecker"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -93,7 +96,8 @@ class ConditionallySucceedsRequest(MockCheckRequest):
 
 
 class SkippedRequest(MockCheckRequest):
-    tool_name = "SkippedChecker"
+    tool_name = "Skipped Checker"
+    tool_id = "skippedchecker"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -114,7 +118,8 @@ class InvalidFieldSet(MockCheckFieldSet):
 
 class InvalidRequest(MockCheckRequest):
     field_set_type = InvalidFieldSet
-    tool_name = "InvalidChecker"
+    tool_name = "Invalid Checker"
+    tool_id = "invalidchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -190,22 +195,22 @@ def test_summary() -> None:
     assert stderr == dedent(
         """\
 
-        ✕ ConditionallySucceedsChecker failed.
-        ✕ FailingChecker failed.
-        ✓ SuccessfulChecker succeeded.
+        ✕ Conditionally Succeeds Checker failed.
+        ✕ Failing Checker failed.
+        ✓ Successful Checker succeeded.
         """
     )
 
     exit_code, stderr = run_typecheck_rule(
         request_types=requests,
         targets=targets,
-        only=[FailingRequest.tool_name, SuccessfulRequest.tool_name],
+        only=[FailingRequest.tool_id, SuccessfulRequest.tool_id],
     )
     assert stderr == dedent(
         """\
 
-        ✕ FailingChecker failed.
-        ✓ SuccessfulChecker succeeded.
+        ✕ Failing Checker failed.
+        ✓ Successful Checker succeeded.
         """
     )
 

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -34,6 +34,7 @@ from pants.engine.unions import UnionMembership
 from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 
 
 class MockMultipleSourcesField(MultipleSourcesField):
@@ -68,7 +69,10 @@ class MockCheckRequest(CheckRequest, metaclass=ABCMeta):
 
 class SuccessfulRequest(MockCheckRequest):
     tool_name = "Successful Checker"
-    tool_id = "successfulchecker"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "successfulchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -77,7 +81,10 @@ class SuccessfulRequest(MockCheckRequest):
 
 class FailingRequest(MockCheckRequest):
     tool_name = "Failing Checker"
-    tool_id = "failingchecker"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "failingchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -86,7 +93,10 @@ class FailingRequest(MockCheckRequest):
 
 class ConditionallySucceedsRequest(MockCheckRequest):
     tool_name = "Conditionally Succeeds Checker"
-    tool_id = "conditionallysucceedschecker"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "conditionallysucceedschecker"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -97,7 +107,10 @@ class ConditionallySucceedsRequest(MockCheckRequest):
 
 class SkippedRequest(MockCheckRequest):
     tool_name = "Skipped Checker"
-    tool_id = "skippedchecker"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "skippedchecker"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -119,7 +132,10 @@ class InvalidFieldSet(MockCheckFieldSet):
 class InvalidRequest(MockCheckRequest):
     field_set_type = InvalidFieldSet
     tool_name = "Invalid Checker"
-    tool_id = "invalidchecker"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "invalidchecker"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:

--- a/src/python/pants/core/goals/fix_test.py
+++ b/src/python/pants/core/goals/fix_test.py
@@ -69,7 +69,11 @@ class FortranFixRequest(FixTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "FortranConditionallyDidChange"
+        return "Fortran Conditionally Did Change"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "fortranconditionallydidchange"
 
 
 class FortranFmtRequest(FmtTargetsRequest):
@@ -77,7 +81,11 @@ class FortranFmtRequest(FmtTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "FortranFormatter"
+        return "Fortran Formatter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "fortranformatter"
 
 
 @rule
@@ -138,7 +146,11 @@ class SmalltalkNoopRequest(FixTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "SmalltalkDidNotChange"
+        return "Smalltalk Did Not Change"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "smalltalkdidnotchange"
 
 
 @rule
@@ -163,7 +175,11 @@ class SmalltalkSkipRequest(FixTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "SmalltalkSkipped"
+        return "Smalltalk Skipped"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "smalltalkskipped"
 
 
 @rule
@@ -181,7 +197,11 @@ class BrickyBuildFileFixer(FixFilesRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "BrickyBobby"
+        return "Bricky Bobby"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "brickybobby"
 
 
 @rule
@@ -288,10 +308,10 @@ def test_summary() -> None:
     assert stderr == dedent(
         """\
 
-        + BrickyBobby made changes.
-        + FortranConditionallyDidChange made changes.
-        ✓ FortranFormatter made no changes.
-        ✓ SmalltalkDidNotChange made no changes.
+        + Bricky Bobby made changes.
+        + Fortran Conditionally Did Change made changes.
+        ✓ Fortran Formatter made no changes.
+        ✓ Smalltalk Did Not Change made no changes.
         """
     )
 
@@ -342,8 +362,8 @@ def test_fixers_first() -> None:
     assert stderr == dedent(
         """\
 
-        + FortranConditionallyDidChange made changes.
-        ✓ FortranFormatter made no changes.
+        + Fortran Conditionally Did Change made changes.
+        ✓ Fortran Formatter made no changes.
         """
     )
 
@@ -364,9 +384,9 @@ def test_only() -> None:
     stderr = run_fix(
         rule_runner,
         target_specs=["::"],
-        only=[SmalltalkNoopRequest.tool_name],
+        only=[SmalltalkNoopRequest.tool_id],
     )
-    assert stderr.strip() == "✓ SmalltalkDidNotChange made no changes."
+    assert stderr.strip() == "✓ Smalltalk Did Not Change made no changes."
 
 
 def test_no_targets() -> None:

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -176,7 +176,7 @@ class LintRequest:
     @classproperty
     def tool_id(cls) -> str:
         """The "id" of the tool, used in tool selection (Eg --only=<id>)."""
-        return
+        return cls.tool_subsystem.options_scope
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
     class Batch(_BatchBase[PartitionElementT, PartitionMetadataT]):

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -175,10 +175,7 @@ class LintRequest:
 
     @classproperty
     def tool_id(cls) -> str:
-        """The "id" of the tool, used in tool selection (E.g.
-
-        --only=<id>).
-        """
+        """The "id" of the tool, used in tool selection (Eg --only=<id>)."""
         return
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -15,7 +15,7 @@ from pants.core.goals.multi_tool_goal_helper import (
     BatchSizeOption,
     OnlyOption,
     SkippableSubsystem,
-    determine_specified_tool_names,
+    determine_specified_tool_slugs,
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -170,6 +170,12 @@ class LintRequest:
 
     @classproperty
     def tool_name(cls) -> str:
+        """The user-facing "name" of the tool."""
+        return cls.tool_subsystem.options_scope
+
+    @classproperty
+    def tool_slug(cls) -> str:
+        """The "slug" of the tool, used in tool selection (E.g. --only=<slug>)."""
         return cls.tool_subsystem.options_scope
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
@@ -326,7 +332,7 @@ async def _get_partitions_by_request_type(
     make_targets_partition_request_get: Callable[[_TargetPartitioner], Get[Partitions]],
     make_files_partition_request_get: Callable[[_FilePartitioner], Get[Partitions]],
 ) -> dict[type[_CoreRequestType], list[Partitions]]:
-    specified_names = determine_specified_tool_names(
+    specified_slugs = determine_specified_tool_slugs(
         subsystem.name,
         subsystem.only,
         core_request_types,
@@ -335,7 +341,7 @@ async def _get_partitions_by_request_type(
     filtered_core_request_types = [
         request_type
         for request_type in core_request_types
-        if request_type.tool_name in specified_names
+        if request_type.tool_slug in specified_slugs
     ]
     if not filtered_core_request_types:
         return {}

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -175,8 +175,8 @@ class LintRequest:
 
     @classproperty
     def tool_id(cls) -> str:
-        """The "slug" of the tool, used in tool selection (E.g. --only=<slug>)."""
-        return cls.tool_subsystem.options_scope
+        """The "id" of the tool, used in tool selection (E.g. --only=<id>)."""
+        return
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
     class Batch(_BatchBase[PartitionElementT, PartitionMetadataT]):
@@ -332,7 +332,7 @@ async def _get_partitions_by_request_type(
     make_targets_partition_request_get: Callable[[_TargetPartitioner], Get[Partitions]],
     make_files_partition_request_get: Callable[[_FilePartitioner], Get[Partitions]],
 ) -> dict[type[_CoreRequestType], list[Partitions]]:
-    specified_slugs = determine_specified_tool_ids(
+    specified_ids = determine_specified_tool_ids(
         subsystem.name,
         subsystem.only,
         core_request_types,
@@ -341,7 +341,7 @@ async def _get_partitions_by_request_type(
     filtered_core_request_types = [
         request_type
         for request_type in core_request_types
-        if request_type.tool_id in specified_slugs
+        if request_type.tool_id in specified_ids
     ]
     if not filtered_core_request_types:
         return {}

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -15,7 +15,7 @@ from pants.core.goals.multi_tool_goal_helper import (
     BatchSizeOption,
     OnlyOption,
     SkippableSubsystem,
-    determine_specified_tool_slugs,
+    determine_specified_tool_ids,
     write_reports,
 )
 from pants.core.util_rules.distdir import DistDir
@@ -174,7 +174,7 @@ class LintRequest:
         return cls.tool_subsystem.options_scope
 
     @classproperty
-    def tool_slug(cls) -> str:
+    def tool_id(cls) -> str:
         """The "slug" of the tool, used in tool selection (E.g. --only=<slug>)."""
         return cls.tool_subsystem.options_scope
 
@@ -332,7 +332,7 @@ async def _get_partitions_by_request_type(
     make_targets_partition_request_get: Callable[[_TargetPartitioner], Get[Partitions]],
     make_files_partition_request_get: Callable[[_FilePartitioner], Get[Partitions]],
 ) -> dict[type[_CoreRequestType], list[Partitions]]:
-    specified_slugs = determine_specified_tool_slugs(
+    specified_slugs = determine_specified_tool_ids(
         subsystem.name,
         subsystem.only,
         core_request_types,
@@ -341,7 +341,7 @@ async def _get_partitions_by_request_type(
     filtered_core_request_types = [
         request_type
         for request_type in core_request_types
-        if request_type.tool_slug in specified_slugs
+        if request_type.tool_id in specified_slugs
     ]
     if not filtered_core_request_types:
         return {}

--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -175,7 +175,10 @@ class LintRequest:
 
     @classproperty
     def tool_id(cls) -> str:
-        """The "id" of the tool, used in tool selection (E.g. --only=<id>)."""
+        """The "id" of the tool, used in tool selection (E.g.
+
+        --only=<id>).
+        """
         return
 
     @distinct_union_type_per_subclass(in_scope_types=[EnvironmentName])
@@ -339,9 +342,7 @@ async def _get_partitions_by_request_type(
     )
 
     filtered_core_request_types = [
-        request_type
-        for request_type in core_request_types
-        if request_type.tool_id in specified_ids
+        request_type for request_type in core_request_types if request_type.tool_id in specified_ids
     ]
     if not filtered_core_request_types:
         return {}

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -83,7 +83,11 @@ class MockLintTargetsRequest(MockLintRequest, LintTargetsRequest):
 class SuccessfulRequest(MockLintTargetsRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "SuccessfulLinter"
+        return "Successful Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "successfullinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -93,7 +97,11 @@ class SuccessfulRequest(MockLintTargetsRequest):
 class FailingRequest(MockLintTargetsRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "FailingLinter"
+        return "Failing Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "failinglinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -103,7 +111,11 @@ class FailingRequest(MockLintTargetsRequest):
 class ConditionallySucceedsRequest(MockLintTargetsRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "ConditionallySucceedsLinter"
+        return "Conditionally Succeeds Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "conditionallysucceedslinter"
 
     @staticmethod
     def exit_code(addresses: Iterable[Address]) -> int:
@@ -115,7 +127,11 @@ class ConditionallySucceedsRequest(MockLintTargetsRequest):
 class SkippedRequest(MockLintTargetsRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "SkippedLinter"
+        return "Skipped Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "skippedlinter"
 
     @staticmethod
     def exit_code(_) -> int:
@@ -135,7 +151,11 @@ class InvalidRequest(MockLintTargetsRequest):
 
     @classproperty
     def tool_name(cls) -> str:
-        return "InvalidLinter"
+        return "Invalid Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "invalidlinter"
 
     @staticmethod
     def exit_code(_: Iterable[Address]) -> int:
@@ -169,7 +189,11 @@ def mock_target_partitioner(
 class MockFilesRequest(MockLintRequest, LintFilesRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "FilesLinter"
+        return "Files Linter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "fileslinter"
 
     @classmethod
     def get_lint_result(cls, files: Iterable[str]) -> LintResult:
@@ -192,7 +216,11 @@ class MockFmtRequest(MockLintRequest, FmtTargetsRequest):
 class SuccessfulFormatter(MockFmtRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "SuccessfulFormatter"
+        return "Successful Formatter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "successfulformatter"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -202,7 +230,11 @@ class SuccessfulFormatter(MockFmtRequest):
 class FailingFormatter(MockFmtRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "FailingFormatter"
+        return "Failing Formatter"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "failingformatter"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -212,7 +244,11 @@ class FailingFormatter(MockFmtRequest):
 class BuildFileFormatter(MockLintRequest, FmtFilesRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "BobTheBUILDer"
+        return "Bob The BUILDer"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "bob"
 
     @classmethod
     def get_lint_result(cls, files: Iterable[str]) -> LintResult:
@@ -226,7 +262,11 @@ class MockFixRequest(MockLintRequest, FixTargetsRequest):
 class SuccessfulFixer(MockFixRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "SuccessfulFixer"
+        return "Successful Fixer"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "successfulfixer"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -236,7 +276,11 @@ class SuccessfulFixer(MockFixRequest):
 class FailingFixer(MockFixRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "FailingFixer"
+        return "Failing Fixer"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "failingfixer"
 
     @classmethod
     def get_lint_result(cls, field_sets: Iterable[MockLinterFieldSet]) -> LintResult:
@@ -246,7 +290,11 @@ class FailingFixer(MockFixRequest):
 class BuildFileFixer(MockLintRequest, FixFilesRequest):
     @classproperty
     def tool_name(cls) -> str:
-        return "BUILDAnnually"
+        return "BUILD Annually"
+
+    @classproperty
+    def tool_id(cls) -> str:
+        return "buildannually"
 
     @classmethod
     def get_lint_result(cls, files: Iterable[str]) -> LintResult:
@@ -389,16 +437,16 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        ✓ BUILDAnnually succeeded.
-        ✓ BobTheBUILDer succeeded.
-        ✕ ConditionallySucceedsLinter failed.
-        ✕ FailingFixer failed.
-        ✕ FailingFormatter failed.
-        ✕ FailingLinter failed.
-        ✓ FilesLinter succeeded.
-        ✓ SuccessfulFixer succeeded.
-        ✓ SuccessfulFormatter succeeded.
-        ✓ SuccessfulLinter succeeded.
+        ✓ BUILD Annually succeeded.
+        ✓ Bob The BUILDer succeeded.
+        ✕ Conditionally Succeeds Linter failed.
+        ✕ Failing Fixer failed.
+        ✕ Failing Formatter failed.
+        ✕ Failing Linter failed.
+        ✓ Files Linter succeeded.
+        ✓ Successful Fixer succeeded.
+        ✓ Successful Formatter succeeded.
+        ✓ Successful Linter succeeded.
 
         (One or more formatters failed. Run `pants fmt` to fix.)
         (One or more fixers failed. Run `pants fix` to fix.)
@@ -410,23 +458,23 @@ def test_summary(rule_runner: RuleRunner) -> None:
         lint_request_types=request_types,
         targets=targets,
         only=[
-            FailingRequest.tool_name,
-            MockFilesRequest.tool_name,
-            FailingFormatter.tool_name,
-            FailingFixer.tool_name,
-            BuildFileFormatter.tool_name,
-            BuildFileFixer.tool_name,
+            FailingRequest.tool_id,
+            MockFilesRequest.tool_id,
+            FailingFormatter.tool_id,
+            FailingFixer.tool_id,
+            BuildFileFormatter.tool_id,
+            BuildFileFixer.tool_id,
         ],
     )
     assert stderr == dedent(
         """\
 
-        ✓ BUILDAnnually succeeded.
-        ✓ BobTheBUILDer succeeded.
-        ✕ FailingFixer failed.
-        ✕ FailingFormatter failed.
-        ✕ FailingLinter failed.
-        ✓ FilesLinter succeeded.
+        ✓ BUILD Annually succeeded.
+        ✓ Bob The BUILDer succeeded.
+        ✕ Failing Fixer failed.
+        ✕ Failing Formatter failed.
+        ✕ Failing Linter failed.
+        ✓ Files Linter succeeded.
 
         (One or more formatters failed. Run `pants fmt` to fix.)
         (One or more fixers failed. Run `pants fix` to fix.)
@@ -443,10 +491,10 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        ✕ ConditionallySucceedsLinter failed.
-        ✕ FailingLinter failed.
-        ✓ FilesLinter succeeded.
-        ✓ SuccessfulLinter succeeded.
+        ✕ Conditionally SucceedsLinter failed.
+        ✕ Failing Linter failed.
+        ✓ Files Linter succeeded.
+        ✓ Successful Linter succeeded.
         """
     )
 
@@ -459,13 +507,13 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        ✓ BobTheBUILDer succeeded.
-        ✕ ConditionallySucceedsLinter failed.
-        ✕ FailingFormatter failed.
-        ✕ FailingLinter failed.
-        ✓ FilesLinter succeeded.
-        ✓ SuccessfulFormatter succeeded.
-        ✓ SuccessfulLinter succeeded.
+        ✓ Bob The BUILDer succeeded.
+        ✕ Conditionally Succeeds Linter failed.
+        ✕ Failing Formatter failed.
+        ✕ Failing Linter failed.
+        ✓ Files Linter succeeded.
+        ✓ Successful Formatter succeeded.
+        ✓ Successful Linter succeeded.
 
         (One or more formatters failed. Run `pants fmt` to fix.)
         """
@@ -480,13 +528,13 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        ✓ BUILDAnnually succeeded.
-        ✕ ConditionallySucceedsLinter failed.
-        ✕ FailingFixer failed.
-        ✕ FailingLinter failed.
-        ✓ FilesLinter succeeded.
-        ✓ SuccessfulFixer succeeded.
-        ✓ SuccessfulLinter succeeded.
+        ✓ BUILD Annually succeeded.
+        ✕ Conditionally Succeeds Linter failed.
+        ✕ Failing Fixer failed.
+        ✕ Failing Linter failed.
+        ✓ Files Linter succeeded.
+        ✓ Successful Fixer succeeded.
+        ✓ Successful Linter succeeded.
 
         (One or more fixers failed. Run `pants fix` to fix.)
         """
@@ -540,9 +588,9 @@ def test_batched(rule_runner: RuleRunner, batch_size: int) -> None:
     assert stderr == dedent(
         """\
 
-        ✓ ConditionallySucceedsLinter succeeded.
-        ✕ FailingLinter failed.
-        ✓ SuccessfulLinter succeeded.
+        ✓ Conditionally Succeeds Linter succeeded.
+        ✕ Failing Linter failed.
+        ✓ Successful Linter succeeded.
         """
     )
 

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -491,7 +491,7 @@ def test_summary(rule_runner: RuleRunner) -> None:
     assert stderr == dedent(
         """\
 
-        ✕ Conditionally SucceedsLinter failed.
+        ✕ Conditionally Succeeds Linter failed.
         ✕ Failing Linter failed.
         ✓ Files Linter succeeded.
         ✓ Successful Linter succeeded.

--- a/src/python/pants/core/goals/multi_tool_goal_helper.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper.py
@@ -79,12 +79,12 @@ def determine_specified_tool_ids(
     only_option: Iterable[str],
     all_requests: Iterable[type],
 ) -> set[str]:
-    all_valid_names = {request.tool_id for request in all_requests}  # type: ignore[attr-defined]
+    all_valid_ids = {request.tool_id for request in all_requests}  # type: ignore[attr-defined]
     if not only_option:
-        return all_valid_names
+        return all_valid_ids
 
     specified = set(only_option)
-    unrecognized_names = specified - all_valid_names
+    unrecognized_names = specified - all_valid_ids
     if unrecognized_names:
         plural = (
             ("s", repr(sorted(unrecognized_names)))
@@ -96,7 +96,7 @@ def determine_specified_tool_ids(
                 f"""
                 Unrecognized name{plural[0]} with the option `--{goal_name}-only`: {plural[1]}
 
-                All valid names: {sorted(all_valid_names)}
+                All valid names: {sorted(all_valid_ids)}
                 """
             )
         )

--- a/src/python/pants/core/goals/multi_tool_goal_helper.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper.py
@@ -74,12 +74,12 @@ class BatchSizeOption(IntOption):
         )
 
 
-def determine_specified_tool_slugs(
+def determine_specified_tool_ids(
     goal_name: str,
     only_option: Iterable[str],
     all_requests: Iterable[type],
 ) -> set[str]:
-    all_valid_names = {request.tool_slug for request in all_requests}  # type: ignore[attr-defined]
+    all_valid_names = {request.tool_id for request in all_requests}  # type: ignore[attr-defined]
     if not only_option:
         return all_valid_names
 

--- a/src/python/pants/core/goals/multi_tool_goal_helper.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper.py
@@ -74,12 +74,12 @@ class BatchSizeOption(IntOption):
         )
 
 
-def determine_specified_tool_names(
+def determine_specified_tool_slugs(
     goal_name: str,
     only_option: Iterable[str],
     all_requests: Iterable[type],
 ) -> set[str]:
-    all_valid_names = {request.tool_name for request in all_requests}  # type: ignore[attr-defined]
+    all_valid_names = {request.tool_slug for request in all_requests}  # type: ignore[attr-defined]
     if not only_option:
         return all_valid_names
 

--- a/src/python/pants/core/goals/multi_tool_goal_helper_test.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper_test.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from pants.core.goals.check import CheckResult, CheckResults
-from pants.core.goals.multi_tool_goal_helper import determine_specified_tool_names, write_reports
+from pants.core.goals.multi_tool_goal_helper import determine_specified_tool_slugs, write_reports
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Workspace
 from pants.testutil.rule_runner import RuleRunner
@@ -17,14 +17,14 @@ from pants.util.meta import classproperty
 from pants.util.strutil import softwrap
 
 
-def test_determine_specified_tool_names() -> None:
+def test_determine_specified_tool_slugs() -> None:
     class StyleReq:
         @classproperty
         def tool_name(cls) -> str:
             return "my-tool"
 
     with pytest.raises(ValueError) as exc:
-        determine_specified_tool_names(
+        determine_specified_tool_slugs(
             "fake-goal",
             only_option=["bad"],
             all_requests=[StyleReq],

--- a/src/python/pants/core/goals/multi_tool_goal_helper_test.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper_test.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from pants.core.goals.check import CheckResult, CheckResults
-from pants.core.goals.multi_tool_goal_helper import determine_specified_tool_slugs, write_reports
+from pants.core.goals.multi_tool_goal_helper import determine_specified_tool_ids, write_reports
 from pants.core.util_rules.distdir import DistDir
 from pants.engine.fs import EMPTY_DIGEST, Workspace
 from pants.testutil.rule_runner import RuleRunner
@@ -17,14 +17,14 @@ from pants.util.meta import classproperty
 from pants.util.strutil import softwrap
 
 
-def test_determine_specified_tool_slugs() -> None:
+def test_determine_specified_tool_ids() -> None:
     class StyleReq:
         @classproperty
         def tool_name(cls) -> str:
             return "my-tool"
 
     with pytest.raises(ValueError) as exc:
-        determine_specified_tool_slugs(
+        determine_specified_tool_ids(
             "fake-goal",
             only_option=["bad"],
             all_requests=[StyleReq],

--- a/src/python/pants/core/goals/multi_tool_goal_helper_test.py
+++ b/src/python/pants/core/goals/multi_tool_goal_helper_test.py
@@ -20,7 +20,7 @@ from pants.util.strutil import softwrap
 def test_determine_specified_tool_ids() -> None:
     class StyleReq:
         @classproperty
-        def tool_name(cls) -> str:
+        def tool_id(cls) -> str:
             return "my-tool"
 
     with pytest.raises(ValueError) as exc:


### PR DESCRIPTION
This change separates the "tool name" (used for user-facing prose strings) from the "tool id" (used for programmatic selection/deselection). This helps for when there's one tool that does multiple things (like `ruff` or `terraform`).