### PR TITLE
Add ruff lint rules (Cherry-pick of #18716)

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -3,27 +3,53 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
 from pants.backend.python.lint.ruff.subsystem import Ruff, RuffFieldSet
 from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.core.goals.fix import FixResult, FixTargetsRequest
+from pants.core.goals.lint import LintResult, LintTargetsRequest
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.partitions import PartitionerType
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import Digest, MergeDigests
+from pants.engine.internals.native_engine import Snapshot
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.util.logging import LogLevel
+from pants.util.meta import classproperty
 from pants.util.strutil import pluralize
 
 
-class RuffRequest(FixTargetsRequest):
+class RuffFixRequest(FixTargetsRequest):
+    field_set_type = RuffFieldSet
+    tool_subsystem = Ruff
+    partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
+
+    @classproperty
+    def tool_name(cls) -> str:
+        return "ruff --fix"
+
+
+class RuffLintRequest(LintTargetsRequest):
     field_set_type = RuffFieldSet
     tool_subsystem = Ruff
     partitioner_type = PartitionerType.DEFAULT_SINGLE_PARTITION
 
 
-@rule(desc="Fix with ruff", level=LogLevel.DEBUG)
-async def ruff_fix(request: RuffRequest.Batch, ruff: Ruff) -> FixResult:
+@dataclass(frozen=True)
+class _RunRuffRequest:
+    snapshot: Snapshot
+    is_fix: bool
+
+
+@rule(level=LogLevel.DEBUG)
+async def run_ruff(
+    request: _RunRuffRequest,
+    ruff: Ruff,
+) -> FallibleProcessResult:
     ruff_pex_get = Get(VenvPex, PexRequest, ruff.to_pex_request())
 
     config_files_get = Get(
@@ -38,20 +64,45 @@ async def ruff_fix(request: RuffRequest.Batch, ruff: Ruff) -> FixResult:
     )
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
+    initial_args = ("--fix",) if request.is_fix else ()
 
     result = await Get(
         FallibleProcessResult,
         VenvPexProcess(
             ruff_pex,
-            argv=("--fix", *conf_args, *ruff.args, *request.files),
+            argv=(*initial_args, *conf_args, *ruff.args, *request.snapshot.files),
             input_digest=input_digest,
-            output_files=request.files,
-            description=f"Run ruff on {pluralize(len(request.elements), 'file')}.",
+            output_files=request.snapshot.files,
+            description=f"Run ruff {' '.join(initial_args)} on {pluralize(len(request.snapshot.files), 'file')}.",
             level=LogLevel.DEBUG,
         ),
+    )
+    return result
+
+
+@rule(desc="Fix with ruff", level=LogLevel.DEBUG)
+async def ruff_fix(request: RuffFixRequest.Batch, ruff: Ruff) -> FixResult:
+    result = await Get(
+        FallibleProcessResult, _RunRuffRequest(snapshot=request.snapshot, is_fix=True)
     )
     return await FixResult.create(request, result, strip_chroot_path=True)
 
 
+@rule(desc="Lint with ruff", level=LogLevel.DEBUG)
+async def ruff_lint(request: RuffLintRequest.Batch[RuffFieldSet, Any]) -> LintResult:
+    source_files = await Get(
+        SourceFiles, SourceFilesRequest(field_set.source for field_set in request.elements)
+    )
+    result = await Get(
+        FallibleProcessResult, _RunRuffRequest(snapshot=source_files.snapshot, is_fix=False)
+    )
+    return LintResult.create(request, result, strip_chroot_path=True)
+
+
 def rules():
-    return [*collect_rules(), *RuffRequest.rules(), *pex.rules()]
+    return [
+        *collect_rules(),
+        *RuffFixRequest.rules(),
+        *RuffLintRequest.rules(),
+        *pex.rules(),
+    ]


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/18430 by also adding the `lint` rules for `ruff`.

You'll get the normal fixing behavior in `fix` still, but in lint we'll run the `fix` process AND the vanilla `check` process. One downside is the `lint` process will complain about fixable errors (See https://github.com/charliermarsh/ruff/issues/3939).


