### PR TITLE
Some 2.18.0.dev0 deprecations

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -9,7 +9,6 @@ from typing import Mapping
 
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
-from pants.base.deprecated import warn_or_error
 from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
@@ -116,20 +115,6 @@ class DockerBinary(BinaryPath):
             env=self._get_process_environment(env or {}),
             immutable_input_digests=self.extra_input_digests,
         )
-
-
-@dataclass(frozen=True)
-class DockerBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(DockerBinary, DockerBinaryRequest)",
-            "Instead, simply use `Get(DockerBinary)` or put `DockerBinary` in the rule signature",
-        )
-
-
-async def find_docker(_: DockerBinaryRequest, docker: DockerBinary) -> DockerBinary:
-    return docker
 
 
 @rule(desc="Finding the `docker` binary and related tooling", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/python/framework/django/detect_apps.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps.py
@@ -10,7 +10,6 @@ from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import InterpreterConstraintsField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
-from pants.base.deprecated import warn_or_error
 from pants.base.specs import FileGlobSpec, RawSpecs
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
@@ -25,16 +24,6 @@ from pants.engine.target import (
 )
 from pants.util.frozendict import FrozenDict
 from pants.util.resources import read_resource
-
-
-@dataclass(frozen=True)
-class DjangoAppsRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(DjangoApps, DjangoAppsRequest)",
-            "Instead, simply use `Get(DjangoApps)` or put `DjangoApps` in the rule signature",
-        )
 
 
 @dataclass(frozen=True)
@@ -131,11 +120,6 @@ async def detect_django_apps(python_setup: PythonSetup) -> DjangoApps:
             ),
         )
         django_apps = django_apps.add_from_json(process_result.stdout or b"{}")
-    return django_apps
-
-
-@rule
-def django_apps_from_request(_: DjangoAppsRequest, django_apps: DjangoApps) -> DjangoApps:
     return django_apps
 
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -7,13 +7,12 @@ import dataclasses
 import logging
 import os
 import uuid
