### PR TITLE
Reduce get_snapshot copypasta

### DIFF
--- a/src/python/pants/backend/build_files/fmt/black/integration_test.py
+++ b/src/python/pants/backend/build_files/fmt/black/integration_test.py
@@ -13,7 +13,7 @@ from pants.backend.python.lint.black.subsystem import rules as black_subsystem_r
 from pants.backend.python.target_types import PythonSourcesGeneratorTarget
 from pants.core.goals.fmt import FmtResult
 from pants.core.util_rules import config_files
-from pants.engine.fs import CreateDigest, Digest, FileContent, PathGlobs
+from pants.engine.fs import PathGlobs
 from pants.engine.internals.native_engine import Snapshot
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -31,12 +31,6 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[PythonSourcesGeneratorTarget],
     )
-
-
-def get_snapshot(rule_runner: RuleRunner, build_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in build_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
 
 
 def run_black(rule_runner: RuleRunner, *, extra_args: list[str] | None = None) -> FmtResult:
@@ -82,7 +76,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
         extra_args=[f"--black-interpreter-constraints=['{interpreter_constraint}']"],
     )
     assert "1 file left unchanged" in fmt_result.stderr
-    assert fmt_result.output == get_snapshot(rule_runner, {"BUILD": 'python_sources(name="t")\n'})
+    assert fmt_result.output == rule_runner.make_snapshot({"BUILD": 'python_sources(name="t")\n'})
     assert fmt_result.did_change is False
 
 
@@ -90,7 +84,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"BUILD": "python_sources(name='t')\n"})
     fmt_result = run_black(rule_runner)
     assert "1 file reformatted" in fmt_result.stderr
-    assert fmt_result.output == get_snapshot(rule_runner, {"BUILD": 'python_sources(name="t")\n'})
+    assert fmt_result.output == rule_runner.make_snapshot({"BUILD": 'python_sources(name="t")\n'})
     assert fmt_result.did_change is True
 
 
@@ -103,9 +97,8 @@ def test_multiple_files(rule_runner: RuleRunner) -> None:
     )
     fmt_result = run_black(rule_runner)
     assert "1 file reformatted, 1 file left unchanged" in fmt_result.stderr
-    assert fmt_result.output == get_snapshot(
-        rule_runner,
-        {"good/BUILD": 'python_sources(name="t")\n', "bad/BUILD": 'python_sources(name="t")\n'},
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good/BUILD": 'python_sources(name="t")\n', "bad/BUILD": 'python_sources(name="t")\n'}
     )
     assert fmt_result.did_change is True
 
@@ -123,7 +116,7 @@ def test_config_file(rule_runner: RuleRunner, config_path: str, extra_args: list
     )
     fmt_result = run_black(rule_runner, extra_args=extra_args)
     assert "1 file left unchanged" in fmt_result.stderr
-    assert fmt_result.output == get_snapshot(rule_runner, {"BUILD": "python_sources(name='t')\n"})
+    assert fmt_result.output == rule_runner.make_snapshot({"BUILD": "python_sources(name='t')\n"})
     assert fmt_result.did_change is False
 
 
@@ -131,5 +124,5 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"BUILD": "python_sources(name='t')\n"})
     fmt_result = run_black(rule_runner, extra_args=["--black-args='--skip-string-normalization'"])
     assert "1 file left unchanged" in fmt_result.stderr
-    assert fmt_result.output == get_snapshot(rule_runner, {"BUILD": "python_sources(name='t')\n"})
+    assert fmt_result.output == rule_runner.make_snapshot({"BUILD": "python_sources(name='t')\n"})
     assert fmt_result.did_change is False

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/format_rules_integration_test.py
@@ -13,8 +13,6 @@ from pants.core.goals.fmt import FmtResult
 from pants.core.util_rules import config_files, external_tool, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, FileContent
-from pants.engine.internals.native_engine import Digest, Snapshot
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -74,18 +72,12 @@ def run_buf(
     return fmt_result
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 def test_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.proto": GOOD_FILE, "BUILD": "protobuf_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
     fmt_result = run_buf(rule_runner, [tgt])
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.proto": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -93,7 +85,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.proto": BAD_FILE, "BUILD": "protobuf_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
     fmt_result = run_buf(rule_runner, [tgt])
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.proto": GOOD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -106,8 +98,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.proto")),
     ]
     fmt_result = run_buf(rule_runner, tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good.proto": GOOD_FILE, "bad.proto": GOOD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good.proto": GOOD_FILE, "bad.proto": GOOD_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -117,5 +109,5 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.proto"))
     fmt_result = run_buf(rule_runner, [tgt], extra_args=["--buf-format-args=--debug"])
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.proto": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.proto": GOOD_FILE})
     assert fmt_result.did_change is False

