### PR TITLE
Have package_dists.InvalidEntryPoint subclass InvalidFieldException

### DIFF
--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -105,7 +105,7 @@ class TargetNotExported(SetupPyError):
     """Indicates a target that was expected to be exported is not."""
 
 
-class InvalidEntryPoint(SetupPyError):
+class InvalidEntryPoint(SetupPyError, InvalidFieldException):
     """Indicates that a specified binary entry point was invalid."""
 
 


### PR DESCRIPTION
Fixes #12430

https://github.com/pantsbuild/pants/pull/12414#discussion_r675383415
> This got my head scratching. I'd like to be consistent, but some code raise InvalidFieldException, where as other InvalidEntryPoint... feels like InvalidEntryPoint ought to inherit from InvalidFieldException too, at least... so a catch for field exceptions would catch this.
> 
> Any way, I went with keeping the tests as is, as that is the user facing interface. But I think we could make a do-over here to make it more consistent. ;)