### PR TITLE
javascript: Support `package` goal in `node_build_script` target

### DIFF
--- a/src/python/pants/backend/javascript/package/rules.py
+++ b/src/python/pants/backend/javascript/package/rules.py
@@ -13,6 +13,7 @@ from pants.backend.javascript.install_node_package import (
 )
 from pants.backend.javascript.nodejs_project_environment import NodeJsProjectEnvironmentProcess
 from pants.backend.javascript.package_json import (
+    NodeBuildScript,
     NodeBuildScriptEntryPointField,
     NodeBuildScriptExtraCaches,
     NodeBuildScriptOutputDirectoriesField,
@@ -22,6 +23,7 @@ from pants.backend.javascript.package_json import (
     NodePackageVersionField,
     PackageJsonSourceField,
 )
+from pants.build_graph.address import Address
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, PackageFieldSet
 from pants.core.target_types import ResourceSourceField
 from pants.engine.internals.native_engine import AddPrefix, Snapshot
@@ -77,28 +79,57 @@ async def pack_node_package_into_tgz_for_publication(
 _NOT_ALPHANUMERIC = re.compile("[^0-9a-zA-Z]+")
 
 
-@rule
-async def run_node_build_script(
-    req: GenerateResourcesFromNodeBuildScriptRequest,
-) -> GeneratedSources:
-    installation = await Get(
-        InstalledNodePackageWithSource, InstalledNodePackageRequest(req.protocol_target.address)
-    )
-    output_files = req.protocol_target[NodeBuildScriptOutputFilesField]
-    output_dirs = req.protocol_target[NodeBuildScriptOutputDirectoriesField]
-    script_name = req.protocol_target[NodeBuildScriptEntryPointField].value
-    extra_caches = req.protocol_target[NodeBuildScriptExtraCaches].value
-    if not (output_dirs.value or output_files.value):
-        raise ValueError(
-            softwrap(
-                f"""
-                Neither the {output_dirs.alias} nor the {output_files.alias} field was provided.
+@dataclass(frozen=True)
+class NodeBuildScriptResult:
+    process: ProcessResult
+    project_directory: str
 
-                One of the fields have to be set, or else the `node_build_script`
-                output will not be captured for further use in the build.
-                """
+
+@dataclass(frozen=True)
+class NodeBuildScriptRequest:
+    address: Address
+    output_files: tuple[str, ...]
+    output_directories: tuple[str, ...]
+    script_name: str
+    extra_caches: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not (self.output_directories or self.output_files):
+            raise ValueError(
+                softwrap(
+                    f"""
+                    Neither the {NodeBuildScriptOutputDirectoriesField.alias} nor the
+                    {NodeBuildScriptOutputFilesField.alias} field was provided.
+
+                    One of the fields have to be set, or else the `{NodeBuildScript.alias}`
+                    output will not be captured for further use in the build.
+                    """
+                )
             )
+
+    @classmethod
+    def from_generate_request(
+        cls, req: GenerateResourcesFromNodeBuildScriptRequest
+    ) -> NodeBuildScriptRequest:
+        return cls(
+            address=req.protocol_target.address,
+            output_files=req.protocol_target[NodeBuildScriptOutputFilesField].value or (),
+            output_directories=req.protocol_target[NodeBuildScriptOutputDirectoriesField].value
+            or (),
+            script_name=req.protocol_target[NodeBuildScriptEntryPointField].value,
+            extra_caches=req.protocol_target[NodeBuildScriptExtraCaches].value or (),
         )
+
+
+@rule
+async def run_node_build_script(req: NodeBuildScriptRequest) -> NodeBuildScriptResult:
+    installation = await Get(
+        InstalledNodePackageWithSource, InstalledNodePackageRequest(req.address)
+    )
+    output_files = req.output_files
+    output_dirs = req.output_directories
+    script_name = req.script_name
+    extra_caches = req.extra_caches
 
     def cache_name(cache_path: str) -> str:
         parts = (installation.project_env.package_dir(), script_name, cache_path)
@@ -113,12 +144,11 @@ async def run_node_build_script(
             description=f"Running node build script '{script_name}'.",
             input_digest=installation.digest,
             output_files=tuple(
-                installation.join_relative_workspace_directory(file)
-                for file in output_files.value or ()
+                installation.join_relative_workspace_directory(file) for file in output_files or ()
             ),
             output_directories=tuple(
                 installation.join_relative_workspace_directory(directory)
-                for directory in output_dirs.value or ()
+                for directory in output_dirs or ()
             ),
             level=LogLevel.INFO,
             per_package_caches=FrozenDict(
@@ -127,8 +157,16 @@ async def run_node_build_script(
         ),
     )
 
+    return NodeBuildScriptResult(result, installation.project_dir)
+
+
+@rule
+async def generate_resources_from_node_build_script(
+    req: GenerateResourcesFromNodeBuildScriptRequest,
+) -> GeneratedSources:
+    result = await Get(NodeBuildScriptResult, NodeBuildScriptRequest.from_generate_request(req))
     return GeneratedSources(
-        await Get(Snapshot, AddPrefix(result.output_digest, installation.project_dir))
+        await Get(Snapshot, AddPrefix(result.process.output_digest, result.project_directory))
     )
 
 

--- a/src/python/pants/backend/javascript/package/rules_integration_test.py
+++ b/src/python/pants/backend/javascript/package/rules_integration_test.py
@@ -11,6 +11,7 @@ import pytest
 from pants.backend.javascript import package_json
 from pants.backend.javascript.package.rules import (
     GenerateResourcesFromNodeBuildScriptRequest,
+    NodeBuildScriptPackageFieldSet,
     NodePackageTarFieldSet,
 )
 from pants.backend.javascript.package.rules import rules as package_rules
@@ -31,6 +32,7 @@ def rule_runner() -> RuleRunner:
             *package_rules(),
             QueryRule(BuiltPackage, (NodePackageTarFieldSet,)),
             QueryRule(GeneratedSources, (GenerateResourcesFromNodeBuildScriptRequest,)),
+            QueryRule(BuiltPackage, (NodeBuildScriptPackageFieldSet,)),
             QueryRule(Snapshot, (Digest,)),
         ],
         target_types=[
@@ -46,16 +48,15 @@ def rule_runner() -> RuleRunner:
     return rule_runner
 
 
-@pytest.mark.parametrize(
-    "lockfile, package_manager",
-    [
-        pytest.param(Path(__file__).parent / "package-lock.json", "npm"),
-        pytest.param(Path(__file__).parent / "pnpm-lock.yaml", "pnpm"),
+@pytest.fixture(
+    params=[
+        pytest.param((Path(__file__).parent / "package-lock.json", "npm"), id="npm"),
+        pytest.param((Path(__file__).parent / "pnpm-lock.yaml", "pnpm"), id="pnpm"),
     ],
+    autouse=True,
 )
-def test_packages_sources_as_resource_using_build_tool(
-    rule_runner: RuleRunner, package_manager: str, lockfile: Path
-) -> None:
+def configure_runner_with_js_project(request, rule_runner: RuleRunner) -> RuleRunner:
+    lockfile, package_manager = request.param
     rule_runner.set_options([f"--nodejs-package-manager={package_manager}"], env_inherit={"PATH"})
     rule_runner.write_files(
         {
@@ -97,6 +98,10 @@ def test_packages_sources_as_resource_using_build_tool(
             "src/js/lib/index.mjs": "import './style.css' ",
         }
     )
+    return rule_runner
+
+
+def test_packages_sources_as_resource_using_build_tool(rule_runner: RuleRunner) -> None:
     tgt = rule_runner.get_target(Address("src/js", generated_name="build"))
     snapshot = rule_runner.request(Snapshot, (EMPTY_DIGEST,))
     result = rule_runner.request(
@@ -108,3 +113,22 @@ def test_packages_sources_as_resource_using_build_tool(
         "src/js/dist/index.js",
         "src/js/dist/index.js.map",
     )
+
+
+def test_packages_sources_as_package_using_build_tool(rule_runner: RuleRunner) -> None:
+    tgt = rule_runner.get_target(Address("src/js", generated_name="build"))
+    result = rule_runner.request(BuiltPackage, [NodeBuildScriptPackageFieldSet.create(tgt)])
+    rule_runner.write_digest(result.digest)
+
+    assert result.artifacts[0].relpath == "dist"
+
+    result_path = Path(rule_runner.build_root) / "dist"
+
+    assert sorted(
+        str(path.relative_to(rule_runner.build_root)) for path in result_path.iterdir()
+    ) == [
+        "dist/index.css",
+        "dist/index.css.map",
+        "dist/index.js",
+        "dist/index.js.map",
+    ]

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -340,6 +340,7 @@ class PackageJsonTarget(TargetGenerator):
 class NodeBuildScriptEntryPointField(StringField):
     alias = "entry_point"
     required = True
+    value: str
 
 
 class NodeBuildScriptSourcesField(SourcesField):

--- a/src/python/pants/backend/javascript/package_json.py
+++ b/src/python/pants/backend/javascript/package_json.py
@@ -17,6 +17,7 @@ from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import AncestorGlobSpec, RawSpecs
 from pants.build_graph.address import Address
 from pants.build_graph.build_file_aliases import BuildFileAliases
+from pants.core.goals.package import OutputPathField
 from pants.core.target_types import (
     TargetGeneratorSourcesHelperSourcesField,
     TargetGeneratorSourcesHelperTarget,
@@ -429,6 +430,7 @@ class NodeBuildScriptTarget(Target):
         NodeBuildScriptSourcesField,
         NodeBuildScriptExtraCaches,
         NodePackageDependenciesField,
+        OutputPathField,
     )
 
     alias = "_node_build_script"
@@ -436,7 +438,7 @@ class NodeBuildScriptTarget(Target):
     help = help_text(
         """
         A package.json script that is invoked by the configured package manager
-        to produce `resource` targets.
+        to produce `resource` targets or a packaged artifact.
         """
     )
 


### PR DESCRIPTION
Add support for the `package` goal when using the `node_build_script` generated target.

This plays nicely with https://github.com/pantsbuild/pants/issues/18922 in that the `package_json` target default behaviour becomes to run the `node_build_script` when you use the `package` goal.

This also enables the docker backend to depend on bundled artifacts from `node_build_script`.

Addresses https://github.com/pantsbuild/pants/issues/18922