### PR TITLE
Use hand-written change detection for PR/push job trimming

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -617,17 +617,18 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v3
       with:
-        fetch-depth: 2
-    - id: files
-      name: Get changed files
-      uses: tj-actions/changed-files@v32
-      with:
-        separator: '|'
+        fetch-depth: 10
+    - id: comparison
+      name: Materialize comparison SHA
+      run: "\nif [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then\n  # push: we need to make sure the parent commit(s) exist\n\
+        \  git fetch --deepen=1\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n  # pull request: just fetch what github is\
+        \ telling us the base is\n  git fetch origin \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
+        \nfi\necho \"comparison_sha=$comparison_sha\" | tee -a $GITHUB_OUTPUT\n"
     - id: classify
       name: Classify changed files
-      run: "affected=$(python build-support/bin/classify_changed_files.py \"${{ steps.files.outputs.all_modified_files }}\"\
-        )\necho \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n  echo \"docs_only=true\" >> $GITHUB_OUTPUT\n \
-        \ echo \"docs_only\"\nfi\nfor i in ${affected}; do\n  echo \"${i}=true\" >> $GITHUB_OUTPUT\n  echo \"${i}\"\ndone\n"
+      run: "affected=$(git diff --name-only  \"${{ steps.comparison.outputs.comparison_sha }}\" HEAD | python build-support/bin/classify_changed_files.py)\n\
+        echo \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n  echo \"docs_only=true\" | tee -a $GITHUB_OUTPUT\n\
+        fi\nfor i in ${affected}; do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
     name: Lint Python and Shell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -618,17 +618,15 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - id: comparison
-      name: Materialize comparison SHA
-      run: "\nif [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then\n  # push: we need to make sure the parent commit(s) exist\n\
-        \  git fetch --deepen=1\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n  # pull request: just fetch what github is\
-        \ telling us the base is\n  git fetch origin --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\n  comparison_sha=\"\
-        $GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\" | tee -a $GITHUB_OUTPUT\n"
     - id: classify
       name: Classify changed files
-      run: "affected=$(git diff --name-only  \"${{ steps.comparison.outputs.comparison_sha }}\" HEAD | python build-support/bin/classify_changed_files.py)\n\
-        echo \"Affected:\"\nif [[ \"${affected}\" == \"docs\" ]]; then\n  echo \"docs_only=true\" | tee -a $GITHUB_OUTPUT\n\
-        fi\nfor i in ${affected}; do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
+      run: "if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then\n  # push: compare to the immediate parent, which should\
+        \ already be fetched\n  # (checkout's fetch_depth defaults to 10)\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n\
+        \  # pull request: compare to the base branch, ensuring that commit exists\n  git fetch --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
+        \n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\"\n\naffected=$(git\
+        \ diff --name-only \"$comparison_sha\" HEAD | python build-support/bin/classify_changed_files.py)\necho \"Affected:\"\
+        \nif [[ \"${affected}\" == \"docs\" ]]; then\n  echo \"docs_only=true\" | tee -a $GITHUB_OUTPUT\nfi\nfor i in ${affected};\
+        \ do\n  echo \"${i}=true\" | tee -a $GITHUB_OUTPUT\ndone\n"
   lint_python:
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
     name: Lint Python and Shell

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -622,8 +622,8 @@ jobs:
       name: Materialize comparison SHA
       run: "\nif [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then\n  # push: we need to make sure the parent commit(s) exist\n\
         \  git fetch --deepen=1\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n  # pull request: just fetch what github is\
-        \ telling us the base is\n  git fetch origin \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
-        \nfi\necho \"comparison_sha=$comparison_sha\" | tee -a $GITHUB_OUTPUT\n"
+        \ telling us the base is\n  git fetch origin --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\n  comparison_sha=\"\
+        $GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\" | tee -a $GITHUB_OUTPUT\n"
     - id: classify
       name: Classify changed files
       run: "affected=$(git diff --name-only  \"${{ steps.comparison.outputs.comparison_sha }}\" HEAD | python build-support/bin/classify_changed_files.py)\n\

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -620,7 +620,7 @@ jobs:
         fetch-depth: 10
     - id: classify
       name: Classify changed files