--- a/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/gofmt/rules_integration_test.py
@@ -25,8 +25,6 @@ from pants.core.goals.fmt import FmtResult
 from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -160,12 +158,6 @@ def run_gofmt(
     return fmt_result
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 def test_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {"f.go": GOOD_FILE, "go.mod": GO_MOD, "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')"}
@@ -173,7 +165,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     fmt_result = run_gofmt(rule_runner, [tgt])
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.go": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.go": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -193,7 +185,7 @@ def test_failing_gofmt_flags(rule_runner: RuleRunner) -> None:
         rule_runner, [tgt], extra_args=["--gofmt-args=-s"]
     )  # -s flag will simplify the code
     assert fmt_result.stderr == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.go": FIXED_BAD_FILE_TO_SIMPLIFY})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.go": FIXED_BAD_FILE_TO_SIMPLIFY})
     assert fmt_result.did_change is True
 
 
@@ -204,7 +196,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     fmt_result = run_gofmt(rule_runner, [tgt])
     assert fmt_result.stderr == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.go": FIXED_BAD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.go": FIXED_BAD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -219,8 +211,8 @@ def test_mixed_sources(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="pkg"))
     fmt_result = run_gofmt(rule_runner, [tgt])
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good.go": GOOD_FILE, "bad.go": FIXED_BAD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good.go": GOOD_FILE, "bad.go": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -238,7 +230,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     )
     tgts = [rule_runner.get_target(Address("good")), rule_runner.get_target(Address("bad"))]
     fmt_result = run_gofmt(rule_runner, tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good/f.go": GOOD_FILE, "bad/f.go": FIXED_BAD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good/f.go": GOOD_FILE, "bad/f.go": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules_integration_test.py
@@ -20,8 +20,6 @@ from pants.core.goals.fmt import FmtResult
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -78,12 +76,6 @@ def run_add_trailing_comma(
     return fmt_result
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 @pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "major_minor_interpreter",
@@ -100,7 +92,7 @@ def test_passing_source(rule_runner: RuleRunner, major_minor_interpreter: str) -
         ],
     )
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.py": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.py": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -108,7 +100,7 @@ def test_failing_source(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     fmt_result = run_add_trailing_comma(rule_runner, [tgt])
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.py": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.py": GOOD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -121,8 +113,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.py")),
     ]
     fmt_result = run_add_trailing_comma(rule_runner, tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good.py": GOOD_FILE, "bad.py": GOOD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good.py": GOOD_FILE, "bad.py": GOOD_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -144,8 +136,8 @@ def test_stub_files(rule_runner: RuleRunner) -> None:
     ]
     fmt_result = run_add_trailing_comma(rule_runner, good_tgts)
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good.py": GOOD_FILE, "good.pyi": GOOD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good.py": GOOD_FILE, "good.pyi": GOOD_FILE}
     )
     assert not fmt_result.did_change
 
@@ -154,7 +146,7 @@ def test_stub_files(rule_runner: RuleRunner) -> None:
         rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.py")),
     ]
     fmt_result = run_add_trailing_comma(rule_runner, bad_tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"bad.py": GOOD_FILE, "bad.pyi": GOOD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"bad.py": GOOD_FILE, "bad.pyi": GOOD_FILE}
     )
     assert fmt_result.did_change

--- a/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/rules_integration_test.py
@@ -15,8 +15,6 @@ from pants.core.goals.fix import FixResult
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.python_interpreter_selection import all_major_minor_python_versions
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -84,12 +82,6 @@ def run_pyupgrade(
     return fix_result
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 @pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "major_minor_interpreter",
@@ -103,7 +95,7 @@ def test_passing(rule_runner: RuleRunner, major_minor_interpreter: str) -> None:
         [tgt],
         extra_args=[f"--pyupgrade-interpreter-constraints=['=={major_minor_interpreter}.*']"],
     )
-    assert fix_result.output == get_snapshot(rule_runner, {"f.py": PY_36_GOOD_FILE})
+    assert fix_result.output == rule_runner.make_snapshot({"f.py": PY_36_GOOD_FILE})
     assert fix_result.did_change is False
 
 
