### PR TITLE
Deprecate [mypy].extra_type_stubs and its lockfile.

### DIFF
--- a/docs/markdown/Python/python/python-third-party-dependencies.md
+++ b/docs/markdown/Python/python/python-third-party-dependencies.md
@@ -472,7 +472,7 @@ data-science = ["numpy"]
 
 [python.resolves_to_no_binary]
 pytest = ["pytest-xdist"]
-mypy_extra_type_stubs = ["django-stubs"]
+mypy = ["django-stubs"]
 ```
 
 You can also set the key `__default__` to apply the same value to every resolve by default.

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -151,6 +151,13 @@ class MyPy(PythonToolBase):
     )
     extra_type_stubs = StrListOption(
         advanced=True,
+        removal_version="2.18.0dev0",
+        removal_hint=softwrap(
+            f"""
+            Extra type stubs are now installed from a named resolve, as described
+            at {doc_url("python-lockfiles")}.
+            """
+        ),
         help=softwrap(
             f"""
             Extra type stub requirements to install when running MyPy.
@@ -176,6 +183,13 @@ class MyPy(PythonToolBase):
         advanced=True,
         # Note that there is no default lockfile, as by default, extra_type_stubs is empty.
         default=NO_TOOL_LOCKFILE,
+        removal_version="2.18.0dev0",
+        removal_hint=softwrap(
+            f"""
+            Extra type stubs are now installed from a named resolve, as described
+            at {doc_url("python-lockfiles")}.
+            """
+        ),
         help=softwrap(
             f"""
             Path to a lockfile for the option `[mypy].extra_type_stubs`.


### PR DESCRIPTION
This should have been deprecated along with tool
lockfiles, but was overlooked. See #18625 for context.