### PR TITLE
Shorten the deprecation for `export` without `--resolve`.

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -529,7 +529,7 @@ async def export_virtualenvs(
     # TODO: After the deprecation exipres, everything in this function below this comment
     #  can be deleted.
     warn_or_error(
-        "2.23.0.dev0",
+        "2.18.0.dev0",
         "exporting resolves without using the --resolve option",
         softwrap(
             f"""


### PR DESCRIPTION
The first release with this deprecation will be 2.16.x, so this isn't a user-facing change yet. 

It doesn't seem necessary to drag out the deprecation until 2.23.x. Getting rid of this in 2.18.x, 
at the same time as some tool lockfile deprecations expire, will allow us to delete a lot of complicated
code much sooner.