### PR TITLE
Deprecate "Secondary Ownership" semantics

### DIFF
--- a/src/python/pants/base/specs.py
+++ b/src/python/pants/base/specs.py
@@ -11,6 +11,7 @@ from typing import ClassVar, Iterable, Iterator, cast
 from typing_extensions import Protocol
 
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
+from pants.build_graph.address import Address
 from pants.engine.fs import GlobExpansionConjunction, PathGlobs
 from pants.util.dirutil import fast_relpath_optional, recursive_dirname
 from pants.util.frozendict import FrozenDict
@@ -61,6 +62,14 @@ class AddressLiteralSpec(Spec):
             self.target_component is None
             and self.generated_component is None
             and not self.parameters
+        )
+
+    def to_address(self) -> Address:
+        return Address(
+            self.path_component,
+            target_name=self.target_component,
+            generated_name=self.generated_component,
+            parameters=self.parameters,
         )
 
 

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -547,7 +547,7 @@ async def find_valid_field_sets_for_target_roots(
                 f"""
                 Refer to the following targets by their addresses:
 
-                {bullet_list(sorted(secondary_owner_targets))}
+                {bullet_list(sorted(tgt.address.spec for tgt in secondary_owner_targets))}
                 """
             )
         )

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -529,10 +529,16 @@ async def find_valid_field_sets_for_target_roots(
         ):
             logger.warning(str(no_applicable_exception))
 
-
     secondary_owner_targets = set()
+    specified_literal_addresses = {
+        address_literal.to_address() for address_literal in specs.includes.address_literals
+    }
     for tgt, field_sets in targets_to_applicable_field_sets.items():
-        if any(isinstance(field, SecondaryOwnerMixin) for field in tgt.field_values.values()):
+        is_secondary = any(
+            isinstance(field, SecondaryOwnerMixin) for field in tgt.field_values.values()
+        )
+        is_explicitly_specified = tgt.address in specified_literal_addresses
+        if is_secondary and not is_explicitly_specified:
             secondary_owner_targets.add(tgt)
     if secondary_owner_targets:
         warn_or_error(
@@ -549,7 +555,7 @@ async def find_valid_field_sets_for_target_roots(
 
                 {bullet_list(sorted(tgt.address.spec for tgt in secondary_owner_targets))}
                 """
-            )
+            ),
         )
 
     if request.num_shards > 0:


### PR DESCRIPTION
Currently only 3 targets have "secondary owners" fields:
- `pex_binary`
- `python_awslambda` (this assumes the filename is `.py` Doh!)
- `python_google_cloud_function` (this assumes the filename is `.py` Doh!)

The secondary ownership ability stems from wanting to use a goal by referring to the file (which presumably the "primary" owner doesn't support the goal). E.g. `package`ing a Python file packages the relevant PEX/Lambda/etc....

However, it is a bit short-sighted:
- You can run both a `pex_binary` (secondary) and a `python_source` (primary). If multiple PEX binaries exist for a single source:
  - Goals like `run` and `paths` error on ambiguity and give unhelpful messages (saying that the filename was ambiguous, and then listing the filename as a valid address)
- There are no secondary owners outside of Python.

So marking for deprecation and removal. Users can find the owners of the files from the specs and pipe that into the relevant goal. (If someone wants, we can add a new goal/flag to aid with this)