### PR TITLE
Switch to [lambdex].layout = "zip" by default, deprecating the section

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -168,7 +168,10 @@ def test_create_hello_world_lambda_with_lambdex(
             "    Complete platform: src/python/foo/bar/platform.json",
             "              Handler: lambdex_handler.handler",
         ),
-        extra_args=[f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']"],
+        extra_args=[
+            f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']",
+            "--lambdex-layout=lambdex",
+        ],
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))
@@ -187,7 +190,10 @@ def test_create_hello_world_lambda_with_lambdex(
             "    Runtime: python3.7",
             "    Handler: lambdex_handler.handler",
         ),
-        extra_args=[f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']"],
+        extra_args=[
+            f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']",
+            "--lambdex-layout=lambdex",
+        ],
     )
     assert "src.python.foo.bar/slimlambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))
@@ -248,6 +254,7 @@ def test_warn_files_targets_with_lambdex(rule_runner: PythonRuleRunner, caplog) 
             "    Runtime: python3.7",
             "    Handler: lambdex_handler.handler",
         ),
+        extra_args=["--lambdex-layout=lambdex"],
     )
     assert caplog.records
     assert "src.py.project/lambda.zip" == zip_file_relpath
@@ -295,7 +302,6 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
         rule_runner,
         Address("src/python/foo/bar", target_name="lambda"),
         expected_extra_log_lines=("    Handler: lambda_function.handler",),
-        extra_args=["--lambdex-layout=zip"],
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
 
@@ -311,7 +317,6 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
         rule_runner,
         Address("src/python/foo/bar", target_name="slimlambda"),
         expected_extra_log_lines=("    Handler: lambda_function.handler",),
-        extra_args=["--lambdex-layout=zip"],
     )
     assert "src.python.foo.bar/slimlambda.zip" == zip_file_relpath
 

--- a/src/python/pants/backend/google_cloud_function/python/rules_test.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules_test.py
@@ -167,7 +167,10 @@ def test_create_hello_world_lambda_with_lambdex(
             "    Complete platform: src/python/foo/bar/platform.json",
             "              Handler: handler",
         ),
-        extra_args=[f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']"],
+        extra_args=[
+            f"--lambdex-interpreter-constraints=['=={major_minor_interpreter}.*']",
+            "--lambdex-layout=lambdex",
+        ],
     )
     assert "src.python.foo.bar/lambda.zip" == zip_file_relpath
     zipfile = ZipFile(BytesIO(content))
@@ -233,6 +236,7 @@ def test_warn_files_targets(rule_runner: PythonRuleRunner, caplog) -> None:
             "    Runtime: python37",
             "    Handler: handler",
         ),
+        extra_args=["--lambdex-layout=lambdex"],
     )
     assert caplog.records
     assert "src.py.project/lambda.zip" == zip_file_relpath
@@ -276,7 +280,6 @@ def test_create_hello_world_gcf(rule_runner: PythonRuleRunner) -> None:
         rule_runner,
         Address("src/python/foo/bar", target_name="gcf"),
         expected_extra_log_lines=("    Handler: handler",),
-        extra_args=["--lambdex-layout=zip"],
     )
     assert "src.python.foo.bar/gcf.zip" == zip_file_relpath
 

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -31,7 +31,7 @@ class Lambdex(PythonToolBase):
     lockfile_rules_type = LockfileRules.SIMPLE
 
     layout = EnumOption(
-        default=LambdexLayout.LAMBDEX,
+        default=LambdexLayout.ZIP,
         help=softwrap(
             """
             Explicitly control the layout used for `python_awslambda` and

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -5,7 +5,6 @@ from enum import Enum
 
 from pants.backend.python.subsystems.python_tool_base import LockfileRules, PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
-from pants.base.deprecated import warn_or_error
 from pants.engine.rules import collect_rules
 from pants.option.option_types import EnumOption
 from pants.util.strutil import softwrap
@@ -39,34 +38,21 @@ class Lambdex(PythonToolBase):
             Lambdex-based layout to the plain zip layout, as recommended by cloud vendors.
             """
         ),
+        removal_version="2.19.0.dev0",
+        removal_hint=softwrap(
+            """
+            Remove the whole [lambdex] section, as Lambdex is deprecated and its functionality be
+            removed. If you have `layout = "zip"`, no further action is required, as you are already using
+            the recommended layout.
+
+            If you have `layout = "lambdex"`, removing the section will switch any
+            `python_awslambda` and `python_google_cloud_function` targets to using the `zip` layout,
+            as recommended by cloud vendors.  (If you are using `python_awslambda`, you will need to
+            also update the handlers configured in the cloud from `lambdex_handler.handler` to
+            `lambda_function.handler`.)
+            """
+        ),
     )
-
-    def warn_for_layout(self, target_alias: str) -> None:
-        if self.options.is_default("layout"):
-            lambda_message = (
-                " (you will need to also update the handlers configured in the cloud from `lambdex_handler.handler` to `lambda_function.handler`)"
-                if target_alias == "python_awslambda"
-                else ""
-            )
-
-            warn_or_error(
-                "2.19.0.dev0",
-                f"using the Lambdex layout for `{target_alias}` targets",
-                softwrap(
-                    f"""
-                    Set the `[lambdex].layout` option explicitly to `zip` (recommended) or `lambdex`
-                    (compatibility), in `pants.toml`. Recommended: set to `zip` to opt-in to the new
-                    layout recommended by cloud vendors{lambda_message}:
-
-                        [lambdex]
-                        layout = "zip"
-
-                    You can also explicitly set `layout = "lambdex"` to silence this warning and
-                    continue using the Lambdex-based layout in this release of Pants. This layout
-                    will disappear in future.
-                    """
-                ),
-            )
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/faas.py
+++ b/src/python/pants/backend/python/util_rules/faas.py
@@ -323,7 +323,6 @@ async def build_lambdex(
             f" {bin_name()} package. (See https://realpython.com/python-wheels/ for more about"
             " wheels.)\n\n(If the build does not raise an exception, it's safe to use macOS.)"
         )
-    lambdex.warn_for_layout(request.target_name)
 
     output_filename = request.output_path.value_or_default(
         # FaaS typically use the .zip suffix, so we use that instead of .pex.


### PR DESCRIPTION
This continues #18879 / #19076, by switching to the new `zip` layout by default, for 2.18. This also deprecates the option entirely, telling users to remove the `[lambdex]` section.

As a reminder, the phasing is:

| release | supports lambdex? | supports zip? | default layout | deprecation warnings |
|---|---|---|---|---|
| 2.17 | ✅ | ✅  | lambdex | if `layout = "lambdex"` is implicit, tell people to set it: recommend `zip`, but allow `lambdex` if they have to |
| 2.18 (this PR) | ✅ | ✅ | zip | if `layout` is set, tell people to remove it and thus switch to (implicit) `zip` |
| 2.19 | ❌ | ✅ | zip | none, migration over (or maybe just about removing the `[lambdex]` section entirely) |
