### PR TITLE
Include committer date in local version identifier of unstable builds

### DIFF
--- a/build-support/bin/release.py
+++ b/build-support/bin/release.py
@@ -391,7 +391,14 @@ class _Constants:
         )
         self._head_committer_date = (
             subprocess.run(
-                ["git", "show", "--no-patch", "--format=%ct", self._head_sha],
+                [
+                    "git",
+                    "show",
+                    "--no-patch",
+                    "--format=%cd",
+                    "--date=format:%Y%m%d%H%M",
+                    self._head_sha,
+                ],
                 stdout=subprocess.PIPE,
                 check=True,
             )

--- a/build-support/bin/release.py
+++ b/build-support/bin/release.py
@@ -389,6 +389,15 @@ class _Constants:
             .stdout.decode()
             .strip()
         )
+        self._head_committer_date = (
+            subprocess.run(
+                ["git", "show", "--no-patch", "--format=%ct", self._head_sha],
+                stdout=subprocess.PIPE,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+        )
         self.pants_version_file = Path("src/python/pants/VERSION")
         self.pants_stable_version = self.pants_version_file.read_text().strip()
 
@@ -418,7 +427,9 @@ class _Constants:
 
     @property
     def pants_unstable_version(self) -> str:
-        return f"{self.pants_stable_version}+git{self._head_sha[:8]}"
+        # include the commit's timestamp to make multiple builds of a single stable version more
+        # easily orderable
+        return f"{self.pants_stable_version}+{self._head_committer_date}.git{self._head_sha[:8]}"
 
     @property
     def twine_venv_dir(self) -> Path:


### PR DESCRIPTION
Fixes #7399 by adjusting the local version identifier of 'unstable' wheels to also include a timestamp, so that builds with the same stable version can be sorted in a vaguely sensible way, without having to dereference the git hash manually.

The timestamp chosen is the committer date of the commit in question, formatted as a vaguely human readable number (`yyyymmddHHMM`). For example, this PR's CI built `pantsbuild.pants-2.18.0.dev0+202305302357.git111f44db-cp39-cp39-macosx_11_0_arm64.whl`, corresponding to 2023-05-30 23:57.