### PR TITLE
Add a workunit logging plugin

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -34,6 +34,7 @@ backend_packages.add = [
   "pants.backend.experimental.scala.debug_goals",
   "pants.backend.experimental.visibility",
   "pants.backend.tools.preamble",
+  "pants.backend.tools.workunit_logger",
   "pants.explorer.server",
   "internal_plugins.releases",
   "internal_plugins.test_lockfile_fixtures",

--- a/src/python/pants/backend/tools/workunit_logger/BUILD
+++ b/src/python/pants/backend/tools/workunit_logger/BUILD
@@ -1,7 +1,4 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
-
-# Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()

--- a/src/python/pants/backend/tools/workunit_logger/BUILD
+++ b/src/python/pants/backend/tools/workunit_logger/BUILD
@@ -1,0 +1,7 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+python_sources()

--- a/src/python/pants/backend/tools/workunit_logger/rules.py
+++ b/src/python/pants/backend/tools/workunit_logger/rules.py
@@ -1,0 +1,100 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+import logging
+from typing import Any, Dict, Tuple
+
+from pants.engine.internals.scheduler import Workunit
+from pants.engine.rules import collect_rules, rule
+from pants.engine.streaming_workunit_handler import (
+    StreamingWorkunitContext,
+    WorkunitsCallback,
+    WorkunitsCallbackFactory,
+    WorkunitsCallbackFactoryRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.option.option_types import BoolOption, StrOption
+from pants.option.subsystem import Subsystem
+
+logger = logging.getLogger(__name__)
+
+
+def just_dump_map(workunits_map):
+    return [
+        {
+            k: v
+            for k, v in wu.items()
+            if k
+            in (
+                "name",
+                "span_id",
+                "level",
+                "parent_id",
+                "start_secs",
+                "start_nanos",
+                "description",
+                "duration_secs",
+                "duration_nanos",
+                "metadata",
+            )
+        }
+        for wu in workunits_map.values()
+    ]
+
+
+class WorkunitLoggerCallback(WorkunitsCallback):
+    """Configuration for WorkunitLogger."""
+
+    def __init__(self, wulogger: "WorkunitLogger"):
+        self.wulogger = wulogger
+        self._completed_workunits: Dict[str, object] = {}
+
+    @property
+    def can_finish_async(self) -> bool:
+        return False
+
+    def __call__(
+        self,
+        *,
+        completed_workunits: Tuple[Workunit, ...],
+        started_workunits: Tuple[Workunit, ...],
+        context: StreamingWorkunitContext,
+        finished: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        for wu in completed_workunits:
+            self._completed_workunits[wu["span_id"]] = wu
+        if finished:
+            filepath = f"{self.wulogger.logdir}/{context.run_tracker.run_id}.json"
+            with open(filepath, "w") as f:
+                json.dump(just_dump_map(self._completed_workunits), f)
+                logger.info(f"Wrote log to {filepath}")
+
+
+class WorkunitLoggerCallbackFactoryRequest:
+    """A unique request type that is installed to trigger construction of our WorkunitsCallback."""
+
+
+class WorkunitLogger(Subsystem):
+    options_scope = "workunit-logger"
+    help = "Workunit Logger subsystem. Useful for debugging."
+
+    enabled = BoolOption("--enabled", default=False, help="Whether to enable workunit logging.")
+    logdir = StrOption("--logdir", default=".pants.d", help="Where to write the log to.")
+
+
+@rule
+def construct_callback(
+    _: WorkunitLoggerCallbackFactoryRequest,
+    wulogger: WorkunitLogger,
+) -> WorkunitsCallbackFactory:
+    return WorkunitsCallbackFactory(
+        lambda: WorkunitLoggerCallback(wulogger) if wulogger.enabled else None
+    )
+
+
+def rules():
+    return [
+        UnionRule(WorkunitsCallbackFactoryRequest, WorkunitLoggerCallbackFactoryRequest),
+        *collect_rules(),
+    ]


### PR DESCRIPTION
This got surfaced in Slack and I realized I had one lying around.

Idea is to unconditionally enable it (like I have in this repo) and then selectively use `pants --workunit-logger-enabled ...`