### PR TITLE
Log new dependency parsing at Debug, not Info

### DIFF
--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -780,7 +780,7 @@ fn parse_python_deps(context: Context, args: Vec<Value>) -> BoxFuture<'static, N
 
     in_workunit!(
       "parse_python_dependencies",
-      Level::Info,
+      Level::Debug,
       desc = Some(format!("Determine Python dependencies for {path:?}")),
       |_workunit| async move {
         let cache_key = CacheKey {


### PR DESCRIPTION
The new Rust Python dependency parser had its work-unit logged at info, which makes it rather noisy. This PR switches it to match the Python Python dependency parser, by logging at debug.

Before this patch, many `pants ...`  commands in the pants repo result in 2996 lines of output like (but only for a fresh start of pantsd, I assume):
```
...
18:09:35.82 [INFO] Starting: Determine Python dependencies for "pants/bsp/spec/__init__.py"
18:09:35.82 [INFO] Starting: Determine Python dependencies for "pants/backend/shell/util_rules/__init__.py"
18:09:35.82 [INFO] Starting: Determine Python dependencies for "pants/backend/terraform/goals/__init__.py"
18:09:35.82 [INFO] Completed: Determine Python dependencies for "pants/jvm/package/__init__.py"
18:09:35.82 [INFO] Starting: Determine Python dependencies for "pants/backend/swift/goals/__init__.py"
...
```