### PR TITLE
Clarify how to set $0 properly in `run_in_shell_command` (Cherry-pick of #19019)

### DIFF
--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -266,7 +266,15 @@ class ShellSourcesGeneratorTarget(TargetFilesGenerator):
 class ShellCommandCommandField(StringField):
     alias = "command"
     required = True
-    help = "Shell command to execute.\n\nThe command is executed as 'bash -c <command>' by default."
+    help = help_text(
+        """
+        Shell command to execute.
+
+        The command is executed as 'bash -c <command>' by default. If you want to invoke a binary
+        use `exec -a $0 <binary> <args>` as the command so that the binary gets the correct `argv[0]`
+        set.
+        """
+    )
 
 
 class ShellCommandOutputsField(StringSequenceField):


### PR DESCRIPTION
Fixes #19017 (well turns out it was a non-issue) by suggesting to users how to get `$0` properly in their binaries.
