### PR TITLE
Use a trait for remote ByteStore network implementation

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -801,9 +801,7 @@ impl Store {
           ingested_digests.keys().cloned().collect()
         } else {
           remote
-            .list_missing_digests(
-              remote.find_missing_blobs_request(ingested_digests.keys().cloned()),
-            )
+            .list_missing_digests(ingested_digests.keys().cloned())
             .await?
         };
 
@@ -958,10 +956,7 @@ impl Store {
     } else {
       return Ok(false);
     };
-    let missing = remote
-      .store
-      .list_missing_digests(remote.store.find_missing_blobs_request(missing_locally))
-      .await?;
+    let missing = remote.store.list_missing_digests(missing_locally).await?;
 
     Ok(missing.is_empty())
   }

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -1,8 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use std::cmp::min;
 use std::collections::{BTreeMap, HashSet};
-use std::convert::TryInto;
 use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
@@ -11,27 +9,17 @@ use std::time::{Duration, Instant};
 use async_oncecell::OnceCell;
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::StreamExt;
-use futures::{Future, FutureExt};
-use grpc_util::retry::{retry_call, status_is_retryable};
-use grpc_util::{
-  headers_to_http_header_map, layered_service, status_ref_to_str, status_to_str, LayeredService,
-};
-use hashing::{Digest, Hasher};
+use futures::Future;
+use hashing::Digest;
 use log::Level;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
-use protos::gen::google::bytestream::byte_stream_client::ByteStreamClient;
-use remexec::{
-  capabilities_client::CapabilitiesClient,
-  content_addressable_storage_client::ContentAddressableStorageClient, BatchUpdateBlobsRequest,
-  ServerCapabilities,
-};
-use tokio::io::{AsyncSeekExt, AsyncWrite, AsyncWriteExt};
-use tokio::sync::Mutex;
-use tonic::{Code, Request, Status};
-use workunit_store::{in_workunit, Metric, ObservationMetric};
+use remexec::ServerCapabilities;
+use tokio::io::{AsyncSeekExt, AsyncWrite};
+use workunit_store::{in_workunit, ObservationMetric};
 
 use crate::StoreError;
+
+mod reapi;
 
 pub type ByteSource = Arc<(dyn Fn(Range<usize>) -> Bytes + Send + Sync + 'static)>;
 
@@ -56,13 +44,7 @@ pub trait ByteStoreProvider: Sync + Send + 'static {
 #[derive(Clone)]
 pub struct ByteStore {
   instance_name: Option<String>,
-  chunk_size_bytes: usize,
-  _rpc_attempts: usize,
-  byte_stream_client: Arc<ByteStreamClient<LayeredService>>,
-  cas_client: Arc<ContentAddressableStorageClient<LayeredService>>,
-  capabilities_cell: Arc<OnceCell<ServerCapabilities>>,
-  capabilities_client: Arc<CapabilitiesClient<LayeredService>>,
-  batch_api_size_limit: usize,
+  provider: Arc<dyn ByteStoreProvider>,
 }
 
 impl fmt::Debug for ByteStore {
@@ -70,53 +52,6 @@ impl fmt::Debug for ByteStore {
     write!(f, "ByteStore(name={:?})", self.instance_name)
   }
 }
-
-/// Represents an error from accessing a remote bytestore.
-#[derive(Debug)]
-enum ByteStoreError {
-  /// gRPC error
-  Grpc(Status),
-
-  /// Other errors
-  Other(String),
-}
-
-impl ByteStoreError {
-  fn retryable(&self) -> bool {
-    match self {
-      ByteStoreError::Grpc(status) => status_is_retryable(status),
-      ByteStoreError::Other(_) => false,
-    }
-  }
-}
-
-impl From<Status> for ByteStoreError {
-  fn from(status: Status) -> ByteStoreError {
-    ByteStoreError::Grpc(status)
-  }
-}
-
-impl From<String> for ByteStoreError {
-  fn from(string: String) -> ByteStoreError {
-    ByteStoreError::Other(string)
-  }
-}
-impl From<std::io::Error> for ByteStoreError {
-  fn from(err: std::io::Error) -> ByteStoreError {
-    ByteStoreError::Other(err.to_string())
-  }
-}
-
-impl fmt::Display for ByteStoreError {
-  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    match self {
-      ByteStoreError::Grpc(status) => fmt::Display::fmt(&status_ref_to_str(status), f),
-      ByteStoreError::Other(msg) => fmt::Display::fmt(msg, f),
-    }
-  }
-}
-
-impl std::error::Error for ByteStoreError {}
 
 /// Places that write the result of a remote `load`
 #[async_trait]