-from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, DefaultDict, Iterable, cast
+from typing import Any, Iterable, cast
 
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import PexLayout, PythonResolveField
+from pants.backend.python.target_types import PexLayout
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists_pep660 import (
     EditableLocalDists,
@@ -24,7 +23,6 @@ from pants.backend.python.util_rules.pex_cli import PexPEX
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.backend.python.util_rules.pex_requirements import EntireLockfile, Lockfile
-from pants.base.deprecated import warn_or_error
 from pants.core.goals.export import (
     Export,
     ExportError,
@@ -34,7 +32,6 @@ from pants.core.goals.export import (
     ExportSubsystem,
     PostProcessingCommand,
 )
-from pants.core.util_rules.distdir import DistDir
 from pants.engine.engine_aware import EngineAwareParameter
 from pants.engine.environment import EnvironmentName
 from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, Snapshot
@@ -44,7 +41,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.option_types import BoolOption, EnumOption, StrListOption
-from pants.util.docutil import bin_name
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
@@ -512,80 +508,17 @@ async def export_tool(request: ExportPythonTool) -> ExportResult:
 @rule
 async def export_virtualenvs(
     request: ExportVenvsRequest,
-    python_setup: PythonSetup,
-    dist_dir: DistDir,
-    union_membership: UnionMembership,
     export_subsys: ExportSubsystem,
 ) -> ExportResults:
-    if export_subsys.options.resolve:
-        if request.targets:
-            raise ExportError("If using the `--resolve` option, do not also provide target specs.")
-        maybe_venvs = await MultiGet(
-            Get(MaybeExportResult, _ExportVenvForResolveRequest(resolve))
-            for resolve in export_subsys.options.resolve
-        )
-        return ExportResults(mv.result for mv in maybe_venvs if mv.result is not None)
-
-    # TODO: After the deprecation exipres, everything in this function below this comment
-    #  can be deleted.
-    warn_or_error(
-        "2.18.0.dev0",
-        "exporting resolves without using the --resolve option",
-        softwrap(
-            f"""
-            Use the --resolve flag one or more times to name the resolves you want to export,
-            and don't provide any target specs. E.g.,
-
-              {bin_name()} export --resolve=python-default --resolve=pytest
-            """
-        ),
+    if not export_subsys.options.resolve:
+        raise ExportError("Must specify at least one --resolve to export")
+    if request.targets:
+        raise ExportError("The `export` goal does not take target specs.")
+    maybe_venvs = await MultiGet(
+        Get(MaybeExportResult, _ExportVenvForResolveRequest(resolve))
+        for resolve in export_subsys.options.resolve
     )
-    resolve_to_root_targets: DefaultDict[str, list[Target]] = defaultdict(list)
-    for tgt in request.targets:
-        if not tgt.has_field(PythonResolveField):
-            continue
-        resolve = tgt[PythonResolveField].normalized_value(python_setup)
-        resolve_to_root_targets[resolve].append(tgt)
-
-    venvs = await MultiGet(
-        Get(
-            ExportResult,
-            _ExportVenvRequest(resolve if python_setup.enable_resolves else None, tuple(tgts)),
-        )
-        for resolve, tgts in resolve_to_root_targets.items()
-    )
-
-    no_resolves_dest = dist_dir.relpath / "python" / "virtualenv"
-    if venvs and python_setup.enable_resolves and no_resolves_dest.exists():
-        logger.warning(
-            softwrap(
-                f"""
-                Because `[python].enable_resolves` is true, `{bin_name()} export ::` no longer
-                writes virtualenvs to {no_resolves_dest}, but instead underneath
-                {dist_dir.relpath / 'python' / 'virtualenvs'}. You will need to
-                update your IDE to point to the new virtualenv.
-
-                To silence this error, delete {no_resolves_dest}
-                """
-            )
-        )
-
-    tool_export_types = cast(
-        "Iterable[type[ExportPythonToolSentinel]]", union_membership.get(ExportPythonToolSentinel)
-    )
-    # TODO: We request the `ExportPythonTool` entries independently of the `ExportResult`s because
-    # inlining the request causes a rule graph issue. Revisit after #11269.
-    all_export_tool_requests = await MultiGet(
-        Get(ExportPythonTool, ExportPythonToolSentinel, tool_export_type())
-        for tool_export_type in tool_export_types
-    )
-    all_tool_results = await MultiGet(
-        Get(ExportResult, ExportPythonTool, request)
-        for request in all_export_tool_requests
-        if request.pex_request is not None
-    )
-
-    return ExportResults(venvs + all_tool_results)
+    return ExportResults(mv.result for mv in maybe_venvs if mv.result is not None)
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -18,7 +18,7 @@ from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
 )
 from pants.backend.python.util_rules import local_dists_pep660, pex_from_targets
-from pants.base.specs import RawSpecs, RecursiveGlobSpec
+from pants.base.specs import RawSpecs
 from pants.core.goals.export import ExportResults
 from pants.core.util_rules import distdir
 from pants.engine.internals.parametrize import Parametrize
@@ -44,122 +44,6 @@ def rule_runner() -> RuleRunner:
         target_types=[PythonRequirementTarget, PythonSourcesGeneratorTarget, PythonDistribution],
         objects={"python_artifact": PythonArtifact, "parametrize": Parametrize},
     )
-
-
-@pytest.mark.parametrize("enable_resolves", [False, True])
-@pytest.mark.parametrize(
-    "py_resolve_format",
-    [
-        PythonResolveExportFormat.symlinked_immutable_virtualenv,
-        PythonResolveExportFormat.mutable_virtualenv,
-    ],
-)
-def test_export_venv_old_codepath(
-    rule_runner: RuleRunner,
-    enable_resolves: bool,
-    py_resolve_format: PythonResolveExportFormat,
-) -> None:
-    # We know that the current interpreter exists on the system.
-    vinfo = sys.version_info
-    current_interpreter = f"{vinfo.major}.{vinfo.minor}.{vinfo.micro}"
-    rule_runner.write_files(
-        {
-            "src/foo/BUILD": dedent(
-                """\
-                python_requirement(name='req1', requirements=['ansicolors==1.1.8'], resolve='a')
-                python_requirement(name='req2', requirements=['ansicolors==1.1.8'], resolve='b')
-                """
-            ),
-            "lock.txt": "ansicolors==1.1.8",
-        }
-    )
-
-    format_flag = f"--export-py-resolve-format={py_resolve_format.value}"
-    rule_runner.set_options(
-        [
-            f"--python-interpreter-constraints=['=={current_interpreter}']",
-            "--python-resolves={'a': 'lock.txt', 'b': 'lock.txt'}",
-            f"--python-enable-resolves={enable_resolves}",
-            # Turn off lockfile validation to make the test simpler.
-            "--python-invalid-lockfile-behavior=ignore",
-            # Turn off python synthetic lockfile targets to make the test simpler.
-            "--no-python-enable-lockfile-targets",
-            format_flag,
-        ],
-        env_inherit={"PATH", "PYENV_ROOT"},
-    )
-    targets = rule_runner.request(
-        Targets,
-        [RawSpecs(recursive_globs=(RecursiveGlobSpec("src/foo"),), description_of_origin="tests")],
-    )
-    all_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets)])
-
-    for result, resolve in zip(all_results, ["a", "b"] if enable_resolves else [""]):
-        if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
-            assert len(result.post_processing_cmds) == 2
-            ppc0, ppc1 = result.post_processing_cmds
-            assert ppc0.argv == ("rmdir", "{digest_root}")
-            assert ppc0.extra_env == FrozenDict()
-            assert ppc1.argv[0:2] == ("ln", "-s")
-            # The third arg is the full path to the venv under the pex_root, which we
-            # don't easily know here, so we ignore it in this comparison.
-            assert ppc1.argv[3] == "{digest_root}"
-            assert ppc1.extra_env == FrozenDict()
-        else:
-            assert len(result.post_processing_cmds) == 2
-
-            ppc0 = result.post_processing_cmds[0]
-            # The first arg is the full path to the python interpreter, which we
-            # don't easily know here, so we ignore it in this comparison.
-
-            # The second arg is expected to be tmpdir/./pex.
-            tmpdir, pex_pex_name = os.path.split(os.path.normpath(ppc0.argv[1]))
-            assert pex_pex_name == "pex"
-            assert re.match(r"\{digest_root\}/\.[0-9a-f]{32}\.tmp", tmpdir)
-
-            # The third arg is expected to be tmpdir/requirements.pex.
-            req_pex_dir, req_pex_name = os.path.split(ppc0.argv[2])
-            assert req_pex_dir == tmpdir
-            assert req_pex_name == "requirements.pex"
-
-            assert ppc0.argv[3:] == (
-                "venv",
-                "--pip",
-                "--collisions-ok",
-                "{digest_root}",
-            )
-            assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"
-            assert ppc0.extra_env.get("PEX_ROOT") is not None
-
-            ppc1 = result.post_processing_cmds[1]
-            assert ppc1.argv == ("rm", "-rf", tmpdir)
-            assert ppc1.extra_env == FrozenDict()
-
-    reldirs = [result.reldir for result in all_results]
-    if enable_resolves:
-        if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
-            assert reldirs == [
-                f"python/virtualenvs/a/{current_interpreter}",
-                f"python/virtualenvs/b/{current_interpreter}",
-                f"python/virtualenvs/tools/flake8/{current_interpreter}",
-            ]
-        else:
-            assert reldirs == [
-                f"python/virtualenvs/a/{current_interpreter}",
-                f"python/virtualenvs/b/{current_interpreter}",
-                "python/virtualenvs/tools/flake8",
-            ]
-    else:
-        if py_resolve_format == PythonResolveExportFormat.symlinked_immutable_virtualenv:
-            assert reldirs == [
-                f"python/virtualenv/{current_interpreter}",
-                f"python/virtualenvs/tools/flake8/{current_interpreter}",
-            ]
-        else:
-            assert reldirs == [
-                f"python/virtualenv/{current_interpreter}",
-                "python/virtualenvs/tools/flake8",
-            ]
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -15,7 +15,6 @@ from typing import Iterable, Mapping, Sequence
 
 from typing_extensions import Self
 
