### PR TITLE
Add support for packaging python AWS Lambda layers

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -34,12 +34,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class PythonAwsLambdaFieldSet(PackageFieldSet):
-    required_fields = (PythonAwsLambdaHandlerField,)
-
-    handler: PythonAwsLambdaHandlerField
+class _BaseFieldSet(PackageFieldSet):
     include_requirements: PythonAwsLambdaIncludeRequirements
-    include_sources: PythonAwsLambdaIncludeSources
     runtime: PythonAwsLambdaRuntime
     complete_platforms: PythonFaaSCompletePlatforms
     output_path: OutputPathField
@@ -47,16 +43,18 @@ class PythonAwsLambdaFieldSet(PackageFieldSet):
 
 
 @dataclass(frozen=True)
-class PythonAwsLambdaLayerFieldSet(PackageFieldSet):
+class PythonAwsLambdaFieldSet(_BaseFieldSet):
+    required_fields = (PythonAwsLambdaHandlerField,)
+
+    handler: PythonAwsLambdaHandlerField
+
+
+@dataclass(frozen=True)
+class PythonAwsLambdaLayerFieldSet(_BaseFieldSet):
     required_fields = (PythonAwsLambdaLayerDependenciesField,)
 
     dependencies: PythonAwsLambdaLayerDependenciesField
-    include_requirements: PythonAwsLambdaIncludeRequirements
     include_sources: PythonAwsLambdaIncludeSources
-    runtime: PythonAwsLambdaRuntime
-    complete_platforms: PythonFaaSCompletePlatforms
-    output_path: OutputPathField
-    environment: EnvironmentField
 
 
 @rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)
@@ -93,7 +91,7 @@ async def package_python_awslambda(
             handler=field_set.handler,
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
-            include_sources=field_set.include_sources.value,
+            include_sources=True,
             reexported_handler_module=PythonAwsLambdaHandlerField.reexported_handler_module,
         ),
     )

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -74,6 +74,7 @@ async def package_python_awslambda(
             handler=field_set.handler,
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
+            include_sources=True,
             reexported_handler_module=PythonAwsLambdaHandlerField.reexported_handler_module,
         ),
     )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -133,7 +133,6 @@ class _AWSLambdaBaseTarget(Target):
         *COMMON_TARGET_FIELDS,
         OutputPathField,
         PythonAwsLambdaIncludeRequirements,
-        PythonAwsLambdaIncludeSources,
         PythonAwsLambdaRuntime,
         PythonFaaSCompletePlatforms,
         PythonResolveField,
