### PR TITLE
Replace `Snapshot::_unsafe_create` with `create_for_testing`.

### DIFF
--- a/src/python/pants/backend/project_info/peek_test.py
+++ b/src/python/pants/backend/project_info/peek_test.py
@@ -15,14 +15,14 @@ from pants.backend.visibility.rules import rules as visibility_rules
 from pants.base.specs import RawSpecs, RecursiveGlobSpec
 from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileTarget, GenericTarget
 from pants.engine.addresses import Address
-from pants.engine.fs import Digest, Snapshot
+from pants.engine.fs import Snapshot
 from pants.engine.internals.dep_rules import DependencyRuleAction, DependencyRuleApplication
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
 
 def _snapshot(fingerprint: str, files: tuple[str, ...]) -> Snapshot:
-    return Snapshot._unsafe_create(Digest(fingerprint.ljust(64, "0"), 1), files, ())
+    return Snapshot.create_for_testing(files, ())
 
 
 @pytest.mark.parametrize(
@@ -74,7 +74,7 @@ def _snapshot(fingerprint: str, files: tuple[str, ...]) -> Snapshot:
                       "bar.txt",
                       "foo.txt"
                     ],
-                    "sources_fingerprint": "2000000000000000000000000000000000000000000000000000000000000000",
+                    "sources_fingerprint": "d3dd0a1f72aaa1fb2623e7024d3ea460b798f6324805cfad5c2b751e2dfb756b",
                     "sources_raw": [
                       "*.txt"
                     ]
@@ -111,7 +111,7 @@ def _snapshot(fingerprint: str, files: tuple[str, ...]) -> Snapshot:
                     "sources": [
                       "foo.txt"
                     ],
-                    "sources_fingerprint": "1000000000000000000000000000000000000000000000000000000000000000",
+                    "sources_fingerprint": "b5e73bb1d7a3f8c2e7f8c43f38ab4d198e3512f082c670706df89f5abe319edf",
                     "sources_raw": [
                       "foo.txt"
                     ],
@@ -158,7 +158,7 @@ def _snapshot(fingerprint: str, files: tuple[str, ...]) -> Snapshot:
                     "target_type": "files",
                     "dependencies": [],
                     "sources": [],
-                    "sources_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "sources_fingerprint": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
                     "sources_raw": [
                       "*.txt"
                     ],
@@ -239,7 +239,7 @@ def _snapshot(fingerprint: str, files: tuple[str, ...]) -> Snapshot:
                     "sources": [
                       "foo/a.txt"
                     ],
-                    "sources_fingerprint": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "sources_fingerprint": "72ceef751c940b5797530e298f4d9f66daf3c51f7d075bfb802295ffb01d5de3",
                     "sources_raw": [
                       "*.txt"
                     ]

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -87,9 +87,7 @@ class Snapshot:
     """
 
     @classmethod
-    def _unsafe_create(
-        cls, digest: Digest, files: Sequence[str], dirs: Sequence[str]
-    ) -> Snapshot: ...
+    def create_for_testing(cls, files: Sequence[str], dirs: Sequence[str]) -> Snapshot: ...
     @property
     def digest(self) -> Digest: ...
     @property

--- a/src/rust/engine/fs/store/src/snapshot.rs
+++ b/src/rust/engine/fs/store/src/snapshot.rs
@@ -177,14 +177,8 @@ impl Snapshot {
     }
   }
 
-  /// # Safety
-  ///
-  /// This should only be used for testing, as this will always create an invalid Snapshot.
-  pub unsafe fn create_for_testing_ffi(
-    digest: Digest,
-    files: Vec<String>,
-    dirs: Vec<String>,
-  ) -> Result<Self, String> {
+  /// Creates a snapshot containing empty Files for testing purposes.
+  pub fn create_for_testing(files: Vec<String>, dirs: Vec<String>) -> Result<Self, String> {
     // NB: All files receive the EMPTY_DIGEST.
     let file_digests = files
       .iter()
@@ -216,8 +210,7 @@ impl Snapshot {
       &file_digests,
     )?;
     Ok(Self {
-      // NB: The DigestTrie's computed digest is ignored in favor of the given Digest.
-      digest,
+      digest: tree.compute_root_digest(),
       tree,
     })
   }

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -157,15 +157,10 @@ pub struct PySnapshot(pub Snapshot);
 #[pymethods]
 impl PySnapshot {
   #[classmethod]
-  fn _unsafe_create(
-    _cls: &PyType,
-    py_digest: PyDigest,
-    files: Vec<String>,
-    dirs: Vec<String>,
-  ) -> PyResult<Self> {
-    let snapshot =
-      unsafe { Snapshot::create_for_testing_ffi(py_digest.0.as_digest(), files, dirs) };
-    Ok(Self(snapshot.map_err(PyException::new_err)?))
+  fn create_for_testing(_cls: &PyType, files: Vec<String>, dirs: Vec<String>) -> PyResult<Self> {
+    Ok(Self(
+      Snapshot::create_for_testing(files, dirs).map_err(PyException::new_err)?,
+    ))
   }
 
   fn __hash__(&self) -> u64 {


### PR DESCRIPTION
When run in `MODE=debug`, (most) tests using `Snapshot::_unsafe_create` were failing a debug assertion for `Digest` equality.

`Snapshot`s can now calculate their own `Digest`s without a `Store`, so replace `_unsafe_create` with `create_for_testing`, which calculates the `Digest` for the `Snapshot`.