### PR TITLE
Switch many tests to use PythonRuleRunner.

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -28,12 +28,13 @@ from pants.engine.target import (
     TransitiveTargets,
     TransitiveTargetsRequest,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *archive.rules(),
             *adhoc_tool_rules(),
@@ -59,7 +60,7 @@ def rule_runner() -> RuleRunner:
 
 
 def assert_adhoc_tool_result(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     address: Address,
     expected_contents: dict[str, str],
 ) -> None:
@@ -72,7 +73,7 @@ def assert_adhoc_tool_result(
         assert fc.content == expected_contents[fc.path].encode()
 
 
-def test_adhoc_tool(rule_runner: RuleRunner) -> None:
+def test_adhoc_tool(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/fruitcake.py": dedent(
@@ -107,7 +108,7 @@ def test_adhoc_tool(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_adhoc_tool_with_workdir(rule_runner: RuleRunner) -> None:
+def test_adhoc_tool_with_workdir(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/fruitcake.py": dedent(
@@ -142,7 +143,7 @@ def test_adhoc_tool_with_workdir(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_adhoc_tool_capture_stdout_err(rule_runner: RuleRunner) -> None:
+def test_adhoc_tool_capture_stdout_err(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/fruitcake.py": dedent(
@@ -193,7 +194,7 @@ def test_adhoc_tool_capture_stdout_err(rule_runner: RuleRunner) -> None:
     ),
 )
 def test_working_directory_special_values(
-    rule_runner: RuleRunner, workdir: str, file_location: str
+    rule_runner: PythonRuleRunner, workdir: str, file_location: str
 ) -> None:
     rule_runner.write_files(
         {
@@ -229,7 +230,7 @@ def test_working_directory_special_values(
     )
 
 
-def test_env_vars(rule_runner: RuleRunner) -> None:
+def test_env_vars(rule_runner: PythonRuleRunner) -> None:
     envvar_value = "clang"
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -38,12 +38,13 @@ from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *awslambda_python_rules(),
             *awslambda_python_subsystem_rules(),
@@ -71,7 +72,7 @@ def rule_runner() -> RuleRunner:
 
 
 def create_python_awslambda(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     addr: Address,
     *,
     expected_extra_log_lines: tuple[str, ...],
@@ -92,7 +93,7 @@ def create_python_awslambda(
 
 
 @pytest.fixture
-def complete_platform(rule_runner: RuleRunner) -> bytes:
+def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     rule_runner.write_files(
         {
             "pex_exe/BUILD": dedent(
@@ -122,7 +123,7 @@ def complete_platform(rule_runner: RuleRunner) -> bytes:
     all_major_minor_python_versions(Lambdex.default_interpreter_constraints),
 )
 def test_create_hello_world_lambda(
-    rule_runner: RuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
+    rule_runner: PythonRuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
 ) -> None:
     rule_runner.write_files(
         {
@@ -196,7 +197,7 @@ def test_create_hello_world_lambda(
     ), "Using include_requirements=False should exclude third-party deps"
 
 
-def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
+def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
     rule_runner.write_files(
         {
             "assets/f.txt": "",

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -42,12 +42,13 @@ from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import DigestContents
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *package_pex_binary.rules(),
             *python_google_cloud_function_rules(),
@@ -74,7 +75,7 @@ def rule_runner() -> RuleRunner:
 
 
 def create_python_google_cloud_function(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     addr: Address,
     *,
     expected_extra_log_lines: tuple[str, ...],
@@ -100,7 +101,7 @@ def create_python_google_cloud_function(
 
 
 @pytest.fixture
-def complete_platform(rule_runner: RuleRunner) -> bytes:
+def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     rule_runner.write_files(
         {
             "pex_exe/BUILD": dedent(
@@ -130,7 +131,7 @@ def complete_platform(rule_runner: RuleRunner) -> bytes:
     all_major_minor_python_versions(Lambdex.default_interpreter_constraints),
 )
 def test_create_hello_world_lambda(
-    rule_runner: RuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
+    rule_runner: PythonRuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
 ) -> None:
     rule_runner.write_files(
         {
@@ -177,7 +178,7 @@ def test_create_hello_world_lambda(
         assert "Google Cloud Functions built on macOS may fail to build." in caplog.text
 
 
-def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
+def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
     rule_runner.write_files(
         {
             "assets/f.txt": "",

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -11,7 +11,7 @@ from pants.backend.project_info.dependencies import Dependencies, rules
 from pants.backend.python import target_types_rules
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
 from pants.engine.target import SpecialCasedDependencies, Target
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
 
 
 # We verify that any subclasses of `SpecialCasedDependencies` will show up with the `dependencies`
@@ -26,8 +26,8 @@ class SpecialDepsTarget(Target):
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *rules(),
             *target_types_rules.rules(),
@@ -37,7 +37,7 @@ def rule_runner() -> RuleRunner:
 
 
 def create_python_sources(
-    rule_runner: RuleRunner, directory: str, *, dependencies: Optional[List[str]] = None
+    rule_runner: PythonRuleRunner, directory: str, *, dependencies: Optional[List[str]] = None
 ) -> None:
     rule_runner.write_files(
         {
@@ -47,7 +47,7 @@ def create_python_sources(
     )
 
 
-def create_python_requirement_tgts(rule_runner: RuleRunner, *names: str) -> None:
+def create_python_requirement_tgts(rule_runner: PythonRuleRunner, *names: str) -> None:
     rule_runner.write_files(
         {
             "3rdparty/python/BUILD": "\n".join(
@@ -66,7 +66,7 @@ def create_python_requirement_tgts(rule_runner: RuleRunner, *names: str) -> None
 
 
 def assert_dependencies(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     *,
     specs: List[str],
     expected: List[str],
@@ -84,12 +84,12 @@ def assert_dependencies(
     assert result.stdout.splitlines() == expected
 
 
-def test_no_target(rule_runner: RuleRunner) -> None:
+def test_no_target(rule_runner: PythonRuleRunner) -> None:
     assert_dependencies(rule_runner, specs=[], expected=[])
     assert_dependencies(rule_runner, specs=[], expected=[], transitive=True)
 
 
-def test_no_dependencies(rule_runner: RuleRunner) -> None:
+def test_no_dependencies(rule_runner: PythonRuleRunner) -> None:
     create_python_sources(rule_runner, "some/target")
     assert_dependencies(rule_runner, specs=["some/target/a.py"], expected=[])
     assert_dependencies(rule_runner, specs=["some/target/a.py"], expected=[], transitive=True)
@@ -105,7 +105,7 @@ def test_no_dependencies(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_special_cased_dependencies(rule_runner: RuleRunner) -> None:
+def test_special_cased_dependencies(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -121,7 +121,7 @@ def test_special_cased_dependencies(rule_runner: RuleRunner) -> None:
     assert_dependencies(rule_runner, specs=["//:t3"], expected=["//:t1", "//:t2"], transitive=True)
 
 
-def test_python_dependencies(rule_runner: RuleRunner) -> None:
+def test_python_dependencies(rule_runner: PythonRuleRunner) -> None:
     create_python_requirement_tgts(rule_runner, "req1", "req2")
     create_python_sources(rule_runner, "dep/target")
     create_python_sources(

--- a/src/python/pants/backend/python/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/python/dependency_inference/rules_test.py
@@ -53,7 +53,8 @@ from pants.engine.addresses import Address
 from pants.engine.internals.parametrize import Parametrize
 from pants.engine.rules import rule
 from pants.engine.target import ExplicitlyProvidedDependencies, InferredDependencies
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, engine_error
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
@@ -72,7 +73,7 @@ def assert_owners_not_found_error(
 
 
 def test_infer_python_imports(caplog) -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *import_rules(),
             *target_types_rules.rules(),
@@ -202,7 +203,7 @@ def test_infer_python_imports(caplog) -> None:
 
 
 def test_infer_python_assets(caplog) -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *import_rules(),
             *target_types_rules.rules(),
@@ -363,7 +364,7 @@ def test_infer_python_assets(caplog) -> None:
 
 @pytest.mark.parametrize("behavior", InitFilesInference)
 def test_infer_python_inits(behavior: InitFilesInference) -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *ancestor_files.rules(),
             *target_types_rules.rules(),
@@ -431,7 +432,7 @@ def test_infer_python_inits(behavior: InitFilesInference) -> None:
 
 
 def test_infer_python_conftests() -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *ancestor_files.rules(),
             *target_types_rules.rules(),
@@ -488,12 +489,12 @@ def test_infer_python_conftests() -> None:
 
 
 @pytest.fixture
-def imports_rule_runner() -> RuleRunner:
+def imports_rule_runner() -> PythonRuleRunner:
     return mk_imports_rule_runner([])
 
 
-def mk_imports_rule_runner(more_rules: Iterable) -> RuleRunner:
-    return RuleRunner(
+def mk_imports_rule_runner(more_rules: Iterable) -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *more_rules,
             *import_rules(),
@@ -512,7 +513,7 @@ def mk_imports_rule_runner(more_rules: Iterable) -> RuleRunner:
     )
 
 
-def test_infer_python_ignore_unowned_imports(imports_rule_runner: RuleRunner, caplog) -> None:
+def test_infer_python_ignore_unowned_imports(imports_rule_runner: PythonRuleRunner, caplog) -> None:
     """Test handling unowned imports that are set explicitly to be ignored."""
     imports_rule_runner.write_files(
         {
@@ -589,7 +590,7 @@ def test_infer_python_ignore_unowned_imports(imports_rule_runner: RuleRunner, ca
         )
 
 
-def test_infer_python_strict(imports_rule_runner: RuleRunner, caplog) -> None:
+def test_infer_python_strict(imports_rule_runner: PythonRuleRunner, caplog) -> None:
     imports_rule_runner.write_files(
         {
             "src/python/cheesey.py": dedent(
@@ -687,7 +688,7 @@ def test_infer_python_strict(imports_rule_runner: RuleRunner, caplog) -> None:
         assert not caplog.records
 
 
-def test_infer_python_strict_multiple_resolves(imports_rule_runner: RuleRunner) -> None:
+def test_infer_python_strict_multiple_resolves(imports_rule_runner: PythonRuleRunner) -> None:
     imports_rule_runner.write_files(
         {
             "project/base.py": "",
@@ -833,35 +834,35 @@ class TestCategoriseImportsInfo:
         assert resolved.status == expected_status
         return resolved
 
-    def test_unambiguous_imports(self, imports_rule_runner: RuleRunner) -> None:
+    def test_unambiguous_imports(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "unambiguous"
         resolved = self.do_test(case_name, ImportOwnerStatus.unambiguous)
         assert resolved.address == self.import_cases[case_name][1].unambiguous
 
-    def test_unambiguous_with_pyi(self, imports_rule_runner: RuleRunner) -> None:
+    def test_unambiguous_with_pyi(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "unambiguous_with_pyi"
         resolved = self.do_test(case_name, ImportOwnerStatus.unambiguous)
         assert resolved.address == self.import_cases[case_name][1].unambiguous
 
-    def test_unownable_root(self, imports_rule_runner: RuleRunner) -> None:
+    def test_unownable_root(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "json"
         self.do_test(case_name, ImportOwnerStatus.unownable)
 
-    def test_unownable_nonroot(self, imports_rule_runner: RuleRunner) -> None:
+    def test_unownable_nonroot(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "os.path"
         self.do_test(case_name, ImportOwnerStatus.unownable)
 
-    def test_weak_owned(self, imports_rule_runner: RuleRunner) -> None:
+    def test_weak_owned(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "weak_owned"
         resolved = self.do_test(case_name, ImportOwnerStatus.unambiguous)
         assert resolved.address == self.import_cases[case_name][1].unambiguous
 
-    def test_weak_unowned(self, imports_rule_runner: RuleRunner) -> None:
+    def test_weak_unowned(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "weak_unowned"
         resolved = self.do_test(case_name, ImportOwnerStatus.weak_ignore)
         assert resolved.address == tuple()
 
-    def test_unowned(self, imports_rule_runner: RuleRunner) -> None:
+    def test_unowned(self, imports_rule_runner: PythonRuleRunner) -> None:
         case_name = "unowned"
         resolved = self.do_test(case_name, ImportOwnerStatus.unowned)
         assert resolved.address == tuple()
@@ -898,7 +899,7 @@ class TestFindOtherOwners:
             ]
         )
 
-    def do_test(self, imports_rule_runner: RuleRunner):
+    def do_test(self, imports_rule_runner: PythonRuleRunner):
         resolves = {"python-default": "", self.other_resolve: "", self.other_other_resolve: ""}
         imports_rule_runner.set_options(
             [
@@ -931,7 +932,7 @@ class TestFindOtherOwners:
         r = self.do_test(_imports_rule_runner)
         assert not r.value
 
-    def test_other_owners_found_in_single_resolve(self, _imports_rule_runner: RuleRunner):
+    def test_other_owners_found_in_single_resolve(self, _imports_rule_runner: PythonRuleRunner):
         _imports_rule_runner.write_files(
             {
                 "other/BUILD": dedent(
@@ -958,7 +959,7 @@ class TestFindOtherOwners:
             )
         ]
 
-    def test_other_owners_found_in_multiple_resolves(self, _imports_rule_runner: RuleRunner):
+    def test_other_owners_found_in_multiple_resolves(self, _imports_rule_runner: PythonRuleRunner):
         _imports_rule_runner.write_files(
             {
                 "other/BUILD": dedent(

--- a/src/python/pants/backend/python/goals/debug_goals_test.py
+++ b/src/python/pants/backend/python/goals/debug_goals_test.py
@@ -27,14 +27,15 @@ from pants.build_graph.address import Address
 from pants.core.target_types import FileTarget
 from pants.core.target_types import rules as core_target_types_rules
 from pants.engine.internals.parametrize import Parametrize
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def imports_rule_runner() -> RuleRunner:
+def imports_rule_runner() -> PythonRuleRunner:
     resolves = {"python-default": "", "other": ""}
 
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *import_rules(),
             *target_types_rules.rules(),
@@ -63,7 +64,7 @@ def imports_rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_debug_goals(imports_rule_runner: RuleRunner):
+def test_debug_goals(imports_rule_runner: PythonRuleRunner):
     filedir = "project"
     filename = "t.py"
 

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -20,14 +20,15 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
 from pants.engine.fs import DigestContents
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import strip_prefix
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *lockfile_rules(),
             *pex.rules(),
@@ -40,7 +41,7 @@ def rule_runner() -> RuleRunner:
 
 def _generate(
     *,
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     ansicolors_version: str = "==1.1.8",
     requirement_constraints_str: str = '//   "requirement_constraints": [],\n',
     only_binary_and_no_binary_str: str = '//   "only_binary": [],\n//   "no_binary": []',
@@ -95,7 +96,7 @@ def _generate(
     ("no_binary", "only_binary"), ((False, False), (False, True), (True, False))
 )
 def test_pex_lockfile_generation(
-    rule_runner: RuleRunner, no_binary: bool, only_binary: bool
+    rule_runner: PythonRuleRunner, no_binary: bool, only_binary: bool
 ) -> None:
     args = ["--python-resolves={'test': 'foo.lock'}"]
     only_binary_lock_str = '//   "only_binary": [],\n'
@@ -164,7 +165,7 @@ def test_pex_lockfile_generation(
         assert artifacts == [wheel]
 
 
-def test_constraints_file(rule_runner: RuleRunner) -> None:
+def test_constraints_file(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"constraints.txt": "ansicolors==1.1.7"})
     rule_runner.set_options(
         [
@@ -194,7 +195,7 @@ def test_constraints_file(rule_runner: RuleRunner) -> None:
 
 
 def test_multiple_resolves() -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             setup_user_lockfile_requests,
             *PythonSetup.rules(),
@@ -235,7 +236,7 @@ def test_multiple_resolves() -> None:
     assert set(result) == {
         GeneratePythonLockfile(
             requirements=FrozenOrderedSet(["a"]),
-            interpreter_constraints=InterpreterConstraints(["CPython>=3.7,<4"]),
+            interpreter_constraints=InterpreterConstraints(["CPython>=3.7,<3.10"]),
             resolve_name="a",
             lockfile_dest="a.lock",
             diff=False,

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -35,12 +35,13 @@ from pants.core.target_types import (
 )
 from pants.core.target_types import rules as core_target_types_rules
 from pants.testutil.python_interpreter_selection import skip_unless_python36_present
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *package_pex_binary.rules(),
             *pex_from_targets.rules(),
@@ -66,7 +67,7 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
+def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
     rule_runner.write_files(
         {
             "assets/f.txt": "",
@@ -111,7 +112,9 @@ def test_warn_files_targets(rule_runner: RuleRunner, caplog) -> None:
     assert result.artifacts[0].relpath == "src.py.project/project.pex"
 
 
-def test_include_sources_avoids_files_targets_warning(rule_runner: RuleRunner, caplog) -> None:
+def test_include_sources_avoids_files_targets_warning(
+    rule_runner: PythonRuleRunner, caplog
+) -> None:
     rule_runner.write_files(
         {
             "assets/f.txt": "",
@@ -170,7 +173,7 @@ def test_include_sources_avoids_files_targets_warning(rule_runner: RuleRunner, c
     "layout",
     [pytest.param(layout, id=layout.value) for layout in PexLayout],
 )
-def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
+def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
     rule_runner.write_files(
         {
             "src/py/project/app.py": dedent(
@@ -220,7 +223,7 @@ def test_layout(rule_runner: RuleRunner, layout: PexLayout) -> None:
 
 
 @pytest.fixture
-def pex_executable(rule_runner: RuleRunner) -> str:
+def pex_executable(rule_runner: PythonRuleRunner) -> str:
     rule_runner.write_files(
         {
             "pex_exe/BUILD": dedent(
@@ -241,7 +244,7 @@ def pex_executable(rule_runner: RuleRunner) -> str:
     return os.path.join(rule_runner.build_root, expected_pex_relpath)
 
 
-def test_resolve_local_platforms(pex_executable: str, rule_runner: RuleRunner) -> None:
+def test_resolve_local_platforms(pex_executable: str, rule_runner: PythonRuleRunner) -> None:
     complete_current_platform = subprocess.run(
         args=[pex_executable, "interpreter", "inspect", "-mt"],
         env=dict(PEX_MODULE="pex.cli", **os.environ),
@@ -280,7 +283,7 @@ def test_resolve_local_platforms(pex_executable: str, rule_runner: RuleRunner) -
 
 
 @skip_unless_python36_present
-def test_complete_platforms(rule_runner: RuleRunner) -> None:
+def test_complete_platforms(rule_runner: PythonRuleRunner) -> None:
     linux_complete_platform = pkgutil.get_data(__name__, "platform-linux-py36.json")
     assert linux_complete_platform is not None
 
@@ -329,7 +332,7 @@ def test_complete_platforms(rule_runner: RuleRunner) -> None:
     ) == sorted(pex_info["distributions"])
 
 
-def test_non_hermetic_venv_scripts(rule_runner: RuleRunner) -> None:
+def test_non_hermetic_venv_scripts(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/py/project/app.py": dedent(

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -53,12 +53,13 @@ from pants.testutil.python_interpreter_selection import (
     all_major_minor_python_versions,
     skip_unless_python27_and_python3_present,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule, mock_console
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             build_runtime_package_dependencies,
             create_or_update_coverage_config,
@@ -102,7 +103,7 @@ GOOD_TEST = dedent(
 
 
 def _configure_pytest_runner(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     *,
     extra_args: list[str] | None = None,
     env: dict[str, str] | None = None,
@@ -117,7 +118,7 @@ def _configure_pytest_runner(
 
 
 def _get_pytest_batch(
-    rule_runner: RuleRunner, test_targets: Iterable[Target]
+    rule_runner: PythonRuleRunner, test_targets: Iterable[Target]
 ) -> PyTestRequest.Batch[PythonTestFieldSet, TestMetadata]:
     field_sets = tuple(PythonTestFieldSet.create(tgt) for tgt in test_targets)
     partitions = rule_runner.request(Partitions, [PyTestRequest.PartitionRequest(field_sets)])
@@ -126,7 +127,7 @@ def _get_pytest_batch(
 
 
 def run_pytest(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     test_targets: Iterable[Target],
     *,
     extra_args: list[str] | None = None,
@@ -158,7 +159,7 @@ def run_pytest(
 
 
 def run_pytest_noninteractive(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     test_target: Target,
     *,
     extra_args: list[str] | None = None,
@@ -169,7 +170,7 @@ def run_pytest_noninteractive(
 
 
 def run_pytest_interactive(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     test_target: Target,
     *,
     extra_args: list[str] | None = None,
@@ -188,7 +189,7 @@ def run_pytest_interactive(
     "major_minor_interpreter",
     all_major_minor_python_versions(["CPython>=3.7,<4"]),
 )
-def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files(
         {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
     )
@@ -203,7 +204,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     assert f"{PACKAGE}/tests.py ." in result.stdout
 
 
-def test_failing(rule_runner: RuleRunner) -> None:
+def test_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -221,7 +222,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/tests.py F" in result.stdout
 
 
-def test_dependencies(rule_runner: RuleRunner) -> None:
+def test_dependencies(rule_runner: PythonRuleRunner) -> None:
     """Ensure direct and transitive dependencies work."""
     rule_runner.write_files(
         {
@@ -280,7 +281,7 @@ def test_dependencies(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python27_and_python3_present
-def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
+def test_uses_correct_python_version(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -318,7 +319,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/tests.py ." in result.stdout
 
 
-def test_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -340,7 +341,7 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert "collected 2 items / 1 deselected / 1 selected" in result.stdout
 
 
-def test_xdist_enabled_noninteractive(rule_runner: RuleRunner) -> None:
+def test_xdist_enabled_noninteractive(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -362,7 +363,7 @@ def test_xdist_enabled_noninteractive(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_xdist_enabled_but_disabled_for_target(rule_runner: RuleRunner) -> None:
+def test_xdist_enabled_but_disabled_for_target(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -384,7 +385,7 @@ def test_xdist_enabled_but_disabled_for_target(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_xdist_enabled_interactive(rule_runner: RuleRunner) -> None:
+def test_xdist_enabled_interactive(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/tests.py": dedent(
@@ -410,7 +411,9 @@ def test_xdist_enabled_interactive(rule_runner: RuleRunner) -> None:
     "config_path,extra_args",
     (["pytest.ini", []], ["custom_config.ini", ["--pytest-config=custom_config.ini"]]),
 )
-def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list[str]) -> None:
+def test_config_file(
+    rule_runner: PythonRuleRunner, config_path: str, extra_args: list[str]
+) -> None:
     rule_runner.write_files(
         {
             config_path: dedent(
@@ -434,7 +437,7 @@ def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list
     assert "All good!" in result.stdout and "Captured" not in result.stdout
 
 
-def test_force(rule_runner: RuleRunner) -> None:
+def test_force(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
     )
@@ -454,7 +457,7 @@ def test_force(rule_runner: RuleRunner) -> None:
     assert result_one is result_two
 
 
-def test_extra_output(rule_runner: RuleRunner) -> None:
+def test_extra_output(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {f"{PACKAGE}/tests.py": GOOD_TEST, f"{PACKAGE}/BUILD": "python_tests()"}
     )
@@ -478,7 +481,7 @@ def test_extra_output(rule_runner: RuleRunner) -> None:
     assert {"assets/style.css", "report.html"} == paths
 
 
-def test_coverage(rule_runner: RuleRunner) -> None:
+def test_coverage(rule_runner: PythonRuleRunner) -> None:
     # Note that we test that rewriting the pyproject.toml doesn't cause a collision
     # between the two code paths by which we pick up that file (coverage and pytest).
     rule_runner.write_files(
@@ -495,7 +498,7 @@ def test_coverage(rule_runner: RuleRunner) -> None:
     assert result.coverage_data is not None
 
 
-def test_conftest_dependency_injection(rule_runner: RuleRunner) -> None:
+def test_conftest_dependency_injection(rule_runner: PythonRuleRunner) -> None:
     # See `test_skip_tests` for a test that we properly skip running on conftest.py.
     rule_runner.write_files(
         {
@@ -516,7 +519,7 @@ def test_conftest_dependency_injection(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/tests.py In conftest!\n." in result.stdout
 
 
-def test_execution_slot_variable(rule_runner: RuleRunner) -> None:
+def test_execution_slot_variable(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_concurrency_slot.py": dedent(
@@ -539,7 +542,7 @@ def test_execution_slot_variable(rule_runner: RuleRunner) -> None:
     assert re.search(r"Value of slot is \d+", result.stdout)
 
 
-def test_extra_env_vars(rule_runner: RuleRunner) -> None:
+def test_extra_env_vars(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_extra_env_vars.py": dedent(
@@ -583,7 +586,7 @@ def test_extra_env_vars(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_pytest_addopts_test_extra_env(rule_runner: RuleRunner) -> None:
+def test_pytest_addopts_test_extra_env(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_pytest_addopts_test_extra_env.py": dedent(
@@ -615,7 +618,7 @@ def test_pytest_addopts_test_extra_env(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_pytest_addopts_field_set_extra_env(rule_runner: RuleRunner) -> None:
+def test_pytest_addopts_field_set_extra_env(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_pytest_addopts_field_set_extra_env.py": dedent(
@@ -677,10 +680,10 @@ async def unused_plugin(_: UnusedPlugin) -> PytestPluginSetup:
     return PytestPluginSetup(digest=digest)
 
 
-def test_setup_plugins_and_runtime_package_dependency(rule_runner: RuleRunner) -> None:
+def test_setup_plugins_and_runtime_package_dependency(rule_runner: PythonRuleRunner) -> None:
     # We test both the generic `PytestPluginSetup` mechanism and our `runtime_package_dependencies`
     # feature in the same test to confirm multiple plugins can be used on the same target.
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             *rule_runner.rules,
             used_plugin,
@@ -726,7 +729,7 @@ def test_setup_plugins_and_runtime_package_dependency(rule_runner: RuleRunner) -
     assert result.exit_code == 0
 
 
-def test_local_dists(rule_runner: RuleRunner) -> None:
+def test_local_dists(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/foo/bar.py": "BAR = 'LOCAL DIST'",
@@ -771,7 +774,7 @@ def test_local_dists(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 0
 
 
-def test_skip_tests(rule_runner: RuleRunner) -> None:
+def test_skip_tests(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "test_skip_me.py": "",
@@ -793,7 +796,7 @@ def test_skip_tests(rule_runner: RuleRunner) -> None:
     assert is_applicable("t2", "test_foo.py")
 
 
-def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
+def test_debug_adaptor_request_argv(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_foo.py": "",
@@ -874,7 +877,7 @@ def test_debug_adaptor_request_argv(rule_runner: RuleRunner) -> None:
     ),
 )
 def test_partition(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     root_build_contents: str,
     package_build_contents: str,
     expected_partitions: list[list[str]],
@@ -926,7 +929,7 @@ def test_partition(
     "major_minor_interpreter",
     all_major_minor_python_versions(["CPython>=3.7,<4"]),
 )
-def test_batched_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_batched_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_1.py": GOOD_TEST,
@@ -949,7 +952,7 @@ def test_batched_passing(rule_runner: RuleRunner, major_minor_interpreter: str) 
     assert f"{PACKAGE}/test_2.py ." in result.stdout
 
 
-def test_batched_failing(rule_runner: RuleRunner) -> None:
+def test_batched_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/test_1.py": GOOD_TEST,

--- a/src/python/pants/backend/python/goals/repl_integration_test.py
+++ b/src/python/pants/backend/python/goals/repl_integration_test.py
@@ -22,18 +22,13 @@ from pants.core.goals.repl import Repl
 from pants.core.goals.repl import rules as repl_rules
 from pants.engine.process import Process
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
-from pants.testutil.rule_runner import (
-    GoalRuleResult,
-    QueryRule,
-    RuleRunner,
-    engine_error,
-    mock_console,
-)
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import GoalRuleResult, QueryRule, engine_error, mock_console
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *repl_rules(),
             *python_repl.rules(),
@@ -65,7 +60,7 @@ def rule_runner() -> RuleRunner:
 
 
 def run_repl(
-    rule_runner: RuleRunner, args: list[str], *, global_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, args: list[str], *, global_args: list[str] | None = None
 ) -> GoalRuleResult:
     # TODO(#9108): Expand `mock_console` to allow for providing input for the repl to verify
     # that, e.g., the generated protobuf code is available. Right now this test prepares for
@@ -79,7 +74,7 @@ def run_repl(
         )
 
 
-def test_default_repl(rule_runner: RuleRunner) -> None:
+def test_default_repl(rule_runner: PythonRuleRunner) -> None:
     assert run_repl(rule_runner, ["src/python/lib.py"]).exit_code == 0
 
 
@@ -88,7 +83,7 @@ def test_default_repl(rule_runner: RuleRunner) -> None:
     "major_minor_interpreter",
     all_major_minor_python_versions(["CPython>=3.7,<4"]),
 )
-def test_ipython(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_ipython(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     assert (
         run_repl(
             rule_runner,
@@ -102,7 +97,7 @@ def test_ipython(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     )
 
 
-def test_eagerly_validate_roots_have_common_resolve(rule_runner: RuleRunner) -> None:
+def test_eagerly_validate_roots_have_common_resolve(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(

--- a/src/python/pants/backend/python/goals/run_python_source_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_python_source_integration_test.py
@@ -39,12 +39,13 @@ from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.debug_adapter_util import debugadapter_port_for_testing
 from pants.testutil.pants_integration_test import run_pants
-from pants.testutil.rule_runner import RuleRunner, mock_console
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import mock_console
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *run_rules(),
             *dependency_inference_rules.rules(),
@@ -71,7 +72,7 @@ def rule_runner() -> RuleRunner:
 
 
 def run_run_request(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     target: Target,
     test_debug_adapter: bool = True,
 ) -> Tuple[int, str, str]:
@@ -132,7 +133,7 @@ def test_run_sample_script(
     global_default_value: bool | None,
     field_value: bool | None,
     run_uses_sandbox: bool,
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
 ) -> None:
     """Test that we properly run a `python_source` target.
 
@@ -212,7 +213,7 @@ def test_run_sample_script(
     assert exit_code == 23
 
 
-def test_no_strip_pex_env_issues_12057(rule_runner: RuleRunner) -> None:
+def test_no_strip_pex_env_issues_12057(rule_runner: PythonRuleRunner) -> None:
     sources = {
         "src/app.py": dedent(
             """\
@@ -246,7 +247,7 @@ def test_no_strip_pex_env_issues_12057(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.parametrize("run_in_sandbox", [False, True])
-def test_pex_root_location(rule_runner: RuleRunner, run_in_sandbox: bool) -> None:
+def test_pex_root_location(rule_runner: PythonRuleRunner, run_in_sandbox: bool) -> None:
     # See issues #12055 and #17750.
     read_config_result = run_pants(["help-all"])
     read_config_result.assert_success()
@@ -286,7 +287,7 @@ def test_pex_root_location(rule_runner: RuleRunner, run_in_sandbox: bool) -> Non
     assert expected_pex_root == pex_root
 
 
-def test_local_dist(rule_runner: RuleRunner) -> None:
+def test_local_dist(rule_runner: PythonRuleRunner) -> None:
     sources = {
         "foo/bar.py": "BAR = 'LOCAL DIST'",
         "foo/setup.py": dedent(
@@ -329,7 +330,7 @@ def test_local_dist(rule_runner: RuleRunner) -> None:
     assert stdout == "LOCAL DIST\n", stderr
 
 
-def test_runs_in_venv(rule_runner: RuleRunner) -> None:
+def test_runs_in_venv(rule_runner: PythonRuleRunner) -> None:
     # NB: We aren't just testing an implementation detail, users can and should expect their code to
     # be run just as if they ran their code in a virtualenv (as is common in the Python ecosystem).
     sources = {

--- a/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/bandit/rules_integration_test.py
@@ -25,12 +25,13 @@ from pants.testutil.python_interpreter_selection import (
     has_python_version,
     skip_unless_python27_and_python3_present,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *bandit_rules(),
             *bandit_subsystem_rules(),
@@ -49,7 +50,7 @@ BAD_FILE = "hashlib.md5()\n"  # An insecure hashing function.
 
 
 def run_bandit(
-    rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
 ) -> Sequence[LintResult]:
     rule_runner.set_options(
         [
@@ -73,7 +74,7 @@ def run_bandit(
 
 
 def assert_success(
-    rule_runner: RuleRunner, target: Target, *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, target: Target, *, extra_args: list[str] | None = None
 ) -> None:
     result = run_bandit(rule_runner, [target], extra_args=extra_args)
     assert len(result) == 1
@@ -87,7 +88,7 @@ def assert_success(
     "major_minor_interpreter",
     all_major_minor_python_versions(["CPython>=3.7,<4"]),
 )
-def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     assert_success(
@@ -97,7 +98,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     )
 
 
-def test_failing(rule_runner: RuleRunner) -> None:
+def test_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_bandit(rule_runner, [tgt])
@@ -107,7 +108,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert result[0].report == EMPTY_DIGEST
 
 
-def test_multiple_targets(rule_runner: RuleRunner) -> None:
+def test_multiple_targets(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {"good.py": GOOD_FILE, "bad.py": BAD_FILE, "BUILD": "python_sources(name='t')"}
     )
@@ -124,7 +125,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python27_and_python3_present
-def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
+def test_uses_correct_python_version(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.py": "version: str = 'Py3 > Py2'\n",
@@ -171,7 +172,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert "No issues identified." in batched_py3_result.stdout
 
 
-def test_respects_config_file(rule_runner: RuleRunner) -> None:
+def test_respects_config_file(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.py": BAD_FILE,
@@ -183,13 +184,13 @@ def test_respects_config_file(rule_runner: RuleRunner) -> None:
     assert_success(rule_runner, tgt, extra_args=["--bandit-config=.bandit"])
 
 
-def test_respects_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_respects_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     assert_success(rule_runner, tgt, extra_args=["--bandit-args='--skip=B303'"])
 
 
-def test_skip(rule_runner: RuleRunner) -> None:
+def test_skip(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_bandit(rule_runner, [tgt], extra_args=["--bandit-skip"])
@@ -197,7 +198,7 @@ def test_skip(rule_runner: RuleRunner) -> None:
 
 
 @pytest.mark.skipif(not (has_python_version("3.7")), reason="Missing requisite Python")
-def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
+def test_3rdparty_plugin(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.py": "aws_key = 'JalrXUtnFEMI/K7MDENG/bPxRfiCYzEXAMPLEKEY'\n",
@@ -218,7 +219,7 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
     assert result[0].report == EMPTY_DIGEST
 
 
-def test_report_file(rule_runner: RuleRunner) -> None:
+def test_report_file(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_bandit(
@@ -234,7 +235,7 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_type_stubs(rule_runner: RuleRunner) -> None:
+def test_type_stubs(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.pyi": BAD_FILE,

--- a/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/flake8/rules_integration_test.py
@@ -24,12 +24,13 @@ from pants.testutil.python_interpreter_selection import (
     all_major_minor_python_versions,
     skip_unless_python27_and_python3_present,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *flake8_rules(),
             *flake8_subsystem_rules(),
@@ -48,7 +49,7 @@ BAD_FILE = "import typing\n"  # Unused import.
 
 
 def run_flake8(
-    rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
 ) -> tuple[LintResult, ...]:
     rule_runner.set_options(
         ["--backend-packages=pants.backend.python.lint.flake8", *(extra_args or ())],
@@ -69,7 +70,7 @@ def run_flake8(
 
 
 def assert_success(
-    rule_runner: RuleRunner, target: Target, *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, target: Target, *, extra_args: list[str] | None = None
 ) -> None:
     result = run_flake8(rule_runner, [target], extra_args=extra_args)
     assert len(result) == 1
@@ -83,7 +84,7 @@ def assert_success(
     "major_minor_interpreter",
     all_major_minor_python_versions(["CPython>=3.7,<4"]),
 )
-def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files({"f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     assert_success(
@@ -93,7 +94,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     )
 
 
-def test_failing(rule_runner: RuleRunner) -> None:
+def test_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_flake8(rule_runner, [tgt])
@@ -103,7 +104,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert result[0].report == EMPTY_DIGEST
 
 
-def test_multiple_targets(rule_runner: RuleRunner) -> None:
+def test_multiple_targets(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {"good.py": GOOD_FILE, "bad.py": BAD_FILE, "BUILD": "python_sources(name='t')"}
     )
@@ -119,7 +120,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python27_and_python3_present
-def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
+def test_uses_correct_python_version(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "f.py": "version: str = 'Py3 > Py2'\n",
@@ -171,7 +172,9 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     "config_path,extra_args",
     ([".flake8", []], ["custom_config.ini", ["--flake8-config=custom_config.ini"]]),
 )
-def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list[str]) -> None:
+def test_config_file(
+    rule_runner: PythonRuleRunner, config_path: str, extra_args: list[str]
+) -> None:
     rule_runner.write_files(
         {
             "f.py": BAD_FILE,
@@ -183,20 +186,20 @@ def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list
     assert_success(rule_runner, tgt, extra_args=extra_args)
 
 
-def test_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     assert_success(rule_runner, tgt, extra_args=["--flake8-args='--ignore=F401'"])
 
 
-def test_skip(rule_runner: RuleRunner) -> None:
+def test_skip(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_flake8(rule_runner, [tgt], extra_args=["--flake8-skip"])
     assert not result
 
 
-def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
+def test_3rdparty_plugin(rule_runner: PythonRuleRunner) -> None:
     # Test extra_files option
     rule_runner.write_files(
         {
@@ -220,7 +223,7 @@ def test_3rdparty_plugin(rule_runner: RuleRunner) -> None:
     assert result[0].exit_code == 0, result[0].stderr
 
 
-def test_report_file(rule_runner: RuleRunner) -> None:
+def test_report_file(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     result = run_flake8(
@@ -234,7 +237,7 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     assert "f.py:1:1: F401" in report_files[0].content.decode()
 
 
-def test_type_stubs(rule_runner: RuleRunner) -> None:
+def test_type_stubs(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {"f.pyi": BAD_FILE, "f.py": GOOD_FILE, "BUILD": "python_sources(name='t')"}
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem_test.py
@@ -26,13 +26,14 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.build_graph.address import Address
 from pants.core.target_types import GenericTarget
 from pants.testutil.python_interpreter_selection import skip_unless_all_pythons_present
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 from pants.util.ordered_set import FrozenOrderedSet
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *subsystem_rules(),
             *skip_field.rules(),
@@ -46,7 +47,7 @@ def rule_runner() -> RuleRunner:
 
 
 @skip_unless_all_pythons_present("3.8", "3.9")
-def test_first_party_plugins(rule_runner: RuleRunner) -> None:
+def test_first_party_plugins(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(

--- a/src/python/pants/backend/python/lint/pylint/subsystem_test.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem_test.py
@@ -26,13 +26,14 @@ from pants.backend.python.util_rules.interpreter_constraints import InterpreterC
 from pants.core.target_types import GenericTarget
 from pants.engine.addresses import Address
 from pants.testutil.python_interpreter_selection import skip_unless_all_pythons_present
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 from pants.util.ordered_set import FrozenOrderedSet
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *subsystem_rules(),
             *skip_field.rules(),
@@ -46,7 +47,7 @@ def rule_runner() -> RuleRunner:
 
 
 @skip_unless_all_pythons_present("3.8", "3.9")
-def test_first_party_plugins(rule_runner: RuleRunner) -> None:
+def test_first_party_plugins(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -105,7 +106,7 @@ def test_first_party_plugins(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_setup_lockfile(rule_runner: RuleRunner) -> None:
+def test_setup_lockfile(rule_runner: PythonRuleRunner) -> None:
     global_constraint = "==3.9.*"
 
     def assert_lockfile_request(

--- a/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules_integration_test.py
@@ -45,12 +45,12 @@ from pants.testutil.python_interpreter_selection import (
     skip_unless_python38_present,
     skip_unless_python39_present,
 )
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *mypy_rules(),
             *mypy_subystem_rules(),
@@ -92,7 +92,7 @@ NEEDS_CONFIG_FILE = dedent(
 
 
 def run_mypy(
-    rule_runner: RuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, targets: list[Target], *, extra_args: list[str] | None = None
 ) -> tuple[CheckResult, ...]:
     rule_runner.set_options(extra_args or (), env_inherit={"PATH", "PYENV_ROOT", "HOME"})
     result = rule_runner.request(
@@ -102,7 +102,7 @@ def run_mypy(
 
 
 def assert_success(
-    rule_runner: RuleRunner, target: Target, *, extra_args: list[str] | None = None
+    rule_runner: PythonRuleRunner, target: Target, *, extra_args: list[str] | None = None
 ) -> None:
     result = run_mypy(rule_runner, [target], extra_args=extra_args)
     assert len(result) == 1
@@ -116,7 +116,7 @@ def assert_success(
     "major_minor_interpreter",
     all_major_minor_python_versions(MyPy.default_interpreter_constraints),
 )
-def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
+def test_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) -> None:
     rule_runner.write_files({f"{PACKAGE}/f.py": GOOD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     assert_success(
@@ -126,7 +126,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
     )
 
 
-def test_failing(rule_runner: RuleRunner) -> None:
+def test_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({f"{PACKAGE}/f.py": BAD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     result = run_mypy(rule_runner, [tgt])
@@ -136,7 +136,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert result[0].report == EMPTY_DIGEST
 
 
-def test_multiple_targets(rule_runner: RuleRunner) -> None:
+def test_multiple_targets(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/good.py": GOOD_FILE,
@@ -161,7 +161,9 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     "config_path,extra_args",
     ([".mypy.ini", []], ["custom_config.ini", ["--mypy-config=custom_config.ini"]]),
 )
-def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list[str]) -> None:
+def test_config_file(
+    rule_runner: PythonRuleRunner, config_path: str, extra_args: list[str]
+) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/f.py": NEEDS_CONFIG_FILE,
@@ -176,7 +178,7 @@ def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list
     assert f"{PACKAGE}/f.py:3" in result[0].stdout
 
 
-def test_passthrough_args(rule_runner: RuleRunner) -> None:
+def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {f"{PACKAGE}/f.py": NEEDS_CONFIG_FILE, f"{PACKAGE}/BUILD": "python_sources()"}
     )
@@ -187,14 +189,14 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/f.py:3" in result[0].stdout
 
 
-def test_skip(rule_runner: RuleRunner) -> None:
+def test_skip(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({f"{PACKAGE}/f.py": BAD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     result = run_mypy(rule_runner, [tgt], extra_args=["--mypy-skip"])
     assert not result
 
 
-def test_report_file(rule_runner: RuleRunner) -> None:
+def test_report_file(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({f"{PACKAGE}/f.py": GOOD_FILE, f"{PACKAGE}/BUILD": "python_sources()"})
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="f.py"))
     result = run_mypy(rule_runner, [tgt], extra_args=["--mypy-args='--linecount-report=reports'"])
@@ -206,7 +208,7 @@ def test_report_file(rule_runner: RuleRunner) -> None:
     assert "4       4      1      1 f" in report_files[0].content.decode()
 
 
-def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
+def test_thirdparty_dependency(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": (
@@ -229,7 +231,7 @@ def test_thirdparty_dependency(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/f.py:3" in result[0].stdout
 
 
-def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
+def test_thirdparty_plugin(rule_runner: PythonRuleRunner) -> None:
     # NB: We install `django-stubs` both with `[mypy].extra_requirements` and
     # `[mypy].extra_type_stubs`. This awkwardness is because its used both as a plugin and
     # type stubs.
@@ -284,7 +286,7 @@ def test_thirdparty_plugin(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/app.py:4" in result[0].stdout
 
 
-def test_extra_type_stubs_lockfile(rule_runner: RuleRunner) -> None:
+def test_extra_type_stubs_lockfile(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/app.py": dedent(
@@ -359,7 +361,7 @@ def test_extra_type_stubs_lockfile(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/app.py:3" in result[0].stdout
 
 
-def test_transitive_dependencies(rule_runner: RuleRunner) -> None:
+def test_transitive_dependencies(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/util/__init__.py": "",
@@ -400,7 +402,7 @@ def test_transitive_dependencies(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python27_present
-def test_works_with_python27(rule_runner: RuleRunner) -> None:
+def test_works_with_python27(rule_runner: PythonRuleRunner) -> None:
     """A regression test that we can properly handle Python 2-only third-party dependencies.
 
     There was a bug that this would cause the runner PEX to fail to execute because it did not have
@@ -465,7 +467,7 @@ def test_works_with_python27(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python38_present
-def test_works_with_python38(rule_runner: RuleRunner) -> None:
+def test_works_with_python38(rule_runner: PythonRuleRunner) -> None:
     """MyPy's typed-ast dependency does not understand Python 3.8, so we must instead run MyPy with
     Python 3.8 when relevant."""
     rule_runner.write_files(
@@ -485,7 +487,7 @@ def test_works_with_python38(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python39_present
-def test_works_with_python39(rule_runner: RuleRunner) -> None:
+def test_works_with_python39(rule_runner: PythonRuleRunner) -> None:
     """MyPy's typed-ast dependency does not understand Python 3.9, so we must instead run MyPy with
     Python 3.9 when relevant."""
     rule_runner.write_files(
@@ -505,7 +507,7 @@ def test_works_with_python39(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python27_and_python3_present
-def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
+def test_uses_correct_python_version(rule_runner: PythonRuleRunner) -> None:
     """We set `--python-version` automatically for the user, and also batch based on interpreter
     constraints.
 
@@ -567,7 +569,7 @@ def test_uses_correct_python_version(rule_runner: RuleRunner) -> None:
     assert "Success: no issues found" in py3_result.stdout
 
 
-def test_run_only_on_specified_files(rule_runner: RuleRunner) -> None:
+def test_run_only_on_specified_files(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/good.py": GOOD_FILE,
@@ -584,7 +586,7 @@ def test_run_only_on_specified_files(rule_runner: RuleRunner) -> None:
     assert_success(rule_runner, tgt)
 
 
-def test_type_stubs(rule_runner: RuleRunner) -> None:
+def test_type_stubs(rule_runner: PythonRuleRunner) -> None:
     """Test that first-party type stubs work for both first-party and third-party code."""
     rule_runner.write_files(
         {
@@ -619,7 +621,7 @@ def test_type_stubs(rule_runner: RuleRunner) -> None:
     assert f"{PACKAGE}/app.py:5: error: Argument 1 to" in result[0].stdout
 
 
-def test_mypy_shadows_requirements(rule_runner: RuleRunner) -> None:
+def test_mypy_shadows_requirements(rule_runner: PythonRuleRunner) -> None:
     """Test the behavior of a MyPy requirement shadowing a user's requirement.
 
     The way we load requirements is complex. We want to ensure that things still work properly in
@@ -638,7 +640,7 @@ def test_mypy_shadows_requirements(rule_runner: RuleRunner) -> None:
     )
 
 
-def test_source_plugin(rule_runner: RuleRunner) -> None:
+def test_source_plugin(rule_runner: PythonRuleRunner) -> None:
     # NB: We make this source plugin fairly complex by having it use transitive dependencies.
     # This is to ensure that we can correctly support plugins with dependencies.
     # The plugin changes the return type of functions ending in `__overridden_by_plugin` to have a
@@ -748,8 +750,8 @@ def test_source_plugin(rule_runner: RuleRunner) -> None:
     assert "Success: no issues found in 1 source file" in result.stdout
 
 
-def test_protobuf_mypy(rule_runner: RuleRunner) -> None:
-    rule_runner = RuleRunner(
+def test_protobuf_mypy(rule_runner: PythonRuleRunner) -> None:
+    rule_runner = PythonRuleRunner(
         rules=[*rule_runner.rules, *protobuf_rules(), *protobuf_subsystem_rules()],
         target_types=[*rule_runner.target_types, ProtobufSourceTarget],
     )
@@ -797,7 +799,7 @@ def test_protobuf_mypy(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_all_pythons_present("3.8", "3.9")
-def test_partition_targets(rule_runner: RuleRunner) -> None:
+def test_partition_targets(rule_runner: PythonRuleRunner) -> None:
     def create_folder(folder: str, resolve: str, interpreter: str) -> dict[str, str]:
         return {
             f"{folder}/dep.py": "",
@@ -891,7 +893,7 @@ def test_determine_python_files() -> None:
     assert determine_python_files(["f.json"]) == ()
 
 
-def test_colors_and_formatting(rule_runner: RuleRunner) -> None:
+def test_colors_and_formatting(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             f"{PACKAGE}/f.py": dedent(

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem_test.py
@@ -24,14 +24,15 @@ from pants.core.target_types import GenericTarget
 from pants.core.util_rules import config_files
 from pants.engine.fs import EMPTY_DIGEST
 from pants.testutil.python_interpreter_selection import skip_unless_python39_present
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *subsystem.rules(),
             *skip_field.rules(),
@@ -47,7 +48,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-def test_warn_if_python_version_configured(rule_runner: RuleRunner, caplog) -> None:
+def test_warn_if_python_version_configured(rule_runner: PythonRuleRunner, caplog) -> None:
     config = {"mypy.ini": "[mypy]\npython_version = 3.6"}
     rule_runner.write_files(config)
     config_digest = rule_runner.make_snapshot(config).digest
@@ -103,7 +104,7 @@ def test_warn_if_python_version_configured(rule_runner: RuleRunner, caplog) -> N
     maybe_assert_configured(has_config=False, args=[])
 
 
-def test_first_party_plugins(rule_runner: RuleRunner) -> None:
+def test_first_party_plugins(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -149,7 +150,7 @@ def test_first_party_plugins(rule_runner: RuleRunner) -> None:
 
 
 @skip_unless_python39_present
-def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None:
+def test_setup_lockfile_interpreter_constraints(rule_runner: PythonRuleRunner) -> None:
     global_constraint = "==3.9.*"
 
     def assert_lockfile_request(
@@ -251,7 +252,9 @@ def test_setup_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None
     )
 
 
-def test_setup_extra_type_stubs_lockfile_interpreter_constraints(rule_runner: RuleRunner) -> None:
+def test_setup_extra_type_stubs_lockfile_interpreter_constraints(
+    rule_runner: PythonRuleRunner,
+) -> None:
     global_constraint = "==3.9.*"
 
     def assert_lockfile_request(build_file: str, expected_ics: list[str]) -> None:

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -14,5 +14,6 @@ python_tests(
         "pex_from_targets_test.py": {"timeout": 200},
         "pex_test.py": {"timeout": 600},
         "package_dists_test.py": {"timeout": 150},
+        "vcs_versioning_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -32,13 +32,14 @@ from pants.testutil.python_interpreter_selection import (
     skip_unless_python27_present,
     skip_unless_python39_present,
 )
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 from pants.util.frozendict import FrozenDict
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    ret = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    ret = PythonRuleRunner(
         rules=[
             *local_dists_pep660.rules(),
             *setuptools_rules(),
@@ -59,7 +60,7 @@ def rule_runner() -> RuleRunner:
     return ret
 
 
-def do_test_backend_wrapper(rule_runner: RuleRunner, constraints: str) -> None:
+def do_test_backend_wrapper(rule_runner: PythonRuleRunner, constraints: str) -> None:
     setup_py = "from setuptools import setup; setup(name='foobar', version='1.2.3')"
     input_digest = rule_runner.request(
         Digest, [CreateDigest([FileContent("setup.py", setup_py.encode())])]
@@ -91,16 +92,16 @@ def do_test_backend_wrapper(rule_runner: RuleRunner, constraints: str) -> None:
 
 
 @skip_unless_python27_present
-def test_works_with_python2(rule_runner: RuleRunner) -> None:
+def test_works_with_python2(rule_runner: PythonRuleRunner) -> None:
     do_test_backend_wrapper(rule_runner, constraints="CPython==2.7.*")
 
 
 @skip_unless_python39_present
-def test_works_with_python39(rule_runner: RuleRunner) -> None:
+def test_works_with_python39(rule_runner: PythonRuleRunner) -> None:
     do_test_backend_wrapper(rule_runner, constraints="CPython==3.9.*")
 
 
-def test_sort_all_python_distributions_by_resolve(rule_runner: RuleRunner) -> None:
+def test_sort_all_python_distributions_by_resolve(rule_runner: PythonRuleRunner) -> None:
     rule_runner.set_options(
         [
             "--python-enable-resolves=True",
@@ -153,7 +154,7 @@ def test_sort_all_python_distributions_by_resolve(rule_runner: RuleRunner) -> No
     assert dist == result.targets["a"][0]
 
 
-def test_build_editable_local_dists(rule_runner: RuleRunner) -> None:
+def test_build_editable_local_dists(rule_runner: PythonRuleRunner) -> None:
     foo = PurePath("foo")
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/python/util_rules/local_dists_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_test.py
@@ -23,12 +23,13 @@ from pants.backend.python.util_rules.python_sources import PythonSourceFiles
 from pants.build_graph.address import Address
 from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import CreateDigest, Digest, DigestContents, FileContent, Snapshot
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *local_dists.rules(),
             *package_dists.rules(),
@@ -43,7 +44,7 @@ def rule_runner() -> RuleRunner:
     )
 
 
-def test_build_local_dists(rule_runner: RuleRunner) -> None:
+def test_build_local_dists(rule_runner: PythonRuleRunner) -> None:
     foo = PurePath("foo")
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/python/util_rules/package_dists_test.py
+++ b/src/python/pants/backend/python/util_rules/package_dists_test.py
@@ -66,14 +66,15 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import rule
 from pants.engine.target import InvalidFieldException
 from pants.engine.unions import UnionRule
-from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule, engine_error
 from pants.util.strutil import softwrap
 
 _namespace_decl = "__import__('pkg_resources').declare_namespace(__name__)"
 
 
-def create_setup_py_rule_runner(*, rules: Iterable) -> RuleRunner:
-    rule_runner = RuleRunner(
+def create_setup_py_rule_runner(*, rules: Iterable) -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=rules,
         target_types=[
             PexBinary,
@@ -104,7 +105,7 @@ def setup_kwargs_plugin(request: PluginSetupKwargsRequest) -> SetupKwargs:
 
 
 @pytest.fixture
-def chroot_rule_runner() -> RuleRunner:
+def chroot_rule_runner() -> PythonRuleRunner:
     return create_setup_py_rule_runner(
         rules=[
             *core_target_types_rules(),
@@ -129,7 +130,7 @@ def chroot_rule_runner() -> RuleRunner:
 
 
 def assert_chroot(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     expected_files: list[str],
     expected_setup_kwargs,
     addr: Address,
@@ -155,7 +156,9 @@ def assert_chroot(
         assert expected_setup_kwargs == setup_kwargs.kwargs
 
 
-def assert_chroot_error(rule_runner: RuleRunner, addr: Address, exc_cls: type[Exception]) -> None:
+def assert_chroot_error(
+    rule_runner: PythonRuleRunner, addr: Address, exc_cls: type[Exception]
+) -> None:
     tgt = rule_runner.get_target(addr)
     with pytest.raises(ExecutionError) as excinfo:
         rule_runner.request(
@@ -347,7 +350,7 @@ def test_merge_entry_points() -> None:
         merge_entry_points(*list(conflicting_sources.items()))
 
 
-def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
+def test_generate_chroot(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/foo/bar/baz/BUILD": textwrap.dedent(
@@ -439,7 +442,7 @@ def test_generate_chroot(chroot_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
+def test_generate_chroot_entry_points(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/foo/qux/BUILD": textwrap.dedent(
@@ -526,7 +529,7 @@ def test_generate_chroot_entry_points(chroot_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_generate_long_description_field_from_file(chroot_rule_runner: RuleRunner) -> None:
+def test_generate_long_description_field_from_file(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/foo/BUILD": textwrap.dedent(
@@ -566,7 +569,7 @@ def test_generate_long_description_field_from_file(chroot_rule_runner: RuleRunne
 
 
 def test_generate_long_description_field_from_file_already_having_it(
-    chroot_rule_runner: RuleRunner,
+    chroot_rule_runner: PythonRuleRunner,
 ) -> None:
     chroot_rule_runner.write_files(
         {
@@ -594,7 +597,7 @@ def test_generate_long_description_field_from_file_already_having_it(
 
 
 def test_generate_long_description_field_from_non_existing_file(
-    chroot_rule_runner: RuleRunner,
+    chroot_rule_runner: PythonRuleRunner,
 ) -> None:
     chroot_rule_runner.write_files(
         {
@@ -619,7 +622,7 @@ def test_generate_long_description_field_from_non_existing_file(
     )
 
 
-def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
+def test_invalid_binary(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/invalid_binary/lib.py": "",
@@ -685,7 +688,7 @@ def test_invalid_binary(chroot_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_binary_shorthand(chroot_rule_runner: RuleRunner) -> None:
+def test_binary_shorthand(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/project/app.py": "",
@@ -1134,7 +1137,7 @@ def test_owned_dependencies() -> None:
 
 
 @pytest.fixture
-def exporting_owner_rule_runner() -> RuleRunner:
+def exporting_owner_rule_runner() -> PythonRuleRunner:
     return create_setup_py_rule_runner(
         rules=[
             get_exporting_owner,
@@ -1144,7 +1147,7 @@ def exporting_owner_rule_runner() -> RuleRunner:
     )
 
 
-def assert_is_owner(rule_runner: RuleRunner, owner: str, owned: Address):
+def assert_is_owner(rule_runner: PythonRuleRunner, owner: str, owned: Address):
     tgt = rule_runner.get_target(owned)
     assert (
         owner
@@ -1167,15 +1170,15 @@ def assert_owner_error(rule_runner, owned: Address, exc_cls: type[Exception]):
     assert type(ex.wrapped_exceptions[0]) == exc_cls
 
 
-def assert_no_owner(rule_runner: RuleRunner, owned: Address):
+def assert_no_owner(rule_runner: PythonRuleRunner, owned: Address):
     assert_owner_error(rule_runner, owned, NoOwnerError)
 
 
-def assert_ambiguous_owner(rule_runner: RuleRunner, owned: Address):
+def assert_ambiguous_owner(rule_runner: PythonRuleRunner, owned: Address):
     assert_owner_error(rule_runner, owned, AmbiguousOwnerError)
 
 
-def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
+def test_get_owner_simple(exporting_owner_rule_runner: PythonRuleRunner) -> None:
     exporting_owner_rule_runner.write_files(
         {
             "src/python/foo/bar/baz/BUILD": textwrap.dedent(
@@ -1258,7 +1261,7 @@ def test_get_owner_simple(exporting_owner_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_get_owner_siblings(exporting_owner_rule_runner: RuleRunner) -> None:
+def test_get_owner_siblings(exporting_owner_rule_runner: PythonRuleRunner) -> None:
     exporting_owner_rule_runner.write_files(
         {
             "src/python/siblings/BUILD": textwrap.dedent(
@@ -1286,7 +1289,7 @@ def test_get_owner_siblings(exporting_owner_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_get_owner_not_an_ancestor(exporting_owner_rule_runner: RuleRunner) -> None:
+def test_get_owner_not_an_ancestor(exporting_owner_rule_runner: PythonRuleRunner) -> None:
     exporting_owner_rule_runner.write_files(
         {
             "src/python/notanancestor/aaa/BUILD": textwrap.dedent(
@@ -1314,7 +1317,9 @@ def test_get_owner_not_an_ancestor(exporting_owner_rule_runner: RuleRunner) -> N
     )
 
 
-def test_get_owner_multiple_ancestor_generations(exporting_owner_rule_runner: RuleRunner) -> None:
+def test_get_owner_multiple_ancestor_generations(
+    exporting_owner_rule_runner: PythonRuleRunner,
+) -> None:
     exporting_owner_rule_runner.write_files(
         {
             "src/python/aaa/bbb/ccc/BUILD": textwrap.dedent(
@@ -1394,7 +1399,7 @@ def test_does_not_declare_pkg_resources_namespace_package(python_src: str) -> No
 
 
 def test_no_dist_type_selected() -> None:
-    rule_runner = RuleRunner(
+    rule_runner = PythonRuleRunner(
         rules=[
             determine_explicitly_provided_setup_kwargs,
             generate_chroot,
@@ -1450,7 +1455,7 @@ def test_no_dist_type_selected() -> None:
     )
 
 
-def test_too_many_interpreter_constraints(chroot_rule_runner: RuleRunner) -> None:
+def test_too_many_interpreter_constraints(chroot_rule_runner: PythonRuleRunner) -> None:
     chroot_rule_runner.write_files(
         {
             "src/python/foo/BUILD": textwrap.dedent(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -58,21 +58,16 @@ from pants.core.goals.generate_lockfiles import NoCompatibleResolveException
 from pants.engine.addresses import Addresses
 from pants.engine.fs import Snapshot
 from pants.testutil.option_util import create_subsystem
-from pants.testutil.rule_runner import (
-    MockGet,
-    QueryRule,
-    RuleRunner,
-    engine_error,
-    run_rule_with_mocks,
-)
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import MockGet, QueryRule, engine_error, run_rule_with_mocks
 from pants.util.contextutil import pushd
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import softwrap
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *pex_test_utils.rules(),
             *pex_from_targets.rules(),
@@ -94,7 +89,7 @@ def rule_runner() -> RuleRunner:
 
 @pytest.mark.skip(reason="TODO(#15824)")
 @pytest.mark.no_error_if_skipped
-def test_choose_compatible_resolve(rule_runner: RuleRunner) -> None:
+def test_choose_compatible_resolve(rule_runner: PythonRuleRunner) -> None:
     def create_target_files(
         directory: str, *, req_resolve: str, source_resolve: str, test_resolve: str
     ) -> dict[str, str]:
@@ -554,11 +549,11 @@ def create_dists(workdir: Path, project: Project, *projects: Project) -> PurePat
     return find_links
 
 
-def requirements(rule_runner: RuleRunner, pex: Pex) -> list[str]:
+def requirements(rule_runner: PythonRuleRunner, pex: Pex) -> list[str]:
     return cast(List[str], get_all_data(rule_runner, pex).info["requirements"])
 
 
-def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None:
+def test_constraints_validation(tmp_path: Path, rule_runner: PythonRuleRunner) -> None:
     sdists = tmp_path / "sdists"
     sdists.mkdir()
     find_links = create_dists(
@@ -689,7 +684,7 @@ def test_constraints_validation(tmp_path: Path, rule_runner: RuleRunner) -> None
 
 @pytest.mark.parametrize("include_requirements", [False, True])
 def test_exclude_requirements(
-    include_requirements: bool, tmp_path: Path, rule_runner: RuleRunner
+    include_requirements: bool, tmp_path: Path, rule_runner: PythonRuleRunner
 ) -> None:
     sdists = tmp_path / "sdists"
     sdists.mkdir()
@@ -729,7 +724,7 @@ def test_exclude_requirements(
 
 
 @pytest.mark.parametrize("include_sources", [False, True])
-def test_exclude_sources(include_sources: bool, rule_runner: RuleRunner) -> None:
+def test_exclude_sources(include_sources: bool, rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
@@ -762,7 +757,7 @@ def test_exclude_sources(include_sources: bool, rule_runner: RuleRunner) -> None
 
 @pytest.mark.parametrize("enable_resolves", [False, True])
 def test_cross_platform_pex_disables_subsetting(
-    rule_runner: RuleRunner, enable_resolves: bool
+    rule_runner: PythonRuleRunner, enable_resolves: bool
 ) -> None:
     # See https://github.com/pantsbuild/pants/issues/12222.
     lockfile = "3rdparty/python/default.lock"
@@ -816,7 +811,7 @@ class ResolveMode(Enum):
     [(m, io, rael) for m in ResolveMode for io in [True, False] for rael in [True, False]],
 )
 def test_lockfile_requirements_selection(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     mode: ResolveMode,
     internal_only: bool,
     run_against_entire_lockfile: bool,

--- a/src/python/pants/backend/python/util_rules/vcs_versioning_test.py
+++ b/src/python/pants/backend/python/util_rules/vcs_versioning_test.py
@@ -19,15 +19,15 @@ from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT
 from pants.engine.rules import QueryRule
 from pants.engine.target import GeneratedSources
-from pants.testutil.rule_runner import RuleRunner
+from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.util.contextutil import environment_as
 from pants.util.dirutil import safe_open
 from pants.vcs import git
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    rule_runner = RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    rule_runner = PythonRuleRunner(
         rules=[
             *vcs_versioning.rules(),
             *setuptools_scm.rules(),
@@ -64,7 +64,7 @@ def rule_runner() -> RuleRunner:
     ),
 )
 def test_vcs_versioning(
-    tag_regex, tag, expected_version, tmp_path: Path, rule_runner: RuleRunner
+    tag_regex, tag, expected_version, tmp_path: Path, rule_runner: PythonRuleRunner
 ) -> None:
     worktree = tmp_path / "worktree"
     gitdir = worktree / ".git"

--- a/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
@@ -37,12 +37,13 @@ from pants.engine.addresses import Address
 from pants.engine.fs import FileContent
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Target
-from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
+from pants.testutil.python_rule_runner import PythonRuleRunner
+from pants.testutil.rule_runner import QueryRule, mock_console
 
 
 @pytest.fixture
-def rule_runner() -> RuleRunner:
-    return RuleRunner(
+def rule_runner() -> PythonRuleRunner:
+    return PythonRuleRunner(
         rules=[
             *shunit2_test_runner.rules(),
             *source_files.rules(),
@@ -77,7 +78,7 @@ GOOD_TEST = dedent(
 
 
 def run_shunit2(
-    rule_runner: RuleRunner,
+    rule_runner: PythonRuleRunner,
     test_target: Target,
     *,
     extra_args: list[str] | None = None,
@@ -103,7 +104,7 @@ def run_shunit2(
     return test_result
 
 
-def test_passing(rule_runner: RuleRunner) -> None:
+def test_passing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"tests.sh": GOOD_TEST, "BUILD": "shunit2_tests(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
@@ -111,7 +112,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     assert "Ran 1 test.\n\nOK" in result.stdout
 
 
-def test_failing(rule_runner: RuleRunner) -> None:
+def test_failing(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "tests.sh": dedent(
@@ -132,7 +133,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     assert "Ran 1 test.\n\nFAILED" in result.stdout
 
 
-def test_dependencies(rule_runner: RuleRunner) -> None:
+def test_dependencies(rule_runner: PythonRuleRunner) -> None:
     """Ensure direct and transitive dependencies work."""
     rule_runner.write_files(
         {
@@ -179,7 +180,7 @@ def test_dependencies(rule_runner: RuleRunner) -> None:
     assert "Ran 1 test.\n\nOK" in result.stdout
 
 
-def test_subdirectories(rule_runner: RuleRunner) -> None:
+def test_subdirectories(rule_runner: PythonRuleRunner) -> None:
     # We always download the shunit2 script to the build root - this test is a smoke screen that
     # we properly source the file.
     rule_runner.write_files({"a/b/c/tests.sh": GOOD_TEST, "a/b/c/BUILD": "shunit2_tests()"})
@@ -195,7 +196,7 @@ def test_subdirectories(rule_runner: RuleRunner) -> None:
     "`--force` does not work properly."
 )
 @pytest.mark.no_error_if_skipped
-def test_force(rule_runner: RuleRunner) -> None:
+def test_force(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files({"tests.sh": GOOD_TEST, "BUILD": "shunit2_tests(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
 
@@ -213,7 +214,7 @@ def test_force(rule_runner: RuleRunner) -> None:
     assert result_one is result_two
 
 
-def test_extra_env_vars(rule_runner: RuleRunner) -> None:
+def test_extra_env_vars(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "tests.sh": dedent(
@@ -240,7 +241,7 @@ def test_extra_env_vars(rule_runner: RuleRunner) -> None:
     assert "Ran 1 test.\n\nOK" in result.stdout
 
 
-def test_runtime_package_dependency(rule_runner: RuleRunner) -> None:
+def test_runtime_package_dependency(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/py/main.py": "",
@@ -270,7 +271,7 @@ def test_runtime_package_dependency(rule_runner: RuleRunner) -> None:
     assert "Ran 1 test.\n\nOK" in result.stdout
 
 
-def test_determine_shell_runner(rule_runner: RuleRunner) -> None:
+def test_determine_shell_runner(rule_runner: PythonRuleRunner) -> None:
     addr = Address("", target_name="t")
     fc = FileContent("tests.sh", b"#!/usr/bin/env sh")
     rule_runner.set_options([], env_inherit={"PATH"})


### PR DESCRIPTION
This is a step towards getting rid of the IC-setting hack introduced in #18627.

This is a very mechanical change that replaced uses of RuleRunner with 
PythonRuleRunner. There is also one change to a test timeout.

This is not exhaustive - there are other tests that will need similar treatment
before we can rid of the hack.