### PR TITLE
Port `Field` to Rust

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -413,7 +413,7 @@ def test_layer_must_have_dependencies(rule_runner: PythonRuleRunner) -> None:
         {"BUILD": "python_aws_lambda_layer(name='lambda', runtime='python3.7')"}
     )
     with pytest.raises(
-        ExecutionError, match="The 'dependencies' field in target //:lambda must be defined"
+        ExecutionError, match="The `dependencies` field in target //:lambda must be defined"
     ):
         create_python_awslambda(
             rule_runner,

--- a/src/python/pants/backend/javascript/goals/test_test.py
+++ b/src/python/pants/backend/javascript/goals/test_test.py
@@ -17,6 +17,7 @@ from pants.backend.javascript.target_types import (
     JSTestBatchCompatibilityTagField,
     JSTestExtraEnvVarsField,
 )
+from pants.build_graph.address import Address
 from pants.testutil.rule_runner import MockGet, run_rule_with_mocks
 
 
@@ -34,13 +35,13 @@ def given_field_set(
 
 
 def test_batches_are_seperated_on_owning_packages() -> None:
-    field_set_1 = given_field_set(sentinel.address_1, batch_compatibility_tag="default")
-    field_set_2 = given_field_set(sentinel.address_2, batch_compatibility_tag="default")
+    field_set_1 = given_field_set(Address("1"), batch_compatibility_tag="default")
+    field_set_2 = given_field_set(Address("2"), batch_compatibility_tag="default")
 
     request = JSTestRequest.PartitionRequest(field_sets=(field_set_1, field_set_2))
 
     def mocked_owning_node_package(r: OwningNodePackageRequest) -> Any:
-        if r.address == sentinel.address_1:
+        if r.address == Address("1"):
             return OwningNodePackage(sentinel.owning_package_1)
         else:
             return OwningNodePackage(sentinel.owning_package_2)
@@ -60,20 +61,20 @@ def test_batches_are_seperated_on_owning_packages() -> None:
     "field_set_1, field_set_2",
     [
         pytest.param(
-            given_field_set(sentinel.address_1, batch_compatibility_tag="1"),
-            given_field_set(sentinel.address_2, batch_compatibility_tag="2"),
+            given_field_set(Address("1"), batch_compatibility_tag="1"),
+            given_field_set(Address("2"), batch_compatibility_tag="2"),
             id="compatibility_tag",
         ),
         pytest.param(
-            given_field_set(sentinel.address_1, batch_compatibility_tag="default"),
+            given_field_set(Address("1"), batch_compatibility_tag="default"),
             given_field_set(
-                sentinel.address_2, batch_compatibility_tag="default", env_vars=("NODE_ENV=dev",)
+                Address("2"), batch_compatibility_tag="default", env_vars=("NODE_ENV=dev",)
             ),
             id="extra_env_vars",
         ),
         pytest.param(
-            given_field_set(sentinel.address_1, batch_compatibility_tag=None),
-            given_field_set(sentinel.address_2, batch_compatibility_tag=None),
+            given_field_set(Address("1"), batch_compatibility_tag=None),
+            given_field_set(Address("2"), batch_compatibility_tag=None),
             id="no_compatibility_tag",
         ),
     ],
@@ -96,9 +97,9 @@ def test_batches_are_seperated_on_metadata(field_set_1: Mock, field_set_2: Mock)
 
 
 def test_batches_are_the_same_for_same_compat_and_package() -> None:
-    field_set_1 = given_field_set(sentinel.address_1, batch_compatibility_tag="default")
+    field_set_1 = given_field_set(Address("1"), batch_compatibility_tag="default")
 
-    field_set_2 = given_field_set(sentinel.address_2, batch_compatibility_tag="default")
+    field_set_2 = given_field_set(Address("2"), batch_compatibility_tag="default")
     request = JSTestRequest.PartitionRequest(field_sets=(field_set_1, field_set_2))
 
     def mocked_owning_node_package(_: OwningNodePackageRequest) -> Any:

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -6,6 +6,8 @@ from __future__ import annotations
 from io import RawIOBase
 from typing import (
     Any,
+    Callable,
+    ClassVar,
     FrozenSet,
     Generic,
     Iterable,
@@ -35,7 +37,7 @@ class PyFailure:
     def get_error(self) -> Exception | None: ...
 
 # ------------------------------------------------------------------------------
-# Address (parsing)
+# Address
 # ------------------------------------------------------------------------------
 
 BANNED_CHARS_IN_TARGET_NAME: FrozenSet
@@ -247,6 +249,97 @@ class PyExecutor:
     def __init__(self, core_threads: int, max_threads: int) -> None: ...
     def to_borrowed(self) -> PyExecutor: ...
     def shutdown(self, duration_secs: float) -> None: ...
+
+# ------------------------------------------------------------------------------
+# Target
+# ------------------------------------------------------------------------------
+
+# Type alias to express the intent that the type should be immutable and hashable. There's nothing
+# to actually enforce this, outside of convention.
+ImmutableValue = Any
+
+# Marker for unspecified field values that should use the default value if applicable.
+NO_VALUE: Any
+
+class Field:
+    """A Field.
+
+    The majority of fields should use field templates like `BoolField`, `StringField`, and
+    `StringSequenceField`. These subclasses will provide sensible type hints and validation
+    automatically.
+
+    If you are directly subclassing `Field`, you should likely override `compute_value()`
+    to perform any custom hydration and/or validation, such as converting unhashable types to
+    hashable types or checking for banned values. The returned value must be hashable
+    (and should be immutable) so that this Field may be used by the engine. This means, for
+    example, using tuples rather than lists and using `FrozenOrderedSet` rather than `set`.
+
+    If you plan to use the engine to fully hydrate the value, you can also inherit
+    `AsyncFieldMixin`, which will store an `address: Address` property on the `Field` instance.
+
+    Subclasses should also override the type hints for `value` and `raw_value` to be more precise
+    than `Any`. The type hint for `raw_value` is used to generate documentation, e.g. for
+    `./pants help $target_type`.
+
+    Set the `help` class property with a description, which will be used in `./pants help`. For the
+    best rendering, use soft wrapping (e.g. implicit string concatenation) within paragraphs, but
+    hard wrapping (`\n`) to separate distinct paragraphs and/or lists.
+
+    Example:
+
+        # NB: Really, this should subclass IntField. We only use Field as an example.
+        class Timeout(Field):
+            alias = "timeout"
+            value: Optional[int]
+            default = None
+            help = "A timeout field.\n\nMore information."
+
+            @classmethod
+            def compute_value(cls, raw_value: Optional[int], address: Address) -> Optional[int]:
+                value_or_default = super().compute_value(raw_value, address=address)
+                if value_or_default is not None and not isinstance(value_or_default, int):
+                    raise ValueError(
+                        "The `timeout` field expects an integer, but was given"
+                        f"{value_or_default} for target {address}."
+                    )
+                return value_or_default
+    """
+
+    # Opt-in per field class to use a "no value" marker for the `raw_value` in `compute_value()` in
+    # case the field was not represented in the BUILD file.
+    #
+    # This will allow users to provide `None` as the field value (when applicable) without getting
+    # the fields default value.
+    none_is_valid_value: ClassVar[bool] = False
+
+    # Subclasses must define these.
+    alias: ClassVar[str]
+    help: ClassVar[str | Callable[[], str]]
+
+    # Subclasses must define at least one of these two.
+    default: ClassVar[ImmutableValue]
+    required: ClassVar[bool] = False
+
+    # Subclasses may define these.
+    removal_version: ClassVar[str | None] = None
+    removal_hint: ClassVar[str | None] = None
+
+    deprecated_alias: ClassVar[str | None] = None
+    deprecated_alias_removal_version: ClassVar[str | None] = None
+
+    value: ImmutableValue | None
+
+    def __init__(self, raw_value: Any | None, address: Address) -> None: ...
+    @classmethod
+    def compute_value(cls, raw_value: Any | None, address: Address) -> ImmutableValue:
+        """Convert the `raw_value` into `self.value`.
+
+        You should perform any optional validation and/or hydration here. For example, you may want
+        to check that an integer is > 0 or convert an `Iterable[str]` to `List[str]`.
+
+        The resulting value must be hashable (and should be immutable).
+        """
+        ...
 
 # ------------------------------------------------------------------------------
 # FS

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -258,8 +258,14 @@ class PyExecutor:
 # to actually enforce this, outside of convention.
 ImmutableValue = Any
 
+class _NoValue:
+    def __bool__(self) -> bool:
+        """NB: Always returns `False`."""
+        ...
+    def __repr__(self) -> str: ...
+
 # Marker for unspecified field values that should use the default value if applicable.
-NO_VALUE: Any
+NO_VALUE: _NoValue
 
 class Field:
     """A Field.

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -39,7 +39,7 @@ from typing import (
     get_type_hints,
 )
 
-from typing_extensions import Protocol, final
+from typing_extensions import Protocol, Self, final
 
 from pants.base.deprecated import warn_or_error
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs, assert_single_address
@@ -57,6 +57,8 @@ from pants.engine.internals.dep_rules import (
     DependencyRuleActionDeniedError,
     DependencyRuleApplication,
 )
+from pants.engine.internals.native_engine import NO_VALUE as NO_VALUE  # noqa: F401
+from pants.engine.internals.native_engine import Field as Field  # noqa: F401
 from pants.engine.unions import UnionMembership, UnionRule, distinct_union_type_per_subclass, union
 from pants.option.global_options import UnmatchedBuildFileGlobs
 from pants.source.filespec import Filespec, FilespecMatcher
@@ -79,141 +81,8 @@ logger = logging.getLogger(__name__)
 ImmutableValue = Any
 
 
-class _NoValue:
-    def __bool__(self) -> bool:
-        return False
-
-    def __repr__(self) -> str:
-        return "<NO_VALUE>"
-
-
-# Marker for unspecified field values that should use the default value if applicable.
-NO_VALUE = _NoValue()
-
-
-@dataclass(frozen=True)
-class Field:
-    """A Field.
-
-    The majority of fields should use field templates like `BoolField`, `StringField`, and
-    `StringSequenceField`. These subclasses will provide sensible type hints and validation
-    automatically.
-
-    If you are directly subclassing `Field`, you should likely override `compute_value()`
-    to perform any custom hydration and/or validation, such as converting unhashable types to
-    hashable types or checking for banned values. The returned value must be hashable
-    (and should be immutable) so that this Field may be used by the engine. This means, for
-    example, using tuples rather than lists and using `FrozenOrderedSet` rather than `set`.
-
-    If you plan to use the engine to fully hydrate the value, you can also inherit
-    `AsyncFieldMixin`, which will store an `address: Address` property on the `Field` instance.
-
-    Subclasses should also override the type hints for `value` and `raw_value` to be more precise
-    than `Any`. The type hint for `raw_value` is used to generate documentation, e.g. for
-    `./pants help $target_type`.
-
-    Set the `help` class property with a description, which will be used in `./pants help`. For the
-    best rendering, use soft wrapping (e.g. implicit string concatenation) within paragraphs, but
-    hard wrapping (`\n`) to separate distinct paragraphs and/or lists.
-
-    Example:
-
-        # NB: Really, this should subclass IntField. We only use Field as an example.
-        class Timeout(Field):
-            alias = "timeout"
-            value: Optional[int]
-            default = None
-            help = "A timeout field.\n\nMore information."
-
-            @classmethod
-            def compute_value(cls, raw_value: Optional[int], address: Address) -> Optional[int]:
-                value_or_default = super().compute_value(raw_value, address=address)
-                if value_or_default is not None and not isinstance(value_or_default, int):
-                    raise ValueError(
-                        "The `timeout` field expects an integer, but was given"
-                        f"{value_or_default} for target {address}."
-                    )
-                return value_or_default
-    """
-
-    # Opt-in per field class to use a "no value" marker for the `raw_value` in `compute_value()` in
-    # case the field was not represented in the BUILD file.
-    #
-    # This will allow users to provide `None` as the field value (when applicable) without getting
-    # the fields default value.
-    none_is_valid_value: ClassVar[bool] = False
-
-    # Subclasses must define these.
-    alias: ClassVar[str]
-    help: ClassVar[str | Callable[[], str]]
-
-    # Subclasses must define at least one of these two.
-    default: ClassVar[ImmutableValue]
-    required: ClassVar[bool] = False
-
-    # Subclasses may define these.
-    removal_version: ClassVar[str | None] = None
-    removal_hint: ClassVar[str | None] = None
-
-    deprecated_alias: ClassVar[str | None] = None
-    deprecated_alias_removal_version: ClassVar[str | None] = None
-
-    value: Optional[ImmutableValue]
-
-    @final
-    def __init__(self, raw_value: Optional[Any], address: Address) -> None:
-        if raw_value is NO_VALUE and not self.none_is_valid_value:
-            raw_value = None
-        self._check_deprecated(raw_value, address)
-
-        object.__setattr__(self, "value", self.compute_value(raw_value, address))
-
-    @classmethod
-    def compute_value(cls, raw_value: Optional[Any], address: Address) -> ImmutableValue:
-        """Convert the `raw_value` into `self.value`.
-
-        You should perform any optional validation and/or hydration here. For example, you may want
-        to check that an integer is > 0 or convert an `Iterable[str]` to `List[str]`.
-
-        The resulting value must be hashable (and should be immutable).
-        """
-        if raw_value is (NO_VALUE if cls.none_is_valid_value else None):
-            if cls.required:
-                raise RequiredFieldMissingException(address, cls.alias)
-            return cls.default
-        return raw_value
-
-    @classmethod
-    def _check_deprecated(cls, raw_value: Optional[Any], address: Address) -> None:
-        if not cls.removal_version or address.is_generated_target or raw_value in (NO_VALUE, None):
-            return
-        if not cls.removal_hint:
-            raise ValueError(
-                f"You specified `removal_version` for {cls}, but not the class property "
-                "`removal_hint`."
-            )
-        warn_or_error(
-            cls.removal_version,
-            entity=f"the {repr(cls.alias)} field",
-            hint=(f"Using the `{cls.alias}` field in the target {address}. {cls.removal_hint}"),
-        )
-
-    def __repr__(self) -> str:
-        params = [f"alias={self.alias!r}", f"value={self.value!r}"]
-        if hasattr(self, "default"):
-            params.append(f"default={self.default!r}")
-        return f"{self.__class__}({', '.join(params)})"
-
-    def __str__(self) -> str:
-        return f"{self.alias}={self.value}"
-
-    def __hash__(self) -> int:
-        return hash((self.__class__, self.value))
-
-
 # NB: By subclassing `Field`, MyPy understands our type hints, and it means it doesn't matter which
 # order you use for inheriting the field template vs. the mixin.
-@dataclass(frozen=True)
 class AsyncFieldMixin(Field):
     """A mixin to store the field's original `Address` for use during hydration by the engine.
 
@@ -262,13 +131,14 @@ class AsyncFieldMixin(Field):
 
     address: Address
 
-    @final  # type: ignore[misc]
-    def __init__(self, raw_value: Optional[Any], address: Address) -> None:
+    @final
+    def __new__(cls, raw_value: Optional[Any], address: Address) -> Self:
+        obj = super().__new__(cls, raw_value, address)  # type: ignore[call-arg]
         # N.B.: We store the address here and not in the Field base class, because the memory usage
         # of storing this value in every field was shown to be excessive / lead to performance
         # issues.
-        object.__setattr__(self, "address", address)
-        super().__init__(raw_value, address)
+        object.__setattr__(obj, "address", address)
+        return obj
 
     def __repr__(self) -> str:
         params = [
@@ -282,6 +152,18 @@ class AsyncFieldMixin(Field):
 
     def __hash__(self) -> int:
         return hash((self.__class__, self.value, self.address))
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, AsyncFieldMixin):
+            return False
+        return (
+            self.__class__ == other.__class__
+            and self.value == other.value
+            and self.address == other.address
+        )
+
+    def __ne__(self, other: Any) -> bool:
+        return not (self == other)
 
 
 @union

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -115,7 +115,7 @@ def test_field_and_target_eq() -> None:
     assert hash(field) == hash(other)
 
     # Ensure the field is frozen.
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises(AttributeError):
         field.value = "foo"
 
     tgt = FortranTarget({"version": "dev0"}, addr)
@@ -445,7 +445,7 @@ def test_async_field_mixin() -> None:
     assert hash(field) != hash(other)
 
     # Ensure it's still frozen.
-    with pytest.raises(FrozenInstanceError):
+    with pytest.raises(AttributeError):
         field.value = 11
 
     # Ensure that subclasses are not equal.

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -903,7 +903,7 @@ dependencies = [
  "process_execution",
  "protos",
  "pyo3",
- "pyo3-build-config 0.18.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pyo3-build-config 0.18.3",
  "rand",
  "regex",
  "remote",
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]
@@ -2553,15 +2553,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.18.3"
-source = "git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c#edb952233159dd6d16089f9c1d855404090a9f4c"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "parking_lot 0.12.1",
- "pyo3-build-config 0.18.3 (git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c)",
+ "pyo3-build-config 0.19.0",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -2579,8 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.3"
-source = "git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c#edb952233159dd6d16089f9c1d855404090a9f4c"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2588,17 +2590,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.3"
-source = "git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c#edb952233159dd6d16089f9c1d855404090a9f4c"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
 dependencies = [
  "libc",
- "pyo3-build-config 0.18.3 (git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c)",
+ "pyo3-build-config 0.19.0",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.3"
-source = "git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c#edb952233159dd6d16089f9c1d855404090a9f4c"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2608,8 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.3"
-source = "git+https://github.com/PyO3/pyo3.git?rev=edb952233159dd6d16089f9c1d855404090a9f4c#edb952233159dd6d16089f9c1d855404090a9f4c"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -154,8 +154,7 @@ num_enum = "0.5"
 parking_lot = "0.12"
 petgraph = "0.6"
 process_execution = { path = "process_execution" }
-# TODO: Change to ^0.18.4 once https://github.com/PyO3/pyo3/pull/3152 is released
-pyo3 =  { git = "https://github.com/PyO3/pyo3.git", rev = "edb952233159dd6d16089f9c1d855404090a9f4c" }
+pyo3 = "0.19"
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", default_features = false, features = ["stream", "rustls-tls"] }

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -517,7 +517,7 @@ impl Address {
   }
 
   #[getter]
-  fn is_generated_target(&self) -> bool {
+  pub fn is_generated_target(&self) -> bool {
     self.generated_name.is_some() || self.is_file_target()
   }
 

--- a/src/rust/engine/src/externs/engine_aware.rs
+++ b/src/rust/engine/src/externs/engine_aware.rs
@@ -72,7 +72,7 @@ impl EngineAwareReturnType {
 
     for kv_pair in artifacts_dict.items().into_iter() {
       let (key, value): (String, &PyAny) = kv_pair.extract().ok()?;
-      let artifact_output = if value.is_instance_of::<PyFileDigest>().unwrap_or(false) {
+      let artifact_output = if value.is_instance_of::<PyFileDigest>() {
         lift_file_digest(value).map(ArtifactOutput::FileDigest)
       } else {
         let digest_value = value.getattr("digest").ok()?;

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -62,6 +62,7 @@ fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
   externs::nailgun::register(py, m)?;
   externs::process::register(m)?;
   externs::scheduler::register(m)?;
+  externs::target::register(m)?;
   externs::testutil::register(m)?;
   externs::workunits::register(m)?;
   externs::dep_inference::register(m)?;

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -371,7 +371,7 @@ impl PyGeneratorResponseGet {
         ))
       }
       (Some(input_arg0), None) => {
-        if input_arg0.is_instance_of::<PyType>()? {
+        if input_arg0.is_instance_of::<PyType>() {
           return Err(PyTypeError::new_err(format!(
             "Invalid Get. Because you are using the shorthand form \
             Get(OutputType, InputType(constructor args)), the second argument should be \
@@ -411,7 +411,7 @@ impl PyGeneratorResponseGet {
           ))
         })?;
 
-        if input_arg1.is_instance_of::<PyType>()? {
+        if input_arg1.is_instance_of::<PyType>() {
           return Err(PyTypeError::new_err(format!(
             "Invalid Get. Because you are using the longhand form \
           Get(OutputType, InputType, input), the third argument should be \

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -33,6 +33,7 @@ pub mod nailgun;
 pub mod process;
 pub mod scheduler;
 mod stdio;
+mod target;
 pub mod testutil;
 pub mod workunits;
 

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -1,0 +1,248 @@
+// Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fmt::Write;
+
+use pyo3::basic::CompareOp;
+use pyo3::exceptions::PyValueError;
+use pyo3::intern;
+use pyo3::prelude::*;
+use pyo3::types::PyType;
+
+use crate::externs::address::Address;
+
+pub fn register(m: &PyModule) -> PyResult<()> {
+  m.add_class::<Field>()?;
+
+  m.add("NO_VALUE", NoFieldValue)?;
+
+  Ok(())
+}
+
+#[pyclass(name = "_NoValue")]
+#[derive(Clone)]
+struct NoFieldValue;
+
+#[pymethods]
+impl NoFieldValue {
+  fn __bool__(&self) -> bool {
+    false
+  }
+
+  fn __repr__(&self) -> &'static str {
+    "<NO_VALUE>"
+  }
+}
+
+#[pyclass(subclass)]
+pub struct Field {
+  value: PyObject,
+}
+
+#[pymethods]
+impl Field {
+  #[new]
+  #[classmethod]
+  #[pyo3(signature = (raw_value, address))]
+  fn __new__(
+    cls: &PyType,
+    raw_value: Option<PyObject>,
+    address: PyRef<Address>,
+    py: Python,
+  ) -> PyResult<Self> {
+    let raw_value = match raw_value {
+      Some(value)
+        if value.extract::<NoFieldValue>(py).is_ok() && !Self::cls_none_is_valid_value(cls)? =>
+      {
+        None
+      }
+      rv => rv,
+    };
+
+    Self::check_deprecated(cls, raw_value.as_ref(), &address, py)?;
+
+    Ok(Self {
+      value: cls
+        .call_method(intern!(py, "compute_value"), (raw_value, address), None)?
+        .into(),
+    })
+  }
+
+  #[classattr]
+  fn none_is_valid_value() -> bool {
+    false
+  }
+
+  #[classattr]
+  fn required() -> bool {
+    false
+  }
+
+  #[classattr]
+  fn removal_version() -> Option<&'static str> {
+    None
+  }
+
+  #[classattr]
+  fn removal_hint() -> Option<&'static str> {
+    None
+  }
+
+  #[classattr]
+  fn deprecated_alias() -> Option<&'static str> {
+    None
+  }
+
+  #[classattr]
+  fn deprecated_alias_removal_version() -> Option<&'static str> {
+    None
+  }
+
+  #[classmethod]
+  #[pyo3(signature = (raw_value, address))]
+  fn compute_value(
+    cls: &PyType,
+    raw_value: Option<PyObject>,
+    address: PyRef<Address>,
+    py: Python,
+  ) -> PyResult<PyObject> {
+    let default = || -> PyResult<PyObject> {
+      if Self::cls_required(cls)? {
+        // TODO: Should be `RequiredFieldMissingException`.
+        Err(PyValueError::new_err(format!(
+          "The `{}` field in target {} must be defined.",
+          Self::cls_alias(cls)?,
+          *address,
+        )))
+      } else {
+        Self::cls_default(cls)
+      }
+    };
+
+    let none_is_valid_value = Self::cls_none_is_valid_value(cls)?;
+    match raw_value {
+      Some(value) if none_is_valid_value && value.extract::<NoFieldValue>(py).is_ok() => default(),
+      None if none_is_valid_value => Ok(py.None()),
+      None => default(),
+      Some(value) => Ok(value),
+    }
+  }
+
+  #[getter]
+  fn value(&self) -> &PyObject {
+    &self.value
+  }
+
+  fn __hash__(self_: &PyCell<Self>, py: Python) -> PyResult<isize> {
+    Ok(self_.get_type().hash()? & self_.borrow().value.as_ref(py).hash()?)
+  }
+
+  fn __repr__(self_: &PyCell<Self>) -> PyResult<String> {
+    let mut result = String::new();
+    write!(
+      result,
+      "{}(alias={}, value={}",
+      self_.get_type(),
+      Self::cls_alias(self_)?,
+      self_.borrow().value
+    )
+    .unwrap();
+    if let Ok(default) = self_.getattr("default") {
+      write!(result, ", default={})", default).unwrap();
+    } else {
+      write!(result, ")").unwrap();
+    }
+    Ok(result)
+  }
+
+  fn __str__(self_: &PyCell<Self>) -> PyResult<String> {
+    Ok(format!(
+      "{}={}",
+      Self::cls_alias(self_)?,
+      self_.borrow().value
+    ))
+  }
+
+  fn __richcmp__(
+    self_: &PyCell<Self>,
+    other: &PyAny,
+    op: CompareOp,
+    py: Python,
+  ) -> PyResult<PyObject> {
+    let is_eq = self_.get_type().eq(other.get_type())?
+      && self_
+        .borrow()
+        .value
+        .as_ref(py)
+        .eq(&other.extract::<PyRef<Field>>()?.value)?;
+    match op {
+      CompareOp::Eq => Ok(is_eq.into_py(py)),
+      CompareOp::Ne => Ok((!is_eq).into_py(py)),
+      _ => Ok(py.NotImplemented()),
+    }
+  }
+}
+
+impl Field {
+  fn cls_none_is_valid_value(cls: &PyAny) -> PyResult<bool> {
+    cls.getattr("none_is_valid_value")?.extract::<bool>()
+  }
+
+  fn cls_default(cls: &PyAny) -> PyResult<PyObject> {
+    cls.getattr("default")?.extract()
+  }
+
+  fn cls_required(cls: &PyAny) -> PyResult<bool> {
+    cls.getattr("required")?.extract()
+  }
+
+  fn cls_alias(cls: &PyAny) -> PyResult<&str> {
+    // TODO: All of these methods should use interned attr names.
+    cls.getattr("alias")?.extract()
+  }
+
+  fn cls_removal_version(cls: &PyAny) -> PyResult<Option<&str>> {
+    cls.getattr("removal_hint")?.extract()
+  }
+
+  fn cls_removal_hint(cls: &PyAny) -> PyResult<Option<&str>> {
+    cls.getattr("removal_hint")?.extract()
+  }
+
+  fn check_deprecated(
+    cls: &PyType,
+    raw_value: Option<&PyObject>,
+    address: &Address,
+    py: Python,
+  ) -> PyResult<()> {
+    if address.is_generated_target() {
+      return Ok(());
+    }
+    let Some(removal_version) = Self::cls_removal_version(cls)? else {
+      return Ok(());
+    };
+    match raw_value {
+      Some(value) if value.extract::<NoFieldValue>(py).is_ok() => return Ok(()),
+      _ => (),
+    }
+
+    let Some(removal_hint) = Self::cls_removal_hint(cls)? else {
+        return Err(PyValueError::new_err(
+            "You specified `removal_version` for {cls:?}, but not the class \
+             property `removal_hint`."
+        ))
+    };
+
+    let alias = Self::cls_alias(cls)?;
+    let deprecated = PyModule::import(py, "pants.base.deprecated")?;
+    deprecated.getattr("warn_or_error")?.call(
+      (
+        removal_version,
+        format!("the {alias} field"),
+        format!("Using the `{alias}` field in the target {address}. {removal_hint}"),
+      ),
+      None,
+    )?;
+    Ok(())
+  }
+}

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -13,6 +13,7 @@ use crate::externs::address::Address;
 
 pub fn register(m: &PyModule) -> PyResult<()> {
   m.add_class::<Field>()?;
+  m.add_class::<NoFieldValue>()?;
 
   m.add("NO_VALUE", NoFieldValue)?;
 


### PR DESCRIPTION
This change ports `Field` to Rust.

One important takeaway was that `pyo3` gives us less of an advantage when subclassing is in use, because most methods of the class need to accept themselves as `PyCell` or `PyRef` (in order to gain access to their subclass instance, which isn't a member of the wrapped struct). Those methods can then only be _called_ via `pyo3` as well.

Despite that, I'll likely still port `Target` to Rust for consistency, and because it has some longer methods which I expect to see actual performance benefit from porting.