### PR TITLE
Fix release script's expected maintainers (Cherry-pick of #18477)

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -70,7 +70,7 @@ _known_packages = [
 
 _expected_owners = {"benjyw", "John.Sirois", "stuhood"}
 
-_expected_maintainers = {"EricArellano", "illicitonion", "wisechengyi"}
+_expected_maintainers = {"EricArellano", "illicitonion", "wisechengyi", "kaos"}
 
 
 # Disable the Pants repository-internal internal_plugins.test_lockfile_fixtures plugin because

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -193,12 +193,10 @@ Note that this step can currently only be performed by a subset of maintainers d
 
 Go to the [documentation dashboard](https://dash.readme.com/). In the top left dropdown, where it says the current version, click "Manage versions". Click "Add new version" and use a "v" with the minor release number, e.g. "v2.9". Fork from the prior release. Mark this new version as public by clicking on "Is public?"
 
-Also, update the [Changelog](doc:changelog) page with the new release series at the top of the table. It's okay if there are no "highlights" yet.
-
 ### Sync the `docs/` content
 
 See the `docs/NOTES.md` for instructions setting up the the necessary Node tooling your first time.
-You'll need to 1st login as outlined there via some variant of `npx rdme login --project pants ...`.
+You'll need to 1st login as outlined there via some variant of `npx rdme login --2fa --project pants ...`.
 On the relevant release branch, run `npx rdme docs docs/markdown --version v<pants major>.<pants minor>`; e.g: `npx rdme docs docs/markdown --version v2.8`.
 
 ### Regenerate the references


### PR DESCRIPTION
The release process fails otherwise.

Also improve the docs on how to approach documentation changes.
