### PR TITLE
Remove superfluous custom helm tool resolves.

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -151,8 +151,6 @@ python-default = "3rdparty/python/user_reqs.lock"
 flake8 = "3rdparty/python/flake8.lock"
 mypy = "3rdparty/python/mypy.lock"
 pytest = "3rdparty/python/pytest.lock"
-helm-post-renderer = "src/python/pants/backend/helm/subsystems/post_renderer.lock"
-helm-k8s-parser = "src/python/pants/backend/helm/subsystems/k8s_parser.lock"
 
 [python.resolves_to_interpreter_constraints]
 # Without setting this explicitly, the 'python-default' resolve uses the Pants default

--- a/src/python/pants/backend/helm/subsystems/BUILD
+++ b/src/python/pants/backend/helm/subsystems/BUILD
@@ -10,19 +10,9 @@ python_tests(name="tests")
 
 # Post-Renderer
 
-python_requirement(
-    name="yamlpath",
-    requirements=[
-        "yamlpath>=3.7,<4",
-        "ruamel.yaml>=0.15.96,!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.21",
-    ],
-    resolve="helm-post-renderer",
-)
-
 python_sources(
     name="__post_renderer_main",
     sources=["post_renderer_main.py"],
-    resolve="helm-post-renderer",
     skip_mypy=True,
 )
 
@@ -30,12 +20,9 @@ resources(name="post_renderer", sources=["post_renderer.lock", "post_renderer_ma
 
 # Kubernetes manifest parser
 
-python_requirement(name="k8s", requirements=["hikaru==0.11.0b"], resolve="helm-k8s-parser")
-
 python_sources(
     name="__k8s_parser_main",
     sources=["k8s_parser_main.py"],
-    resolve="helm-k8s-parser",
     skip_mypy=True,
 )
 


### PR DESCRIPTION
It's unclear why these existed, since they just pointed to the location of the 
builtin lockfiles for those tools, and specified the same input requirements 
as the default ones. 

I suspect it was due to lack of clarity around the tool lockfiles feature.