### PR TITLE
Additional release job publishing fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,21 +302,21 @@ jobs:
       run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
 
         '
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Tell Pants to use Python ${{ matrix.python-version }}
-      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+        python-version: '3.9'
+    - name: Tell Pants to use Python 3.9
+      run: 'echo "PY=python3.9" >> $GITHUB_ENV
 
-        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
-        }}.*'']" >> $GITHUB_ENV
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==3.9.*'']" >> $GITHUB_ENV
 
         '
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:
         MODE: debug
+        USE_PY39: 'true'
       name: Fetch and stabilize wheels
       run: ./build-support/bin/release.sh fetch-and-stabilize
     - name: Create Release -> Commit Mapping

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -297,6 +297,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ needs.determine_ref.outputs.build-ref }}
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Tell Pants to use Python ${{ matrix.python-version }}
+      run: 'echo "PY=python${{ matrix.python-version }}" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==${{ matrix.python-version
+        }}.*'']" >> $GITHUB_ENV
+
+        '
+    - name: Expose Pythons
+      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:
         MODE: debug
       name: Fetch and stabilize wheels

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -318,7 +318,7 @@ jobs:
         MODE: debug
         USE_PY39: 'true'
       name: Fetch and stabilize wheels
-      run: ./build-support/bin/release.sh fetch-and-stabilize
+      run: ./build-support/bin/release.sh fetch-and-stabilize --dest=dest/pypi_release
     - name: Create Release -> Commit Mapping
       run: 'tag="${{ needs.determine_ref.outputs.build-ref }}"
 
@@ -335,7 +335,9 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        packages-dir: dest/pypi_release
         password: ${{ secrets.PANTSBUILD_PYPI_API_TOKEN }}
+        skip-existing: true
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -423,25 +423,26 @@ class Helper:
             },
         ]
 
-    def setup_primary_python(self) -> Sequence[Step]:
+    def setup_primary_python(self, version: str | None = None) -> Sequence[Step]:
+        version = version or gha_expr("matrix.python-version")
         ret = []
         # We pre-install Pythons on our self-hosted platforms.
         # We must set them up on Github-hosted platforms.
         if self.platform in GITHUB_HOSTED:
             ret.append(
                 {
-                    "name": f"Set up Python {gha_expr('matrix.python-version')}",
+                    "name": f"Set up Python {version}",
                     "uses": "actions/setup-python@v4",
-                    "with": {"python-version": f"{gha_expr('matrix.python-version')}"},
+                    "with": {"python-version": version},
                 }
             )
         ret.append(
             {
-                "name": f"Tell Pants to use Python {gha_expr('matrix.python-version')}",
+                "name": f"Tell Pants to use Python {version}",
                 "run": dedent(
                     f"""\
-                    echo "PY=python{gha_expr('matrix.python-version')}" >> $GITHUB_ENV
-                    echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['=={gha_expr('matrix.python-version')}.*']" >> $GITHUB_ENV
+                    echo "PY=python{version}" >> $GITHUB_ENV
+                    echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=['=={version}.*']" >> $GITHUB_ENV
                     """
                 ),
             }
@@ -1009,7 +1010,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     "with": {"ref": f"{gha_expr('needs.determine_ref.outputs.build-ref')}"},
                 },
                 setup_toolchain_auth(),
-                *helper.setup_primary_python(),
+                *helper.setup_primary_python(PYTHON39_VERSION),
                 *helper.expose_all_pythons(),
                 {
                     "name": "Fetch and stabilize wheels",
@@ -1017,6 +1018,8 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     "env": {
                         # This step does not actually build anything: only download wheels from S3.
                         "MODE": "debug",
+                        # We're not building anything, but without specifying a version, we get 3.10.
+                        "USE_PY39": "true",
                     },
                 },
                 {

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -962,6 +962,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
     """Builds and releases a git ref to S3, and (if the ref is a release tag) to PyPI."""
     inputs, env = workflow_dispatch_inputs([WorkflowInput("REF", "string")])
 
+    helper = Helper(Platform.LINUX_X86_64)
     wheels_jobs = build_wheels_jobs(
         needs=["determine_ref"], for_deploy_ref=gha_expr("needs.determine_ref.outputs.build-ref")
     )
@@ -1007,6 +1008,9 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     "uses": "actions/checkout@v3",
                     "with": {"ref": f"{gha_expr('needs.determine_ref.outputs.build-ref')}"},
                 },
+                setup_toolchain_auth(),
+                *helper.setup_primary_python(),
+                *helper.expose_all_pythons(),
                 {
                     "name": "Fetch and stabilize wheels",
                     "run": "./build-support/bin/release.sh fetch-and-stabilize",

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -1,6 +1,12 @@
 # 2.17.x Release Series
 
+## 2.17.0a1 (May 19, 2023)
+
+Due to infrastructure issues, `2.17.0a1` is a second attempt at publishing `2.17.0a0`.
+
 ## 2.17.0a0 (May 18, 2023)
+
+NOTE: `2.17.0a0` was not released to PyPI due to infrastructure issues.
 
 ### New Features
 


### PR DESCRIPTION
The publishing job needs additional fixes, which unfortunately can't (all) be accomplished using workflow edits. This change needs cherry-picking to `2.17.x` in order to make a second attempt at `2.17.0a1`.