### PR TITLE
javascript: Manage npm version with corepack

### DIFF
--- a/src/python/pants/backend/javascript/dependency_inference/import_parser/package.json
+++ b/src/python/pants/backend/javascript/dependency_inference/import_parser/package.json
@@ -19,5 +19,6 @@
   "dependencies": {
     "@babel/parser": "^7.20.13",
     "@babel/traverse": "^7.20.13"
-  }
+  },
+  "packageManager": "npm@8.5.5"
 }

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -39,14 +39,14 @@ from pants.core.util_rules.system_binaries import (
     BinaryShimsRequest,
 )
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest, PathEnvironmentVariable
-from pants.engine.fs import EMPTY_DIGEST, Digest, DownloadFile
-from pants.engine.internals.native_engine import FileDigest
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, Directory, DownloadFile
+from pants.engine.internals.native_engine import FileDigest, MergeDigests
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.platform import Platform
-from pants.engine.process import Process
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import Get, Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.option.option_types import DictOption, StrListOption
+from pants.option.option_types import DictOption, ShellStrListOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.docutil import bin_name
 from pants.util.frozendict import FrozenDict
@@ -59,7 +59,7 @@ _logger = logging.getLogger(__name__)
 
 class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
     options_scope = "nodejs"
-    help = "The Node.js Javascript runtime (including npm and npx)."
+    help = "The Node.js Javascript runtime (including Corepack)."
 
     default_version = "v16.15.0"
     default_known_versions = [
@@ -120,6 +120,22 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
         download_file = DownloadFile(url, FileDigest(known_version.sha256, known_version.filesize))
         return await Get(DownloadedExternalTool, ExternalToolRequest(download_file, exe))
 
+    package_managers = DictOption[str](
+        default={"npm": "8.5.5"},
+        help=help_text(
+            """
+            A mapping of package manager versions to semver releases.
+
+            Many organizations only need a single version of a package manager, which is
+            a good default and often the simplest thing to do.
+
+            The version download is managed by Corepack. This mapping corresponds to
+            the https://github.com/nodejs/corepack#known-good-releases setting, using
+            the `--activate` flag.
+            """
+        ),
+    )
+
     class EnvironmentAware(ExecutableSearchPathsOptionMixin, Subsystem.EnvironmentAware):
         search_path = StrListOption(
             default=["<PATH>"],
@@ -160,6 +176,25 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
             The PATH value that will be used to find any tools required to run nodejs processes.
             """
         )
+
+        _corepack_env_vars = ShellStrListOption(
+            help=softwrap(
+                """
+                Environment variables to set for `corepack` invocations.
+
+                Entries are either strings in the form `ENV_VAR=value` to set an explicit value;
+                or just `ENV_VAR` to copy the value from Pants's own environment.
+
+                Review https://github.com/nodejs/corepack#environment-variables
+                for available variables.
+                """
+            ),
+            advanced=True,
+        )
+
+        @property
+        def corepack_env_vars(self) -> tuple[str, ...]:
+            return tuple(sorted(set(self._corepack_env_vars)))
 
 
 class UserChosenNodeJSResolveAliases(FrozenDict[str, str]):
@@ -243,18 +278,23 @@ class NodeJSProcessEnvironment:
     binaries: NodeJSBinaries
     npm_config_cache: str
     tool_binaries: BinaryShims
+    corepack_home: str
+    corepack_shims: str
+    corepack_env_vars: EnvironmentVars
 
     base_bin_dir: ClassVar[str] = "__node"
 
     def to_env_dict(self) -> dict[str, str]:
         return {
-            "PATH": f"{self.tool_binaries.path_component}:{self.binary_directory}",
-            "npm_config_cache": self.npm_config_cache,  # Normally stored at ~/.npm
+            "PATH": f"{self.tool_binaries.path_component}:{self.corepack_shims}:{self.binary_directory}",
+            "npm_config_cache": self.npm_config_cache,  # Normally stored at ~/.npm,
+            "COREPACK_HOME": self.corepack_home,
+            **self.corepack_env_vars,
         }
 
     @property
     def append_only_caches(self) -> Mapping[str, str]:
-        return {"npm": self.npm_config_cache}
+        return {"npm": self.npm_config_cache, "corepack": self.corepack_home}
 
     @property
     def binary_directory(self) -> str:
@@ -266,6 +306,35 @@ class NodeJSProcessEnvironment:
             if self.binaries.digest
             else {**self.tool_binaries.immutable_input_digests}
         )
+
+
+async def add_corepack_shims_to_digest(
+    binaries: NodeJSBinaries, tool_shims: BinaryShims, corepack_env_vars: EnvironmentVars
+) -> Digest:
+    directory_digest = await Get(Digest, CreateDigest([Directory("._corepack")]))
+    binary_digest = binaries.digest if binaries.digest else EMPTY_DIGEST
+    input_digest = await Get(Digest, MergeDigests((directory_digest, binary_digest)))
+
+    none_immutable_binary_path = binaries.binary_dir.replace(
+        f"/{NodeJSProcessEnvironment.base_bin_dir}", ""
+    )
+    enable_corepack_result = await Get(
+        ProcessResult,
+        Process(
+            argv=("corepack", "enable", "npm", "--install-directory", "._corepack"),
+            input_digest=input_digest,
+            immutable_input_digests={**tool_shims.immutable_input_digests},
+            output_directories=["._corepack"],
+            description="Enabling corepack shims",
+            level=LogLevel.DEBUG,
+            env={
+                "PATH": f"{tool_shims.path_component}:{none_immutable_binary_path}",
+                "COREPACK_HOME": "._corepack_home",
+                **corepack_env_vars,
+            },
+        ),
+    )
+    return await Get(Digest, MergeDigests((binary_digest, enable_corepack_result.output_digest)))
 
 
 @rule(level=LogLevel.DEBUG)
@@ -284,8 +353,21 @@ async def node_process_environment(
             search_path=nodejs.executable_search_path,
         ),
     )
+    corepack_env_vars = await Get(EnvironmentVars, EnvironmentVarsRequest(nodejs.corepack_env_vars))
+    binary_digest_with_shims = await add_corepack_shims_to_digest(
+        binaries, binary_shims, corepack_env_vars
+    )
+    binaries = NodeJSBinaries(binaries.binary_dir, binary_digest_with_shims)
+
     return NodeJSProcessEnvironment(
-        binaries=binaries, npm_config_cache="._npm", tool_binaries=binary_shims
+        binaries=binaries,
+        npm_config_cache="._npm",
+        tool_binaries=binary_shims,
+        corepack_home="._corepack_home",
+        corepack_shims=os.path.join(
+            "{chroot}", NodeJSProcessEnvironment.base_bin_dir, "._corepack"
+        ),
+        corepack_env_vars=corepack_env_vars,
     )
 
 
@@ -441,10 +523,35 @@ async def determine_nodejs_binaries(
     return NodeJSBinaries(os.path.dirname(paths_per_version[satisfying_version][0].path))
 
 
+async def prepare_default_package_managers(
+    environment: NodeJSProcessEnvironment, nodejs: NodeJS
+) -> list[str]:
+    version_tuples = sorted(
+        f"{pkg_manager}@{version}" for pkg_manager, version in nodejs.package_managers.items()
+    )
+    if version_tuples:
+        await Get(
+            ProcessResult,
+            Process(
+                argv=("corepack", "prepare", *version_tuples, "--activate"),
+                description=f"Preparing default configured package managers {', '.join(version_tuples)}.",
+                immutable_input_digests=environment.immutable_digest(),
+                level=LogLevel.DEBUG,
+                env={**environment.to_env_dict()},
+                append_only_caches={**environment.append_only_caches},
+            ),
+        )
+    return version_tuples
+
+
 @rule(level=LogLevel.DEBUG)
 async def setup_node_tool_process(
-    request: NodeJSToolProcess, environment: NodeJSProcessEnvironment
+    request: NodeJSToolProcess, environment: NodeJSProcessEnvironment, nodejs: NodeJS
 ) -> Process:
+    versions = await prepare_default_package_managers(environment, nodejs)
+    pkg_manager_env = {
+        "__PACKAGE_MANAGER_VERSIONS": ",".join(versions)
+    }  # Invalidates cached process in event of update
     return Process(
         argv=filter(None, request.args),
         input_digest=request.input_digest,
@@ -453,7 +560,7 @@ async def setup_node_tool_process(
         output_directories=request.output_directories,
         description=request.description,
         level=request.level,
-        env={**environment.to_env_dict(), **request.extra_env},
+        env={**request.extra_env, **pkg_manager_env, **environment.to_env_dict()},
         working_directory=request.working_directory,
         append_only_caches={**request.append_only_caches, **environment.append_only_caches},
         timeout_seconds=request.timeout_seconds,

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -60,6 +60,7 @@ def rule_runner() -> RuleRunner:
 
 
 def test_npx_process(rule_runner: RuleRunner):
+    rule_runner.set_options(["--nodejs-package-managers={'npm': '8.5.5'}"], env_inherit={"PATH"})
     result = rule_runner.request(
         ProcessResult,
         [
@@ -91,6 +92,7 @@ def test_npx_process_with_different_version(rule_runner: RuleRunner):
 
 
 def test_npm_process(rule_runner: RuleRunner):
+    rule_runner.set_options(["--nodejs-package-managers={'npm': '8.5.5'}"], env_inherit={"PATH"})
     result = rule_runner.request(
         ProcessResult,
         [nodejs.NodeJSToolProcess.npm(args=("--version",), description="Testing NpmProcess")],

--- a/src/python/pants/backend/javascript/subsystems/nodejs_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_test.py
@@ -74,18 +74,39 @@ def test_npx_process(rule_runner: RuleRunner):
     assert result.stdout.strip() == b"8.5.5"
 
 
-def test_npm_process(rule_runner: RuleRunner):
+def test_npx_process_with_different_version(rule_runner: RuleRunner):
+    rule_runner.set_options(["--nodejs-package-managers={'npm': '7.20.0'}"], env_inherit={"PATH"})
     result = rule_runner.request(
         ProcessResult,
         [
-            nodejs.NodeJSToolProcess.npm(
+            nodejs.NodeJSToolProcess.npx(
+                npm_package="",
                 args=("--version",),
-                description="Testing NpmProcess",
+                description="Testing NpxProcess",
             )
         ],
     )
 
+    assert result.stdout.strip() == b"7.20.0"
+
+
+def test_npm_process(rule_runner: RuleRunner):
+    result = rule_runner.request(
+        ProcessResult,
+        [nodejs.NodeJSToolProcess.npm(args=("--version",), description="Testing NpmProcess")],
+    )
+
     assert result.stdout.strip() == b"8.5.5"
+
+
+def test_npm_process_with_different_version(rule_runner: RuleRunner):
+    rule_runner.set_options(["--nodejs-package-managers={'npm': '7.20.0'}"], env_inherit={"PATH"})
+    result = rule_runner.request(
+        ProcessResult,
+        [nodejs.NodeJSToolProcess.npm(args=("--version",), description="Testing NpmProcess")],
+    )
+
+    assert result.stdout.strip() == b"7.20.0"
 
 
 def given_known_version(version: str) -> str:


### PR DESCRIPTION
Enables users to configure a wanted version of a package manager blessed by Corepack, either by:
1. Setting a package manager version in the nodejs subsystem; or
2. Placing a `packageManager` entry in their `package.json`, the feature of Corepack.

This is a prerequisite for pnpm and yarn support.

Fixes https://github.com/pantsbuild/pants/issues/18525.