### PR TITLE
Dedup graph errors.

### DIFF
--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -1233,6 +1233,7 @@ impl<R: Rule> Builder<R> {
       .collect::<Vec<_>>();
 
     leaf_errors.sort();
+    leaf_errors.dedup();
 
     let subgraph = graph.filter_map(
       |node_id, node| {


### PR DESCRIPTION
This is an incremental improvement in case of rule graph errors.

We can expect a not fully monomorphized graph in case of errors, and as such the same nodes (with the same errors) may be present multiple times with different node ids. By removing duplicated error messages from the resulting list of errors we can reduce the ratio between number of distinct errors and the number of error messages significantly.

For a simple error I got it down from 15 to 2 errors while for a more involved error (the same kind but introduced at a point with far more dependencies) it went down from 3495 to 120.
