### PR TITLE
Ensure pyenv install directory doesn't exist.

### DIFF
--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -147,7 +147,7 @@ async def get_pyenv_install_info(
                         if [ ! -f "$PYENV_ROOT"/done/$1/DONE ]; then
                             {python_binary.path} install_python_shim.py $1
                         fi
-                        echo "$DEST"/bin/python
+                        echo "$PYENV_ROOT"/versions/$1/bin/python
                         """
                     ).encode(),
                     is_executable=True,
@@ -180,7 +180,7 @@ async def get_pyenv_install_info(
                                 return
                             # If a previous install failed this directory may exist in an intermediate
                             # state, and pyenv may choke trying to install into it, so we remove it.
-                            shutil.rmtree(SPECIFIC_VERSION_PATH)
+                            shutil.rmtree(SPECIFIC_VERSION_PATH, ignore_errors=True)
                             subprocess.run(["{pyenv.exe}", "install", SPECIFIC_VERSION], check=True)
                             # Removing write perms helps ensure users aren't accidentally modifying
                             # Python or the site-packages

--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -144,7 +144,7 @@ async def get_pyenv_install_info(
                         #!/usr/bin/env bash
                         set -e
                         export PYENV_ROOT=$(readlink {PYENV_NAMED_CACHE})/{installation_fingerprint}
-                        if [ ! -f "$PYENV_ROOT"/pants_donefiles/$1/DONE ]; then
+                        if [ ! -f "$PYENV_ROOT"/pants_donefiles/$1.DONE ]; then
                             {python_binary.path} install_python_shim.py $1
                         fi
                         echo "$PYENV_ROOT"/versions/$1/bin/python
@@ -166,8 +166,8 @@ async def get_pyenv_install_info(
                         PYENV_ROOT = pathlib.Path("{PYENV_NAMED_CACHE}", "{installation_fingerprint}").resolve()
                         SPECIFIC_VERSION = sys.argv[1]
                         SPECIFIC_VERSION_PATH = PYENV_ROOT / "versions" / SPECIFIC_VERSION
-                        DONEFILE_DIR = PYENV_ROOT / "pants_donefiles" / SPECIFIC_VERSION
-                        DONEFILE_PATH = DONEFILE_DIR / "DONE"
+                        DONEFILE_DIR = PYENV_ROOT / "pants_donefiles"
+                        DONEFILE_PATH = DONEFILE_DIR / (SPECIFIC_VERSION + ".DONE")
                         DONEFILE_LOCK_PATH = DONEFILE_DIR / "DONE.lock"
 
                         def main():

--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -144,7 +144,7 @@ async def get_pyenv_install_info(
                         #!/usr/bin/env bash
                         set -e
                         export PYENV_ROOT=$(readlink {PYENV_NAMED_CACHE})/{installation_fingerprint}
-                        if [ ! -f "$PYENV_ROOT"/done/$1/DONE ]; then
+                        if [ ! -f "$PYENV_ROOT"/pants_donefiles/$1/DONE ]; then
                             {python_binary.path} install_python_shim.py $1
                         fi
                         echo "$PYENV_ROOT"/versions/$1/bin/python
@@ -166,7 +166,7 @@ async def get_pyenv_install_info(
                         PYENV_ROOT = pathlib.Path("{PYENV_NAMED_CACHE}", "{installation_fingerprint}").resolve()
                         SPECIFIC_VERSION = sys.argv[1]
                         SPECIFIC_VERSION_PATH = PYENV_ROOT / "versions" / SPECIFIC_VERSION
-                        DONEFILE_DIR = PYENV_ROOT / "done" / SPECIFIC_VERSION
+                        DONEFILE_DIR = PYENV_ROOT / "pants_donefiles" / SPECIFIC_VERSION
                         DONEFILE_PATH = DONEFILE_DIR / "DONE"
                         DONEFILE_LOCK_PATH = DONEFILE_DIR / "DONE.lock"
 


### PR DESCRIPTION
If a prior pyenv install failed, leaving a version in a partial state,
reinstalling to the same directory will cause pyenv to error
because the directory exists.

This change nukes the directory before trying to install to it. 
This required moving the DONE/DONE.lock files outside the directory.

Fixes #19171