### PR TITLE
Add concrete `Context` type to the `graph` crate

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1270,6 +1270,7 @@ dependencies = [
  "rand",
  "task_executor",
  "tokio",
+ "workunit_store",
 ]
 
 [[package]]

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -16,6 +16,7 @@ parking_lot = "0.12"
 petgraph = "0.6"
 task_executor = { path = "../task_executor" }
 tokio = { version = "1.21", features = ["time", "parking_lot"] }
+workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/rust/engine/graph/src/context.rs
+++ b/src/rust/engine/graph/src/context.rs
@@ -1,0 +1,110 @@
+// Copyright 2018 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::ops::Deref;
+use std::sync::atomic::{self, AtomicU32, AtomicUsize};
+use std::sync::Arc;
+
+use workunit_store::RunId;
+
+use crate::node::{CompoundNode, EntryId, Node};
+use crate::Graph;
+
+struct InnerContext<N: Node + Send> {
+  context: N::Context,
+  run_id: AtomicU32,
+  stats: Stats,
+  graph: Graph<N>,
+}
+
+///
+/// A context passed between running Nodes which is used to request and record dependencies.
+///
+/// Parametrized by:
+///     N: Node - The Node type that this Context is being used for.
+///
+#[derive(Clone)]
+pub struct Context<N: Node + Send> {
+  entry_id: Option<EntryId>,
+  inner: Arc<InnerContext<N>>,
+}
+
+impl<N: Node + Send> Context<N> {
+  pub(crate) fn new(graph: Graph<N>, context: N::Context, run_id: RunId) -> Self {
+    Self {
+      entry_id: None,
+      inner: Arc::new(InnerContext {
+        context,
+        run_id: AtomicU32::new(run_id.0),
+        stats: Stats::default(),
+        graph,
+      }),
+    }
+  }
+
+  ///
+  /// Get the future value for the given Node implementation.
+  ///
+  pub async fn get<CN: CompoundNode<N>>(&self, node: CN) -> Result<CN::Item, N::Error> {
+    let node_result = self
+      .inner
+      .graph
+      .get(self.entry_id, self, node.into())
+      .await?;
+    Ok(
+      node_result
+        .try_into()
+        .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
+    )
+  }
+
+  pub fn run_id(&self) -> RunId {
+    RunId(self.inner.run_id.load(atomic::Ordering::SeqCst))
+  }
+
+  pub fn new_run_id(&self) {
+    self.inner.run_id.store(
+      self.inner.graph.generate_run_id().0,
+      atomic::Ordering::SeqCst,
+    );
+  }
+
+  pub fn context(&self) -> &N::Context {
+    &self.inner.context
+  }
+
+  pub fn graph(&self) -> &Graph<N> {
+    &self.inner.graph
+  }
+
+  pub(crate) fn stats(&self) -> &Stats {
+    &self.inner.stats
+  }
+
+  ///
+  /// Creates a clone of this Context to be used for a different Node.
+  ///
+  /// To clone a Context for use by the _same_ Node, `Clone` is used directly.
+  ///
+  pub(crate) fn clone_for(&self, entry_id: EntryId) -> Self {
+    Context {
+      entry_id: Some(entry_id),
+      inner: self.inner.clone(),
+    }
+  }
+}
+
+impl<N: Node> Deref for Context<N> {
+  type Target = N::Context;
+
+  fn deref(&self) -> &Self::Target {
+    &self.inner.context
+  }
+}
+
+#[derive(Default)]
+pub(crate) struct Stats {
+  pub ran: AtomicUsize,
+  pub cleaning_succeeded: AtomicUsize,
+  pub cleaning_failed: AtomicUsize,
+}

