### PR TITLE
Release doc and script fixes

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -18,7 +18,7 @@ venv_dir_prefix="${HOME}/.cache/pants/pants_dev_deps/${platform}"
 
 function venv_dir() {
   # Include the entire version string in order to differentiate e.g. PyPy from CPython.
-  py_venv_version=$(${PY} --version | shasum | awk '{print $1}')
+  py_venv_version=$(${PY} --version | fingerprint_data)
   echo "${venv_dir_prefix}.py.${py_venv_version}.venv"
 }
 

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -35,10 +35,10 @@ npm install rdme
 ### Log in.
 
 ```
-npx rdme login --project pants --2fa
+npx rdme login --project pants
 ```
 
-(the `--2fa` flag makes `rdme` prompt for 2fa codes, which is necessary if you have TOTP 2fa set up on your account)
+(`rdme` will prompt for two-factor-authentication codes if necessary)
 
 ## When cutting a new release branch
 

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -28,36 +28,7 @@ See <https://docs.github.com/en/github/authenticating-to-github/telling-git-abou
 
 Note: the last step is required on macOS.
 
-### 4. Create a PyPI account
-
-[pypi.org/account/register](https://pypi.org/account/register).
-
-Please enable two-factor authentication under "Account Settings".
-
-Generate an API token under "Account Settings" for all projects. Copy the token for the last step.
-
-### 5. Get added to pantsbuild.pants PyPI
-
-You can ask any of the current Owners to add you as a maintainer.
-
-### 6. Configure `~/.pypirc`
-
-Fill in with your PyPI token by running:
-
-```bash
-$ cat << EOF > ~/.pypirc && chmod 600 ~/.pypirc
-[pypi]
-username: __token__
-password: <fill me in>
-
-[server-login]
-username: __token__
-password: <fill me in>
-
-EOF
-```
-
-### 7. Authenticate with the Github API
+### 4. Authenticate with the Github API
 
 Ensure that you have a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for your Github account in your `.netrc` file.
 


### PR DESCRIPTION
#18916 moved to fingerprinting the entire `python --version` using `shasum`, which is apparently not available on some Linux distributions (but which thanks to the magic of bash scripts, [did not fail in CI](https://github.com/pantsbuild/pants/actions/runs/5018337243/jobs/8997619843#step:8:926)).