### PR TITLE
Increase test timeouts (Cherry pick of #18627, #18712, #18847, #18857)

### DIFF
--- a/src/python/pants/backend/go/util_rules/BUILD
+++ b/src/python/pants/backend/go/util_rules/BUILD
@@ -7,5 +7,6 @@ python_tests(
     timeout=120,
     overrides={
         "embed_integration_test.py": {"timeout": 240},
+        "cgo_test.py": {"timeout": 240},
     },
 )

--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -11,7 +11,7 @@ python_tests(
         "coverage_py_test.py": {"timeout": 20},
         "coverage_py_integration_test.py": {
             "tags": ["platform_specific_behavior"],
-            "timeout": 480,
+            "timeout": 540,
         },
         "export_integration_test.py": {"timeout": 300},
         "export_test.py": {"timeout": 90},

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -9,5 +9,6 @@ python_tests(
         "local_dists_test.py": {"timeout": 120},
         "pex_from_targets_test.py": {"timeout": 200},
         "pex_test.py": {"timeout": 600},
+        "vcs_versioning_test.py": {"timeout": 120},
     },
 )

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -30,4 +30,4 @@ python_tests(
 
 python_tests(name="exiter_integration_test", sources=["exiter_integration_test.py"], timeout=180)
 
-python_tests(name="specs_integration_test", sources=["specs_integration_test.py"], timeout=180)
+python_tests(name="specs_integration_test", sources=["specs_integration_test.py"], timeout=240)

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -17,5 +17,5 @@ python_tests(
         # Loaded reflectively as a backend in `streaming_workunit_handler_integration_test.py`.
         "testprojects/pants-plugins/src/python/workunit_logger"
     ],
-    timeout=120,
+    timeout=240,
 )

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -17,6 +17,6 @@ python_sources(
 python_tests(
     name="tests",
     overrides={
-        "load_backends_integration_test.py": {"timeout": 600},
+        "load_backends_integration_test.py": {"timeout": 800},
     },
 )


### PR DESCRIPTION
This cherry-picks a bunch of test timeout increases from main to 2.16.x, to reduce the number of spurious re-attempts required for other cherry-picks.

Fully cherry-picked: #18847, #18857

Partially cherry-picked (just the timeout increases): #18627, #18712.

Motivation: when cherry-picking, #18832 required 8 re-attempts, #18839 required 5 and #18850 got to 13, almost all due to tests timing out. Various other cherry-picks likely required many re-attempts too.