### PR TITLE
javascript: Handle package.json placed at the root of the repository

### DIFF
--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -175,10 +175,8 @@ class ProjectPaths:
         path = PurePath(pkg_json.root_dir)
 
         def safe_match(glob: str) -> bool:
-            if pkg_json.root_dir == "":
-                return pkg_json.root_dir == glob
-            elif not glob:
-                return False
+            if glob == "":
+                return pkg_json.root_dir == ""
             return path.match(glob)
 
         return any(safe_match(glob) for glob in self.full_globs())

--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -173,7 +173,15 @@ class ProjectPaths:
 
     def matches_glob(self, pkg_json: PackageJson) -> bool:
         path = PurePath(pkg_json.root_dir)
-        return any(path.match(glob) for glob in self.full_globs())
+
+        def safe_match(glob: str) -> bool:
+            if pkg_json.root_dir == "":
+                return pkg_json.root_dir == glob
+            elif not glob:
+                return False
+            return path.match(glob)
+
+        return any(safe_match(glob) for glob in self.full_globs())
 
 
 async def _get_default_resolve_name(path: str) -> str:

--- a/src/python/pants/backend/javascript/nodejs_project_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_test.py
@@ -71,6 +71,19 @@ def test_parses_projects(rule_runner: RuleRunner) -> None:
     assert {project.root_dir for project in projects} == {"src/js/foo", "src/js/bar"}
 
 
+def test_root_package_json_is_supported(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "package_json()",
+            "package.json": given_package("ham", "0.0.1"),
+            "src/js/bar/BUILD": "package_json()",
+            "src/js/bar/package.json": given_package("spam", "0.0.2"),
+        }
+    )
+    projects = rule_runner.request(AllNodeJSProjects, [])
+    assert {project.root_dir for project in projects} == {"", "src/js/bar"}
+
+
 def test_parses_project_with_workspaces(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {


### PR DESCRIPTION
`pathlib.PurePath.match` fails with a nondescript `ValueError` if either the `PurePath` is the empty string or the match argument is the empty string.

Addresses https://github.com/pantsbuild/pants/issues/18918