### PR TITLE
The `OverridesField.compute_value()` must return a hashable value. (Cherry-pick of #18787)

### DIFF
--- a/src/python/pants/engine/internals/defaults.py
+++ b/src/python/pants/engine/internals/defaults.py
@@ -27,7 +27,6 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionMembership
 from pants.util.frozendict import FrozenDict
-from pants.util.meta import frozen_after_init
 
 SetDefaultsValueT = Mapping[str, Any]
 SetDefaultsKeyT = Union[str, Tuple[str, ...]]
@@ -38,22 +37,12 @@ class BuildFileDefaults(FrozenDict[str, FrozenDict[str, ImmutableValue]]):
     """Map target types to default field values."""
 
 
-@frozen_after_init
-@dataclass(unsafe_hash=True)
 class ParametrizeDefault(Parametrize):
-    """A frozen version of `Parametrize` for defaults.
+    """Parametrize for default field values.
 
-    This is needed since all defaults must be hashable, which the `Parametrize` class is not nor can
-    it be as it may get unhashable data as input and is unaware of the field type it is being
-    applied to.
+    This is to have eager validation on the field values rather than erroring first when applied on
+    an actual target.
     """
-
-    args: tuple[str, ...]
-    kwargs: FrozenDict[str, ImmutableValue]  # type: ignore[assignment]
-
-    def __init__(self, *args: str, **kwargs: ImmutableValue) -> None:
-        self.args = args
-        self.kwargs = FrozenDict(kwargs)
 
     @classmethod
     def create(

--- a/src/python/pants/engine/internals/defaults_test.py
+++ b/src/python/pants/engine/internals/defaults_test.py
@@ -18,6 +18,7 @@ from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     Dependencies,
     InvalidFieldException,
+    OverridesField,
     RegisteredTargetTypes,
     TargetGenerator,
 )
@@ -41,7 +42,10 @@ class TestGenTarget(GenericTarget):
 class TestGenTargetGenerator(TargetGenerator):
     alias = "test_gen_targets"
     generated_target_cls = TestGenTarget
-    core_fields = COMMON_TARGET_FIELDS
+    core_fields = (
+        OverridesField,
+        *COMMON_TARGET_FIELDS,
+    )
     copied_fields = COMMON_TARGET_FIELDS
     moved_fields = (GenericTargetDependenciesField,)
 
@@ -239,6 +243,25 @@ Scenario = namedtuple(
                 },
             ),
             id="parametrize default field value",
+        ),
+        pytest.param(
+            Scenario(
+                args=(
+                    {
+                        ("test_gen_targets",): dict(
+                            overrides={"*_generated.py": {"skip_yapf": True}},
+                        ),
+                    },
+                ),
+                expected_defaults={
+                    "test_gen_targets": dict(
+                        overrides=FrozenDict.deep_freeze(
+                            {("*_generated.py",): {"skip_yapf": True}}
+                        ),
+                    ),
+                },
+            ),
+            id="overrides value not frozen (issue #18784)",
         ),
     ],
 )

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -12,7 +12,13 @@ from pants.build_graph.address import BANNED_CHARS_IN_PARAMETERS
 from pants.engine.addresses import Address
 from pants.engine.collection import Collection
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.target import Field, FieldDefaults, Target, TargetTypesToGenerateTargetsRequests
+from pants.engine.target import (
+    Field,
+    FieldDefaults,
+    ImmutableValue,
+    Target,
+    TargetTypesToGenerateTargetsRequests,
+)
 from pants.util.frozendict import FrozenDict
 from pants.util.meta import frozen_after_init
 from pants.util.strutil import bullet_list, softwrap
@@ -35,11 +41,11 @@ class Parametrize:
     """
 
     args: tuple[str, ...]
-    kwargs: dict[str, Any]
+    kwargs: FrozenDict[str, ImmutableValue]
 
     def __init__(self, *args: str, **kwargs: Any) -> None:
         self.args = args
-        self.kwargs = kwargs
+        self.kwargs = FrozenDict.deep_freeze(kwargs)
 
     def to_parameters(self) -> dict[str, Any]:
         """Validates and returns a mapping from aliases to parameter values.

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1403,15 +1403,16 @@ def test_overrides_field_normalization() -> None:
     addr = Address("", target_name="example")
 
     assert OverridesField(None, addr).value is None
-    assert OverridesField({}, addr).value == {}
+    assert OverridesField({}, addr).value == FrozenDict({})
 
-    # Note that `list_field` is not hashable. We have to override `__hash__` for this to work.
     tgt1_override = {"str_field": "value", "list_field": [0, 1, 3]}
     tgt2_override = {"int_field": 0, "dict_field": {"a": 0}}
 
     # Convert a `str` key to `tuple[str, ...]`.
     field = OverridesField({"tgt1": tgt1_override, ("tgt1", "tgt2"): tgt2_override}, addr)
-    assert field.value == {("tgt1",): tgt1_override, ("tgt1", "tgt2"): tgt2_override}
+    assert field.value == FrozenDict.deep_freeze(
+        {("tgt1",): tgt1_override, ("tgt1", "tgt2"): tgt2_override}
+    )
     with no_exception():
         hash(field)
 
@@ -1443,8 +1444,8 @@ def test_overrides_field_normalization() -> None:
         "dir/bar2.ext": tgt2_override,
     }
     assert path_field.flatten() == {
-        "foo.ext": {**tgt2_override, **tgt1_override},
-        "bar*.ext": tgt2_override,
+        "foo.ext": dict(FrozenDict.deep_freeze({**tgt2_override, **tgt1_override})),
+        "bar*.ext": dict(FrozenDict.deep_freeze(tgt2_override)),
     }
     with pytest.raises(InvalidFieldException):
         # Same field is overridden for the same file multiple times, which is an error.

--- a/src/python/pants/util/frozendict.py
+++ b/src/python/pants/util/frozendict.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, Iterator, Mapping, TypeVar, cast, overload
 
 from pants.util.memo import memoized_method
+from pants.util.strutil import softwrap
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -47,6 +48,31 @@ class FrozenDict(Mapping[K, V]):
         # performance bottleneck.
         self._hash = self._calculate_hash()
 
+    @classmethod
+    def deep_freeze(cls, data: Mapping[K, V]) -> FrozenDict[K, V]:
+        """Convert mutable values to their frozen counter parts.
+
+        Sets and lists are turned into tuples and dicts into FrozenDicts.
+        """
+
+        def _freeze(obj):
+            if isinstance(obj, dict):
+                return cls.deep_freeze(obj)
+            if isinstance(obj, (list, set)):
+                return tuple(map(_freeze, obj))
+            return obj
+
+        return cls({k: _freeze(v) for k, v in data.items()})
+
+    @staticmethod
+    def frozen(to_freeze: Mapping[K, V]) -> FrozenDict[K, V]:
+        """Returns a `FrozenDict` containing the keys and values of `to_freeze`.
+
+        If `to_freeze` is already a `FrozenDict`, returns the same object.
+        """
+
+        return to_freeze if isinstance(to_freeze, FrozenDict) else FrozenDict(to_freeze)
+
     def __getitem__(self, k: K) -> V:
         return self._data[k]
 
@@ -74,11 +100,18 @@ class FrozenDict(Mapping[K, V]):
             return hash(tuple(self._data.items()))
         except TypeError as e:
             raise TypeError(
-                f"Even though you are using a `{type(self).__name__}`, the underlying values are "
-                "not hashable. Please use hashable (and preferably immutable) types for the "
-                "underlying values, e.g. use tuples instead of lists and use FrozenOrderedSet "
-                "instead of set().\n\n"
-                f"Original error message: {e}\n\nValue: {self}"
+                softwrap(
+                    f"""
+                    Even though you are using a `{type(self).__name__}`, the underlying values are
+                    not hashable. Please use hashable (and preferably immutable) types for the
+                    underlying values, e.g. use tuples instead of lists and use FrozenOrderedSet
+                    instead of set().
+
+                    Original error message: {e}
+
+                    Value: {self}
+                    """
+                )
             )
 
     def __hash__(self) -> int:

--- a/src/python/pants/util/frozendict_test.py
+++ b/src/python/pants/util/frozendict_test.py
@@ -166,3 +166,13 @@ def test_lazy_frozen_dict() -> None:
 
     # Hash value should be stable regardless if we've loaded the values or not.
     assert hash(ld1) == hashvalue
+
+
+def test_frozendict_dot_frozen() -> None:
+    a = {1: 2}
+    b = FrozenDict(a)
+    frozen_a = FrozenDict.frozen(a)
+    frozen_b = FrozenDict.frozen(b)
+
+    assert frozen_a == FrozenDict(a)
+    assert frozen_b is b


### PR DESCRIPTION
The `OverridesField` broke the hashability contract for its value making it unusable in `__defaults__`.

Fixes #18784.

