### PR TITLE
Make `DigestSubset` symlink-aware (Cherry-pick of #18963)

### DIFF
--- a/src/rust/engine/fs/store/src/snapshot_ops.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops.rs
@@ -228,7 +228,7 @@ pub trait SnapshotOps: Clone + Send + Sync + 'static {
   ) -> Result<DirectoryDigest, Self::Error> {
     let input_tree = self.load_digest_trie(directory_digest.clone()).await?;
     let path_stats = input_tree
-      .expand_globs(params.globs, SymlinkBehavior::Oblivious, None)
+      .expand_globs(params.globs, SymlinkBehavior::Aware, None)
       .await
       .map_err(|err| format!("Error matching globs against {directory_digest:?}: {err}"))?;
 

--- a/src/rust/engine/fs/store/src/snapshot_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_tests.rs
@@ -554,7 +554,7 @@ pub async fn expand_all_sorted(posix_fs: Arc<PosixFS>) -> Vec<PathStat> {
   .parse()
   .unwrap();
   let mut v = posix_fs
-    .expand_globs(path_globs, SymlinkBehavior::Oblivious, None)
+    .expand_globs(path_globs, SymlinkBehavior::Aware, None)
     .await
     .unwrap();
   v.sort_by(|a, b| a.path().cmp(b.path()));


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/18956

Added a new test. Fails before, passes after!
