### PR TITLE
If a shebang already exists when adding a preamble, preserve it. (Cherry-pick of #19133)

### DIFF
--- a/src/python/pants/backend/tools/preamble/rules_integration_test.py
+++ b/src/python/pants/backend/tools/preamble/rules_integration_test.py
@@ -141,6 +141,27 @@ def test_ignores_shebang(rule_runner: RuleRunner) -> None:
     assert fmt_result.did_change is False
 
 
+def test_preserves_shebang(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "foo.py": "#!/usr/bin/env python3\n...",
+        }
+    )
+    fmt_result = run_preamble(
+        rule_runner,
+        {
+            "**/*.py": "# Copyright\n",
+        },
+    )
+
+    assert fmt_result.did_change is True
+    assert fmt_result.output == rule_runner.make_snapshot(
+        {
+            "foo.py": "#!/usr/bin/env python3\n# Copyright\n...",
+        }
+    )
+
+
 def test_preamble_includes_shebang(rule_runner: RuleRunner) -> None:
     files_before = {"foo.py": "#!/usr/bin/env python3\n# Copyright"}
 


### PR DESCRIPTION
Currently if a file contains a shebang but no preamble, the premable linter will break the shebang by prepending the preamble.

This change adjusts the regex match to preserve the existing shebang.