--- a/src/rust/engine/graph/src/context.rs
+++ b/src/rust/engine/graph/src/context.rs
@@ -51,11 +51,12 @@ impl<N: Node + Send> Context<N> {
       .graph
       .get(self.entry_id, self, node.into())
       .await?;
-    Ok(
-      node_result
-        .try_into()
-        .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
-    )
+    Ok(node_result.try_into().unwrap_or_else(|_| {
+      panic!(
+        "The CompoundNode implementation for {} was ambiguous.",
+        std::any::type_name::<CN>()
+      )
+    }))
   }
 
   pub fn run_id(&self) -> RunId {

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -2,18 +2,16 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::fmt::{Debug, Display};
-use std::future::Future;
 use std::hash::Hash;
-use std::ops::DerefMut;
 
 use async_trait::async_trait;
 
-use petgraph::stable_graph;
+use petgraph::graph;
 
-use crate::Graph;
+use crate::context::Context;
 
 // 2^32 Nodes ought to be more than enough for anyone!
-pub type EntryId = stable_graph::NodeIndex<u32>;
+pub type EntryId = graph::NodeIndex<u32>;
 
 ///
 /// Defines executing a cacheable/memoizable step within the given NodeContext.
@@ -22,12 +20,13 @@ pub type EntryId = stable_graph::NodeIndex<u32>;
 ///
 #[async_trait]
 pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
-  type Context: NodeContext<Node = Self>;
+  /// An implementation-specific context required to run this Node.
+  type Context: Send + Sync;
 
   type Item: Clone + Debug + Eq + Send + Sync + 'static;
   type Error: NodeError;
 
-  async fn run(self, context: Self::Context) -> Result<Self::Item, Self::Error>;
+  async fn run(self, context: Context<Self>) -> Result<Self::Item, Self::Error>;
 
   ///
   /// True if this Node may be restarted while running. This property is consumed at the point when
@@ -74,63 +73,16 @@ pub trait NodeError: Clone + Debug + Eq + Send + Sync {
 }
 
 ///
-/// A context passed between Nodes that also stores an EntryId to uniquely identify them.
+/// A trait to enable easy (un)wrapping in the common case of `enum`-based Nodes. Primarily used
+/// with `Context::get`.
 ///
-pub trait NodeContext: Clone + Send + Sync + 'static {
-  ///
-  /// The type generated when this Context is cloned for another Node.
-  ///
-  type Node: Node;
-
-  ///
-  /// The Run ID type for this Context. Some Node behaviours have Run-specific semantics. In
-  /// particular: an uncacheable (Node::cacheable) Node will execute once per Run, regardless
-  /// of other invalidation.
-  ///
-  type RunId: Clone + Debug + Eq + Send;
-
-  ///
-  /// Return a reference to a Stats instance that the Graph will use to record relevant statistics
-  /// about a run.
-  ///
-  /// TODO: This API is awkward because it assumes that you need a lock inside your NodeContext
-  /// implementation. We should likely make NodeContext a concrete struct with a type parameter
-  /// for other user specific context rather than having such a large trait.
-  ///
-  fn stats<'a>(&'a self) -> Box<dyn DerefMut<Target = Stats> + 'a>;
-
-  ///
-  /// Creates a clone of this NodeContext to be used for a different Node.
-  ///
-  /// To clone a Context for use for the same Node, `Clone` is used directly.
-  ///
-  fn clone_for(&self, entry_id: EntryId) -> <Self::Node as Node>::Context;
-
-  ///
-  /// Returns the RunId for this Context, which should uniquely identify a caller's run for the
-  /// purposes of "once per Run" behaviour.
-  ///
-  fn run_id(&self) -> &Self::RunId;
-
-  ///
-  /// Returns a reference to the Graph for this Context.
-  ///
-  fn graph(&self) -> &Graph<Self::Node>;
-
-  ///
-  /// Spawns a Future on an Executor provided by the context.
-  ///
-  /// NB: Unlike the futures `Executor` trait itself, this implementation _must_ spawn the work
-  /// on another thread, as it is called from within the Graph lock.
-  ///
-  fn spawn<F>(&self, future: F)
-  where
-    F: Future<Output = ()> + Send + 'static;
+pub trait CompoundNode<N>: Into<N> + Send
+where
+  N: Node,
+{
+  type Item: TryFrom<N::Item>;
 }
 
