### PR TITLE
Prepare 2.15.1rc3.

### DIFF
--- a/src/python/pants/notes/2.15.x.md
+++ b/src/python/pants/notes/2.15.x.md
@@ -98,7 +98,7 @@ for more information.
 
 ----
 
-## 2.15.1rc3 (May 12, 2023)
+## 2.15.1rc3 (May 14, 2023)
 
 ### Bug Fixes
 

--- a/src/python/pants/notes/2.15.x.md
+++ b/src/python/pants/notes/2.15.x.md
@@ -98,6 +98,22 @@ for more information.
 
 ----
 
+## 2.15.1rc3 (May 12, 2023)
+
+### Bug Fixes
+
+* Require urllib3<2, to reduce installation issues (cherry-pick of #18959) ([#18973](https://github.com/pantsbuild/pants/pull/18973))
+
+* Do not choke on missing lockfiles. (Cherry-pick of #18940) ([#18947](https://github.com/pantsbuild/pants/pull/18947))
+
+### Performance
+
+* Optimize `Target` and `FieldSet` operations (Cherry-pick of #18917) ([#18949](https://github.com/pantsbuild/pants/pull/18949))
+
+### Documentation
+
+* Fix `awslambda-python` documentation (Cherry-pick of #18302) ([#18929](https://github.com/pantsbuild/pants/pull/18929))
+
 ## 2.15.1rc2 (Apr 23, 2023)
 
 ### Bug Fixes


### PR DESCRIPTION
### Internal

* [2.15.x branch] Remove the Toolchain plugin ([#18980](https://github.com/pantsbuild/pants/pull/18980))

* Fix release script's expected maintainers (Cherry-pick of #18477) ([#18820](https://github.com/pantsbuild/pants/pull/18820))

* Don't specify interpreter_constraints when building the release pex. (Cherry-pick of #18280) ([#18818](https://github.com/pantsbuild/pants/pull/18818))