### PR TITLE
Option required flag

### DIFF
--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -28,12 +28,12 @@ class PathsSubsystem(Outputting, GoalSubsystem):
     help = "List the paths between two addresses."
 
     from_ = StrOption(
-        default=None,
+        required=True,
         help="The path starting address",
     )
 
     to = StrOption(
-        default=None,
+        required=True,
         help="The path end address",
     )
 
@@ -81,15 +81,8 @@ def find_paths_breadth_first(
 
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
-    path_from = paths_subsystem.from_
-    path_to = paths_subsystem.to
-
-    if path_from is None:
-        raise ValueError("Must set --from")
-
-    if path_to is None:
-        raise ValueError("Must set --to")
-
+    paths_from = paths_subsystem.from_
+    paths_to = paths_subsystem.to
     specs_parser = SpecsParser()
 
     from_tgts, to_tgts = await MultiGet(
@@ -97,7 +90,7 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [path_from],
+                [paths_from],
                 description_of_origin="the option `--paths-from`",
             ),
         ),
@@ -105,7 +98,7 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [path_to],
+                [paths_to],
                 description_of_origin="the option `--paths-to`",
             ),
         ),

--- a/src/python/pants/backend/project_info/paths_test.py
+++ b/src/python/pants/backend/project_info/paths_test.py
@@ -98,12 +98,12 @@ def assert_paths(
 
 
 def test_no_from(rule_runner: RuleRunner) -> None:
-    with pytest.raises(ExecutionError, match="Must set --from"):
+    with pytest.raises(ExecutionError, match="The option --from in scope 'paths' is required."):
         assert_paths(rule_runner, path_from="", path_to="base:base")
 
 
 def test_no_to(rule_runner: RuleRunner) -> None:
-    with pytest.raises(ExecutionError, match="Must set --to"):
+    with pytest.raises(ExecutionError, match="The option --to in scope 'paths' is required."):
         assert_paths(rule_runner, path_from="intermediate:intermediate", path_to="")
 
 

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -321,8 +321,13 @@ def test_get_all_help_info():
                         "env_var": "PANTS_OPT1",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": 42, "details": None},
+                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
+                                {
+                                    "rank": Rank.HARDCODED,
+                                    "value": 42,
+                                    "details": None,
+                                    "error": None,
+                                },
                             ),
                         },
                         "typ": int,
@@ -346,8 +351,13 @@ def test_get_all_help_info():
                         "env_var": "PANTS_LEVEL",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": LogLevel.INFO, "details": None},
+                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
+                                {
+                                    "rank": Rank.HARDCODED,
+                                    "value": LogLevel.INFO,
+                                    "details": None,
+                                    "error": None,
+                                },
                             ),
                         },
                         "typ": LogLevel,
@@ -382,12 +392,13 @@ def test_get_all_help_info():
                         "unscoped_cmd_line_args": ("--backend-packages",),
                         "value_history": {
                             "ranked_values": (
-                                {"details": "", "rank": Rank.NONE, "value": []},
-                                {"details": "", "rank": Rank.HARDCODED, "value": []},
+                                {"details": "", "rank": Rank.NONE, "value": [], "error": None},
+                                {"details": "", "rank": Rank.HARDCODED, "value": [], "error": None},
                                 {
                                     "details": "from command-line flag",
                                     "rank": Rank.FLAG,
                                     "value": ["internal_plugins.releases"],
+                                    "error": None,
                                 },
                             ),
                         },
@@ -412,11 +423,12 @@ def test_get_all_help_info():
                         "unscoped_cmd_line_args": ("--pythonpath",),
                         "value_history": {
                             "ranked_values": (
-                                {"details": "", "rank": Rank.NONE, "value": []},
+                                {"details": "", "rank": Rank.NONE, "value": [], "error": None},
                                 {
                                     "details": "",
                                     "rank": Rank.HARDCODED,
                                     "value": [f"{get_buildroot()}/pants-plugins"],
+                                    "error": None,
                                 },
                             ),
                         },
