### PR TITLE
Use build root as workdir for shell_command(workdir="")

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -203,7 +203,7 @@ def test_working_directory_special_values(
             "src/BUILD": dedent(
                 f"""\
                 system_binary(name="bash", binary_name="bash")
-                system_binary(name="sed", binary_name="sed")
+                system_binary(name="sed", binary_name="sed", fingerprint_args=["q"])
 
                 adhoc_tool(
                   name="workdir",

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import os
 from textwrap import dedent
 
 import pytest
@@ -183,40 +182,37 @@ def test_adhoc_tool_capture_stdout_err(rule_runner: PythonRuleRunner) -> None:
 
 
 @pytest.mark.parametrize(
-    ("workdir", "file_location"),
+    ("workdir", "expected_dir"),
     (
-        ("src", "src"),
-        (".", "src"),
-        ("./", "src"),
+        ("src", "/src"),
+        (".", "/src"),
+        ("./", "/src"),
+        ("./dst", "/src/dst"),
         ("/", ""),
         ("", ""),
-        ("/src", "src"),
+        ("/src", "/src"),
+        ("/dst", "/dst"),
+        (None, "/src"),
     ),
 )
 def test_working_directory_special_values(
-    rule_runner: PythonRuleRunner, workdir: str, file_location: str
+    rule_runner: PythonRuleRunner, workdir: str, expected_dir: str
 ) -> None:
     rule_runner.write_files(
         {
-            "src/fruitcake.py": dedent(
-                """\
-                f = open("fruitcake.txt", "w")
-                f.write("fruitcake\\n")
-                f.close()
-                """
-            ),
             "src/BUILD": dedent(
                 f"""\
-                python_source(
-                    source="fruitcake.py",
-                    name="fruitcake",
-                )
+                system_binary(name="bash", binary_name="bash")
+                system_binary(name="sed", binary_name="sed")
 
                 adhoc_tool(
-                  name="run_fruitcake",
-                  runnable=":fruitcake",
-                  output_files=["fruitcake.txt"],
-                  workdir="{workdir}",
+                  name="workdir",
+                  runnable=":bash",
+                  args=['-c', 'echo $PWD | sed s@^{{chroot}}@@ > out.log'],
+                  runnable_dependencies=[":sed"],
+                  workdir={workdir!r},
+                  output_files=["out.log"],
+                  root_output_directory=".",
                 )
                 """
             ),
@@ -225,8 +221,8 @@ def test_working_directory_special_values(
 
     assert_adhoc_tool_result(
         rule_runner,
-        Address("src", target_name="run_fruitcake"),
-        expected_contents={os.path.join(file_location, "fruitcake.txt"): "fruitcake\n"},
+        Address("src", target_name="workdir"),
+        expected_contents={"out.log": f"{expected_dir}\n"},
     )
 
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -76,9 +76,7 @@ async def _prepare_process_request_from_target(
     description = f"the `{shell_command.alias}` at `{shell_command.address}`"
 
     working_directory = shell_command[ShellCommandWorkdirField].value
-
-    if not working_directory:
-        working_directory = "."
+    assert working_directory is not None, "working_directory should always be a string"
 
     command = shell_command[ShellCommandCommandField].value
     if not command:
@@ -241,9 +239,8 @@ async def _interactive_shell_command(
     )
     dependencies_digest = execution_environment.digest
 
-    _working_directory = working_directory or "."
     relpath = os.path.relpath(
-        _working_directory, start="/" if os.path.isabs(_working_directory) else "."
+        working_directory, start="/" if os.path.isabs(working_directory) else "."
     )
     boot_script = f"cd {shlex.quote(relpath)}; " if relpath != "." else ""
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -789,3 +789,47 @@ def test_env_vars(rule_runner: RuleRunner) -> None:
         Address("src", target_name="envvars"),
         expected_contents={"out.log": f"{envvar_value}\n"},
     )
+
+
+_DEFAULT = object()
+
+
+@pytest.mark.parametrize(
+    ("workdir", "expected_dir"),
+    [
+        ("src", "/src"),
+        (".", "/src"),
+        ("./", "/src"),
+        ("./dst", "/src/dst"),
+        ("/", ""),
+        ("", ""),
+        ("/src", "/src"),
+        ("/dst", "/dst"),
+        (None, "/src"),
+    ],
+)
+def test_working_directory_special_values(
+    rule_runner: RuleRunner, workdir: str | None, expected_dir: str
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                f"""\
+                shell_command(
+                  name="workdir",
+                  tools=['sed'],
+                  command='echo $PWD | sed s@^{{chroot}}@@ > out.log',
+                  workdir={workdir!r},
+                  output_files=["out.log"],
+                  root_output_directory=".",
+                )
+                """
+            ),
+        }
+    )
+
+    assert_shell_command_result(
+        rule_runner,
+        Address("src", target_name="workdir"),
+        expected_contents={"out.log": f"{expected_dir}\n"},
+    )


### PR DESCRIPTION
This fixes #18811 by removing the extraneous layer of defaulting of the adhoc tool workdir arguments: it already has `default="."`, which I think means `.value` will never be `None`.

Previously, tests like `field.value or "."` or `if not field.value: ...` would use the fallback case for `""`, and, for `shell_command` that extra fallback (`"."`) doesn't match the documented behaviour:

> * `/` or the empty string specifies the build root.

This adjusts the adhoc tool tests to explicitly check the working directory by checking `$PWD` (previously they were testing the combination of working directory and root output directory, by checking file locations), although no fix was required to `adhoc_tool`.