### PR TITLE
javascript: Pass node_modules as immutable digests to sandboxes

### DIFF
--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -223,6 +223,7 @@ async def run_javascript_tests(
                 installation.join_relative_workspace_directory(directory)
                 for directory in output_directories or ()
             ),
+            immutable_digests=FrozenDict(installation.immutable_input_digest()),
         ),
     )
     if test.force:

--- a/src/python/pants/backend/javascript/nodejs_project_environment.py
+++ b/src/python/pants/backend/javascript/nodejs_project_environment.py
@@ -93,6 +93,7 @@ class NodeJsProjectEnvironmentProcess:
     per_package_caches: FrozenDict[str, str] = field(default_factory=FrozenDict)
     timeout_seconds: int | None = None
     extra_env: FrozenDict[str, str] = field(default_factory=FrozenDict)
+    immutable_digests: FrozenDict[str, Digest] = field(default_factory=FrozenDict)
 
 
 @rule(desc="Assembling nodejs project environment")
@@ -148,6 +149,7 @@ async def setup_nodejs_project_environment_process(req: NodeJsProjectEnvironment
             timeout_seconds=req.timeout_seconds,
             project_digest=project_digest,
             extra_env=FrozenDict(**req.extra_env, **req.env.project.extra_env()),
+            immutable_digests=req.immutable_digests,
         ),
     )
 

--- a/src/python/pants/backend/javascript/package/rules.py
+++ b/src/python/pants/backend/javascript/package/rules.py
@@ -98,6 +98,7 @@ async def pack_node_package_into_tgz_for_publication(
             args=("pack",),
             description=f"Packaging .tgz archive for {name}@{version}",
             input_digest=installation.digest,
+            immutable_digests=installation.immutable_input_digest(),
             output_files=(installation.join_relative_workspace_directory(archive_file),),
             level=LogLevel.INFO,
         ),
@@ -200,6 +201,7 @@ async def run_node_build_script(req: NodeBuildScriptRequest) -> NodeBuildScriptR
                 installation.join_relative_workspace_directory(directory)
                 for directory in output_dirs or ()
             ),
+            immutable_digests=installation.immutable_input_digest(),
             level=LogLevel.INFO,
             per_package_caches=FrozenDict(
                 {cache_name(extra_cache): extra_cache for extra_cache in extra_caches or ()}

--- a/src/python/pants/backend/javascript/run/rules.py
+++ b/src/python/pants/backend/javascript/run/rules.py
@@ -46,6 +46,7 @@ async def run_node_build_script(
             args=("--prefix", "{chroot}", "run", str(field_set.entry_point.value)),
             description=f"Running {str(field_set.entry_point.value)}.",
             input_digest=installation.digest,
+            immutable_digests=installation.immutable_input_digest(),
         ),
     )
 

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -245,6 +245,7 @@ class NodeJSToolProcess:
     timeout_seconds: int | None = None
     extra_env: Mapping[str, str] = field(default_factory=FrozenDict)
     project_digest: Digest | None = None
+    immutable_digests: FrozenDict[str, Digest] = field(default_factory=FrozenDict)
 
     @classmethod
     def npm(
@@ -619,7 +620,7 @@ async def setup_node_tool_process(
         argv=list(filter(None, (request.tool, *request.args))),
         input_digest=input_digest,
         output_files=request.output_files,
-        immutable_input_digests=environment.immutable_digest(),
+        immutable_input_digests={**environment.immutable_digest(), **request.immutable_digests},
         output_directories=request.output_directories,
         description=request.description,
         level=request.level,


### PR DESCRIPTION
Inject a mirrored directory structure which node can traverse when resolving modules, symlink to locations in sandbox where node is invoked.

Fixes https://github.com/pantsbuild/pants/issues/19054