### PR TITLE
Additional release job publishing fixes (Cherry-pick of #19058)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -297,10 +297,28 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ needs.determine_ref.outputs.build-ref }}
+    - if: github.event_name != 'pull_request'
+      name: Setup toolchain auth
+      run: 'echo TOOLCHAIN_AUTH_TOKEN="${{ secrets.TOOLCHAIN_AUTH_TOKEN }}" >> $GITHUB_ENV
+
+        '
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Tell Pants to use Python 3.9
+      run: 'echo "PY=python3.9" >> $GITHUB_ENV
+
+        echo "PANTS_PYTHON_INTERPRETER_CONSTRAINTS=[''==3.9.*'']" >> $GITHUB_ENV
+
+        '
+    - name: Expose Pythons
+      uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:
         MODE: debug
+        USE_PY39: 'true'
       name: Fetch and stabilize wheels
-      run: ./build-support/bin/release.sh fetch-and-stabilize
+      run: ./build-support/bin/release.sh fetch-and-stabilize --dest=dest/pypi_release
     - name: Create Release -> Commit Mapping
       run: 'tag="${{ needs.determine_ref.outputs.build-ref }}"
 
@@ -317,7 +335,9 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
+        packages-dir: dest/pypi_release
         password: ${{ secrets.PANTSBUILD_PYPI_API_TOKEN }}
+        skip-existing: true
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -1,6 +1,12 @@
 # 2.17.x Release Series
 
+## 2.17.0a1 (May 19, 2023)
+
+Due to infrastructure issues, `2.17.0a1` is a second attempt at publishing `2.17.0a0`.
+
 ## 2.17.0a0 (May 18, 2023)
+
+NOTE: `2.17.0a0` was not released to PyPI due to infrastructure issues.
 
 ### New Features
 


### PR DESCRIPTION
The publishing job needs additional fixes, which unfortunately can't (all) be accomplished using workflow edits. This change needs cherry-picking to `2.17.x` in order to make a second attempt at `2.17.0a1`.
