### PR TITLE
Implement layout="zip" for Lambda/GCF, skipping lambdex

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -78,9 +78,10 @@ async def package_python_awslambda(
             layout=layout,
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
-            # this isn't built or run via lambdex, but the name is arbitrary, so we stick with the
-            # 'tradition' to reduce churn.
-            reexported_handler_module="lambdex_handler",
+            # This doesn't matter (just needs to be fixed), but is the default name used by the AWS
+            # console when creating a Python lambda, so is as good as any
+            # https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+            reexported_handler_module="lambda_function",
         ),
     )
 

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -12,8 +12,14 @@ from pants.backend.awslambda.python.target_types import (
     PythonAwsLambdaIncludeRequirements,
     PythonAwsLambdaRuntime,
 )
-from pants.backend.python.util_rules import pex_from_targets
-from pants.backend.python.util_rules.faas import BuildLambdexRequest, PythonFaaSCompletePlatforms
+from pants.backend.python.util_rules.faas import (
+    BuildLambdexRequest,
+    BuildPythonFaaSRequest,
+    PythonFaaSCompletePlatforms,
+    PythonFaaSLayout,
+    PythonFaaSLayoutField,
+)
+from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, collect_rules, rule
@@ -33,27 +39,45 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
     complete_platforms: PythonFaaSCompletePlatforms
     output_path: OutputPathField
     environment: EnvironmentField
+    layout: PythonFaaSLayoutField
 
 
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)
 async def package_python_awslambda(
     field_set: PythonAwsLambdaFieldSet,
 ) -> BuiltPackage:
+    layout = PythonFaaSLayout(field_set.layout.value)
+
+    if layout is PythonFaaSLayout.LAMBDEX:
+        return await Get(
+            BuiltPackage,
+            BuildLambdexRequest(
+                address=field_set.address,
+                target_name=PythonAWSLambda.alias,
+                complete_platforms=field_set.complete_platforms,
+                runtime=field_set.runtime,
+                handler=field_set.handler,
+                output_path=field_set.output_path,
+                include_requirements=field_set.include_requirements.value,
+                script_handler=None,
+                script_module=None,
+                # The AWS-facing handler function is always lambdex_handler.handler, which is the
+                # wrapper injected by lambdex that manages invocation of the actual handler.
+                handler_log_message="lambdex_handler.handler",
+            ),
+        )
+
     return await Get(
         BuiltPackage,
-        BuildLambdexRequest(
+        BuildPythonFaaSRequest(
             address=field_set.address,
             target_name=PythonAWSLambda.alias,
             complete_platforms=field_set.complete_platforms,
             runtime=field_set.runtime,
             handler=field_set.handler,
+            layout=layout,
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
-            script_handler=None,
-            script_module=None,
-            # The AWS-facing handler function is always lambdex_handler.handler, which is the
-            # wrapper injected by lambdex that manages invocation of the actual handler.
-            handler_log_message="lambdex_handler.handler",
         ),
     )
 
@@ -62,5 +86,5 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(PackageFieldSet, PythonAwsLambdaFieldSet),
-        *pex_from_targets.rules(),
+        *faas_rules(),
     ]

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -78,6 +78,9 @@ async def package_python_awslambda(
             layout=layout,
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
+            # this isn't built or run via lambdex, but the name is arbitrary, so we stick with the
+            # 'tradition' to reduce churn.
+            reexported_handler_module="lambdex_handler",
         ),
     )
 

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -122,7 +122,7 @@ def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     "major_minor_interpreter",
     all_major_minor_python_versions(Lambdex.default_interpreter_constraints),
 )
