### PR TITLE
Ensure non-ambiguous args/env vars injection into PEXes

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -181,7 +181,7 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
                 import os
                 import sys
                 print(f"FOO={os.environ.get('FOO')}")
-                print(f"BAR={os.environ.get('BAR')}")
+                print(f"--inject-arg={os.environ.get('--inject-arg')}")
                 print(f"ARGV={sys.argv[1:]}")
                 """
             ),
@@ -190,8 +190,8 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
                 python_sources(name="lib")
                 pex_binary(
                     entry_point="app.py",
-                    args=['123', 'abc'],
-                    env={{'FOO': 'xxx', 'BAR': 'yyy'}},
+                    args=['123', 'abc', '--inject-env'],
+                    env={{'FOO': 'xxx', '--inject-arg': 'yyy'}},
                     layout="{layout.value}",
                 )
                 """
@@ -215,8 +215,8 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
     stdout = dedent(
         """\
         FOO=xxx
-        BAR=yyy
-        ARGV=['123', 'abc']
+        --inject-arg=yyy
+        ARGV=['123', 'abc', '--inject-env']
         """
     ).encode()
     assert stdout == subprocess.run([executable], check=True, stdout=subprocess.PIPE).stdout

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -180,8 +180,8 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
                 """\
                 import os
                 import sys
-                print(f"FOO={os.environ.get('FOO')}")
-                print(f"--inject-arg={os.environ.get('--inject-arg')}")
+                for env in ["FOO", "--inject-arg", "quotes '"]:
+                    print(f"{env}={os.environ.get(env)}")
                 print(f"ARGV={sys.argv[1:]}")
                 """
             ),
@@ -190,8 +190,8 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
                 python_sources(name="lib")
                 pex_binary(
                     entry_point="app.py",
-                    args=['123', 'abc', '--inject-env'],
-                    env={{'FOO': 'xxx', '--inject-arg': 'yyy'}},
+                    args=['123', 'abc', '--inject-env', "quotes 'n spaces"],
+                    env={{'FOO': 'xxx', '--inject-arg': 'yyy', "quotes '": 'n spaces'}},
                     layout="{layout.value}",
                 )
                 """
@@ -216,7 +216,8 @@ def test_layout(rule_runner: PythonRuleRunner, layout: PexLayout) -> None:
         """\
         FOO=xxx
         --inject-arg=yyy
-        ARGV=['123', 'abc', '--inject-env']
+        quotes '=n spaces
+        ARGV=['123', 'abc', '--inject-env', "quotes 'n spaces"]
         """
     ).encode()
     assert stdout == subprocess.run([executable], check=True, stdout=subprocess.PIPE).stdout

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -615,7 +615,7 @@ async def build_pex(
     if request.main is not None:
         argv.extend(request.main.iter_pex_args())
 
-    argv.extend(f"--inject-args={injected_arg}" for injected_arg in request.inject_args)
+    argv.extend(f"--inject-args={shlex.quote(injected_arg)}" for injected_arg in request.inject_args)
     argv.extend(f"--inject-env={k}={v}" for k, v in sorted(request.inject_env.items()))
 
     # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -615,7 +615,9 @@ async def build_pex(
     if request.main is not None:
         argv.extend(request.main.iter_pex_args())
 
-    argv.extend(f"--inject-args={shlex.quote(injected_arg)}" for injected_arg in request.inject_args)
+    argv.extend(
+        f"--inject-args={shlex.quote(injected_arg)}" for injected_arg in request.inject_args
+    )
     argv.extend(f"--inject-env={k}={v}" for k, v in sorted(request.inject_env.items()))
 
     # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -615,10 +615,8 @@ async def build_pex(
     if request.main is not None:
         argv.extend(request.main.iter_pex_args())
 
-    for injected_arg in request.inject_args:
-        argv.extend(["--inject-args", str(injected_arg)])
-    for k, v in sorted(request.inject_env.items()):
-        argv.extend(["--inject-env", f"{k}={v}"])
+    argv.extend(f"--inject-args={injected_arg}" for injected_arg in request.inject_args)
+    argv.extend(f"--inject-env={k}={v}" for k, v in sorted(request.inject_env.items()))
 
     # TODO(John Sirois): Right now any request requirements will shadow corresponding pex path
     #  requirements, which could lead to problems. Support shading python binaries.


### PR DESCRIPTION
This fixes #18779 by ensuring that injecting arguments and environment variables into a pex doesn't risk them being interpreted by the pex CLI itself if they start with `-`, and ensuring they're quoted appropriately to match the `shlex.split` within pex (https://github.com/pantsbuild/pex/blob/ff220b9e41484450e0c78136f98d6899f2e2325c/pex/bin/pex.py#L433).

The issue noted in #18779 was specifically ambiguity with `args`, but the same problem will apply to `env` and so that is fixed here too (although it's rather less common to have env vars starting with `-`). NB. `shlex.quote`ing alone won't handle the `-` ambiguity, `shlex.quote("--foo") == "--foo"`.

For a target like `pex_binary(..., args=["--foo"], env={"--bar": "baz"})`:

- Previously, this would invoke `pex ... --inject-args --foo --inject-env --bar=baz`, and argparse within the pex CLI will intepret `--foo` and `--bar=...` as independent parameters, rather than arguments to `--inject-args`/`--inject-env`.
- After this change (as suggested by @jsirois), the invocation will be `pex ... --inject-args=--foo --inject-env=--bar=baz` and there's no risk of misinterpretation.

For a target like `pex_binary(..., args=["spaces 'n' quotes"])`:

- Previously this would invoke with (equivalently) an arg `--inject-args=spaces 'n' quotes`, which would `shlex.split` to three arguments in the PEX, the same as passing `args=["spaces", "n", "quotes"])`
- Now, this will invoke with `--inject-args='spaces '"'"'n'"'"' quotes'`, which, is correctly `shlex.split` to the single value: `spaces 'n' quotes`.