-from pants.base.deprecated import warn_or_error
 from pants.core.subsystems import python_bootstrap
 from pants.core.subsystems.python_bootstrap import PythonBootstrap
 from pants.core.util_rules.environments import EnvironmentTarget
@@ -250,18 +249,6 @@ class BashBinary(BinaryPath):
     DEFAULT_SEARCH_PATH = SearchPath(("/usr/bin", "/bin", "/usr/local/bin"))
 
 
-@dataclass(frozen=True)
-class BashBinaryRequest:
-    search_path: SearchPath = BashBinary.DEFAULT_SEARCH_PATH
-
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(BashBinary, BashBinaryRequest)",
-            "Instead, simply use `Get(BashBinary)` or put `BashBinary` in the rule signature.",
-        )
-
-
 class PythonBinary(BinaryPath):
     """A Python3 interpreter for use by `@rule` code as an alternative to BashBinary scripts.
 
@@ -473,11 +460,6 @@ def _create_shim(bash: str, binary: str) -> bytes:
         exec "{binary}" "$@"
         """
     ).encode()
-
-
-@rule(desc="Finding the `bash` binary", level=LogLevel.DEBUG)
-async def find_bash(_: BashBinaryRequest, bash_binary: BashBinary) -> BashBinary:
-    return bash_binary
 
 
 @rule(desc="Finding the `bash` binary", level=LogLevel.DEBUG)
