### PR TITLE
Use realpath when looking up pants_dev_deps python intepreter

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -69,6 +69,11 @@ function determine_python() {
     if [[ "$("${interpreter_path}" --version 2>&1 > /dev/null)" == "pyenv: python${version}"* ]]; then
       continue
     fi
+    # Sometimes the 'python3.Y' binary is a symlink to a suffixed version: 'python3.Ym'.
+    # We use 'realpath' to get the most precise version (the suffixed version or the real file),
+    # or pex can fail to find the interpreter in the venv and then fail to reexecute.
+    # See: https://github.com/pantsbuild/pex/issues/2119
+    interpreter_path="$(realpath "${interpreter_path}")"
     echo "${interpreter_path}" && return 0
   done
   echo "pants: failed to find suitable Python interpreter, looking for: ${candidate_versions[*]}" >&2


### PR DESCRIPTION
This works around https://github.com/pantsbuild/pex/issues/2119

Sometimes the `python3.Y` binary is a symlink to a suffixed version: `python3.Ym`.

We use `realpath` to get the most precise version (the suffixed version or the real file),
or pex can fail to find the interpreter in the venv and then fail to reexecute.

This internal change needs to be cherry-picked to 2.16.x and maybe 2.15.x so that
I can actually use pants in the pants repo on my gentoo linux box for those versions.
