### PR TITLE
DRY Lambda/GCF FaaS targets

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -35,7 +35,6 @@ from pants.core.goals.package import (
 )
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.environments import EnvironmentField
-from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -62,15 +61,6 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
     complete_platforms: PythonFaaSCompletePlatforms
     output_path: OutputPathField
     environment: EnvironmentField
-
-
-@rule
-async def digest_complete_platforms(
-    complete_platforms: PythonFaaSCompletePlatforms,
-) -> CompletePlatforms:
-    return await Get(
-        CompletePlatforms, UnparsedAddressInputs, complete_platforms.to_unparsed_address_inputs()
-    )
 
 
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -7,46 +7,18 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.awslambda.python.target_types import (
+    PythonAWSLambda,
     PythonAwsLambdaHandlerField,
     PythonAwsLambdaIncludeRequirements,
     PythonAwsLambdaRuntime,
 )
-from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.util_rules import pex_from_targets
-from pants.backend.python.util_rules.faas import (
-    PythonFaaSCompletePlatforms,
-    ResolvedPythonFaaSHandler,
-    ResolvePythonFaaSHandlerRequest,
-)
-from pants.backend.python.util_rules.pex import (
-    CompletePlatforms,
-    Pex,
-    PexPlatforms,
-    PexRequest,
-    VenvPex,
-    VenvPexProcess,
-)
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.core.goals.package import (
-    BuiltPackage,
-    BuiltPackageArtifact,
-    OutputPathField,
-    PackageFieldSet,
-)
-from pants.core.target_types import FileSourceField
+from pants.backend.python.util_rules.faas import BuildLambdexRequest, PythonFaaSCompletePlatforms
+from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.core.util_rules.environments import EnvironmentField
-from pants.engine.platform import Platform
-from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-    targets_with_sources_types,
-)
-from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.docutil import bin_name, doc_url
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -66,125 +38,24 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)
 async def package_python_awslambda(
     field_set: PythonAwsLambdaFieldSet,
-    lambdex: Lambdex,
-    platform: Platform,
-    union_membership: UnionMembership,
 ) -> BuiltPackage:
-    if platform.is_macos:
-        logger.warning(
-            softwrap(
-                f"""
-                AWS Lambdas built on macOS may fail to build. If your lambda uses any third-party
-                dependencies without binary wheels (bdist) for Linux available, it will fail to
-                build. If this happens, you will either need to update your dependencies to only use
-                dependencies with pre-built wheels, or find a Linux environment to run {bin_name()}
-                package. (See https://realpython.com/python-wheels/ for more about wheels.)
-
-                (If the build does not raise an exception, it's safe to use macOS.)
-                """
-            )
-        )
-
-    # Lambdas typically use the .zip suffix.
-    output_filename = field_set.output_path.value_or_default(file_ending="zip")
-
-    # We hardcode the platform value to the appropriate one for each AWS Lambda runtime.
-    # (Running the "hello world" lambda in the example code will report the platform, and can be
-    # used to verify correctness of these platform strings.)
-    pex_platforms = []
-    interpreter_version = field_set.runtime.to_interpreter_version()
-    if interpreter_version:
-        py_major, py_minor = interpreter_version
-        platform_str = f"linux_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
-        # set pymalloc ABI flag - this was removed in python 3.8 https://bugs.python.org/issue36707
-        if py_major <= 3 and py_minor < 8:
-            platform_str += "m"
-        if (py_major, py_minor) == (2, 7):
-            platform_str += "u"
-        pex_platforms.append(platform_str)
-
-    additional_pex_args = (
-        # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
-        "--manylinux=manylinux2014",
-        # When we're executing Pex on Linux, allow a local interpreter to be resolved if
-        # available and matching the AMI platform.
-        "--resolve-local-platforms",
-    )
-
-    complete_platforms = await Get(
-        CompletePlatforms, PythonFaaSCompletePlatforms, field_set.complete_platforms
-    )
-
-    pex_filename = f"{output_filename}.pex"
-    pex_request = PexFromTargetsRequest(
-        addresses=[field_set.address],
-        internal_only=False,
-        include_requirements=field_set.include_requirements.value,
-        output_filename=pex_filename,
-        platforms=PexPlatforms(pex_platforms),
-        complete_platforms=complete_platforms,
-        additional_args=additional_pex_args,
-        additional_lockfile_args=additional_pex_args,
-    )
-
-    lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
-        Get(VenvPex, PexRequest, lambdex.to_pex_request()),
-        Get(Pex, PexFromTargetsRequest, pex_request),
-        Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(field_set.handler)),
-        Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
-    )
-
-    # Warn if users depend on `files` targets, which won't be included in the PEX and is a common
-    # gotcha.
-    file_tgts = targets_with_sources_types(
-        [FileSourceField], transitive_targets.dependencies, union_membership
-    )
-    if file_tgts:
-        files_addresses = sorted(tgt.address.spec for tgt in file_tgts)
-        logger.warning(
-            softwrap(
-                f"""
-                The `python_awslambda` target {field_set.address} transitively depends on the below
-                `files` targets, but Pants will not include them in the built Lambda. Filesystem APIs
-                like `open()` are not able to load files within the binary itself; instead, they
-                read from the current working directory.
-
-                Instead, use `resources` targets. See {doc_url('resources')}.
-
-                Files targets dependencies: {files_addresses}
-                """
-            )
-        )
-
-    # NB: Lambdex can modify its input pex in-place, but the REAPI doesn't support that,
-    #  so we provide it with an explicit `-o` option to write to a new file.
-    result = await Get(
-        ProcessResult,
-        VenvPexProcess(
-            lambdex_pex,
-            argv=("build", "-e", handler.val, "-o", output_filename, pex_filename),
-            input_digest=pex_result.digest,
-            output_files=(output_filename,),
-            description=f"Setting up handler in {output_filename}",
+    return await Get(
+        BuiltPackage,
+        BuildLambdexRequest(
+            address=field_set.address,
+            target_name=PythonAWSLambda.alias,
+            complete_platforms=field_set.complete_platforms,
+            runtime=field_set.runtime,
+            handler=field_set.handler,
+            output_path=field_set.output_path,
+            include_requirements=field_set.include_requirements.value,
+            script_handler=None,
+            script_module=None,
+            # The AWS-facing handler function is always lambdex_handler.handler, which is the
+            # wrapper injected by lambdex that manages invocation of the actual handler.
+            handler_log_message="lambdex_handler.handler",
         ),
     )
-
-    extra_log_data: list[tuple[str, str]] = []
-    if field_set.runtime.value:
-        extra_log_data.append(("Runtime", field_set.runtime.value))
-    extra_log_data.extend(("Complete platform", path) for path in complete_platforms)
-    # The AWS-facing handler function is always lambdex_handler.handler, which is the
-    # wrapper injected by lambdex that manages invocation of the actual handler.
-    extra_log_data.append(("Handler", "lambdex_handler.handler"))
-    first_column_width = 4 + max(len(header) for header, _ in extra_log_data)
-
-    artifact = BuiltPackageArtifact(
-        output_filename,
-        extra_log_lines=tuple(
-            f"{header.rjust(first_column_width, ' ')}: {data}" for header, data in extra_log_data
-        ),
-    )
-    return BuiltPackage(digest=result.output_digest, artifacts=(artifact,))
 
 
 def rules():

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -178,7 +178,7 @@ def test_create_hello_world_lambda(
         ".deps/mureq-0.2.0-py3-none-any.whl/mureq/__init__.py" in names
     ), "third-party dep `mureq` must be included"
     if sys.platform == "darwin":
-        assert "AWS Lambdas built on macOS may fail to build." in caplog.text
+        assert "`python_awslambda` targets built on macOS may fail to build." in caplog.text
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
+    PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import OutputPathField
@@ -21,7 +22,6 @@ from pants.engine.target import (
     BoolField,
     InvalidFieldException,
     InvalidTargetException,
-    StringField,
     Target,
 )
 from pants.util.docutil import doc_url
@@ -61,11 +61,9 @@ class PythonAwsLambdaIncludeRequirements(BoolField):
     )
 
 
-class PythonAwsLambdaRuntime(StringField):
+class PythonAwsLambdaRuntime(PythonFaaSRuntimeField):
     PYTHON_RUNTIME_REGEX = r"python(?P<major>\d)\.(?P<minor>\d+)"
 
-    alias = "runtime"
-    default = None
     help = help_text(
         """
         The identifier of the AWS Lambda runtime to target (pythonX.Y).

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -1,87 +1,41 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 import re
 from dataclasses import dataclass
 from typing import Match, Optional, Tuple, cast
 
-from pants.backend.python.dependency_inference.module_mapper import (
-    PythonModuleOwners,
-    PythonModuleOwnersRequest,
-)
-from pants.backend.python.dependency_inference.rules import import_rules
-from pants.backend.python.dependency_inference.subsystem import (
-    AmbiguityResolution,
-    PythonInferSubsystem,
-)
-from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
+from pants.backend.python.util_rules.faas import (
+    PythonFaaSCompletePlatforms,
+    PythonFaaSDependencies,
+    PythonFaaSHandlerField,
+)
+from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import OutputPathField
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
-    AsyncFieldMixin,
     BoolField,
-    Dependencies,
-    DependenciesRequest,
-    ExplicitlyProvidedDependencies,
-    FieldSet,
-    InferDependenciesRequest,
-    InferredDependencies,
     InvalidFieldException,
     InvalidTargetException,
-    SecondaryOwnerMixin,
     StringField,
     Target,
 )
-from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec
-from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
 from pants.util.strutil import help_text, softwrap
 
 
-class PythonAwsLambdaHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
-    alias = "handler"
-    required = True
-    value: str
+class PythonAwsLambdaHandlerField(PythonFaaSHandlerField):
     help = help_text(
-        """
+        f"""
         Entry point to the AWS Lambda handler.
 
-        You can specify a full module like 'path.to.module:handler_func' or use a shorthand to
-        specify a file name, using the same syntax as the `sources` field, e.g.
-        'lambda.py:handler_func'.
-
-        You must use the file name shorthand for file arguments to work with this target.
+        {PythonFaaSHandlerField.help}
         """
     )
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address))
-        if ":" not in value:
-            raise InvalidFieldException(
-                softwrap(
-                    f"""
-                    The `{cls.alias}` field in target at {address} must end in the format
-                    `:my_handler_func`, but was {value}.
-                    """
-                )
-            )
-        return value
-
-    @property
-    def filespec(self) -> Filespec:
-        path, _, func = self.value.partition(":")
-        if not path.endswith(".py"):
-            return {"includes": []}
-        full_glob = os.path.join(self.address.spec_path, path)
-        return {"includes": [full_glob]}
 
 
 @dataclass(frozen=True)
