### PR TITLE
Add info on how to configure Docker Desktop for using docker_environment

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -269,7 +269,7 @@ class DockerEnvironmentTarget(Target):
         To use this environment, map this target's address with a memorable name in
         `[environments-preview].names`. You can then consume this environment by specifying the name in
         the `environment` field defined on other targets.
-        
+
         Before running Pants using this environment, if you are using Docker Desktop, make sure the option
         **Enable default Docker socket** is enabled, you can find it in **Docker Desktop Settings > Advanced**
         panel. That option tells Docker to create a socket at `/var/run/docker.sock` which Pants can use to

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -272,7 +272,7 @@ class DockerEnvironmentTarget(Target):
         
         Before running Pants using this environment, if you are using Docker Desktop, make sure the option
         **Enable default Docker socket** is enabled, you can find it in **Docker Desktop Settings > Advanced**
-        panel. That option makes sures of creating a socket at `/var/run/docker.sock` which Pants can use to
+        panel. That option tells Docker to create a socket at `/var/run/docker.sock` which Pants can use to
         communicate with Docker.
         """
         # TODO(#17096) Add a link to the environments docs once they land.

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -269,6 +269,11 @@ class DockerEnvironmentTarget(Target):
         To use this environment, map this target's address with a memorable name in
         `[environments-preview].names`. You can then consume this environment by specifying the name in
         the `environment` field defined on other targets.
+        
+        Before running Pants using this environment, if you are using Docker Desktop, make sure the option
+        **Enable default Docker socket** is enabled, you can find it in **Docker Desktop Settings > Advanced**
+        panel. That option makes sures of creating a socket at `/var/run/docker.sock` which Pants can use to
+        communicate with Docker.
         """
         # TODO(#17096) Add a link to the environments docs once they land.
     )


### PR DESCRIPTION
Hello! I added some info on how to configure [Docker Desktop](https://www.docker.com/products/docker-desktop/) so Pants is able to communicate with it, otherwise I get the error: `Exception: Failed to obtain version from local Docker: error trying to connect: No such file or directory (os error 2)`

In my case I'm using Docker Desktop for Mac.

![image](https://user-images.githubusercontent.com/83847/233777047-6707d74e-0f63-4e5a-ad9c-ff1a6303523d.png)
