### PR TITLE
docs: reorder contributor steps, rustup is required for git hooks install to work smoothly

### DIFF
--- a/docs/markdown/Contributions/development/contributor-setup.md
+++ b/docs/markdown/Contributions/development/contributor-setup.md
@@ -23,7 +23,33 @@ We use the popular forking workflow typically used by open source projects. See 
 > 
 > (If you don't have `brew` installed, see <https://brew.sh.>)
 
-Step 2: (Optional) Set up a Git hook
+Step 2: Bootstrap the Rust engine
+---------------------------------
+
+Pants uses Rustup to install Rust. Run the command from <https://rustup.rs> to install Rustup; ensure that `rustup` is on your `$PATH`.
+
+Then, run `pants` to set up the Python virtual environment and compile the engine.
+
+> 🚧 This will take several minutes
+> 
+> Rust compilation is really slow. Fortunately, this step gets cached, so you will only need to wait the first time.
+
+> 📘 Want a faster compile?
+> 
+> We default to compiling with Rust's `release` mode, instead of its `debug` mode, because this makes Pants substantially faster.  However, this results in the compile taking 5-10x longer.
+> 
+> If you are okay with Pants running much slower when iterating, set the environment variable `MODE=debug` and rerun `pants` to compile in debug mode.
+
+> 🚧 Rust compilation can use lots of storage
+> 
+> Compiling the engine typically results in several gigabytes of storage over time. We have not yet implemented automated garbage collection for building the engine because contributors are the only ones to need to compile Rust, not every-day users.
+> 
+> To free up space, run `rm -rf src/rust/engine/target`.
+> 
+> Warning: this will cause Rust to recompile everything.
+
+
+Step 3: (Optional) Set up a Git hook
 ------------------------------------
 
 We have a [Git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) that runs some useful checks and lints when you `git commit`.
@@ -51,31 +77,6 @@ $ MODE=debug git commit ...
 > 📘 How to temporarily skip the pre-commit checks
 > 
 > Use `git commit --no-verify` or `git commit -n` to skip the checks.
-
-Step 3: Bootstrap the Rust engine
----------------------------------
-
-Pants uses Rustup to install Rust. Run the command from <https://rustup.rs> to install Rustup; ensure that `rustup` is on your `$PATH`.
-
-Then, run `pants` to set up the Python virtual environment and compile the engine.
-
-> 🚧 This will take several minutes
-> 
-> Rust compilation is really slow. Fortunately, this step gets cached, so you will only need to wait the first time.
-
-> 📘 Want a faster compile?
-> 
-> We default to compiling with Rust's `release` mode, instead of its `debug` mode, because this makes Pants substantially faster.  However, this results in the compile taking 5-10x longer.
-> 
-> If you are okay with Pants running much slower when iterating, set the environment variable `MODE=debug` and rerun `pants` to compile in debug mode.
-
-> 🚧 Rust compilation can use lots of storage
-> 
-> Compiling the engine typically results in several gigabytes of storage over time. We have not yet implemented automated garbage collection for building the engine because contributors are the only ones to need to compile Rust, not every-day users.
-> 
-> To free up space, run `rm -rf src/rust/engine/target`.
-> 
-> Warning: this will cause Rust to recompile everything.
 
 Configure your IDE (optional)
 -----------------------------


### PR DESCRIPTION
While doing the contributor setup steps, I stopped for a second to read the rustup error when installing the git hooks.

I then saw that step 3 literally tells to install rustup.

It'd be nice to have those reodered in order to have a smoother start for new contributors.