### PR TITLE
Upgrade Pex to 2.1.135.

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -16,7 +16,7 @@ humbug==0.2.7
 importlib_resources==5.0.*
 ijson==3.1.4
 packaging==21.3
-pex==2.1.134
+pex==2.1.135
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -23,7 +23,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.1.134",
+//     "pex==2.1.135",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -940,13 +940,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "cd4687a8df60d9aefd424ed9364a8f29def203a9482ec8eb8e8070ef06075f89",
-              "url": "https://files.pythonhosted.org/packages/ab/30/ee571b05f6486a2f47954d76bd65ec357da2c59b069a5ec66a7197e6bf88/importlib_metadata-6.5.1-py3-none-any.whl"
+              "hash": "43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed",
+              "url": "https://files.pythonhosted.org/packages/30/bb/bf2944b8b88c65b797acc2c6a2cb0fb817f7364debf0675792e034013858/importlib_metadata-6.6.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b986d197242e4e9960a12743a6ec5a9fc8b3d7054612d90489452170785c98a5",
-              "url": "https://files.pythonhosted.org/packages/b8/dd/6bb4cf11470be75cb648812cd965b8695e121838c868b5637aaa54abd8db/importlib_metadata-6.5.1.tar.gz"
+              "hash": "92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705",
+              "url": "https://files.pythonhosted.org/packages/0b/1f/9de392c2b939384e08812ef93adf37684ec170b5b6e7ea302d9f163c2ea0/importlib_metadata-6.6.0.tar.gz"
             }
           ],
           "project_name": "importlib-metadata",
@@ -975,7 +975,7 @@
             "zipp>=0.5"
           ],
           "requires_python": ">=3.7",
-          "version": "6.5.1"
+          "version": "6.6.0"
         },
         {
           "artifacts": [
@@ -1087,13 +1087,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "13700c2c5b792b9c14576a7235b1063e01cb1c537197d606cb98c9e2191e0650",
-              "url": "https://files.pythonhosted.org/packages/2f/0f/9852900735ea85f793a47c35af4c28e24c2ae5b94dd5a3fdb34bc2f98b18/pex-2.1.134-py2.py3-none-any.whl"
+              "hash": "bd3a8c500d11b439d0a42b3b117413a1e133d0ee1b6b2c61ec6e44e86b53fe6f",
+              "url": "https://files.pythonhosted.org/packages/40/90/b260cbedb249fd24e733d524f7d6f85052b45f07c5e6cf0c7bc28058c4e4/pex-2.1.135-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "85587c37f79324be47a7121490bb270fdf39ce6d691a70f960383027fdcde9d5",
-              "url": "https://files.pythonhosted.org/packages/37/b1/fd95e7c5bdf88cb92e25e5aa5e707feae2b94b72c5aace6e2037c8447bed/pex-2.1.134.tar.gz"
+              "hash": "87a9eff7522423eebe70b1d2f026309bdb5d75b8e238e5ac764d7ed7b3eeb6f5",
+              "url": "https://files.pythonhosted.org/packages/35/ee/af772c967c288e3175a9b37e226543778c7215dc06da2c920b9c5b91123b/pex-2.1.135.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -1101,7 +1101,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.134"
+          "version": "2.1.135"
         },
         {
           "artifacts": [
@@ -1587,13 +1587,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
-              "url": "https://files.pythonhosted.org/packages/d2/f4/274d1dbe96b41cf4e0efb70cbced278ffd61b5c7bb70338b62af94ccb25b/requests-2.28.2-py3-none-any.whl"
+              "hash": "e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
+              "url": "https://files.pythonhosted.org/packages/cf/e1/2aa539876d9ed0ddc95882451deb57cfd7aa8dbf0b8dbce68e045549ba56/requests-2.29.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf",
-              "url": "https://files.pythonhosted.org/packages/9d/ee/391076f5937f0a8cdf5e53b701ffc91753e87b07d66bae4a09aa671897bf/requests-2.28.2.tar.gz"
+              "hash": "f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059",
+              "url": "https://files.pythonhosted.org/packages/4c/d2/70fc708727b62d55bc24e43cc85f073039023212d482553d853c44e57bdb/requests-2.29.0.tar.gz"
             }
           ],
           "project_name": "requests",
@@ -1605,8 +1605,8 @@
             "idna<4,>=2.5",
             "urllib3<1.27,>=1.21.1"
           ],