@@ -787,161 +769,6 @@ async def find_git() -> GitBinary:
         request, rationale="track changes to files in your build environment"
     )
     return GitBinary(first_path.path, first_path.fingerprint)
-
-
-# -------------------------------------------------------------------------------------------
-# (Deprecated). Rules for lazy requests
-# -------------------------------------------------------------------------------------------
-
-
-@dataclass(frozen=True)
-class ZipBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(ZipBinary, ZipBinaryRequest)",
-            "Instead, simply use `Get(ZipBinary)` or put `ZipBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class UnzipBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(UnzipBinary, UnzipBinaryRequest)",
-            "Instead, simply use `Get(UnipBinary)` or put `UnzipBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class GunzipBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(GunzipBinary, GunzipBinaryRequest)",
-            "Instead, simply use `Get(GunzipBinary)` or put `GunzipBinary` in the rule signature",
-        )
-
-
-class CatBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(CatBinary, CatBinaryRequest)",
-            "Instead, simply use `Get(CatBinary)` or put `CatBinary` in the rule signature",
-        )
-
-
-class TarBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(TarBinary, TarBinaryRequest)",
-            "Instead, simply use `Get(TarBinary)` or put `TarBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class MkdirBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(MkdirBinary, MkdirBinaryRequest)",
-            "Instead, simply use `Get(MkdirBinary)` or put `MkdirBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class ChmodBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(ChmodBinary, ChmodBinaryRequest)",
-            "Instead, simply use `Get(ChmodBinary)` or put `ChmodBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class DiffBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(DiffBinary, DiffBinaryRequest)",
-            "Instead, simply use `Get(DiffBinary)` or put `DiffBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class ReadlinkBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(ReadlinkBinary, ReadlinkBinaryRequest)",
-            "Instead, simply use `Get(ReadlinkBinary)` or put `ReadlinkBinary` in the rule signature",
-        )
-
-
-@dataclass(frozen=True)
-class GitBinaryRequest:
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(GitBinary, GitBinaryRequest)",
-            "Instead, simply use `Get(GitBinary)` or put `GitBinary` in the rule signature",
-        )
-
-
-@rule
-async def find_zip_wrapper(_: ZipBinaryRequest, zip_binary: ZipBinary) -> ZipBinary:
-    return zip_binary
-
-
-@rule
-async def find_unzip_wrapper(_: UnzipBinaryRequest, unzip_binary: UnzipBinary) -> UnzipBinary:
-    return unzip_binary
-
-
-@rule
-async def find_gunzip_wrapper(_: GunzipBinaryRequest, gunzip: GunzipBinary) -> GunzipBinary:
-    return gunzip
-
-
-@rule
-async def find_tar_wrapper(_: TarBinaryRequest, tar_binary: TarBinary) -> TarBinary:
-    return tar_binary
-
-
-@rule
-async def find_cat_wrapper(_: CatBinaryRequest, cat_binary: CatBinary) -> CatBinary:
-    return cat_binary
-
-
-@rule
-async def find_mkdir_wrapper(_: MkdirBinaryRequest, mkdir_binary: MkdirBinary) -> MkdirBinary:
-    return mkdir_binary
-
-
-@rule
-async def find_readlink_wrapper(
-    _: ReadlinkBinaryRequest, readlink_binary: ReadlinkBinary
-) -> ReadlinkBinary:
-    return readlink_binary
-
-
-@rule
-async def find_chmod_wrapper(_: ChmodBinaryRequest, chmod_binary: ChmodBinary) -> ChmodBinary:
-    return chmod_binary
-
-
-@rule
-async def find_diff_wrapper(_: DiffBinaryRequest, diff_binary: DiffBinary) -> DiffBinary:
-    return diff_binary
-
-
-@rule
-async def find_git_wrapper(_: GitBinaryRequest, git_binary: GitBinary) -> GitBinary:
-    return git_binary
 
 
 def rules():

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -40,7 +40,6 @@ from pants.engine.internals.target_adaptor import TargetAdaptor, TargetAdaptorRe
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     AllTargets,
-    AllTargetsRequest,
     AllUnexpandedTargets,
     CoarsenedTarget,
     CoarsenedTargets,
