### PR TITLE
Check for `CI=true`, not `CI=1` for cherry-picking

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -23,7 +23,8 @@ jobs:
         with:
           # Always checkout the latest commit of main, for latest changes to the script
           ref: "main"
-          # NB: `fetch-depth: 1` causes merge-conflicts if `main` points to merge-commit of the PR.
+          # NB: we're usually cherrypicking the HEAD of main, and we need its parent commit to diff
+          # for the cherry-pick, so we can save an extra round-trip by just getting that parent now
           fetch-depth: 2
 
       - name: Cherry-Pick

--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -20,7 +20,7 @@ function git_fetch_with_depth {
   # setting --depth will forcibly truncate history, which is fine in the temporary checkout on CI,
   # but would be annoying locally: people will usually already have the full history, so doing a
   # full fetch is fine
-  if [[ $CI = 1 ]]; then
+  if [[ $CI = true ]]; then
     DEPTH_ARGS=("--depth=$DEPTH")
   else
     DEPTH_ARGS=()


### PR DESCRIPTION
This fixes #19127, which accidentally checked for `CI=1` to determine if it's running on CI, but CI services (and GHA in particular) actually [set `CI=true`](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables), and so the script was operating in (unchanged) local mode on CI 💥 

This will fix a bug with #19125 if running on the second commit on `main` (i.e. `HEAD^`), and so adjusts the `fetch-depth` comment to explain that. This patch also ensures the shallow-clone optimisations apply on CI.