### PR TITLE
Actually run deprecated targets fixer

### DIFF
--- a/src/python/pants/backend/build_files/fix/deprecations/renamed_targets_rules_test.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/renamed_targets_rules_test.py
@@ -6,10 +6,11 @@ from __future__ import annotations
 import pytest
 
 from pants.backend.build_files.fix.deprecations.renamed_targets_rules import (
-    RenameRequest,
+    RenamedTargetTypes,
     RenameTargetsInFileRequest,
     fix_single,
 )
+from pants.util.frozendict import FrozenDict
 
 
 @pytest.mark.parametrize(
@@ -29,8 +30,8 @@ from pants.backend.build_files.fix.deprecations.renamed_targets_rules import (
 def test_rename_deprecated_target_types_noops(lines: list[str]) -> None:
     content = "\n".join(lines).encode("utf-8")
     result = fix_single(
-        RenameRequest("BUILD", content=content),
-        RenameTargetsInFileRequest({"deprecated_name": "new_name"}),
+        RenameTargetsInFileRequest("BUILD", content=content),
+        RenamedTargetTypes(FrozenDict({"deprecated_name": "new_name"})),
     )
     assert result.content == content
 
@@ -46,7 +47,7 @@ def test_rename_deprecated_target_types_noops(lines: list[str]) -> None:
 )
 def test_rename_deprecated_target_types_rewrite(lines: list[str], expected: list[str]) -> None:
     result = fix_single(
-        RenameRequest("BUILD", content="\n".join(lines).encode("utf-8")),
-        RenameTargetsInFileRequest({"deprecated_name": "new_name"}),
+        RenameTargetsInFileRequest("BUILD", content="\n".join(lines).encode("utf-8")),
+        RenamedTargetTypes(FrozenDict({"deprecated_name": "new_name"})),
     )
     assert result.content == "\n".join(expected).encode("utf-8")

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -382,7 +382,7 @@ async def maybe_rename_deprecated_targets(
     old_bytes = "\n".join(request.lines).encode("utf-8")
     new_content = await Get(
         FixedBUILDFile,
-        renamed_fields_rules.RenameFieldsInFileRequest(path=request.path, content=old_bytes),
+        renamed_targets_rules.RenameTargetsInFileRequest(path=request.path, content=old_bytes),
     )
 
     return RewrittenBuildFile(


### PR DESCRIPTION
This fixes #18509 by updating `update-build-files`'s `maybe_rename_deprecated_targets` rule to run the deprecated target fixers: previously, that rule was accidentally rerunning the deprecated _fields_ fixers and deprecated targets weren't being fixed. This fix ensures `experimental_shell_command` is switched to `shell_command` and `experimental_run_shell_command` is switched to `run_shell_command`.

As part of this, I rewrote `renamed_targets_rules.py` to match the current phrasing of `renamed_fields_rules.py`: without doing that, I was getting graph errors. I suspect there was smaller rewrites that would've worked, but it didn't seem unreasonable to have both the `renamed_..._rules.py` files basically match from top to bottom, with only the type names and transformation details differing.

This _doesn't_ do the update to `workdir="/"` for `run_shell_command` that I flagged in https://github.com/pantsbuild/pants/issues/18509#issuecomment-1528908938. With the current token-based rewrites, doing that seems like a lot of work, although, it would be possible (do something similar to `renamed_fields_rules.py` matching parens/brackets and iterate looking for a `workdir=...` field, and updating/inserting it, all packaged up to be vaguely reusable).