-def test_create_hello_world_lambda(
+def test_create_hello_world_lambda_with_lambdex(
     rule_runner: PythonRuleRunner, major_minor_interpreter: str, complete_platform: str, caplog
 ) -> None:
     rule_runner.write_files(
@@ -197,7 +197,7 @@ def test_create_hello_world_lambda(
     ), "Using include_requirements=False should exclude third-party deps"
 
 
-def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
+def test_warn_files_targets_with_lambdex(rule_runner: PythonRuleRunner, caplog) -> None:
     rule_runner.write_files(
         {
             "assets/f.txt": "",
@@ -257,3 +257,66 @@ def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
     assert "assets/f.txt:files" in caplog.text
     assert "assets:relocated" in caplog.text
     assert "assets:resources" not in caplog.text
+
+
+def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/python/foo/bar/hello_world.py": dedent(
+                """
+                import mureq
+
+                def handler(event, context):
+                    print('Hello, World!')
+                """
+            ),
+            "src/python/foo/bar/BUILD": dedent(
+                """
+                python_requirement(name="mureq", requirements=["mureq==0.2"])
+                python_sources()
+
+                python_awslambda(
+                    name='lambda',
+                    handler='foo.bar.hello_world:handler',
+                    runtime="python3.7",
+                    layout='zip',
+                )
+                python_awslambda(
+                    name='slimlambda',
+                    include_requirements=False,
+                    handler='foo.bar.hello_world:handler',
+                    runtime="python3.7",
+                    layout='zip',
+                )
+                """
+            ),
+        }
+    )
+
+    zip_file_relpath, content = create_python_awslambda(
+        rule_runner,
+        Address("src/python/foo/bar", target_name="lambda"),
+        expected_extra_log_lines=(
+            "    Handler: foo.bar.hello_world.handler",
+        ),
+    )
+    assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
+
+    zipfile = ZipFile(BytesIO(content))
+    names = set(zipfile.namelist())
+    assert "mureq/__init__.py" in names
+    assert "foo/bar/hello_world.py" in names
+
+    zip_file_relpath, content = create_python_awslambda(
+        rule_runner,
+        Address("src/python/foo/bar", target_name="slimlambda"),
+        expected_extra_log_lines=(
+            "    Handler: foo.bar.hello_world.handler",
+        ),
+    )
+    assert "src.python.foo.bar/slimlambda.zip" == zip_file_relpath
+
+    zipfile = ZipFile(BytesIO(content))
+    names = set(zipfile.namelist())
+    assert "mureq/__init__.py" not in names
+    assert "foo/bar/hello_world.py" in names

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -296,9 +296,7 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,
         Address("src/python/foo/bar", target_name="lambda"),
-        expected_extra_log_lines=(
-            "    Handler: foo.bar.hello_world.handler",
-        ),
+        expected_extra_log_lines=("    Handler: lambdex_handler.handler",),
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
 
@@ -306,13 +304,14 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     names = set(zipfile.namelist())
     assert "mureq/__init__.py" in names
     assert "foo/bar/hello_world.py" in names
+    assert (
+        zipfile.read("lambdex_handler.py") == b"from foo.bar.hello_world import handler as handler"
+    )
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,
         Address("src/python/foo/bar", target_name="slimlambda"),
-        expected_extra_log_lines=(
-            "    Handler: foo.bar.hello_world.handler",
-        ),
+        expected_extra_log_lines=("    Handler: lambdex_handler.handler",),
     )
     assert "src.python.foo.bar/slimlambda.zip" == zip_file_relpath
 
@@ -320,3 +319,6 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     names = set(zipfile.namelist())
     assert "mureq/__init__.py" not in names
     assert "foo/bar/hello_world.py" in names
+    assert (
+        zipfile.read("lambdex_handler.py") == b"from foo.bar.hello_world import handler as handler"
+    )

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -296,7 +296,7 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,
         Address("src/python/foo/bar", target_name="lambda"),
-        expected_extra_log_lines=("    Handler: lambdex_handler.handler",),
+        expected_extra_log_lines=("    Handler: lambda_function.handler",),
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
 
