### PR TITLE
Workaround `botocore` bug in S3 URL Handler backend

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -1,11 +1,11 @@
 name: Auto Cherry-Picker
 
 on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
+  # NB: This is safe since we already have merged the PR.
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       PR_number:

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -75,7 +75,7 @@ async def download_from_s3(request: S3DownloadFile, aws_credentials: AWSCredenti
     headers = {}
     if aws_credentials.creds.token:
         # Workaround https://github.com/boto/botocore/pull/2948
-        headers['x-amz-security-token'] = None
+        headers['X-Amz-Security-Token'] = None
 
     http_request = SimpleNamespace(
         url=path_style_url,

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -1,5 +1,7 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -72,10 +74,10 @@ async def download_from_s3(request: S3DownloadFile, aws_credentials: AWSCredenti
     if request.query:
         path_style_url += f"?{request.query}"
 
-    headers = {}
+    headers: dict[str, str] = {}
     if aws_credentials.creds.token:
         # Workaround https://github.com/boto/botocore/pull/2948
-        headers['X-Amz-Security-Token'] = None
+        headers["X-Amz-Security-Token"] = ""
 
     http_request = SimpleNamespace(
         url=path_style_url,

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -72,9 +72,14 @@ async def download_from_s3(request: S3DownloadFile, aws_credentials: AWSCredenti
     if request.query:
         path_style_url += f"?{request.query}"
 
+    headers = {}
+    if aws_credentials.creds.token:
+        # Workaround https://github.com/boto/botocore/pull/2948
+        headers['x-amz-security-token'] = None
+
     http_request = SimpleNamespace(
         url=path_style_url,
-        headers={},
+        headers=headers,
         method="GET",
         auth_path=None,
     )

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -2,7 +2,6 @@
 
 ## What's New
 
-
 ### BUILD files
 
 The new `env` function in BUILD files allows access to environment variables in BUILD files.
@@ -169,6 +168,18 @@ The deprecated `Platform.current` has been removed. Instead, have the affected r
 The `ToolCustomLockfile` and `ToolDefaultLockfile` classes [have been removed](https://github.com/pantsbuild/pants/pull/17843).
 
 ----
+
+## 2.16.0rc3 (May 18, 2023)
+
+### User API Changes
+
+* Support Python requirement target addrs in tool requirements. (Cherry-pick of #19014) ([#19023](https://github.com/pantsbuild/pants/pull/19023))
+
+### Documentation
+
+* Clarify how to set $0 properly in `run_in_shell_command` (Cherry-pick of #19019) ([#19031](https://github.com/pantsbuild/pants/pull/19031))
+
+* Docs tweaks for 2.16.x (Cherry-pick of #19009) ([#19012](https://github.com/pantsbuild/pants/pull/19012))
 
 ## 2.16.0rc2 (May 11, 2023)
 


### PR DESCRIPTION
See https://github.com/boto/botocore/pull/2948 for the upstream bug fix.

This only occurs for toekn-based auth, and therefore wasn't caught in tests or in local testing.