### PR TITLE
Use a trait for remote action result caching

### DIFF
--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -282,7 +282,6 @@ impl CommandRunner {
       let response = check_action_cache(
         action_digest,
         &request.description,
-        self.instance_name.clone(),
         request.execution_environment.clone(),
         &context,
         self.provider.clone(),
@@ -386,7 +385,6 @@ impl CommandRunner {
   async fn update_action_cache(
     &self,
     result: &FallibleProcessResultWithPlatform,
-    _instance_name: Option<String>,
     command: &Command,
     action_digest: Digest,
     command_digest: Digest,
@@ -516,13 +514,7 @@ impl process_execution::CommandRunner for CommandRunner {
       let write_fut = in_workunit!("remote_cache_write", Level::Trace, |workunit| async move {
         workunit.increment_counter(Metric::RemoteCacheWriteAttempts, 1);
         let write_result = command_runner
-          .update_action_cache(
-            &result,
-            command_runner.instance_name.clone(),
-            &command,
-            action_digest,
-            command_digest,
-          )
+          .update_action_cache(&result, &command, action_digest, command_digest)
           .await;
         match write_result {
           Ok(_) => workunit.increment_counter(Metric::RemoteCacheWriteSuccesses, 1),
@@ -558,7 +550,6 @@ impl process_execution::CommandRunner for CommandRunner {
 async fn check_action_cache(
   action_digest: Digest,
   command_description: &str,
-  _instance_name: Option<String>,
   environment: ProcessExecutionEnvironment,
   context: &Context,
   provider: Arc<dyn ActionCacheProvider>,

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -40,6 +40,23 @@ pub enum RemoteCacheWarningsBehavior {
   Backoff,
 }
 
+/// This `ActionCacheProvider` trait captures the operations required to be able to cache command
+/// executions remotely.
+#[async_trait]
+trait ActionCacheProvider: Sync + Send + 'static {
+  async fn update_action_result(
+    &self,
+    action_digest: Digest,
+    action_result: ActionResult,
+  ) -> Result<(), String>;
+
+  async fn get_action_result(
+    &self,
+    action_digest: Digest,
+    context: &Context,
+  ) -> Result<Option<ActionResult>, String>;
+}
+
 /// This `CommandRunner` implementation caches results remotely using the Action Cache service
 /// of the Remote Execution API.
 ///

--- a/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
@@ -1,0 +1,123 @@
+// Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use std::collections::BTreeMap;
+use std::convert::TryInto;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use grpc_util::retry::{retry_call, status_is_retryable};
+use grpc_util::{headers_to_http_header_map, layered_service, status_to_str, LayeredService};
+use hashing::Digest;
+use protos::gen::build::bazel::remote::execution::v2 as remexec;
+use remexec::action_cache_client::ActionCacheClient;
+use remexec::ActionResult;
+use workunit_store::Metric;
+
+use crate::remote::apply_headers;
+use process_execution::Context;
+use tonic::{Code, Request};
+
+use super::ActionCacheProvider;
+
+pub struct Provider {
+  instance_name: Option<String>,
+  action_cache_client: Arc<ActionCacheClient<LayeredService>>,
+}
+
+impl Provider {
+  pub fn new(
+    instance_name: Option<String>,
+    action_cache_address: &str,
+    root_ca_certs: Option<Vec<u8>>,
+    mut headers: BTreeMap<String, String>,
+    concurrency_limit: usize,
+    rpc_timeout: Duration,
+  ) -> Result<Self, String> {
+    let tls_client_config = if action_cache_address.starts_with("https://") {
+      Some(grpc_util::tls::Config::new_without_mtls(root_ca_certs).try_into()?)
+    } else {
+      None
+    };
+
+    let endpoint = grpc_util::create_endpoint(
+      action_cache_address,
+      tls_client_config.as_ref(),
+      &mut headers,
+    )?;
+    let http_headers = headers_to_http_header_map(&headers)?;
+    let channel = layered_service(
+      tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
+      concurrency_limit,
+      http_headers,
+      Some((rpc_timeout, Metric::RemoteCacheRequestTimeouts)),
+    );
+    let action_cache_client = Arc::new(ActionCacheClient::new(channel));
+
+    Ok(Provider {
+      instance_name,
+      action_cache_client,
+    })
+  }
+}
+
+#[async_trait]
+impl ActionCacheProvider for Provider {
+  async fn update_action_result(
+    &self,
+    action_digest: Digest,
+    action_result: ActionResult,
+  ) -> Result<(), String> {
+    let client = self.action_cache_client.as_ref().clone();
+    retry_call(
+      client,
+      move |mut client| {
+        let update_action_cache_request = remexec::UpdateActionResultRequest {
+          instance_name: self.instance_name.clone().unwrap_or_else(|| "".to_owned()),
+          action_digest: Some(action_digest.into()),
+          action_result: Some(action_result.clone()),
+          ..remexec::UpdateActionResultRequest::default()
+        };
+
+        async move {
+          client
+            .update_action_result(update_action_cache_request)
+            .await
+        }
+      },
+      status_is_retryable,
+    )
+    .await
+    .map_err(status_to_str)?;
+
+    Ok(())
+  }
+
+  async fn get_action_result(
+    &self,
+    action_digest: Digest,
+    context: &Context,
+  ) -> Result<Option<ActionResult>, String> {
+    let client = self.action_cache_client.as_ref().clone();
+    let response = retry_call(
+      client,
+      move |mut client| {
+        let request = remexec::GetActionResultRequest {
+          action_digest: Some(action_digest.into()),
+          instance_name: self.instance_name.clone().unwrap_or_default(),
+          ..remexec::GetActionResultRequest::default()
+        };
+        let request = apply_headers(Request::new(request), &context.build_id);
+        async move { client.get_action_result(request).await }
+      },
+      status_is_retryable,
+    )
+    .await;
+
+    match response {
+      Ok(response) => Ok(Some(response.into_inner())),
+      Err(status) if status.code() == Code::NotFound => Ok(None),
+      Err(status) => Err(status_to_str(status)),
+    }
+  }
+}


### PR DESCRIPTION
This separates the `remote::remote_cache` coordination code from the gRPC REAPI implementation by:

- adding a `remote::remote_cache::ActionCacheProvider` trait
- moving the REAPI implementation into `remote::remote_cache::reapi` and implementing that trait

This is, in theory, just a lift-and-shift, with no functionality change.

This is preparation work for supporting more remote stores like GHA cache or S3, for https://github.com/pantsbuild/pants/issues/11149, and is specifically broken out of https://github.com/pantsbuild/pants/pull/17840. It continues #19050. Additional work required to actually solve https://github.com/pantsbuild/pants/issues/11149:

- implementing other byte store and action cache providers
- dynamically choosing the right providers for `store::remote::ByteStore` and `remote::remote_cache`

The commits are individually reviewable:
1. preparatory breaking out of gRPC code2. 
2. defining the trait
3. move the REAPI code and implement the trait, close to naively as possible:
   - https://gist.github.com/huonw/a60ad807b05ecea98387294c22de67cb has a white-space-ignoring diff between `remote_cache.rs` after 1, and the `reapi.rs` file in this commit (it's less useful than #19050, since most of the code is deleted, but, buried in there are chunks of completely unchanged code)
4. minor clean-up