### PR TITLE
Support Python requirement target addrs in tool requirements. (Cherry-pick of #19014)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -165,9 +165,9 @@ args = ["--wrap-summaries=100", "--wrap-descriptions=100"]
 
 [flake8]
 config = "build-support/flake8/.flake8"
-
 source_plugins = ["build-support/flake8"]
 install_from_resolve = "flake8"
+requirements = ["//3rdparty/python:flake8"]
 
 [shellcheck]
 args = ["--external-sources"]
@@ -180,6 +180,7 @@ args = ["-i 2", "-ci", "-sr"]
 args = ["--no-header"]
 execution_slot_var = "TEST_EXECUTION_SLOT"
 install_from_resolve = "pytest"
+requirements = ["//3rdparty/python:pytest"]
 
 [test]
 extra_env_vars = [
@@ -197,6 +198,7 @@ timeout_default = 60
 [mypy]
 interpreter_constraints = [">=3.7,<3.10"]
 install_from_resolve = "mypy"
+requirements = ["//3rdparty/python:mypy"]
 
 
 [coverage-py]

--- a/src/python/pants/backend/python/subsystems/python_tool_base_test.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base_test.py
@@ -28,4 +28,4 @@ def test_install_from_resolve_default() -> None:
     pex_reqs = tool.pex_requirements()
     assert isinstance(pex_reqs, PexRequirements)
     assert pex_reqs.from_superset == Resolve("dummy_resolve", False)
-    assert pex_reqs.req_strings == FrozenOrderedSet(["bar", "baz", "foo"])
+    assert pex_reqs.req_strings_or_addrs == FrozenOrderedSet(["bar", "baz", "foo"])

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -1,11 +1,7 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources(
-    overrides={
-        "local_dists_pep660.py": dict(dependencies=["./scripts/pep660_backend_wrapper.py"]),
-    },
-)
+python_sources()
 
 python_tests(
     name="tests",

--- a/src/python/pants/backend/python/util_rules/BUILD
+++ b/src/python/pants/backend/python/util_rules/BUILD
@@ -1,7 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-python_sources()
+python_sources(
+    overrides={
+        "local_dists_pep660.py": dict(dependencies=["./scripts/pep660_backend_wrapper.py"]),
+    },
+)
 
 python_tests(
     name="tests",

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -11,7 +11,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import PurePath
 from textwrap import dedent  # noqa: PNT20
-from typing import Iterable, Iterator, Mapping, TypeVar
+from typing import Iterable, Iterator, Mapping, Sequence, TypeVar
 
 import packaging.specifiers
 import packaging.version
@@ -24,6 +24,7 @@ from pants.backend.python.target_types import (
     PexLayout,
 )
 from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
+from pants.backend.python.target_types import PythonRequirementsField
 from pants.backend.python.util_rules import pex_cli, pex_requirements
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex_cli import PexCliProcess, PexPEX
@@ -48,10 +49,11 @@ from pants.backend.python.util_rules.pex_requirements import (
     ResolvePexConfigRequest,
     validate_metadata,
 )
+from pants.build_graph.address import Address
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary
-from pants.engine.addresses import UnparsedAddressInputs
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName
@@ -60,7 +62,14 @@ from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import Get, collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest, SourcesField, Targets
+from pants.engine.target import (
+    HydratedSources,
+    HydrateSourcesRequest,
+    SourcesField,
+    Targets,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
 from pants.engine.unions import UnionMembership, union
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -453,6 +462,49 @@ class _BuildPexRequirementsSetup:
     concurrency_available: int
 
 
+@dataclass(frozen=True)
+class ReqStrings:
+    req_strings: tuple[str, ...]
+
+
+@rule
+async def get_req_strings(pex_reqs: PexRequirements) -> ReqStrings:
+    addrs: list[Address] = []
+    specs: list[str] = []
+    req_strings: list[str] = []
+    for req_str_or_addr in pex_reqs.req_strings_or_addrs:
+        if isinstance(req_str_or_addr, Address):
+            addrs.append(req_str_or_addr)
+        else:
+            assert isinstance(req_str_or_addr, str)
+            # Require a `//` prefix, to distinguish address specs from
+            # local or VCS requirements.
+            if req_str_or_addr.startswith(os.path.sep * 2):
+                specs.append(req_str_or_addr)
+            else:
+                req_strings.append(req_str_or_addr)
+    if specs:
+        addrs_from_specs = await Get(
+            Addresses,
+            UnparsedAddressInputs(
+                specs,
+                owning_address=None,
+                description_of_origin=pex_reqs.description_of_origin,
+            ),
+        )
+        addrs.extend(addrs_from_specs)
+    if addrs:
+        transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(addrs))
+        req_strings.extend(
+            PexRequirements.req_strings_from_requirement_fields(
+                tgt[PythonRequirementsField]
+                for tgt in transitive_targets.closure
+                if tgt.has_field(PythonRequirementsField)
+            )
+        )
+    return ReqStrings(tuple(sorted(req_strings)))
+
+
 async def _setup_pex_requirements(
     request: PexRequest, python_setup: PythonSetup
 ) -> _BuildPexRequirementsSetup:
@@ -509,16 +561,19 @@ async def _setup_pex_requirements(
             [loaded_lockfile.lockfile_digest], argv, loaded_lockfile.requirement_estimate
         )
 
+    assert isinstance(request.requirements, PexRequirements)
+    req_strings = (await Get(ReqStrings, PexRequirements, request.requirements)).req_strings
+
     # TODO: This is not the best heuristic for available concurrency, since the
     # requirements almost certainly have transitive deps which also need building, but it
     # is better than using something hardcoded.
-    concurrency_available = len(request.requirements.req_strings)
+    concurrency_available = len(req_strings)
 
     if isinstance(request.requirements.from_superset, Pex):
         repository_pex = request.requirements.from_superset
         return _BuildPexRequirementsSetup(
             [repository_pex.digest],
-            [*request.requirements.req_strings, "--pex-repository", repository_pex.name],
+            [*req_strings, "--pex-repository", repository_pex.name],
             concurrency_available,
         )
 
@@ -528,7 +583,7 @@ async def _setup_pex_requirements(
 
         # NB: This is also validated in the constructor.
         assert loaded_lockfile.is_pex_native
-        if not request.requirements.req_strings:
+        if not req_strings:
             return _BuildPexRequirementsSetup([], [], concurrency_available)
 
         if loaded_lockfile.metadata:
@@ -536,7 +591,7 @@ async def _setup_pex_requirements(
                 loaded_lockfile.metadata,
                 request.interpreter_constraints,
                 loaded_lockfile.original_lockfile,
-                consumed_req_strings=request.requirements.req_strings,
+                consumed_req_strings=req_strings,
                 # Don't validate user requirements when subsetting a resolve, as Pex's
                 # validation during the subsetting is far more precise than our naive string
                 # comparison. For example, if a lockfile was generated with `foo==1.2.3`
@@ -550,7 +605,7 @@ async def _setup_pex_requirements(
         return _BuildPexRequirementsSetup(
             [loaded_lockfile.lockfile_digest],
             [
-                *request.requirements.req_strings,
+                *req_strings,
                 "--lock",
                 loaded_lockfile.lockfile_path,
                 *pex_lock_resolver_args,
@@ -560,7 +615,7 @@ async def _setup_pex_requirements(
 
     # We use pip to perform a normal resolve.
     digests = []
-    argv = [*request.requirements.req_strings, *pip_resolver_args]
+    argv = [*req_strings, *pip_resolver_args]
     if request.requirements.constraints_strings:
         constraints_file = "__constraints.txt"
         constraints_content = "\n".join(request.requirements.constraints_strings)
@@ -657,13 +712,18 @@ async def build_pex(
     else:
         output_directories = [request.output_filename]
 
+    req_strings = (
+        (await Get(ReqStrings, PexRequirements, request.requirements)).req_strings
+        if isinstance(request.requirements, PexRequirements)
+        else []
+    )
     result = await Get(
         ProcessResult,
         PexCliProcess(
             subcommand=(),
             extra_args=argv,
             additional_input_digest=merged_digest,
-            description=_build_pex_description(request, python_setup.resolves),
+            description=await _build_pex_description(request, req_strings, python_setup.resolves),
             output_files=output_files,
             output_directories=output_directories,
             concurrency_available=requirements_setup.concurrency_available,
@@ -692,7 +752,9 @@ async def build_pex(
     )
 
 
-def _build_pex_description(request: PexRequest, resolve_to_lockfile: Mapping[str, str]) -> str:
+async def _build_pex_description(
+    request: PexRequest, req_strings: Sequence[str], resolve_to_lockfile: Mapping[str, str]
+) -> str:
     if request.description:
         return request.description
 
@@ -700,15 +762,15 @@ def _build_pex_description(request: PexRequest, resolve_to_lockfile: Mapping[str
         lockfile = request.requirements.lockfile
         desc_suffix = f"from {lockfile.url}"
     else:
-        if not request.requirements.req_strings:
+        if not req_strings:
             return f"Building {request.output_filename}"
         elif isinstance(request.requirements.from_superset, Pex):
             repo_pex = request.requirements.from_superset.name
             return softwrap(
                 f"""
-                Extracting {pluralize(len(request.requirements.req_strings), 'requirement')}
+                Extracting {pluralize(len(req_strings), 'requirement')}
                 to build {request.output_filename} from {repo_pex}:
-                {', '.join(request.requirements.req_strings)}
+                {', '.join(req_strings)}
                 """
             )
         elif isinstance(request.requirements.from_superset, Resolve):
@@ -718,16 +780,16 @@ def _build_pex_description(request: PexRequest, resolve_to_lockfile: Mapping[str
             lockfile_path = resolve_to_lockfile.get(request.requirements.from_superset.name, "")
             return softwrap(
                 f"""
-                Building {pluralize(len(request.requirements.req_strings), 'requirement')}
+                Building {pluralize(len(req_strings), 'requirement')}
                 for {request.output_filename} from the {lockfile_path} resolve:
-                {', '.join(request.requirements.req_strings)}
+                {', '.join(req_strings)}
                 """
             )
         else:
             desc_suffix = softwrap(
                 f"""
-                with {pluralize(len(request.requirements.req_strings), 'requirement')}:
-                {', '.join(request.requirements.req_strings)}
+                with {pluralize(len(req_strings), 'requirement')}:
+                {', '.join(req_strings)}
                 """
             )
     return f"Building {request.output_filename} {desc_suffix}"

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -333,16 +333,20 @@ class _PexRequirementsRequest:
 async def determine_requirement_strings_in_closure(
     request: _PexRequirementsRequest, global_requirement_constraints: GlobalRequirementConstraints
 ) -> PexRequirements:
-    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest(request.addresses))
-    return PexRequirements.create_from_requirement_fields(
-        (
-            tgt[PythonRequirementsField]
-            for tgt in transitive_targets.closure
-            if tgt.has_field(PythonRequirementsField)
-        ),
+    addrs = request.addresses
+    if len(addrs) == 0:
+        description_of_origin = ""
+    elif len(addrs) == 1:
+        description_of_origin = addrs[0].spec
+    else:
+        description_of_origin = f"{addrs[0].spec} and {len(addrs)-1} other targets"
+
+    return PexRequirements(
+        request.addresses,
         # This is only set if `[python].requirement_constraints` is configured, which is mutually
         # exclusive with resolves.
         constraints_strings=(str(constraint) for constraint in global_requirement_constraints),
+        description_of_origin=description_of_origin,
     )
 
 
@@ -669,6 +673,7 @@ async def _setup_constraints_repository_pex(
         requirements=PexRequirements(
             all_constraints,
             constraints_strings=(str(constraint) for constraint in global_requirement_constraints),
+            description_of_origin=constraints_path,
         ),
         # Monolithic PEXes like the repository PEX should always use the Packed layout.
         layout=PexLayout.PACKED,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -32,6 +32,7 @@ from pants.backend.python.util_rules.pex import (
     PexProcess,
     PexRequest,
     PexResolveInfo,
+    ReqStrings,
     VenvPex,
     VenvPexProcess,
     _build_pex_description,
@@ -279,11 +280,12 @@ def test_pex_working_directory(rule_runner: RuleRunner, pex_type: type[Pex | Ven
 
 
 def test_resolves_dependencies(rule_runner: RuleRunner) -> None:
-    requirements = PexRequirements(["six==1.12.0", "jsonschema==2.6.0", "requests==2.23.0"])
+    req_strings = ["six==1.12.0", "jsonschema==2.6.0", "requests==2.23.0"]
+    requirements = PexRequirements(req_strings)
     pex_info = create_pex_and_get_pex_info(rule_runner, requirements=requirements)
     # NB: We do not check for transitive dependencies, which PEX-INFO will include. We only check
     # that at least the dependencies we requested are included.
-    assert set(parse_requirements(requirements.req_strings)).issubset(
+    assert set(parse_requirements(req_strings)).issubset(
         set(parse_requirements(pex_info["requirements"]))
     )
 
@@ -721,6 +723,15 @@ def test_setup_pex_requirements() -> None:
                     mock=lambda _: create_loaded_lockfile(is_pex_lock),
                 ),
                 MockGet(
+                    output_type=ReqStrings,
+                    input_types=(PexRequirements,),
+                    mock=lambda _: ReqStrings(
+                        tuple(str(x) for x in requirements.req_strings_or_addrs)
+                        if isinstance(requirements, PexRequirements)
+                        else tuple()
+                    ),
+                ),
+                MockGet(
                     output_type=ResolvePexConfig,
                     input_types=(ResolvePexConfigRequest,),
                     mock=lambda _: ResolvePexConfig(
@@ -794,7 +805,7 @@ def test_setup_pex_requirements() -> None:
     )
 
 
-def test_build_pex_description() -> None:
+def test_build_pex_description(rule_runner: RuleRunner) -> None:
     def assert_description(
         requirements: PexRequirements | EntireLockfile,
         *,
@@ -807,7 +818,16 @@ def test_build_pex_description() -> None:
             requirements=requirements,
             description=description,
         )
-        assert _build_pex_description(request, {}) == expected
+        req_strings = (
+            requirements.req_strings_or_addrs if isinstance(requirements, PexRequirements) else []
+        )
+        assert (
+            run_rule_with_mocks(
+                _build_pex_description,
+                rule_args=[request, req_strings, {}],
+            )
+            == expected
+        )
 
     repo_pex = Pex(EMPTY_DIGEST, "repo.pex", None)
 

--- a/src/python/pants/init/plugin_resolver.py
+++ b/src/python/pants/init/plugin_resolver.py
@@ -57,9 +57,11 @@ async def resolve_plugins(
     `named_caches` directory), but consequently needs to disable the process cache: see the
     ProcessCacheScope reference in the body.
     """
+    req_strings = sorted(global_options.plugins)
     requirements = PexRequirements(
-        req_strings=sorted(global_options.plugins),
+        req_strings_or_addrs=req_strings,
         constraints_strings=(str(constraint) for constraint in request.constraints),
+        description_of_origin="configured Pants plugins",
     )
     if not requirements:
         return ResolvedPluginDistributions()
@@ -81,7 +83,7 @@ async def resolve_plugins(
             python=python,
             requirements=requirements,
             interpreter_constraints=request.interpreter_constraints or InterpreterConstraints(),
-            description=f"Resolving plugins: {', '.join(requirements.req_strings)}",
+            description=f"Resolving plugins: {', '.join(req_strings)}",
         ),
     )
 


### PR DESCRIPTION
Currently users can enumerate `requirements` for a Python tool, which will cause
Pants to use that requirement subset from the tool's lockfile. This supports resolving
a tool from a larger lockfile, when that makes sense. If no requirements are provided
the entire lockfile is used.

Two examples of when resolving a tool from a subset of a larger lockfile is useful:
1. Resolving `pytest` as a tool at the same version as its runtime library without
  specifying it in two places.
2. Having a single lockfile for all tools, and user code, to be consumed by VSCode.

However, the value of this `requirements` option is typically redundant with the
input requirements used to generate the lockfile. 

This change allows `requirements` to specify addresses (or address specs). 
This can be used to avoid the redundancy: You can point to some
python_requirement targets that are a subset of all those used to generate
the lockfile.

The implementation turns out to be reasonably neat, as it just pushes
some code that turns addresses into requirement strings to slightly 
later in the pex creation logic, and actually allowed us to reduce some
redundancy and trim some code.

This addresses #18816.
