### PR TITLE
javascript: Implement dependency inference opt-out and improve resillience

### DIFF
--- a/src/python/pants/backend/javascript/dependency_inference/import_parser/package-lock.json
+++ b/src/python/pants/backend/javascript/dependency_inference/import_parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pants/javascript-source-import-parser",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pants/javascript-source-import-parser",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "APACHE2",
       "dependencies": {
         "@babel/parser": "^7.20.13",

--- a/src/python/pants/backend/javascript/dependency_inference/import_parser/package.json
+++ b/src/python/pants/backend/javascript/dependency_inference/import_parser/package.json
@@ -12,7 +12,7 @@
   },
   "license": "APACHE2",
   "files": ["script.cjs"],
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Parses commonjs and esmodule import statements.",
   "keywords": [],
   "author": "",

--- a/src/python/pants/backend/javascript/dependency_inference/import_parser/script.cjs
+++ b/src/python/pants/backend/javascript/dependency_inference/import_parser/script.cjs
@@ -4,6 +4,8 @@ const parser = require("@babel/parser");
 const traverse = require("@babel/traverse").default;
 const fs = require("fs").promises;
 
+const PRAGMA_IGNORE = "pants: no-infer-dep";
+
 const printStringArguments = (callPath) => {
   for (const arg of callPath.node.arguments) {
     if (arg.type === "StringLiteral") {
@@ -12,25 +14,54 @@ const printStringArguments = (callPath) => {
   }
 };
 
-const functionImportsVisitor = {
-  CallExpression: (callPath) => {
-    callPath.traverse({
-      Identifier: (identPath) => {
-        if (identPath.node.name === "require") {
-          printStringArguments(callPath);
-        }
-      },
-      Import: () => printStringArguments(callPath),
-    });
-  },
+const ignorePath = (pragmaIgnoredLines, path) =>
+  pragmaIgnoredLines.has(path.node.loc.start.line);
+
+const functionImportsVisitor = (pragmaIgnoredLines) => {
+  return {
+    CallExpression: (callPath) => {
+      if (ignorePath(pragmaIgnoredLines, callPath)) {
+        return;
+      }
+      callPath.traverse({
+        Identifier: (identPath) => {
+          if (identPath.node.name === "require") {
+            printStringArguments(callPath);
+          }
+        },
+        Import: () => printStringArguments(callPath),
+      });
+    },
+  };
 };
 
-const staticImportVisitor = {
-  ImportDeclaration: (importPath) => {
-    importPath.traverse({
-      StringLiteral: (literalPath) => console.log(literalPath.node.value),
-    });
-  },
+const staticImportVisitor = (pragmaIgnoredLines) => {
+  return {
+    ImportDeclaration: (importPath) => {
+      if (ignorePath(pragmaIgnoredLines, importPath)) {
+        return;
+      }
+      importPath.traverse({
+        StringLiteral: (literalPath) => console.log(literalPath.node.value),
+      });
+    },
+  };
+};
+
+const getPragmaIgnoredLines = (ast) => {
+  if (Array.isArray(ast.comments)) {
+    return new Set(
+      ast.comments
+        .filter((comment) => {
+          return (
+            comment.type === "CommentLine" &&
+            comment.value.includes(PRAGMA_IGNORE)
+          );
+        })
+        .map((commentLine) => commentLine.loc.start.line)
+    );
+  }
+  return new Set();
 };
 
 const main = async () => {
@@ -42,11 +73,13 @@ const main = async () => {
     sourceType: "unambiguous",
     errorRecovery: true,
   });
+  const pragmaIgnoredLines = getPragmaIgnoredLines(ast);
+
   traverse(ast, {
     Program: (programPath) =>
       console.error(`Determined SourceType: ${programPath.node.sourceType}.`),
-    ...functionImportsVisitor,
-    ...staticImportVisitor,
+    ...functionImportsVisitor(pragmaIgnoredLines),
+    ...staticImportVisitor(pragmaIgnoredLines),
   });
 };
 

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -24,6 +24,7 @@ from pants.backend.javascript.package_json import (
     PackageJsonEntryPoints,
     PackageJsonSourceField,
 )
+from pants.backend.javascript.subsystems.nodejs_infer import NodeJSInfer
 from pants.backend.javascript.target_types import JSDependenciesField, JSSourceField
 from pants.build_graph.address import Address
 from pants.engine.addresses import Addresses
@@ -97,8 +98,12 @@ async def map_candidate_node_packages(
 @rule
 async def infer_js_source_dependencies(
     request: InferJSDependenciesRequest,
+    nodejs_infer: NodeJSInfer,
 ) -> InferredDependencies:
     source: JSSourceField = request.field_set.source
+    if not nodejs_infer.imports:
+        return InferredDependencies(())
+
     import_strings = await Get(JSImportStrings, ParseJsImportStrings(source))
     path_strings = FrozenOrderedSet(
         os.path.normpath(os.path.join(os.path.dirname(source.file_path), import_string))

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -64,7 +64,10 @@ class InferJSDependenciesRequest(InferDependenciesRequest):
 @rule
 async def infer_node_package_dependencies(
     request: InferNodePackageDependenciesRequest,
+    nodejs_infer: NodeJSInfer,
 ) -> InferredDependencies:
+    if not nodejs_infer.package_json_entry_points:
+        return InferredDependencies(())
     entry_points = await Get(
         PackageJsonEntryPoints, PackageJsonSourceField, request.field_set.source
     )

--- a/src/python/pants/backend/javascript/subsystems/nodejs_infer.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_infer.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pants.backend.javascript.package_json import PackageJsonEntryPoints
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
@@ -20,6 +21,20 @@ class NodeJSInfer(Subsystem):
 
             To ignore a false positive, you can either put `// pants: no-infer-dep` on the line of
             the import or put `!{bad_address}` in the `dependencies` field of your target.
+            """
+        ),
+    )
+
+    package_json_entry_points = BoolOption(
+        default=True,
+        help=softwrap(
+            f"""
+            Infer a `package_json`'s dependencies by parsing entry point statements from the package.json file.
+
+            To ignore a false positive, you can put `!{{bad_address}}` in the `dependencies` field of the `package_json`
+            target.
+
+            {PackageJsonEntryPoints.__doc__}
             """
         ),
     )

--- a/src/python/pants/backend/javascript/subsystems/nodejs_infer.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_infer.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.option.option_types import BoolOption
+from pants.option.subsystem import Subsystem
+from pants.util.strutil import softwrap
+
+
+class NodeJSInfer(Subsystem):
+    options_scope = "nodejs-infer"
+    help = "Options controlling which dependencies will be inferred for javascript targets."
+
+    imports = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            Infer a target's imported dependencies by parsing import statements from sources.
+
+            To ignore a false positive, you can either put `// pants: no-infer-dep` on the line of
+            the import or put `!{bad_address}` in the `dependencies` field of your target.
+            """
+        ),
+    )


### PR DESCRIPTION
1. Adds the `nodejs-infer` subsystem where you can disable dependency inference for the javascript backend.
2. Adds support for the `// pants: no-infer-dep` comment for per-line ignores for the import parser.
3. Change the import parser to be ran as a fallible process, avoiding issues with source files containing ast that babel will not process (only example I have right now is rebinding of imports).