### PR TITLE
Update to tokio 1.28.0

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -368,16 +368,16 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.10"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9de88456263e249e241fcd211d3954e2c9b0ef7ccfc235a444eb367cae3689"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -1322,7 +1322,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.4",
  "tracing",
 ]
 
@@ -1715,9 +1715,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "link-cplusplus"
@@ -3180,9 +3180,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -3501,14 +3501,13 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.23.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eab6d665857cc6ca78d6e80303a02cea7a7851e85dfbd77cbdc09bd129f1ef46"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -3516,7 +3515,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3531,13 +3530,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.81",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4134,26 +4133,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -4162,13 +4155,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -4176,6 +4184,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4196,6 +4210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4212,6 +4232,12 @@ name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4232,6 +4258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4250,10 +4282,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4272,6 +4316,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -165,7 +165,7 @@ task_executor = { path = "task_executor" }
 tempfile = "3.5.0"
 testutil_mock = { package = "mock", path = "testutil/mock" }
 time = "0.3.20"
-tokio = { version = "1.21", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["macros", "rt", "rt-multi-thread"] }
 tokio-retry = "0.3"
 tokio-util = { version = "0.7", features = ["io"] }
 tryfuture = { path = "tryfuture" }

--- a/src/rust/engine/async_latch/Cargo.toml
+++ b/src/rust/engine/async_latch/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 parking_lot = "0.12"
-tokio = { version = "1.21", features = ["sync"] }
+tokio = { version = "1.28", features = ["sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["rt", "macros", "time"] }
+tokio = { version = "1.28", features = ["rt", "macros", "time"] }

--- a/src/rust/engine/async_value/Cargo.toml
+++ b/src/rust/engine/async_value/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "1.21", features = ["macros", "sync"] }
+tokio = { version = "1.28", features = ["macros", "sync"] }
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["macros", "rt", "sync", "time"] }
+tokio = { version = "1.28", features = ["macros", "rt", "sync", "time"] }

--- a/src/rust/engine/client/Cargo.toml
+++ b/src/rust/engine/client/Cargo.toml
@@ -21,7 +21,7 @@ sha2 = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
 sysinfo = "0.20.0"
-tokio = { version = "1.21", features = ["rt-multi-thread", "macros", "net", "io-std", "io-util"] }
+tokio = { version = "1.28", features = ["rt-multi-thread", "macros", "net", "io-std", "io-util"] }
 uname = "0.1"
 
 [dev-dependencies]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -26,10 +26,10 @@ protos = { path = "../protos" }
 rlimit = "0.8"
 serde = "1.0.136"
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.21", features = ["fs"] }
+tokio = { version = "1.28", features = ["fs"] }
 workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
 tempfile = "3.5.0"
 testutil = { path = "../testutil" }
-tokio = { version = "1.21", features = ["rt", "macros"] }
+tokio = { version = "1.28", features = ["rt", "macros"] }

--- a/src/rust/engine/fs/brfs/Cargo.toml
+++ b/src/rust/engine/fs/brfs/Cargo.toml
@@ -21,7 +21,7 @@ parking_lot = "0.12"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
 time = "0.3.20"
-tokio = { version = "1.21", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1.28", features = ["rt-multi-thread", "macros", "signal"] }
 tokio-stream = { version = "0.1", features = ["signal"] }
 workunit_store = { path = "../../workunit_store" }
 

--- a/src/rust/engine/fs/fs_util/Cargo.toml
+++ b/src/rust/engine/fs/fs_util/Cargo.toml
@@ -23,5 +23,5 @@ serde_json = "1.0"
 serde_derive = "1.0"
 store = { path = "../store" }
 task_executor = { path = "../../task_executor" }
-tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.28", features = ["rt-multi-thread", "macros"] }
 workunit_store = { path = "../../workunit_store" }

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -36,7 +36,7 @@ sharded_lmdb = { path = "../../sharded_lmdb" }
 task_executor = { path = "../../task_executor" }
 tempfile = "3.5.0"
 tokio-rustls = "0.23"
-tokio = { version = "1.21", features = ["fs"] }
+tokio = { version = "1.28", features = ["fs"] }
 tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }
 tower-service = "0.3"
 tryfuture = { path = "../../tryfuture" }
@@ -48,7 +48,7 @@ criterion = "0.4"
 mock = { path = "../../testutil/mock" }
 num_cpus = "1"
 testutil = { path = "../../testutil" }
