### PR TITLE
Run `terraform init` as part of `check` goal

### DIFF
--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.goals import lockfile as python_lockfile
-from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform import dependency_inference, tool
 from pants.backend.terraform.goals import check, tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
@@ -23,7 +22,6 @@ def rules():
         *tailor.rules(),
         *target_types_rules(),
         *tool.rules(),
-        *pex_rules(),
         *tffmt_rules(),
         *python_lockfile.rules(),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-import shlex
 from dataclasses import dataclass
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from typing import Tuple
 
 from pants.backend.python.subsystems.python_tool_base import (
@@ -167,11 +166,12 @@ async def get_terraform_providers(
         Get(
             FallibleProcessResult,
             TerraformProcess(
-                args=(f"-chdir={shlex.quote(directory)}", "init"),
+                args=("init",),
                 input_digest=req.source_files.snapshot.digest,
-                output_files=((Path(directory) / ".terraform.lock.hcl").as_posix(),),
-                output_directories=((Path(directory) / ".terraform").as_posix(),),
+                output_files=(".terraform.lock.hcl",),
+                output_directories=(".terraform",),
                 description="Run `terraform init` to fetch dependencies",
+                chdir=directory,
             ),
         )
         for directory in req.directories

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -11,6 +11,7 @@ from pants.backend.python.subsystems.python_tool_base import (
 )
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
@@ -146,5 +147,6 @@ async def infer_terraform_module_dependencies(
 def rules():
     return [
         *collect_rules(),
+        *pex_rules(),
         UnionRule(InferDependenciesRequest, InferTerraformModuleDependenciesRequest),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -4,7 +4,6 @@ import textwrap
 
 import pytest
 
-from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform import dependency_inference
 from pants.backend.terraform.dependency_inference import (
     InferTerraformModuleDependenciesRequest,
@@ -36,7 +35,6 @@ def rule_runner() -> RuleRunner:
         rules=[
             *external_tool.rules(),
             *source_files.rules(),
-            *pex_rules(),
             *dependency_inference.rules(),
             QueryRule(InferredDependencies, [InferTerraformModuleDependenciesRequest]),
             QueryRule(HydratedSources, [HydrateSourcesRequest]),

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -1,6 +1,5 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import shlex
 
 from pants.backend.terraform.dependency_inference import (
     GetTerraformDependenciesRequest,
@@ -61,10 +60,11 @@ async def terraform_check(
         Get(
             FallibleProcessResult,
             TerraformProcess(
-                args=(f"-chdir={shlex.quote(directory)}", "validate"),
+                args=("validate",),
                 input_digest=sources_and_deps,
                 output_files=tuple(files),
                 description=f"Run `terraform fmt` on {pluralize(len(files), 'file')}.",
+                chdir=directory,
             ),
         )
         for directory, files in files_by_directory.items()

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -155,3 +155,22 @@ def test_with_dependency(rule_runner: RuleRunner) -> None:
     targets = [make_target(rule_runner, [SOURCE_WITH_PROVIDER])]
     check_results = run_terraform_validate(rule_runner, targets)
     assert check_results[0].exit_code == 0
+
+
+def test_in_folder(rule_runner: RuleRunner) -> None:
+    """Test that we can `check` terraform files not in the root folder."""
+    target_name = "in_folder"
+    files = {
+        "folder/BUILD": f"terraform_module(name='{target_name}')\n",
+        "folder/provided.tf": textwrap.dedent(
+            """
+            resource "null_resource" "dep" {}
+            resource "random_pet" "random" {}
+            """
+        ),
+    }
+    rule_runner.write_files(files)
+    target = rule_runner.get_target(Address("folder", target_name=target_name))
+
+    check_results = run_terraform_validate(rule_runner, [target])
+    assert check_results[0].exit_code == 0

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -7,7 +7,7 @@ from typing import Sequence
 
 import pytest
 
-from pants.backend.terraform import tool
+from pants.backend.terraform import dependency_inference, tool
 from pants.backend.terraform.goals import check
 from pants.backend.terraform.goals.check import TerraformCheckRequest
 from pants.backend.terraform.target_types import TerraformFieldSet, TerraformModuleTarget
@@ -29,6 +29,7 @@ def rule_runner() -> RuleRunner:
             *check.rules(),
             *tool.rules(),
             *source_files.rules(),
+            *dependency_inference.rules(),
             QueryRule(CheckResults, (TerraformCheckRequest,)),
             QueryRule(SourceFiles, (SourceFilesRequest,)),
         ],

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -185,6 +185,7 @@ class TerraformProcess:
     description: str
     input_digest: Digest = EMPTY_DIGEST
     output_files: tuple[str, ...] = ()
+    output_directories: tuple[str, ...] = ()
 
 
 @rule
@@ -204,6 +205,7 @@ async def setup_terraform_process(
         input_digest=request.input_digest,
         immutable_input_digests=immutable_input_digests,
         output_files=request.output_files,
+        output_directories=request.output_directories,
         description=request.description,
         level=LogLevel.DEBUG,
     )


### PR DESCRIPTION
Many Terraform tools require Providers and Modules to be installed with `terraform init` for them to work properly. This includes `terraform validate` which is the backbone of the current `check` goal for Terraform.
This is the simplest way of installing these. It makes no effort to actually understand what modules are used, and defers entirely to the `terraform init`. As the providers will be downloaded as one block, this might take up a lot of space in the pants cache (I'm not sure tho).
We could do smarter things. Terraform has separate was of listing the required providers; saving lockfiles of them; and downloading the providers. (We could also parse the version specs from the Terraform sources themselves and make lockfiles ourselves.) That sounds like a cool thing to do, but definitely more complicated than bundling the dependencies into a Digest. I think it's worth getting this support working since `check` is not functional for any Terraform sources which use Providers or Modules, which is probably most of them. This will also allow us to integrate more Terraform tools. I think the improvements to Provider fetching are unlikely to resolve real problems. Terraform deployments usually pull in all their sibling files, contrasting with Python where siblings might not be imported; therefore, we are unlikely to see large gains in separating the downloaded Providers.

resolves #18489 