### PR TITLE
Fix example `first_party_dependency_version_scheme` in docs

### DIFF
--- a/docs/markdown/Python/python/python-distributions.md
+++ b/docs/markdown/Python/python/python-distributions.md
@@ -205,7 +205,7 @@ The generated `setup.py` will have its `install_requires` set to include the 3rd
 > 
 > ```toml
 > [setup-py-generation]
-> first_party_depenency_version_scheme = "compatible"
+> first_party_dependency_version_scheme = "compatible"
 > ```
 > 
 > See <https://www.python.org/dev/peps/pep-0440/#version-specifiers> for more information on the `~=` specifier.


### PR DESCRIPTION
Fixes a typo in the documentation of the `first_party_dependency_version_scheme` configuration setting