@@ -305,13 +305,13 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     assert "mureq/__init__.py" in names
     assert "foo/bar/hello_world.py" in names
     assert (
-        zipfile.read("lambdex_handler.py") == b"from foo.bar.hello_world import handler as handler"
+        zipfile.read("lambda_function.py") == b"from foo.bar.hello_world import handler as handler"
     )
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,
         Address("src/python/foo/bar", target_name="slimlambda"),
-        expected_extra_log_lines=("    Handler: lambdex_handler.handler",),
+        expected_extra_log_lines=("    Handler: lambda_function.handler",),
     )
     assert "src.python.foo.bar/slimlambda.zip" == zip_file_relpath
 
@@ -320,5 +320,5 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
     assert "mureq/__init__.py" not in names
     assert "foo/bar/hello_world.py" in names
     assert (
-        zipfile.read("lambdex_handler.py") == b"from foo.bar.hello_world import handler as handler"
+        zipfile.read("lambda_function.py") == b"from foo.bar.hello_world import handler as handler"
     )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
+    PythonFaaSLayoutField,
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
@@ -111,6 +112,7 @@ class PythonAWSLambda(Target):
         PythonAwsLambdaRuntime,
         PythonFaaSCompletePlatforms,
         PythonResolveField,
+        PythonFaaSLayoutField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -30,11 +30,20 @@ from pants.util.strutil import help_text, softwrap
 
 
 class PythonAwsLambdaHandlerField(PythonFaaSHandlerField):
+    # This doesn't matter (just needs to be fixed), but is the default name used by the AWS
+    # console when creating a Python lambda, so is as good as any
+    # https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html
+    reexported_handler_module = "lambda_function"
+
     help = help_text(
         f"""
         Entry point to the AWS Lambda handler.
 
         {PythonFaaSHandlerField.help}
+
+        This is re-exported at `{reexported_handler_module}.handler` in the resulting package to be
+        used as the configured handler of the Lambda in AWS. It can also be accessed under its
+        source-root-relative module path, for example: `path.to.module.handler_func`.
         """
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -83,6 +83,14 @@ async def package_python_google_cloud_function(
             layout=layout,
             output_path=field_set.output_path,
             include_requirements=True,
+            # GCP requires "Your main file must be named main.py"
+            # https://cloud.google.com/functions/docs/writing#directory-structure-python
+            # setting a `GOOGLE_FUNCTION_SOURCE` Google Cloud build environment variable; e.g.:
+            # `gcloud functions deploy {--build-env-vars-file,--set-build-env-vars}`, but it's non-trivial
+            # to do this right or with intended effect) and the handler name you configure GCF with is just
+            # the unqualified function name, which we log here.
+            reexported_handler_module="main",
+            log_only_reexported_handler_func=True,
         ),
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -83,13 +83,7 @@ async def package_python_google_cloud_function(
             layout=layout,
             output_path=field_set.output_path,
             include_requirements=True,
-            # GCP requires "Your main file must be named main.py"
-            # https://cloud.google.com/functions/docs/writing#directory-structure-python
-            # setting a `GOOGLE_FUNCTION_SOURCE` Google Cloud build environment variable; e.g.:
-            # `gcloud functions deploy {--build-env-vars-file,--set-build-env-vars}`, but it's non-trivial
-            # to do this right or with intended effect) and the handler name you configure GCF with is just
-            # the unqualified function name, which we log here.
-            reexported_handler_module="main",
+            reexported_handler_module=PythonGoogleCloudFunctionHandlerField.reexported_handler_module,
             log_only_reexported_handler_func=True,
         ),
     )

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -276,9 +276,7 @@ def test_create_hello_world_gcf(rule_runner: PythonRuleRunner) -> None:
     zip_file_relpath, content = create_python_google_cloud_function(
         rule_runner,
         Address("src/python/foo/bar", target_name="gcf"),
-        expected_extra_log_lines=(
-            "    Handler: foo.bar.hello_world.handler",
-        ),
+        expected_extra_log_lines=("    Handler: handler",),
     )
     assert "src.python.foo.bar/gcf.zip" == zip_file_relpath
 
