### PR TITLE
Fix adhoc output_... example, document run_shell_command workdir changes (Cherry-pick of #18894)

### DIFF
--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -264,8 +264,8 @@ class AdhocToolTarget(Target):
                 {AdhocToolRunnableField.alias}=":python_source",
                 {AdhocToolArgumentsField.alias}=[""],
                 {AdhocToolExecutionDependenciesField.alias}=[":scripts"],
-                {AdhocToolOutputDirectoriesField.alias}=["logs/my-script.log"],
-                {AdhocToolOutputFilesField.alias}=["results/"],
+                {AdhocToolOutputDirectoriesField.alias}=["results/"],
+                {AdhocToolOutputFilesField.alias}=["logs/my-script.log"],
             )
 
             shell_sources(name="scripts")

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -89,6 +89,8 @@ tool may be invoked as a "runnable" by the `adhoc_tool` target type, while also 
 - Defining arbitrary shell commands as tests which can be invoked using `pants test` via the
 new `experimental_test_shell_command` target type.
 
+- The `workdir` field to `run_shell_command` has been switched to match the documented behavior: it now runs from the same directory as the `BUILD` file by default. To preserve the old behavior, explicitly set `workdir="/"`. The stabilisation also fixes other bugs with relative paths passed to the `workdir` field and thus may require updates.
+
 Ad-hoc tool support, with the `adhoc_tool` or `shell_command` targets, can be used to compile third party
 libraries in unsupported languages, run tools from ecosystems Pants doesn't yet directly support, and other similar code-generation tasks. 
 These targets can be used for first-party code generation, making use of existing backends that define


### PR DESCRIPTION
This does two minor doc tweaks related to the shell/adhoc tool work in 2.16:

- the `adhoc_tool` docs had flipped the file vs directory for the `output_...` example (fixes #18890)
- the `run_shell_command` workdir field (including its default behaviour) has changed in 2.16 (#18840, #18850), and this is added to the changelog, rather than migrated (quite hard #18860) or properly deprecated (also a bit awkward, and this is an `experimental_...` target)
