### PR TITLE
Get rid of spectral rust crate.

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "parking_lot 0.12.1",
  "process_execution",
  "sharded_lmdb",
- "spectral",
  "store",
  "task_executor",
  "tempfile",
@@ -919,7 +918,7 @@ dependencies = [
  "protos",
  "pyo3",
  "pyo3-build-config 0.17.2",
- "rand 0.8.5",
+ "rand",
  "regex",
  "remote",
  "reqwest",
@@ -1101,7 +1100,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "prost",
  "protos",
- "rand 0.8.5",
+ "rand",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1119,12 +1118,6 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuser"
@@ -1300,7 +1293,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "petgraph",
- "rand 0.8.5",
+ "rand",
  "task_executor",
  "tokio",
 ]
@@ -1323,7 +1316,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
- "rand 0.8.5",
+ "rand",
  "rustls 0.19.1",
  "rustls-native-certs",
  "rustls-pemfile 0.2.1",
@@ -2039,42 +2032,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
-dependencies = [
- "num-integer",
- "num-traits",
- "rand 0.4.6",
- "rustc-serialize",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b288631d7878aaf59442cffd36910ea604ecd7745c36054328595114001c9656"
-dependencies = [
- "num-traits",
- "rustc-serialize",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,29 +2039,6 @@ checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee314c74bd753fc86b4780aa9475da469155f3848473a261d2d18e35245a784e"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
- "rustc-serialize",
 ]
 
 [[package]]
@@ -2291,7 +2225,6 @@ dependencies = [
  "process_execution",
  "regex",
  "sharded_lmdb",
- "spectral",
  "store",
  "task_executor",
  "tempfile",
@@ -2512,13 +2445,12 @@ dependencies = [
  "prost",
  "prost-types",
  "protos",
- "rand 0.8.5",
+ "rand",
  "regex",
  "serde",
  "sha2",
  "sharded_lmdb",
  "shell-quote",
- "spectral",
  "store",
  "strum",
  "strum_macros",
@@ -2717,26 +2649,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.2",
+ "rand_core",
 ]
 
 [[package]]
@@ -2746,23 +2665,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.2",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2796,15 +2700,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2895,9 +2790,8 @@ dependencies = [
  "prost",
  "prost-types",
  "protos",
- "rand 0.8.5",
+ "rand",
  "sharded_lmdb",
- "spectral",
  "store",
  "strum",
  "strum_macros",
@@ -2997,12 +2891,6 @@ dependencies = [
  "petgraph",
  "smallvec",
 ]
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 
 [[package]]
 name = "rustix"
@@ -3333,15 +3221,6 @@ checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "spectral"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
-dependencies = [
- "num",
 ]
 
 [[package]]
@@ -3676,7 +3555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project 1.0.12",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -3805,7 +3684,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "pin-project 1.0.12",
- "rand 0.8.5",
+ "rand",
  "slab",
  "tokio",
  "tokio-stream",
@@ -4419,7 +4298,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "petgraph",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "strum",
  "strum_macros",

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -57,7 +57,6 @@ maplit = "1.0.1"
 mock = { path = "../testutil/mock" }
 parking_lot = "0.12"
 sharded_lmdb = { path = "../sharded_lmdb" }
-spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../testutil" }
 tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/process_execution/docker/Cargo.toml
+++ b/src/rust/engine/process_execution/docker/Cargo.toml
@@ -35,7 +35,6 @@ maplit = "1.0.1"
 mock = { path = "../../testutil/mock" }
 parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
-spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../../testutil" }
 tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/process_execution/docker/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/docker/src/docker_tests.rs
@@ -8,8 +8,6 @@ use std::time::Duration;
 use bollard::Docker;
 use fs::{RelativePath, EMPTY_DIRECTORY_DIGEST};
 use maplit::hashset;
-use spectral::assert_that;
-use spectral::string::StrAssertions;
 use store::{ImmutableInputs, Store};
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory};
@@ -605,9 +603,9 @@ async fn timeout() {
   assert_eq!(result.original.exit_code, -15);
   let stdout = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   let stderr = String::from_utf8(result.stderr_bytes.to_vec()).unwrap();
-  assert_that(&stdout).contains("Calculating...");
-  assert_that(&stderr).contains("Exceeded timeout");
-  assert_that(&stderr).contains("sleepy-cat");
+  assert!(&stdout.contains("Calculating..."));
+  assert!(&stderr.contains("Exceeded timeout"));
+  assert!(&stderr.contains("sleepy-cat"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]

--- a/src/rust/engine/process_execution/pe_nailgun/Cargo.toml
+++ b/src/rust/engine/process_execution/pe_nailgun/Cargo.toml
@@ -32,7 +32,6 @@ maplit = "1.0.1"
 mock = { path = "../../testutil/mock" }
 parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
-spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../../testutil" }
 tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/process_execution/remote/Cargo.toml
+++ b/src/rust/engine/process_execution/remote/Cargo.toml
@@ -44,7 +44,6 @@ maplit = "1.0.1"
 mock = { path = "../../testutil/mock" }
 parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
-spectral = "0.6.0"
 tempfile = "3"
 testutil = { path = "../../testutil" }
 tokio = { version = "1.21", features = ["macros"] }

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -1222,7 +1222,7 @@ async fn server_rejecting_execute_request_gives_error() {
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
     .expect_err("Want Err");
-  aasert!(&error.to_string().contains("InvalidArgument"));
+  assert!(&error.to_string().contains("InvalidArgument"));
   assert!(&error.to_string().contains("Did not expect this request"));
 }
 

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -1222,7 +1222,7 @@ async fn server_rejecting_execute_request_gives_error() {
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
     .expect_err("Want Err");
-  aassert!(&error.to_string().contains("InvalidArgument"));
+  aasert!(&error.to_string().contains("InvalidArgument"));
   assert!(&error.to_string().contains("Did not expect this request"));
 }
 

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -14,8 +14,6 @@ use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use protos::gen::google::longrunning::Operation;
 use remexec::{execution_stage::Value as ExecutionStageValue, ExecutedActionMetadata};
-use spectral::prelude::*;
-use spectral::{assert_that, string::StrAssertions};
 use store::{SnapshotOps, Store, StoreError};
 use tempfile::TempDir;
 use testutil::data::{TestData, TestDirectory, TestTree};
@@ -1224,8 +1222,8 @@ async fn server_rejecting_execute_request_gives_error() {
   let error = run_command_remote(mock_server.address(), execute_request)
     .await
     .expect_err("Want Err");
-  assert_that(&error.to_string()).contains("InvalidArgument");
-  assert_that(&error.to_string()).contains("Did not expect this request");
+  aassert!(&error.to_string().contains("InvalidArgument"));
+  assert!(&error.to_string().contains("Did not expect this request"));
 }
 
 #[tokio::test]
@@ -1343,7 +1341,7 @@ async fn sends_headers() {
     .iter()
     .map(|received_message| received_message.headers.clone())
     .collect();
-  assert_that!(message_headers).has_length(1);
+  assert_eq!(message_headers.len(), 1);
   for headers in message_headers {
     {
       let want_key = "google.devtools.remoteexecution.v1test.requestmetadata-bin";

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 
 use maplit::hashset;
 use shell_quote::bash;
-use spectral::{assert_that, string::StrAssertions};
 use tempfile::TempDir;
 
 use fs::EMPTY_DIRECTORY_DIGEST;
@@ -568,9 +567,9 @@ async fn timeout() {
   assert_eq!(result.original.exit_code, -15);
   let stdout = String::from_utf8(result.stdout_bytes.to_vec()).unwrap();
   let stderr = String::from_utf8(result.stderr_bytes.to_vec()).unwrap();
-  assert_that(&stdout).contains("Calculating...");
-  assert_that(&stderr).contains("Exceeded timeout");
-  assert_that(&stderr).contains("sleepy-cat");
+  assert!(&stdout.contains("Calculating..."));
+  assert!(&stderr.contains("Exceeded timeout"));
+  assert!(&stderr.contains("sleepy-cat"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
This get rids of a bunch of packages we don't really need (num-*) and one package [rustc-serialize](https://github.com/rust-lang-deprecated/rustc-serialize)  which was deprecated

from what I can tell, this package was added ~4 years ago... my guess back then, rust was missing some of the testing features that it provided, I think this is no longer the case.

since this is only used in rust tests, the `internal` category for this PR seems appropriate. someone please add that.