@@ -174,6 +173,7 @@ class PythonAWSLambdaLayer(_AWSLambdaBaseTarget):
     alias = "python_aws_lambda_layer"
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,
+        PythonAwsLambdaIncludeSources,
         PythonAwsLambdaLayerDependenciesField,
     )
     help = help_text(

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -1,9 +1,11 @@
 # Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
-from typing import Match, Optional, Tuple, cast
+from typing import ClassVar, Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
@@ -20,6 +22,7 @@ from pants.engine.rules import collect_rules
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
+    Field,
     InvalidFieldException,
     InvalidTargetException,
     Target,
@@ -63,8 +66,20 @@ class PythonAwsLambdaIncludeRequirements(BoolField):
     default = True
     help = help_text(
         """
-        Whether to resolve requirements and include them in the Pex. This is most useful with Lambda
-        Layers to make code uploads smaller when deps are in layers.
+        Whether to resolve requirements and include them in the AWS Lambda artifact. This is most useful with Lambda
+        Layers to make code uploads smaller when third-party requirements are in layers.
+        https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
+        """
+    )
+
+
+class PythonAwsLambdaIncludeSources(BoolField):
+    alias = "include_sources"
+    default = True
+    help = help_text(
+        """
+        Whether to resolve first party sources and include them in the AWS Lambda artifact. This is
+        most useful to allow creating a Lambda Layer with only third-party requirements.
         https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html
         """
     )
@@ -109,25 +124,20 @@ class PythonAwsLambdaRuntime(PythonFaaSRuntimeField):
         return int(mo.group("major")), int(mo.group("minor"))
 
 
-class PythonAWSLambda(Target):
-    alias = "python_awslambda"
-    core_fields = (
+class PythonAwsLambdaLayerDependenciesField(PythonFaaSDependencies):
+    required = True
+
+
+class _AWSLambdaBaseTarget(Target):
+    core_fields: ClassVar[tuple[type[Field], ...]] = (
         *COMMON_TARGET_FIELDS,
         OutputPathField,
-        PythonFaaSDependencies,
-        PythonAwsLambdaHandlerField,
         PythonAwsLambdaIncludeRequirements,
+        PythonAwsLambdaIncludeSources,
         PythonAwsLambdaRuntime,
         PythonFaaSCompletePlatforms,
         PythonResolveField,
         EnvironmentField,
-    )
-    help = help_text(
-        f"""
-        A self-contained Python function suitable for uploading to AWS Lambda.
-
-        See {doc_url('awslambda-python')}.
-        """
     )
 
     def validate(self) -> None:
@@ -141,6 +151,38 @@ class PythonAWSLambda(Target):
                     """
                 )
             )
+
+
+class PythonAWSLambda(_AWSLambdaBaseTarget):
+    # TODO: rename to python_aws_lambda_function
+    alias = "python_awslambda"
+    core_fields = (
+        *_AWSLambdaBaseTarget.core_fields,
+        PythonFaaSDependencies,
+        PythonAwsLambdaHandlerField,
+    )
+    help = help_text(
+        f"""
+        A self-contained Python function suitable for uploading to AWS Lambda.
+
+        See {doc_url('awslambda-python')}.
+        """
+    )
+
+
+class PythonAWSLambdaLayer(_AWSLambdaBaseTarget):
+    alias = "python_aws_lambda_layer"
+    core_fields = (
+        *_AWSLambdaBaseTarget.core_fields,
+        PythonAwsLambdaLayerDependenciesField,
+    )
+    help = help_text(
+        f"""
+        A Python layer suitable for uploading to AWS Lambda.
+
+        See {doc_url('awslambda-python')}.
+        """
+    )
 
 
 def rules():

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -80,6 +80,7 @@ async def package_python_google_cloud_function(
             handler=field_set.handler,
             output_path=field_set.output_path,
             include_requirements=True,
+            include_sources=True,
             reexported_handler_module=PythonGoogleCloudFunctionHandlerField.reexported_handler_module,
             log_only_reexported_handler_func=True,
         ),

--- a/src/python/pants/backend/python/util_rules/pex_venv.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv.py
@@ -1,5 +1,7 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -28,6 +30,7 @@ class PexVenvRequest:
 
     platforms: PexPlatforms = PexPlatforms()
     complete_platforms: CompletePlatforms = CompletePlatforms()
+    prefix: None | str = None
 
 
 @dataclass(frozen=True)
@@ -73,6 +76,7 @@ async def pex_venv(request: PexVenvRequest) -> PexVenv:
                 f"--dest-dir={dest_dir}",
                 f"--pex-repository={request.pex.name}",
                 f"--layout={request.layout.value}",
+                *((f"--prefix={request.prefix}",) if request.prefix is not None else ()),
                 # NB. Specifying more than one of these args doesn't make sense for `venv
                 # create`. Incorrect usage will be surfaced as a subprocess failure.
                 *request.platforms.generate_pex_arg_list(),

--- a/src/python/pants/backend/python/util_rules/pex_venv_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv_test.py
@@ -196,3 +196,23 @@ def test_complete_platforms_should_choose_appropriate_dependencies_when_possible
             "out/psycopg2/__init__.py",
         ),
     )
+
+
+def test_prefix_should_add_path(
+    local_pex: Pex,
+    rule_runner: RuleRunner,
+) -> None:
+    run_and_validate(
+        rule_runner,
+        PexVenvRequest(
+            pex=local_pex,
+            layout=PexVenvLayout.FLAT,
+            prefix="some/prefix",
+            output_path=Path("out/dir"),
+            description="testing",
+        ),
+        check_globs_exist=(
+            "out/dir/some/prefix/psycopg2/__init__.py",
+            "out/dir/some/prefix/first/party.py",
+        ),
+    )


### PR DESCRIPTION
This fixes #18880 by making pants able to create a AWS Lambda package with the layout expected by a "Layer" (https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html). For Python, this the same as a normal Lambda, except within a `python/`: `python/cowsay/__init__.py` will be importable via `import cowsay`.

The big win here is easily separating requirements from sources:

```python
# path/to/BUILD
python_sources()

python_awslambda(
  name="lambda",
  entry_point="./foo.py:handler",
  include_requirements=False
)
python_aws_lambda_layer(
  name="layer",
  dependencies=["./foo.py"],
  include_requirements=True,
  include_sources=False,
)
```

Packaging that will result in `path.to/lambda.zip` that contains only first-party sources, and `path.to/layer.zip` that contains only third-party requirements. This results in faster builds, less cache usage, and smaller deploy packages when only changing first-party sources. This side-steps some of the slowness in #19076. For the example in that PR:

| metric | Lambdex | zip, no layers | using zip + layers (this PR) |
|---|---|---|---|
| init time on cold start | 2.3-2.5s | 1.3-1.4s | not yet tested |
| compressed size | 24.6MB | 23.8MB | 28KB (lambda), 23.8MB (layer) |
| uncompressed size | 117.8MB | 115.8MB | 72KB (lambda), 115.7MB (layer) |
| PEX-construction build time | ~5s | ~5s | ~1.5s (lambda), ~5s (layer) |
| PEX-postprocessing build time | 0.14s | 4.8s | 1s (lambda), ~5s (layer) |

That is, the first-party-only lambda package ~1000&times; smaller, and is ~2&times; faster to build than even the Lambdex version.

This uses a separate target, `python_aws_lambda_layer`. The target has its inputs configured using the `dependencies=[...]` field. For instance, the example above is saying create a lambda using all of the third-party requirements required (transitively) by `./foo.py`, and none of the first-party sources.

([The initial implementation](https://github.com/pantsbuild/pants/commit/bdbc1cbec4f39f49a672da1dc5c580a6f2a17bc5) just added a `layout="layer"` option to the existing `python_awslambda` target, but, per the discussion in this PR, that was deemed unnecessarily confusing, e.g. it'd keep the `handler` field around, which is meaningless for a layer.)

Follow-up not handled here:

- for 2.18:
  - documentation
  - renaming the `python_awslambda` target to `python_aws_lambda_function` to be clearer (NB. I proposing also taking the chance to add an underscore in the name, which I've done with the `python_aws_lambda_layer` target. Let me know if there's a strong reason for the `awslambda` name without an underscore. I note the GCF target is `python_google_cloud_function`)
- not necessarily for 2.18:
  - potentially, adding "sizzle" like the ability to have `python_aws_lambda_function` specify which layers it will be used with, and thus automatically exclude the contents of the layer from the function (e.g. the example above could hypothetically replace `include_requirements=False` with `layers=[":layer"]`)

The commits are individually reviewable.