@@ -115,7 +107,7 @@ def test_convergance(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     fix_result = run_pyupgrade(rule_runner, [tgt], extra_args=["--pyupgrade-args=--py36-plus"])
-    assert fix_result.output == get_snapshot(rule_runner, {"f.py": 'f"{foo} {bar}"\n'})
+    assert fix_result.output == rule_runner.make_snapshot({"f.py": 'f"{foo} {bar}"\n'})
     assert fix_result.did_change is True
 
 
@@ -123,7 +115,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.py": PY_36_BAD_FILE, "BUILD": "python_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.py"))
     fix_result = run_pyupgrade(rule_runner, [tgt])
-    assert fix_result.output == get_snapshot(rule_runner, {"f.py": PY_36_FIXED_BAD_FILE})
+    assert fix_result.output == rule_runner.make_snapshot({"f.py": PY_36_FIXED_BAD_FILE})
     assert fix_result.did_change is True
 
 
@@ -136,8 +128,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner.get_target(Address("", target_name="t", relative_file_path="bad.py")),
     ]
     fix_result = run_pyupgrade(rule_runner, tgts)
-    assert fix_result.output == get_snapshot(
-        rule_runner, {"good.py": PY_36_GOOD_FILE, "bad.py": PY_36_FIXED_BAD_FILE}
+    assert fix_result.output == rule_runner.make_snapshot(
+        {"good.py": PY_36_GOOD_FILE, "bad.py": PY_36_FIXED_BAD_FILE}
     )
     assert fix_result.did_change is True
 
@@ -154,7 +146,7 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
         [tgt],
         pyupgrade_arg="--py38-plus",
     )
-    assert fix_result.output == get_snapshot(
-        rule_runner, {"some_file_name.py": PY_38_FIXED_BAD_FILE}
+    assert fix_result.output == rule_runner.make_snapshot(
+        {"some_file_name.py": PY_38_FIXED_BAD_FILE}
     )
     assert fix_result.did_change is True

--- a/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/rules_integration_test.py
@@ -23,7 +23,7 @@ from pants.build_graph.address import Address
 from pants.core.goals.fmt import FmtResult, Partitions
 from pants.core.util_rules import config_files, source_files
 from pants.core.util_rules.external_tool import rules as external_tool_rules
-from pants.engine.fs import CreateDigest, Digest, FileContent, PathGlobs, Snapshot
+from pants.engine.fs import PathGlobs, Snapshot
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.jvm import classpath
@@ -157,12 +157,6 @@ def run_scalafmt(
     return fmt_results if expected_partitions else fmt_results[0]
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 def test_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
@@ -173,7 +167,7 @@ def test_passing(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Foo.scala"))
     fmt_result = run_scalafmt(rule_runner, [tgt])
-    assert fmt_result.output == get_snapshot(rule_runner, {"Foo.scala": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"Foo.scala": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -187,7 +181,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     )
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala"))
     fmt_result = run_scalafmt(rule_runner, [tgt])
-    assert fmt_result.output == get_snapshot(rule_runner, {"Bar.scala": FIXED_BAD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"Bar.scala": FIXED_BAD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -205,8 +199,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         rule_runner.get_target(Address("", target_name="t", relative_file_path="Bar.scala")),
     ]
     fmt_result = run_scalafmt(rule_runner, tgts)
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"Foo.scala": GOOD_FILE, "Bar.scala": FIXED_BAD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"Foo.scala": GOOD_FILE, "Bar.scala": FIXED_BAD_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -242,10 +236,10 @@ def test_multiple_config_files(rule_runner: RuleRunner) -> None:
         },
     )
     assert not fmt_results[0].did_change
-    assert fmt_results[0].output == get_snapshot(rule_runner, {"foo/Foo.scala": GOOD_FILE})
+    assert fmt_results[0].output == rule_runner.make_snapshot({"foo/Foo.scala": GOOD_FILE})
     assert fmt_results[1].did_change
-    assert fmt_results[1].output == get_snapshot(
-        rule_runner, {"foo/bar/Bar.scala": FIXED_BAD_FILE_INDENT_4}
+    assert fmt_results[1].output == rule_runner.make_snapshot(
+        {"foo/bar/Bar.scala": FIXED_BAD_FILE_INDENT_4}
     )
 
 

--- a/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
+++ b/src/python/pants/backend/shell/lint/shfmt/rules_integration_test.py
@@ -15,8 +15,6 @@ from pants.core.goals.fmt import FmtResult
 from pants.core.util_rules import config_files, external_tool, source_files
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
-from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.target import Target
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
@@ -98,18 +96,12 @@ def run_shfmt(
     return fmt_result
 
 
-def get_snapshot(rule_runner: RuleRunner, source_files: dict[str, str]) -> Snapshot:
-    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
-    digest = rule_runner.request(Digest, [CreateDigest(files)])
-    return rule_runner.request(Snapshot, [digest])
-
-
 def test_passing(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"f.sh": GOOD_FILE, "BUILD": "shell_sources(name='t')"})
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.sh"))
     fmt_result = run_shfmt(rule_runner, [tgt])
     assert fmt_result.stdout == ""
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.sh": GOOD_FILE})
     assert fmt_result.did_change is False
 
 
@@ -118,7 +110,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.sh"))
     fmt_result = run_shfmt(rule_runner, [tgt])
     assert fmt_result.stdout == "f.sh\n"
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": GOOD_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.sh": GOOD_FILE})
     assert fmt_result.did_change is True
 
 
@@ -132,8 +124,8 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
     ]
     fmt_result = run_shfmt(rule_runner, tgts)
     assert "bad.sh\n" == fmt_result.stdout
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"good.sh": GOOD_FILE, "bad.sh": GOOD_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"good.sh": GOOD_FILE, "bad.sh": GOOD_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -154,8 +146,8 @@ def test_config_files(rule_runner: RuleRunner) -> None:
     ]
     fmt_result = run_shfmt(rule_runner, tgts)
     assert fmt_result.stdout == "a/f.sh\n"