@@ -93,137 +47,6 @@ class ResolvedPythonAwsHandler:
 @dataclass(frozen=True)
 class ResolvePythonAwsHandlerRequest:
     field: PythonAwsLambdaHandlerField
-
-
-@rule(desc="Determining the handler for a `python_awslambda` target")
-async def resolve_python_aws_handler(
-    request: ResolvePythonAwsHandlerRequest,
-) -> ResolvedPythonAwsHandler:
-    handler_val = request.field.value
-    field_alias = request.field.alias
-    address = request.field.address
-    path, _, func = handler_val.partition(":")
-
-    # If it's already a module, simply use that. Otherwise, convert the file name into a module
-    # path.
-    if not path.endswith(".py"):
-        return ResolvedPythonAwsHandler(handler_val, file_name_used=False)
-
-    # Use the engine to validate that the file exists and that it resolves to only one file.
-    full_glob = os.path.join(address.spec_path, path)
-    handler_paths = await Get(
-        Paths,
-        PathGlobs(
-            [full_glob],
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin=f"{address}'s `{field_alias}` field",
-        ),
-    )
-    # We will have already raised if the glob did not match, i.e. if there were no files. But
-    # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
-    if len(handler_paths.files) != 1:
-        raise InvalidFieldException(
-            softwrap(
-                f"""
-                Multiple files matched for the `{field_alias}` {repr(handler_val)} for the target
-                {address}, but only one file expected.
-                Are you using a glob, rather than a file name?
-
-                All matching files: {list(handler_paths.files)}.
-                """
-            )
-        )
-    handler_path = handler_paths.files[0]
-    source_root = await Get(
-        SourceRoot,
-        SourceRootRequest,
-        SourceRootRequest.for_file(handler_path),
-    )
-    stripped_source_path = os.path.relpath(handler_path, source_root.path)
-    module_base, _ = os.path.splitext(stripped_source_path)
-    normalized_path = module_base.replace(os.path.sep, ".")
-    return ResolvedPythonAwsHandler(f"{normalized_path}:{func}", file_name_used=True)
-
-
-class PythonAwsLambdaDependencies(Dependencies):
-    supports_transitive_excludes = True
-
-
-@dataclass(frozen=True)
-class PythonLambdaHandlerDependencyInferenceFieldSet(FieldSet):
-    required_fields = (
-        PythonAwsLambdaDependencies,
-        PythonAwsLambdaHandlerField,
-        PythonResolveField,
-    )
-
-    dependencies: PythonAwsLambdaDependencies
-    handler: PythonAwsLambdaHandlerField
-    resolve: PythonResolveField
-
-
-class InferPythonLambdaHandlerDependency(InferDependenciesRequest):
-    infer_from = PythonLambdaHandlerDependencyInferenceFieldSet
-
-
-@rule(desc="Inferring dependency from the python_awslambda `handler` field")
-async def infer_lambda_handler_dependency(
-    request: InferPythonLambdaHandlerDependency,
-    python_infer_subsystem: PythonInferSubsystem,
-    python_setup: PythonSetup,
-) -> InferredDependencies:
-    if not python_infer_subsystem.entry_points:
-        return InferredDependencies([])
-    explicitly_provided_deps, handler = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
-        Get(
-            ResolvedPythonAwsHandler,
-            ResolvePythonAwsHandlerRequest(request.field_set.handler),
-        ),
-    )
-    module, _, _func = handler.val.partition(":")
-
-    # Only set locality if needed, to avoid unnecessary rule graph memoization misses.
-    # When set, use the source root, which is useful in practice, but incurs fewer memoization
-    # misses than using the full spec_path.
-    locality = None
-    if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
-        source_root = await Get(
-            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
-        )
-        locality = source_root.path
-
-    owners = await Get(
-        PythonModuleOwners,
-        PythonModuleOwnersRequest(
-            module,
-            resolve=request.field_set.resolve.normalized_value(python_setup),
-            locality=locality,
-        ),
-    )
-    address = request.field_set.address
-    explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-        owners.ambiguous,
-        address,
-        # If the handler was specified as a file, like `app.py`, we know the module must
-        # live in the python_awslambda's directory or subdirectory, so the owners must be ancestors.
-        owners_must_be_ancestors=handler.file_name_used,
-        import_reference="module",
-        context=softwrap(
-            f"""
-            The python_awslambda target {address} has the field
-            `handler={repr(request.field_set.handler.value)}`,
-            which maps to the Python module `{module}`"
-            """
-        ),
-    )
-    maybe_disambiguated = explicitly_provided_deps.disambiguated(
-        owners.ambiguous, owners_must_be_ancestors=handler.file_name_used
-    )
-    unambiguous_owners = owners.unambiguous or (
-        (maybe_disambiguated,) if maybe_disambiguated else ()
-    )
-    return InferredDependencies(unambiguous_owners)
 
 
 class PythonAwsLambdaIncludeRequirements(BoolField):
@@ -279,28 +102,16 @@ class PythonAwsLambdaRuntime(StringField):
         return int(mo.group("major")), int(mo.group("minor"))
 
 
-class PythonAwsLambdaCompletePlatforms(PexCompletePlatformsField):
-    help = help_text(
-        f"""
-        {PexCompletePlatformsField.help}
-
-        N.B.: If specifying `complete_platforms` to work around packaging failures encountered when
-        using the `runtime` field, ensure you delete the `runtime` field from your
-        `python_awslambda` target.
-        """
-    )
-
-
 class PythonAWSLambda(Target):
     alias = "python_awslambda"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        PythonAwsLambdaDependencies,
+        PythonFaaSDependencies,
         PythonAwsLambdaHandlerField,
         PythonAwsLambdaIncludeRequirements,
         PythonAwsLambdaRuntime,
-        PythonAwsLambdaCompletePlatforms,
+        PythonFaaSCompletePlatforms,
         PythonResolveField,
         EnvironmentField,
     )
@@ -328,6 +139,5 @@ class PythonAWSLambda(Target):
 def rules():
     return (
         *collect_rules(),
-        *import_rules(),
-        UnionRule(InferDependenciesRequest, InferPythonLambdaHandlerDependency),
+        *faas_rules(),
     )

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -2,28 +2,19 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import re
 from textwrap import dedent
-from typing import List, Optional
 
 import pytest
 
-from pants.backend.awslambda.python.target_types import (
-    InferPythonLambdaHandlerDependency,
-    PythonAWSLambda,
-    PythonAwsLambdaCompletePlatforms,
-    PythonAwsLambdaHandlerField,
-    PythonAwsLambdaRuntime,
-    PythonLambdaHandlerDependencyInferenceFieldSet,
-    ResolvedPythonAwsHandler,
-    ResolvePythonAwsHandlerRequest,
-)
+from pants.backend.awslambda.python.target_types import PythonAWSLambda, PythonAwsLambdaRuntime
 from pants.backend.awslambda.python.target_types import rules as target_type_rules
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.faas import PythonFaaSCompletePlatforms
 from pants.build_graph.address import Address
 from pants.core.target_types import FileTarget
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import InferredDependencies, InvalidFieldException
-from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+from pants.engine.target import InvalidFieldException
+from pants.testutil.rule_runner import RuleRunner
 from pants.util.strutil import softwrap
 
 