@@ -569,18 +568,6 @@ async def resolve_targets(
         for tgt in parametrizations.generated_or_generator(generator.address)
     )
     return Targets(expanded_targets)
-
-
-@rule(_masked_types=[EnvironmentName])
-def find_all_targets_deprecated(_: AllTargetsRequest, all_targets: AllTargets) -> AllTargets:
-    return all_targets
-
-
-@rule(_masked_types=[EnvironmentName])
-def find_all_unexpanded_targets_deprecated(
-    _: AllTargetsRequest, all_targets: AllUnexpandedTargets
-) -> AllUnexpandedTargets:
-    return all_targets
 
 
 @rule(desc="Find all targets in the project", level=LogLevel.DEBUG, _masked_types=[EnvironmentName])

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -33,7 +33,6 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import Get, MultiGet, rule
 from pants.engine.target import (
     AllTargets,
-    AllTargetsRequest,
     AllUnexpandedTargets,
     AsyncFieldMixin,
     CoarsenedTargets,
@@ -145,8 +144,8 @@ class MockTargetGenerator(TargetFilesGenerator):
 def transitive_targets_rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
-            QueryRule(AllTargets, [AllTargetsRequest]),
-            QueryRule(AllUnexpandedTargets, [AllTargetsRequest]),
+            QueryRule(AllTargets, []),
+            QueryRule(AllUnexpandedTargets, []),
             QueryRule(CoarsenedTargets, [Addresses]),
             QueryRule(Targets, [DependenciesRequest]),
             QueryRule(TransitiveTargets, [TransitiveTargetsRequest]),
@@ -670,7 +669,7 @@ def test_find_all_targets(transitive_targets_rule_runner: RuleRunner) -> None:
             "dir/BUILD": "target()",
         }
     )
-    all_tgts = transitive_targets_rule_runner.request(AllTargets, [AllTargetsRequest()])
+    all_tgts = transitive_targets_rule_runner.request(AllTargets, [])
     expected = {
         Address("", target_name="generator", relative_file_path="f1.txt"),
         Address("", target_name="generator", relative_file_path="f2.txt"),
@@ -679,9 +678,7 @@ def test_find_all_targets(transitive_targets_rule_runner: RuleRunner) -> None:
     }
     assert {t.address for t in all_tgts} == expected
 
-    all_unexpanded = transitive_targets_rule_runner.request(
-        AllUnexpandedTargets, [AllTargetsRequest()]
-    )
+    all_unexpanded = transitive_targets_rule_runner.request(AllUnexpandedTargets, [])
     assert {t.address for t in all_unexpanded} == {*expected, Address("", target_name="generator")}
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1044,21 +1044,6 @@ class AllUnexpandedTargets(Collection[Target]):
     """
 
 
-@dataclass(frozen=True)
-class AllTargetsRequest:
-    """Find all targets in the project.
-
-    Use with either `AllUnexpandedTargets` or `AllTargets`.
-    """
-
-    def __post_init__(self) -> None:
-        warn_or_error(
-            "2.18.0.dev0",
-            "using `Get(AllTargets, AllTargetsRequest)",
-            "Instead, simply use `Get(AllTargets)` or put `AllTargets` in the rule signature",
-        )
-
-
 # -----------------------------------------------------------------------------------------------
 # Target generation
 # -----------------------------------------------------------------------------------------------


### PR DESCRIPTION
- Remove support for exporting resolves based on target specs (now we require the `--resolve` flag)
- Remove many unneeded request types.