### PR TITLE
Allow BinaryPaths to close over their type.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -92,7 +92,7 @@ class PexSubsystem(Subsystem):
 
 
 @dataclass(frozen=True)
-class PythonExecutable(BinaryPath, EngineAwareReturnType):
+class PythonExecutable(BinaryPath["PythonExecutable"], EngineAwareReturnType):
     """The BinaryPath of a Python executable for user code, along with some extras."""
 
     append_only_caches: FrozenDict[str, str] = FrozenDict({})

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -40,11 +40,11 @@ logger = logging.getLogger(__name__)
 SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin")
 
 
-Tbp = TypeVar("Tbp", bound="BinaryPath")
+BinaryPathT = TypeVar("BinaryPathT", bound="BinaryPath")
 
 
 @dataclass(frozen=True)
-class BinaryPath(Generic[Tbp]):
+class BinaryPath(Generic[BinaryPathT]):
     path: str
     fingerprint: str
 
@@ -61,8 +61,8 @@ class BinaryPath(Generic[Tbp]):
 
     @classmethod
     def fingerprinted(
-        cls: type[Tbp], path: str, representative_content: bytes | bytearray | memoryview
-    ) -> Tbp:
+        cls: type[BinaryPathT], path: str, representative_content: bytes | bytearray | memoryview
+    ) -> BinaryPathT:
         return cls(path, fingerprint=cls._fingerprint(representative_content))
 
 

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -11,7 +11,7 @@ import subprocess
 from dataclasses import dataclass
 from enum import Enum
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Mapping, Sequence
+from typing import Generic, Iterable, Mapping, Sequence, TypeVar
 
 from pants.base.deprecated import warn_or_error
 from pants.core.subsystems import python_bootstrap
@@ -40,8 +40,11 @@ logger = logging.getLogger(__name__)
 SEARCH_PATHS = ("/usr/bin", "/bin", "/usr/local/bin", "/opt/homebrew/bin")
 
 
+Tbp = TypeVar("Tbp", bound="BinaryPath")
+
+
 @dataclass(frozen=True)
-class BinaryPath:
+class BinaryPath(Generic[Tbp]):
     path: str
     fingerprint: str
 
@@ -58,8 +61,8 @@ class BinaryPath:
 
     @classmethod
     def fingerprinted(
-        cls, path: str, representative_content: bytes | bytearray | memoryview
-    ) -> BinaryPath:
+        cls: type[Tbp], path: str, representative_content: bytes | bytearray | memoryview
+    ) -> Tbp:
         return cls(path, fingerprint=cls._fingerprint(representative_content))
 
 

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -66,11 +66,8 @@ async def resolve_plugins(
 
     python: PythonExecutable | None = None
     if not request.interpreter_constraints:
-        python = cast(
-            PythonExecutable,
-            PythonExecutable.fingerprinted(
-                sys.executable, ".".join(map(str, sys.version_info[:3])).encode("utf8")
-            ),
+        python = PythonExecutable.fingerprinted(
+            sys.executable, ".".join(map(str, sys.version_info[:3])).encode("utf8")
         )
 
     plugins_pex = await Get(


### PR DESCRIPTION
This fix allows subclasses to seal in their type and eliminate consumers
needing to cast.