### PR TITLE
Fix golangci-lint runner script

### DIFF
--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -126,7 +126,7 @@ async def run_golangci_lint(
             export GOROOT={goroot.path}
             sandbox_root="$(/bin/pwd)"
             export PATH="${{GOROOT}}/bin:{cgo_tool_search_paths}"
-            export GOPATH="${{sandbox_root}})/gopath"
+            export GOPATH="${{sandbox_root}}/gopath"
             export GOCACHE="${{sandbox_root}}/gocache"
             export GOLANGCI_LINT_CACHE="$GOCACHE"
             export CGO_ENABLED={1 if golang_subsystem.cgo_enabled else 0}


### PR DESCRIPTION
This PR fixes two issues with golangci-lint:
- A typo in the generated golangci-lint runner script, which results in gocache escaping the sandbox and being leftover
- A missing value for the PATH environment variable, which is used by golangci-lint to locate tools needed for cgo

The second bug shows up as this error when linting:
```
10:04:09.12 [ERROR] Completed: Lint with golangci-lint - golangci-lint failed (exit code 3).
level=warning msg="[runner] Can't run linter goanalysis_metalinter: buildir: failed to load package cgo: could not load export data: no export data for \"runtime/cgo\""
level=error msg="Running error: 1 error occurred:\n\t* can't run linter goanalysis_metalinter: buildir: failed to load package cgo: could not load export data: no export data for \"runtime/cgo\"\n\n"
```