### PR TITLE
Bring the tool `--export` option deprecation forward. (Cherry-pick of #19079)

### DIFF
--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -478,7 +478,7 @@ class ExportToolOption(BoolOption):
         return super().__new__(
             cls,
             default=True,
-            removal_version="2.23.0.dev0",
+            removal_version="2.18.0.dev0",
             removal_hint="Use the export goal's --resolve option to select tools to export, instead "
             "of using this option to exempt a tool from export-by-default.",
             help=(


### PR DESCRIPTION
This is largely moot: in 2.18.0.dev0 we're requiring the user to specify the
resolves they want to export explicitly via the --resolve option, so this
--export option will be a no-op. 

Still, it's good to deprecate it now so people can remove it from their
config files and know not to expect it to have any effect.

This deprecation wasn't in any stable release yet, so it's OK to change it.
