### PR TITLE
pass "--debug" flag to all helm invocations if requested

### DIFF
--- a/src/python/pants/backend/helm/util_rules/tool.py
+++ b/src/python/pants/backend/helm/util_rules/tool.py
@@ -443,7 +443,6 @@ async def helm_process(
     request: HelmProcess,
     helm_binary: HelmBinary,
     helm_subsystem: HelmSubsystem,
-    log_level: LogLevel,
 ) -> Process:
     global_extra_env = await Get(
         EnvironmentVars, EnvironmentVarsRequest(helm_subsystem.extra_env_vars)
@@ -465,8 +464,8 @@ async def helm_process(
     # not just the final one.
     # For example, we want this applied to the call to `template`, not just the call to `install`
     # Also, we can be helpful and automatically forward a request to debug Pants to also debug Helm
-    debug_requested = (
-        "--debug" in helm_subsystem.valid_args() or max(request.level, log_level) >= LogLevel.DEBUG  # type: ignore[operator]
+    debug_requested = "--debug" in helm_subsystem.valid_args() or (
+        0 < logger.getEffectiveLevel() <= LogLevel.DEBUG.level
     )
     if debug_requested and "--debug" not in request.argv:
         argv.append("--debug")

--- a/src/python/pants/util/logging.py
+++ b/src/python/pants/util/logging.py
@@ -17,7 +17,7 @@ class LogLevel(Enum):
 
     NB: The `logging` module uses the opposite integer ordering of levels from Rust's `log` crate,
     but the ordering implementation of this enum inverts its comparison to make its ordering align
-    with Rust's.
+    with Rust's. That is, TRACE > DEBUG > INFO > WARN > ERROR
     """
 
     TRACE = ("trace", TRACE)


### PR DESCRIPTION
The `experimental-deploy` goal on a `helm_deployment` target need to call out to 2 Helm commands: `template` and `upgrade`. The passthrough args are only passed to `upgrade`. Helm will sometimes indicate that passing "--debug" will give more infomation on a failure, including the call to `template`. Together, this is confusing to users, who would assume that `./pants experimental-deploy src/chart/foo:deployfoo -- --debug` would do so. However, the flag would only be passed to `upgrade` (which we don't get to).
Forwarding the "--debug" flag to all commands is probably what the user expected. It should also be safe, as it is one of Helm's global arguments.

fixes #18089 