### PR TITLE
backport pip 23.1 support

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -36,6 +36,8 @@ class PipVersion(enum.Enum):
     V22_3_1 = "22.3.1"
     V23_0 = "23.0"
     V23_0_1 = "23.0.1"
+    V23_1 = "23.1"
+    LATEST = "latest"
 
 
 @enum.unique


### PR DESCRIPTION
Support for pip 23.1 was added in #18753 which upgraded to Pex 2.1.132, but only #18785 (Pex 2.1.134) was cherry picked to 2.16.x.  So the 2.16.x branch got the nice new Pex version, but not the pip version support that had been part of a slightly older commit.