@@ -286,3 +284,4 @@ def test_create_hello_world_gcf(rule_runner: PythonRuleRunner) -> None:
     names = set(zipfile.namelist())
     assert "mureq/__init__.py" in names
     assert "foo/bar/hello_world.py" in names
+    assert zipfile.read("main.py") == b"from foo.bar.hello_world import handler as handler"

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -30,11 +30,19 @@ from pants.util.strutil import help_text
 
 
 class PythonGoogleCloudFunctionHandlerField(PythonFaaSHandlerField):
+    # GCP requires "Your main file must be named main.py"
+    # https://cloud.google.com/functions/docs/writing#directory-structure-python
+    reexported_handler_module = "main"
+
     help = help_text(
         f"""
         Entry point to the Google Cloud Function handler.
 
         {PythonFaaSHandlerField.help}
+
+        This is re-exported at `{reexported_handler_module}.handler` in the resulting package to
+        used as the configured handler of the Google Cloud Function in GCP.  It can also be accessed
+        under its source-root-relative module path, for example: `path.to.module.handler_func`.
         """
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.python.util_rules.faas import (
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
+    PythonFaaSLayoutField,
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
@@ -111,6 +112,7 @@ class PythonGoogleCloudFunction(Target):
         PythonFaaSCompletePlatforms,
         PythonGoogleCloudFunctionType,
         PythonResolveField,
+        PythonFaaSLayoutField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -296,16 +296,17 @@ class PythonFaaSLayoutField(StringField):
 
     help = help_text(
         """
-        The layout used for the function artefact.
+        The layout used for the function artifact.
 
-        With the `lambdex` layout (default), the artefact is created as a Lambdex, which is a normal
+        With the `lambdex` layout (default), the artifact is created as a Lambdex, which is a normal
         PEX that's been adjusted to include a shim file for the handler. This requires dynamically
         choosing dependencies on start-up.
 
-        With the `zip` layout, the artefact contains first and third party code at the top level,
-        similar to building with `pip install --target=...`. This layout chooses the appropriate
-        versions of dependencies at build time, and so at most one platform can be specified via
-        `runtime` or `complete_platforms`.
+        With the `zip` layout (recommended), the artifact contains first and third party code at the
+        top level, similar to building with `pip install --target=...`. This layout chooses the
+        appropriate versions of dependencies at build time, and so at most one platform can be
+        specified via `runtime` or `complete_platforms`. This matches the layout recommended by
+        cloud providers.
 
         """
     )
@@ -523,7 +524,7 @@ async def build_python_faas(
             platforms=pex_platforms,
             complete_platforms=complete_platforms,
             output_path=Path(output_filename),
-            description=f"Build {request.target_name} artefact for {request.address}",
+            description=f"Build {request.target_name} artifact for {request.address}",
         ),
     )
 

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -45,7 +45,14 @@ from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
 from pants.core.goals.package import BuiltPackage, BuiltPackageArtifact, OutputPathField
 from pants.core.target_types import FileSourceField
 from pants.engine.addresses import Address, UnparsedAddressInputs
-from pants.engine.fs import GlobMatchErrorBehavior, PathGlobs, Paths
+from pants.engine.fs import (
+    CreateDigest,
+    Digest,
+    FileContent,
+    GlobMatchErrorBehavior,
+    PathGlobs,
+    Paths,
+)
 from pants.engine.platform import Platform
 from pants.engine.process import ProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
@@ -450,6 +457,9 @@ class BuildPythonFaaSRequest:
 
     include_requirements: bool
 
+    reexported_handler_module: str
+    log_only_reexported_handler_func: bool = False
+
 
 @rule
 async def build_python_faas(
@@ -466,11 +476,26 @@ async def build_python_faas(
         "--resolve-local-platforms",
     )
 
-    complete_platforms = await Get(
-        CompletePlatforms, PythonFaaSCompletePlatforms, request.complete_platforms
+    complete_platforms, handler = await MultiGet(
+        Get(CompletePlatforms, PythonFaaSCompletePlatforms, request.complete_platforms),
+        Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(request.handler)),
     )
 
     # TODO: improve diagnostics if there's more than one platform/complete_platform
+
+    # synthesise a source file that gives a fixed handler path, no matter what the entry point is:
+    # some platforms require a certain name (e.g. GCF), and even on others, giving a fixed name
+    # means users don't need to duplicate the entry_point config in both the pants BUILD file and
+    # infrastructure definitions (the latter can always use the same names, for every lambda).
+    reexported_handler_file = f"{request.reexported_handler_module}.py"
+    reexported_handler_func = "handler"
+    reexported_handler_content = (
+        f"from {handler.module} import {handler.func} as {reexported_handler_func}"
+    )
+    additional_sources = await Get(
+        Digest,
+        CreateDigest([FileContent(reexported_handler_file, reexported_handler_content.encode())]),
+    )
 
     repository_filename = "faas_repository.pex"
     pex_request = PexFromTargetsRequest(
@@ -483,12 +508,10 @@ async def build_python_faas(
         layout=PexLayout.PACKED,
         additional_args=additional_pex_args,
         additional_lockfile_args=additional_pex_args,
+        additional_sources=additional_sources,
     )
 
-    pex_result, handler = await MultiGet(
-        Get(Pex, PexFromTargetsRequest, pex_request),
-        Get(ResolvedPythonFaaSHandler, ResolvePythonFaaSHandlerRequest(request.handler)),
-    )
+    pex_result = await Get(Pex, PexFromTargetsRequest, pex_request)
 
     output_filename = request.output_path.value_or_default(file_ending="zip")
 
@@ -504,11 +527,14 @@ async def build_python_faas(
         ),
     )
 
+    if request.log_only_reexported_handler_func:
+        handler_text = reexported_handler_func
+    else:
+        handler_text = f"{request.reexported_handler_module}.{reexported_handler_func}"
+
     artifact = BuiltPackageArtifact(
         output_filename,
-        extra_log_lines=(
-            f"    Handler: {handler.module}.{handler.func}",
-        ),
+        extra_log_lines=(f"    Handler: {handler_text}",),
     )
     return BuiltPackage(digest=result.digest, artifacts=(artifact,))
 

--- a/src/python/pants/backend/python/util_rules/pex_venv.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from pants.backend.python.util_rules import pex_cli
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex_cli import PexCliProcess
+from pants.engine.fs import Digest
+from pants.engine.internals.native_engine import MergeDigests
+from pants.engine.process import ProcessResult
+from pants.engine.rules import Get, collect_rules, rule
+
+
+class PexVenvLayout(Enum):
+    VENV = "venv"
+    FLAT = "flat"
+    FLAT_ZIPPED = "flat-zipped"
+
+
+@dataclass(frozen=True)
+class PexVenvRequest:
+    pex: Pex
+    layout: PexVenvLayout
+    output_path: Path
+    description: str
+
+    platforms: PexPlatforms = PexPlatforms()
+    complete_platforms: CompletePlatforms = CompletePlatforms()
+
+
+@dataclass(frozen=True)
+class PexVenv:
+    digest: Digest
+    path: Path
+
+
+@rule
+async def pex_venv(request: PexVenvRequest) -> PexVenv:
+    # TODO: create the output with a fixed name and then rename
+    # (https://github.com/pantsbuild/pants/issues/15102)
+    if request.layout is PexVenvLayout.FLAT_ZIPPED:
+        # --layout=flat-zipped takes --dest-dir=foo and zips it up to `foo.zip`, so we cannot
+        # directly control the full path until we do a rename
+        if request.output_path.suffix != ".zip":
+            raise ValueError(
+                f"layout=FLAT_ZIPPED requires output_path to end in '.zip', but found output_path='{request.output_path}' ending in {request.output_path.suffix!r}"
+            )
+        dest_dir = request.output_path.with_suffix("")
+        output_files = [str(request.output_path)]
+        output_directories = []
+    else:
+        dest_dir = request.output_path
+        output_files = []
+        output_directories = [str(request.output_path)]
+
+    input_digest = await Get(
+        Digest,
+        MergeDigests(
+            [
+                request.pex.digest,
+                request.complete_platforms.digest,
+            ]
+        ),
+    )
+
+    result = await Get(
+        ProcessResult,
+        PexCliProcess(
+            subcommand=("venv", "create"),
+            extra_args=(
+                f"--dest-dir={dest_dir}",
+                f"--pex-repository={request.pex.name}",
+                f"--layout={request.layout.value}",
+                # NB. Specifying more than one of these args doesn't make sense for `venv
+                # create`. Incorrect usage will be surfaced as a subprocess failure.
+                *request.platforms.generate_pex_arg_list(),
+                *request.complete_platforms.generate_pex_arg_list(),
+            ),
+            additional_input_digest=input_digest,
+            output_files=output_files,
+            output_directories=output_directories,
+            description=request.description,
+        ),
+    )
+
+    return PexVenv(digest=result.output_digest, path=request.output_path)
+
+
+def rules():
+    return [*collect_rules(), *pex_cli.rules()]

--- a/src/python/pants/backend/python/util_rules/pex_venv_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv_test.py
@@ -1,0 +1,198 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import fnmatch
+import io
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from pants.backend.python.util_rules import pex_test_utils
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_requirements import PexRequirements
+from pants.backend.python.util_rules.pex_test_utils import create_pex_and_get_all_data
+from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvLayout, PexVenvRequest
+from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
+from pants.engine.fs import CreateDigest, DigestContents, FileContent
+from pants.engine.internals.native_engine import Digest, Snapshot
+from pants.engine.internals.scheduler import ExecutionError
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *pex_test_utils.rules(),
+            *pex_rules(),
+            *pex_venv_rules(),
+            QueryRule(PexVenv, (PexVenvRequest,)),
+            QueryRule(Snapshot, (CreateDigest,)),
+        ],
+    )
+
+
+requirements = PexRequirements(["psycopg2-binary==2.9.6"])
+
+
+@pytest.fixture
+def sources(rule_runner: RuleRunner) -> Digest:
+    return rule_runner.request(
+        Digest, [CreateDigest([FileContent(path="first/party.py", content=b"")])]
+    )
+
+
+@pytest.fixture
+def local_pex(rule_runner: RuleRunner, sources: Digest) -> Pex:
+    result = create_pex_and_get_all_data(
+        rule_runner,
+        requirements=requirements,
+        sources=sources,
+        internal_only=False,
+    )
+    assert isinstance(result.pex, Pex)
+    return result.pex
+
+
+# at least one of these will be foreign
+WIN_311 = "win-amd64-cp-311-cp311"
+MAC_310 = "macosx_11_0-arm64-cp-310-cp310"
+
+# subset of the complete platforms for MAC_310
+MAC_310_CP = b"""{"path": "....", "compatible_tags": ["cp310-cp310-macosx_12_0_arm64", "cp310-cp310-macosx_12_0_universal2", "cp310-cp310-macosx_11_0_arm64", "py31-none-any", "py30-none-any"], "marker_environment": {"implementation_name": "cpython", "implementation_version": "3.10.10", "os_name": "posix", "platform_machine": "arm64", "platform_python_implementation": "CPython", "platform_release": "21.6.0", "platform_system": "Darwin", "platform_version": "Darwin Kernel Version 21.6.0: Wed Aug 10 14:28:35 PDT 2022; root:xnu-8020.141.5~2/RELEASE_ARM64_T8101", "python_full_version": "3.10.10", "python_version": "3.10", "sys_platform": "darwin"}}"""
+
+
+@pytest.fixture
+def foreign_pex(rule_runner: RuleRunner, sources: Digest) -> Pex:
+    result = create_pex_and_get_all_data(
+        rule_runner,
+        requirements=requirements,
+        sources=sources,
+        platforms=PexPlatforms([WIN_311, MAC_310]),
+        internal_only=False,
+    )
+    assert isinstance(result.pex, Pex)
+    return result.pex
+
+
+def run_and_validate(
+    rule_runner: RuleRunner, request: PexVenvRequest, check_globs_exist: tuple[str, ...]
+) -> PexVenv:
+    venv = rule_runner.request(PexVenv, [request])
+
+    assert venv.path == request.output_path
+
+    snapshot = rule_runner.request(Snapshot, [venv.digest])
+    for glob in check_globs_exist:
+        assert len(fnmatch.filter(snapshot.files, glob)) == 1, glob
+
+    return venv
+
+
+@pytest.mark.parametrize(
+    ("layout", "expected_directory"),
+    [(PexVenvLayout.FLAT, ""), (PexVenvLayout.VENV, "lib/python*/site-packages/")],
+)
+def test_layout_venv_and_flat_should_give_plausible_output_for_local_platform(
+    layout: PexVenvLayout, expected_directory: str, local_pex: Pex, rule_runner: RuleRunner
+) -> None:
+    run_and_validate(
+        rule_runner,
+        PexVenvRequest(
+            pex=local_pex, layout=layout, output_path=Path("out/dir"), description="testing"
+        ),
+        check_globs_exist=(
+            f"out/dir/{expected_directory}psycopg2/__init__.py",
+            f"out/dir/{expected_directory}first/party.py",
+        ),
+    )
+
+
+def test_layout_flat_zipped_should_give_plausible_output_for_local_platform(
+    local_pex: Pex, rule_runner: RuleRunner
+) -> None:
+    venv = run_and_validate(
+        rule_runner,
+        PexVenvRequest(
+            pex=local_pex,
+            layout=PexVenvLayout.FLAT_ZIPPED,
+            output_path=Path("out/file.zip"),
+            description="testing",
+        ),
+        check_globs_exist=("out/file.zip",),
+    )
+
+    contents = rule_runner.request(DigestContents, [venv.digest])
+    assert len(contents) == 1
+    with zipfile.ZipFile(io.BytesIO(contents[0].content)) as f:
+        files = set(f.namelist())
+        assert "psycopg2/__init__.py" in files
+        assert "first/party.py" in files
+
+
+def test_layout_flat_zipped_should_require_zip_suffix(
+    local_pex: Pex, rule_runner: RuleRunner
+) -> None:
+    with pytest.raises(
+        ExecutionError,
+        match="layout=FLAT_ZIPPED requires output_path to end in '\\.zip', but found output_path='out/file\\.other' ending in '\\.other'",
+    ):
+        run_and_validate(
+            rule_runner,
+            PexVenvRequest(
+                pex=local_pex,
+                layout=PexVenvLayout.FLAT_ZIPPED,
+                output_path=Path("out/file.other"),
+                description="testing",
+            ),
+            check_globs_exist=(),
+        )
+
+
+def test_platforms_should_choose_appropriate_dependencies_when_possible(
+    foreign_pex: Pex, rule_runner: RuleRunner
+) -> None:
+    # smoke test that platforms are passed through in the right way
+    run_and_validate(
+        rule_runner,
+        PexVenvRequest(
+            pex=foreign_pex,
+            layout=PexVenvLayout.FLAT,
+            output_path=Path("out"),
+            platforms=PexPlatforms([WIN_311]),
+            description="testing",
+        ),
+        check_globs_exist=(
+            "out/first/party.py",
+            "out/psycopg2/__init__.py",
+        ),
+    )
+
+
+def test_complete_platforms_should_choose_appropriate_dependencies_when_possible(
+    foreign_pex: Pex,
+    rule_runner: RuleRunner,
+) -> None:
+    # smoke test that complete platforms are passed through in the right way
+    cp_snapshot = rule_runner.request(
+        Snapshot, [CreateDigest([FileContent("cp", content=MAC_310_CP)])]
+    )
+
+    run_and_validate(
+        rule_runner,
+        PexVenvRequest(
+            pex=foreign_pex,
+            layout=PexVenvLayout.FLAT,
+            output_path=Path("out"),
+            complete_platforms=CompletePlatforms.from_snapshot(cp_snapshot),
+            description="testing",
+        ),
+        check_globs_exist=(
+            "out/first/party.py",
+            "out/psycopg2/__init__.py",
+        ),
+    )


