### PR TITLE
Only build and release wheels for Python 3.9.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -367,11 +367,7 @@ jobs:
       run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-wheels
-
-        USE_PY38=true ./build-support/bin/release.sh build-wheels'
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -434,11 +430,7 @@ jobs:
       run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-wheels
-
-        USE_PY38=true ./build-support/bin/release.sh build-wheels'
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -502,11 +494,7 @@ jobs:
       run: 'USE_PY39=true ./build-support/bin/release.sh build-local-pex
 
 
-        USE_PY39=true ./build-support/bin/release.sh build-wheels
-
-        ./build-support/bin/release.sh build-wheels
-
-        USE_PY38=true ./build-support/bin/release.sh build-wheels'
+        USE_PY39=true ./build-support/bin/release.sh build-wheels'
     - continue-on-error: true
       if: always()
       name: Upload pants.log

--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -786,20 +786,16 @@ def build_fs_util() -> None:
 def build_pex(fetch: bool) -> None:
     stable = os.environ.get("PANTS_PEX_RELEASE", "") == "STABLE"
     if fetch:
-        # TODO: Support macOS on ARM64.
+        # TODO: Support macos and linux arm64.
         extra_pex_args = [
             "--python-shebang",
             "/usr/bin/env python",
-            *(
-                f"--platform={plat}-{abi}"
-                for plat in ("linux_x86_64", "macosx_11.0_x86_64")
-                for abi in ("cp-37-m", "cp-38-cp38", "cp-39-cp39")
-            ),
+            *(f"--platform={plat}-cp-39-cp39" for plat in ("linux_x86_64", "macosx_11.0_x86_64")),
         ]
         pex_name = f"pants.{CONSTANTS.pants_unstable_version}.pex"
         banner(f"Building {pex_name} by fetching wheels.")
     else:
-        # TODO: Support macOS on ARM64. Will require qualifying the pex name with the arch.
+        # TODO: Support macos and linux arm64. Will require qualifying the pex name with the arch.
         major, minor = sys.version_info[:2]
         extra_pex_args = [
             f"--interpreter-constraint=CPython=={major}.{minor}.*",
@@ -1177,13 +1173,12 @@ def check_pants_wheels_present(check_dir: str | Path) -> None:
         if not local_files:
             missing_packages.append(package.name)
             continue
-        if is_cross_platform(local_files) and len(local_files) != 10:
+        if is_cross_platform(local_files) and len(local_files) != 4:
             formatted_local_files = "\n    ".join(sorted(f.name for f in local_files))
             missing_packages.append(
                 softwrap(
                     f"""
-                    {package.name}. Expected 10 wheels ({{cp37m, cp38, cp39}} x
-                    {{macosx10.15-x86_64, macosx11-x86_64, linux-x86_64}} + cp39-macosx-arm64),
+                    {package.name}. Expected 4 wheels (linux/mac X x86_64/arm64),
                     but found {len(local_files)}:\n    {formatted_local_files}
                     """
                 )

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -75,7 +75,7 @@ NATIVE_FILES = [
 PYTHON37_VERSION = "3.7"
 PYTHON38_VERSION = "3.8"
 PYTHON39_VERSION = "3.9"
-ALL_PYTHON_VERSIONS = [PYTHON37_VERSION, PYTHON38_VERSION, PYTHON39_VERSION]
+ALL_PYTHON_VERSIONS = [PYTHON39_VERSION]
 
 DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == 'true'"
 DONT_SKIP_WHEELS = "github.event_name == 'push' || needs.classify_changes.outputs.release == 'true'"


### PR DESCRIPTION
Now that scie-pants is the norm, and it provides Python 3.9,
there is no need to release for 3.7 or 3.8. 

This will save us CI time as well as PyPI space.

This is a step on the road to deprecating running pants
in any way other than scie-pants. For now we still
have the escape hatch of installing Python 3.9 and
running from a `./pants` script.

Once we're comfortable with this, a future change can 
clean up the CI scripts, ensure that tests always run on
3.9, etc. For now this is the smallest change that 
achieves the desired effect.
