### PR TITLE
Flush metadata to disk before renaming immutable store files

### DIFF
--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -246,6 +246,10 @@ impl ShardedFSDB {
               .shutdown()
               .await
               .map_err(|e| format!("Failed to shutdown {tmp_path:?}: {e}"))?;
+            tokio_file
+              .sync_all()
+              .await
+              .map_err(|e| format!("Failed to sync {tmp_path:?}: {e}"))?;
 
             tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o555))
               .await

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -246,14 +246,17 @@ impl ShardedFSDB {
               .shutdown()
               .await
               .map_err(|e| format!("Failed to shutdown {tmp_path:?}: {e}"))?;
+            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o555))
+              .await
+              .map_err(|e| format!("Failed to set permissions on {:?}: {e}", tmp_path))?;
+            // NB: Syncing metadata to disk ensures the `hard_link` we do later has the opportunity
+            // to succeed. Otherwise, if later when we try to `hard_link` the metadata isn't
+            // persisted to disk, we'll get `No such file or directory`.
+            // See https://github.com/pantsbuild/pants/pull/18768
             tokio_file
               .sync_all()
               .await
               .map_err(|e| format!("Failed to sync {tmp_path:?}: {e}"))?;
-
-            tokio::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o555))
-              .await
-              .map_err(|e| format!("Failed to set permissions on {:?}: {e}", tmp_path))?;
             tokio::fs::rename(tmp_path.clone(), dest_path.clone())
               .await
               .map_err(|e| format!("Error while renaming: {e}."))?;


### PR DESCRIPTION
Otherwise if we're really unlucky, the metadata isn't persisted to disk before we try to `hard_link` it and the OS returns an error.

Fixes https://github.com/pantsbuild/pants/issues/18661

(Tested locally using work repo. Always reproduced before PR. Doesn't reproduce after)