### PR TITLE
Use address as stable key when batching field sets in `lint`/`test` (Cherry-pick of #18725)

### DIFF
--- a/src/python/pants/core/goals/lint.py
+++ b/src/python/pants/core/goals/lint.py
@@ -427,12 +427,10 @@ async def lint(
     if not partitions_by_request_type:
         return Lint(exit_code=0)
 
-    def batch_by_size(
-        iterable: Iterable[_T], key: Callable[[_T], str] = lambda x: str(x)
-    ) -> Iterator[tuple[_T, ...]]:
+    def batch_by_size(iterable: Iterable[_T]) -> Iterator[tuple[_T, ...]]:
         batches = partition_sequentially(
             iterable,
-            key=key,
+            key=lambda x: str(x.address) if isinstance(x, FieldSet) else str(x),
             size_target=lint_subsystem.batch_size,
             size_max=4 * lint_subsystem.batch_size,
         )

--- a/src/python/pants/core/goals/lint_test.py
+++ b/src/python/pants/core/goals/lint_test.py
@@ -32,7 +32,7 @@ from pants.engine.environment import EnvironmentName
 from pants.engine.fs import PathGlobs, SpecsPaths, Workspace
 from pants.engine.internals.native_engine import EMPTY_SNAPSHOT, Snapshot
 from pants.engine.rules import QueryRule
-from pants.engine.target import FieldSet, FilteredTargets, MultipleSourcesField, Target
+from pants.engine.target import Field, FieldSet, FilteredTargets, MultipleSourcesField, Target
 from pants.engine.unions import UnionMembership
 from pants.option.option_types import SkipOption
 from pants.option.subsystem import Subsystem
@@ -48,15 +48,21 @@ class MockMultipleSourcesField(MultipleSourcesField):
     pass
 
 
+class MockRequiredField(Field):
+    alias = "required"
+    required = True
+
+
 class MockTarget(Target):
     alias = "mock_target"
-    core_fields = (MockMultipleSourcesField,)
+    core_fields = (MockMultipleSourcesField, MockRequiredField)
 
 
 @dataclass(frozen=True)
 class MockLinterFieldSet(FieldSet):
     required_fields = (MultipleSourcesField,)
     sources: MultipleSourcesField
+    required: MockRequiredField
 
 
 class MockLintRequest(LintRequest, metaclass=ABCMeta):
@@ -259,7 +265,9 @@ def rule_runner() -> RuleRunner:
 
 
 def make_target(address: Optional[Address] = None) -> Target:
-    return MockTarget({}, address or Address("", target_name="tests"))
+    return MockTarget(
+        {MockRequiredField.alias: "present"}, address or Address("", target_name="tests")
+    )
 
 
 def run_lint_rule(
@@ -511,8 +519,16 @@ def test_default_single_partition_partitioner() -> None:
     ]
     rule_runner = RuleRunner(rules=rules)
     field_sets = (
-        MockLinterFieldSet(Address("knife"), MultipleSourcesField(["knife"], Address("knife"))),
-        MockLinterFieldSet(Address("bowl"), MultipleSourcesField(["bowl"], Address("bowl"))),
+        MockLinterFieldSet(
+            Address("knife"),
+            MultipleSourcesField(["knife"], Address("knife")),
+            MockRequiredField("present", Address("")),
+        ),
+        MockLinterFieldSet(
+            Address("bowl"),
+            MultipleSourcesField(["bowl"], Address("bowl")),
+            MockRequiredField("present", Address("")),
+        ),
     )
     partitions = rule_runner.request(Partitions, [LintKitchenRequest.PartitionRequest(field_sets)])
     assert len(partitions) == 1

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -705,7 +705,7 @@ async def _get_test_batches(
         for partition in partitions
         for batch in partition_sequentially(
             partition.elements,
-            key=lambda x: str(x),
+            key=lambda x: str(x.address) if isinstance(x, FieldSet) else str(x),
             size_target=test_subsystem.batch_size,
             size_max=2 * test_subsystem.batch_size,
         )


### PR DESCRIPTION
Closes #18566

Using `str(x)` as the stable batching key ends up using `repr` when `x` is a field set. After #18719 this no longer raises an exception, but it's still an unintended behavior change introduced as part of the new partitioning logic in 2.15.x.

Revert back to using `.address` as the partitioning key for field sets, and add regression tests.
