### PR TITLE
Increase the optimization level for dev/debug builds, and reduce debug info in release builds

### DIFF
--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -9,10 +9,15 @@ publish = false
 # tokio_unstable is necessary for access to the `id`-related functions of tokio::task::JoinSet.
 # See https://docs.rs/tokio/1.21.1/tokio/task/struct.JoinSet.html#method.join_next_with_id.
 
+[profile.dev]
+# Increase the optimization level of the dev profile slightly, as otherwise `rule_graph`
+# solving takes prohibitively long.
+opt-level = 1
+
 [profile.release]
-# Enable debug symbols in the `release` profile: doesn't add a noticeable overhead in size/speed,
-# but enables profiling of optimized builds.
-debug = true
+# Enable only "line tables", which give line information in backtraces, but do not record information
+# about local variables.
+debug = 1
 # Optimise for the speed of our binary, rather than the speed of compilation.
 codegen-units = 1
 


### PR DESCRIPTION
Currently, the `dev` (`MODE=debug`) profile results in slow enough code (particularly in `rule_graph` solving) that it can make more sense to use the `release` profile when iterating. But because the `release` profile (rightly) does not enable [incremental compilation](https://doc.rust-lang.org/cargo/reference/profiles.html#incremental), it is much slower to iterate in `release` mode.

This change increases the optimization level of the `dev` profile to the (current) sweet spot in terms of "time to running" for incremental builds. After a one line change in the engine crate, `time MODE=debug ./pants help` (i.e. including all of compilation time, `pantsd` startup time, and scheduler initialization time) with various optimization levels takes the following amount of time:
* `opt-level = 0` (default):
   ```
    real    3m13.930s
    user    0m7.670s
    sys 0m2.179s
    ```
* `opt-level = 1`:
   ```
    real    1m1.623s
    user    1m59.027s
    sys 0m6.097s
    ```
* `opt-level = 2`:
   ```
    real    1m8.660s
    user    3m14.690s
    sys 0m9.502s
    ```

Consequently, we set `opt-level = 1`.

----

Additionally, to reduce the size of `release` binaries (which currently contain full debug info), we switch to using [line-tables-only](https://doc.rust-lang.org/cargo/reference/profiles.html#debug), which still allows for line-level information in backtraces, but [skips including local variable and scope information](https://stackoverflow.com/questions/72264937/what-are-the-downsides-of-using-gline-tables-only-instead-of-g).