### PR TITLE
Triage some noqa: PNT30 await-in-loops

### DIFF
--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -238,7 +238,7 @@ async def update_build_files(
     }
     build_file_to_change_descriptions: DefaultDict[str, list[str]] = defaultdict(list)
     for rewrite_request_cls in rewrite_request_classes:
-        all_rewritten_files = await MultiGet(  # noqa: PNT30: requires triage
+        all_rewritten_files = await MultiGet(  # noqa: PNT30: this is inherently sequential
             Get(
                 RewrittenBuildFile,
                 RewrittenBuildFileRequest,

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -236,20 +236,6 @@ class BUILDFileEnvVarExtractor(ast.NodeVisitor):
             self.visit(kwarg)
 
 
-async def _extract_env_vars(
-    file_content: FileContent, extra_env: Sequence[str], env: CompleteEnvironmentVars
-) -> EnvironmentVars:
-    """For BUILD file env vars, we only ever consult the local systems env."""
-    env_vars = (*BUILDFileEnvVarExtractor.get_env_vars(file_content), *extra_env)
-    return await Get(
-        EnvironmentVars,
-        {
-            EnvironmentVarsRequest(env_vars): EnvironmentVarsRequest,
-            env: CompleteEnvironmentVars,
-        },
-    )
-
-
 @rule(desc="Search for addresses in BUILD files")
 async def parse_address_family(
     parser: Parser,
@@ -318,12 +304,25 @@ async def parse_address_family(
         dependents_rules_parser_state = None
         dependencies_rules_parser_state = None
 
-    all_env_vars = [
-        await _extract_env_vars(
+    def _extract_env_vars(
+        file_content: FileContent, extra_env: Sequence[str], env: CompleteEnvironmentVars
+    ) -> Get[EnvironmentVars]:
+        """For BUILD file env vars, we only ever consult the local systems env."""
+        env_vars = (*BUILDFileEnvVarExtractor.get_env_vars(file_content), *extra_env)
+        return Get(
+            EnvironmentVars,
+            {
+                EnvironmentVarsRequest(env_vars): EnvironmentVarsRequest,
+                env: CompleteEnvironmentVars,
+            },
+        )
+
+    all_env_vars = await MultiGet(
+        _extract_env_vars(
             fc, prelude_symbols.referenced_env_vars, session_values[CompleteEnvironmentVars]
         )
         for fc in digest_contents
-    ]
+    )
 
     address_maps = [
         AddressMap.parse(

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -234,10 +234,8 @@ async def get_optional_source_roots(
     }
     dirs.update(file_to_dir.values())
 
-    dir_to_root: dict[PurePath, OptionalSourceRoot] = {}
-    for d in dirs:
-        root = await Get(OptionalSourceRoot, SourceRootRequest(d))  # noqa: PNT30: requires triage
-        dir_to_root[d] = root
+    roots = await MultiGet(Get(OptionalSourceRoot, SourceRootRequest(d)) for d in dirs)
+    dir_to_root = {d: root for d, root in zip(dirs, roots)}
 
     path_to_optional_root: dict[PurePath, OptionalSourceRoot] = {}
     for d in source_roots_request.dirs:


### PR DESCRIPTION
This triages/resolves a few `# noqa: PNT30` exclusions about the concurrency hazard of awaits in loops:

- two instances that almost-trivially can switch from (something like) `(await Get(args) for ...)` to `await MultiGet(args for ...)`
- one instance that's actually sequential

This relates to #18365.