### PR TITLE
Deprecate lambdex for building FaaS packages (pending)

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -24,6 +24,7 @@ from pants.core.goals.package import BuiltPackage, OutputPathField, PackageField
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -44,9 +45,9 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
 
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)
 async def package_python_awslambda(
-    field_set: PythonAwsLambdaFieldSet,
+    field_set: PythonAwsLambdaFieldSet, global_options: GlobalOptions
 ) -> BuiltPackage:
-    layout = PythonFaaSLayout(field_set.layout.value)
+    layout = field_set.layout.resolve_value(field_set.address, global_options)
 
     if layout is PythonFaaSLayout.LAMBDEX:
         return await Get(

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -117,6 +117,9 @@ def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     ).stdout
 
 
+_first_run_of_deprecated_warning = True
+
+
 @pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "major_minor_interpreter",
@@ -179,6 +182,15 @@ def test_create_hello_world_lambda_with_lambdex(
     ), "third-party dep `mureq` must be included"
     if sys.platform == "darwin":
         assert "`python_awslambda` targets built on macOS may fail to build." in caplog.text
+
+    global _first_run_of_deprecated_warning
+    if _first_run_of_deprecated_warning:
+        _first_run_of_deprecated_warning = False
+        assert (
+            'DEPRECATED: use of `layout="lambdex"` (set by default) in target src/python/foo/bar:lambda is scheduled to be removed'
+            in caplog.text
+        )
+        assert "use_deprecated_lambdex_layout" in caplog.text
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -24,6 +24,7 @@ from pants.core.goals.package import BuiltPackage, OutputPathField, PackageField
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.unions import UnionRule
+from pants.option.global_options import GlobalOptions
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -44,9 +45,10 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
 
 @rule(desc="Create Python Google Cloud Function", level=LogLevel.DEBUG)
 async def package_python_google_cloud_function(
-    field_set: PythonGoogleCloudFunctionFieldSet,
+    field_set: PythonGoogleCloudFunctionFieldSet, global_options: GlobalOptions
 ) -> BuiltPackage:
-    layout = PythonFaaSLayout(field_set.layout.value)
+    layout = field_set.layout.resolve_value(field_set.address, global_options)
+
     if layout is PythonFaaSLayout.LAMBDEX:
         return await Get(
             BuiltPackage,

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -125,6 +125,9 @@ def complete_platform(rule_runner: PythonRuleRunner) -> bytes:
     ).stdout
 
 
+_first_run_of_deprecated_warning = True
+
+
 @pytest.mark.platform_specific_behavior
 @pytest.mark.parametrize(
     "major_minor_interpreter",
@@ -179,6 +182,15 @@ def test_create_hello_world_lambda_with_lambdex(
             "`python_google_cloud_function` targets built on macOS may fail to build."
             in caplog.text
         )
+
+    global _first_run_of_deprecated_warning
+    if _first_run_of_deprecated_warning:
+        _first_run_of_deprecated_warning = False
+        assert (
+            'DEPRECATED: use of `layout="lambdex"` (set by default) in target src/python/foo/bar:lambda is scheduled to be removed'
+            in caplog.text
+        )
+        assert "use_deprecated_lambdex_layout" in caplog.text
 
 
 def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -4,11 +4,33 @@
 from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.engine.rules import collect_rules
+from pants.util.strutil import softwrap
 
 
 class Lambdex(PythonToolBase):
+    # these aren't read automatically, but are defined for use in faas.py
+    removal_hint = softwrap(
+        """
+        Either use `layout=\"zip\"` in `python_awslambda` or `python_google_cloud_function` targets
+        to build flat packages without dynamic PEX start-up (recommended), or use `pex_binary` if dependency
+        selection is required on start-up (for instance, one package is deployed to multiple
+        runtimes). For a `pex_binary`, add `__pex__` to the import path for the handler: for
+        example, if the handler function `func` is defined in `foo/bar.py`, configure
+        `__pex__.foo.bar.func` as the handler.
+        """
+    )
+    removal_version = "2.19.0.dev0"
+
     options_scope = "lambdex"
-    help = "A tool for turning .pex files into Function-as-a-Service artifacts (https://github.com/pantsbuild/lambdex)."
+    help = softwrap(
+        f"""
+        A tool for turning .pex files into Function-as-a-Service artifacts (https://github.com/pantsbuild/lambdex).
+
+        Lambdex is no longer necessary: {removal_hint}
+
+        This will be removed in Pants {removal_version}.
+        """
+    )
 
     default_version = "lambdex>=0.1.9"
     default_main = ConsoleScript("lambdex")

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1752,6 +1752,20 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         default=[],
     )
 
+    use_deprecated_lambdex_layout = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            If `true`, any `python_awslambda` and `python_google_cloud_function` targets use the
+            `layout="lambdex"` by default. This is the older behaviour of these targets, and is
+            being removed.
+
+            If `false`, they will instead use the improved `layout="zip"` by default, which will
+            become the default in future.
+            """
+        ),
+    )
+
     @classmethod
     def validate_instance(cls, opts):
         """Validates an instance of global options for cases that are not prohibited via


### PR DESCRIPTION
We're changing the approach, so this may not be necessary: https://github.com/pantsbuild/pants/pull/19032#discussion_r1199622348

---

This deprecates the `layout="lambdex"` value for FaaS packages (`python_awslambda` and `python_google_cloud_function`), now that #19022 has implemented `layout="zip"`, which is the cloud-vendor's recommended layout.

This doesn't change the behaviour by default, other than a new warning. This also adds a flag `use_deprecated_lambdex_layout` that can be explicitly set to `true` to preserve behaviour and silence the warning, or set to `false` to opt in to `layout="zip"` by default.

Questions:

- I'm not sure how to deprecate/emit warnings about the `[lambdex]` subsystem section in `pants.toml`, if someone has that set? I guess for now it's fine to leave it there, without a warning, and once we remove Lambdex support, we tell people that the section is unused/irrelevant?
- I'm not sure if there's a better way to deprecate a particular value to a field, rather than the whole field itself (`removal_hint` etc.)?