### PR TITLE
Include `pants.backend.url_handlers.s3` in pants distribution. (Cherry-pick of #18826)

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -83,6 +83,7 @@ target(
         "src/python/pants/backend/shell/lint/shellcheck",
         "src/python/pants/backend/shell/lint/shfmt",
         "src/python/pants/backend/tools/preamble",
+        "src/python/pants/backend/url_handlers/s3",
         "src/python/pants/core",
     ],
 )


### PR DESCRIPTION
Fixes #18574 

