### PR TITLE
Clear FSDB materialization cache when `remove`ing a file

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -308,10 +308,10 @@ impl UnderlyingByteStore for ShardedFSDB {
   }
 
   async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
+    let _ = self.dest_initializer.lock().remove(&fingerprint);
     let removed = tokio::fs::remove_file(self.get_path(fingerprint))
       .await
       .is_ok();
-    let _ = self.dest_initializer.lock().remove(&fingerprint);
     Ok(removed)
   }
 

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -309,10 +309,11 @@ impl UnderlyingByteStore for ShardedFSDB {
 
   async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
     let _ = self.dest_initializer.lock().remove(&fingerprint);
-    let removed = tokio::fs::remove_file(self.get_path(fingerprint))
-      .await
-      .is_ok();
-    Ok(removed)
+    Ok(
+      tokio::fs::remove_file(self.get_path(fingerprint))
+        .await
+        .is_ok(),
+    )
   }
 
   async fn store_bytes_batch(

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -308,11 +308,11 @@ impl UnderlyingByteStore for ShardedFSDB {
   }
 
   async fn remove(&self, fingerprint: Fingerprint) -> Result<bool, String> {
-    Ok(
-      tokio::fs::remove_file(self.get_path(fingerprint))
-        .await
-        .is_ok(),
-    )
+    let removed = tokio::fs::remove_file(self.get_path(fingerprint))
+      .await
+      .is_ok();
+    let _ = self.dest_initializer.lock().remove(&fingerprint);
+    Ok(removed)
   }
 
   async fn store_bytes_batch(

--- a/src/rust/engine/fs/store/src/local_tests.rs
+++ b/src/rust/engine/fs/store/src/local_tests.rs
@@ -575,10 +575,12 @@ async fn remove_big_file_and_store_again() {
     "Expect size to be at least 2MB but was {size}"
   );
 
-  store.remove(EntryType::File, digest1)
+  store
+    .remove(EntryType::File, digest1)
     .await
     .expect("Error removing");
-  store.remove(EntryType::File, digest2)
+  store
+    .remove(EntryType::File, digest2)
     .await
     .expect("Error removing");
 


### PR DESCRIPTION
Scenario:
- daemon starts
- materializes FSDB file, entry added to `dest_initializer`
- GC eventually kicks in and calls `remove` on an FSDB file
- `all_fingerprints` doesn't return a fingerprint for the file because it was removed
- Attempt to `store` the file, but we re-use the `OnceCell` entry in `dest_initializer`, so it's a no-op
- Hardlinking fails :cry: 

New test fails before, passes after

I don't think this bug is https://github.com/pantsbuild/pants/issues/18661 though :/