### PR TITLE
Keep `option.get()` from throwing for missing required options.

### DIFF
--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -6,6 +6,9 @@ python_tests(
     name="tests",
     timeout=120,
     overrides={
-        "embed_integration_test.py": {"timeout": 240},
+        (
+            "cgo_test.py",
+            "embed_integration_test.py",
+        ): {"timeout": 240},
     },
 )

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -509,6 +509,7 @@ def test_required_option(caplog) -> None:
         opts.register(GLOBAL_SCOPE, "--opt", type=bool, required=True)
 
     opts = create_options([GLOBAL_SCOPE], register, config={}).for_global_scope()
+    assert opts.get("opt") is False
     with pytest.raises(
         MissingRequiredOptionError, match="The option --opt in global scope is required."
     ):


### PR DESCRIPTION
Fixes regression introduced in #18780.

Classified as internal as we've not yet released the aforementioned PR so this is merely a fixup for that one.

The toolchain plugin relies on using `option.get()` to collect all configuration values. Let's keep that working also for "required" options. Added a `throw_errors: bool` arg to `.get()` in cases where it is desirable to not return a value for a missing required option.