### PR TITLE
Set up remote caching in CI  (cherry-pick of #19144)

### DIFF
--- a/.github/workflows/test-cron.yaml
+++ b/.github/workflows/test-cron.yaml
@@ -332,6 +332,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -430,6 +453,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -500,6 +546,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -570,6 +639,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -640,6 +732,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -710,6 +825,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -780,6 +918,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -850,6 +1011,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -920,6 +1104,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -990,6 +1197,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1060,6 +1290,29 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n\
+        \  CACHE_WRITE=false\n  # If no secret read/write creds, use hard-coded read-only\
+        \ creds, so that\n  # cross-fork PRs can at least read from the cache.\n \
+        \ # These creds are hard-coded here in this public repo, which makes the bucket\n\
+        \  # world-readable. But since putting raw AWS tokens in a public repo, even\n\
+        \  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it\
+        \ would be terrible if we were scanned, since this is public\n  # on purpose,\
+        \ but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo='\
+        \ | base64 -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000\
+        \                   -v ~/bazel-remote:/data                   -p 9092:9092\
+        \                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"          \
+        \         --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"            \
+        \       --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com\
+        \                   --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\"\
+        \ >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\
+        \necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -586,6 +586,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -729,6 +747,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -798,6 +834,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -867,6 +921,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -936,6 +1008,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1005,6 +1095,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1074,6 +1182,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1143,6 +1269,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1212,6 +1356,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1281,6 +1443,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:
@@ -1350,6 +1530,24 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
+    - env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      name: Launch bazel-remote
+      run: "mkdir -p ~/bazel-remote\nif [[ -z \"${AWS_ACCESS_KEY_ID}\" ]]; then\n  CACHE_WRITE=false\n  # If no secret read/write\
+        \ creds, use hard-coded read-only creds, so that\n  # cross-fork PRs can at least read from the cache.\n  # These\
+        \ creds are hard-coded here in this public repo, which makes the bucket\n  # world-readable. But since putting raw\
+        \ AWS tokens in a public repo, even\n  # deliberately, is icky, we base64-them. This will at least help hide from\n\
+        \  # automated scanners that look for checked in AWS keys.\n  # Not that it would be terrible if we were scanned,\
+        \ since this is public\n  # on purpose, but it's best not to draw attention.\n  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK'\
+        \ | base64 -d)\n  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64\
+        \ -d)\nelse\n  CACHE_WRITE=true\nfi\ndocker run --detach -u 1001:1000                   -v ~/bazel-remote:/data  \
+        \                 -p 9092:9092                   buchgr/bazel-remote-cache:v2.4.1                   --s3.auth_method=access_key\
+        \                   --s3.access_key_id=\"${AWS_ACCESS_KEY_ID}\"                   --s3.secret_access_key=\"${AWS_SECRET_ACCESS_KEY}\"\
+        \                   --s3.bucket=cache.pantsbuild.org                   --s3.endpoint=s3.us-east-1.amazonaws.com  \
+        \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
+        \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
+        \n"
     - name: Install AdoptJDK
       uses: actions/setup-java@v3
       with:

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -666,7 +666,11 @@ def bootstrap_jobs(
 
 
 def test_jobs(
-    helper: Helper, python_versions: list[str], shard: str | None, platform_specific: bool, with_remote_caching: bool
+    helper: Helper,
+    python_versions: list[str],
+    shard: str | None,
+    platform_specific: bool,
+    with_remote_caching: bool,
 ) -> Jobs:
     human_readable_job_name = f"Test Python ({helper.platform_name()})"
     human_readable_step_name = "Run Python tests"
@@ -722,7 +726,10 @@ def linux_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
     helper = Helper(Platform.LINUX_X86_64)
 
     def test_python_linux(shard: str) -> dict[str, Any]:
-        return test_jobs(helper, python_versions, shard, platform_specific=False, with_remote_caching=True)
+        return test_jobs(
+            helper, python_versions, shard, platform_specific=False, with_remote_caching=True
+        )
+
     shard_name_prefix = helper.job_name("test_python")
     jobs = {
         helper.job_name("bootstrap_pants"): bootstrap_jobs(

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -199,6 +199,58 @@ def checkout(
     return steps
 
 
+def launch_bazel_remote() -> Sequence[Step]:
+    """Run a sidecar bazel-remote instance.
+
+    This process proxies to a public-read/private-write S3 bucket (cache.pantsbuild.org). PRs within
+    pantsbuild/pants will have AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY secrets set and so will be
+    able to read and write the cache. PRs across forks will not, so they use hard-coded read only
+    creds so they can at least read from the cache.
+    """
+    return [
+        {
+            "name": "Launch bazel-remote",
+            "run": dedent(
+                """\
+                mkdir -p ~/bazel-remote
+                if [[ -z "${AWS_ACCESS_KEY_ID}" ]]; then
+                  CACHE_WRITE=false
+                  # If no secret read/write creds, use hard-coded read-only creds, so that
+                  # cross-fork PRs can at least read from the cache.
+                  # These creds are hard-coded here in this public repo, which makes the bucket
+                  # world-readable. But since putting raw AWS tokens in a public repo, even
+                  # deliberately, is icky, we base64-them. This will at least help hide from
+                  # automated scanners that look for checked in AWS keys.
+                  # Not that it would be terrible if we were scanned, since this is public
+                  # on purpose, but it's best not to draw attention.
+                  AWS_ACCESS_KEY_ID=$(echo 'QUtJQVY2QTZHN1JRVkJJUVM1RUEK' | base64 -d)
+                  AWS_SECRET_ACCESS_KEY=$(echo 'd3dOQ1k1eHJJWVVtejZBblV6M0l1endXV0loQWZWcW9GZlVjMDlKRwo=' | base64 -d)
+                else
+                  CACHE_WRITE=true
+                fi
+                docker run --detach -u 1001:1000 \
+                  -v ~/bazel-remote:/data \
+                  -p 9092:9092 \
+                  buchgr/bazel-remote-cache:v2.4.1 \
+                  --s3.auth_method=access_key \
+                  --s3.access_key_id="${AWS_ACCESS_KEY_ID}" \
+                  --s3.secret_access_key="${AWS_SECRET_ACCESS_KEY}" \
+                  --s3.bucket=cache.pantsbuild.org \
+                  --s3.endpoint=s3.us-east-1.amazonaws.com \
+                  --max_size 30
+                echo "PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092" >> "$GITHUB_ENV"
+                echo "PANTS_REMOTE_CACHE_READ=true" >> "$GITHUB_ENV"
+                echo "PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}" >> "$GITHUB_ENV"
+                """
+            ),
+            "env": {
+                "AWS_ACCESS_KEY_ID": f"{gha_expr('secrets.AWS_ACCESS_KEY_ID')}",
+                "AWS_SECRET_ACCESS_KEY": f"{gha_expr('secrets.AWS_SECRET_ACCESS_KEY')}",
+            },
+        }
+    ]
+
+
 def global_env() -> Env:
     return {
         "PANTS_CONFIG_FILES": "+['pants.ci.toml']",
@@ -614,7 +666,7 @@ def bootstrap_jobs(
 
 
 def test_jobs(
-    helper: Helper, python_versions: list[str], shard: str | None, platform_specific: bool
+    helper: Helper, python_versions: list[str], shard: str | None, platform_specific: bool, with_remote_caching: bool
 ) -> Jobs:
     human_readable_job_name = f"Test Python ({helper.platform_name()})"
     human_readable_step_name = "Run Python tests"
@@ -645,6 +697,7 @@ def test_jobs(
         "if": IS_PANTS_OWNER,
         "steps": [
             *checkout(),
+            *(launch_bazel_remote() if with_remote_caching else []),
             install_jdk(),
             *(
                 [install_go(), download_apache_thrift()]
@@ -669,8 +722,7 @@ def linux_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
     helper = Helper(Platform.LINUX_X86_64)
 
     def test_python_linux(shard: str) -> dict[str, Any]:
-        return test_jobs(helper, python_versions, shard, platform_specific=False)
-
+        return test_jobs(helper, python_versions, shard, platform_specific=False, with_remote_caching=True)
     shard_name_prefix = helper.job_name("test_python")
     jobs = {
         helper.job_name("bootstrap_pants"): bootstrap_jobs(
@@ -699,8 +751,10 @@ def linux_arm64_test_jobs(python_versions: list[str]) -> Jobs:
             validate_ci_config=False,
             rust_testing=RustTesting.SOME,
         ),
+        # We run these on a dedicated host with ample local cache, so remote caching
+        # just adds cost but little value.
         helper.job_name("test_python"): test_jobs(
-            helper, python_versions, shard=None, platform_specific=True
+            helper, python_versions, shard=None, platform_specific=True, with_remote_caching=False
         ),
     }
     return jobs
@@ -715,8 +769,10 @@ def macos11_x86_64_test_jobs(python_versions: list[str]) -> Jobs:
             validate_ci_config=False,
             rust_testing=RustTesting.SOME,
         ),
+        # We run these on a dedicated host with ample local cache, so remote caching
+        # just adds cost but little value.
         helper.job_name("test_python"): test_jobs(
-            helper, python_versions, shard=None, platform_specific=True
+            helper, python_versions, shard=None, platform_specific=True, with_remote_caching=False
         ),
     }
     return jobs
@@ -838,6 +894,7 @@ def test_workflow_jobs(python_versions: list[str], *, cron: bool) -> Jobs:
                 "if": IS_PANTS_OWNER,
                 "steps": [
                     *checkout(),
+                    *launch_bazel_remote(),
                     *linux_x86_64_helper.setup_primary_python(),
                     *linux_x86_64_helper.native_binaries_download(),
                     {


### PR DESCRIPTION
Runs a sidecar [bazel-remote](https://github.com/buchgr/bazel-remote/) server in a docker container. This server uses S3 as its storage backend, specifically a new cache.pantsbuild.org bucket.

Read/write access requires our AWS secret key, which is not accessible to PRs across forks. So to write to this cache, a PR must be from a branch in the pantsbuild/pants repo.

We can establish protocols by which a set of trusted contributors can push to feature branches in pantsbuild/pants and submit PRs from them, rather than from forks, to get the best CI speedups.

PRs across forks can still read from the cache, via restricted creds.