### PR TITLE
Make `DigestSubset` symlink-aware

### DIFF
--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -228,7 +228,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, Self::Error> {
     let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
     let path_stats = input_tree
-      .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
+      .expand_globs(params.globs, SymlinkBehavior::Aware, None)
       .await
       .map_err(|err| format!("Error matching globs against {directory_digest:?}: {err}"))?;
 

--- a/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
@@ -1,13 +1,14 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::fs::create_dir_all;
+use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::sync::Arc;
 
 use fs::{
   DirectoryDigest, GlobExpansionConjunction, PosixFS, PreparedPathGlobs, StrictGlobMatching,
 };
-use testutil::{make_file, make_link};
+use testutil::make_file;
 
 use crate::{
   snapshot_tests::{expand_all_sorted, setup, STR, STR2},
@@ -100,10 +101,7 @@ async fn subset_symlink() {
   // Make the second snapshot with a symlink pointing to the file in the first snapshot.
   let (_store2, tempdir2, posix_fs2, digester2) = setup();
   create_dir_all(tempdir2.path().join("subdir")).unwrap();
-  make_link(
-    &tempdir2.path().join("subdir/roland2"),
-    &Path::new("./roland1"),
-  );
+  symlink("./roland1", &tempdir2.path().join("subdir/roland2")).unwrap();
   let snapshot_with_symlink =
     Snapshot::from_path_stats(digester2, expand_all_sorted(posix_fs2).await)
       .await

--- a/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use fs::{
   DirectoryDigest, GlobExpansionConjunction, PosixFS, PreparedPathGlobs, StrictGlobMatching,
 };
-use testutil::make_file;
+use testutil::{make_file, make_link};
 
 use crate::{
   snapshot_tests::{expand_all_sorted, setup, STR, STR2},
@@ -80,6 +80,51 @@ async fn subset_single_files() {
     .await
     .unwrap();
   assert_eq!(subset_roland2, snapshot2.into());
+}
+
+#[tokio::test]
+async fn subset_symlink() {
+  // Make the first snapshot with a file
+  let (store, tempdir1, posix_fs1, digester1) = setup();
+  create_dir_all(tempdir1.path().join("subdir")).unwrap();
+  make_file(
+    &tempdir1.path().join("subdir/roland1"),
+    STR.as_bytes(),
+    0o600,
+  );
+  let snapshot_with_real_file =
+    Snapshot::from_path_stats(digester1.clone(), expand_all_sorted(posix_fs1).await)
+      .await
+      .unwrap();
+
+  // Make the second snapshot with a symlink pointing to the file in the first snapshot.
+  let (_store2, tempdir2, posix_fs2, digester2) = setup();
+  create_dir_all(tempdir2.path().join("subdir")).unwrap();
+  make_link(
+    &tempdir2.path().join("subdir/roland2"),
+    &Path::new("./roland1"),
+  );
+  let snapshot_with_symlink =
+    Snapshot::from_path_stats(digester2, expand_all_sorted(posix_fs2).await)
+      .await
+      .unwrap();
+
+  let merged_digest = store
+    .merge(vec![
+      snapshot_with_real_file.clone().into(),
+      snapshot_with_symlink.clone().into(),
+    ])
+    .await
+    .unwrap();
+
+  let subset_params = make_subset_params(&["subdir/roland2"]);
+  let subset_symlink = store
+    .clone()
+    .subset(merged_digest.clone(), subset_params)
+    .await
+    .unwrap();
+  // NB: The digest subset should still be the symlink.
+  assert_eq!(subset_symlink, snapshot_with_symlink.into());
 }
 
 #[tokio::test]

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -554,7 +554,7 @@ pub async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
   .parse()
   .unwrap();
   let mut v = posix_fs
-    .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
+    .expand_globs(path_globs, SymlinkBehavior::Aware, None)
     .await
     .unwrap();
   v.sort_by(|a, b| a.path().cmp(b.path()));

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -27,7 +27,7 @@
 
 use bytes::Bytes;
 use std::io::Write;
-use std::os::unix::fs::{symlink, PermissionsExt};
+use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use fs::RelativePath;
@@ -58,10 +58,6 @@ pub fn make_file(path: &Path, contents: &[u8], mode: u32) {
   let mut permissions = std::fs::metadata(path).unwrap().permissions();
   permissions.set_mode(mode);
   file.set_permissions(permissions).unwrap();
-}
-
-pub fn make_link(path: &Path, target: &Path) {
-  symlink(target, path).unwrap();
 }
 
 pub fn append_to_existing_file(path: &Path, contents: &[u8]) {

--- a/src/rust/engine/testutil/src/lib.rs
+++ b/src/rust/engine/testutil/src/lib.rs
@@ -27,7 +27,7 @@
 
 use bytes::Bytes;
 use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::path::Path;
 
 use fs::RelativePath;
@@ -58,6 +58,10 @@ pub fn make_file(path: &Path, contents: &[u8], mode: u32) {
   let mut permissions = std::fs::metadata(path).unwrap().permissions();
   permissions.set_mode(mode);
   file.set_permissions(permissions).unwrap();
+}
+
+pub fn make_link(path: &Path, target: &Path) {
+  symlink(target, path).unwrap();
 }
 
 pub fn append_to_existing_file(path: &Path, contents: &[u8]) {


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/18956

Added a new test. Fails before, passes after!