### PR TITLE
Eagerly clean running nodes rather than interrupting them.

### DIFF
--- a/src/rust/engine/async_value/src/tests.rs
+++ b/src/rust/engine/async_value/src/tests.rs
@@ -8,17 +8,17 @@ use tokio::time::sleep;
 
 #[tokio::test]
 async fn send() {
-  let (_value, sender, receiver) = AsyncValue::new();
+  let (_value, sender, receiver) = AsyncValue::<_, ()>::new();
   let _send_task = tokio::spawn(async move { sender.send(42) });
   assert_eq!(Some(42), receiver.recv().await);
 }
 
 #[tokio::test]
 async fn cancel_explicit() {
-  let (value, mut sender, receiver) = AsyncValue::<()>::new();
+  let (value, mut sender, receiver) = AsyncValue::<(), ()>::new();
 
   // A task that will never do any meaningful work, and just wait to be canceled.
-  let _send_task = tokio::spawn(async move { sender.aborted().await });
+  let _send_task = tokio::spawn(async move { sender.interrupted().await });
 
   // Ensure that a value is not received.
   tokio::select! {
@@ -33,10 +33,10 @@ async fn cancel_explicit() {
 
 #[tokio::test]
 async fn cancel_implicit() {
-  let (value, mut sender, receiver) = AsyncValue::<()>::new();
+  let (value, mut sender, receiver) = AsyncValue::<(), ()>::new();
 
   // A task that will never do any meaningful work, and just wait to be canceled.
-  let send_task = tokio::spawn(async move { sender.aborted().await });
+  let send_task = tokio::spawn(async move { sender.interrupted().await });
 
   // Ensure that a value is not received.
   tokio::select! {
@@ -52,11 +52,11 @@ async fn cancel_implicit() {
 }
 
 #[tokio::test]
-async fn abort_explicit() {
-  let (mut value, mut sender, receiver) = AsyncValue::<()>::new();
+async fn interrupt_explicit() {
+  let (mut value, mut sender, receiver) = AsyncValue::<(), ()>::new();
 
   // A task that will never do any meaningful work, and just wait to be canceled.
-  let send_task = tokio::spawn(async move { sender.aborted().await });
+  let send_task = tokio::spawn(async move { sender.interrupted().await });
 
   // Ensure that a value is not received.
   tokio::select! {
@@ -64,8 +64,8 @@ async fn abort_explicit() {
     _ = receiver.recv() => { panic!("Should have continued to wait.") }
   }
 
-  // Explicitly abort the task, and confirm that it exits and cancels the work.
-  value.try_abort(()).unwrap();
+  // Explicitly interrupt the task, and confirm that it exits and cancels the work.
+  value.try_interrupt(()).unwrap();
   assert_eq!(Some(()), send_task.await.unwrap());
   assert_eq!(None, receiver.recv().await);
 }

--- a/src/rust/engine/graph/src/context.rs
+++ b/src/rust/engine/graph/src/context.rs
@@ -118,10 +118,10 @@ impl<N: Node + Send> Context<N> {
   /// Gets the dependency generations which have been computed for this Node so far. May not be
   /// called after `complete` has been called for a node.
   ///
-  pub(crate) fn dep_generations_so_far(&self) -> Vec<(EntryId, Generation)> {
+  pub(crate) fn dep_generations_so_far(&self, node: &N) -> Vec<(EntryId, Generation)> {
     (*self.dep_state.lock())
       .clone()
-      .expect("Node has already completed.")
+      .unwrap_or_else(|| panic!("Node {node} has already completed."))
       .generations
   }
 
@@ -129,12 +129,12 @@ impl<N: Node + Send> Context<N> {
   /// Completes the Context for this EntryId, returning the dependency generations that were
   /// recorded while it was running. May only be called once.
   ///
-  pub(crate) fn complete(&self) -> DepState {
+  pub(crate) fn complete(&self, node: &N) -> DepState {
     self
       .dep_state
       .lock()
       .take()
-      .expect("Node was completed multiple times.")
+      .unwrap_or_else(|| panic!("Node {node} was completed multiple times."))
   }
 
   ///

--- a/src/rust/engine/graph/src/context.rs
+++ b/src/rust/engine/graph/src/context.rs
@@ -5,9 +5,11 @@ use std::ops::Deref;
 use std::sync::atomic::{self, AtomicU32, AtomicUsize};
 use std::sync::Arc;
 
+use parking_lot::Mutex;
 use workunit_store::RunId;
 
-use crate::node::{CompoundNode, EntryId, Node};
+use crate::entry::Generation;
+use crate::node::{CompoundNode, EntryId, Node, NodeError};
 use crate::Graph;
 
 struct InnerContext<N: Node + Send> {
@@ -15,6 +17,12 @@ struct InnerContext<N: Node + Send> {
   run_id: AtomicU32,
   stats: Stats,
   graph: Graph<N>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct DepState {
+  pub(crate) generations: Vec<(EntryId, Generation)>,
+  pub(crate) has_uncacheable_deps: bool,
 }
 
 ///
@@ -26,6 +34,7 @@ struct InnerContext<N: Node + Send> {
 #[derive(Clone)]
 pub struct Context<N: Node + Send> {
   entry_id: Option<EntryId>,
+  dep_state: Arc<Mutex<Option<DepState>>>,
   inner: Arc<InnerContext<N>>,
 }
 
@@ -33,6 +42,7 @@ impl<N: Node + Send> Context<N> {
   pub(crate) fn new(graph: Graph<N>, context: N::Context, run_id: RunId) -> Self {
     Self {
       entry_id: None,
+      dep_state: Arc::default(),
       inner: Arc::new(InnerContext {
         context,
         run_id: AtomicU32::new(run_id.0),
@@ -46,17 +56,18 @@ impl<N: Node + Send> Context<N> {
   /// Get the future value for the given Node implementation.
   ///
   pub async fn get<CN: CompoundNode<N>>(&self, node: CN) -> Result<CN::Item, N::Error> {
-    let node_result = self
+    let (node_result, _generation) = self
       .inner
       .graph
-      .get(self.entry_id, self, node.into())
-      .await?;
-    Ok(node_result.try_into().unwrap_or_else(|_| {
-      panic!(
+      .get_inner(self.entry_id, self, node.into())
+      .await;
+
+    node_result?.try_into().map_err(|_| {
+      N::Error::generic(format!(
         "The CompoundNode implementation for {} was ambiguous.",
         std::any::type_name::<CN>()
-      )
-    }))
+      ))
+    })
   }
 
   pub fn run_id(&self) -> RunId {
@@ -82,14 +93,59 @@ impl<N: Node + Send> Context<N> {
     &self.inner.stats
   }
 
+  pub(crate) fn dep_record(
+    &self,
+    dep_id: EntryId,
+    generation: Generation,
+    uncacheable: bool,
+  ) -> Result<(), N::Error> {
+    let mut maybe_dep_state = self.dep_state.lock();
+    if let Some(dep_state) = maybe_dep_state.as_mut() {
+      dep_state.generations.push((dep_id, generation));
+      dep_state.has_uncacheable_deps |= uncacheable;
+      Ok(())
+    } else {
+      // This case can occur if a Node has spawned background work which continues to attempt
+      // to request dependencies in the background.
+      Err(N::Error::generic(format!(
+        "Could not request additional dependencies for {:?}: the Node has completed.",
+        self.entry_id
+      )))
+    }
+  }
+
+  ///
+  /// Gets the dependency generations which have been computed for this Node so far. May not be
+  /// called after `complete` has been called for a node.
+  ///
+  pub(crate) fn dep_generations_so_far(&self) -> Vec<(EntryId, Generation)> {
+    (*self.dep_state.lock())
+      .clone()
+      .expect("Node has already completed.")
+      .generations
+  }
+
+  ///
+  /// Completes the Context for this EntryId, returning the dependency generations that were
+  /// recorded while it was running. May only be called once.
+  ///
+  pub(crate) fn complete(&self) -> DepState {
+    self
+      .dep_state
+      .lock()
+      .take()
+      .expect("Node was completed multiple times.")
+  }
+
   ///
   /// Creates a clone of this Context to be used for a different Node.
   ///
   /// To clone a Context for use by the _same_ Node, `Clone` is used directly.
   ///
   pub(crate) fn clone_for(&self, entry_id: EntryId) -> Self {
-    Context {
+    Self {
       entry_id: Some(entry_id),
+      dep_state: Arc::new(Mutex::new(Some(DepState::default()))),
       inner: self.inner.clone(),
     }
   }

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -703,7 +703,7 @@ impl<N: Node> Graph<N> {
     context: &Context<N>,
     entry_id: EntryId,
     run_token: RunToken,
-    sender: AsyncValueSender<NodeResult<N>>,
+    sender: AsyncValueSender<NodeResult<N>, NodeResult<N>>,
     result: Option<Result<N::Item, N::Error>>,
   ) {
     let (entry, has_uncacheable_deps, dep_generations) = {

--- a/src/rust/engine/graph/src/lib.rs
+++ b/src/rust/engine/graph/src/lib.rs
@@ -29,7 +29,7 @@ mod context;
 mod entry;
 mod node;
 
-use crate::entry::{Entry, Generation, NodeInterrupt, NodeResult, RunToken};
+use crate::entry::{Entry, Generation, RunToken};
 
 use std::collections::VecDeque;
 use std::fs::File;
@@ -38,7 +38,6 @@ use std::path::Path;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
-use async_value::AsyncValueSender;
 use fixedbitset::FixedBitSet;
 use fnv::{FnvHashMap as HashMap, FnvHashSet as HashSet};
 use futures::future;
@@ -465,87 +464,65 @@ impl<N: Node> Graph<N> {
     dst_node: N,
   ) -> (Result<N::Item, N::Error>, Generation) {
     // Compute information about the dst under the Graph lock, and then release it.
-    let (dst_retry, mut entry, entry_id) = {
+    let (entry, entry_id) = {
       // Get or create the destination, and then insert the dep and return its state.
       let mut inner = self.inner.lock();
 
       let dst_id = inner.ensure_entry(dst_node);
-      let dst_retry = if let Some(src_id) = src_id {
+      if let Some(src_id) = src_id {
         test_trace_log!(
           "Adding dependency from {:?} to {:?}",
           inner.entry_for_id(src_id).unwrap().node(),
           inner.entry_for_id(dst_id).unwrap().node()
         );
         inner.pg.add_edge(src_id, dst_id, ());
-
-        // We should retry the dst Node if the src Node is not restartable. If the src is not
-        // restartable, it is only allowed to run once, and so Node invalidation does not pass
-        // through it.
-        !inner.entry_for_id(src_id).unwrap().node().restartable()
       } else {
         // Otherwise, this is an external request: always retry.
         test_trace_log!(
           "Requesting node {:?}",
           inner.entry_for_id(dst_id).unwrap().node()
         );
-        true
-      };
+      }
 
       let dst_entry = inner.entry_for_id(dst_id).cloned().unwrap();
-      (dst_retry, dst_entry, dst_id)
+      (dst_entry, dst_id)
     };
 
-    // Return the state of the destination.
-    if dst_retry {
-      // Retry the dst a number of times to handle Node invalidation.
-      let context = context.clone();
-      loop {
-        match entry.get_node_result(&context, entry_id).await {
-          (Err(err), _) if err == N::Error::invalidated() => {
-            let node = {
-              let inner = self.inner.lock();
-              inner.unsafe_entry_for_id(entry_id).node().clone()
-            };
-            info!(
-              "Filesystem changed during run: retrying `{}` in {:?}...",
-              node, self.invalidation_delay
-            );
-            sleep(self.invalidation_delay).await;
-            continue;
-          }
-          res => break res,
+    // Return the state of the destination, retrying the dst to handle Node invalidation.
+    let context = context.clone();
+    let (result, generation, uncacheable) = loop {
+      match entry.get_node_result(&context, entry_id).await {
+        (Err(err), _, _) if err == N::Error::invalidated() => {
+          let node = {
+            let inner = self.inner.lock();
+            inner.unsafe_entry_for_id(entry_id).node().clone()
+          };
+          info!(
+            "Filesystem changed during run: retrying `{}` in {:?}...",
+            node, self.invalidation_delay
+          );
+          sleep(self.invalidation_delay).await;
+          continue;
         }
+        res => break res,
       }
-    } else {
-      // Not retriable.
-      entry.get_node_result(context, entry_id).await
+    };
+
+    if src_id.is_some() {
+      if let Err(e) = context.dep_record(entry_id, generation, uncacheable) {
+        return (Err(e), generation);
+      }
     }
+
+    (result, generation)
   }
 
   ///
-  /// Request the given dst Node, optionally in the context of the given src Node.
-  ///
-  /// If there is no src Node, or the src Node is not restartable, this method will retry for
-  /// invalidation until the Node completes.
-  ///
-  /// Invalidation events in the graph (generally, filesystem changes) will cause restartable
-  /// Nodes to be retried here for up to `invalidation_timeout`.
-  ///
-  pub async fn get(
-    &self,
-    src_id: Option<EntryId>,
-    context: &Context<N>,
-    dst_node: N,
-  ) -> Result<N::Item, N::Error> {
-    let (res, _generation) = self.get_inner(src_id, context, dst_node).await;
-    res
-  }
-
-  ///
-  /// Return the value of the given Node. Shorthand for `self.get(None, context, node)`.
+  /// Return the value of the given Node.
   ///
   pub async fn create(&self, node: N, context: &Context<N>) -> Result<N::Item, N::Error> {
-    self.get(None, context, node).await
+    let (res, _generation) = self.get_inner(None, context, node).await;
+    res
   }
 
   ///
@@ -580,15 +557,18 @@ impl<N: Node> Graph<N> {
 
   ///
   /// Compares the generations of the dependencies of the given EntryId to their previous
-  /// generation values (re-computing or cleaning them first if necessary), and returns true if any
-  /// dependency has changed.
+  /// generation values (re-computing or cleaning them first if necessary).
   ///
-  async fn dependencies_changed(
+  /// Returns `Ok(uncacheable_deps)` if the node was successfully cleaned, and clears the node's
+  /// edges if it was not successfully cleaned.
+  ///
+  async fn attempt_cleaning(
     &self,
     entry_id: EntryId,
-    previous_dep_generations: Vec<Generation>,
+    run_token: RunToken,
+    previous_dep_generations: &[(EntryId, Generation)],
     context: &Context<N>,
-  ) -> bool {
+  ) -> Result<bool, ()> {
     let generation_matches = {
       let inner = self.inner.lock();
       let entry = if log::log_enabled!(log::Level::Debug) {
@@ -596,31 +576,21 @@ impl<N: Node> Graph<N> {
       } else {
         None
       };
-      let dependency_ids = inner
-        .pg
-        .neighbors_directed(entry_id, Direction::Outgoing)
-        .collect::<Vec<_>>();
 
-      if dependency_ids.len() != previous_dep_generations.len() {
-        // If we don't have the same number of current dependencies as there were generations
-        // previously, then they cannot match.
-        return true;
-      }
-
-      dependency_ids
-        .into_iter()
-        .zip(previous_dep_generations.into_iter())
-        .map(|(dep_id, previous_dep_generation)| {
+      previous_dep_generations
+        .iter()
+        .map(|&(dep_id, previous_dep_generation)| {
           let entry = entry.clone();
-          let mut dep_entry = inner
+          let dep_entry = inner
             .entry_for_id(dep_id)
             .unwrap_or_else(|| panic!("Dependency not present in Graph."))
             .clone();
+
           async move {
-            let (_, generation) = dep_entry.get_node_result(context, dep_id).await;
+            let (_, generation, uncacheable) = dep_entry.get_node_result(context, dep_id).await;
             if generation == previous_dep_generation {
               // Matched.
-              Ok(())
+              Ok(uncacheable)
             } else {
               // Did not match. We error here to trigger fail-fast in `try_join_all`.
               log::debug!(
@@ -639,99 +609,36 @@ impl<N: Node> Graph<N> {
     // generation mismatches. The first mismatch encountered will cause any extraneous cleaning
     // work to be canceled. See #11290 for more information about the tradeoffs inherent in
     // speculation.
-    future::try_join_all(generation_matches).await.is_err()
-  }
-
-  ///
-  /// Clears the dependency edges of the given EntryId if the RunToken matches.
-  ///
-  fn cleaning_failed(&self, entry_id: EntryId, run_token: RunToken) {
-    let mut inner = self.inner.lock();
-    // If the RunToken mismatches, return.
-    if let Some(entry) = inner.entry_for_id_mut(entry_id) {
-      if entry.run_token() != run_token {
-        return;
+    match future::try_join_all(generation_matches).await {
+      Ok(uncacheable_deps) => {
+        // Cleaning succeeded.
+        //
+        // Return true if any dep was uncacheable.
+        Ok(uncacheable_deps.into_iter().any(|u| u))
       }
-      entry.cleaning_failed()
-    }
-
-    // Otherwise, clear the deps. We remove edges in reverse index order, because `remove_edge` is
-    // implemented in terms of `swap_remove`, and so affects edge ids greater than the removed edge
-    // id. See https://docs.rs/petgraph/0.5.1/petgraph/graph/struct.Graph.html#method.remove_edge
-    let mut edge_ids = inner
-      .pg
-      .edges_directed(entry_id, Direction::Outgoing)
-      .map(|e| e.id())
-      .collect::<Vec<_>>();
-    edge_ids.sort_by_key(|id| std::cmp::Reverse(id.index()));
-    for edge_id in edge_ids {
-      inner.pg.remove_edge(edge_id);
-    }
-  }
-
-  ///
-  /// When a Node is canceled because all receivers go away, the Executor for that Node will call
-  /// back to ensure that it is canceled.
-  ///
-  /// See also: `Self::complete`.
-  ///
-  fn cancel(&self, entry_id: EntryId, run_token: RunToken) {
-    let mut inner = self.inner.lock();
-    if let Some(ref mut entry) = inner.entry_for_id_mut(entry_id) {
-      entry.cancel(run_token);
-    }
-  }
-
-  ///
-  /// When the Executor finishes executing a Node it calls back to store the result value. We use
-  /// the run_token to determine whether the Node changed while we were busy executing it, so that
-  /// we can discard the work.
-  ///
-  /// See also: `Self::cancel`.
-  ///
-  fn complete(
-    &self,
-    context: &Context<N>,
-    entry_id: EntryId,
-    run_token: RunToken,
-    sender: AsyncValueSender<NodeResult<N>, NodeInterrupt<N>>,
-    result: Option<Result<N::Item, N::Error>>,
-  ) {
-    let (entry, has_uncacheable_deps, dep_generations) = {
-      let inner = self.inner.lock();
-      let mut has_uncacheable_deps = false;
-      // Get the Generations of all dependencies of the Node. We can trust that these have not changed
-      // since we began executing, as long as we are not currently marked dirty (see the method doc).
-      let dep_generations = inner
-        .pg
-        .neighbors_directed(entry_id, Direction::Outgoing)
-        .filter_map(|dep_id| inner.entry_for_id(dep_id))
-        .map(|entry| {
-          // If a dependency is itself uncacheable or has uncacheable deps, this Node should
-          // also complete as having uncacheable deps, independent of matching Generation values.
-          // This is to allow for the behaviour that an uncacheable Node should always have "dirty"
-          // (marked as UncacheableDependencies) dependents, transitively.
-          if entry.has_uncacheable_deps() {
-            has_uncacheable_deps = true;
+      Err(()) => {
+        // Cleaning failed.
+        //
+        // If the RunToken still matches, clear all edges of the Node before returning.
+        let mut inner = self.inner.lock();
+        if let Some(entry) = inner.entry_for_id_mut(entry_id) {
+          if entry.cleaning_failed(run_token).is_ok() {
+            // Clear the deps. We remove edges in reverse index order, because `remove_edge` is
+            // implemented in terms of `swap_remove`, and so affects edge ids greater than the removed edge
+            // id. See https://docs.rs/petgraph/0.5.1/petgraph/graph/struct.Graph.html#method.remove_edge
+            let mut edge_ids = inner
+              .pg
+              .edges_directed(entry_id, Direction::Outgoing)
+              .map(|e| e.id())
+              .collect::<Vec<_>>();
+            edge_ids.sort_by_key(|id| std::cmp::Reverse(id.index()));
+            for edge_id in edge_ids {
+              inner.pg.remove_edge(edge_id);
+            }
           }
-          entry.generation()
-        })
-        .collect();
-      (
-        inner.entry_for_id(entry_id).cloned(),
-        has_uncacheable_deps,
-        dep_generations,
-      )
-    };
-    if let Some(mut entry) = entry {
-      entry.complete(
-        context,
-        run_token,
-        dep_generations,
-        sender,
-        result,
-        has_uncacheable_deps,
-      );
+        }
+        Err(())
+      }
     }
   }
 

--- a/src/rust/engine/graph/src/node.rs
+++ b/src/rust/engine/graph/src/node.rs
@@ -19,7 +19,7 @@ pub type EntryId = graph::NodeIndex<u32>;
 /// Note that it is assumed that Nodes are very cheap to clone.
 ///
 #[async_trait]
-pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
+pub trait Node: Clone + Debug + Display + Eq + Hash + Send + Sync + 'static {
   /// An implementation-specific context required to run this Node.
   type Context: Send + Sync;
 
@@ -65,6 +65,11 @@ pub trait Node: Clone + Debug + Display + Eq + Hash + Send + 'static {
 }
 
 pub trait NodeError: Clone + Debug + Eq + Send + Sync {
+  ///
+  /// Creates a generic Error of type NodeError.
+  ///
+  fn generic(message: String) -> Self;
+
   ///
   /// Creates an instance that represents that a Node was invalidated out of the
   /// Graph (generally while running).

--- a/src/rust/engine/graph/src/tests.rs
+++ b/src/rust/engine/graph/src/tests.rs
@@ -395,7 +395,7 @@ async fn non_restartable_node_only_runs_once() {
     graph.context(
       TContext::new()
         .with_non_restartable(non_restartable)
-        .with_delays(delays),
+        .with_delays_pre(delays),
     )
   };
 
@@ -525,7 +525,7 @@ async fn retries() {
     let sleep_root = Duration::from_millis(100);
     let mut delays = HashMap::new();
     delays.insert(TNode::new(0), sleep_root);
-    graph.context(TContext::new().with_delays(delays))
+    graph.context(TContext::new().with_delays_pre(delays))
   };
 
   // Spawn a thread that will invalidate in a loop for one second (much less than our timeout).
@@ -549,55 +549,74 @@ async fn retries() {
 }
 
 #[tokio::test]
-async fn canceled_on_invalidation() {
+async fn eager_cleaning_success() {
+  // Test that invalidation does not cause a Running node to restart if the dependencies that it
+  // has already requested can successfully be cleaned.
   let _logger = env_logger::try_init();
-  let invalidation_delay = Duration::from_millis(10);
+  let invalidation_delay = Duration::from_millis(100);
   let graph = Arc::new(Graph::<TNode>::new_with_invalidation_delay(
     Executor::new(),
     invalidation_delay,
   ));
 
   let sleep_middle = Duration::from_millis(2000);
-  let start_time = Instant::now();
   let context = {
     let mut delays = HashMap::new();
     delays.insert(TNode::new(1), sleep_middle);
-    graph.context(TContext::new().with_delays(delays))
+    graph.context(TContext::new().with_delays_pre(delays))
   };
 
-  // We invalidate three times: the mid should only actually run to completion once, because we
-  // should cancel it the other times. We wait longer than the invalidation_delay for each
-  // invalidation to ensure that work actually starts before being invalidated.
-  let iterations = 3;
-  let sleep_per_invalidation = invalidation_delay * 10;
-  assert!(sleep_middle > sleep_per_invalidation * 3);
+  // Invalidate the bottom Node (after the middle node has already requested it).
+  assert!(sleep_middle > invalidation_delay * 3);
   let graph2 = graph.clone();
   let _join = thread::spawn(move || {
-    for _ in 0..iterations {
-      thread::sleep(sleep_per_invalidation);
-      graph2.invalidate_from_roots(true, |n| n.id == 1);
-    }
+    thread::sleep(invalidation_delay);
+    graph2.invalidate_from_roots(true, |n| n.id == 0);
   });
   assert_eq!(
     graph.create(TNode::new(2), &context).await,
     Ok(vec![T(0, 0), T(1, 0), T(2, 0)])
   );
 
-  // We should have waited much less than the time it would have taken to complete three times.
-  assert!(Instant::now() < start_time + (sleep_middle * iterations));
+  // No nodes should have seen aborts, since the dirtied nodes had already completed, and the
+  // running node should not have been interrupted.
+  assert!(context.aborts().is_empty(), "{:?}", context.aborts());
+}
 
-  // And the top nodes should have seen three aborts.
+#[tokio::test]
+async fn eager_cleaning_failure() {
+  // Test that invalidation causes a Running node to restart if the dependencies that it
+  // has already requested end up with new values before it completes.
+  let _logger = env_logger::try_init();
+  let invalidation_delay = Duration::from_millis(100);
+  let graph = Arc::new(Graph::new_with_invalidation_delay(
+    Executor::new(),
+    invalidation_delay,
+  ));
+
+  let sleep_middle = Duration::from_millis(2000);
+  let context = {
+    let mut delays = HashMap::new();
+    delays.insert(TNode::new(1), sleep_middle);
+    TContext::new(graph.clone()).with_delays_post(delays)
+  };
+
+  // Invalidate the bottom Node with a new salt (after the middle node has already requested it).
+  assert!(sleep_middle > invalidation_delay * 3);
+  let graph2 = graph.clone();
+  let context2 = context.clone();
+  let _join = thread::spawn(move || {
+    thread::sleep(invalidation_delay);
+    context2.set_salt(1);
+    graph2.invalidate_from_roots(true, |n| n.id == 0);
+  });
   assert_eq!(
-    vec![
-      TNode::new(1),
-      TNode::new(2),
-      TNode::new(1),
-      TNode::new(2),
-      TNode::new(1),
-      TNode::new(2)
-    ],
-    context.aborts(),
+    graph.create(TNode::new(2), &context).await,
+    Ok(vec![T(0, 1), T(1, 1), T(2, 1)])
   );
+
+  // The middle and top node should have seen aborts, since their dependencies could not be cleaned.
+  assert_eq!(vec![TNode::new(1), TNode::new(2)], context.aborts());
 }
 
 #[tokio::test]
@@ -610,7 +629,7 @@ async fn canceled_on_loss_of_interest() {
   let context = {
     let mut delays = HashMap::new();
     delays.insert(TNode::new(1), sleep_middle);
-    graph.context(TContext::new().with_delays(delays))
+    graph.context(TContext::new().with_delays_pre(delays))
   };
 
   // Start a run, but cancel it well before the delayed middle node can complete.
@@ -654,7 +673,7 @@ async fn clean_speculatively() {
     delays.insert(TNode::new(2), delay);
     graph.context(
       TContext::new()
-        .with_delays(delays)
+        .with_delays_pre(delays)
         .with_dependencies(dependencies.clone()),
     )
   };
@@ -791,7 +810,7 @@ impl Node for TNode {
       return Err(TError::Error);
     }
     let token = T(self.id, context.salt());
-    context.maybe_delay(&self).await;
+    context.maybe_delay_pre(&self).await;
     let res = match context.dependencies_of(&self) {
       deps if !deps.is_empty() => {
         // Request all dependencies, but include only the first in our output value.
@@ -808,6 +827,7 @@ impl Node for TNode {
       }
       _ => Ok(vec![token]),
     };
+    context.maybe_delay_post(&self).await;
     abort_guard.did_not_abort();
     res
   }
@@ -885,12 +905,13 @@ struct TContext {
   // A value that is included in every value computed by this context. Stands in for "the state of the
   // outside world". A test that wants to "change the outside world" and observe its effect on the
   // graph should change the salt to do so.
-  salt: usize,
+  salt: Arc<AtomicUsize>,
   // A mapping from source to destinations that drives what values each TNode depends on.
   // If there is no entry in this map for a node, then TNode::run will default to requesting
   // the next smallest node.
   edges: Arc<HashMap<TNode, Vec<TNode>>>,
-  delays: Arc<HashMap<TNode, Duration>>,
+  delays_pre: Arc<HashMap<TNode, Duration>>,
+  delays_post: Arc<HashMap<TNode, Duration>>,
   // Nodes which should error when they run.
   errors: Arc<HashSet<TNode>>,
   non_restartable: Arc<HashSet<TNode>>,
@@ -902,9 +923,10 @@ struct TContext {
 impl TContext {
   fn new() -> TContext {
     TContext {
-      salt: 0,
+      salt: Arc::new(AtomicUsize::new(0)),
       edges: Arc::default(),
-      delays: Arc::default(),
+      delays_pre: Arc::default(),
+      delays_post: Arc::default(),
       errors: Arc::default(),
       non_restartable: Arc::default(),
       uncacheable: Arc::default(),
@@ -918,8 +940,15 @@ impl TContext {
     self
   }
 
-  fn with_delays(mut self, delays: HashMap<TNode, Duration>) -> TContext {
-    self.delays = Arc::new(delays);
+  /// Delays incurred before a node has requested its dependencies.
+  fn with_delays_pre(mut self, delays: HashMap<TNode, Duration>) -> TContext {
+    self.delays_pre = Arc::new(delays);
+    self
+  }
+
+  /// Delays incurred after a node has requested its dependencies.
+  fn with_delays_post(mut self, delays: HashMap<TNode, Duration>) -> TContext {
+    self.delays_post = Arc::new(delays);
     self
   }
 
@@ -939,12 +968,16 @@ impl TContext {
   }
 
   fn with_salt(mut self, salt: usize) -> TContext {
-    self.salt = salt;
+    self.salt = Arc::new(AtomicUsize::new(salt));
     self
   }
 
   fn salt(&self) -> usize {
-    self.salt
+    self.salt.load(Ordering::SeqCst)
+  }
+
+  fn set_salt(&self, salt: usize) {
+    self.salt.store(salt, Ordering::SeqCst)
   }
 
   fn abort_guard(&self, node: TNode) -> AbortGuard {
@@ -964,8 +997,14 @@ impl TContext {
     runs.push(node);
   }
 
-  async fn maybe_delay(&self, node: &TNode) {
-    if let Some(delay) = self.delays.get(node) {
+  async fn maybe_delay_pre(&self, node: &TNode) {
+    if let Some(delay) = self.delays_pre.get(node) {
+      sleep(*delay).await;
+    }
+  }
+
+  async fn maybe_delay_post(&self, node: &TNode) {
+    if let Some(delay) = self.delays_post.get(node) {
       sleep(*delay).await;
     }
   }

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -675,7 +675,6 @@ impl Paths {
         SymlinkBehavior::Oblivious,
         unmatched_globs_additional_context(),
       )
-      .map_err(|e| throw(format!("{e}")))
       .await
   }
 
@@ -948,7 +947,6 @@ impl Snapshot {
         SymlinkBehavior::Oblivious,
         unmatched_globs_additional_context(),
       )
-      .map_err(|e| throw(format!("{e}")))
       .await?;
 
     store::Snapshot::from_path_stats(context.clone(), path_stats)
@@ -1630,6 +1628,10 @@ impl Display for NodeKey {
 impl NodeError for Failure {
   fn invalidated() -> Failure {
     Failure::Invalidated
+  }
+
+  fn generic(message: String) -> Failure {
+    throw(message)
   }
 }
 


### PR DESCRIPTION
As reported in #10705: our current strategy for dirtying running nodes eagerly interrupts them, even if cleaning their dependencies might show that it is not necessary. In practice, this means that almost any file change in the repository will cause a run of pants to restart (most) of what it was doing.

This change moves to dirtying running nodes (in `Entry::dirty`) by notifying them that their dependencies might have changed (via `AsyncValueSender.interrupt`, which is received in `spawn_node_execution`), and allowing them to attempt to clean the dependencies that they have observed so far. If the node determines that the dependencies it has observed so far are unchanged, it continues running without being interrupted: otherwise, it is canceled as it would have been before this change.

Since dependency generations used to be collected lazily in `complete` (meaning that they weren't available to be used to clean a node _while_ it was running), #18835 made `graph::Context` concrete, and this change begins recording dependency generations on the concrete `Context` as they are requested by a node.

This change fixes #10705, meaning that it should be possible to make edits to unrelated files in more cases, without causing running processes (e.g. those spawned by `test` or `run`) to restart. For example, try adding comments to relevant `BUILD` files while a test is running, and observe that it does not restart unless the edit impacts the inputs to the test run.