### PR DESCRIPTION
This fixes #18879 by allowing the `python_awslambda` and `python_google_cloud_function` FaaS artefacts to be generated in "simple" format, using the `pex3 venv create --layout=flat-zipped` functionality recently added in PEX 2.1.135 (https://github.com/pantsbuild/pex/releases/tag/v2.1.135). This format is just: put everything at the top-level, e.g. the zip contains `cowsay/__init__.py` etc., rather than `.deps/cowsay-....whl` (plus the dynamic PEX initialisation).

This shifts the dynamic dependency computation/extraction/layout from run-time to build-time, relying on the FaaS environment to be generally consistent. It shouldn't change what actually happens after initialisation. This can:

- reduce cold-starts noticeably: for instance, some of our lambdas spend 1s doing PEX/Lambdex start up. 
- reduce package size somewhat (the PEX `.bootstrap/` folder seems to be about 2MB uncompressed, ~1MB compressed). 
- increase build times.
 
For instance, for one Python 3.9 Lambda in our codebase:

| metric | before | after |
|---|---|---|
| init time on cold start | 2.3-2.5s | 1.3-1.4s (-1s) |
| compressed size |  24.6MB | 23.8MB (-0.8MB) |
| uncompressed size | 117.8MB | 115.8MB (-2.0MB) |
| PEX-construction build time | ~5s | ~5s |
| PEX-postprocessing build time | 0.14s | 4.8s |

