### PR TITLE
Default to using the entire tool lockfile. (Cherry-pick of #18793)

### DIFF
--- a/docs/markdown/Python/python/python-linters-and-formatters.md
+++ b/docs/markdown/Python/python/python-linters-and-formatters.md
@@ -74,13 +74,13 @@ Configuring the tools, for example, adding plugins
 
 You can configure each formatter and linter using these options:
 
-| Option                    | What it does                                                                                                                                                                           |
-| :------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `interpreter_constraints` | What interpreter to run the tool with. (`bandit`, `flake8`, and `pylint` instead determine this based on your [code's interpreter constraints](doc:python-interpreter-compatibility).) |
-| `args`                    | Any command-line arguments you want to pass to the tool.                                                                                                                               |
-| `config`                  | Path to a config file. Useful if the file is in a non-standard location such that it cannot be auto-discovered.                                                                        |
-| `requirements`                        | List of requirements to be included with this formatter or linter. See [Lockfiles for tools](doc:python-lockfiles#lockfiles-for-tools).                  |
-| `install_from_resolve`                | Name of a custom resolve to use for tool versions and plugins. See [Lockfiles for tools](doc:python-lockfiles#lockfiles-for-tools).                  |
+| Option                               | What it does                                                                                                                                                                   |
+|:-------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `interpreter_constraints`            | What interpreter to run the tool with. (`bandit`, `flake8`, and `pylint` determine this based on your [code's interpreter constraints](doc:python-interpreter-compatibility).) |
+| `args`                               | Any command-line arguments you want to pass to the tool.                                                                                                                       |
+| `config`                             | Path to a config file. Useful if the file is in a non-standard location such that it cannot be auto-discovered.                                                                |
+| `install_from_resolve`               | Name of a custom resolve to use for tool versions and plugins. See [Lockfiles for tools](doc:python-lockfiles#lockfiles-for-tools).                                            |
+| `requirements`                       | Optional subset of requirements to install from the custom resolve for this formatter or linter. See [Lockfiles for tools](doc:python-lockfiles#lockfiles-for-tools).          |
 
 For example:
 
@@ -89,17 +89,13 @@ For example:
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]
 
 [python.resolves]
+# A custom resolve that updates the version and adds a custom plugin.
 flake8 = "3rdparty/python/flake8.lock"
 
 [flake8]
 # Load a config file in a non-standard location.
 config = "build-support/flake8"
-# Change the version and add a custom plugin. Because we do this, we
-# use a custom resolve.
 install_from_resolve = "flake8"
-requirements.add = [
-    "flake8-bugbear",
-]
 ```
 
 Then set up the resolve's inputs:

--- a/pants.toml
+++ b/pants.toml
@@ -166,11 +166,6 @@ args = ["--wrap-summaries=100", "--wrap-descriptions=100"]
 
 [flake8]
 config = "build-support/flake8/.flake8"
-requirements.add = [
-  "flake8-2020",
-  "flake8-no-implicit-concat",
-  "flake8-comprehensions",
-]
 
 source_plugins = ["build-support/flake8"]
 install_from_resolve = "flake8"
@@ -184,13 +179,6 @@ args = ["-i 2", "-ci", "-sr"]
 
 [pytest]
 args = ["--no-header"]
-requirements.add = [
-  "ipdb",
-  "pytest-asyncio",
-  "pytest-html",
-  "pytest-icdiff",
-  "pygments",
-]
 execution_slot_var = "TEST_EXECUTION_SLOT"
 install_from_resolve = "pytest"
 
@@ -209,10 +197,6 @@ timeout_default = 60
 
 [mypy]
 interpreter_constraints = [">=3.7,<3.10"]
-requirements.add = [
-  "mypy-typing-asserts",
-  "strawberry-graphql",
-]
 install_from_resolve = "mypy"
 
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base_test.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base_test.py
@@ -27,5 +27,5 @@ def test_install_from_resolve_default() -> None:
     )
     pex_reqs = tool.pex_requirements()
     assert isinstance(pex_reqs, PexRequirements)
-    assert pex_reqs.from_superset == Resolve("dummy_resolve")
+    assert pex_reqs.from_superset == Resolve("dummy_resolve", False)
     assert pex_reqs.req_strings == FrozenOrderedSet(["bar", "baz", "foo"])

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -471,10 +471,19 @@ async def _setup_pex_requirements(
     pex_lock_resolver_args = list(resolve_config.pex_args())
     pip_resolver_args = [*resolve_config.pex_args(), "--resolver-version", "pip-2020-resolver"]
 
-    if isinstance(request.requirements, EntireLockfile):
-        loaded_lockfile = await Get(
-            LoadedLockfile, LoadedLockfileRequest(request.requirements.lockfile)
-        )
+    # TODO: This is clunky, but can be simplified once we get rid of old-style tool
+    #  lockfiles, because we can unify EntireLockfile and Resolve.
+    if isinstance(request.requirements, EntireLockfile) or (
+        isinstance(request.requirements.from_superset, Resolve)
+        and request.requirements.from_superset.use_entire_lockfile
+    ):
+        if isinstance(request.requirements, EntireLockfile):
+            complete_req_strings = request.requirements.complete_req_strings
+            lockfile = request.requirements.lockfile
+        else:
+            complete_req_strings = None
+            lockfile = await Get(Lockfile, Resolve, request.requirements.from_superset)
+        loaded_lockfile = await Get(LoadedLockfile, LoadedLockfileRequest(lockfile))
         argv = (
             ["--lock", loaded_lockfile.lockfile_path, *pex_lock_resolver_args]
             if loaded_lockfile.is_pex_native
@@ -482,12 +491,12 @@ async def _setup_pex_requirements(
             # We use pip to resolve a requirements.txt pseudo-lockfile, possibly with hashes.
             ["--requirement", loaded_lockfile.lockfile_path, "--no-transitive", *pip_resolver_args]
         )
-        if loaded_lockfile.metadata and request.requirements.complete_req_strings:
+        if loaded_lockfile.metadata and complete_req_strings:
             validate_metadata(
                 loaded_lockfile.metadata,
                 request.interpreter_constraints,
                 loaded_lockfile.original_lockfile,
-                request.requirements.complete_req_strings,
+                complete_req_strings,
                 # We're using the entire lockfile, so there is no Pex subsetting operation we
                 # can delegate requirement validation to.  So we do our naive string-matching
                 # validation.

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -429,7 +429,12 @@ async def _determine_requirements_for_pex_from_targets(
         chosen_resolve = await Get(
             ChosenPythonResolve, ChosenPythonResolveRequest(request.addresses)
         )
-        return dataclasses.replace(requirements, from_superset=Resolve(chosen_resolve.name)), ()
+        return (
+            dataclasses.replace(
+                requirements, from_superset=Resolve(chosen_resolve.name, use_entire_lockfile=False)
+            ),
+            (),
+        )
 
     # Else, request the repository PEX and possibly subset it.
     repository_pex_request = await Get(

--- a/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets_test.py
@@ -167,11 +167,11 @@ def test_determine_requirements_for_pex_from_targets() -> None:
     req_strings = ["req1", "req2"]
     global_requirement_constraints = ["constraint1", "constraint2"]
 
-    resolve__pex = Resolve("pex")
+    resolve__pex = Resolve("pex", False)
     loaded_lockfile__pex = Mock(is_pex_native=True, as_constraints_strings=None)
     chosen_resolve__pex = Mock(lockfile=Mock())
     chosen_resolve__pex.name = "pex"  # name has special meaning in Mock(), so must set it here.
-    resolve__not_pex = Resolve("not_pex")
+    resolve__not_pex = Resolve("not_pex", False)
     loaded_lockfile__not_pex = Mock(is_pex_native=False, as_constraints_strings=req_strings)
     chosen_resolve__not_pex = Mock(lockfile=Mock())
     chosen_resolve__not_pex.name = "not_pex"  # ditto.

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -52,7 +52,13 @@ class Resolve:
     # A named resolve for a "user lockfile".
     # Soon to be the only kind of lockfile, as this class will help
     # get rid of the "tool lockfile" concept.
+    # TODO: Once we get rid of old-style tool lockfiles we can possibly
+    #  unify this with EntireLockfile.
+    # TODO: We might want to add the requirements subset to this data structure,
+    #  to further detangle this from PexRequirements.
     name: str
+
+    use_entire_lockfile: bool
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -776,7 +776,7 @@ def test_setup_pex_requirements() -> None:
 
     # Subset of Pex lockfile.
     assert_setup(
-        PexRequirements(["req1"], from_superset=Resolve("resolve")),
+        PexRequirements(["req1"], from_superset=Resolve("resolve", False)),
         _BuildPexRequirementsSetup(
             [lockfile_digest], ["req1", "--lock", lockfile_path, *pex_args], 1
         ),


### PR DESCRIPTION
The initial implementation of installing tools from regular user
lockfiles was designed with the feature of subsetting from a
larger lockfile in mind.

Therefore, we introduced the `requirements` option, which
enumerated the requirements to be installed for the tool,
and defaulted to the requirements in the built-in lockfile
provided with Pants.

However now that users have started experimenting with this
feature, it turns out to be quite laborious - in the more common
case where you create a custom lockfile that is intended to be
used in its entirety, you still have to update `requirements`
(e.g., to tweak versions or add extra requirements) even though
you already enumerated the requirements as inputs to lockfile
generation.

This PR changes the semantics of the `requirements` option. 
It now defaults to an empty list, indicating that the entire lockfile
should be used.  Only if you truly need to subset do you enumerate
`requirements` (which can be versionless, since the lockfile provides
the version).

This has the side-effect of no longer validating that a custom tool
lockfile provides a tool version that Pants believes it can handle. 
But this nannying has also been found by users to be annoying, and
is an example of Pants getting in the way (users were just
bypassing this check by updating versions in `requirements`, which
seems like unnecessary hoop-jumping).

Now if a user-provided tool version doesn't work, e.g., because a
CLI arg is no longer available, or other semantics have changed,
then the user will get an error, or unwanted behavior, from the tool,
and it will be up to them to YOLO that.

This change doesn't require deprecation, since the `requirements`
option has not been released yet.
