### PR TITLE
Upgrade to `actions/checkout@v3`

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Always checkout the latest commit of main
           ref: "main"


### PR DESCRIPTION
This works around some node version deprecation we see in the log.