### PR TITLE
Change CI trigger to includelist `main` and `2.*.x`

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1039,5 +1039,6 @@ name: Pull Request CI
 'on':
   pull_request: {}
   push:
-    branches-ignore:
-    - dependabot/**
+    branches:
+    - main
+    - 2.*.x

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -1150,7 +1150,7 @@ def generate() -> dict[Path, str]:
                 "group": "${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}",
                 "cancel-in-progress": True,
             },
-            "on": {"pull_request": {}, "push": {"branches-ignore": ["dependabot/**"]}},
+            "on": {"pull_request": {}, "push": {"branches": ["main", "2.*.x"]}},
             "jobs": pr_jobs,
             "env": global_env(),
         },


### PR DESCRIPTION
We're currently matching branches pushed to this repo (and not a fork, as GitHub UI does as does the cherry-pick script).
So this attempts to not do that.