### PR TITLE
Increase timeouts of several tests

### DIFF
--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -11,7 +11,7 @@ python_tests(
         "coverage_py_test.py": {"timeout": 20},
         "coverage_py_integration_test.py": {
             "tags": ["platform_specific_behavior"],
-            "timeout": 480,
+            "timeout": 540,
         },
         "export_integration_test.py": {"timeout": 300},
         "export_test.py": {"timeout": 90},

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -30,4 +30,4 @@ python_tests(
 
 python_tests(name="exiter_integration_test", sources=["exiter_integration_test.py"], timeout=180)
 
-python_tests(name="specs_integration_test", sources=["specs_integration_test.py"], timeout=180)
+python_tests(name="specs_integration_test", sources=["specs_integration_test.py"], timeout=240)

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -17,6 +17,6 @@ python_sources(
 python_tests(
     name="tests",
     overrides={
-        "load_backends_integration_test.py": {"timeout": 600},
+        "load_backends_integration_test.py": {"timeout": 800},
     },
 )


### PR DESCRIPTION
This bumps up the timeouts of several tests that are regularly causing spurious failures:

1. `src/python/pants/init/load_backends_integration_test.py`
2. `src/python/pants/base/specs_integration_test.py`
3. `src/python/pants/backend/python/goals/coverage_py_integration_test.py`

The most common of these is 1, especially for cherry-picks to 2.16. For instance, #18832 required 8 re-attempts, #18839 required 5 and #18850 got to 13.

Given these seem to affect 2.16 cherry-picks so much, I'm thinking it makes sense to cherry pick this back to that branch too, along with the increase in #18847, and part of #18627 (the increase to `src/python/pants/engine/streaming_workunit_handler_integration_test.py`).