-#[derive(Default)]
-pub struct Stats {
-  pub ran: usize,
-  pub cleaning_succeeded: usize,
-  pub cleaning_failed: usize,
+impl<N: Node> CompoundNode<N> for N {
+  type Item = N::Item;
 }

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -3,16 +3,15 @@
 
 use std::cmp::max;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::{Into, TryInto};
-use std::future::Future;
+use std::convert::Into;
 use std::io::Read;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use crate::intrinsics::Intrinsics;
-use crate::nodes::{ExecuteProcess, NodeKey, NodeOutput, NodeResult, WrappedNode};
+use crate::nodes::{ExecuteProcess, NodeKey, NodeOutput, NodeResult};
 use crate::python::{throw, Failure};
 use crate::session::{Session, Sessions};
 use crate::tasks::{Rule, Tasks};
@@ -22,7 +21,7 @@ use async_oncecell::OnceCell;
 use cache::PersistentCache;
 use fs::{GitignoreStyleExcludes, PosixFS};
 use futures::FutureExt;
-use graph::{self, EntryId, Graph, InvalidationResult, NodeContext};
+use graph::{Graph, InvalidationResult};
 use hashing::Digest;
 use log::info;
 use parking_lot::Mutex;
@@ -40,7 +39,7 @@ use rule_graph::RuleGraph;
 use store::{self, ImmutableInputs, Store};
 use task_executor::Executor;
 use watch::{Invalidatable, InvalidationWatcher};
-use workunit_store::{Metric, RunId, RunningWorkunit};
+use workunit_store::{Metric, RunningWorkunit};
 
 // The reqwest crate has no support for ingesting multiple certificates in a single file,
 // and requires single PEM blocks. There is a crate (https://crates.io/crates/pem) that can decode
@@ -684,12 +683,12 @@ impl Deref for InvalidatableGraph {
   }
 }
 
