### PR TITLE
Remove redundant PythonToolBase/JvmToolBase features.

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -17,7 +17,6 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.strutil import help_text
 
 
@@ -41,10 +40,7 @@ class ClangFormat(PythonToolBase):
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--version")
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.cc.lint.clangformat", "clangformat.lock")
-    default_lockfile_path = "src/python/pants/backend/cc/lint/clangformat/clangformat.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     export = ExportToolOption()

--- a/src/python/pants/backend/codegen/avro/java/subsystem.py
+++ b/src/python/pants/backend/codegen/avro/java/subsystem.py
@@ -1,7 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.util.docutil import git_url
 
 
 class AvroSubsystem(JvmToolBase):
@@ -14,7 +13,3 @@ class AvroSubsystem(JvmToolBase):
         "pants.backend.codegen.avro.java",
         "avro-tools.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/codegen/avro/java/avro-tools.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)

--- a/src/python/pants/backend/codegen/protobuf/java/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/java/subsystem.py
@@ -1,7 +1,6 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.util.docutil import git_url
 
 
 class JavaProtobufGrpcSubsystem(JvmToolBase):
@@ -19,7 +18,3 @@ class JavaProtobufGrpcSubsystem(JvmToolBase):
         "pants.backend.codegen.protobuf.java",
         "grpc-java.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/codegen/protobuf/java/grpc-java.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -20,7 +20,7 @@ from pants.engine.target import FieldSet, InferDependenciesRequest, InferredDepe
 from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import doc_url
 from pants.util.strutil import help_text, softwrap
 
 