@@ -148,7 +83,7 @@ impl ByteStore {
     cas_address: &str,
     instance_name: Option<String>,
     tls_config: grpc_util::tls::Config,
-    mut headers: BTreeMap<String, String>,
+    headers: BTreeMap<String, String>,
     chunk_size_bytes: usize,
     rpc_timeout: Duration,
     rpc_retries: usize,
@@ -156,42 +91,26 @@ impl ByteStore {
     capabilities_cell_opt: Option<Arc<OnceCell<ServerCapabilities>>>,
     batch_api_size_limit: usize,
   ) -> Result<ByteStore, String> {
-    let tls_client_config = if cas_address.starts_with("https://") {
-      Some(tls_config.try_into()?)
-    } else {
-      None
-    };
-
-    let endpoint =
-      grpc_util::create_endpoint(cas_address, tls_client_config.as_ref(), &mut headers)?;
-    let http_headers = headers_to_http_header_map(&headers)?;
-    let channel = layered_service(
-      tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
+    let provider = Arc::new(reapi::Provider::new(
+      cas_address,
+      instance_name.clone(),
+      tls_config,
+      headers,
+      chunk_size_bytes,
+      rpc_timeout,
+      rpc_retries,
       rpc_concurrency_limit,
-      http_headers,
-      Some((rpc_timeout, Metric::RemoteStoreRequestTimeouts)),
-    );
-
-    let byte_stream_client = Arc::new(ByteStreamClient::new(channel.clone()));
-
-    let cas_client = Arc::new(ContentAddressableStorageClient::new(channel.clone()));
-
-    let capabilities_client = Arc::new(CapabilitiesClient::new(channel));
-
+      capabilities_cell_opt,
+      batch_api_size_limit,
+    )?);
     Ok(ByteStore {
       instance_name,
-      chunk_size_bytes,
-      _rpc_attempts: rpc_retries + 1,
-      byte_stream_client,
-      cas_client,
-      capabilities_cell: capabilities_cell_opt.unwrap_or_else(|| Arc::new(OnceCell::new())),
-      capabilities_client,
-      batch_api_size_limit,
+      provider,
     })
   }
 
   pub(crate) fn chunk_size_bytes(&self) -> usize {
-    self.chunk_size_bytes
+    self.provider.chunk_size_bytes()
   }
 
   pub async fn store_buffered<WriteToBuffer, WriteResult>(
@@ -234,154 +153,41 @@ impl ByteStore {
       Ok(mapping) as Result<memmap::Mmap, String>
     }?);
 
-    retry_call(
-      mmap,
-      |mmap| self.store_bytes_source(digest, move |range| Bytes::copy_from_slice(&mmap[range])),
-      ByteStoreError::retryable,
-    )
-    .await
-    .map_err(|e| e.to_string().into())
+    self
+      .store_bytes_source(
+        digest,
+        Arc::new(move |range| Bytes::copy_from_slice(&mmap[range])),
+      )
+      .await?;
+
+    Ok(())
   }
 
   pub async fn store_bytes(&self, bytes: Bytes) -> Result<(), String> {
     let digest = Digest::of_bytes(&bytes);
-    retry_call(
-      bytes,
-      |bytes| self.store_bytes_source(digest, move |range| bytes.slice(range)),
-      ByteStoreError::retryable,
-    )
-    .await
-    .map_err(|e| e.to_string())
+    self
+      .store_bytes_source(digest, Arc::new(move |range| bytes.slice(range)))
+      .await
   }
 
