### PR TITLE
Add an auto-cherry-pick GitHub Action

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -14,34 +14,21 @@ on:
         required: true
 
 jobs:
-  inputs:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    outputs:
-      merge_commit: ${{ steps.step1.outputs.merge_commit }}
-    steps:
-      - id: step1
-        name: Get merge commit
-        run: |
-          COMMIT=$(gh pr view --repo "${{ github.repository }}" "${{ github.event.pull_request.number || inputs.PR_number }}" --json mergeCommit --jq '.mergeCommit.oid')
-          echo "merge_commit=$COMMIT" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   picker:
     if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-cherrypick') ) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    needs: inputs
     steps:
       - name: Check out code
         uses: actions/checkout@v2
         with:
-          ref: ${{ needs.inputs.outputs.merge_commit }}
+          # Always checkout the latest commit of main
+          ref: "main"
+          token: ${{ secrets.WORKER_PANTS_PAT }}
 
       - name: Cherry-Pick
         run: |
           git config --local user.email "pantsbuild+github-automation@gmail.com"
-          git config --local user.name "Worker Pants (Pantsbuild GitHub Automation Bot) "
-          build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number || inputs.PR_number }}
+          git config --local user.name "Worker Pants (Pantsbuild GitHub Automation Bot)"
+          build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number || inputs.PR_number }} origin
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKER_PANTS_PAT }}

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   picker:
-    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-cherrypick') ) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: inputs
     steps:
@@ -40,6 +40,8 @@ jobs:
 
       - name: Cherry-Pick
         run: |
+          git config --local user.email "pantsbuild+github-automation@gmail.com"
+          git config --local user.name "Worker Pants (Pantsbuild GitHub Automation Bot) "
           build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number || inputs.PR_number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -6,18 +6,40 @@ on:
       - closed
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      PR_number:
+        description: The PR number to cherry-pick
+        type: string
+        required: true
 
 jobs:
-  build:
-    if: github.event.pull_request.merged == true
+  inputs:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      merge_commit: ${{ steps.step1.outputs.merge_commit }}
+    steps:
+      - id: step1
+        name: Get merge commit
+        run: |
+          COMMIT=$(gh pr view --repo "${{ github.repository }}" "${{ github.event.pull_request.number || inputs.PR_number }}" --json mergeCommit --jq '.mergeCommit.oid')
+          echo "merge_commit=$COMMIT" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  picker:
+    if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: inputs
     steps:
       - name: Check out code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.inputs.outputs.merge_commit }}
 
       - name: Cherry-Pick
         run: |
-          build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number }}
+          build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number || inputs.PR_number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           # Always checkout the latest commit of main
           ref: "main"
-          token: ${{ secrets.WORKER_PANTS_PAT }}
 
       - name: Cherry-Pick
         run: |

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -1,0 +1,23 @@
+name: Auto Cherry-Picker
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  build:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Cherry-Pick
+        run: |
+          build-support/bin/cherry_pick.sh ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -51,6 +51,7 @@ COMMIT=$(gh pr view "$PR_NUM" --json mergeCommit --jq '.mergeCommit.oid')
 if [[ -z $COMMIT ]]; then
   fail "Wasn't able to retrieve merge commit for $PR_NUM."
 fi
+git fetch https://github.com/thejcannon/pants "$COMMIT"
 
 TITLE=$(gh pr view "$PR_NUM" --json title --jq '.title')
 CATEGORY_LABEL=$(gh pr view "$PR_NUM" --json labels --jq '.labels.[] | select(.name|test("category:.")).name')

--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -61,7 +61,8 @@ if [[ -z $CATEGORY_LABEL ]]; then
   echo "Couldn't detect category label on PR. What's the label? (E.g., category:bugfix)"
   read -r CATEGORY_LABEL
 fi
-REVIEWERS=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews.[].author.login' | sort | uniq)
+REVIEWERS=$(gh pr view "$PR_NUM" --json author --jq '.author.login')
+REVIEWERS+=$(gh pr view "$PR_NUM" --json reviews --jq '.reviews.[].author.login' | sort | uniq)
 
 BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.XXXXXX")
 gh pr view "$PR_NUM" --json body --jq '.body' > "$BODY_FILE"


### PR DESCRIPTION
This adds a new GitHub action that runs after a PR is merged which is labeled "needs-cherrypick" as well as can be run manually.

I've done a decent amount of testing on my fork, but wasn't able to test the actual PR creation (it failed on me not configuring `git` over there)