-tokio = { version = "1.21", features = ["rt", "macros"] }
+tokio = { version = "1.28", features = ["rt", "macros"] }
 walkdir = "2"
 
 [[bench]]

--- a/src/rust/engine/graph/Cargo.toml
+++ b/src/rust/engine/graph/Cargo.toml
@@ -15,10 +15,10 @@ log = "0.4"
 parking_lot = "0.12"
 petgraph = "0.6"
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.21", features = ["time", "parking_lot"] }
+tokio = { version = "1.28", features = ["time", "parking_lot"] }
 workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
 rand = "0.8"
 env_logger = "0.10.0"
-tokio = { version = "1.21", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread", "time"] }

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -20,7 +20,7 @@ prost = "0.9"
 rand = "0.8"
 rustls = { version = "0.19", features = ["dangerous_configuration"] }
 rustls-pemfile = "0.2"
-tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.22"
 tokio-util = { version = "0.6", features = ["codec"] }
 tonic = { version = "0.6", features = ["transport", "codegen", "tls", "tls-roots", "prost"] }

--- a/src/rust/engine/hashing/Cargo.toml
+++ b/src/rust/engine/hashing/Cargo.toml
@@ -14,7 +14,7 @@ generic-array = "0.14"
 hex = "0.4.3"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
-tokio = { version = "1.21", features = ["io-util"] }
+tokio = { version = "1.28", features = ["io-util"] }
 
 [dev-dependencies]
 serde_test = "1.0"

--- a/src/rust/engine/logging/Cargo.toml
+++ b/src/rust/engine/logging/Cargo.toml
@@ -15,7 +15,7 @@ num_enum = "0.5"
 parking_lot = "0.12"
 regex = "1"
 stdio = { path = "../stdio" }
-tokio = { version = "1.21" }
+tokio = { version = "1.28" }
 uuid = { version = "1.1", features = ["v4"] }
 
 [build-dependencies]

--- a/src/rust/engine/nailgun/Cargo.toml
+++ b/src/rust/engine/nailgun/Cargo.toml
@@ -13,8 +13,8 @@ log = "0.4"
 nails = "0.13"
 os_pipe = { version = "1.1", features = ["io_safety"] }
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.21", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }
+tokio = { version = "1.28", features = ["fs", "io-std", "io-util", "net", "signal", "sync"] }
 tokio-stream = "0.1"
 
 [dev-dependencies]
-tokio = { version = "1.21", features = ["io-std", "macros", "net", "rt-multi-thread"] }
+tokio = { version = "1.28", features = ["io-std", "macros", "net", "rt-multi-thread"] }

--- a/src/rust/engine/process_execution/Cargo.toml
+++ b/src/rust/engine/process_execution/Cargo.toml
@@ -31,7 +31,7 @@ store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
 tempfile = "3.5.0"
 concrete_time = { path = "../concrete_time" }
-tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
 tokio-util = { version = "0.7", features = ["codec"] }
 uname = "0.1.1"
@@ -59,4 +59,4 @@ parking_lot = "0.12"
 sharded_lmdb = { path = "../sharded_lmdb" }
 tempfile = "3.5.0"
 testutil = { path = "../testutil" }
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }

--- a/src/rust/engine/process_execution/docker/Cargo.toml
+++ b/src/rust/engine/process_execution/docker/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 nails = "0.13"
 store = { path = "../../fs/store" }
 task_executor = { path = "../../task_executor" }
-tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
 tokio-util = { version = "0.7", features = ["codec"] }
 workunit_store = { path = "../../workunit_store" }
@@ -36,4 +36,4 @@ parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 tempfile = "3.5.0"
 testutil = { path = "../../testutil" }
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }

--- a/src/rust/engine/process_execution/pe_nailgun/Cargo.toml
+++ b/src/rust/engine/process_execution/pe_nailgun/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4"
 nails = "0.13"
 store = { path = "../../fs/store" }
 task_executor = { path = "../../task_executor" }
-tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
 tokio-util = { version = "0.7", features = ["codec"] }
 workunit_store = { path = "../../workunit_store" }
@@ -34,5 +34,5 @@ parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 tempfile = "3.5.0"
 testutil = { path = "../../testutil" }
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }
 process_execution = { path = ".." }