@@ -33,8 +24,6 @@ def rule_runner() -> RuleRunner:
         rules=[
             *target_type_rules(),
             *python_target_types_rules(),
-            QueryRule(ResolvedPythonAwsHandler, [ResolvePythonAwsHandlerRequest]),
-            QueryRule(InferredDependencies, [InferPythonLambdaHandlerDependency]),
         ],
         target_types=[
             FileTarget,
@@ -66,180 +55,6 @@ def test_to_interpreter_version(runtime: str, expected_major: int, expected_mino
 def test_runtime_validation(invalid_runtime: str) -> None:
     with pytest.raises(InvalidFieldException):
         PythonAwsLambdaRuntime(invalid_runtime, Address("", target_name="t"))
-
-
-@pytest.mark.parametrize("invalid_handler", ("path.to.lambda", "lambda.py"))
-def test_handler_validation(invalid_handler: str) -> None:
-    with pytest.raises(InvalidFieldException):
-        PythonAwsLambdaHandlerField(invalid_handler, Address("", target_name="t"))
-
-
-@pytest.mark.parametrize(
-    ["handler", "expected"],
-    (("path.to.module:func", []), ("lambda.py:func", ["project/dir/lambda.py"])),
-)
-def test_handler_filespec(handler: str, expected: List[str]) -> None:
-    field = PythonAwsLambdaHandlerField(handler, Address("project/dir"))
-    assert field.filespec == {"includes": expected}
-
-
-def test_resolve_handler(rule_runner: RuleRunner) -> None:
-    def assert_resolved(handler: str, *, expected: str, is_file: bool) -> None:
-        addr = Address("src/python/project")
-        rule_runner.write_files(
-            {"src/python/project/lambda.py": "", "src/python/project/f2.py": ""}
-        )
-        field = PythonAwsLambdaHandlerField(handler, addr)
-        result = rule_runner.request(
-            ResolvedPythonAwsHandler, [ResolvePythonAwsHandlerRequest(field)]
-        )
-        assert result.val == expected
-        assert result.file_name_used == is_file
-
-    assert_resolved("path.to.lambda:func", expected="path.to.lambda:func", is_file=False)
-    assert_resolved("lambda.py:func", expected="project.lambda:func", is_file=True)
-
-    with engine_error(contains="Unmatched glob"):
-        assert_resolved("doesnt_exist.py:func", expected="doesnt matter", is_file=True)
-    # Resolving >1 file is an error.
-    with engine_error(InvalidFieldException):
-        assert_resolved("*.py:func", expected="doesnt matter", is_file=True)
-
-
-def test_infer_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                python_requirement(
-                    name='ansicolors',
-                    requirements=['ansicolors'],
-                    modules=['colors'],
-                )
-                """
-            ),
-            "project/app.py": "",
-            "project/ambiguous.py": "",
-            "project/ambiguous_in_another_root.py": "",
-            "project/BUILD": dedent(
-                """\
-                python_sources(sources=['app.py'])
-                python_awslambda(name='first_party', handler='project.app:func', runtime='python3.7')
-                python_awslambda(name='first_party_shorthand', handler='app.py:func', runtime='python3.7')
-                python_awslambda(name='third_party', handler='colors:func', runtime='python3.7')
-                python_awslambda(name='unrecognized', handler='who_knows.module:func', runtime='python3.7')
-
-                python_sources(name="dep1", sources=["ambiguous.py"])
-                python_sources(name="dep2", sources=["ambiguous.py"])
-                python_awslambda(
-                    name="ambiguous",
-                    handler='ambiguous.py:func',
-                    runtime='python3.7',
-                )
-                python_awslambda(
-                    name="disambiguated",
-                    handler='ambiguous.py:func',
-                    runtime='python3.7',
-                    dependencies=["!./ambiguous.py:dep2"],
-                )
-
-                python_sources(
-                    name="ambiguous_in_another_root", sources=["ambiguous_in_another_root.py"]
-                )
-                python_awslambda(
-                    name="another_root__file_used",
-                    handler="ambiguous_in_another_root.py:func",
-                    runtime="python3.7",
-                )
-                python_awslambda(
-                    name="another_root__module_used",
-                    handler="project.ambiguous_in_another_root:func",
-                    runtime="python3.7",
-                )
-                """
-            ),
-            "src/py/project/ambiguous_in_another_root.py": "",
-            "src/py/project/BUILD.py": "python_sources()",
-        }
-    )
-
-    def assert_inferred(address: Address, *, expected: Optional[Address]) -> None:
-        tgt = rule_runner.get_target(address)
-        inferred = rule_runner.request(
-            InferredDependencies,
-            [
-                InferPythonLambdaHandlerDependency(
-                    PythonLambdaHandlerDependencyInferenceFieldSet.create(tgt)
-                )
-            ],
-        )
-        assert inferred == InferredDependencies([expected] if expected else [])
-
-    assert_inferred(
-        Address("project", target_name="first_party"),
-        expected=Address("project", relative_file_path="app.py"),
-    )
-    assert_inferred(
-        Address("project", target_name="first_party_shorthand"),
-        expected=Address("project", relative_file_path="app.py"),
-    )
-    assert_inferred(
-        Address("project", target_name="third_party"),
-        expected=Address("", target_name="ansicolors"),
-    )
-    assert_inferred(Address("project", target_name="unrecognized"), expected=None)
-
-    # Warn if there's ambiguity, meaning we cannot infer.
-    caplog.clear()
-    assert_inferred(Address("project", target_name="ambiguous"), expected=None)
-    assert len(caplog.records) == 1
-    assert (
-        softwrap(
-            """
-            project:ambiguous has the field `handler='ambiguous.py:func'`, which maps to the Python
-            module `project.ambiguous`
-            """
-        )
-        in caplog.text
-    )
-    assert "['project/ambiguous.py:dep1', 'project/ambiguous.py:dep2']" in caplog.text
-
-    # Test that ignores can disambiguate an otherwise ambiguous handler. Ensure we don't log a
-    # warning about ambiguity.
-    caplog.clear()
-    assert_inferred(
-        Address("project", target_name="disambiguated"),
-        expected=Address("project", target_name="dep1", relative_file_path="ambiguous.py"),
-    )
-    assert not caplog.records
-
-    # Test that using a file path results in ignoring all targets which are not an ancestor. We can
-    # do this because we know the file name must be in the current directory or subdir of the
-    # `python_awslambda`.
-    assert_inferred(
-        Address("project", target_name="another_root__file_used"),
-        expected=Address(
-            "project",
-            target_name="ambiguous_in_another_root",
-            relative_file_path="ambiguous_in_another_root.py",
-        ),
-    )
-    caplog.clear()
-    assert_inferred(Address("project", target_name="another_root__module_used"), expected=None)
-    assert len(caplog.records) == 1
-    assert (
-        softwrap(
-            """
-            ['project/ambiguous_in_another_root.py:ambiguous_in_another_root',
-            'src/py/project/ambiguous_in_another_root.py']
-            """
-        )
-        in caplog.text
-    )
-
-    # Test that we can turn off the inference.
-    rule_runner.set_options(["--no-python-infer-entry-points"])
-    assert_inferred(Address("project", target_name="first_party"), expected=None)
 
 
 def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
@@ -277,17 +92,17 @@ def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
 
     runtime = rule_runner.get_target(Address("project", target_name="runtime"))
     assert "python3.7" == runtime[PythonAwsLambdaRuntime].value
-    assert runtime[PythonAwsLambdaCompletePlatforms].value is None
+    assert runtime[PythonFaaSCompletePlatforms].value is None
 
     complete_platforms = rule_runner.get_target(
         Address("project", target_name="complete_platforms")
     )
     assert complete_platforms[PythonAwsLambdaRuntime].value is None
-    assert (":python37",) == complete_platforms[PythonAwsLambdaCompletePlatforms].value
+    assert (":python37",) == complete_platforms[PythonFaaSCompletePlatforms].value
 
     both = rule_runner.get_target(Address("project", target_name="both"))
     assert "python3.7" == both[PythonAwsLambdaRuntime].value
-    assert (":python37",) == both[PythonAwsLambdaCompletePlatforms].value
+    assert (":python37",) == both[PythonFaaSCompletePlatforms].value
 
     with pytest.raises(
         ExecutionError,

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -7,44 +7,17 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.google_cloud_function.python.target_types import (
+    PythonGoogleCloudFunction,
     PythonGoogleCloudFunctionHandlerField,
     PythonGoogleCloudFunctionRuntime,
     PythonGoogleCloudFunctionType,
 )
-from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.util_rules import pex_from_targets
-from pants.backend.python.util_rules.faas import (
-    PythonFaaSCompletePlatforms,
-    ResolvedPythonFaaSHandler,
-    ResolvePythonFaaSHandlerRequest,
-)
-from pants.backend.python.util_rules.pex import (
-    CompletePlatforms,
-    Pex,
-    PexPlatforms,
-    PexRequest,
-    VenvPex,
-    VenvPexProcess,
-)
-from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
-from pants.core.goals.package import (
-    BuiltPackage,
-    BuiltPackageArtifact,
-    OutputPathField,
-    PackageFieldSet,
-)
-from pants.core.target_types import FileSourceField
+from pants.backend.python.util_rules.faas import BuildLambdexRequest, PythonFaaSCompletePlatforms
+from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.core.util_rules.environments import EnvironmentField
-from pants.engine.platform import Platform
-from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.engine.target import (
-    TransitiveTargets,
-    TransitiveTargetsRequest,
-    targets_with_sources_types,
-)
-from pants.engine.unions import UnionMembership, UnionRule
-from pants.util.docutil import bin_name, doc_url
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -65,118 +38,30 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
 @rule(desc="Create Python Google Cloud Function", level=LogLevel.DEBUG)
 async def package_python_google_cloud_function(
     field_set: PythonGoogleCloudFunctionFieldSet,
-    lambdex: Lambdex,
-    platform: Platform,
-    union_membership: UnionMembership,
 ) -> BuiltPackage:
-    if platform.is_macos:
-        logger.warning(
-            "Google Cloud Functions built on macOS may fail to build. If your function uses any"
-            " third-party dependencies without binary wheels (bdist) for Linux available, it will"
-            " fail to build. If this happens, you will either need to update your dependencies to"
-            " only use dependencies with pre-built wheels, or find a Linux environment to run"
-            f" {bin_name()} package. (See https://realpython.com/python-wheels/ for more about"
-            " wheels.)\n\n(If the build does not raise an exception, it's safe to use macOS.)"
-        )
-
-    output_filename = field_set.output_path.value_or_default(
-        # Cloud Functions typically use the .zip suffix, so we use that instead of .pex.
-        file_ending="zip",
-    )
-
-    # We hardcode the platform value to the appropriate one for each Google Cloud Function runtime.
-    # (Running the "hello world" cloud function in the example code will report the platform, and can be
-    # used to verify correctness of these platform strings.)
-    pex_platforms = []
-    interpreter_version = field_set.runtime.to_interpreter_version()
-    if interpreter_version:
-        py_major, py_minor = interpreter_version
-        platform_str = f"linux_x86_64-cp-{py_major}{py_minor}-cp{py_major}{py_minor}"
-        # set pymalloc ABI flag - this was removed in python 3.8 https://bugs.python.org/issue36707
-        if py_major <= 3 and py_minor < 8:
-            platform_str += "m"
-        pex_platforms.append(platform_str)
-
-    additional_pex_args = (
-        # Ensure we can resolve manylinux wheels in addition to any AMI-specific wheels.
-        "--manylinux=manylinux2014",
-        # When we're executing Pex on Linux, allow a local interpreter to be resolved if
-        # available and matching the AMI platform.
-        "--resolve-local-platforms",
-    )
-
-    complete_platforms = await Get(
-        CompletePlatforms, PythonFaaSCompletePlatforms, field_set.complete_platforms
-    )
-
-    pex_request = PexFromTargetsRequest(
-        addresses=[field_set.address],
-        internal_only=False,
-        output_filename=output_filename,
-        platforms=PexPlatforms(pex_platforms),
-        complete_platforms=complete_platforms,
-        additional_args=additional_pex_args,
-        additional_lockfile_args=additional_pex_args,
-    )
-    lambdex_request = lambdex.to_pex_request()
-
-    lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
-        Get(VenvPex, PexRequest, lambdex_request),
-        Get(Pex, PexFromTargetsRequest, pex_request),
-        Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(field_set.handler)),
-        Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
-    )
-
-    # Warn if users depend on `files` targets, which won't be included in the PEX and is a common
-    # gotcha.
-    file_tgts = targets_with_sources_types(
-        [FileSourceField], transitive_targets.dependencies, union_membership
-    )
-    if file_tgts:
-        files_addresses = sorted(tgt.address.spec for tgt in file_tgts)
-        logger.warning(
-            f"The `python_google_cloud_function` target {field_set.address} transitively depends "
-            "on the below `files` targets, but Pants will not include them in the built Cloud "
-            "Function. Filesystem APIs like `open()` are not able to load files within the binary "
-            "itself; instead, they read from the current working directory."
-            f"\n\nInstead, use `resources` targets. See {doc_url('resources')}."
-            f"\n\nFiles targets dependencies: {files_addresses}"
-        )
-
-    # NB: Lambdex modifies its input pex in-place, so the input file is also the output file.
-    result = await Get(
-        ProcessResult,
-        VenvPexProcess(
-            lambdex_pex,
-            argv=("build", "-M", "main.py", "-H", "handler", "-e", handler.val, output_filename),
-            input_digest=pex_result.digest,
-            output_files=(output_filename,),
-            description=f"Setting up handler in {output_filename}",
+    return await Get(
+        BuiltPackage,
+        BuildLambdexRequest(
+            address=field_set.address,
+            target_name=PythonGoogleCloudFunction.alias,
+            complete_platforms=field_set.complete_platforms,
+            runtime=field_set.runtime,
+            handler=field_set.handler,
+            output_path=field_set.output_path,
+            include_requirements=True,
+            # The GCP-facing handler function is always `main.handler` (We pass `-M main.py -H handler` to
+            # Lambdex to ensure this), which is the wrapper injected by Lambdex that manages invocation of
+            # the actual user-supplied handler function. This arrangement works well since GCF assumes the
+            # handler function is housed in `main.py` in the root of the zip (you can re-direct this by
+            # setting a `GOOGLE_FUNCTION_SOURCE` Google Cloud build environment variable; e.g.:
+            # `gcloud functions deploy {--build-env-vars-file,--set-build-env-vars}`, but it's non-trivial
+            # to do this right or with intended effect) and the handler name you configure GCF with is just
+            # the unqualified function name, which we log here.
+            script_handler="handler",
+            script_module="main.py",
+            handler_log_message="handler",
         ),
     )
-
-    extra_log_data: list[tuple[str, str]] = []
-    if field_set.runtime.value:
-        extra_log_data.append(("Runtime", field_set.runtime.value))
-    extra_log_data.extend(("Complete platform", path) for path in complete_platforms)
-    # The GCP-facing handler function is always `main.handler` (We pass `-M main.py -H handler` to
-    # Lambdex to ensure this), which is the wrapper injected by Lambdex that manages invocation of
-    # the actual user-supplied handler function. This arrangement works well since GCF assumes the
-    # handler function is housed in `main.py` in the root of the zip (you can re-direct this by
-    # setting a `GOOGLE_FUNCTION_SOURCE` Google Cloud build environment variable; e.g.:
-    # `gcloud functions deploy {--build-env-vars-file,--set-build-env-vars}`, but it's non-trivial
-    # to do this right or with intended effect) and the handler name you configure GCF with is just
-    # the unqualified function name, which we log here.
-    extra_log_data.append(("Handler", "handler"))
-
-    first_column_width = 4 + max(len(header) for header, _ in extra_log_data)
-    artifact = BuiltPackageArtifact(
-        output_filename,
-        extra_log_lines=tuple(
-            f"{header.rjust(first_column_width, ' ')}: {data}" for header, data in extra_log_data
-        ),
-    )
-    return BuiltPackage(digest=result.output_digest, artifacts=(artifact,))
 
 
 def rules():

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -7,15 +7,17 @@ import logging
 from dataclasses import dataclass
 
 from pants.backend.google_cloud_function.python.target_types import (
-    PythonGoogleCloudFunctionCompletePlatforms,
     PythonGoogleCloudFunctionHandlerField,
     PythonGoogleCloudFunctionRuntime,
     PythonGoogleCloudFunctionType,
-    ResolvedPythonGoogleHandler,
-    ResolvePythonGoogleHandlerRequest,
 )
 from pants.backend.python.subsystems.lambdex import Lambdex
 from pants.backend.python.util_rules import pex_from_targets
+from pants.backend.python.util_rules.faas import (
+    PythonFaaSCompletePlatforms,
+    ResolvedPythonFaaSHandler,
+    ResolvePythonFaaSHandlerRequest,
+)
 from pants.backend.python.util_rules.pex import (
     CompletePlatforms,
     Pex,
@@ -55,7 +57,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
 
     handler: PythonGoogleCloudFunctionHandlerField
     runtime: PythonGoogleCloudFunctionRuntime
-    complete_platforms: PythonGoogleCloudFunctionCompletePlatforms
+    complete_platforms: PythonFaaSCompletePlatforms
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
     environment: EnvironmentField
@@ -63,7 +65,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
 
 @rule
 async def digest_complete_platforms(
-    complete_platforms: PythonGoogleCloudFunctionCompletePlatforms,
+    complete_platforms: PythonFaaSCompletePlatforms,
 ) -> CompletePlatforms:
     return await Get(
         CompletePlatforms, UnparsedAddressInputs, complete_platforms.to_unparsed_address_inputs()
@@ -114,7 +116,7 @@ async def package_python_google_cloud_function(
     )
 
     complete_platforms = await Get(
-        CompletePlatforms, PythonGoogleCloudFunctionCompletePlatforms, field_set.complete_platforms
+        CompletePlatforms, PythonFaaSCompletePlatforms, field_set.complete_platforms
     )
 
     pex_request = PexFromTargetsRequest(
@@ -131,7 +133,7 @@ async def package_python_google_cloud_function(
     lambdex_pex, pex_result, handler, transitive_targets = await MultiGet(
         Get(VenvPex, PexRequest, lambdex_request),
         Get(Pex, PexFromTargetsRequest, pex_request),
-        Get(ResolvedPythonGoogleHandler, ResolvePythonGoogleHandlerRequest(field_set.handler)),
+        Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(field_set.handler)),
         Get(TransitiveTargets, TransitiveTargetsRequest([field_set.address])),
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -35,7 +35,6 @@ from pants.core.goals.package import (
 )
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.environments import EnvironmentField
-from pants.engine.addresses import UnparsedAddressInputs
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -61,15 +60,6 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
     environment: EnvironmentField
-
-
-@rule
-async def digest_complete_platforms(
-    complete_platforms: PythonFaaSCompletePlatforms,
-) -> CompletePlatforms:
-    return await Get(
-        CompletePlatforms, UnparsedAddressInputs, complete_platforms.to_unparsed_address_inputs()
-    )
 
 
 @rule(desc="Create Python Google Cloud Function", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -175,7 +175,10 @@ def test_create_hello_world_lambda(
     assert "main.py" in names
     assert "foo/bar/hello_world.py" in names
     if sys.platform == "darwin":
-        assert "Google Cloud Functions built on macOS may fail to build." in caplog.text
+        assert (
+            "`python_google_cloud_function` targets built on macOS may fail to build."
+            in caplog.text
+        )
 
 
 def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -1,218 +1,40 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import os.path
 import re
-from dataclasses import dataclass
 from enum import Enum
 from typing import Match, Optional, Tuple, cast
 
-from pants.backend.python.dependency_inference.module_mapper import (
-    PythonModuleOwners,
-    PythonModuleOwnersRequest,
-)
-from pants.backend.python.dependency_inference.rules import import_rules
-from pants.backend.python.dependency_inference.subsystem import (
-    AmbiguityResolution,
-    PythonInferSubsystem,
-)
-from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
+from pants.backend.python.util_rules.faas import (
+    PythonFaaSCompletePlatforms,
+    PythonFaaSDependencies,
+    PythonFaaSHandlerField,
+)
+from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import OutputPathField
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
-    AsyncFieldMixin,
-    Dependencies,
-    DependenciesRequest,
-    ExplicitlyProvidedDependencies,
-    FieldSet,
-    InferDependenciesRequest,
-    InferredDependencies,
     InvalidFieldException,
     InvalidTargetException,
-    SecondaryOwnerMixin,
     StringField,
     Target,
 )
-from pants.engine.unions import UnionRule
-from pants.source.filespec import Filespec
-from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
 from pants.util.strutil import help_text
 
 
-class PythonGoogleCloudFunctionHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
-    alias = "handler"
-    required = True
-    value: str
+class PythonGoogleCloudFunctionHandlerField(PythonFaaSHandlerField):
     help = help_text(
-        """
+        f"""
         Entry point to the Google Cloud Function handler.
 
-        You can specify a full module like 'path.to.module:handler_func' or use a shorthand to
-        specify a file name, using the same syntax as the `sources` field, e.g.
-        'cloud_function.py:handler_func'.
-
-        You must use the file name shorthand for file arguments to work with this target.
+        {PythonFaaSHandlerField.help}
         """
     )
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
-        value = cast(str, super().compute_value(raw_value, address))
-        if ":" not in value:
-            raise InvalidFieldException(
-                f"The `{cls.alias}` field in target at {address} must end in the "
-                f"format `:my_handler_func`, but was {value}."
-            )
-        return value
-
-    @property
-    def filespec(self) -> Filespec:
-        path, _, func = self.value.partition(":")
-        if not path.endswith(".py"):
-            return {"includes": []}
-        full_glob = os.path.join(self.address.spec_path, path)
-        return {"includes": [full_glob]}
-
-
-@dataclass(frozen=True)
-class ResolvedPythonGoogleHandler:
-    val: str
-    file_name_used: bool
-
-
-@dataclass(frozen=True)
-class ResolvePythonGoogleHandlerRequest:
-    field: PythonGoogleCloudFunctionHandlerField
-
-
-@rule(desc="Determining the handler for a `python_google_cloud_function` target")
-async def resolve_python_google_cloud_function_handler(
-    request: ResolvePythonGoogleHandlerRequest,
-) -> ResolvedPythonGoogleHandler:
-    handler_val = request.field.value
-    field_alias = request.field.alias
-    address = request.field.address
-    path, _, func = handler_val.partition(":")
-
-    # If it's already a module, simply use that. Otherwise, convert the file name into a module
-    # path.
-    if not path.endswith(".py"):
-        return ResolvedPythonGoogleHandler(handler_val, file_name_used=False)
-
-    # Use the engine to validate that the file exists and that it resolves to only one file.
-    full_glob = os.path.join(address.spec_path, path)
-    handler_paths = await Get(
-        Paths,
-        PathGlobs(
-            [full_glob],
-            glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin=f"{address}'s `{field_alias}` field",
-        ),
-    )
-    # We will have already raised if the glob did not match, i.e. if there were no files. But
-    # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
-    if len(handler_paths.files) != 1:
-        raise InvalidFieldException(
-            f"Multiple files matched for the `{field_alias}` {repr(handler_val)} for the target "
-            f"{address}, but only one file expected. Are you using a glob, rather than a file "
-            f"name?\n\nAll matching files: {list(handler_paths.files)}."
-        )
-    handler_path = handler_paths.files[0]
-    source_root = await Get(
-        SourceRoot,
-        SourceRootRequest,
-        SourceRootRequest.for_file(handler_path),
-    )
-    stripped_source_path = os.path.relpath(handler_path, source_root.path)
-    module_base, _ = os.path.splitext(stripped_source_path)
-    normalized_path = module_base.replace(os.path.sep, ".")
-    return ResolvedPythonGoogleHandler(f"{normalized_path}:{func}", file_name_used=True)
-
-
-class PythonGoogleCloudFunctionDependencies(Dependencies):
-    supports_transitive_excludes = True
-
-
-@dataclass(frozen=True)
-class PythonCloudFunctionHandlerInferenceFieldSet(FieldSet):
-    required_fields = (
-        PythonGoogleCloudFunctionDependencies,
-        PythonGoogleCloudFunctionHandlerField,
-        PythonResolveField,
-    )
-
-    dependencies: PythonGoogleCloudFunctionDependencies
-    handler: PythonGoogleCloudFunctionHandlerField
-    resolve: PythonResolveField
-
-
-class InferPythonCloudFunctionHandlerDependency(InferDependenciesRequest):
-    infer_from = PythonCloudFunctionHandlerInferenceFieldSet
-
-
-@rule(desc="Inferring dependency from the python_google_cloud_function `handler` field")
-async def infer_cloud_function_handler_dependency(
-    request: InferPythonCloudFunctionHandlerDependency,
-    python_infer_subsystem: PythonInferSubsystem,
-    python_setup: PythonSetup,
-) -> InferredDependencies:
-    if not python_infer_subsystem.entry_points:
-        return InferredDependencies([])
-
-    explicitly_provided_deps, handler = await MultiGet(
-        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
-        Get(
-            ResolvedPythonGoogleHandler,
-            ResolvePythonGoogleHandlerRequest(request.field_set.handler),
-        ),
-    )
-    module, _, _func = handler.val.partition(":")
-
-    # Only set locality if needed, to avoid unnecessary rule graph memoization misses.
-    # When set, use the source root, which is useful in practice, but incurs fewer memoization
-    # misses than using the full spec_path.
-    locality = None
-    if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
-        source_root = await Get(
-            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
-        )
-        locality = source_root.path
-
-    owners = await Get(
-        PythonModuleOwners,
-        PythonModuleOwnersRequest(
-            module,
-            resolve=request.field_set.resolve.normalized_value(python_setup),
-            locality=locality,
-        ),
-    )
-    address = request.field_set.address
-    explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-        owners.ambiguous,
-        address,
-        # If the handler was specified as a file, like `app.py`, we know the module must
-        # live in the python_google_cloud_function's directory or subdirectory, so the owners must be ancestors.
-        owners_must_be_ancestors=handler.file_name_used,
-        import_reference="module",
-        context=(
-            f"The python_google_cloud_function target {address} has the field "
-            f"`handler={repr(request.field_set.handler.value)}`, which maps "
-            f"to the Python module `{module}`"
-        ),
-    )
-    maybe_disambiguated = explicitly_provided_deps.disambiguated(
-        owners.ambiguous, owners_must_be_ancestors=handler.file_name_used
-    )
-    unambiguous_owners = owners.unambiguous or (
-        (maybe_disambiguated,) if maybe_disambiguated else ()
-    )
-    return InferredDependencies(unambiguous_owners)
 
 
 class PythonGoogleCloudFunctionRuntimes(Enum):
