### PR TITLE
Revert "Option required flag"

### DIFF
--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -28,12 +28,12 @@ class PathsSubsystem(Outputting, GoalSubsystem):
     help = "List the paths between two addresses."
 
     from_ = StrOption(
-        required=True,
+        default=None,
         help="The path starting address",
     )
 
     to = StrOption(
-        required=True,
+        default=None,
         help="The path end address",
     )
 
@@ -81,8 +81,15 @@ def find_paths_breadth_first(
 
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
-    paths_from = paths_subsystem.from_
-    paths_to = paths_subsystem.to
+    path_from = paths_subsystem.from_
+    path_to = paths_subsystem.to
+
+    if path_from is None:
+        raise ValueError("Must set --from")
+
+    if path_to is None:
+        raise ValueError("Must set --to")
+
     specs_parser = SpecsParser()
 
     from_tgts, to_tgts = await MultiGet(
@@ -90,7 +97,7 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [paths_from],
+                [path_from],
                 description_of_origin="the option `--paths-from`",
             ),
         ),
@@ -98,7 +105,7 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
             Targets,
             Specs,
             specs_parser.parse_specs(
-                [paths_to],
+                [path_to],
                 description_of_origin="the option `--paths-to`",
             ),
         ),

--- a/src/python/pants/backend/project_info/paths_test.py
+++ b/src/python/pants/backend/project_info/paths_test.py
@@ -98,12 +98,12 @@ def assert_paths(
 
 
 def test_no_from(rule_runner: RuleRunner) -> None:
-    with pytest.raises(ExecutionError, match="The option --from in scope 'paths' is required."):
+    with pytest.raises(ExecutionError, match="Must set --from"):
         assert_paths(rule_runner, path_from="", path_to="base:base")
 
 
 def test_no_to(rule_runner: RuleRunner) -> None:
-    with pytest.raises(ExecutionError, match="The option --to in scope 'paths' is required."):
+    with pytest.raises(ExecutionError, match="Must set --to"):
         assert_paths(rule_runner, path_from="intermediate:intermediate", path_to="")
 
 

--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -321,13 +321,8 @@ def test_get_all_help_info():
                         "env_var": "PANTS_OPT1",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
-                                {
-                                    "rank": Rank.HARDCODED,
-                                    "value": 42,
-                                    "details": None,
-                                    "error": None,
-                                },
+                                {"rank": Rank.NONE, "value": None, "details": None},
+                                {"rank": Rank.HARDCODED, "value": 42, "details": None},
                             ),
                         },
                         "typ": int,
@@ -351,13 +346,8 @@ def test_get_all_help_info():
                         "env_var": "PANTS_LEVEL",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
-                                {
-                                    "rank": Rank.HARDCODED,
-                                    "value": LogLevel.INFO,
-                                    "details": None,
-                                    "error": None,
-                                },
+                                {"rank": Rank.NONE, "value": None, "details": None},
+                                {"rank": Rank.HARDCODED, "value": LogLevel.INFO, "details": None},
                             ),
                         },
                         "typ": LogLevel,
@@ -392,13 +382,12 @@ def test_get_all_help_info():
                         "unscoped_cmd_line_args": ("--backend-packages",),
                         "value_history": {
                             "ranked_values": (
-                                {"details": "", "rank": Rank.NONE, "value": [], "error": None},
-                                {"details": "", "rank": Rank.HARDCODED, "value": [], "error": None},
+                                {"details": "", "rank": Rank.NONE, "value": []},
+                                {"details": "", "rank": Rank.HARDCODED, "value": []},
                                 {
                                     "details": "from command-line flag",
                                     "rank": Rank.FLAG,
                                     "value": ["internal_plugins.releases"],
-                                    "error": None,
                                 },
                             ),
                         },
@@ -423,12 +412,11 @@ def test_get_all_help_info():
                         "unscoped_cmd_line_args": ("--pythonpath",),
                         "value_history": {
                             "ranked_values": (
-                                {"details": "", "rank": Rank.NONE, "value": [], "error": None},
+                                {"details": "", "rank": Rank.NONE, "value": []},
                                 {
                                     "details": "",
                                     "rank": Rank.HARDCODED,
                                     "value": [f"{get_buildroot()}/pants-plugins"],
-                                    "error": None,
                                 },
                             ),
                         },
@@ -454,13 +442,8 @@ def test_get_all_help_info():
                         "env_var": "PANTS_FOO_OPT2",
                         "value_history": {
                             "ranked_values": (
-                                {"rank": Rank.NONE, "value": None, "details": None, "error": None},
-                                {
-                                    "rank": Rank.HARDCODED,
-                                    "value": True,
-                                    "details": None,
-                                    "error": None,
-                                },
+                                {"rank": Rank.NONE, "value": None, "details": None},
+                                {"rank": Rank.HARDCODED, "value": True, "details": None},
                             ),
                         },
                         "typ": bool,

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -113,10 +113,6 @@ class MutuallyExclusiveOptionError(ParseError):
     """Indicates that two options in the same mutually exclusive group were specified."""
 
 
