### PR TITLE
Increase the logging of release version file publishing.

### DIFF
--- a/build-support/bin/create_s3_index_file.sh
+++ b/build-support/bin/create_s3_index_file.sh
@@ -7,7 +7,7 @@ if [[ -z "$1" ]]; then
   exit 1
 fi
 
-set -euo pipefail
+set -euox pipefail
 
 SHA=$1
 WHEEL_DIR=binaries.pantsbuild.org/wheels/pantsbuild.pants

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -38,8 +38,8 @@ def _run(args, env=None) -> None:
         )
     except subprocess.CalledProcessError as ex:
         logger.error(f"Process `{' '.join(args)}` failed with exit code {ex.returncode}.")
-        logger.error(f"stdout: {ex.stdout}")
-        logger.error(f"stderr: {ex.stderr}")
+        logger.error(f"stdout:\n{ex.stdout.decode()}\n")
+        logger.error(f"stderr:\n{ex.stderr.decode()}\n")
         raise
 
 


### PR DESCRIPTION
Deploying the version index file to S3 failed without much additional info on the previous run: https://github.com/pantsbuild/pants/actions/runs/5028704069/jobs/9020209345

Add `set -x`.