@@ -261,18 +83,6 @@ class PythonGoogleCloudFunctionRuntime(StringField):
         return int(mo.group("major")), int(mo.group("minor"))
 
 
-class PythonGoogleCloudFunctionCompletePlatforms(PexCompletePlatformsField):
-    help = help_text(
-        f"""
-        {PexCompletePlatformsField.help}
-
-        N.B.: If specifying `complete_platforms` to work around packaging failures encountered when
-        using the `runtime` field, ensure you delete the `runtime` field from your
-        `python_google_cloud_function` target.
-        """
-    )
-
-
 class GoogleCloudFunctionTypes(Enum):
     EVENT = "event"
     HTTP = "http"
@@ -296,10 +106,10 @@ class PythonGoogleCloudFunction(Target):
     core_fields = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        PythonGoogleCloudFunctionDependencies,
+        PythonFaaSDependencies,
         PythonGoogleCloudFunctionHandlerField,
         PythonGoogleCloudFunctionRuntime,
-        PythonGoogleCloudFunctionCompletePlatforms,
+        PythonFaaSCompletePlatforms,
         PythonGoogleCloudFunctionType,
         PythonResolveField,
         EnvironmentField,
@@ -327,6 +137,5 @@ class PythonGoogleCloudFunction(Target):
 def rules():
     return (
         *collect_rules(),
-        *import_rules(),
-        UnionRule(InferDependenciesRequest, InferPythonCloudFunctionHandlerDependency),
+        *faas_rules(),
     )

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
+    PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import OutputPathField
@@ -45,11 +46,9 @@ class PythonGoogleCloudFunctionRuntimes(Enum):
     PYTHON_311 = "python311"
 
 