-      run: "if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then\n  # push: compare to the immediate parent, which should\
+      run: "if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_SHA ]]; then\n  # push: compare to the immediate parent, which should\
         \ already be fetched\n  # (checkout's fetch_depth defaults to 10)\n  comparison_sha=$(git rev-parse HEAD^)\nelse\n\
         \  # pull request: compare to the base branch, ensuring that commit exists\n  git fetch --depth=1 \"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\
         \n  comparison_sha=\"$GITHUB_EVENT_PULL_REQUEST_BASE_SHA\"\nfi\necho \"comparison_sha=$comparison_sha\"\n\naffected=$(git\

--- a/build-support/bin/classify_changed_files.py
+++ b/build-support/bin/classify_changed_files.py
@@ -67,9 +67,7 @@ def classify(changed_files: list[str]) -> set[Affected]:
 
 
 def main() -> None:
-    if len(sys.argv) < 2:
-        return
-    affecteds = classify(sys.argv[1].split("|"))
+    affecteds = classify(sys.stdin.read().splitlines())
     for affected in sorted([a.name for a in affecteds]):
         print(affected)
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -115,7 +115,7 @@ def classify_changes() -> Jobs:
                     "name": "Classify changed files",
                     "run": dedent(
                         """\
-                        if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then
+                        if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_SHA ]]; then
                           # push: compare to the immediate parent, which should already be fetched
                           # (checkout's fetch_depth defaults to 10)
                           comparison_sha=$(git rev-parse HEAD^)

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -114,7 +114,7 @@ def classify_changes() -> Jobs:
                     "id": "classify",
                     "name": "Classify changed files",
                     "run": dedent(
-                        f"""\
+                        """\
                         if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then
                           # push: compare to the immediate parent, which should already be fetched
                           # (checkout's fetch_depth defaults to 10)
@@ -128,11 +128,11 @@ def classify_changes() -> Jobs:
 
                         affected=$(git diff --name-only "$comparison_sha" HEAD | python build-support/bin/classify_changed_files.py)
                         echo "Affected:"
-                        if [[ "${{affected}}" == "docs" ]]; then
+                        if [[ "${affected}" == "docs" ]]; then
                           echo "docs_only=true" | tee -a $GITHUB_OUTPUT
                         fi
-                        for i in ${{affected}}; do
-                          echo "${{i}}=true" | tee -a $GITHUB_OUTPUT
+                        for i in ${affected}; do
+                          echo "${i}=true" | tee -a $GITHUB_OUTPUT
                         done
                         """
                     ),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -109,28 +109,37 @@ def classify_changes() -> Jobs:
                 "other": gha_expr("steps.classify.outputs.other"),
             },
             "steps": [
-                # fetch_depth must be 2.
-                *checkout(fetch_depth=2),
+                *checkout(),
                 {
-                    "id": "files",
-                    "name": "Get changed files",
-                    "uses": "tj-actions/changed-files@v32",
-                    "with": {"separator": "|"},
+                    "id": "comparison",
+                    "name": "Materialize comparison SHA",
+                    "run": dedent(
+                        """
+                        if [[ -z $GITHUB_EVENT_PULL_REQUEST_BASE_REF ]]; then
+                          # push: we need to make sure the parent commit(s) exist
+                          git fetch --deepen=1
+                          comparison_sha=$(git rev-parse HEAD^)
+                        else
+                          # pull request: just fetch what github is telling us the base is
+                          git fetch origin "$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+                          comparison_sha="$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+                        fi
+                        echo "comparison_sha=$comparison_sha" | tee -a $GITHUB_OUTPUT
+                        """
+                    )
                 },
                 {
                     "id": "classify",
                     "name": "Classify changed files",
                     "run": dedent(
                         f"""\
-                        affected=$(python build-support/bin/classify_changed_files.py "{gha_expr("steps.files.outputs.all_modified_files")}")
+                        affected=$(git diff --name-only  "{gha_expr("steps.comparison.outputs.comparison_sha")}" HEAD | python build-support/bin/classify_changed_files.py)
                         echo "Affected:"
                         if [[ "${{affected}}" == "docs" ]]; then
-                          echo "docs_only=true" >> $GITHUB_OUTPUT
-                          echo "docs_only"
+                          echo "docs_only=true" | tee -a $GITHUB_OUTPUT
                         fi
                         for i in ${{affected}}; do
-                          echo "${{i}}=true" >> $GITHUB_OUTPUT
-                          echo "${{i}}"
+                          echo "${{i}}=true" | tee -a $GITHUB_OUTPUT
                         done
                         """
                     ),

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -121,7 +121,7 @@ def classify_changes() -> Jobs:
                           comparison_sha=$(git rev-parse HEAD^)
                         else
                           # pull request: just fetch what github is telling us the base is
-                          git fetch origin "$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
+                          git fetch origin --depth=1 "$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
                           comparison_sha="$GITHUB_EVENT_PULL_REQUEST_BASE_SHA"
                         fi
                         echo "comparison_sha=$comparison_sha" | tee -a $GITHUB_OUTPUT


### PR DESCRIPTION
This replaces the use of https://github.com/tj-actions/changed-files with a much simpler hand-written version:

1. determine the commit to compare the PR to
   1. for a push, this is the immediate parent (i.e. `HEAD^`)
   2. for a pull request, this is the `HEAD` of the base branch
3. do the comparison using `git diff --name-only $comparison_sha HEAD`

This is basically what the action does, except it needs to handle a lot more edge cases/functionality that don't matter to pants: categorising the changes in detail (e.g. which files are specifically added vs. modified vs. renamed etc.), submodules, and various other forms of customisation. Pants just cares which files have any changes at all, which is much simpler.

Handling PRs is a bit subtle, but the 'simple' implementation (just diff Actions' `HEAD` vs base branch `HEAD` in isolation) is correct, without needing to deal with commit ranges or finding a merge base, I think: 

1. GHA runs on the _merge_ of base branch `HEAD` and PR `HEAD` by default: this is why actions don't run if there's merge conflicts
3. This merge commit is the default checked-out commit/aka the GHA `HEAD`
4. Thus, the GHA `HEAD` _includes_ the base branch `HEAD` and any changes there. Diffing the base branch `HEAD` and GHA `HEAD` will identify only the changes from the PR that were merged in.

For instance, this PR branches off af8004a206 from last week, which is 30 commits older than the current `main` `HEAD` a267fef3be. Here's the results of various `git diff --name-only $sha1 $sha2 | pants run build-support/bin/classify_changed_files.py` calls:

| description | sha1 | sha2 | changes |
|---|---|---|---|
| branch point vs. `main` | af8004a206 | a267fef3be | `ci_config docs other release rust` |
| PR vs. `main` | a267fef3be | 3f04618f15 | `ci_config docs other release rust` |
| PR vs. branch point | af8004a206 | 3f04618f15 | `ci_config other` |
| CI: PR merge vs. `main` |  a267fef3be | (transient on CI) | `ci_config other` |

This approach ensures we're diffing the actual changes that would get merged (if nothing else merged, cf. a merge queue), meaning the contents of the eventual squash-and-merge commit, which can be slightly different to what's shown in the PR UI. It also means we don't need to worry about PRs getting too far from `main` for change detection to work, because it's literally diffing commits and their file trees in isolation, rather than needing to traverse far into history.

This PR tests the PR logic, and I've [tested the push logic on my fork](https://github.com/huonw/pants/actions/runs/5019084704/jobs/8999204595).