### PR TITLE
Write adhoc_tool(stdout/stderr="...") relative to workdir, support absolute paths

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -34,7 +34,7 @@ from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_s
 from pants.core.util_rules.environments import EnvironmentNameRequest
 from pants.engine.addresses import Addresses
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, Snapshot
+from pants.engine.fs import Digest, MergeDigests, Snapshot
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
@@ -165,6 +165,8 @@ async def run_in_sandbox_request(
         supplied_env_var_values=FrozenDict(extra_env),
         log_on_process_errors=None,
         log_output=target[AdhocToolLogOutputField].value,
+        capture_stderr_file=target[AdhocToolStderrFilenameField].value,
+        capture_stdout_file=target[AdhocToolStdoutFilenameField].value,
     )
 
     adhoc_result = await Get(
@@ -175,23 +177,7 @@ async def run_in_sandbox_request(
         },
     )
 
-    result = adhoc_result.process_result
-    adjusted = adhoc_result.adjusted_digest
-
-    extras = (
-        (target[AdhocToolStdoutFilenameField].value, result.stdout),
-        (target[AdhocToolStderrFilenameField].value, result.stderr),
-    )
-    extra_contents = {i: j for i, j in extras if i}
-
-    if extra_contents:
-        extra_digest = await Get(
-            Digest,
-            CreateDigest(FileContent(name, content) for name, content in extra_contents.items()),
-        )
-        adjusted = await Get(Digest, MergeDigests((adjusted, extra_digest)))
-
-    output = await Get(Snapshot, Digest, adjusted)
+    output = await Get(Snapshot, Digest, adhoc_result.adjusted_digest)
     return GeneratedSources(output)
 
 

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -146,23 +146,14 @@ def test_adhoc_tool_with_workdir(rule_runner: PythonRuleRunner) -> None:
 def test_adhoc_tool_capture_stdout_err(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
-            "src/fruitcake.py": dedent(
-                """\
-                import sys
-                print("fruitcake")
-                print("inconceivable", file=sys.stderr)
-                """
-            ),
             "src/BUILD": dedent(
                 """\
-                python_source(
-                    source="fruitcake.py",
-                    name="fruitcake",
-                )
+                system_binary(name="bash", binary_name="bash")
 
                 adhoc_tool(
                   name="run_fruitcake",
-                  runnable=":fruitcake",
+                  runnable=":bash",
+                  args=["-c", "echo fruitcake; echo inconceivable >&2"],
                   stdout="dir/stdout",
                   stderr="dir/stderr",
                 )

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -163,9 +163,8 @@ def test_adhoc_tool_capture_stdout_err(rule_runner: PythonRuleRunner) -> None:
                 adhoc_tool(
                   name="run_fruitcake",
                   runnable=":fruitcake",
-                  stdout="stdout",
-                  stderr="stderr",
-                  root_output_directory=".",
+                  stdout="dir/stdout",
+                  stderr="dir/stderr",
                 )
                 """
             ),
@@ -176,8 +175,8 @@ def test_adhoc_tool_capture_stdout_err(rule_runner: PythonRuleRunner) -> None:
         rule_runner,
         Address("src", target_name="run_fruitcake"),
         expected_contents={
-            "stderr": "inconceivable\n",
-            "stdout": "fruitcake\n",
+            "src/dir/stderr": "inconceivable\n",
+            "src/dir/stdout": "fruitcake\n",
         },
     )
 

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -149,8 +149,9 @@ class AdhocToolStdoutFilenameField(StringField):
     default = None
     help = help_text(
         lambda: f"""
-        A filename to capture the contents of `stdout` to, relative to the value of
-        `{AdhocToolWorkdirField.alias}`.
+        A filename to capture the contents of `stdout` to. Relative paths are
+        relative to the value of `{AdhocToolWorkdirField.alias}`, absolute paths
+        start at the build root.
         """
     )
 
@@ -160,8 +161,9 @@ class AdhocToolStderrFilenameField(StringField):
     default = None
     help = help_text(
         lambda: f"""
-        A filename to capture the contents of `stderr` to, relative to the value of
-        `{AdhocToolWorkdirField.alias}`
+        A filename to capture the contents of `stderr` to. Relative paths are
+        relative to the value of `{AdhocToolWorkdirField.alias}`, absolute paths
+        start at the build root.
         """
     )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -157,6 +157,8 @@ async def _prepare_process_request_from_target(
         immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,
         log_output=shell_command[ShellCommandLogOutputField].value,
+        capture_stdout_file=None,
+        capture_stderr_file=None,
     )
 
 

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -404,7 +404,7 @@ async def run_adhoc_process(
         extra_digest = await Get(
             Digest,
             CreateDigest(
-                FileContent(os.path.join(working_directory, name), content)
+                FileContent(_parse_relative_file(name, working_directory), content)
                 for name, content in extra_contents.items()
             ),
         )
@@ -506,6 +506,16 @@ def _parse_relative_directory(workdir_in: str, relative_to: Union[Address, str])
         return workdir_in[1:]
     else:
         return workdir_in
+
+
+def _parse_relative_file(file_in: str, relative_to: str) -> str:
+    """Convert the `capture_std..._file` fields into something that can be understood by
+    `Process`."""
+
+    if file_in.startswith("/"):
+        return file_in[1:]
+
+    return os.path.join(relative_to, file_in)
 
 
 def rules():


### PR DESCRIPTION
This fixes #18810 by ensuring `adhoc_tool(stdout="...", stderr="...")` are written relative to the working directory, and before the `root_output_directory` filtering happens.

This also fixes a second bug I noticed while working on this: if the path is absolute, e.g. `stdout="/out.txt"`, pants crashes: ```panic at 'called `Result::unwrap()` on an `Err` value: "Absolute paths are not allowed: \"/out.txt\""', src/intrinsics.rs:420```. After this PR, they are supported, and taken to start at the build root.