### PR TITLE
refactor(internal): adjust pants_venv venv_dir calculation

### DIFF
--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -11,15 +11,16 @@ REQUIREMENTS=(
   "${REPO_ROOT}/3rdparty/python/requirements.txt"
 )
 
-# NB: We house these outside the working copy to avoid needing to gitignore them, but also to
-# dodge https://github.com/hashicorp/vagrant/issues/12057.
-platform=$(uname -mps | sed 's/ /./g')
-venv_dir_prefix="${HOME}/.cache/pants/pants_dev_deps/${platform}"
+platform=$(uname -mps)
 
 function venv_dir() {
   # Include the entire version string in order to differentiate e.g. PyPy from CPython.
-  py_venv_version=$(${PY} --version | fingerprint_data)
-  echo "${venv_dir_prefix}.py.${py_venv_version}.venv"
+  # Fingerprinting uname and python output avoids shebang length limits and any odd chars.
+  venv_fingerprint=$( (echo "${platform}"; ${PY} --version) | fingerprint_data)
+
+  # NB: We house these outside the working copy to avoid needing to gitignore them, but also to
+  # dodge https://github.com/hashicorp/vagrant/issues/12057.
+  echo "${HOME}/.cache/pants/pants_dev_deps/${venv_fingerprint}.venv"
 }
 
 function activate_venv() {

--- a/build-support/pants_venv
+++ b/build-support/pants_venv
@@ -16,7 +16,10 @@ platform=$(uname -mps)
 function venv_dir() {
   # Include the entire version string in order to differentiate e.g. PyPy from CPython.
   # Fingerprinting uname and python output avoids shebang length limits and any odd chars.
-  venv_fingerprint=$( (echo "${platform}"; ${PY} --version) | fingerprint_data)
+  venv_fingerprint=$( (
+    echo "${platform}"
+    ${PY} --version
+  ) | fingerprint_data)
 
   # NB: We house these outside the working copy to avoid needing to gitignore them, but also to
   # dodge https://github.com/hashicorp/vagrant/issues/12057.


### PR DESCRIPTION
The "uname -mps" output on my machine includes odd chars and is really long:
```
Linux x86_64 Intel(R) Core(TM) i7-3610QM CPU @ 2.30GHz
```

As of #18916, the entire python version is a fingerprint instead of 2 chars "39". The longer fingerprint plus my excessively long processor name trips over the shebang max length (127 chars).

Once the python interpreter becomes longer than the shebang max length, that triggers distlib's long shebang logic (which writes the shebangs for scripts like `pip` in the `venv/bin` dir), But, that distlib logic breaks with the special uname chars on my machine because distlib does not escape the special chars in the path.
https://github.com/pypa/distlib/blob/0.3.6/distlib/scripts.py#L152-L157

So, this bypasses the whole mess by generating one fingerprint for uname + python version and then use that fingerprint (which doesn't have any special chars) in the venv dir name.