### PR TITLE
Avoid extra `.` in `from .. import` parent imports in Rust Python dep inference (Cherry-pick of #19175)

### DIFF
--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -177,11 +177,11 @@ impl ImportCollector<'_> {
     };
     let full_name = match module_name {
       Some(module_name) => {
-        let mut mod_text = self.code_at(module_name.range());
-        if mod_text == "." {
-          mod_text = "";
-        }
-        [mod_text, name_ref].join(".")
+        let mod_text = self.code_at(module_name.range());
+        // `from ... import a` => `...a` mod_text alone, but `from x import a` => `x.a` needs to
+        // insert a .
+        let joiner = if mod_text.ends_with('.') { "" } else { "." };
+        [mod_text, name_ref].join(joiner)
       }
       None => name_ref.to_string(),
     };

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -78,8 +78,10 @@ from a.b import (
 
   assert_imports("from . import b", &[".b"]);
   assert_imports("from .a import b", &[".a.b"]);
+  assert_imports("from .. import b", &["..b"]);
   assert_imports("from ..a import b", &["..a.b"]);
   assert_imports("from ..a import b.c", &["..a.b.c"]);
+  assert_imports("from ... import b.c", &["...b.c"]);
   assert_imports("from ...a import b.c", &["...a.b.c"]);
   assert_imports("from ....a import b.c", &["....a.b.c"]);
   assert_imports("from ....a import b, c", &["....a.b", "....a.c"]);
@@ -488,7 +490,9 @@ fn relative_imports_resolution() {
   let filename = "foo/bar/baz.py";
   assert_relative_imports(filename, "from . import b", &["foo.bar.b"]);
   assert_relative_imports(filename, "from .a import b", &["foo.bar.a.b"]);
+  assert_relative_imports(filename, "from .. import b", &["foo.b"]);
   assert_relative_imports(filename, "from ..a import b", &["foo.a.b"]);
+  assert_relative_imports(filename, "from .. import b.c", &["foo.b.c"]);
   assert_relative_imports(filename, "from ..a import b.c", &["foo.a.b.c"]);
 
   let filename = "bingo/bango/bongo/himom.py";
@@ -496,9 +500,11 @@ fn relative_imports_resolution() {
   assert_relative_imports(filename, "from .a import b", &["bingo.bango.bongo.a.b"]);
   assert_relative_imports(filename, "from ..a import b", &["bingo.bango.a.b"]);
   assert_relative_imports(filename, "from ..a import b.c", &["bingo.bango.a.b.c"]);
+  assert_relative_imports(filename, "from ... import b.c", &["bingo.b.c"]);
   assert_relative_imports(filename, "from ...a import b.c", &["bingo.a.b.c"]);
 
   // Left unchanged, since we blew through the top, let Pants error using this string as a message
+  assert_relative_imports(filename, "from .... import b.c", &["....b.c"]);
   assert_relative_imports(filename, "from ....a import b.c", &["....a.b.c"]);
   assert_relative_imports(filename, "from ....a import b, c", &["....a.b", "....a.c"]);
   assert_relative_imports(
@@ -521,6 +527,7 @@ fn syntax_errors_and_other_fun() {
   assert_imports("from a imp x", &[]);
   assert_imports("from from import a as .as", &[]);
   assert_imports("from a import ......g", &["a.g"]);
+  assert_imports("from a. import b", &[]);
   assert_imports("try:...\nexcept:import a", &["a"]);
   assert_imports("try:...\nexcept 1:import a", &["a"]);
   assert_imports("try:...\nexcept x=1:import a", &["a"]);


### PR DESCRIPTION
This fixes #19173 by generalising the `from . import a` special case to also handle `from .. import a` etc.: _any_ module path that ends with a `.` doesn't need an extra `.` to separate the module path from the name(s).

Before this fix, `from . import a` was special cased to avoid an extra dot (becoming `.a` as desired), while `from .. import a` was not special cased. It became `...a` (extra `.`), by  joining the module path (`..`) and the name (`a`) with the usual `.` separator. This separator is only appropriate for normal names like `from x import a`.