--- a/src/rust/engine/process_execution/remote/Cargo.toml
+++ b/src/rust/engine/process_execution/remote/Cargo.toml
@@ -23,7 +23,7 @@ log = "0.4"
 store = { path = "../../fs/store" }
 task_executor = { path = "../../task_executor" }
 concrete_time = { path = "../../concrete_time" }
-tokio = { version = "1.21", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.28", features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = "0.23"
 tokio-util = { version = "0.7", features = ["codec"] }
 workunit_store = { path = "../../workunit_store" }
@@ -46,4 +46,4 @@ parking_lot = "0.12"
 sharded_lmdb = { path = "../../sharded_lmdb" }
 tempfile = "3.5.0"
 testutil = { path = "../../testutil" }
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }

--- a/src/rust/engine/process_executor/Cargo.toml
+++ b/src/rust/engine/process_executor/Cargo.toml
@@ -20,6 +20,6 @@ prost = "0.9"
 shlex = "1.1.0"
 store = { path = "../fs/store" }
 task_executor = { path = "../task_executor" }
-tokio = { version = "1.21", features = ["rt-multi-thread", "macros"] }
+tokio = { version = "1.28", features = ["rt-multi-thread", "macros"] }
 workunit_store = { path = "../workunit_store"}
 remote = { path = "../process_execution/remote"}

--- a/src/rust/engine/sharded_lmdb/Cargo.toml
+++ b/src/rust/engine/sharded_lmdb/Cargo.toml
@@ -16,4 +16,4 @@ tempfile = "3.5.0"
 
 [dev-dependencies]
 parking_lot = "0.12"
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }

--- a/src/rust/engine/stdio/Cargo.toml
+++ b/src/rust/engine/stdio/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 [dependencies]
 log = "0.4"
 parking_lot = "0.12"
-tokio = { version = "1.21", features = ["rt"] }
+tokio = { version = "1.28", features = ["rt"] }

--- a/src/rust/engine/task_executor/Cargo.toml
+++ b/src/rust/engine/task_executor/Cargo.toml
@@ -11,5 +11,5 @@ itertools = "0.10"
 log = "0.4"
 parking_lot = "0.12"
 stdio = { path = "../stdio" }
-tokio = { version = "1.21", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.28", features = ["macros", "rt-multi-thread", "time"] }
 workunit_store = { path = "../workunit_store" }

--- a/src/rust/engine/testutil/mock/Cargo.toml
+++ b/src/rust/engine/testutil/mock/Cargo.toml
@@ -18,5 +18,5 @@ prost = "0.9"
 prost-types = "0.9"
 protos = { path = "../../protos" }
 testutil = { path = ".." }
-tokio = { version = "1.21", features = ["time"] }
+tokio = { version = "1.28", features = ["time"] }
 tonic = { version = "0.6" }

--- a/src/rust/engine/watch/Cargo.toml
+++ b/src/rust/engine/watch/Cargo.toml
@@ -19,4 +19,4 @@ task_executor = { path = "../task_executor" }
 [dev-dependencies]
 tempfile = "3.5.0"
 testutil = { path = "../testutil" }
-tokio = { version = "1.21", features = ["rt", "macros"] }
+tokio = { version = "1.28", features = ["rt", "macros"] }

--- a/src/rust/engine/workunit_store/Cargo.toml
+++ b/src/rust/engine/workunit_store/Cargo.toml
@@ -19,9 +19,9 @@ rand = "0.8"
 smallvec = { version = "1", features=["union"] }
 strum = "0.24"
 strum_macros = "0.24"
-tokio = { version = "1.21", features = ["rt", "sync"] }
+tokio = { version = "1.28", features = ["rt", "sync"] }
 
 [dev-dependencies]
 futures = "0.3"
 internment = "0.6"
-tokio = { version = "1.21", features = ["macros"] }
+tokio = { version = "1.28", features = ["macros"] }


### PR DESCRIPTION
fixes reject_remote_clients Configuration corruption https://rustsec.org/advisories/RUSTSEC-2023-0001
https://github.com/pantsbuild/pants/actions/runs/4849679506/jobs/8641892369#step:3:180

![Screenshot 2023-05-01 at 9 47 52 AM](https://user-images.githubusercontent.com/1268088/235460802-ac589f0f-0486-4b79-86e0-d70ad96b6d97.png)