(The PEX-postprocessing  time metric is specifically the time to run the `Setting up handler` (lambdex) or `Build python_awslambda` (`pex3 venv create`) process, computed by running `pants --keep-sandboxes=always package ...` for each layout, and then `hyperfine -r3 -w1 path/to/first/__run.sh path/to/second/__run.sh`. This _doesn't_ include the time to construct the input PEX, which is the same for both.)

This functionality is driven by adding a new `layout` field. It defaults to `lambdex` (retaining the current code paths), but also supports `zip`, which keys into the functionality above. I've tried to keep the non-lambdex implementation generally separate to the lambdex one, rather than reusing all of the code that happens to be common currently, because it'd make sense to deprecate/remove the lambdex functionality and thus I feel it's best for this new functionality to be mostly a fresh start.

This PR's commits can be reviewed independently. It comes in three phases:

1. Add the `pex_venv.py` util rules for running `pex3 venv create ...`. Currently this only supports a limited subset of the functionality there, but can presumably be expanded freely as required. (First commit)
2. Do some minor refactoring. (Commits labelled "refactor: ...")
3. Draw the rest of the owl. (The others.)

I _think_ this is an acceptable MVP for this functionality, but there's various bits of follow-up:

- deprecate `layout="lambdex"` (in favour of `layout="zip"` and/or normal `pex_binary`) (#19032)
- add a warning about `files` being loaded into these packages, which has been temporarily lost (#19027)
- adjust documentation
- other improvements like #18195 and #18880 
- improve performance, e.g. potentially `pex3 venv create ...` could use the lock file and sources to directly compute the appropriate files, without having to materialise a normal pex first