-class MissingRequiredOptionError(ParseError):
-    """Indicates that a required option has not been configured with a value."""
-
-
 class UnknownFlagsError(ParseError):
     """Indicates that unknown command-line flags were encountered in some scope."""
 

--- a/src/python/pants/option/option_types_test.py
+++ b/src/python/pants/option/option_types_test.py
@@ -422,9 +422,6 @@ def test_property_types() -> None:
         skip_opt = SkipOption("fmt")
         args_opt = ArgsListOption(example="--whatever")
 
-        # Required opts
-        req_opt = StrOption(required=True, help="")
-
     my_subsystem = MySubsystem()
     if TYPE_CHECKING:
         assert_type["str"](my_subsystem.str_opt)
@@ -477,5 +474,3 @@ def test_property_types() -> None:
 
         assert_type["bool"](my_subsystem.skip_opt)
         assert_type["tuple[str, ...]"](my_subsystem.args_opt)
-
-        assert_type["str"](my_subsystem.req_opt)

--- a/src/python/pants/option/option_value_container.py
+++ b/src/python/pants/option/option_value_container.py
@@ -126,8 +126,6 @@ class OptionValueContainer:
         if key not in self._value_map:
             raise AttributeError(key)
         ranked_val = self._value_map[key]
-        if ranked_val.error is not None:
-            raise ranked_val.error
         return ranked_val.value
 
     # Support natural dynamic access, e.g., opts[foo] is more idiomatic than getattr(opts, 'foo').

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -34,7 +34,6 @@ from pants.option.errors import (
     InvalidKwarg,
     InvalidMemberType,
     MemberTypeNotAllowed,
-    MissingRequiredOptionError,
     MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
@@ -502,17 +501,6 @@ def test_scope_deprecation_default_config_section(caplog) -> None:
     caplog.clear()
     assert opts.for_scope(Subsystem1.options_scope).foo == "xx"
     assert not caplog.records
-
-
-def test_required_option(caplog) -> None:
-    def register(opts: Options) -> None:
-        opts.register(GLOBAL_SCOPE, "--opt", type=bool, required=True)
-
-    opts = create_options([GLOBAL_SCOPE], register, config={}).for_global_scope()
-    with pytest.raises(
-        MissingRequiredOptionError, match="The option --opt in global scope is required."
-    ):
-        opts.opt
 
 
 # ----------------------------------------------------------------------------------------

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -9,7 +9,7 @@ import json
 import re
 import typing
 from collections import defaultdict
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any, DefaultDict, Iterable, Mapping
@@ -40,7 +40,6 @@ from pants.option.errors import (
     InvalidKwargNonGlobalScope,
     InvalidMemberType,
     MemberTypeNotAllowed,
-    MissingRequiredOptionError,
     MutuallyExclusiveOptionError,
     NoOptionNames,
     OptionAlreadyRegistered,
@@ -282,18 +281,6 @@ class Parser:
                             """
                         )
                     )
-            elif kwargs.get("required"):
-                args_str = ", ".join(args)
-                val = replace(
-                    val,
-                    error=MissingRequiredOptionError(
-                        softwrap(
-                            f"""
-                            The option {args_str} in {self._scope_str()} is required.
-                            """
-                        )
-                    ),
-                )
 
             setattr(namespace, dest, val)
 
@@ -370,26 +357,25 @@ class Parser:
             )
 
     _allowed_registration_kwargs = {
-        "advanced",
+        "type",
+        "member_type",
         "choices",
-        "daemon",
+        "dest",
         "default",
         "default_help_repr",
-        "deprecation_start_version",
-        "dest",
-        "environment_aware",
-        "fingerprint",
-        "fromfile",
-        "help",
         "implicit_value",
-        "member_type",
         "metavar",
-        "mutually_exclusive_group",
-        "passthrough",
-        "removal_hint",
+        "help",
+        "advanced",
+        "fingerprint",
         "removal_version",
-        "required",
-        "type",
+        "removal_hint",
+        "deprecation_start_version",
+        "fromfile",
+        "mutually_exclusive_group",
+        "daemon",
+        "passthrough",
+        "environment_aware",
     }
 
     _allowed_member_types = {

--- a/src/python/pants/option/ranked_value.py
+++ b/src/python/pants/option/ranked_value.py
@@ -96,7 +96,4 @@ class RankedValue:
 
     rank: Rank
     value: Value
-    # Optional details about the derivation of the value.
-    details: str | None = None
-    # Any deferred error that should be triggered if this value is accessed.
-    error: Exception | None = None
+    details: str | None = None  # Optional details about the derivation of the value.


### PR DESCRIPTION
Reverts pantsbuild/pants#18780.

As discussed in #18792 a less invasive approach is to indicate an options requiredness at runtime when looking up the value rather than as a static declaration enforced at parse time.