-class PythonGoogleCloudFunctionRuntime(StringField):
+class PythonGoogleCloudFunctionRuntime(PythonFaaSRuntimeField):
     PYTHON_RUNTIME_REGEX = r"^python(?P<major>\d)(?P<minor>\d+)$"
 
-    alias = "runtime"
-    default = None
     valid_choices = PythonGoogleCloudFunctionRuntimes
     help = help_text(
         """

--- a/src/python/pants/backend/google_cloud_function/python/target_types_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types_test.py
@@ -2,28 +2,22 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import re
 from textwrap import dedent
-from typing import List, Optional
 
 import pytest
 
 from pants.backend.google_cloud_function.python.target_types import (
-    InferPythonCloudFunctionHandlerDependency,
-    PythonCloudFunctionHandlerInferenceFieldSet,
     PythonGoogleCloudFunction,
-    PythonGoogleCloudFunctionCompletePlatforms,
-    PythonGoogleCloudFunctionHandlerField,
     PythonGoogleCloudFunctionRuntime,
-    ResolvedPythonGoogleHandler,
-    ResolvePythonGoogleHandlerRequest,
 )
 from pants.backend.google_cloud_function.python.target_types import rules as target_type_rules
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.faas import PythonFaaSCompletePlatforms
 from pants.build_graph.address import Address
 from pants.core.target_types import FileTarget
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.target import InferredDependencies, InvalidFieldException
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.target import InvalidFieldException
+from pants.testutil.rule_runner import RuleRunner
 
 
 @pytest.fixture
@@ -32,8 +26,6 @@ def rule_runner() -> RuleRunner:
         rules=[
             *target_type_rules(),
             *python_target_types_rules(),
-            QueryRule(ResolvedPythonGoogleHandler, [ResolvePythonGoogleHandlerRequest]),
-            QueryRule(InferredDependencies, [InferPythonCloudFunctionHandlerDependency]),
         ],
         target_types=[
             FileTarget,
@@ -66,196 +58,6 @@ def test_to_interpreter_version(runtime: str, expected_major: int, expected_mino
 def test_runtime_validation(invalid_runtime: str) -> None:
     with pytest.raises(InvalidFieldException):
         PythonGoogleCloudFunctionRuntime(invalid_runtime, Address("", target_name="t"))
-
-
-@pytest.mark.parametrize("invalid_handler", ("path.to.function", "function.py"))
-def test_handler_validation(invalid_handler: str) -> None:
-    with pytest.raises(InvalidFieldException):
-        PythonGoogleCloudFunctionHandlerField(invalid_handler, Address("", target_name="t"))
-
-
-@pytest.mark.parametrize(
-    ["handler", "expected"],
-    (("path.to.module:func", []), ("cloud_function.py:func", ["project/dir/cloud_function.py"])),
-)
-def test_handler_filespec(handler: str, expected: List[str]) -> None:
-    field = PythonGoogleCloudFunctionHandlerField(handler, Address("project/dir"))
-    assert field.filespec == {"includes": expected}
-
-
-def test_resolve_handler(rule_runner: RuleRunner) -> None:
-    def assert_resolved(handler: str, *, expected: str, is_file: bool) -> None:
-        addr = Address("src/python/project")
-        rule_runner.write_files(
-            {"src/python/project/cloud_function.py": "", "src/python/project/f2.py": ""}
-        )
-        field = PythonGoogleCloudFunctionHandlerField(handler, addr)
-        result = rule_runner.request(
-            ResolvedPythonGoogleHandler, [ResolvePythonGoogleHandlerRequest(field)]
-        )
-        assert result.val == expected
-        assert result.file_name_used == is_file
-
-    assert_resolved(
-        "path.to.cloud_function:func", expected="path.to.cloud_function:func", is_file=False
-    )
-    assert_resolved("cloud_function.py:func", expected="project.cloud_function:func", is_file=True)
-
-    with pytest.raises(ExecutionError):
-        assert_resolved("doesnt_exist.py:func", expected="doesnt matter", is_file=True)
-    # Resolving >1 file is an error.
-    with pytest.raises(ExecutionError):
-        assert_resolved("*.py:func", expected="doesnt matter", is_file=True)
-
-
-def test_infer_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
-    rule_runner.write_files(
-        {
-            "BUILD": dedent(
-                """\
-                python_requirement(
-                    name='ansicolors',
-                    requirements=['ansicolors'],
-                    modules=['colors'],
-                )
-                """
-            ),
-            "project/app.py": "",
-            "project/ambiguous.py": "",
-            "project/ambiguous_in_another_root.py": "",
-            "project/BUILD": dedent(
-                """\
-                python_sources(sources=['app.py'])
-                python_google_cloud_function(
-                    name='first_party',
-                    handler='project.app:func',
-                    runtime='python37',
-                    type='event',
-                )
-                python_google_cloud_function(
-                    name='first_party_shorthand',
-                    handler='app.py:func',
-                    runtime='python37',
-                    type='event',
-                )
-                python_google_cloud_function(
-                    name='third_party',
-                    handler='colors:func',
-                    runtime='python37',
-                    type='event',
-                )
-                python_google_cloud_function(
-                    name='unrecognized',
-                    handler='who_knows.module:func',
-                    runtime='python37',
-                    type='event',
-                )
-
-                python_sources(name="dep1", sources=["ambiguous.py"])
-                python_sources(name="dep2", sources=["ambiguous.py"])
-                python_google_cloud_function(
-                    name="ambiguous",
-                    handler='ambiguous.py:func',
-                    runtime='python37',
-                    type='event',
-                )
-                python_google_cloud_function(
-                    name="disambiguated",
-                    handler='ambiguous.py:func',
-                    runtime='python37',
-                    type='event',
-                    dependencies=["!./ambiguous.py:dep2"],
-                )
-
-                python_sources(
-                    name="ambiguous_in_another_root", sources=["ambiguous_in_another_root.py"]
-                )
-                python_google_cloud_function(
-                    name="another_root__file_used",
-                    handler="ambiguous_in_another_root.py:func",
-                    runtime="python37",
-                    type="event",
-                )
-                python_google_cloud_function(
-                    name="another_root__module_used",
-                    handler="project.ambiguous_in_another_root:func",
-                    runtime="python37",
-                    type="event",
-                )
-                """
-            ),
-            "src/py/project/ambiguous_in_another_root.py": "",
-            "src/py/project/BUILD.py": "python_sources()",
-        }
-    )
-
-    def assert_inferred(address: Address, *, expected: Optional[Address]) -> None:
-        tgt = rule_runner.get_target(address)
-        inferred = rule_runner.request(
-            InferredDependencies,
-            [
-                InferPythonCloudFunctionHandlerDependency(
-                    PythonCloudFunctionHandlerInferenceFieldSet.create(tgt)
-                )
-            ],
-        )
-        assert inferred == InferredDependencies([expected] if expected else [])
-
-    assert_inferred(
-        Address("project", target_name="first_party"),
-        expected=Address("project", relative_file_path="app.py"),
-    )
-    assert_inferred(
-        Address("project", target_name="first_party_shorthand"),
-        expected=Address("project", relative_file_path="app.py"),
-    )
-    assert_inferred(
-        Address("project", target_name="third_party"),
-        expected=Address("", target_name="ansicolors"),
-    )
-    assert_inferred(Address("project", target_name="unrecognized"), expected=None)
-
-    # Warn if there's ambiguity, meaning we cannot infer.
-    caplog.clear()
-    assert_inferred(Address("project", target_name="ambiguous"), expected=None)
-    assert len(caplog.records) == 1
-    assert (
-        "project:ambiguous has the field `handler='ambiguous.py:func'`, which maps to the Python "
-        "module `project.ambiguous`"
-    ) in caplog.text
-    assert "['project/ambiguous.py:dep1', 'project/ambiguous.py:dep2']" in caplog.text
-
-    # Test that ignores can disambiguate an otherwise ambiguous handler. Ensure we don't log a
-    # warning about ambiguity.
-    caplog.clear()
-    assert_inferred(
-        Address("project", target_name="disambiguated"),
-        expected=Address("project", target_name="dep1", relative_file_path="ambiguous.py"),
-    )
-    assert not caplog.records
-
-    # Test that using a file path results in ignoring all targets which are not an ancestor. We can
-    # do this because we know the file name must be in the current directory or subdir of the
-    # `python_google_cloud_function`.
-    assert_inferred(
-        Address("project", target_name="another_root__file_used"),
-        expected=Address(
-            "project",
-            target_name="ambiguous_in_another_root",
-            relative_file_path="ambiguous_in_another_root.py",
-        ),
-    )
-    caplog.clear()
-    assert_inferred(Address("project", target_name="another_root__module_used"), expected=None)
-    assert len(caplog.records) == 1
-    assert (
-        "['project/ambiguous_in_another_root.py:ambiguous_in_another_root', 'src/py/project/"
-        "ambiguous_in_another_root.py']"
-    ) in caplog.text
-
-    # Test that we can turn off the inference.
-    rule_runner.set_options(["--no-python-infer-entry-points"])
-    assert_inferred(Address("project", target_name="first_party"), expected=None)
 
 
 def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
@@ -297,17 +99,17 @@ def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
 
     runtime = rule_runner.get_target(Address("project", target_name="runtime"))
     assert "python37" == runtime[PythonGoogleCloudFunctionRuntime].value
-    assert runtime[PythonGoogleCloudFunctionCompletePlatforms].value is None
+    assert runtime[PythonFaaSCompletePlatforms].value is None
 
     complete_platforms = rule_runner.get_target(
         Address("project", target_name="complete_platforms")
     )
     assert complete_platforms[PythonGoogleCloudFunctionRuntime].value is None
-    assert (":python37",) == complete_platforms[PythonGoogleCloudFunctionCompletePlatforms].value
+    assert (":python37",) == complete_platforms[PythonFaaSCompletePlatforms].value
 
     both = rule_runner.get_target(Address("project", target_name="both"))
     assert "python37" == both[PythonGoogleCloudFunctionRuntime].value
-    assert (":python37",) == both[PythonGoogleCloudFunctionCompletePlatforms].value
+    assert (":python37",) == both[PythonFaaSCompletePlatforms].value
 
     with pytest.raises(
         ExecutionError,

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -17,7 +17,8 @@ from pants.backend.python.dependency_inference.subsystem import (
 )
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
-from pants.engine.addresses import Address
+from pants.backend.python.util_rules.pex import CompletePlatforms
+from pants.engine.addresses import Address, UnparsedAddressInputs
 from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -214,6 +215,15 @@ class PythonFaaSCompletePlatforms(PexCompletePlatformsField):
         N.B.: If specifying `complete_platforms` to work around packaging failures encountered when
         using the `runtime` field, ensure you delete the `runtime` field from the target.
         """
+    )
+
+
+@rule
+async def digest_complete_platforms(
+    complete_platforms: PythonFaaSCompletePlatforms,
+) -> CompletePlatforms:
+    return await Get(
+        CompletePlatforms, UnparsedAddressInputs, complete_platforms.to_unparsed_address_inputs()
     )
 
 

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -2,7 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 """Function-as-a-service (FaaS) support like AWS Lambda and Google Cloud Functions."""
 
