### PR TITLE
Add [lambdex].layout to opt-in to soon-to-be-deprecated FaaS behaviour

### DIFF
--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -1,9 +1,18 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from enum import Enum
+
 from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.base.deprecated import warn_or_error
 from pants.engine.rules import collect_rules
+from pants.option.option_types import EnumOption
+from pants.util.strutil import softwrap
+
+
+class LambdexLayout(Enum):
+    LAMBDEX = "lambdex"
 
 
 class Lambdex(PythonToolBase):
@@ -19,6 +28,34 @@ class Lambdex(PythonToolBase):
 
     default_lockfile_resource = ("pants.backend.python.subsystems", "lambdex.lock")
     lockfile_rules_type = LockfileRules.SIMPLE
+
+    layout = EnumOption(
+        default=LambdexLayout.LAMBDEX,
+        help=softwrap(
+            """
+            Explicitly control the layout used for `python_awslambda` and
+            `python_google_cloud_function` targets. This option exists for the transition from
+            Lambdex-based layout to the plain zip layout, as recommended by cloud vendors.
+            """
+        ),
+    )
+
+    def warn_for_layout(self, target_alias: str) -> None:
+        if self.options.is_default("layout"):
+            warn_or_error(
+                "2.18.0.dev0",
+                f"using the Lambdex layout by default for `{target_alias}` targets",
+                softwrap(
+                    f"""
+                    To prepare for the transition to the new layout for `{target_alias}` targets in
+                    Pants 2.18, set the `[lambdex].layout` option to `lambdex` explicitly, in
+                    `pants.toml`:
+
+                        [lambdex]
+                        layout = "lambdex"
+                    """
+                ),
+            )
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -293,6 +293,7 @@ async def build_lambdex(
             f" {bin_name()} package. (See https://realpython.com/python-wheels/ for more about"
             " wheels.)\n\n(If the build does not raise an exception, it's safe to use macOS.)"
         )
+    lambdex.warn_for_layout(request.target_name)
 
     output_filename = request.output_path.value_or_default(
         # FaaS typically use the .zip suffix, so we use that instead of .pex.


### PR DESCRIPTION
This adds a `layout` options to the `[lambdex]` scope, so that current users can explicitly opt-in to the current behaviour for building FaaS artifacts (`python_awslambda`, `python_google_cloud_function`), to allow us to change the default behaviour without breaking them.

The current behaviour uses Lambdex to adjust a PEX to be runnable in the FaaS environments, but it's still a PEX under the hood, with dynamic dependency selection on start-up. The new behaviour (#18879, first attempted in #19022) will be to lay out a "normal" zip with the dependencies statically included at the top level, since the serverless environments are fixed and known at build-time. We plan to switch the default to the new behaviour in 2.18, and remove the `lambdex` option in 2.19.

The suggestion is to cherry-pick this back to 2.17.x, to allow us to deprecate and remove Lambdex sooner. See https://github.com/pantsbuild/pants/pull/19032#discussion_r1199622348 for discussion.

(This PR is currently stacked on top of #19071.)