-    assert fmt_result.output == get_snapshot(
-        rule_runner, {"a/f.sh": FIXED_NEEDS_CONFIG_FILE, "b/f.sh": NEEDS_CONFIG_FILE}
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {"a/f.sh": FIXED_NEEDS_CONFIG_FILE, "b/f.sh": NEEDS_CONFIG_FILE}
     )
     assert fmt_result.did_change is True
 
@@ -165,5 +157,5 @@ def test_passthrough_args(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="f.sh"))
     fmt_result = run_shfmt(rule_runner, [tgt], extra_args=["--shfmt-args=-ci"])
     assert fmt_result.stdout == "f.sh\n"
-    assert fmt_result.output == get_snapshot(rule_runner, {"f.sh": FIXED_NEEDS_CONFIG_FILE})
+    assert fmt_result.output == rule_runner.make_snapshot({"f.sh": FIXED_NEEDS_CONFIG_FILE})
     assert fmt_result.did_change is True

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -40,7 +40,7 @@ from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import Digest, PathGlobs, PathGlobsAndRoot, Snapshot, Workspace
+from pants.engine.fs import CreateDigest, Digest, FileContent, Snapshot, Workspace
 from pants.engine.goal import Goal
 from pants.engine.internals import native_engine
 from pants.engine.internals.native_engine import ProcessExecutionEnvironment, PyExecutor
@@ -65,13 +65,7 @@ from pants.source import source_root
 from pants.testutil.option_util import create_options_bootstrapper
 from pants.util.collections import assert_single_element
 from pants.util.contextutil import pushd, temporary_dir, temporary_file
-from pants.util.dirutil import (
-    recursive_dirname,
-    safe_file_dump,
-    safe_mkdir,
-    safe_mkdtemp,
-    safe_open,
-)
+from pants.util.dirutil import recursive_dirname, safe_mkdir, safe_mkdtemp, safe_open
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import OrderedSet
 from pants.util.strutil import softwrap
@@ -565,13 +559,12 @@ class RuleRunner:
 
         :API: public
         """
-        with temporary_dir() as temp_dir:
-            for file_name, content in files.items():
-                mode = "wb" if isinstance(content, bytes) else "w"
-                safe_file_dump(os.path.join(temp_dir, file_name), content, mode=mode)
-            return self.scheduler.capture_snapshots(
-                (PathGlobsAndRoot(PathGlobs(("**",)), temp_dir),)
-            )[0]
+        file_contents = [
+            FileContent(path, content.encode() if isinstance(content, str) else content)
+            for path, content in files.items()
+        ]
+        digest = self.request(Digest, [CreateDigest(file_contents)])
+        return self.request(Snapshot, [digest])
 
     def make_snapshot_of_empty_files(self, files: Iterable[str]) -> Snapshot:
         """Makes a snapshot with empty content for each file.


### PR DESCRIPTION
Everyone and their dog has implemented the same `get_snapshot()` in the integration tests of various tools, as pointed out by @kaos in #18553.

There is already a `make_snapshot()` method on `RuleRunner`, with the same signature but with a different (inferior?) implementation. I've updated this method to use the copy/pasted implementation instead, as well as refactor all copy/pasted implementations into using this reusable one (except [one implementation](https://github.com/pantsbuild/pants/blob/main/src/python/pants/backend/terraform/lint/tffmt/tffmt_integration_test.py#L162-L164) that expects `List[FileContent]` instead of `Mapping[str, str]`).