@@ -442,8 +454,13 @@ def test_get_all_help_info():
                         "env_var": "PANTS_FOO_OPT2",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None},
-                                {"rank": Rank.HARDCODED, "value": True, "details": None},
+                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
+                                {
+                                    "rank": Rank.HARDCODED,
+                                    "value": True,
+                                    "details": None,
+                                    "error": None,
+                                },
                             ),
                         },
                         "typ": bool,

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -113,6 +113,10 @@ class MutuallyExclusiveOptionError(ParseError):
     """Indicates that two options in the same mutually exclusive group were specified."""
 
 
+class MissingRequiredOptionError(ParseError):
+    """Indicates that a required option has not been configured with a value."""
+
+
 class UnknownFlagsError(ParseError):
     """Indicates that unknown command-line flags were encountered in some scope."""
 

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -56,8 +56,20 @@ _HelpT = _MaybeDynamicT[str]
 _RegisterIfFuncT = Callable[[_SubsystemType], Any]
 
 
-def _eval_maybe_dynamic(val: _MaybeDynamicT[_DefaultT], subsystem_cls: _SubsystemType) -> _DefaultT:
-    return val(subsystem_cls) if inspect.isfunction(val) else val  # type: ignore[no-any-return]
+# Missing arg sentinel.
+class Missing:
+    pass
+
+
+_MISSING = Missing()
+
+
+def _eval_maybe_dynamic(
+    val: _MaybeDynamicT[_DefaultT] | Missing, subsystem_cls: _SubsystemType
+) -> _DefaultT | None:
+    if isinstance(val, Missing):
+        return None
+    return val(subsystem_cls) if inspect.isfunction(val) else cast(_DefaultT, val)
 
 
 class _OptionBase(Generic[_OptT, _DefaultT]):
@@ -71,7 +83,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
     """
 
     _flag_names: tuple[str, ...] | None
-    _default: _MaybeDynamicT[_DefaultT]
+    _default: _MaybeDynamicT[_DefaultT] | Missing
     _help: _HelpT
     _register_if: _RegisterIfFuncT
     _extra_kwargs: dict[str, Any]
@@ -82,8 +94,8 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         cls,
         flag_name: str | None = None,
         *,
-        default: _MaybeDynamicT[_DefaultT],
         help: _HelpT,
+        default: _MaybeDynamicT[_DefaultT] | Missing = _MISSING,
         # Additional bells/whistles
         register_if: _RegisterIfFuncT | None = None,
         advanced: bool | None = None,
@@ -94,6 +106,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
         removal_version: str | None = None,
         removal_hint: _HelpT | None = None,
         deprecation_start_version: str | None = None,
+        required: bool | None = None,
         # Internal bells/whistles
         daemon: bool | None = None,
         fingerprint: bool | None = None,
@@ -132,7 +145,11 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
             user when running `help`.
         :param deprecation_start_version: If the option is deprecated, sets the version at which the
             deprecation will begin. Must be less than the `removal_version`.
+        :param required: Asserts that a value is provided by the user.
         """
+        if default is _MISSING and not required:
+            raise ValueError("`default` must be provided unless `required=True`.")
+
         self = super().__new__(cls)
         self._flag_names = (flag_name,) if flag_name else None
         self._default = default
@@ -151,6 +168,7 @@ class _OptionBase(Generic[_OptT, _DefaultT]):
                 "removal_hint": removal_hint,
                 "removal_version": removal_version,
                 "deprecation_start_version": deprecation_start_version,
+                "required": required,
             }.items()
             if v is not None
         }

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -422,6 +422,9 @@ def test_property_types() -> None:
         skip_opt = SkipOption("fmt")
         args_opt = ArgsListOption(example="--whatever")
 
+        # Required opts
+        req_opt = StrOption(required=True, help="")
+
     my_subsystem = MySubsystem()
     if TYPE_CHECKING:
         assert_type["str"](my_subsystem.str_opt)
