### PR TITLE
update troubleshooting document about self-hosted action runner (Cherry-pick of #18900)

### DIFF
--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -271,3 +271,14 @@ It works mostly same as a normal installation, but has an important difference: 
 This may cause problems if your code or tests ry to create a container with a bind-mount of a directory or file _under the current working directory_.  Container creation will fail with "invalid mount config for type "bind": bind source path does not exist", because Pants' default `local_execution_root_dir` option is `/tmp`, which the Snap-based Docker service cannot access.
 
 You can work around this issue by explicitly setting `[GLOBAL].local_execution_root_dir` to a directory outside the system `/tmp` directory, such as `"%(buildroot)s/tmp"`.
+
+Using pants on self-hosted GitHub actions runner
+------------------------------------------------
+
+Setting up pants to run with Python executables provided by [setup-python](https://github.com/marketplace/actions/setup-python) will not work on vanilla actions runner setup. This is due to the [known limitation](https://github.com/pantsbuild/pants/issues/16565) of pants which does not allow leaking arbitrary environment variable (in this case `LD_LIBRARY_PATH` for us) when evaluating dependency inference rules. If you fall into this situation, you will face an error complaining about missing shared object files, like this:
+
+```
+/home/ubuntu/.cache/python-tools/Python/3.11.3/x64/bin/python3.11: error while loading shared libraries: libpython3.11.so.1.0: cannot open shared object file: No such file or directory
+```
+
+One of the workaround to fix this issue is setting up python tool cache files at `/opt/hostedtoolcache` directory. This is the default path which `setup-python` action uses to download relevant files on hosted GitHub actions runner. Overriding tool cache download directory can be achieved by following [setup-python documentation](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#linux).


### PR DESCRIPTION
This PR describes a workaround solution to make Pants run on a GitHub action job which is executed on self-hosted GitHub actions runner. 
