### PR TITLE
Update linter documentation to refer to install_from_resolve

### DIFF
--- a/docs/markdown/Python/python/python-lockfiles.md
+++ b/docs/markdown/Python/python/python-lockfiles.md
@@ -181,7 +181,7 @@ Pants's Python support typically involves invoking underlying tools, such as `py
 
 It is strongly recommended that these tools be installed from a hermetic lockfile, for the same security and stability reasons stated above. In fact, Pants ships with built-in lockfiles for every Python tool it uses, and uses them automatically.
 
-The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (e.g., tool plugins).
+The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (for example, tool plugins).
 
 If you want a tool to be installed from some resolve, instead of from the built-in lockfile, you set `install_from_resolve` on the tool's config section, and enumerate any non-default requirements you need from that resolve:
 


### PR DESCRIPTION
The linter documentation didn't mention the newer method of using `install_from_resolve` to add plugins or change the flake8 version. Also, per the Slack conversation below, @benjyw is going to be working on changing how versions can be overridden from resolve files. So these docs won't be fully up-to-date until that work is done.

Slack conversation: [here](https://pantsbuild.slack.com/archives/C046T6T9U/p1681993796670199)
