### PR TITLE
Use the resolve's ICs for tools.

### DIFF
--- a/src/python/pants/backend/docker/goals/run_image_integration_test.py
+++ b/src/python/pants/backend/docker/goals/run_image_integration_test.py
@@ -12,7 +12,8 @@ def run_pants_with_sources(sources: dict[str, str], *args: str) -> PantsResult:
     with setup_tmpdir(sources) as tmpdir:
         return run_pants(
             [
-                "--backend-packages=pants.backend.docker",
+                "--backend-packages=['pants.backend.docker']",
+                "--python-interpreter-constraints=['>=3.7,<4']",
                 "--pants-ignore=__pycache__",
             ]
             + [arg.format(tmpdir=tmpdir) for arg in args]

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules_integration_test.py
@@ -70,6 +70,7 @@ def test_end_to_end() -> None:
     with setup_tmpdir(sources) as tmpdir:
         package_args = [
             "--backend-packages=['pants.backend.python', 'pants.backend.experimental.python.packaging.pyoxidizer']",
+            "--python-interpreter-constraints=['>=3.8,<4']",
             f"--source-root-patterns=['/{tmpdir}']",
             "package",
             f"{tmpdir}/hellotest:bin",
@@ -86,6 +87,7 @@ def test_end_to_end() -> None:
         # Check that the binary runs.
         run_args = [
             "--backend-packages=['pants.backend.python', 'pants.backend.experimental.python.packaging.pyoxidizer']",
+            "--python-interpreter-constraints=['>=3.8,<4']",
             f"--source-root-patterns=['/{tmpdir}']",
             "run",
             f"{tmpdir}/hellotest:bin",

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -329,11 +329,20 @@ class PythonToolRequirementsBase(Subsystem):
         main: MainSpecification | None = None,
         sources: Digest | None = None,
     ) -> PexRequest:
+        if not interpreter_constraints:
+            if self.install_from_resolve and self.options.is_default("interpreter_constraints"):
+                # If installing the tool from a regular resolve, and custom ICs weren't
+                # explicitly set, leave these blank. This will cause the ones for the resolve
+                # to be used, which is clearly what the user intends, rather than forcing the
+                # user to override interpreter_constraints to match those of the resolve.
+                interpreter_constraints = InterpreterConstraints()
+            else:
+                interpreter_constraints = self.interpreter_constraints
         return PexRequest(
             output_filename=f"{self.options_scope.replace('-', '_')}.pex",
             internal_only=True,
             requirements=self.pex_requirements(extra_requirements=extra_requirements),
-            interpreter_constraints=interpreter_constraints or self.interpreter_constraints,
+            interpreter_constraints=interpreter_constraints,
             main=main,
             sources=sources,
         )

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -329,11 +329,18 @@ class PythonToolRequirementsBase(Subsystem):
         main: MainSpecification | None = None,
         sources: Digest | None = None,
     ) -> PexRequest:
+        requirements = self.pex_requirements(extra_requirements=extra_requirements)
         if not interpreter_constraints:
-            if self.install_from_resolve and self.options.is_default("interpreter_constraints"):
-                # If installing the tool from a regular resolve, and custom ICs weren't
-                # explicitly set, leave these blank. This will cause the ones for the resolve
-                # to be used, which is clearly what the user intends, rather than forcing the
+            if self.options.is_default("interpreter_constraints") and (
+                isinstance(requirements, EntireLockfile)
+                or (
+                    isinstance(requirements, PexRequirements)
+                    and isinstance(requirements.from_superset, Resolve)
+                )
+            ):
+                # If installing the tool from a resolve, and custom ICs weren't explicitly set,
+                # leave these blank. This will cause the ones for the resolve to be used,
+                # which is clearly what the user intends, rather than forcing the
                 # user to override interpreter_constraints to match those of the resolve.
                 interpreter_constraints = InterpreterConstraints()
             else:

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -573,24 +573,23 @@ async def build_pex(
 
     if not request.interpreter_constraints:
         # Blank ICs in the request means that the caller wants us to use the ICs configured
-        # for the resolve (or the global ICs, if using the builtin lockfile).
+        # for the resolve (falling back to the global ICs).
+        resolve_name = ""
         if isinstance(request.requirements, PexRequirements) and isinstance(
             request.requirements.from_superset, Resolve
         ):
+            resolve_name = request.requirements.from_superset.name
+        elif isinstance(request.requirements, EntireLockfile):
+            resolve_name = request.requirements.lockfile.resolve_name
+
+        if resolve_name:
             request = dataclasses.replace(
                 request,
                 interpreter_constraints=InterpreterConstraints(
                     python_setup.resolves_to_interpreter_constraints.get(
-                        request.requirements.from_superset.name,
+                        resolve_name,
                         python_setup.interpreter_constraints,
                     )
-                ),
-            )
-        elif isinstance(request.requirements, EntireLockfile):
-            request = dataclasses.replace(
-                request,
-                interpreter_constraints=InterpreterConstraints(
-                    python_setup.interpreter_constraints
                 ),
             )
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -570,6 +570,21 @@ async def build_pex(
     request: PexRequest, python_setup: PythonSetup, pex_subsystem: PexSubsystem
 ) -> BuildPexResult:
     """Returns a PEX with the given settings."""
+
+    if (
+        isinstance(request.requirements, PexRequirements)
+        and isinstance(request.requirements.from_superset, Resolve)
+        and not request.interpreter_constraints
+    ):
+        # Blank ICs in the request means that the caller wants us to use
+        # the ICs configured for the resolve.
+        interpreter_constraints = InterpreterConstraints(
+            python_setup.resolves_to_interpreter_constraints.get(
+                request.requirements.from_superset.name, python_setup.interpreter_constraints
+            )
+        )
+        request = dataclasses.replace(request, interpreter_constraints=interpreter_constraints)
+
     argv = [
         "--output-file",
         request.output_filename,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -571,19 +571,28 @@ async def build_pex(
 ) -> BuildPexResult:
     """Returns a PEX with the given settings."""
 
-    if (
-        isinstance(request.requirements, PexRequirements)
-        and isinstance(request.requirements.from_superset, Resolve)
-        and not request.interpreter_constraints
-    ):
-        # Blank ICs in the request means that the caller wants us to use
-        # the ICs configured for the resolve.
-        interpreter_constraints = InterpreterConstraints(
-            python_setup.resolves_to_interpreter_constraints.get(
-                request.requirements.from_superset.name, python_setup.interpreter_constraints
+    if not request.interpreter_constraints:
+        # Blank ICs in the request means that the caller wants us to use the ICs configured
+        # for the resolve (or the global ICs, if using the builtin lockfile).
+        if isinstance(request.requirements, PexRequirements) and isinstance(
+            request.requirements.from_superset, Resolve
+        ):
+            request = dataclasses.replace(
+                request,
+                interpreter_constraints=InterpreterConstraints(
+                    python_setup.resolves_to_interpreter_constraints.get(
+                        request.requirements.from_superset.name,
+                        python_setup.interpreter_constraints,
+                    )
+                ),
             )
-        )
-        request = dataclasses.replace(request, interpreter_constraints=interpreter_constraints)
+        elif isinstance(request.requirements, EntireLockfile):
+            request = dataclasses.replace(
+                request,
+                interpreter_constraints=InterpreterConstraints(
+                    python_setup.interpreter_constraints
+                ),
+            )
 
     argv = [
         "--output-file",

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -503,7 +503,7 @@ def test_local_requirements_and_path_mappings(
             [
                 GeneratePythonLockfile(
                     requirements=FrozenOrderedSet([wheel_req_str]),
-                    interpreter_constraints=InterpreterConstraints(),
+                    interpreter_constraints=InterpreterConstraints([">=3.7,<4"]),
                     resolve_name="test",
                     lockfile_dest="test.lock",
                     diff=False,


### PR DESCRIPTION
The default ICs for tools are deliberately loose, because we currently
use them to generate the builtin tool lockfiles.

But if the user chooses to install a tool from a custom resolve
(which may even be an existing user resolve) then the resolve's
lockfile is likely to have much tighter ICs. As a result, the user
has to tighten the ICs on the tool, so that it's compatible.

This is superfluous config hoop-jumping, since Pants knows
the ICs to use.

Also, even if using the builtin lockfile, the user will likely want
to use a tighter IC than the very loose one the lockfile was built 
with, and the repowide default seems like the right choice.

This change makes Pants use the ICs configured for the resolve,
unless explicitly overridden. For the builtin lockfile, it will use
the repo-wide default.

Fixes https://github.com/pantsbuild/pants/issues/15358
