### PR TITLE
Do not choke on missing lockfiles. (Cherry-pick of #18940)

### DIFF
--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -762,7 +762,16 @@ class LockfileTarget(Target):
 
 
 class LockfilesGeneratorSourcesField(MultipleSourcesField):
+    """Sources field for synthesized `_lockfiles` targets.
+
+    It is special in that it always ignores any missing files, regardless of the global
+    `--unmatched-build-file-globs` option.
+    """
+
     help = generate_multiple_sources_field_help_message("Example: `sources=['example.lock']`")
+
+    def path_globs(self, unmatched_build_file_globs: UnmatchedBuildFileGlobs) -> PathGlobs:  # type: ignore[misc]
+        return super().path_globs(UnmatchedBuildFileGlobs.ignore())
 
 
 class LockfilesGeneratorTarget(TargetFilesGenerator):

--- a/src/python/pants/core/target_types_test.py
+++ b/src/python/pants/core/target_types_test.py
@@ -24,6 +24,7 @@ from pants.core.target_types import (
     FileSourceField,
     FileTarget,
     HTTPSource,
+    LockfilesGeneratorSourcesField,
     LockfileSourceField,
     RelocatedFiles,
     RelocateFilesViaCodegenRequest,
@@ -441,6 +442,23 @@ def test_lockfile_glob_match_error_behavior(
     assert (
         GlobMatchErrorBehavior.ignore
         == lockfile_source.path_globs(
+            UnmatchedBuildFileGlobs(error_behavior)
+        ).glob_match_error_behavior
+    )
+
+
+@pytest.mark.parametrize(
+    "error_behavior", [GlobMatchErrorBehavior.warn, GlobMatchErrorBehavior.error]
+)
+def test_lockfiles_glob_match_error_behavior(
+    error_behavior: GlobMatchErrorBehavior,
+) -> None:
+    lockfile_sources = LockfilesGeneratorSourcesField(
+        ["test.lock"], Address("", target_name="lockfiles-test")
+    )
+    assert (
+        GlobMatchErrorBehavior.ignore
+        == lockfile_sources.path_globs(
             UnmatchedBuildFileGlobs(error_behavior)
         ).glob_match_error_behavior
     )


### PR DESCRIPTION
Fixes #18933 (and #18404). Original attempt at fixing this but failed was in #18406 due to an oversight that it was the `_lockfiles` target generator with a `sources` field that was being synthesized, not the `_lockfile` target with a single `source` file only.

Either use should work equally well, and now they do.
