### PR TITLE
Add annotation to `Goal.name`

### DIFF
--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -54,7 +54,7 @@ class GoalSubsystem(Subsystem):
 
     @classproperty
     @abstractmethod
-    def name(cls):
+    def name(cls) -> str:
         """The name used to select the corresponding Goal on the commandline and the options_scope
         for its options."""
 


### PR DESCRIPTION
This solves 64 type errors when running against `pyright` :smile: 