@@ -474,3 +477,5 @@ def test_property_types() -> None:
 
         assert_type["bool"](my_subsystem.skip_opt)
         assert_type["tuple[str, ...]"](my_subsystem.args_opt)
+
+        assert_type["str"](my_subsystem.req_opt)

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -126,6 +126,8 @@ class OptionValueContainer:
         if key not in self._value_map:
             raise AttributeError(key)
         ranked_val = self._value_map[key]
+        if ranked_val.error is not None:
+            raise ranked_val.error
         return ranked_val.value
 
     # Support natural dynamic access, e.g., opts[foo] is more idiomatic than getattr(opts, 'foo').

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -34,6 +34,7 @@ from pants.option.errors import (
     InvalidKwarg,
     InvalidMemberType,
     MemberTypeNotAllowed,
+    MissingRequiredOptionError,
     MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
@@ -501,6 +502,17 @@ def test_scope_deprecation_default_config_section(caplog) -> None:
     caplog.clear()
     assert opts.for_scope(Subsystem1.options_scope).foo == "xx"
     assert not caplog.records
+
+
+def test_required_option(caplog) -> None:
+    def register(opts: Options) -> None:
+        opts.register(GLOBAL_SCOPE, "--opt", type=bool, required=True)
+
+    opts = create_options([GLOBAL_SCOPE], register, config={}).for_global_scope()
+    with pytest.raises(
+        MissingRequiredOptionError, match="The option --opt in global scope is required."
+    ):
+        opts.opt
 
 
 # ----------------------------------------------------------------------------------------

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -289,8 +289,8 @@ class Parser:
                     error=MissingRequiredOptionError(
                         softwrap(
                             f"""
-                        The option {args_str} in {self._scope_str()} is required.
-                        """
+                            The option {args_str} in {self._scope_str()} is required.
+                            """
                         )
                     ),
                 )

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -9,7 +9,7 @@ import json
 import re
 import typing
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 from typing import Any, DefaultDict, Iterable, Mapping
@@ -40,6 +40,7 @@ from pants.option.errors import (
     InvalidKwargNonGlobalScope,
     InvalidMemberType,
     MemberTypeNotAllowed,
+    MissingRequiredOptionError,
     MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
@@ -281,6 +282,18 @@ class Parser:
                             """
                         )
                     )
+            elif kwargs.get("required"):
+                args_str = ", ".join(args)
+                val = replace(
+                    val,
+                    error=MissingRequiredOptionError(
+                        softwrap(
+                            f"""
+                        The option {args_str} in {self._scope_str()} is required.
+                        """
+                        )
+                    ),
+                )
 
             setattr(namespace, dest, val)
 
@@ -357,25 +370,26 @@ class Parser:
             )
 
     _allowed_registration_kwargs = {
-        "type",
-        "member_type",
+        "advanced",
         "choices",
-        "dest",
+        "daemon",
         "default",
         "default_help_repr",
-        "implicit_value",
-        "metavar",
-        "help",
-        "advanced",
-        "fingerprint",
-        "removal_version",
-        "removal_hint",
         "deprecation_start_version",
-        "fromfile",
-        "mutually_exclusive_group",
-        "daemon",
-        "passthrough",
+        "dest",
         "environment_aware",
+        "fingerprint",
+        "fromfile",
+        "help",
+        "implicit_value",
+        "member_type",
+        "metavar",
+        "mutually_exclusive_group",
+        "passthrough",
+        "removal_hint",
+        "removal_version",
+        "required",
+        "type",
     }
 
     _allowed_member_types = {

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -96,4 +96,7 @@ class RankedValue:
 
     rank: Rank
     value: Value
-    details: str | None = None  # Optional details about the derivation of the value.
+    # Optional details about the derivation of the value.
+    details: str | None = None
+    # Any deferred error that should be triggered if this value is accessed.
+    error: Exception | None = None


### PR DESCRIPTION
Support required options. 

The validation is deferred until actually referenced to make them usable on the command line for goals.