-#[derive(Clone)]
-pub struct Context {
-  entry_id: Option<EntryId>,
+pub type Context = graph::Context<NodeKey>;
+
+pub struct SessionCore {
+  // TODO: This field is also accessible via the Session: move to an accessor.
   pub core: Arc<Core>,
   pub session: Session,
-  run_id: RunId,
   /// The number of attempts which have been made to backtrack to a particular ExecuteProcess node.
   ///
   /// Presence in this map at process runtime indicates that the process is being retried, and that
@@ -698,37 +697,16 @@ pub struct Context {
   backtrack_levels: Arc<Mutex<HashMap<ExecuteProcess, usize>>>,
   /// The Digests that we have successfully invalidated a Node for.
   backtrack_digests: Arc<Mutex<HashSet<Digest>>>,
-  stats: Arc<Mutex<graph::Stats>>,
 }
 
-impl Context {
-  pub fn new(core: Arc<Core>, session: Session) -> Context {
-    let run_id = session.run_id();
-    Context {
-      entry_id: None,
-      core,
+impl SessionCore {
+  pub fn new(session: Session) -> Self {
+    Self {
+      core: session.core().clone(),
       session,
-      run_id,
       backtrack_levels: Arc::default(),
       backtrack_digests: Arc::default(),
-      stats: Arc::default(),
     }
-  }
-
-  ///
-  /// Get the future value for the given Node implementation.
-  ///
-  pub async fn get<N: WrappedNode>(&self, node: N) -> NodeResult<N::Item> {
-    let node_result = self
-      .core
-      .graph
-      .get(self.entry_id, self, node.into())
-      .await?;
-    Ok(
-      node_result
-        .try_into()
-        .unwrap_or_else(|_| panic!("A Node implementation was ambiguous.")),
-    )
   }
 
   ///
@@ -738,8 +716,12 @@ impl Context {
   /// If we successfully locate and restart the source of the Digest, converts the Result into a
   /// `Failure::Invalidated`, which will cause retry at some level above us.
   ///
+  /// TODO: This takes both `self` and `context: Context`, but could take `self: Context` after
+  /// the `arbitrary_self_types` feature has stabilized.
+  ///
   pub fn maybe_backtrack(
     &self,
+    context: &Context,
     result: NodeResult<NodeOutput>,
     workunit: &mut RunningWorkunit,
   ) -> NodeResult<NodeOutput> {
@@ -754,7 +736,7 @@ impl Context {
     // `invalidate_from_roots` cannot view `Node` results. Would be more efficient as a merged
     // method.
     let mut candidate_roots = Vec::new();
-    self.core.graph.visit_live(self, |k, v| match k {
+    self.core.graph.visit_live(context, |k, v| match k {
       NodeKey::ExecuteProcess(p) if v.digests().contains(&digest) => {
         if let NodeOutput::ProcessResult(pr) = v {
           candidate_roots.push((p.clone(), pr.backtrack_level));
@@ -843,45 +825,5 @@ impl Context {
   ///
   pub fn maybe_start_backtracking(&self, node: &ExecuteProcess) -> usize {
     self.backtrack_levels.lock().get(node).cloned().unwrap_or(0)
-  }
-}
-
-impl NodeContext for Context {
-  type Node = NodeKey;
-  type RunId = RunId;
-
-  fn stats<'a>(&'a self) -> Box<dyn DerefMut<Target = graph::Stats> + 'a> {
-    Box::new(self.stats.lock())
-  }
-
-  ///
-  /// Clones this Context for a new EntryId. Because the Core of the context is an Arc, this
-  /// is a shallow clone.
-  ///
-  fn clone_for(&self, entry_id: EntryId) -> Context {
-    Context {
-      entry_id: Some(entry_id),
-      core: self.core.clone(),
-      session: self.session.clone(),
-      run_id: self.run_id,
-      backtrack_levels: self.backtrack_levels.clone(),
-      backtrack_digests: self.backtrack_digests.clone(),
-      stats: self.stats.clone(),
-    }
-  }
-
-  fn run_id(&self) -> &Self::RunId {
-    &self.run_id
-  }
-
-  fn graph(&self) -> &Graph<NodeKey> {
-    &self.core.graph
-  }
-
-  fn spawn<F>(&self, future: F)
-  where
-    F: Future<Output = ()> + Send + 'static,
-  {
-    let _join = self.core.executor.native_spawn(future);
   }
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -49,9 +49,9 @@ use workunit_store::{
 use crate::externs::fs::{possible_store_missing_digest, PyFileDigest};
 use crate::externs::process::PyProcessExecutionEnvironment;
 use crate::{
-  externs, nodes, Context, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination,
-  Failure, Function, Intrinsic, Intrinsics, Key, LocalStoreOptions, Params, RemotingOptions, Rule,
-  Scheduler, Session, Tasks, TypeId, Types, Value,
+  externs, nodes, Core, ExecutionRequest, ExecutionStrategyOptions, ExecutionTermination, Failure,
+  Function, Intrinsic, Intrinsics, Key, LocalStoreOptions, Params, RemotingOptions, Rule,
+  Scheduler, Session, SessionCore, Tasks, TypeId, Types, Value,
 };
 
 #[pymodule]
@@ -996,7 +996,11 @@ fn session_run_interactive_process(
   process_config_from_environment: PyProcessExecutionEnvironment,
 ) -> PyO3Result<PyObject> {
   let core = py_session.0.core();
-  let context = Context::new(core.clone(), py_session.0.clone());
+  let context = py_session
+    .0
+    .core()
+    .graph
+    .context(SessionCore::new(py_session.0.clone()));
   let interactive_process: Value = interactive_process.into();
   let process_config = Value::new(process_config_from_environment.into_py(py));
   py.allow_threads(|| {

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -326,7 +326,7 @@ fn merge_digests_request_to_digest(
   context: Context,
   args: Vec<Value>,
 ) -> BoxFuture<'static, NodeResult<Value>> {
-  let core = context.core;
+  let core = &context.core;
   let store = core.store();
   async move {
     let digests = Python::with_gil(|py| {
@@ -558,7 +558,7 @@ fn interactive_process(
         (run_in_workspace, restartable, keep_sandboxes)
       });
 
-      let session = context.session;
+      let session = context.session.clone();
 
       let mut tempdir = create_sandbox(
         context.core.executor.clone(),

--- a/src/rust/engine/src/lib.rs
+++ b/src/rust/engine/src/lib.rs
@@ -44,7 +44,7 @@ mod tasks;
 mod types;
 
 pub use crate::context::{
-  Context, Core, ExecutionStrategyOptions, LocalStoreOptions, RemotingOptions,
+  Context, Core, ExecutionStrategyOptions, LocalStoreOptions, RemotingOptions, SessionCore,
 };
 pub use crate::intrinsics::Intrinsics;
 pub use crate::python::{Failure, Function, Key, Params, TypeId, Value};

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -70,7 +70,7 @@ impl Scheduler {
   }
 
   pub fn visualize(&self, session: &Session, path: &Path) -> io::Result<()> {
-    let context = Context::new(self.core.clone(), session.clone());
+    let context = session.graph_context();
     self
       .core
       .graph
@@ -120,7 +120,7 @@ impl Scheduler {
   /// Return Scheduler and per-Session metrics.
   ///
   pub fn metrics(&self, session: &Session) -> HashMap<&str, i64> {
-    let context = Context::new(self.core.clone(), session.clone());
+    let context = session.graph_context();
     let mut m = HashMap::new();
     m.insert("affected_file_count", {
       let mut count = 0;
@@ -150,7 +150,7 @@ impl Scheduler {
     &self,
     session: &Session,
   ) -> (Vec<Value>, HashMap<&'static str, (usize, usize)>) {
-    let context = Context::new(self.core.clone(), session.clone());
+    let context = session.graph_context();
     let mut items = vec![];
     let mut sizes: HashMap<&'static str, (usize, usize)> = HashMap::new();
     // TODO: Creation of a Context is exposed in https://github.com/Aeledfyr/deepsize/pull/31.
@@ -192,7 +192,7 @@ impl Scheduler {
   /// Return all Digests currently in memory in this Scheduler.
   ///
   pub fn all_digests(&self, session: &Session) -> HashSet<hashing::Digest> {
-    let context = Context::new(self.core.clone(), session.clone());
+    let context = session.graph_context();
     let mut digests = HashSet::new();
     self
       .core
@@ -236,7 +236,7 @@ impl Scheduler {
     request: &ExecutionRequest,
     session: &Session,
   ) -> Vec<ObservedValueResult> {
-    let context = Context::new(session.core().clone(), session.clone());
+    let context = session.graph_context();
     let roots = session.roots_zip_last_observed(&request.roots);
     let poll = request.poll;
     let poll_delay = request.poll_delay;

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -60,7 +60,7 @@ mod metrics;
 /// ordering.
 ///
 /// NB: This type is defined here to make it easily accessible to both the `process_execution`
-/// and `engine` crates: it's not actually used by the WorkunitStore.
+/// and `graph` crates: it's not actually used by the WorkunitStore.
 ///
 #[derive(Clone, Copy, Debug, DeepSizeOf, PartialEq, Eq, Hash)]
 pub struct RunId(pub u32);


### PR DESCRIPTION
The `graph` crate currently has a `trait Context`, but no concrete `Context`. As the use-cases for the `Context` have expanded, many implementation details of the `Graph` have ended up as public in the trait, even though they would be better off as private.

This change extracts a concrete `struct graph::Context` which holds an opaque user context. `graph::Context` has `impl Deref` to the user context type, which minimizes edits to callsites. There should be no changes in performance or behavior.

(The primary motivation for this change is that #18855 needs to record additional information on the `Context`, which felt like the straw that broke the camel's back and justified splitting out a concrete `Context`.)