-          "requires_python": "<4,>=3.7",
-          "version": "2.28.2"
+          "requires_python": ">=3.7",
+          "version": "2.29.0"
         },
         {
           "artifacts": [
@@ -2127,19 +2127,19 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "12c744609d588340a07e45d333bf870069fc8793bcf96bae7a96d4712a42591d",
-              "url": "https://files.pythonhosted.org/packages/a4/ac/52e7adc38af8bfdcfa6c7117f4d499ec672ccd71a32e2e400ace9d1195b3/types_urllib3-1.26.25.10-py3-none-any.whl"
+              "hash": "3ba3d3a8ee46e0d5512c6bd0594da4f10b2584b47a470f8422044a2ab462f1df",
+              "url": "https://files.pythonhosted.org/packages/18/1a/a69209af0bbc268613e103597fd6559d1d1804f1a8a4d97004434c0608f4/types_urllib3-1.26.25.12-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "c44881cde9fc8256d05ad6b21f50c4681eb20092552351570ab0a8a0653286d6",
-              "url": "https://files.pythonhosted.org/packages/24/fe/3d379bc854adb3e89309939273dc29471bf790c574cc7cf8bcc3eb8aa840/types-urllib3-1.26.25.10.tar.gz"
+              "hash": "a1557355ce8d350a555d142589f3001903757d2d36c18a66f588d9659bbc917d",
+              "url": "https://files.pythonhosted.org/packages/54/4d/3a522d870d2e41067bea9faedb338b028eb7a1f3e1f894e6b6c35e350dbd/types-urllib3-1.26.25.12.tar.gz"
             }
           ],
           "project_name": "types-urllib3",
           "requires_dists": [],
           "requires_python": null,
-          "version": "1.26.25.10"
+          "version": "1.26.25.12"
         },
         {
           "artifacts": [
@@ -2791,8 +2791,8 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.134",
-  "pip_version": "23.1",
+  "pex_version": "2.1.135",
+  "pip_version": "23.1.2",
   "prefer_older_binary": false,
   "requirements": [
     "PyYAML<7.0,>=6.0",
@@ -2809,7 +2809,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.1.134",
+    "pex==2.1.135",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/subsystems/lambdex.lock
+++ b/src/python/pants/backend/python/subsystems/lambdex.lock
@@ -54,13 +54,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "13700c2c5b792b9c14576a7235b1063e01cb1c537197d606cb98c9e2191e0650",
-              "url": "https://files.pythonhosted.org/packages/2f/0f/9852900735ea85f793a47c35af4c28e24c2ae5b94dd5a3fdb34bc2f98b18/pex-2.1.134-py2.py3-none-any.whl"
+              "hash": "bd3a8c500d11b439d0a42b3b117413a1e133d0ee1b6b2c61ec6e44e86b53fe6f",
+              "url": "https://files.pythonhosted.org/packages/40/90/b260cbedb249fd24e733d524f7d6f85052b45f07c5e6cf0c7bc28058c4e4/pex-2.1.135-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "85587c37f79324be47a7121490bb270fdf39ce6d691a70f960383027fdcde9d5",
-              "url": "https://files.pythonhosted.org/packages/37/b1/fd95e7c5bdf88cb92e25e5aa5e707feae2b94b72c5aace6e2037c8447bed/pex-2.1.134.tar.gz"
+              "hash": "87a9eff7522423eebe70b1d2f026309bdb5d75b8e238e5ac764d7ed7b3eeb6f5",
+              "url": "https://files.pythonhosted.org/packages/35/ee/af772c967c288e3175a9b37e226543778c7215dc06da2c920b9c5b91123b/pex-2.1.135.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -68,14 +68,14 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.134"
+          "version": "2.1.135"
         }
       ],
       "platform_tag": null
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.134",
+  "pex_version": "2.1.135",
   "pip_version": "23.0.1",
   "prefer_older_binary": false,
   "requirements": [

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -37,6 +37,8 @@ class PipVersion(enum.Enum):
     V23_0 = "23.0"
     V23_0_1 = "23.0.1"
     V23_1 = "23.1"
+    V23_1_1 = "23.1.1"
+    V23_1_2 = "23.1.2"
     LATEST = "latest"
 
 

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -35,9 +35,9 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.134"
+    default_version = "v2.1.135"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.134,<3.0"
+    version_constraints = ">=2.1.135,<3.0"
 
     @classproperty
     def default_known_versions(cls):
@@ -46,8 +46,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "82b24645769c19483c1306c1ba7a888471a5e1df3a2b538788bc7e0d1b20dbf0",
-                    "4085867",
+                    "53948bf34646d8274932ad51b8cb8c5f1c9a8f829c95054529117cce927d0a5c",
+                    "4098060",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This pulls in support for Pip 23.1.1 & 23.1.2 and the new
`pex3 venv {inspect,create}` commands.

Pants likely has use for the `pex3 venv create` command in an overhaul
of AWS Lambda function and GCF support as well as in possible new
direct support for AWS Lambda layers.

The change-log is here:
  https://github.com/pantsbuild/pex/releases/tag/v2.1.135