-  async fn store_bytes_source<ByteSource>(
-    &self,
-    digest: Digest,
-    bytes: ByteSource,
-  ) -> Result<(), ByteStoreError>
-  where
-    ByteSource: Fn(Range<usize>) -> Bytes + Send + Sync + 'static,
-  {
-    let len = digest.size_bytes;
-
-    let max_batch_total_size_bytes = {
-      let capabilities = self.get_capabilities().await?;
-
-      capabilities
-        .cache_capabilities
-        .as_ref()
-        .map(|c| c.max_batch_total_size_bytes as usize)
-        .unwrap_or_default()
-    };
-
-    let batch_api_allowed_by_local_config = len <= self.batch_api_size_limit;
-    let batch_api_allowed_by_server_config =
-      max_batch_total_size_bytes == 0 || len < max_batch_total_size_bytes;
-
+  async fn store_bytes_source(&self, digest: Digest, bytes: ByteSource) -> Result<(), String> {
     in_workunit!(
       "store_bytes",
       Level::Trace,
       desc = Some(format!("Storing {digest:?}")),
       |workunit| async move {
-        let result = if batch_api_allowed_by_local_config && batch_api_allowed_by_server_config {
-          self.store_bytes_source_batch(digest, bytes).await
-        } else {
-          self.store_bytes_source_stream(digest, bytes).await
-        };
+        let result = self.provider.store_bytes(digest, bytes).await;
 
         if result.is_ok() {
-          workunit.record_observation(ObservationMetric::RemoteStoreBlobBytesUploaded, len as u64);
+          workunit.record_observation(
+            ObservationMetric::RemoteStoreBlobBytesUploaded,
+            digest.size_bytes as u64,
+          );
         }
 
         result
       }
     )
-    .await
-  }
-
-  async fn store_bytes_source_batch<ByteSource>(
-    &self,
-    digest: Digest,
-    bytes: ByteSource,
-  ) -> Result<(), ByteStoreError>
-  where
-    ByteSource: Fn(Range<usize>) -> Bytes + Send + Sync + 'static,
-  {
-    let request = BatchUpdateBlobsRequest {
-      instance_name: self.instance_name.clone().unwrap_or_default(),
-      requests: vec![remexec::batch_update_blobs_request::Request {
-        digest: Some(digest.into()),
-        data: bytes(0..digest.size_bytes),
-        compressor: remexec::compressor::Value::Identity as i32,
-      }],
-    };
-
-    let mut client = self.cas_client.as_ref().clone();
-    client
-      .batch_update_blobs(request)
-      .await
-      .map_err(ByteStoreError::Grpc)?;
-    Ok(())
-  }
-
-  async fn store_bytes_source_stream<ByteSource>(
-    &self,
-    digest: Digest,
-    bytes: ByteSource,
-  ) -> Result<(), ByteStoreError>
-  where
-    ByteSource: Fn(Range<usize>) -> Bytes + Send + Sync + 'static,
-  {
-    let len = digest.size_bytes;
-    let instance_name = self.instance_name.clone().unwrap_or_default();
-    let resource_name = format!(
-      "{}{}uploads/{}/blobs/{}/{}",
-      &instance_name,
-      if instance_name.is_empty() { "" } else { "/" },
-      uuid::Uuid::new_v4(),
-      digest.hash,
-      digest.size_bytes,
-    );
-    let store = self.clone();
-
-    let mut client = self.byte_stream_client.as_ref().clone();
-
-    let chunk_size_bytes = store.chunk_size_bytes;
-
-    let stream = futures::stream::unfold((0, false), move |(offset, has_sent_any)| {
-      if offset >= len && has_sent_any {
-        futures::future::ready(None)
-      } else {
-        let next_offset = min(offset + chunk_size_bytes, len);
-        let req = protos::gen::google::bytestream::WriteRequest {
-          resource_name: resource_name.clone(),
-          write_offset: offset as i64,
-          finish_write: next_offset == len,
-          // TODO(tonic): Explore using the unreleased `Bytes` support in Prost from:
-          // https://github.com/danburkert/prost/pull/341
-          data: bytes(offset..next_offset),
-        };
-        futures::future::ready(Some((req, (next_offset, true))))
-      }
-    });
-
-    // NB: We must box the future to avoid a stack overflow.
-    Box::pin(async move {
-      let response = client
-        .write(Request::new(stream))
-        .await
-        .map_err(ByteStoreError::Grpc)?;
-
-      let response = response.into_inner();
-      if response.committed_size == len as i64 {
-        Ok(())
-      } else {
-        Err(ByteStoreError::Other(format!(
-          "Uploading file with digest {:?}: want committed size {} but got {}",
-          digest, len, response.committed_size
-        )))
-      }
-    })
     .await
   }
 
@@ -391,76 +197,11 @@ impl ByteStore {
     destination: &mut dyn LoadDestination,
   ) -> Result<bool, String> {
     let start = Instant::now();
-    let store = self.clone();
-    let instance_name = store.instance_name.clone().unwrap_or_default();
-    let resource_name = format!(
-      "{}{}blobs/{}/{}",
-      &instance_name,
-      if instance_name.is_empty() { "" } else { "/" },
+    let workunit_desc = format!(
+      "Loading bytes at: {} {} ({} bytes)",
+      self.instance_name.as_ref().map_or("", |s| s),
       digest.hash,
       digest.size_bytes
-    );
-    let workunit_desc = format!("Loading bytes at: {resource_name}");
-
-    let request = protos::gen::google::bytestream::ReadRequest {
-      resource_name,
-      read_offset: 0,
-      // 0 means no limit.
-      read_limit: 0,
-    };
-    let client = self.byte_stream_client.as_ref().clone();
-
-    let destination = Arc::new(Mutex::new(destination));
-
-    let result_future = retry_call(
-      (client, request, destination),
-      move |(mut client, request, destination)| {
-        async move {
-          let mut start_opt = Some(Instant::now());
-          let response = client.read(request).await?;
-
-          let mut stream = response.into_inner().inspect(|_| {
-            // Record the observed time to receive the first response for this read.
-            if let Some(start) = start_opt.take() {
-              if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
-                let timing: Result<u64, _> =
-                  Instant::now().duration_since(start).as_micros().try_into();
-                if let Ok(obs) = timing {
-                  workunit_store_handle
-                    .store
-                    .record_observation(ObservationMetric::RemoteStoreTimeToFirstByteMicros, obs);
-                }
-              }
-            }
-          });
-
-          let mut writer = destination.lock().await;
-          let mut hasher = Hasher::new();
-          writer.reset().await?;
-          while let Some(response) = stream.next().await {
-            let response = response?;
-            writer.write_all(&response.data).await?;
-            hasher.update(&response.data);
-          }
-          writer.shutdown().await?;
-
-          let actual_digest = hasher.finish();
-          if actual_digest != digest {
-            // Return an `internal` status to attempt retry.
-            return Err(ByteStoreError::Grpc(Status::internal(format!(
-              "Remote CAS gave wrong digest: expected {digest:?}, got {actual_digest:?}"
-            ))));
-          }
-
-          Ok(())
-        }
-        .map(|read_result| match read_result {
-          Ok(()) => Ok(true),
-          Err(ByteStoreError::Grpc(status)) if status.code() == Code::NotFound => Ok(false),
-          Err(err) => Err(err),
-        })
-      },
-      ByteStoreError::retryable,
     );
 
     in_workunit!(
@@ -468,7 +209,7 @@ impl ByteStore {
       Level::Trace,
       desc = Some(workunit_desc),
       |workunit| async move {
-        let result = result_future.await.map_err(|e| e.to_string());
+        let result = self.provider.load(digest, destination).await;
         workunit.record_observation(
           ObservationMetric::RemoteStoreReadBlobTimeMicros,
           start.elapsed().as_micros() as u64,
@@ -523,61 +264,12 @@ impl ByteStore {
     I: IntoIterator<Item = Digest>,
     I::IntoIter: Send,
   {
-    let request = remexec::FindMissingBlobsRequest {
-      instance_name: self.instance_name.as_ref().cloned().unwrap_or_default(),
-      blob_digests: digests.into_iter().map(|d| d.into()).collect::<Vec<_>>(),
-    };
-
-    let store = self.clone();
-    async {
-      in_workunit!(
-        "list_missing_digests",
-        Level::Trace,
-        |_workunit| async move {
-          let store2 = store.clone();
-          let client = store2.cas_client.as_ref().clone();
-          let response = retry_call(
-            client,
-            move |mut client| {
-              let request = request.clone();
-              async move { client.find_missing_blobs(request).await }
-            },
-            status_is_retryable,
-          )
-          .await
-          .map_err(status_to_str)?;
-
-          response
-            .into_inner()
-            .missing_blob_digests
-            .iter()
-            .map(|digest| digest.try_into())
-            .collect::<Result<HashSet<_>, _>>()
-        }
-      )
-      .await
-    }
+    let mut iter = digests.into_iter();
+    in_workunit!(
+      "list_missing_digests",
+      Level::Trace,
+      |_workunit| async move { self.provider.list_missing_digests(&mut iter).await }
+    )
     .await
-  }
-
-  async fn get_capabilities(&self) -> Result<&remexec::ServerCapabilities, ByteStoreError> {
-    let capabilities_fut = async {
-      let mut request = remexec::GetCapabilitiesRequest::default();
-      if let Some(s) = self.instance_name.as_ref() {
-        request.instance_name = s.clone();
-      }
-
-      let mut client = self.capabilities_client.as_ref().clone();
-      client
-        .get_capabilities(request)
-        .await
-        .map(|r| r.into_inner())
-        .map_err(ByteStoreError::Grpc)
-    };
-
-    self
-      .capabilities_cell
-      .get_or_try_init(capabilities_fut)
-      .await
   }
 }

--- a/src/rust/engine/fs/store/src/remote/reapi.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi.rs
@@ -1,0 +1,410 @@
+// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use std::cmp::min;
+use std::collections::{BTreeMap, HashSet};
+use std::convert::TryInto;
+use std::fmt;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_oncecell::OnceCell;
+use async_trait::async_trait;
+use futures::{FutureExt, StreamExt};
+use grpc_util::retry::{retry_call, status_is_retryable};
+use grpc_util::{
+  headers_to_http_header_map, layered_service, status_ref_to_str, status_to_str, LayeredService,
+};
+use hashing::{Digest, Hasher};
+use protos::gen::build::bazel::remote::execution::v2 as remexec;
+use protos::gen::google::bytestream::byte_stream_client::ByteStreamClient;
+use remexec::{
+  capabilities_client::CapabilitiesClient,
+  content_addressable_storage_client::ContentAddressableStorageClient, BatchUpdateBlobsRequest,
+  ServerCapabilities,
+};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
+use tonic::{Code, Request, Status};
+use workunit_store::{Metric, ObservationMetric};
+
+use super::{ByteSource, ByteStoreProvider, LoadDestination};
+
+#[derive(Clone)]
+pub struct Provider {
+  instance_name: Option<String>,
+  chunk_size_bytes: usize,
+  _rpc_attempts: usize,
+  byte_stream_client: Arc<ByteStreamClient<LayeredService>>,
+  cas_client: Arc<ContentAddressableStorageClient<LayeredService>>,
+  capabilities_cell: Arc<OnceCell<ServerCapabilities>>,
+  capabilities_client: Arc<CapabilitiesClient<LayeredService>>,
+  batch_api_size_limit: usize,
+}
+
+/// Represents an error from accessing a remote bytestore.
+#[derive(Debug)]
+enum ByteStoreError {
+  /// gRPC error
+  Grpc(Status),
+
+  /// Other errors
+  Other(String),
+}
+
+impl ByteStoreError {
+  fn retryable(&self) -> bool {
+    match self {
+      ByteStoreError::Grpc(status) => status_is_retryable(status),
+      ByteStoreError::Other(_) => false,
+    }
+  }
+}
+
+impl From<Status> for ByteStoreError {
+  fn from(status: Status) -> ByteStoreError {
+    ByteStoreError::Grpc(status)
+  }
+}
+
+impl From<String> for ByteStoreError {
+  fn from(string: String) -> ByteStoreError {
+    ByteStoreError::Other(string)
+  }
+}
+impl From<std::io::Error> for ByteStoreError {
+  fn from(err: std::io::Error) -> ByteStoreError {
+    ByteStoreError::Other(err.to_string())
+  }
+}
+
+impl fmt::Display for ByteStoreError {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    match self {
+      ByteStoreError::Grpc(status) => fmt::Display::fmt(&status_ref_to_str(status), f),
+      ByteStoreError::Other(msg) => fmt::Display::fmt(msg, f),
+    }
+  }
+}
+
+impl std::error::Error for ByteStoreError {}
+
+impl Provider {
+  // TODO: Consider extracting these options to a struct with `impl Default`, similar to
+  // `super::LocalOptions`.
+  pub fn new(
+    cas_address: &str,
+    instance_name: Option<String>,
+    tls_config: grpc_util::tls::Config,
+    mut headers: BTreeMap<String, String>,
+    chunk_size_bytes: usize,
+    rpc_timeout: Duration,
+    rpc_retries: usize,
+    rpc_concurrency_limit: usize,
+    capabilities_cell_opt: Option<Arc<OnceCell<ServerCapabilities>>>,
+    batch_api_size_limit: usize,
+  ) -> Result<Provider, String> {
+    let tls_client_config = if cas_address.starts_with("https://") {
+      Some(tls_config.try_into()?)
+    } else {
+      None
+    };
+
+    let endpoint =
+      grpc_util::create_endpoint(cas_address, tls_client_config.as_ref(), &mut headers)?;
+    let http_headers = headers_to_http_header_map(&headers)?;
+    let channel = layered_service(
+      tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
+      rpc_concurrency_limit,
+      http_headers,
+      Some((rpc_timeout, Metric::RemoteStoreRequestTimeouts)),
+    );
+
+    let byte_stream_client = Arc::new(ByteStreamClient::new(channel.clone()));
+
+    let cas_client = Arc::new(ContentAddressableStorageClient::new(channel.clone()));
+
+    let capabilities_client = Arc::new(CapabilitiesClient::new(channel));
+
+    Ok(Provider {
+      instance_name,
+      chunk_size_bytes,
+      _rpc_attempts: rpc_retries + 1,
+      byte_stream_client,
+      cas_client,
+      capabilities_cell: capabilities_cell_opt.unwrap_or_else(|| Arc::new(OnceCell::new())),
+      capabilities_client,
+      batch_api_size_limit,
+    })
+  }
+
+  async fn store_bytes_source(
+    &self,
+    digest: Digest,
+    bytes: ByteSource,
+  ) -> Result<(), ByteStoreError> {
+    let len = digest.size_bytes;
+
+    let max_batch_total_size_bytes = {
+      let capabilities = self.get_capabilities().await?;
+
+      capabilities
+        .cache_capabilities
+        .as_ref()
+        .map(|c| c.max_batch_total_size_bytes as usize)
+        .unwrap_or_default()
+    };
+
+    let batch_api_allowed_by_local_config = len <= self.batch_api_size_limit;
+    let batch_api_allowed_by_server_config =
+      max_batch_total_size_bytes == 0 || len < max_batch_total_size_bytes;
+
+    let result = if batch_api_allowed_by_local_config && batch_api_allowed_by_server_config {
+      self.store_bytes_source_batch(digest, bytes).await
+    } else {
+      self.store_bytes_source_stream(digest, bytes).await
+    };
+    result
+  }
+
+  async fn store_bytes_source_batch(
+    &self,
+    digest: Digest,
+    bytes: ByteSource,
+  ) -> Result<(), ByteStoreError> {
+    let request = BatchUpdateBlobsRequest {
+      instance_name: self.instance_name.clone().unwrap_or_default(),
+      requests: vec![remexec::batch_update_blobs_request::Request {
+        digest: Some(digest.into()),
+        data: bytes(0..digest.size_bytes),
+        compressor: remexec::compressor::Value::Identity as i32,
+      }],
+    };
+
+    let mut client = self.cas_client.as_ref().clone();
+    client
+      .batch_update_blobs(request)
+      .await
+      .map_err(ByteStoreError::Grpc)?;
+    Ok(())
+  }
+
+  async fn store_bytes_source_stream(
+    &self,
+    digest: Digest,
+    bytes: ByteSource,
+  ) -> Result<(), ByteStoreError> {
+    let len = digest.size_bytes;
+    let instance_name = self.instance_name.clone().unwrap_or_default();
+    let resource_name = format!(
+      "{}{}uploads/{}/blobs/{}/{}",
+      &instance_name,
+      if instance_name.is_empty() { "" } else { "/" },
+      uuid::Uuid::new_v4(),
+      digest.hash,
+      digest.size_bytes,
+    );
+    let store = self.clone();
+
+    let mut client = self.byte_stream_client.as_ref().clone();
+
+    let chunk_size_bytes = store.chunk_size_bytes;
+
+    let stream = futures::stream::unfold((0, false), move |(offset, has_sent_any)| {
+      if offset >= len && has_sent_any {
+        futures::future::ready(None)
+      } else {
+        let next_offset = min(offset + chunk_size_bytes, len);
+        let req = protos::gen::google::bytestream::WriteRequest {
+          resource_name: resource_name.clone(),
+          write_offset: offset as i64,
+          finish_write: next_offset == len,
+          // TODO(tonic): Explore using the unreleased `Bytes` support in Prost from:
+          // https://github.com/danburkert/prost/pull/341
+          data: bytes(offset..next_offset),
+        };
+        futures::future::ready(Some((req, (next_offset, true))))
+      }
+    });
+
+    // NB: We must box the future to avoid a stack overflow.
+    // Explicit type annotation is a workaround for https://github.com/rust-lang/rust/issues/64552
+    let future: std::pin::Pin<
+      Box<dyn futures::Future<Output = Result<(), ByteStoreError>> + Send>,
+    > = Box::pin(client.write(Request::new(stream)).map(|r| match r {
+      Err(err) => Err(ByteStoreError::Grpc(err)),
+      Ok(response) => {
+        let response = response.into_inner();
+        if response.committed_size == len as i64 {
+          Ok(())
+        } else {
+          Err(ByteStoreError::Other(format!(
+            "Uploading file with digest {:?}: want committed size {} but got {}",
+            digest, len, response.committed_size
+          )))
+        }
+      }
+    }));
+    future.await
+  }
+
+  async fn load_monomorphic(
+    &self,
+    digest: Digest,
+    destination: &mut dyn LoadDestination,
+  ) -> Result<bool, String> {
+    let store = self.clone();
+    let instance_name = store.instance_name.clone().unwrap_or_default();
+    let resource_name = format!(
+      "{}{}blobs/{}/{}",
+      &instance_name,
+      if instance_name.is_empty() { "" } else { "/" },
+      digest.hash,
+      digest.size_bytes
+    );
+
+    let request = protos::gen::google::bytestream::ReadRequest {
+      resource_name,
+      read_offset: 0,
+      // 0 means no limit.
+      read_limit: 0,
+    };
+    let client = self.byte_stream_client.as_ref().clone();
+
+    let destination = Arc::new(Mutex::new(destination));
+
+    let result_future = retry_call(
+      (client, request, destination),
+      move |(mut client, request, destination)| {
+        async move {
+          let mut start_opt = Some(Instant::now());
+          let response = client.read(request).await?;
+
+          let mut stream = response.into_inner().inspect(|_| {
+            // Record the observed time to receive the first response for this read.
+            if let Some(start) = start_opt.take() {
+              if let Some(workunit_store_handle) = workunit_store::get_workunit_store_handle() {
+                let timing: Result<u64, _> =
+                  Instant::now().duration_since(start).as_micros().try_into();
+                if let Ok(obs) = timing {
+                  workunit_store_handle
+                    .store
+                    .record_observation(ObservationMetric::RemoteStoreTimeToFirstByteMicros, obs);
+                }
+              }
+            }
+          });
+
+          let mut writer = destination.lock().await;
+          let mut hasher = Hasher::new();
+          writer.reset().await?;
+          while let Some(response) = stream.next().await {
+            let response = response?;
+            writer.write_all(&response.data).await?;
+            hasher.update(&response.data);
+          }
+          writer.shutdown().await?;
+
+          let actual_digest = hasher.finish();
+          if actual_digest != digest {
+            // Return an `internal` status to attempt retry.
+            return Err(ByteStoreError::Grpc(Status::internal(format!(
+              "Remote CAS gave wrong digest: expected {digest:?}, got {actual_digest:?}"
+            ))));
+          }
+
+          Ok(())
+        }
+        .map(|read_result| match read_result {
+          Ok(()) => Ok(true),
+          Err(ByteStoreError::Grpc(status)) if status.code() == Code::NotFound => Ok(false),
+          Err(err) => Err(err),
+        })
+      },
+      ByteStoreError::retryable,
+    );
+
+    let result = result_future.await.map_err(|e| e.to_string());
+    result
+  }
+
+  async fn list_missing_digests_(
+    &self,
+    digests: &mut (dyn Iterator<Item = Digest> + Send),
+  ) -> Result<HashSet<Digest>, String> {
+    let request = remexec::FindMissingBlobsRequest {
+      instance_name: self.instance_name.as_ref().cloned().unwrap_or_default(),
+      blob_digests: digests.into_iter().map(|d| d.into()).collect::<Vec<_>>(),
+    };
+
+    let store = self.clone();
+    let store2 = store.clone();
+    let client = store2.cas_client.as_ref().clone();
+    let response = retry_call(
+      client,
+      move |mut client| {
+        let request = request.clone();
+        async move { client.find_missing_blobs(request).await }
+      },
+      status_is_retryable,
+    )
+    .await
+    .map_err(status_to_str)?;
+
+    response
+      .into_inner()
+      .missing_blob_digests
+      .iter()
+      .map(|digest| digest.try_into())
+      .collect::<Result<HashSet<_>, _>>()
+  }
+
+  async fn get_capabilities(&self) -> Result<&remexec::ServerCapabilities, ByteStoreError> {
+    let capabilities_fut = async {
+      let mut request = remexec::GetCapabilitiesRequest::default();
+      if let Some(s) = self.instance_name.as_ref() {
+        request.instance_name = s.clone();
+      }
+
+      let mut client = self.capabilities_client.as_ref().clone();
+      client
+        .get_capabilities(request)
+        .await
+        .map(|r| r.into_inner())
+        .map_err(ByteStoreError::Grpc)
+    };
+
+    self
+      .capabilities_cell
+      .get_or_try_init(capabilities_fut)
+      .await
+  }
+}
+
+#[async_trait]
+impl ByteStoreProvider for Provider {
+  async fn store_bytes(&self, digest: Digest, bytes: ByteSource) -> Result<(), String> {
+    self
+      .store_bytes_source(digest, bytes)
+      .await
+      .map_err(|e| e.to_string())
+  }
+
+  async fn load(
+    &self,
+    digest: Digest,
+    destination: &mut dyn LoadDestination,
+  ) -> Result<bool, String> {
+    self.load_monomorphic(digest, destination).await
+  }
+
+  async fn list_missing_digests(
+    &self,
+    digests: &mut (dyn Iterator<Item = Digest> + Send),
+  ) -> Result<HashSet<Digest>, String> {
+    self.list_missing_digests_(digests).await
+  }
+
+  fn chunk_size_bytes(&self) -> usize {
+    self.chunk_size_bytes
+  }
+}

--- a/src/rust/engine/fs/store/src/remote/reapi.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::cmp::min;
 use std::collections::{BTreeMap, HashSet};
@@ -29,7 +29,6 @@ use workunit_store::{Metric, ObservationMetric};
 
 use super::{ByteSource, ByteStoreProvider, LoadDestination};
 
-#[derive(Clone)]
 pub struct Provider {
   instance_name: Option<String>,
   chunk_size_bytes: usize,

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -292,7 +292,7 @@ async fn list_missing_digests_none_missing() {
   let store = new_byte_store(&cas);
   assert_eq!(
     store
-      .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]),)
+      .list_missing_digests(vec![TestData::roland().digest()])
       .await,
     Ok(HashSet::new())
   );
@@ -311,9 +311,7 @@ async fn list_missing_digests_some_missing() {
   digest_set.insert(digest);
 
   assert_eq!(
-    store
-      .list_missing_digests(store.find_missing_blobs_request(vec![digest]))
-      .await,
+    store.list_missing_digests(vec![digest]).await,
     Ok(digest_set)
   );
 }
@@ -326,7 +324,7 @@ async fn list_missing_digests_error() {
   let store = new_byte_store(&cas);
 
   let error = store
-    .list_missing_digests(store.find_missing_blobs_request(vec![TestData::roland().digest()]))
+    .list_missing_digests(vec![TestData::roland().digest()])
     .await
     .expect_err("Want error");
   assert!(

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -262,6 +262,7 @@ async fn write_file_errors() {
 
 #[tokio::test]
 async fn write_connection_error() {
+  let _ = WorkunitStore::setup_for_tests();
   let store = ByteStore::new(
     "http://doesnotexist.example",
     None,


### PR DESCRIPTION
This separates the `store::remote::ByteStore` coordination code from the gRPC REAPI implementation code, by:

- adding a `store::remote::ByteStoreProvider` trait
- moving the REAPI implementation into `store::remote::reapi` and implementing that trait

This is, in theory, just a lift-and-shift, with no functionality change, other than maybe changing some logging and when exactly a work-unit is created.

This is partial preparation work for supporting more remote stores like GHA cache or S3, for #11149, and is specifically broken out of #17840. Additional work required to actually solve #11149:

- generalising the action cache too
- implementing other byte store providers
- dynamically choosing the right provider for `store::remote::ByteStore`

The commits are individually reviewable:

1. preparatory clean-up
2. define the trait
3. move the REAPI code and implement the trait, close to naively as possible:
   - https://gist.github.com/huonw/475e4f0c281fe39e3d0c2e7e492cf823 has a white-space-ignoring diff between `remote.rs` after 1, and the `reapi.rs` file in this commit
   - there are some changes: making functions non-generic, and eliminating the work-units etc. (all the code that was left in `remote.rs`)
5. minor clean-up
6. more major clean-up: inline the method calls into the trait definition, so that they're not just `fn method(&self, ...) { self.real_method(...) }`:
   - as with 3, this is just a move, without changing the details of the code...
   - ...except for some minor changes like converting `?` into `.map(|e| e.to_string())?` on the `get_capabilities` call in `store_bytes`
