### PR TITLE
docs: Fix typo on requirements-overrides code snippet

### DIFF
--- a/src/python/pants/backend/python/macros/common_fields.py
+++ b/src/python/pants/backend/python/macros/common_fields.py
@@ -79,7 +79,7 @@ class RequirementsOverrideField(OverridesField):
 
             ```
             overrides={
-                "django": {"dependencies": ["#setuptools"]]},
+                "django": {"dependencies": ["#setuptools"]},
                 "ansicolors": {"description": "pretty colors"]},
                 ("ansicolors, "django"): {"tags": ["overridden"]},
             }


### PR DESCRIPTION
- Fixes small typo on docstring (requirements-overrides)