@@ -75,10 +75,7 @@ class PythonProtobufMypyPlugin(PythonToolRequirementsBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.codegen.protobuf.python", "mypy_protobuf.lock")
-    default_lockfile_path = "src/python/pants/backend/codegen/protobuf/python/mypy_protobuf.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/subsystem.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import StrListOption
-from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
@@ -37,10 +36,6 @@ class ScalaPBSubsystem(JvmToolBase):
         "pants.backend.codegen.protobuf.scala",
         "scalapbc.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/codegen/protobuf/scala/scalapbc.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
 
     _jvm_plugins = StrListOption(
         help=softwrap(

--- a/src/python/pants/backend/codegen/soap/java/jaxws.py
+++ b/src/python/pants/backend/codegen/soap/java/jaxws.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.util.docutil import git_url
 
 
 class JaxWsTools(JvmToolBase):
@@ -15,5 +14,3 @@ class JaxWsTools(JvmToolBase):
         "pants.backend.codegen.soap.java",
         "jaxws.default.lockfile.txt",
     )
-    default_lockfile_path = "pants/backend/codegen/soap/java/jaxws.default.lockfile.txt"
-    default_lockfile_url = git_url(default_lockfile_path)

--- a/src/python/pants/backend/codegen/thrift/scrooge/subsystem.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/subsystem.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.util.docutil import git_url
 
 
 class ScroogeSubsystem(JvmToolBase):
@@ -16,7 +15,3 @@ class ScroogeSubsystem(JvmToolBase):
         "pants.backend.codegen.thrift.scrooge",
         "scrooge.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/codegen/thrift/scrooge/scrooge.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)

--- a/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_parser.py
@@ -27,7 +27,6 @@ from pants.engine.target import (
     WrappedTarget,
     WrappedTargetRequest,
 )
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.resources import read_resource
 
@@ -44,10 +43,7 @@ class DockerfileParser(PythonToolRequirementsBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = (_DOCKERFILE_PACKAGE, "dockerfile.lock")
-    default_lockfile_path = f"src/python/{_DOCKERFILE_PACKAGE.replace('.', '/')}/dockerfile.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/helm/subsystems/k8s_parser.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser.py
@@ -21,7 +21,6 @@ from pants.engine.engine_aware import EngineAwareParameter, EngineAwareReturnTyp
 from pants.engine.fs import CreateDigest, Digest, FileContent, FileEntry
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, collect_rules, rule
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize, softwrap
 
@@ -41,12 +40,7 @@ class HelmKubeParserSubsystem(PythonToolRequirementsBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.10"]
 
-    register_lockfile = True
     default_lockfile_resource = (_HELM_K8S_PARSER_PACKAGE, "k8s_parser.lock")
-    default_lockfile_path = (
-        f"src/python/{_HELM_K8S_PARSER_PACKAGE.replace('.', '/')}/k8s_parser.lock"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/helm/subsystems/post_renderer.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer.py
@@ -31,7 +31,6 @@ from pants.engine.internals.native_engine import MergeDigests
 from pants.engine.process import Process
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import FieldSetsPerTarget, FieldSetsPerTargetRequest, Targets
-from pants.util.docutil import git_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.strutil import bullet_list, pluralize, softwrap
@@ -55,12 +54,7 @@ class HelmPostRendererSubsystem(PythonToolRequirementsBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.10"]
 
-    register_lockfile = True
     default_lockfile_resource = (_HELM_POSTRENDERER_PACKAGE, "post_renderer.lock")
-    default_lockfile_path = (
-        f"src/python/{_HELM_POSTRENDERER_PACKAGE.replace('.', '/')}/post_renderer.lock"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/java/lint/google_java_format/subsystem.py
+++ b/src/python/pants/backend/java/lint/google_java_format/subsystem.py
@@ -3,7 +3,6 @@
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import BoolOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
@@ -18,8 +17,6 @@ class GoogleJavaFormatSubsystem(JvmToolBase):
         "pants.backend.java.lint.google_java_format",
         "google_java_format.default.lockfile.txt",
     )
-    default_lockfile_path = "src/python/pants/backend/java/lint/google_java_format/google_java_format.default.lockfile.txt"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("fmt", "lint")
     aosp = BoolOption(

--- a/src/python/pants/backend/java/subsystems/junit.py
+++ b/src/python/pants/backend/java/subsystems/junit.py
@@ -3,7 +3,6 @@
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class JUnit(JvmToolBase):
@@ -18,8 +17,6 @@ class JUnit(JvmToolBase):
         "org.junit.vintage:junit-vintage-engine:{version}",
     )
     default_lockfile_resource = ("pants.jvm.test", "junit.default.lockfile.txt")
-    default_lockfile_path = "src/python/pants/jvm/test/junit.default.lockfile.txt"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     args = ArgsListOption(example="--disable-ansi-colors", passthrough=True)
 

--- a/src/python/pants/backend/kotlin/lint/ktlint/subsystem.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/subsystem.py
@@ -3,7 +3,6 @@
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import SkipOption
-from pants.util.docutil import git_url
 
 
 class KtlintSubsystem(JvmToolBase):
@@ -17,7 +16,5 @@ class KtlintSubsystem(JvmToolBase):
         "pants.backend.kotlin.lint.ktlint",
         "ktlint.lock",
     )
-    default_lockfile_path = "src/python/pants/backend/kotlin/lint/ktlint/ktlint.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/openapi/subsystems/openapi_generator.py
+++ b/src/python/pants/backend/openapi/subsystems/openapi_generator.py
@@ -5,7 +5,6 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
-from pants.util.docutil import git_url
 
 
 class OpenAPIGenerator(JvmToolBase):
@@ -18,10 +17,6 @@ class OpenAPIGenerator(JvmToolBase):
         "pants.backend.openapi.subsystems",
         "openapi_generator.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/openapi/subsystems/openapi_generator.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
 
 
 class OpenAPIGeneratorLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -55,7 +55,6 @@ from pants.option.option_types import (
     StrOption,
 )
 from pants.source.source_root import AllSourceRoots
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -115,10 +114,7 @@ class CoverageSubsystem(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "coverage_py.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/coverage_py.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     filter = StrListOption(

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class AddTrailingComma(PythonToolBase):
@@ -27,15 +26,10 @@ class AddTrailingComma(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = (
         "pants.backend.python.lint.add_trailing_comma",
         "add_trailing_comma.lock",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/python/lint/add_trailing_comma/add_trailing_comma.lock"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class Autoflake(PythonToolBase):
@@ -27,10 +26,7 @@ class Autoflake(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.autoflake", "autoflake.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/autoflake/autoflake.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -26,7 +26,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, FileOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -60,10 +59,7 @@ class Bandit(PythonToolBase):
     default_main = ConsoleScript("bandit")
     default_requirements = [default_version, *default_extra_requirements]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.bandit", "bandit.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/bandit/bandit.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("lint")
     args = ArgsListOption(example="--skip B101,B308 --confidence")

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -29,7 +29,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -58,10 +57,7 @@ class Black(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.black", "black.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/black/black.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("fmt", "lint")
     args = ArgsListOption(example="--target-version=py37 --quiet")

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -12,7 +12,6 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class Docformatter(PythonToolBase):
@@ -26,10 +25,7 @@ class Docformatter(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.docformatter", "docformatter.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/docformatter/docformatter.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -43,7 +43,7 @@ from pants.option.option_types import (
     SkipOption,
     TargetListOption,
 )
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
@@ -70,10 +70,7 @@ class Flake8(PythonToolBase):
     default_main = ConsoleScript("flake8")
     default_requirements = [default_version]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.flake8", "flake8.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/flake8/flake8.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("lint")
     args = ArgsListOption(example="--ignore E123,W456 --enable-extensions H111")

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -17,7 +17,6 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileListOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
@@ -32,10 +31,7 @@ class Isort(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.isort", "isort.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/isort/isort.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
@@ -22,7 +22,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
-from pants.util.docutil import bin_name, git_url
+from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -49,10 +49,7 @@ class Pydocstyle(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.pydocstyle", "pydocstyle.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/pydocstyle/pydocstyle.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("lint")
     args = ArgsListOption(example="--select=D101,D102")

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -43,7 +43,7 @@ from pants.option.option_types import (
     SkipOption,
     TargetListOption,
 )
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import doc_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.strutil import softwrap
@@ -76,10 +76,7 @@ class Pylint(PythonToolBase):
     default_main = ConsoleScript("pylint")
     default_requirements = [default_version]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.pylint", "pylint.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/pylint/pylint.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("lint")
     args = ArgsListOption(example="--ignore=foo.py,bar.py --disable=C0330,W0311")

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -13,7 +13,6 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class PyUpgrade(PythonToolBase):
@@ -29,10 +28,7 @@ class PyUpgrade(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.pyupgrade", "pyupgrade.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/pyupgrade/pyupgrade.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -26,7 +26,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet, Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -60,10 +59,7 @@ class Ruff(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.ruff", "ruff.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/ruff/ruff.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -17,7 +17,6 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
-from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
@@ -33,10 +32,7 @@ class Yapf(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.lint.yapf", "yapf.lock")
-    default_lockfile_path = "src/python/pants/backend/python/lint/yapf/yapf.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -5,7 +5,6 @@ from pants.backend.python.subsystems.python_tool_base import LockfileRules, Pyth
 from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
-from pants.util.docutil import git_url
 from pants.util.strutil import help_text
 
 
@@ -28,10 +27,7 @@ class PyOxidizer(PythonToolBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.8,<4"]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.packaging.pyoxidizer", "pyoxidizer.lock")
-    default_lockfile_path = "src/python/pants/backend/python/packaging/pyoxidizer/pyoxidizer.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     args = ArgsListOption(example="--release")

--- a/src/python/pants/backend/python/subsystems/debugpy.py
+++ b/src/python/pants/backend/python/subsystems/debugpy.py
@@ -8,7 +8,6 @@ from pants.backend.python.target_types import EntryPoint
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
 from pants.engine.rules import collect_rules
 from pants.option.option_types import ArgsListOption
-from pants.util.docutil import git_url
 
 
 class DebugPy(PythonToolBase):
@@ -22,10 +21,7 @@ class DebugPy(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "debugpy.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/debugpy.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     args = ArgsListOption(example="--log-to-stderr")

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -17,7 +17,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import FieldSet
 from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -30,10 +29,7 @@ class IPython(PythonToolBase):
     default_main = ConsoleScript("ipython")
     default_requirements = ["ipython>=7.34,<9"]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "ipython.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/ipython.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     ignore_cwd = BoolOption(
         advanced=True,

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -4,7 +4,6 @@
 from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules
-from pants.util.docutil import git_url
 
 
 class Lambdex(PythonToolBase):
@@ -18,10 +17,7 @@ class Lambdex(PythonToolBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<3.12"]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/lambdex.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -38,7 +38,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
-from pants.util.docutil import bin_name, doc_url, git_url
+from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_method
 from pants.util.strutil import softwrap
@@ -81,10 +81,7 @@ class PyTest(PythonToolBase):
 
     default_main = ConsoleScript("pytest")
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "pytest.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/pytest.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     args = ArgsListOption(example="-k test_foo --quiet", passthrough=True)
     junit_family = StrOption(

--- a/src/python/pants/backend/python/subsystems/python_tool_base_test.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base_test.py
@@ -11,9 +11,7 @@ from pants.util.ordered_set import FrozenOrderedSet
 
 class _DummyTool(PythonToolBase):
     options_scope = "dummy"
-    register_lockfile = True
     default_lockfile_resource = ("dummy", "dummy")
-    default_lockfile_url = "dummy"
 
 
 def test_install_from_resolve_default() -> None:

--- a/src/python/pants/backend/python/subsystems/setuptools.py
+++ b/src/python/pants/backend/python/subsystems/setuptools.py
@@ -16,7 +16,6 @@ from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.goals.package import PackageFieldSet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.strutil import softwrap
 
@@ -36,10 +35,7 @@ class Setuptools(PythonToolRequirementsBase):
     default_extra_requirements = ["wheel>=0.35.1,<0.38"]
     default_requirements = [default_version, *default_extra_requirements]
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "setuptools.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/setuptools.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
 
 class SetuptoolsLockfileSentinel(GeneratePythonToolLockfileSentinel):

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -4,7 +4,6 @@
 from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import EntryPoint
 from pants.engine.rules import collect_rules
-from pants.util.docutil import git_url
 
 
 class SetuptoolsSCM(PythonToolBase):
@@ -19,10 +18,7 @@ class SetuptoolsSCM(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "setuptools_scm.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/setuptools_scm.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -10,7 +10,7 @@ from pants.engine.fs import CreateDigest
 from pants.engine.rules import collect_rules
 from pants.option.global_options import ca_certs_path_to_file_content
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
-from pants.util.docutil import doc_url, git_url
+from pants.util.docutil import doc_url
 from pants.util.strutil import softwrap
 
 
@@ -31,10 +31,7 @@ class TwineSubsystem(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.subsystems", "twine.lock")
-    default_lockfile_path = "src/python/pants/backend/python/subsystems/twine.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     skip = SkipOption("publish")

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -62,7 +62,7 @@ from pants.option.option_types import (
     StrOption,
     TargetListOption,
 )
-from pants.util.docutil import bin_name, doc_url, git_url
+from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
@@ -100,10 +100,7 @@ class MyPy(PythonToolBase):
     # See `mypy/rules.py`. We only use these default constraints in some situations.
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.python.typecheck.mypy", "mypy.lock")
-    default_lockfile_path = "src/python/pants/backend/python/typecheck/mypy/mypy.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--python-version 3.7 --disallow-any-expr")

--- a/src/python/pants/backend/python/util_rules/lockfile_test.py
+++ b/src/python/pants/backend/python/util_rules/lockfile_test.py
@@ -42,10 +42,7 @@ class FakeTool(PythonToolBase):
     register_interpreter_constraints = True
     default_interpreter_constraints = ["CPython>=3.7,<4"]
 
-    register_lockfile = True
-    default_lockfile_path = "cowsay.lock"
-    default_lockfile_resource = ("", "")
-    default_lockfile_url = " "
+    default_lockfile_resource = ("", "cowsay.lock")
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
@@ -3,7 +3,6 @@
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import SkipOption
-from pants.util.docutil import git_url
 
 
 class ScalafmtSubsystem(JvmToolBase):
@@ -17,9 +16,5 @@ class ScalafmtSubsystem(JvmToolBase):
         "pants.backend.scala.lint.scalafmt",
         "scalafmt.default.lockfile.txt",
     )
-    default_lockfile_path = (
-        "src/python/pants/backend/scala/lint/scalafmt/scalafmt.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/scala/subsystems/scalatest.py
+++ b/src/python/pants/backend/scala/subsystems/scalatest.py
@@ -3,7 +3,6 @@
 
 from pants.jvm.resolve.jvm_tool import JvmToolBase
 from pants.option.option_types import ArgsListOption, SkipOption
-from pants.util.docutil import git_url
 
 
 class Scalatest(JvmToolBase):
@@ -14,10 +13,6 @@ class Scalatest(JvmToolBase):
     default_version = "3.2.10"
     default_artifacts = ("org.scalatest:scalatest_2.13:{version}",)
     default_lockfile_resource = ("pants.backend.scala.subsystems", "scalatest.default.lockfile.txt")
-    default_lockfile_path = (
-        "src/python/pants/backend/scala/subsystems/scalatest.default.lockfile.txt"
-    )
-    default_lockfile_url = git_url(default_lockfile_path)
 
     args = ArgsListOption(
         example="-t $testname",

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -28,7 +28,6 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
-from pants.util.docutil import git_url
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 from pants.util.resources import read_resource
@@ -43,10 +42,7 @@ class TerraformHcl2Parser(PythonToolRequirementsBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.terraform", "hcl2.lock")
-    default_lockfile_path = "src/python/pants/backend/terraform/hcl2.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
 

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -15,7 +15,6 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption, StrOption
-from pants.util.docutil import git_url
 from pants.util.strutil import softwrap
 
 
@@ -30,10 +29,7 @@ class Yamllint(PythonToolBase):
 
     register_interpreter_constraints = True
 
-    register_lockfile = True
     default_lockfile_resource = ("pants.backend.tools.yamllint", "yamllint.lock")
-    default_lockfile_path = "src/python/pants/backend/tools/yamllint/yamllint.lock"
-    default_lockfile_url = git_url(default_lockfile_path)
     lockfile_rules_type = LockfileRules.SIMPLE
 
     export = ExportToolOption()

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -22,7 +23,8 @@ from pants.jvm.resolve.common import (
 from pants.jvm.target_types import JvmArtifactFieldSet
 from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem
-from pants.util.docutil import bin_name
+from pants.util.docutil import bin_name, git_url
+from pants.util.meta import classproperty
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.strutil import softwrap
 
@@ -39,8 +41,6 @@ class JvmToolBase(Subsystem):
 
     # Default resource for the tool's lockfile. (Subclasses must set.)
     default_lockfile_resource: ClassVar[tuple[str, str]]
-
-    default_lockfile_url: ClassVar[str | None] = None
 
     version = StrOption(
         advanced=True,
@@ -92,6 +92,17 @@ class JvmToolBase(Subsystem):
         ),
         advanced=True,
     )
+
+    @classproperty
+    def default_lockfile_url(cls) -> str:
+        return git_url(
+            os.path.join(
+                "src",
+                "python",
+                cls.default_lockfile_resource[0].replace(".", os.path.sep),
+                cls.default_lockfile_resource[1],
+            )
+        )
 
     @property
     def artifact_inputs(self) -> tuple[str, ...]:

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -30,7 +30,6 @@ class MockJvmTool(JvmToolBase):
     default_version = "1.3"
     default_artifacts = ("org.hamcrest:hamcrest-core:{version}",)
     default_lockfile_resource = ("pants.backend.jvm.resolve", "mock-tool.default.lockfile.txt")
-    default_lockfile_url = ""
 
 
 class MockJvmToolLockfileSentinel(GenerateToolLockfileSentinel):

--- a/src/python/pants/jvm/shading/jarjar.py
+++ b/src/python/pants/jvm/shading/jarjar.py
@@ -8,7 +8,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
 from pants.option.option_types import BoolOption, EnumOption
-from pants.util.docutil import git_url
 
 
 @unique
@@ -29,8 +28,6 @@ class JarJar(JvmToolBase):
         "pants.jvm.shading",
         "jarjar.default.lockfile.txt",
     )
-    default_lockfile_path = "src/python/pants/jvm/shading/jarjar.default.lockfile.txt"
-    default_lockfile_url = git_url(default_lockfile_path)
 
     skip_manifest = BoolOption(default=False, help="Skip the processing of the JAR manifest.")
     misplaced_class_strategy = EnumOption(


### PR DESCRIPTION
1. All Python tools set register_lockfile = True, so there is 
   no need to support not registering one.
3. default_lockfile_url can be generated from default_lockfile_resource,
   so does not need to be set per-tool. And this URL is only used in an
   option help message anyway, it is not required for functionality.
4. default_lockfile_path was only used to calculate default_lockfile_url,
   so it does not need to exist at all.