### PR TITLE
Fix `repr` for `Field`s that don't define `default`.

### DIFF
--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -197,9 +197,9 @@ class Field:
         )
 
     def __repr__(self) -> str:
-        params = [f"alias={repr(self.alias)}", f"value={repr(self.value)}"]
+        params = [f"alias={self.alias!r}", f"value={self.value!r}"]
         if hasattr(self, "default"):
-            params.append(f"default={repr(self.default)}")
+            params.append(f"default={self.default!r}")
         return f"{self.__class__}({', '.join(params)})"
 
     def __str__(self) -> str:
@@ -270,12 +270,12 @@ class AsyncFieldMixin(Field):
 
     def __repr__(self) -> str:
         params = [
-            f"alias={repr(self.alias)}",
+            f"alias={self.alias!r}",
             f"address={self.address}",
-            f"value={repr(self.value)}",
+            f"value={self.value!r}",
         ]
         if hasattr(self, "default"):
-            params.append(f"default={repr(self.default)}")
+            params.append(f"default={self.default!r}")
         return f"{self.__class__}({', '.join(params)})"
 
     def __hash__(self) -> int:

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -197,10 +197,10 @@ class Field:
         )
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__}(alias={repr(self.alias)}, value={repr(self.value)}, "
-            f"default={repr(self.default)})"
-        )
+        params = [f"alias={repr(self.alias)}", f"value={repr(self.value)}"]
+        if hasattr(self, "default"):
+            params.append(f"default={repr(self.default)}")
+        return f"{self.__class__}({', '.join(params)})"
 
     def __str__(self) -> str:
         return f"{self.alias}={self.value}"
@@ -269,10 +269,14 @@ class AsyncFieldMixin(Field):
         super().__init__(raw_value, address)
 
     def __repr__(self) -> str:
-        return (
-            f"{self.__class__}(alias={repr(self.alias)}, address={self.address}, "
-            f"value={repr(self.value)}, default={repr(self.default)})"
-        )
+        params = [
+            f"alias={repr(self.alias)}",
+            f"address={self.address}",
+            f"value={repr(self.value)}",
+        ]
+        if hasattr(self, "default"):
+            params.append(f"default={repr(self.default)}")
+        return f"{self.__class__}({', '.join(params)})"
 
     def __hash__(self) -> int:
         return hash((self.__class__, self.value, self.address))

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -400,7 +400,7 @@ def test_override_preexisting_field_via_new_target() -> None:
 
 
 def test_required_field() -> None:
-    class RequiredField(StringField):
+    class RequiredField(Field):
         alias = "field"
         required = True
 
@@ -409,6 +409,8 @@ def test_required_field() -> None:
         core_fields = (RequiredField,)
 
     address = Address("", target_name="lib")
+    # No errors getting the repr
+    assert repr(RequiredField("present", address))
 
     # No errors when defined
     RequiredTarget({"field": "present"}, address)


### PR DESCRIPTION
Found while working on #18566

The code for `Field` declares that subclasses must define one of `default` and `required`, and leaves `default` without a value. However its implementation of `__repr__` assumes that `default` will always be defined. This can cause errors like:
```
AttributeError: 'RequiredField' object has no attribute 'default'
```
In various places, i.e. when stringifying a `FieldSet` or when converting a `Target` to a `FieldSet` via `field_set_type.create(tgt)`.