### PR TITLE
Prepare 2.14.2.

### DIFF
--- a/src/python/pants/notes/2.14.x.md
+++ b/src/python/pants/notes/2.14.x.md
@@ -1,6 +1,6 @@
 # 2.14.x Release Series
 
-## 2.14.2 (May 12, 2023)
+## 2.14.2 (May 14, 2023)
 
 The third stable release of the `2.14.x` series, with no changes since the previous release candidate!
 

--- a/src/python/pants/notes/2.14.x.md
+++ b/src/python/pants/notes/2.14.x.md
@@ -1,5 +1,9 @@
 # 2.14.x Release Series
 
+## 2.14.2 (May 12, 2023)
+
+The third stable release of the `2.14.x` series, with no changes since the previous release candidate!
+
 ## 2.14.2rc2 (Apr 23, 2023)
 
 ### Bug Fixes


### PR DESCRIPTION
### Internal

* Fix release script's expected maintainers (Cherry-pick of #18477) ([#18819](https://github.com/pantsbuild/pants/pull/18819))

* Don't specify interpreter_constraints when building the release pex. (Cherry-pick of #18280) ([#18817](https://github.com/pantsbuild/pants/pull/18817))