+from __future__ import annotations
+
 import os.path
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, cast
 
@@ -216,6 +219,15 @@ class PythonFaaSCompletePlatforms(PexCompletePlatformsField):
         using the `runtime` field, ensure you delete the `runtime` field from the target.
         """
     )
+
+
+class PythonFaaSRuntimeField(StringField, ABC):
+    alias = "runtime"
+    default = None
+
+    @abstractmethod
+    def to_interpreter_version(self) -> None | tuple[int, int]:
+        """Returns the Python version implied by the runtime, as (major, minor)."""
 
 
 @rule

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -1,0 +1,225 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Function-as-a-service (FaaS) support like AWS Lambda and Google Cloud Functions."""
+
+import os.path
+from dataclasses import dataclass
+from typing import Optional, cast
+
+from pants.backend.python.dependency_inference.module_mapper import (
+    PythonModuleOwners,
+    PythonModuleOwnersRequest,
+)
+from pants.backend.python.dependency_inference.rules import import_rules
+from pants.backend.python.dependency_inference.subsystem import (
+    AmbiguityResolution,
+    PythonInferSubsystem,
+)
+from pants.backend.python.subsystems.setup import PythonSetup
+from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
+from pants.engine.addresses import Address
+from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
+from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.target import (
+    AsyncFieldMixin,
+    Dependencies,
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    FieldSet,
+    InferDependenciesRequest,
+    InferredDependencies,
+    InvalidFieldException,
+    SecondaryOwnerMixin,
+    StringField,
+)
+from pants.engine.unions import UnionRule
+from pants.source.filespec import Filespec
+from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.strutil import help_text
+
+
+class PythonFaaSHandlerField(StringField, AsyncFieldMixin, SecondaryOwnerMixin):
+    alias = "handler"
+    required = True
+    value: str
+    help = help_text(
+        """
+        You can specify a full module like 'path.to.module:handler_func' or use a shorthand to
+        specify a file name, using the same syntax as the `sources` field, e.g.
+        'cloud_function.py:handler_func'.
+
+        You must use the file name shorthand for file arguments to work with this target.
+        """
+    )
+
+    @classmethod
+    def compute_value(cls, raw_value: Optional[str], address: Address) -> str:
+        value = cast(str, super().compute_value(raw_value, address))
+        if ":" not in value:
+            raise InvalidFieldException(
+                f"The `{cls.alias}` field in target at {address} must end in the "
+                f"format `:my_handler_func`, but was {value}."
+            )
+        return value
+
+    @property
+    def filespec(self) -> Filespec:
+        path, _, func = self.value.partition(":")
+        if not path.endswith(".py"):
+            return {"includes": []}
+        full_glob = os.path.join(self.address.spec_path, path)
+        return {"includes": [full_glob]}
+
+
+@dataclass(frozen=True)
+class ResolvedPythonFaaSHandler:
+    val: str
+    file_name_used: bool
+
+
+@dataclass(frozen=True)
+class ResolvePythonFaaSHandlerRequest:
+    field: PythonFaaSHandlerField
+
+
+@rule(desc="Determining the handler for a python FaaS target")
+async def resolve_python_faas_handler(
+    request: ResolvePythonFaaSHandlerRequest,
+) -> ResolvedPythonFaaSHandler:
+    handler_val = request.field.value
+    field_alias = request.field.alias
+    address = request.field.address
+    path, _, func = handler_val.partition(":")
+
+    # If it's already a module, simply use that. Otherwise, convert the file name into a module
+    # path.
+    if not path.endswith(".py"):
+        return ResolvedPythonFaaSHandler(handler_val, file_name_used=False)
+
+    # Use the engine to validate that the file exists and that it resolves to only one file.
+    full_glob = os.path.join(address.spec_path, path)
+    handler_paths = await Get(
+        Paths,
+        PathGlobs(
+            [full_glob],
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=f"{address}'s `{field_alias}` field",
+        ),
+    )
+    # We will have already raised if the glob did not match, i.e. if there were no files. But
+    # we need to check if they used a file glob (`*` or `**`) that resolved to >1 file.
+    if len(handler_paths.files) != 1:
+        raise InvalidFieldException(
+            f"Multiple files matched for the `{field_alias}` {repr(handler_val)} for the target "
+            f"{address}, but only one file expected. Are you using a glob, rather than a file "
+            f"name?\n\nAll matching files: {list(handler_paths.files)}."
+        )
+    handler_path = handler_paths.files[0]
+    source_root = await Get(
+        SourceRoot,
+        SourceRootRequest,
+        SourceRootRequest.for_file(handler_path),
+    )
+    stripped_source_path = os.path.relpath(handler_path, source_root.path)
+    module_base, _ = os.path.splitext(stripped_source_path)
+    normalized_path = module_base.replace(os.path.sep, ".")
+    return ResolvedPythonFaaSHandler(f"{normalized_path}:{func}", file_name_used=True)
+
+
+class PythonFaaSDependencies(Dependencies):
+    supports_transitive_excludes = True
+
+
+@dataclass(frozen=True)
+class PythonFaaSHandlerInferenceFieldSet(FieldSet):
+    required_fields = (
+        PythonFaaSDependencies,
+        PythonFaaSHandlerField,
+        PythonResolveField,
+    )
+
+    dependencies: PythonFaaSDependencies
+    handler: PythonFaaSHandlerField
+    resolve: PythonResolveField
+
+
+class InferPythonFaaSHandlerDependency(InferDependenciesRequest):
+    infer_from = PythonFaaSHandlerInferenceFieldSet
+
+
+@rule(desc="Inferring dependency from the python FaaS `handler` field")
+async def infer_faas_handler_dependency(
+    request: InferPythonFaaSHandlerDependency,
+    python_infer_subsystem: PythonInferSubsystem,
+    python_setup: PythonSetup,
+) -> InferredDependencies:
+    if not python_infer_subsystem.entry_points:
+        return InferredDependencies([])
+
+    explicitly_provided_deps, handler = await MultiGet(
+        Get(ExplicitlyProvidedDependencies, DependenciesRequest(request.field_set.dependencies)),
+        Get(
+            ResolvedPythonFaaSHandler,
+            ResolvePythonFaaSHandlerRequest(request.field_set.handler),
+        ),
+    )
+    module, _, _func = handler.val.partition(":")
+
+    # Only set locality if needed, to avoid unnecessary rule graph memoization misses.
+    # When set, use the source root, which is useful in practice, but incurs fewer memoization
+    # misses than using the full spec_path.
+    locality = None
+    if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
+        source_root = await Get(
+            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
+        )
+        locality = source_root.path
+
+    owners = await Get(
+        PythonModuleOwners,
+        PythonModuleOwnersRequest(
+            module,
+            resolve=request.field_set.resolve.normalized_value(python_setup),
+            locality=locality,
+        ),
+    )
+    address = request.field_set.address
+    explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+        owners.ambiguous,
+        address,
+        # If the handler was specified as a file, like `app.py`, we know the module must
+        # live in the python_google_cloud_function's directory or subdirectory, so the owners must be ancestors.
+        owners_must_be_ancestors=handler.file_name_used,
+        import_reference="module",
+        context=(
+            f"The target {address} has the field "
+            f"`handler={repr(request.field_set.handler.value)}`, which maps "
+            f"to the Python module `{module}`"
+        ),
+    )
+    maybe_disambiguated = explicitly_provided_deps.disambiguated(
+        owners.ambiguous, owners_must_be_ancestors=handler.file_name_used
+    )
+    unambiguous_owners = owners.unambiguous or (
+        (maybe_disambiguated,) if maybe_disambiguated else ()
+    )
+    return InferredDependencies(unambiguous_owners)
+
+
+class PythonFaaSCompletePlatforms(PexCompletePlatformsField):
+    help = help_text(
+        f"""
+        {PexCompletePlatformsField.help}
+
+        N.B.: If specifying `complete_platforms` to work around packaging failures encountered when
+        using the `runtime` field, ensure you delete the `runtime` field from the target.
+        """
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *import_rules(),
+        UnionRule(InferDependenciesRequest, InferPythonFaaSHandlerDependency),
+    )

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -1,0 +1,216 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from textwrap import dedent
+from typing import List, Optional
+
+import pytest
+
+from pants.backend.awslambda.python.target_types import rules as target_type_rules
+from pants.backend.python.target_types import (
+    PythonRequirementTarget,
+    PythonResolveField,
+    PythonSourcesGeneratorTarget,
+)
+from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.faas import (
+    InferPythonFaaSHandlerDependency,
+    PythonFaaSDependencies,
+    PythonFaaSHandlerField,
+    PythonFaaSHandlerInferenceFieldSet,
+    ResolvedPythonFaaSHandler,
+    ResolvePythonFaaSHandlerRequest,
+)
+from pants.build_graph.address import Address
+from pants.core.target_types import FileTarget
+from pants.engine.target import InferredDependencies, InvalidFieldException, Target
+from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+from pants.util.strutil import softwrap
+
+
+class MockFaaS(Target):
+    alias = "mock_faas"
+    core_fields = (PythonFaaSDependencies, PythonFaaSHandlerField, PythonResolveField)
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *target_type_rules(),
+            *python_target_types_rules(),
+            QueryRule(ResolvedPythonFaaSHandler, [ResolvePythonFaaSHandlerRequest]),
+            QueryRule(InferredDependencies, [InferPythonFaaSHandlerDependency]),
+        ],
+        target_types=[
+            FileTarget,
+            MockFaaS,
+            PythonRequirementTarget,
+            PythonSourcesGeneratorTarget,
+        ],
+    )
+
+
+@pytest.mark.parametrize("invalid_handler", ("path.to.lambda", "lambda.py"))
+def test_handler_validation(invalid_handler: str) -> None:
+    with pytest.raises(InvalidFieldException):
+        PythonFaaSHandlerField(invalid_handler, Address("", target_name="t"))
+
+
+@pytest.mark.parametrize(
+    ["handler", "expected"],
+    (("path.to.module:func", []), ("lambda.py:func", ["project/dir/lambda.py"])),
+)
+def test_handler_filespec(handler: str, expected: List[str]) -> None:
+    field = PythonFaaSHandlerField(handler, Address("project/dir"))
+    assert field.filespec == {"includes": expected}
+
+
+def test_resolve_handler(rule_runner: RuleRunner) -> None:
+    def assert_resolved(handler: str, *, expected: str, is_file: bool) -> None:
+        addr = Address("src/python/project")
+        rule_runner.write_files(
+            {"src/python/project/lambda.py": "", "src/python/project/f2.py": ""}
+        )
+        field = PythonFaaSHandlerField(handler, addr)
+        result = rule_runner.request(
+            ResolvedPythonFaaSHandler, [ResolvePythonFaaSHandlerRequest(field)]
+        )
+        assert result.val == expected
+        assert result.file_name_used == is_file
+
+    assert_resolved("path.to.lambda:func", expected="path.to.lambda:func", is_file=False)
+    assert_resolved("lambda.py:func", expected="project.lambda:func", is_file=True)
+
+    with engine_error(contains="Unmatched glob"):
+        assert_resolved("doesnt_exist.py:func", expected="doesnt matter", is_file=True)
+    # Resolving >1 file is an error.
+    with engine_error(InvalidFieldException):
+        assert_resolved("*.py:func", expected="doesnt matter", is_file=True)
+
+
+def test_infer_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+                python_requirement(
+                    name='ansicolors',
+                    requirements=['ansicolors'],
+                    modules=['colors'],
+                )
+                """
+            ),
+            "project/app.py": "",
+            "project/ambiguous.py": "",
+            "project/ambiguous_in_another_root.py": "",
+            "project/BUILD": dedent(
+                """\
+                python_sources(sources=['app.py'])
+                mock_faas(name='first_party', handler='project.app:func')
+                mock_faas(name='first_party_shorthand', handler='app.py:func')
+                mock_faas(name='third_party', handler='colors:func')
+                mock_faas(name='unrecognized', handler='who_knows.module:func')
+
+                python_sources(name="dep1", sources=["ambiguous.py"])
+                python_sources(name="dep2", sources=["ambiguous.py"])
+                mock_faas(
+                    name="ambiguous",
+                    handler='ambiguous.py:func',
+                )
+                mock_faas(
+                    name="disambiguated",
+                    handler='ambiguous.py:func',
+                    dependencies=["!./ambiguous.py:dep2"],
+                )
+
+                python_sources(
+                    name="ambiguous_in_another_root", sources=["ambiguous_in_another_root.py"]
+                )
+                mock_faas(
+                    name="another_root__file_used",
+                    handler="ambiguous_in_another_root.py:func",
+                )
+                mock_faas(
+                    name="another_root__module_used",
+                    handler="project.ambiguous_in_another_root:func",
+                )
+                """
+            ),
+            "src/py/project/ambiguous_in_another_root.py": "",
+            "src/py/project/BUILD.py": "python_sources()",
+        }
+    )
+
+    def assert_inferred(address: Address, *, expected: Optional[Address]) -> None:
+        tgt = rule_runner.get_target(address)
+        inferred = rule_runner.request(
+            InferredDependencies,
+            [InferPythonFaaSHandlerDependency(PythonFaaSHandlerInferenceFieldSet.create(tgt))],
+        )
+        assert inferred == InferredDependencies([expected] if expected else [])
+
+    assert_inferred(
+        Address("project", target_name="first_party"),
+        expected=Address("project", relative_file_path="app.py"),
+    )
+    assert_inferred(
+        Address("project", target_name="first_party_shorthand"),
+        expected=Address("project", relative_file_path="app.py"),
+    )
+    assert_inferred(
+        Address("project", target_name="third_party"),
+        expected=Address("", target_name="ansicolors"),
+    )
+    assert_inferred(Address("project", target_name="unrecognized"), expected=None)
+
+    # Warn if there's ambiguity, meaning we cannot infer.
+    caplog.clear()
+    assert_inferred(Address("project", target_name="ambiguous"), expected=None)
+    assert len(caplog.records) == 1
+    assert (
+        softwrap(
+            """
+            project:ambiguous has the field `handler='ambiguous.py:func'`, which maps to the Python
+            module `project.ambiguous`
+            """
+        )
+        in caplog.text
+    )
+    assert "['project/ambiguous.py:dep1', 'project/ambiguous.py:dep2']" in caplog.text
+
+    # Test that ignores can disambiguate an otherwise ambiguous handler. Ensure we don't log a
+    # warning about ambiguity.
+    caplog.clear()
+    assert_inferred(
+        Address("project", target_name="disambiguated"),
+        expected=Address("project", target_name="dep1", relative_file_path="ambiguous.py"),
+    )
+    assert not caplog.records
+
+    # Test that using a file path results in ignoring all targets which are not an ancestor. We can
+    # do this because we know the file name must be in the current directory or subdir of the
+    # `python_awslambda`.
+    assert_inferred(
+        Address("project", target_name="another_root__file_used"),
+        expected=Address(
+            "project",
+            target_name="ambiguous_in_another_root",
+            relative_file_path="ambiguous_in_another_root.py",
+        ),
+    )
+    caplog.clear()
+    assert_inferred(Address("project", target_name="another_root__module_used"), expected=None)
+    assert len(caplog.records) == 1
+    assert (
+        softwrap(
+            """
+            ['project/ambiguous_in_another_root.py:ambiguous_in_another_root',
+            'src/py/project/ambiguous_in_another_root.py']
+            """
+        )
+        in caplog.text
+    )
+
+    # Test that we can turn off the inference.
+    rule_runner.set_options(["--no-python-infer-entry-points"])
+    assert_inferred(Address("project", target_name="first_party"), expected=None)


### PR DESCRIPTION
This reduces duplication between the two FaaS packaging backends (https://en.wikipedia.org/wiki/Function_as_a_service, I didn't invent the name 😅 ): AWS Lambdas, and Google Cloud Functions.

These are almost identical, with slight variations like the syntax for specifying the runtime version, whether they support `include_requirements` and how exactly they set up the handler file. Otherwise, they're both basically just "invoke PEX then Lambdex". This PR is basically just a move-and-adjust, with, theoretically, no functionality change, other than tweaks to error messages to avoid having to pass a bunch of different phrasings of user-facing strings around.

This is refactoring in preparation for #18879: using the new PEX functionality to output non-Lambdex based artefacts. It felt better to start from a point of similarity.

The commits are individually reviewable (the first is a little larger than it exactly needed to be, sorry!).