### PR TITLE
store stdout/stderr output from tests as bytes

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -574,8 +574,8 @@ async def run_go_tests(
     if fallible_test_binary.exit_code != 0:
         return TestResult(
             exit_code=fallible_test_binary.exit_code,
-            stdout=fallible_test_binary.stdout,
-            stderr=fallible_test_binary.stderr,
+            stdout_bytes=fallible_test_binary.stdout.encode(),
+            stderr_bytes=fallible_test_binary.stderr.encode(),
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             addresses=(field_set.address,),

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -11,6 +11,7 @@ from enum import Enum
 from pathlib import PurePath
 from typing import Any, ClassVar, Iterable, Optional, Sequence, TypeVar, cast
 
+from pants.base.deprecated import deprecated
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
 from pants.core.subsystems.debug_adapter import DebugAdapterSubsystem
@@ -64,7 +65,7 @@ from pants.option.option_types import BoolOption, EnumOption, IntOption, StrList
 from pants.util.collections import partition_sequentially
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized
+from pants.util.memo import memoized, memoized_property
 from pants.util.meta import classproperty
 from pants.util.strutil import help_text, softwrap
 
@@ -76,9 +77,9 @@ class TestResult(EngineAwareReturnType):
     # A None exit_code indicates a backend that performs its own test discovery/selection
     # (rather than delegating that to the underlying test tool), and discovered no tests.
     exit_code: int | None
-    stdout: str
+    stdout_bytes: bytes
     stdout_digest: FileDigest
-    stderr: str
+    stderr_bytes: bytes
     stderr_digest: FileDigest
     addresses: tuple[Address, ...]
     output_setting: ShowOutput
@@ -105,8 +106,8 @@ class TestResult(EngineAwareReturnType):
         """Used when we do test discovery ourselves, and we didn't find any."""
         return TestResult(
             exit_code=None,
-            stdout="",
-            stderr="",
+            stdout_bytes=b"",
+            stderr_bytes=b"",
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             addresses=(address,),
@@ -121,8 +122,8 @@ class TestResult(EngineAwareReturnType):
         """Used when we do test discovery ourselves, and we didn't find any."""
         return TestResult(
             exit_code=None,
-            stdout="",
-            stderr="",
+            stdout_bytes=b"",
+            stderr_bytes=b"",
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             addresses=tuple(field_set.address for field_set in batch.elements),
@@ -144,9 +145,9 @@ class TestResult(EngineAwareReturnType):
     ) -> TestResult:
         return TestResult(
             exit_code=process_result.exit_code,
-            stdout=process_result.stdout.decode(),
+            stdout_bytes=process_result.stdout,
             stdout_digest=process_result.stdout_digest,
-            stderr=process_result.stderr.decode(),
+            stderr_bytes=process_result.stderr,
             stderr_digest=process_result.stderr_digest,
             addresses=(address,),
             output_setting=output_setting,
@@ -170,9 +171,9 @@ class TestResult(EngineAwareReturnType):
     ) -> TestResult:
         return TestResult(
             exit_code=process_result.exit_code,
-            stdout=process_result.stdout.decode(),
+            stdout_bytes=process_result.stdout,
             stdout_digest=process_result.stdout_digest,
-            stderr=process_result.stderr.decode(),
+            stderr_bytes=process_result.stderr,
             stderr_digest=process_result.stderr_digest,
             addresses=tuple(field_set.address for field_set in batch.elements),
             output_setting=output_setting,
@@ -183,6 +184,20 @@ class TestResult(EngineAwareReturnType):
             log_extra_output=log_extra_output,
             partition_description=batch.partition_metadata.description,
         )
+
+    @memoized_property
+    @deprecated(
+        removal_version="2.19.0.dev0", hint="Use `TestResult.stdout_bytes` instead of `stdout`."
+    )
+    def stdout(self) -> str:
+        return self.stdout_bytes.decode(errors="replace")
+
+    @memoized_property
+    @deprecated(
+        removal_version="2.19.0.dev0", hint="Use `TestResult.stderr_bytes` instead of `stderr`."
+    )
+    def stderr(self) -> str:
+        return self.stderr_bytes.decode(errors="replace")
 
     @property
     def description(self) -> str:
@@ -236,10 +251,10 @@ class TestResult(EngineAwareReturnType):
         ):
             return message
         output = ""
-        if self.stdout:
-            output += f"\n{self.stdout}"
-        if self.stderr:
-            output += f"\n{self.stderr}"
+        if self.stdout_bytes:
+            output += f"\n{self.stdout_bytes.decode(errors='replace')}"
+        if self.stderr_bytes:
+            output += f"\n{self.stderr_bytes.decode(errors='replace')}"
         if output:
             output = f"{output.rstrip()}\n\n"
         return f"{message}{output}"

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -717,3 +717,17 @@ def test_timeout_calculation() -> None:
     assert_timeout_calculated(field_value=None, expected=None)
     assert_timeout_calculated(field_value=None, global_default=20, global_max=10, expected=10)
     assert_timeout_calculated(field_value=10, timeouts_enabled=False, expected=None)
+
+
+def test_non_utf8_output() -> None:
+    test_result = TestResult(
+        exit_code=1,  # "test error" so stdout/stderr are output in message
+        stdout_bytes=b"\x80\xBF",  # invalid UTF-8 as required by the test
+        stdout_digest=EMPTY_FILE_DIGEST,  # incorrect but we do not check in this test
+        stderr_bytes=b"\x80\xBF",  # invalid UTF-8 as required by the test
+        stderr_digest=EMPTY_FILE_DIGEST,  # incorrect but we do not check in this test
+        addresses=(),
+        output_setting=ShowOutput.ALL,
+        result_metadata=None,
+    )
+    assert test_result.message() == "failed (exit code 1).\n��\n��\n\n"

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -180,9 +180,9 @@ class MockTestRequest(TestRequest):
         addresses = [field_set.address for field_set in field_sets]
         return TestResult(
             exit_code=cls.exit_code(addresses),
-            stdout="",
+            stdout_bytes=b"",
             stdout_digest=EMPTY_FILE_DIGEST,
-            stderr="",
+            stderr_bytes=b"",
             stderr_digest=EMPTY_FILE_DIGEST,
             addresses=tuple(addresses),
             coverage_data=MockCoverageData(addresses),
@@ -438,8 +438,8 @@ def _assert_test_summary(
     assert expected == _format_test_summary(
         TestResult(
             exit_code=exit_code,
-            stdout="",
-            stderr="",
+            stdout_bytes=b"",
+            stderr_bytes=b"",
             stdout_digest=EMPTY_FILE_DIGEST,
             stderr_digest=EMPTY_FILE_DIGEST,
             addresses=(Address(spec_path="", target_name="dummy_address"),),
@@ -599,9 +599,9 @@ def assert_streaming_output(
 ) -> None:
     result = TestResult(
         exit_code=exit_code,
-        stdout=stdout,
+        stdout_bytes=stdout.encode(),
         stdout_digest=EMPTY_FILE_DIGEST,
-        stderr=stderr,
+        stderr_bytes=stderr.encode(),
         stderr_digest=EMPTY_FILE_DIGEST,
         output_setting=output_setting,
         addresses=(Address("demo_test"),),


### PR DESCRIPTION
## Problem

Pants expects test output to be in UTF-8 even though this assumption is not a valid to make given that test output comes from process invocations. As described in https://github.com/pantsbuild/pants/issues/19121, this causes a `UnicodeDecodeError` under the conditions mentioned there.

## Solution

Instead of storing a `str`, just store the binary output for stdout and stderr from the underlying `Process`  to avoid string encoding issues as much as possible. When creating a message for output, only then decode the stings as UTF-8 and replace invalid characters.

The `stdout` and `stderr` attributes are renamed to `stdout_bytes` and `stderr_bytes`, respectively, Introduce `stdout` and `stderr` properties so that external plugins get a deprecation warning.

Fixes https://github.com/pantsbuild/pants/issues/19121.
