### PR TITLE
Avoid using private type `hashlib._Hash`, which may not exist

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_build_context.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context.py
@@ -130,7 +130,7 @@ class DockerBuildContext:
         # Data from Pants.
         interpolation_context["pants"] = {
             # Present hash for all inputs that can be used for image tagging.
-            "hash": stable_hash((build_args, build_env, snapshot.digest)).hexdigest(),
+            "hash": stable_hash((build_args, build_env, snapshot.digest)),
         }
 
         # Base image tags values for all stages (as parsed from the Dockerfile instructions).

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -365,7 +365,7 @@ class _JsonEncoder(json.JSONEncoder):
         return super().default(o)
 
 
-def stable_hash(value: Any, *, name: str = "sha256") -> hashlib._Hash:
+def stable_hash(value: Any, *, name: str = "sha256") -> str:
     """Attempts to return a stable hash of the value stable across processes.
 
     "Stable" here means that if `value` is equivalent in multiple invocations (across multiple
@@ -377,4 +377,4 @@ def stable_hash(value: Any, *, name: str = "sha256") -> hashlib._Hash:
         json.dumps(
             value, indent=None, separators=(",", ":"), sort_keys=True, cls=_JsonEncoder
         ).encode("utf-8"),
-    )
+    ).hexdigest()

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -412,7 +412,4 @@ def test_stable_hash() -> None:
             {alpha: alpha.lower() for alpha in [chr(a) for a in range(ord("A"), ord("Z") + 1)]}
         )
     )
-    assert (
-        stable_hash(data).hexdigest()
-        == "1f2a0caa2588274fa99dc7397c1687dbbe6159be0de646a37ba7af241ecf1add"
-    )
+    assert stable_hash(data) == "1f2a0caa2588274fa99dc7397c1687dbbe6159be0de646a37ba7af241ecf1add"


### PR DESCRIPTION
This avoids `E   AttributeError: module 'hashlib' has no attribute '_Hash'`