### PR TITLE
WIP: Clear workspace paths before writing codegen outputs

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -169,17 +169,19 @@ async def run_in_sandbox_request(
         capture_stdout_file=target[AdhocToolStdoutFilenameField].value,
     )
 
-    adhoc_result = await Get(
-        AdhocProcessResult,
+    return await Get(
+        GeneratedSources,
         {
             environment_name: EnvironmentName,
             process_request: AdhocProcessRequest,
         },
     )
 
-    output = await Get(Snapshot, Digest, adhoc_result.adjusted_digest)
-    return GeneratedSources(output)
 
+@rule
+async def generated_sources_from_adhoc_process_result(adhoc_result: AdhocProcessResult) -> GeneratedSources:
+    output = await Get(Snapshot, Digest, adhoc_result.adjusted_digest)
+    return GeneratedSources(output, managed_globs=adhoc_result.managed_globs)
 
 def rules():
     return [

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -198,8 +198,8 @@ async def shell_command_in_sandbox(
         EnvironmentName, EnvironmentNameRequest, EnvironmentNameRequest.from_target(shell_command)
     )
 
-    adhoc_result = await Get(
-        AdhocProcessResult,
+    return await Get(
+        GeneratedSources
         {
             environment_name: EnvironmentName,
             ShellCommandProcessFromTargetRequest(
@@ -207,9 +207,6 @@ async def shell_command_in_sandbox(
             ): ShellCommandProcessFromTargetRequest,
         },
     )
-
-    output = await Get(Snapshot, Digest, adhoc_result.adjusted_digest)
-    return GeneratedSources(output)
 
 
 async def _interactive_shell_command(

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -295,7 +295,7 @@ async def _hydrate_asset_source(
     target = request.protocol_target
     source_field = target[AssetSourceField]
     if isinstance(source_field.value, str):
-        return GeneratedSources(request.protocol_sources)
+        return GeneratedSources(request.protocol_sources, managed_globs=request.protocol_sources.files)
 
     source = source_field.value
     if isinstance(source, per_platform):
@@ -317,7 +317,7 @@ async def _hydrate_asset_source(
         ),
     )
 
-    return GeneratedSources(snapshot)
+    return GeneratedSources(snapshot, managed_globs=source_field.file_path)
 
 
 # -----------------------------------------------------------------------------------------------
@@ -534,7 +534,11 @@ async def relocate_files(request: RelocateFilesViaCodegenRequest) -> GeneratedSo
         snapshot = await Get(Snapshot, RemovePrefix(snapshot.digest, src_val))
     if dest_val:
         snapshot = await Get(Snapshot, AddPrefix(snapshot.digest, dest_val))
-    return GeneratedSources(snapshot)
+    return GeneratedSources(snapshot, managed_globs=tuple(
+        glob # TODO: remove src/dest as appropriate
+        for sources in original_files_sources
+        for glob in sources.managed_globs
+    ))
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -68,6 +68,7 @@ class AdhocProcessRequest:
 class AdhocProcessResult:
     process_result: ProcessResult
     adjusted_digest: Digest
+    managed_globs: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -412,7 +413,7 @@ async def run_adhoc_process(
 
     adjusted = await Get(Digest, RemovePrefix(output_digest, root_output_directory))
 
-    return AdhocProcessResult(result, adjusted)
+    return AdhocProcessResult(result, adjusted, managed_globs=tuple(sorted(request.output_files + request.output_directories)))
 
 
 @rule

--- a/src/python/pants/core/util_rules/wrap_source.py
+++ b/src/python/pants/core/util_rules/wrap_source.py
@@ -95,7 +95,7 @@ async def _wrap_source(wrapper: GenerateSourcesRequest) -> GeneratedSources:
     )
 
     snapshot = await Get(Snapshot, Digest, filter_digest)
-    return GeneratedSources(snapshot)
+    return GeneratedSources(snapshot, managed_globs=())
 
 
 def wrap_source_rule_and_target(

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, Mapping, Optional, Sequence, Tuple, Union
 
 # Note: several of these types are re-exported as the public API of `engine/fs.py`.
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior as GlobMatchErrorBehavior
@@ -286,7 +286,7 @@ class Workspace(SideEffecting):
         digest: Digest,
         *,
         path_prefix: Optional[str] = None,
-        clear_destination: bool = False,
+        clear_paths: Sequence[str] = (),
         side_effecting: bool = True,
     ) -> None:
         """Write a digest to disk, relative to the build root.
@@ -300,7 +300,7 @@ class Workspace(SideEffecting):
         if side_effecting:
             self.side_effected()
         self._scheduler.write_digest(
-            digest, path_prefix=path_prefix, clear_destination=clear_destination
+            digest, path_prefix=path_prefix, clear_paths=clear_paths
         )
 
 

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -1185,7 +1185,7 @@ def test_write_digest_workspace(rule_runner: RuleRunner) -> None:
     assert path2.read_text() == "goodbye"
 
 
-def test_write_digest_workspace_clear_destination(rule_runner: RuleRunner) -> None:
+def test_write_digest_workspace_clear_paths(rule_runner: RuleRunner) -> None:
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
     digest_a = rule_runner.request(
         Digest,
@@ -1203,12 +1203,12 @@ def test_write_digest_workspace_clear_destination(rule_runner: RuleRunner) -> No
     path2 = Path(rule_runner.build_root, "newdir/b.txt")
     path3 = Path(rule_runner.build_root, "newdir/c.txt")
 
-    workspace.write_digest(digest_a, clear_destination=False)
-    workspace.write_digest(digest_b, clear_destination=False)
+    workspace.write_digest(digest_a, clear_paths=())
+    workspace.write_digest(digest_b, clear_paths=())
     assert path1.exists()
     assert path2.exists()
 
-    workspace.write_digest(digest_c, clear_destination=True)
+    workspace.write_digest(digest_c, clear_paths=("newdir",))
     assert not path1.exists()
     assert not path2.exists()
     assert path3.read_text() == "hello again"

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -1120,7 +1120,7 @@ async def hydrate_sources(
         None,
     )
     if sources_type is None:
-        return HydratedSources(EMPTY_SNAPSHOT, sources_field.filespec, sources_type=None)
+        return HydratedSources(EMPTY_SNAPSHOT, sources_field.filespec, sources_type=None, managed_globs=())
 
     # Now, hydrate the `globs`. Even if we are going to use codegen, we will need the original
     # protocol sources to be hydrated.
@@ -1130,7 +1130,7 @@ async def hydrate_sources(
 
     # Finally, return if codegen is not in use; otherwise, run the relevant code generator.
     if not request.enable_codegen or generate_request_type is None:
-        return HydratedSources(snapshot, sources_field.filespec, sources_type=sources_type)
+        return HydratedSources(snapshot, sources_field.filespec, sources_type=sources_type, managed_globs=path_globs)
     wrapped_protocol_target = await Get(
         WrappedTarget,
         WrappedTargetRequest(
@@ -1145,7 +1145,7 @@ async def hydrate_sources(
         generate_request_type(snapshot, wrapped_protocol_target.target),
     )
     return HydratedSources(
-        generated_sources.snapshot, sources_field.filespec, sources_type=sources_type
+        generated_sources.snapshot, sources_field.filespec, sources_type=sources_type, managed_globs=generated_sources.managed_globs,
     )
 
 

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -607,7 +607,7 @@ class SchedulerSession:
         native_engine.ensure_directory_digest_persisted(self.py_scheduler, digest)
 
     def write_digest(
-        self, digest: Digest, *, path_prefix: str | None = None, clear_destination: bool = False
+        self, digest: Digest, *, path_prefix: str | None = None, clear_paths: Sequence[str] = ()
     ) -> None:
         """Write a digest to disk, relative to the build root."""
         if path_prefix and PurePath(path_prefix).is_absolute():

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2405,6 +2405,7 @@ class HydratedSources:
     snapshot: Snapshot
     filespec: Filespec
     sources_type: type[SourcesField] | None
+    managed_globs: tuple[str, ...]
 
 
 @union(in_scope_types=[EnvironmentName])
@@ -2451,6 +2452,7 @@ class GenerateSourcesRequest:
 @dataclass(frozen=True)
 class GeneratedSources:
     snapshot: Snapshot
+    managed_globs: tuple[str, ...]
 
 
 class SourcesPaths(Paths):

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -71,6 +71,7 @@ use sharded_lmdb::DEFAULT_LEASE_TIME;
 use tokio::fs::copy;
 #[cfg(not(target_os = "macos"))]
 use tokio::fs::hard_link;
+use tokio::fs::remove_dir_all;
 use tokio::fs::symlink;
 use tryfuture::try_future;
 use workunit_store::{in_workunit, Level, Metric};
@@ -1288,6 +1289,13 @@ impl Store {
     perms: Permissions,
   ) -> BoxFuture<'a, Result<(), StoreError>> {
     let store = self.clone();
+
+    async fn remove_for_replacement(path: &Path) -> Result<(), String> {
+      remove_dir_all(&path)
+        .await
+        .map_err(|e| format!("Failed to remove {} before replacing: {e}", path.display()))
+    }
+
     async move {
       if !is_root {
         // NB: Although we know that all parent directories already exist, we use `create_dir_all`
@@ -1308,6 +1316,8 @@ impl Store {
 
             match child {
               directory::Entry::File(f) => {
+                remove_for_replacement(&path).await?;
+
                 store
                   .materialize_file_maybe_hardlink(
                     path,
@@ -1319,11 +1329,16 @@ impl Store {
                   .await
               }
               directory::Entry::Symlink(s) => {
+                remove_for_replacement(&path).await?;
                 store
                   .materialize_symlink(path, s.target().to_str().unwrap().to_string())
                   .await
               }
               directory::Entry::Directory(_) => {
+                // TODO(#17758): naively calling remove_for_replacement here might delete things it
+                // shouldn't, e.g. a `pants package path/to:target` call may materialize
+                // dist/path.to/target, and this code will traverse through dist/ and dist/path.to/,
+                // neither of which should be deleted.
                 store
                   .materialize_directory_children(
                     path.clone(),


### PR DESCRIPTION
Fixes #18941 

Plan: allow passing `clear_paths` to the `write_digest` call by tracking which parts of the `export-codegen` are 'real' outputs, and which are just location (e.g. `path/to:some_target` shouldn't clear `dist/codegen/path` or `dist/codegen/path/to`). Build on infrastructure in #18930.


Work remaining:

- rebasing on top of #18930 
- accurately passing around "this is the artefact" for all codegen targets
- adding the appropriate `clear_paths` call