### PR TITLE
Have this repo use the new rust parser for Python

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -160,7 +160,7 @@ python-default = [">=3.7,<3.10"]
 [python-infer]
 assets = true
 unowned_dependency_behavior = "error"
-use_rust_parser = false
+use_rust_parser = true
 
 [docformatter]
 args = ["--wrap-summaries=100", "--wrap-descriptions=100"]


### PR DESCRIPTION
It's the future, and it's faster, and it's correct:

```
$ pants peek :: > before.json
...
$ pants --python-infer-use-rust-parser :: > after.json
...
$ diff -u before.json after.json
$
```