### PR TITLE
javascript: Support Node.js subpath imports

### DIFF
--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -137,7 +137,7 @@ async def infer_js_source_dependencies(
     owning_targets = await Get(Targets, Addresses(owners))
 
     non_path_string_bases = FrozenOrderedSet(
-        non_path_string.split(os.path.sep, 1)[0]
+        non_path_string.partition(os.path.sep)[0]
         for non_path_string in import_strings - path_strings
     )
 

--- a/src/python/pants/backend/javascript/dependency_inference/rules.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules.py
@@ -22,6 +22,7 @@ from pants.backend.javascript.package_json import (
     OwningNodePackage,
     OwningNodePackageRequest,
     PackageJsonEntryPoints,
+    PackageJsonImports,
     PackageJsonSourceField,
 )
 from pants.backend.javascript.subsystems.nodejs_infer import NodeJSInfer
@@ -98,6 +99,22 @@ async def map_candidate_node_packages(
     )
 
 
+async def _replace_subpath_imports(
+    req: InferJSDependenciesRequest, import_strings: JSImportStrings
+) -> JSImportStrings:
+    owning_pkg = await Get(OwningNodePackage, OwningNodePackageRequest(req.field_set.address))
+    if owning_pkg.target:
+        subpath_imports = await Get(
+            PackageJsonImports, PackageJsonSourceField, owning_pkg.target[PackageJsonSourceField]
+        )
+        return JSImportStrings(
+            replace_string
+            for string in import_strings
+            for replace_string in subpath_imports.replacements(string) or (string,)
+        )
+    return import_strings
+
+
 @rule
 async def infer_js_source_dependencies(
     request: InferJSDependenciesRequest,
@@ -108,6 +125,8 @@ async def infer_js_source_dependencies(
         return InferredDependencies(())
 
     import_strings = await Get(JSImportStrings, ParseJsImportStrings(source))
+    import_strings = await _replace_subpath_imports(request, import_strings)
+
     path_strings = FrozenOrderedSet(
         os.path.normpath(os.path.join(os.path.dirname(source.file_path), import_string))
         for import_string in import_strings
@@ -118,8 +137,10 @@ async def infer_js_source_dependencies(
     owning_targets = await Get(Targets, Addresses(owners))
 
     non_path_string_bases = FrozenOrderedSet(
-        os.path.basename(non_path_string) for non_path_string in import_strings - path_strings
+        non_path_string.split(os.path.sep, 1)[0]
+        for non_path_string in import_strings - path_strings
     )
+
     candidate_pkgs = await Get(
         NodePackageCandidateMap, RequestNodePackagesCandidateMap(request.field_set.address)
     )

--- a/src/python/pants/backend/javascript/dependency_inference/rules_test.py
+++ b/src/python/pants/backend/javascript/dependency_inference/rules_test.py
@@ -287,6 +287,68 @@ def test_infers_third_party_package_json_field_js_source_dependency(
     assert set(addresses) == {Address("src/js", generated_name="chalk")}
 
 
+def test_infers_third_party_package_json_field_js_source_dependency_with_import_subpaths(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": given_package(
+                "ham",
+                "0.0.1",
+                main="lib/index.js",
+                dependencies={"chalk": "5.0.2"},
+                imports={"#myChalk": "chalk"},
+            ),
+            "src/js/lib/BUILD": "javascript_sources()",
+            "src/js/lib/index.js": dedent(
+                """\
+                import chalk from "#myChalk";
+                """
+            ),
+        }
+    )
+
+    pkg_tgt = rule_runner.get_target(Address("src/js/lib", relative_file_path="index.js"))
+    addresses = rule_runner.request(
+        InferredDependencies,
+        [InferJSDependenciesRequest(JSSourceInferenceFieldSet.create(pkg_tgt))],
+    ).include
+
+    assert set(addresses) == {Address("src/js", generated_name="chalk")}
+
+
+def test_infers_third_party_package_json_field_js_source_dependency_with_import_subpaths_with_star_replacements(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/BUILD": "package_json()",
+            "src/js/package.json": given_package(
+                "ham",
+                "0.0.1",
+                main="lib/index.js",
+                dependencies={"chalk": "5.0.2"},
+                imports={"#myChalk/*.js": "chalk/stuff/*.js"},
+            ),
+            "src/js/lib/BUILD": "javascript_sources()",
+            "src/js/lib/index.js": dedent(
+                """\
+                import chalk from "#myChalk/index.js";
+                """
+            ),
+        }
+    )
+
+    pkg_tgt = rule_runner.get_target(Address("src/js/lib", relative_file_path="index.js"))
+    addresses = rule_runner.request(
+        InferredDependencies,
+        [InferJSDependenciesRequest(JSSourceInferenceFieldSet.create(pkg_tgt))],
+    ).include
+
+    assert set(addresses) == {Address("src/js", generated_name="chalk")}
+
+
 def test_infers_first_party_package_json_field_js_source_dependency(
     rule_runner: RuleRunner,
 ) -> None:
@@ -298,6 +360,66 @@ def test_infers_first_party_package_json_field_js_source_dependency(
             "src/js/a/lib/index.js": dedent(
                 """\
                 import { x } from "spam";
+                """
+            ),
+            "src/js/b/BUILD": "package_json()",
+            "src/js/b/package.json": given_package("spam", "0.0.1"),
+            "src/js/b/lib/BUILD": "javascript_sources()",
+            "src/js/b/lib/index.js": "const x = 2;",
+        }
+    )
+
+    pkg_tgt = rule_runner.get_target(Address("src/js/a/lib", relative_file_path="index.js"))
+    addresses = rule_runner.request(
+        InferredDependencies,
+        [InferJSDependenciesRequest(JSSourceInferenceFieldSet.create(pkg_tgt))],
+    ).include
+
+    assert set(addresses) == {Address("src/js/b", generated_name="spam")}
+
+
+def test_infers_first_party_package_json_field_js_source_dependency_with_import_subpaths(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/a/BUILD": "package_json()",
+            "src/js/a/package.json": given_package("ham", "0.0.1", imports={"#spam": "spam"}),
+            "src/js/a/lib/BUILD": "javascript_sources()",
+            "src/js/a/lib/index.js": dedent(
+                """\
+                import { x } from "#spam";
+                """
+            ),
+            "src/js/b/BUILD": "package_json()",
+            "src/js/b/package.json": given_package("spam", "0.0.1"),
+            "src/js/b/lib/BUILD": "javascript_sources()",
+            "src/js/b/lib/index.js": "const x = 2;",
+        }
+    )
+
+    pkg_tgt = rule_runner.get_target(Address("src/js/a/lib", relative_file_path="index.js"))
+    addresses = rule_runner.request(
+        InferredDependencies,
+        [InferJSDependenciesRequest(JSSourceInferenceFieldSet.create(pkg_tgt))],
+    ).include
+
+    assert set(addresses) == {Address("src/js/b", generated_name="spam")}
+
+
+def test_infers_first_party_package_json_field_js_source_dependency_with_starred_import_subpaths(
+    rule_runner: RuleRunner,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/js/a/BUILD": "package_json()",
+            "src/js/a/package.json": given_package(
+                "ham", "0.0.1", imports={"#spam/*.js": "spam/lib/*.js"}
+            ),
+            "src/js/a/lib/BUILD": "javascript_sources()",
+            "src/js/a/lib/index.js": dedent(
+                """\
+                import { x } from "#spam/index.js";
                 """
             ),
             "src/js/b/BUILD": "package_json()",

--- a/src/python/pants/backend/javascript/package_json_test.py
+++ b/src/python/pants/backend/javascript/package_json_test.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from textwrap import dedent
 from typing import Iterable
 
@@ -304,12 +305,14 @@ def test_parses_subpath_imports(
 
     assert imports.imports == FrozenDict(
         {
-            "#a": ("./yep.js",),
-            "#b": ("some-package",),
-            "#c": (
+            re.compile(r"^\#a"): ("./yep.js",),  # noqa: W605 # Escape added by re.escape
+            re.compile(r"^\#b"): ("some-package",),  # noqa: W605 # Escape added by re.escape
+            re.compile("^\#c"): (  # noqa: W605 # Escape added by re.escape
                 "./polyfill.js",
                 "polyfill",
             ),
-            "#d/module/js/*.js": ("./module/*.js",),
+            re.compile(r"^\#d/module/js/(.*)\.js"): (  # noqa: W605 # Escape added by re.escape
+                "./module/*.js",
+            ),
         }
     )


### PR DESCRIPTION
Adds support for the inference impl to inspect `package.json#imports`, and backwards map this object to find dependencies known by pants.

Relevant part of Node.js docs: https://nodejs.org/api/packages.html#subpath-imports.