### PR TITLE
Terraform: Add `experimental-deploy` and wire-in dependency inference

### DIFF
--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -5,13 +5,13 @@ from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.terraform import dependency_inference, tool
 from pants.backend.terraform.goals import check, tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
-from pants.backend.terraform.target_types import TerraformModuleTarget
+from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
 from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModuleTarget]
+    return [TerraformModuleTarget, TerraformDeploymentTarget]
 
 
 def rules():

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -3,7 +3,7 @@
 
 from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.terraform import dependency_inference, tool
-from pants.backend.terraform.goals import check, tailor
+from pants.backend.terraform.goals import check, deploy, tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
 from pants.backend.terraform.target_types import rules as target_types_rules
@@ -23,5 +23,6 @@ def rules():
         *target_types_rules(),
         *tool.rules(),
         *tffmt_rules(),
+        *deploy.rules(),
         *python_lockfile.rules(),
     ]

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from pants.backend.python.goals import lockfile as python_lockfile
-from pants.backend.terraform import dependency_inference, tool
+from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.goals import check, deploy, tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
@@ -17,6 +17,7 @@ def target_types():
 def rules():
     return [
         *collect_rules(),
+        *dependencies.rules(),
         *check.rules(),
         *dependency_inference.rules(),
         *tailor.rules(),

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -1,0 +1,55 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from pants.backend.terraform.dependency_inference import (
+    GetTerraformDependenciesRequest,
+    TerraformDependencies,
+)
+from pants.backend.terraform.partition import partition_files_by_directory
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import SourcesField
+
+
+@dataclass(frozen=True)
+class TerraformInitRequest:
+    sources: Iterable[SourcesField]
+    # backend_config: Any
+
+
+@dataclass(frozen=True)
+class InitialisedTerraform:
+    sources_and_deps: Digest
+    terraform_files: tuple[str, ...]
+    chdir: str
+
+
+@rule
+async def init_terraform(request: TerraformInitRequest) -> InitialisedTerraform:
+    source_files = await Get(SourceFiles, SourceFilesRequest(request.sources))
+    files_by_directory = partition_files_by_directory(source_files.files)
+
+    fetched_deps = await Get(
+        TerraformDependencies,
+        GetTerraformDependenciesRequest(source_files, tuple(files_by_directory.keys())),
+    )
+
+    merged_fetched_deps = await Get(Digest, MergeDigests([x[1] for x in fetched_deps.fetched_deps]))
+
+    sources_and_deps = await Get(
+        Digest, MergeDigests([source_files.snapshot.digest, merged_fetched_deps])
+    )
+
+    assert len(files_by_directory) == 1, "Multiple directories found, unable to identify a root"
+    chdir, files = next(iter(files_by_directory.items()))
+    return InitialisedTerraform(sources_and_deps, tuple(files), chdir)
+
+
+def rules():
+    return collect_rules()

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from typing import Iterable, Tuple
 
 from pants.backend.terraform.partition import partition_files_by_directory
-from pants.backend.terraform.target_types import TerraformBackendConfigField
+from pants.backend.terraform.target_types import (
+    TerraformBackendConfigField,
+    TerraformDependenciesField,
+)
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -14,7 +17,7 @@ from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDige
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import SourcesField
+from pants.engine.target import DependenciesRequest, SourcesField, Targets
 
 
 @dataclass(frozen=True)
@@ -22,6 +25,7 @@ class GetTerraformDependenciesRequest:
     source_files: SourceFiles
     directories: Tuple[str, ...]
     backend_config: SourceFiles
+    dependencies_files: SourceFiles
 
     # Not initialising the backend means we won't access remote state. Useful for `validate`
     initialise_backend: bool = False
@@ -51,7 +55,14 @@ async def get_terraform_providers(
     args.append(terraform_arg("-backend", str(req.initialise_backend)))
 
     with_backend_config = await Get(
-        Digest, MergeDigests([req.source_files.snapshot.digest, backend_digest])
+        Digest,
+        MergeDigests(
+            [
+                req.source_files.snapshot.digest,
+                backend_digest,
+                req.dependencies_files.snapshot.digest,
+            ]
+        ),
     )
 
     # TODO: Does this need to be a MultiGet? I think we will now always get one directory
@@ -79,6 +90,7 @@ async def get_terraform_providers(
 class TerraformInitRequest:
     sources: Iterable[SourcesField]
     backend_config: TerraformBackendConfigField
+    dependencies: TerraformDependenciesField
 
     # Not initialising the backend means we won't access remote state. Useful for `validate`
     initialise_backend: bool = False
@@ -93,9 +105,12 @@ class InitialisedTerraform:
 
 @rule
 async def init_terraform(request: TerraformInitRequest) -> InitialisedTerraform:
-    source_files, backend_config = await MultiGet(
+    root_dependencies = await Get(Targets, DependenciesRequest(request.dependencies))
+
+    source_files, backend_config, dependencies_files = await MultiGet(
         Get(SourceFiles, SourceFilesRequest(request.sources)),
         Get(SourceFiles, SourceFilesRequest([request.backend_config])),
+        Get(SourceFiles, SourceFilesRequest([tgt.get(SourcesField) for tgt in root_dependencies])),
     )
     files_by_directory = partition_files_by_directory(source_files.files)
 
@@ -105,6 +120,7 @@ async def init_terraform(request: TerraformInitRequest) -> InitialisedTerraform:
             source_files,
             tuple(files_by_directory.keys()),
             backend_config,
+            dependencies_files,
             initialise_backend=request.initialise_backend,
         ),
     )
@@ -112,7 +128,10 @@ async def init_terraform(request: TerraformInitRequest) -> InitialisedTerraform:
     merged_fetched_deps = await Get(Digest, MergeDigests([x[1] for x in fetched_deps.fetched_deps]))
 
     sources_and_deps = await Get(
-        Digest, MergeDigests([source_files.snapshot.digest, merged_fetched_deps])
+        Digest,
+        MergeDigests(
+            [source_files.snapshot.digest, merged_fetched_deps, dependencies_files.snapshot.digest]
+        ),
     )
 
     assert len(files_by_directory) == 1, "Multiple directories found, unable to identify a root"

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -1,0 +1,85 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from pathlib import Path
+from typing import Optional
+
+from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
+from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
+from pants.backend.terraform.goals.deploy_test import (
+    StandardDeployment,
+    rule_runner,
+    standard_deployment,
+)
+from pants.engine.fs import DigestContents, FileContent
+from pants.engine.internals.native_engine import Address
+from pants.testutil.rule_runner import RuleRunner
+
+rule_runner = rule_runner
+standard_deployment = standard_deployment
+
+
+def _do_init_terraform(
+    rule_runner, standard_deployment, initialise_backend: bool
+) -> DigestContents:
+    rule_runner.write_files(standard_deployment.files)
+    target = rule_runner.get_target(Address("src/tf", target_name="stg"))
+    field_set = DeployTerraformFieldSet.create(target)
+    result = rule_runner.request(
+        InitialisedTerraform,
+        [
+            TerraformInitRequest(
+                (field_set.sources,),
+                field_set.backend_config,
+                initialise_backend=initialise_backend,
+            )
+        ],
+    )
+    initialised_files = rule_runner.request(DigestContents, [result.sources_and_deps])
+    assert isinstance(initialised_files, DigestContents)
+    return initialised_files
+
+
+def find_file(files: DigestContents, pattern: str) -> Optional[FileContent]:
+    return next((file for file in files if Path(file.path).match(pattern)), None)
+
+
+def test_init_terraform(rule_runner: RuleRunner, standard_deployment: StandardDeployment) -> None:
+    """Test for the happy path of initialising Terraform with a backend config."""
+    initialised_files = _do_init_terraform(
+        rule_runner, standard_deployment, initialise_backend=True
+    )
+
+    # Assert uses backend by checking that the overrides in the backend file are present in the local stub state file
+    stub_tfstate_raw = find_file(initialised_files, "src/tf/.terraform/terraform.tfstate")
+    assert stub_tfstate_raw
+    stub_tfstate = json.loads(stub_tfstate_raw.content)
+    assert stub_tfstate["backend"]["config"]["path"] == str(standard_deployment.state_file)
+
+    # Assert dependencies are initialised by checking for the dependency itself
+    assert find_file(
+        initialised_files,
+        ".terraform/providers/registry.terraform.io/hashicorp/null/*/*/terraform-provider-null*",
+    ), "Did not find expected provider"
+
+    # Assert lockfile is included
+    assert find_file(initialised_files, ".terraform.lock.hcl"), "Did not find expected provider"
+
+
+def test_init_terraform_without_backends(
+    rule_runner: RuleRunner, standard_deployment: StandardDeployment
+) -> None:
+    initialised_files = _do_init_terraform(
+        rule_runner, standard_deployment, initialise_backend=False
+    )
+
+    # Not initialising the backend means that ./.terraform/.terraform.tfstate will not be present
+    assert not find_file(
+        initialised_files, "**/*.tfstate"
+    ), "Terraform state file should not be present if the the request was to not initialise the backend"
+
+    # The dependencies should still be present
+    assert find_file(
+        initialised_files,
+        ".terraform/providers/registry.terraform.io/hashicorp/null/*/*/terraform-provider-null*",
+    ), "Did not find expected provider"

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -30,7 +30,7 @@ def _do_init_terraform(
         TerraformInitResponse,
         [
             TerraformInitRequest(
-                (field_set.sources,),
+                field_set.root_module,
                 field_set.backend_config,
                 field_set.dependencies,
                 initialise_backend=initialise_backend,
@@ -89,12 +89,18 @@ def test_init_terraform_without_backends(
 
 def test_init_terraform_with_in_repo_module(rule_runner: RuleRunner, tmpdir) -> None:
     deployment_files = {
-        "src/tf/deployment/BUILD": 'terraform_deployment(name="root")',
+        "src/tf/deployment/BUILD": textwrap.dedent(
+            """\
+            terraform_deployment(name="root", root_module=":mod")
+            terraform_module(name="mod")
+        """
+        ),
         "src/tf/deployment/main.tf": textwrap.dedent(
             """\
             module "mod0" {
               source = "../module/"
-            }"""
+            }
+        """
         ),
     }
     module_files = {

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -5,7 +5,7 @@ import textwrap
 from pathlib import Path
 from typing import Optional
 
-from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy_test import (
     StandardDeployment,
@@ -27,7 +27,7 @@ def _do_init_terraform(
     target = rule_runner.get_target(standard_deployment.target)
     field_set = DeployTerraformFieldSet.create(target)
     result = rule_runner.request(
-        InitialisedTerraform,
+        TerraformInitResponse,
         [
             TerraformInitRequest(
                 (field_set.sources,),

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -109,4 +109,17 @@ def test_init_terraform_with_in_repo_module(rule_runner: RuleRunner, tmpdir) -> 
     )
     initialised_files = _do_init_terraform(rule_runner, deployment, initialise_backend=True)
 
+    # Assert that our module got included in the module.json
     assert initialised_files
+    modules_file_raw = find_file(initialised_files, ".terraform/modules/modules.json")
+    assert modules_file_raw
+    modules_file = json.loads(modules_file_raw.content)
+    assert any(
+        module for module in modules_file["Modules"] if module["Key"] == "mod0"
+    ), "Did not find our module in modules.json"
+
+    # Assert that the module was explored as part of init
+    assert find_file(
+        initialised_files,
+        ".terraform/providers/registry.terraform.io/hashicorp/null/*/*/terraform-provider-null*",
+    ), "Did not find expected provider contained in module, did we successfully include it in the files passed to `init`?"

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -4,22 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Tuple
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform.target_types import TerraformModuleSourcesField
-from pants.backend.terraform.tool import TerraformProcess
-from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
-from pants.core.util_rules.source_files import SourceFiles
 from pants.engine.fs import CreateDigest, Digest, FileContent
-from pants.engine.internals.native_engine import EMPTY_DIGEST, MergeDigests
-from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.internals.selectors import Get
+from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     FieldSet,
@@ -142,64 +137,6 @@ async def infer_terraform_module_dependencies(
         tgt.address for tgt in candidate_targets if tgt.has_field(TerraformModuleSourcesField)
     ]
     return InferredDependencies(terraform_module_addresses)
-
-
-@dataclass(frozen=True)
-class GetTerraformDependenciesRequest:
-    source_files: SourceFiles
-    directories: Tuple[str, ...]
-    backend_config: SourceFiles
-
-    # Not initialising the backend means we won't access remote state. Useful for `validate`
-    initialise_backend: bool = False
-
-
-@dataclass(frozen=True)
-class TerraformDependencies:
-    fetched_deps: Tuple[Tuple[str, Digest], ...]
-
-
-@rule
-async def get_terraform_providers(
-    req: GetTerraformDependenciesRequest,
-) -> TerraformDependencies:
-    args = ["init"]
-    if req.backend_config.files:
-        args.append(
-            terraform_arg(
-                "-backend-config",
-                terraform_relpath(req.directories[0], req.backend_config.files[0]),
-            )
-        )
-        backend_digest = req.backend_config.snapshot.digest
-    else:
-        backend_digest = EMPTY_DIGEST
-
-    args.append(terraform_arg("-backend", str(req.initialise_backend)))
-
-    with_backend_config = await Get(
-        Digest, MergeDigests([req.source_files.snapshot.digest, backend_digest])
-    )
-
-    # TODO: Does this need to be a MultiGet? I think we will now always get one directory
-    fetched_deps = await MultiGet(
-        Get(
-            FallibleProcessResult,
-            TerraformProcess(
-                args=tuple(args),
-                input_digest=with_backend_config,
-                output_files=(".terraform.lock.hcl",),
-                output_directories=(".terraform",),
-                description="Run `terraform init` to fetch dependencies",
-                chdir=directory,
-            ),
-        )
-        for directory in req.directories
-    )
-
-    return TerraformDependencies(
-        tuple(zip(req.directories, (x.output_digest for x in fetched_deps)))
-    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -37,7 +37,7 @@ async def terraform_check(
         Get(
             TerraformInitResponse,
             TerraformInitRequest(
-                (deployment.sources,), deployment.backend_config, deployment.dependencies
+                deployment.root_module, deployment.backend_config, deployment.dependencies
             ),
         )
         for deployment in request.field_sets
@@ -58,10 +58,10 @@ async def terraform_check(
     )
 
     check_results = []
-    for deployment, result in zip(initialised_terraforms, results):
+    for deployment, result, field_set in zip(initialised_terraforms, results, request.field_sets):
         check_results.append(
             CheckResult.from_fallible_process_result(
-                result, partition_description=f"`terraform validate` on `{deployment.chdir}`"
+                result, partition_description=f"`terraform validate` on `{field_set.address}`"
             )
         )
 

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
-from pants.backend.terraform.target_types import TerraformFieldSet
+from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
 from pants.backend.terraform.tool import TerraformProcess
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
 from pants.engine.internals.selectors import Get, MultiGet
@@ -22,7 +22,7 @@ class TerraformValidateSubsystem(Subsystem):
 
 
 class TerraformCheckRequest(CheckRequest):
-    field_set_type = TerraformFieldSet
+    field_set_type = TerraformDeploymentFieldSet
     tool_name = TerraformValidateSubsystem.options_scope
 
 
@@ -34,7 +34,10 @@ async def terraform_check(
         return CheckResults([], checker_name=request.tool_name)
 
     initialised_terraforms = await MultiGet(
-        Get(InitialisedTerraform, TerraformInitRequest((deployment.sources,)))
+        Get(
+            InitialisedTerraform,
+            TerraformInitRequest((deployment.sources,), deployment.backend_config),
+        )
         for deployment in request.field_sets
     )
 

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -36,7 +36,9 @@ async def terraform_check(
     initialised_terraforms = await MultiGet(
         Get(
             InitialisedTerraform,
-            TerraformInitRequest((deployment.sources,), deployment.backend_config),
+            TerraformInitRequest(
+                (deployment.sources,), deployment.backend_config, deployment.dependencies
+            ),
         )
         for deployment in request.field_sets
     )

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -1,6 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
 from pants.backend.terraform.tool import TerraformProcess
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
@@ -35,7 +35,7 @@ async def terraform_check(
 
     initialised_terraforms = await MultiGet(
         Get(
-            InitialisedTerraform,
+            TerraformInitResponse,
             TerraformInitRequest(
                 (deployment.sources,), deployment.backend_config, deployment.dependencies
             ),

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 
 from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
-from pants.backend.terraform.tool import TerraformProcess
+from pants.backend.terraform.tool import TerraformProcess, TerraformTool
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.core.goals.deploy import DeployFieldSet, DeployProcess
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -34,7 +34,7 @@ class TerraformDeploymentRequest(EngineAwareParameter):
 
 @rule
 async def prepare_terraform_deployment(
-    request: TerraformDeploymentRequest,
+    request: TerraformDeploymentRequest, terraform_subsystem: TerraformTool
 ) -> InteractiveProcess:
     initialised_terraform = await Get(
         InitialisedTerraform,
@@ -58,8 +58,8 @@ async def prepare_terraform_deployment(
         Digest, MergeDigests([var_files.snapshot.digest, initialised_terraform.sources_and_deps])
     )
 
-    if request.field_set.extra_args.value:
-        args.extend(request.field_set.extra_args.value)
+    if terraform_subsystem.args:
+        args.extend(terraform_subsystem.args)
 
     process = await Get(
         Process,

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -39,7 +39,7 @@ async def prepare_terraform_deployment(
     initialised_terraform = await Get(
         TerraformInitResponse,
         TerraformInitRequest(
-            (request.field_set.sources,),
+            request.field_set.root_module,
             request.field_set.backend_config,
             request.field_set.dependencies,
             initialise_backend=True,

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
 from pants.backend.terraform.tool import TerraformProcess, TerraformTool
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
@@ -37,7 +37,7 @@ async def prepare_terraform_deployment(
     request: TerraformDeploymentRequest, terraform_subsystem: TerraformTool
 ) -> InteractiveProcess:
     initialised_terraform = await Get(
-        InitialisedTerraform,
+        TerraformInitResponse,
         TerraformInitRequest(
             (request.field_set.sources,),
             request.field_set.backend_config,

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from pants.backend.terraform.dependency_inference import (
-    GetTerraformDependenciesRequest,
-    TerraformDependencies,
-)
-from pants.backend.terraform.partition import partition_files_by_directory
+from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
 from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
 from pants.backend.terraform.tool import TerraformProcess, TerraformTool
 from pants.core.goals.deploy import DeployFieldSet, DeployProcess
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.native_engine import Digest, MergeDigests
 from pants.engine.internals.selectors import Get
 from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import collect_rules, rule
@@ -41,27 +35,17 @@ class TerraformDeploymentRequest(EngineAwareParameter):
 async def prepare_terraform_deployment(
     request: TerraformDeploymentRequest,
 ) -> InteractiveProcess:
-    source_files = await Get(SourceFiles, SourceFilesRequest([request.field_set.sources]))
-    files_by_directory = partition_files_by_directory(source_files.files)
-
-    fetched_deps = await Get(
-        TerraformDependencies,
-        GetTerraformDependenciesRequest(source_files, tuple(files_by_directory.keys())),
-    )
-
-    merged_fetched_deps = await Get(Digest, MergeDigests([x[1] for x in fetched_deps.fetched_deps]))
-
-    sources_and_deps = await Get(
-        Digest, MergeDigests([source_files.snapshot.digest, merged_fetched_deps])
+    initialised_terraform = await Get(
+        InitialisedTerraform, TerraformInitRequest((request.field_set.sources,))
     )
 
     process = await Get(
         Process,
         TerraformProcess(
             args=("apply",),
-            input_digest=sources_and_deps,
+            input_digest=initialised_terraform.sources_and_deps,
             description="Terraform apply",
-            chdir=next(iter(files_by_directory.keys())),
+            chdir=initialised_terraform.chdir,
         ),
     )
     return InteractiveProcess.from_process(process)

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -41,6 +41,7 @@ async def prepare_terraform_deployment(
         TerraformInitRequest(
             (request.field_set.sources,),
             request.field_set.backend_config,
+            request.field_set.dependencies,
             initialise_backend=True,
         ),
     )

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -36,7 +36,12 @@ async def prepare_terraform_deployment(
     request: TerraformDeploymentRequest,
 ) -> InteractiveProcess:
     initialised_terraform = await Get(
-        InitialisedTerraform, TerraformInitRequest((request.field_set.sources,))
+        InitialisedTerraform,
+        TerraformInitRequest(
+            (request.field_set.sources,),
+            request.field_set.backend_config,
+            initialise_backend=True,
+        ),
     )
 
     process = await Get(

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -1,0 +1,85 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from pants.backend.terraform.dependency_inference import (
+    GetTerraformDependenciesRequest,
+    TerraformDependencies,
+)
+from pants.backend.terraform.partition import partition_files_by_directory
+from pants.backend.terraform.target_types import TerraformDeploymentFieldSet
+from pants.backend.terraform.tool import TerraformProcess, TerraformTool
+from pants.core.goals.deploy import DeployFieldSet, DeployProcess
+from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals.native_engine import Digest, MergeDigests
+from pants.engine.internals.selectors import Get
+from pants.engine.process import InteractiveProcess, Process
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DeployTerraformFieldSet(TerraformDeploymentFieldSet, DeployFieldSet):
+    pass
+
+
+@dataclass(frozen=True)
+class TerraformDeploymentRequest(EngineAwareParameter):
+    field_set: TerraformDeploymentFieldSet
+
+    extra_argv: tuple[str, ...]
+
+
+@rule
+async def prepare_terraform_deployment(
+    request: TerraformDeploymentRequest,
+) -> InteractiveProcess:
+    source_files = await Get(SourceFiles, SourceFilesRequest([request.field_set.sources]))
+    files_by_directory = partition_files_by_directory(source_files.files)
+
+    fetched_deps = await Get(
+        TerraformDependencies,
+        GetTerraformDependenciesRequest(source_files, tuple(files_by_directory.keys())),
+    )
+
+    merged_fetched_deps = await Get(Digest, MergeDigests([x[1] for x in fetched_deps.fetched_deps]))
+
+    sources_and_deps = await Get(
+        Digest, MergeDigests([source_files.snapshot.digest, merged_fetched_deps])
+    )
+
+    process = await Get(
+        Process,
+        TerraformProcess(
+            args=("apply",),
+            input_digest=sources_and_deps,
+            description="Terraform apply",
+            chdir=next(iter(files_by_directory.keys())),
+        ),
+    )
+    return InteractiveProcess.from_process(process)
+
+
+@rule(desc="Run Terraform deploy process", level=LogLevel.DEBUG)
+async def run_terraform_deploy(
+    field_set: DeployTerraformFieldSet, terraform_subsystem: TerraformTool
+) -> DeployProcess:
+    interactive_process = await Get(
+        InteractiveProcess, TerraformDeploymentRequest(field_set=field_set, extra_argv=tuple())
+    )
+
+    return DeployProcess(
+        name=field_set.address.spec,
+        process=interactive_process,
+    )
+
+
+def rules():
+    return [*collect_rules(), UnionRule(DeployFieldSet, DeployTerraformFieldSet)]

--- a/src/python/pants/backend/terraform/goals/deploy_test.py
+++ b/src/python/pants/backend/terraform/goals/deploy_test.py
@@ -1,0 +1,92 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from pants.backend.terraform import dependencies, dependency_inference, tool
+from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
+from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
+from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.core.goals import deploy
+from pants.core.goals.deploy import Deploy, DeployProcess
+from pants.core.register import rules as core_rules
+from pants.core.util_rules import source_files
+from pants.engine import process
+from pants.engine.rules import QueryRule
+from pants.testutil.rule_runner import RuleRunner, mock_console
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        rules=[
+            *dependency_inference.rules(),
+            *dependencies.rules(),
+            *tool.rules(),
+            *terraform_deploy_rules(),
+            *source_files.rules(),
+            *deploy.rules(),
+            # *publish.rules(),
+            *core_rules(),
+            *process.rules(),
+            QueryRule(DeployProcess, (DeployTerraformFieldSet,)),
+        ],
+        preserve_tmpdirs=True,
+    )
+    return rule_runner
+
+
+@dataclass
+class StandardDeployment:
+    files: dict[str, str]
+    state_file: Path
+
+
+@pytest.fixture
+def standard_deployment(tmpdir) -> StandardDeployment:
+    # We have to forward "--auto-approve" to TF because `mock_console` is noninteractive
+    state_file = Path(str(tmpdir.mkdir(".terraform").join("state.json")))
+    return StandardDeployment(
+        {
+            "src/tf/BUILD": """terraform_deployment(name="stg", var_files=["stg.tfvars"],extra_args=["--auto-approve"],backend_config="stg.tfbackend")""",
+            "src/tf/main.tf": textwrap.dedent(
+                """\
+        terraform {
+            backend "local" {
+                path = "/tmp/will/not/exist"
+            }
+        }
+        variable "var0" {}
+        resource "null_resource" "dep" {}
+        """
+            ),
+            "src/tf/stg.tfvars": "var0=0",
+            "src/tf/stg.tfbackend": f'path="{state_file}"',
+        },
+        state_file,
+    )
+
+
+def test_run_terraform_deploy(rule_runner: RuleRunner, standard_deployment, tmpdir) -> None:
+    """Test end-to-end running of a deployment."""
+    rule_runner.write_files(standard_deployment.files)
+    with mock_console(rule_runner.options_bootstrapper, stdin_content="yes"):
+        result = rule_runner.run_goal_rule(Deploy, args=["src/tf:stg"])
+
+    # assert Pants thinks we succeeded
+    assert result.stdout.splitlines() == []
+    assert "✓ src/tf:stg deployed" in result.stderr.splitlines()
+
+    # assert Terraform did things
+    with open(standard_deployment.state_file) as raw_state_file:
+        raw_state = raw_state_file.read()
+    assert raw_state, "Terraform state file not found where expected."
+    state = json.loads(raw_state)
+    assert len(state["resources"]) == 1, "Resource not found in terraform state"

--- a/src/python/pants/backend/terraform/goals/deploy_test.py
+++ b/src/python/pants/backend/terraform/goals/deploy_test.py
@@ -49,6 +49,7 @@ def rule_runner() -> RuleRunner:
 class StandardDeployment:
     files: dict[str, str]
     state_file: Path
+    target: Address = Address("src/tf", target_name="stg")
 
 
 @pytest.fixture

--- a/src/python/pants/backend/terraform/goals/deploy_test.py
+++ b/src/python/pants/backend/terraform/goals/deploy_test.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pytest
 
 from pants.backend.terraform import dependencies, dependency_inference, tool
-from pants.backend.terraform.dependencies import InitialisedTerraform, TerraformInitRequest
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
 from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
@@ -38,7 +38,7 @@ def rule_runner() -> RuleRunner:
             *core_rules(),
             *process.rules(),
             QueryRule(DeployProcess, (DeployTerraformFieldSet,)),
-            QueryRule(InitialisedTerraform, (TerraformInitRequest,)),
+            QueryRule(TerraformInitResponse, (TerraformInitRequest,)),
         ],
         preserve_tmpdirs=True,
     )

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -40,6 +40,7 @@ class TerraformFieldSet(FieldSet):
     required_fields = (TerraformModuleSourcesField,)
 
     sources: TerraformModuleSourcesField
+    dependencies: TerraformDependenciesField
 
 
 class TerraformModuleTarget(Target):
@@ -104,6 +105,7 @@ class TerraformDeploymentFieldSet(FieldSet):
     )
     description: DescriptionField
     sources: TerraformModuleSourcesField
+    dependencies: TerraformDependenciesField
 
     backend_config: TerraformBackendConfigField
     var_files: TerraformVarFilesField

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -64,6 +64,15 @@ class TerraformBackendConfigField(OptionalSingleSourceField):
         return TerraformBackendConfigField(None, self.address)
 
 
+class TerraformVarFilesField(MultipleSourcesField):
+    alias = "var_files"
+    default = ("*.tfvars",)
+    expected_file_extensions = (".tfvars",)
+    help = generate_multiple_sources_field_help_message(
+        "Example: `var_files=['common.tfvars', 'prod.tfvars']`"
+    )
+
+
 class TerraformDeploymentTarget(Target):
     alias = "terraform_deployment"
     core_fields = (
@@ -71,6 +80,7 @@ class TerraformDeploymentTarget(Target):
         TerraformDependenciesField,
         TerraformModuleSourcesField,
         TerraformBackendConfigField,
+        TerraformVarFilesField,
     )
     help = "A deployment of Terraform"
 
@@ -85,6 +95,7 @@ class TerraformDeploymentFieldSet(FieldSet):
     sources: TerraformModuleSourcesField
 
     backend_config: TerraformBackendConfigField
+    var_files: TerraformVarFilesField
 
 
 class AllTerraformDeploymentTargets(Targets):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -67,7 +67,6 @@ class TerraformBackendConfigField(OptionalSingleSourceField):
 
 class TerraformVarFilesField(MultipleSourcesField):
     alias = "var_files"
-    default = ("*.tfvars",)
     expected_file_extensions = (".tfvars",)
     help = generate_multiple_sources_field_help_message(
         "Example: `var_files=['common.tfvars', 'prod.tfvars']`"

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -14,7 +14,6 @@ from pants.engine.target import (
     FieldSet,
     MultipleSourcesField,
     OptionalSingleSourceField,
-    StringSequenceField,
     Target,
     Targets,
     generate_multiple_sources_field_help_message,
@@ -70,16 +69,6 @@ class TerraformVarFileSourcesField(MultipleSourcesField):
     )
 
 
-class TerraformExtraArgs(StringSequenceField):
-    alias = "extra_args"
-    help = help_text(
-        """
-        Extra arguments for `terraform apply`
-        Example: `extra_args=["-var" "'var0=hihello'"]`"
-        """
-    )
-
-
 class TerraformDeploymentTarget(Target):
     alias = "terraform_deployment"
     core_fields = (
@@ -88,7 +77,6 @@ class TerraformDeploymentTarget(Target):
         TerraformModuleSourcesField,
         TerraformBackendConfigField,
         TerraformVarFileSourcesField,
-        TerraformExtraArgs,
     )
     help = "A deployment of Terraform"
 
@@ -105,7 +93,6 @@ class TerraformDeploymentFieldSet(FieldSet):
 
     backend_config: TerraformBackendConfigField
     var_files: TerraformVarFileSourcesField
-    extra_args: TerraformExtraArgs
 
 
 class AllTerraformDeploymentTargets(Targets):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.engine.rules import collect_rules
+from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
+    AllTargets,
     Dependencies,
+    DescriptionField,
     FieldSet,
     MultipleSourcesField,
     Target,
+    Targets,
     generate_multiple_sources_field_help_message,
 )
 from pants.util.strutil import help_text
@@ -48,6 +51,33 @@ class TerraformModuleTarget(Target):
 
         Use `terraform_modules` to generate `terraform_module` targets for less boilerplate.
         """
+    )
+
+
+class TerraformDeploymentTarget(Target):
+    alias = "terraform_deployment"
+    core_fields = (*COMMON_TARGET_FIELDS, TerraformDependenciesField, TerraformModuleSourcesField)
+    help = "A deployment of Terraform"
+
+
+@dataclass(frozen=True)
+class TerraformDeploymentFieldSet(FieldSet):
+    required_fields = (
+        TerraformDependenciesField,
+        TerraformModuleSourcesField,
+    )
+    description: DescriptionField
+    sources: TerraformModuleSourcesField
+
+
+class AllTerraformDeploymentTargets(Targets):
+    pass
+
+
+@rule
+def all_terraform_deployment_targets(targets: AllTargets) -> AllTerraformDeploymentTargets:
+    return AllTerraformDeploymentTargets(
+        tgt for tgt in targets if TerraformDeploymentFieldSet.is_applicable(tgt)
     )
 
 

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -61,10 +61,6 @@ class TerraformBackendConfigField(OptionalSingleSourceField):
     alias = "backend_config"
     help = "Configuration to be merged with what is in the configuration file's 'backend' block"
 
-    def empty(self) -> TerraformBackendConfigField:
-        """Clear the backend config to ensure that."""
-        return TerraformBackendConfigField(None, self.address)
-
 
 class TerraformVarFilesField(MultipleSourcesField):
     alias = "var_files"

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -13,6 +13,7 @@ from pants.engine.target import (
     DescriptionField,
     FieldSet,
     MultipleSourcesField,
+    OptionalSingleSourceField,
     Target,
     Targets,
     generate_multiple_sources_field_help_message,
@@ -54,9 +55,23 @@ class TerraformModuleTarget(Target):
     )
 
 
+class TerraformBackendConfigField(OptionalSingleSourceField):
+    alias = "backend_config"
+    help = "Configuration to be merged with what is in the configuration file's 'backend' block"
+
+    def empty(self) -> TerraformBackendConfigField:
+        """Clear the backend config to ensure that."""
+        return TerraformBackendConfigField(None, self.address)
+
+
 class TerraformDeploymentTarget(Target):
     alias = "terraform_deployment"
-    core_fields = (*COMMON_TARGET_FIELDS, TerraformDependenciesField, TerraformModuleSourcesField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        TerraformDependenciesField,
+        TerraformModuleSourcesField,
+        TerraformBackendConfigField,
+    )
     help = "A deployment of Terraform"
 
 
@@ -68,6 +83,8 @@ class TerraformDeploymentFieldSet(FieldSet):
     )
     description: DescriptionField
     sources: TerraformModuleSourcesField
+
+    backend_config: TerraformBackendConfigField
 
 
 class AllTerraformDeploymentTargets(Targets):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -62,7 +62,7 @@ class TerraformBackendConfigField(OptionalSingleSourceField):
     help = "Configuration to be merged with what is in the configuration file's 'backend' block"
 
 
-class TerraformVarFilesField(MultipleSourcesField):
+class TerraformVarFileSourcesField(MultipleSourcesField):
     alias = "var_files"
     expected_file_extensions = (".tfvars",)
     help = generate_multiple_sources_field_help_message(
@@ -87,7 +87,7 @@ class TerraformDeploymentTarget(Target):
         TerraformDependenciesField,
         TerraformModuleSourcesField,
         TerraformBackendConfigField,
-        TerraformVarFilesField,
+        TerraformVarFileSourcesField,
         TerraformExtraArgs,
     )
     help = "A deployment of Terraform"
@@ -104,7 +104,7 @@ class TerraformDeploymentFieldSet(FieldSet):
     dependencies: TerraformDependenciesField
 
     backend_config: TerraformBackendConfigField
-    var_files: TerraformVarFilesField
+    var_files: TerraformVarFileSourcesField
     extra_args: TerraformExtraArgs
 
 

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -14,6 +14,7 @@ from pants.engine.target import (
     FieldSet,
     MultipleSourcesField,
     OptionalSingleSourceField,
+    StringSequenceField,
     Target,
     Targets,
     generate_multiple_sources_field_help_message,
@@ -73,6 +74,16 @@ class TerraformVarFilesField(MultipleSourcesField):
     )
 
 
+class TerraformExtraArgs(StringSequenceField):
+    alias = "extra_args"
+    help = help_text(
+        """
+        Extra arguments for `terraform apply`
+        Example: `extra_args=["-var" "'var0=hihello'"]`"
+        """
+    )
+
+
 class TerraformDeploymentTarget(Target):
     alias = "terraform_deployment"
     core_fields = (
@@ -81,6 +92,7 @@ class TerraformDeploymentTarget(Target):
         TerraformModuleSourcesField,
         TerraformBackendConfigField,
         TerraformVarFilesField,
+        TerraformExtraArgs,
     )
     help = "A deployment of Terraform"
 
@@ -96,6 +108,7 @@ class TerraformDeploymentFieldSet(FieldSet):
 
     backend_config: TerraformBackendConfigField
     var_files: TerraformVarFilesField
+    extra_args: TerraformExtraArgs
 
 
 class AllTerraformDeploymentTargets(Targets):

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -12,14 +12,16 @@ from pants.core.util_rules.external_tool import (
     ExternalToolRequest,
     TemplatedExternalTool,
 )
+from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import collect_rules, rule
-from pants.option.option_types import BoolOption
+from pants.option.option_types import BoolOption, StrListOption
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
+from pants.util.strutil import softwrap
 
 
 class TerraformTool(TemplatedExternalTool):
@@ -217,6 +219,19 @@ class TerraformTool(TemplatedExternalTool):
             "1.0.6|linux_arm64|2047f8afc7d0d7b645a0422181ba3fe47b3547c4fe658f95eebeb872752ec129|30514636",
         ]
 
+    extra_env_vars = StrListOption(
+        help=softwrap(
+            """
+            Additional environment variables that would be made available to all Terraform processes.
+            """
+        ),
+        advanced=True,
+    )
+
+    @property
+    def env_vars(self) -> tuple[str, ...]:
+        return tuple(sorted(set(self.extra_env_vars)))
+
     tailor = BoolOption(
         default=True,
         help="If true, add `terraform_module` targets with the `tailor` goal.",
@@ -245,6 +260,7 @@ async def setup_terraform_process(
         ExternalToolRequest,
         terraform.get_request(platform),
     )
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(terraform.env_vars))
 
     immutable_input_digests = {"__terraform": downloaded_terraform.digest}
 
@@ -257,6 +273,7 @@ async def setup_terraform_process(
         immutable_input_digests=immutable_input_digests,
         output_files=prepend_paths(request.output_files),
         output_directories=prepend_paths(request.output_directories),
+        env=env,
         description=request.description,
         level=LogLevel.DEBUG,
     )

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -227,11 +227,6 @@ class TerraformTool(TemplatedExternalTool):
         ),
         advanced=True,
     )
-
-    @property
-    def env_vars(self) -> tuple[str, ...]:
-        return tuple(sorted(set(self.extra_env_vars)))
-
     tailor = BoolOption(
         default=True,
         help="If true, add `terraform_module` targets with the `tailor` goal.",
@@ -260,7 +255,7 @@ async def setup_terraform_process(
         ExternalToolRequest,
         terraform.get_request(platform),
     )
-    env = await Get(EnvironmentVars, EnvironmentVarsRequest(terraform.env_vars))
+    env = await Get(EnvironmentVars, EnvironmentVarsRequest(terraform.extra_env_vars))
 
     immutable_input_digests = {"__terraform": downloaded_terraform.digest}
 

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -18,7 +18,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.platform import Platform
 from pants.engine.process import Process
 from pants.engine.rules import collect_rules, rule
-from pants.option.option_types import BoolOption, StrListOption
+from pants.option.option_types import ArgsListOption, BoolOption, StrListOption
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 from pants.util.strutil import softwrap
@@ -227,6 +227,16 @@ class TerraformTool(TemplatedExternalTool):
         ),
         advanced=True,
     )
+    args = ArgsListOption(
+        example="-auto-approve",
+        passthrough=True,
+        extra_help=softwrap(
+            """
+            Additional arguments to pass to the Terraform command line.
+            """
+        ),
+    )
+
     tailor = BoolOption(
         default=True,
         help="If true, add `terraform_module` targets with the `tailor` goal.",

--- a/src/python/pants/backend/terraform/utils.py
+++ b/src/python/pants/backend/terraform/utils.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import shlex
+from pathlib import PurePath
+
+
+def terraform_arg(name: str, value: str) -> str:
+    """Format a Terraform arg."""
+    return f"{name}={shlex.quote(value)}"
+
+
+def terraform_relpath(chdir: str, target: str) -> str:
+    """Compute the relative path of a target file to the Terraform deployment root."""
+    return PurePath(target).relative_to(chdir).as_posix()


### PR DESCRIPTION
This was actually some prework for lockfiles. But Terraform has some ideas about differences between a "root" module (one you would deploy) and other modules (ones which would be included in a deployment). To model that, I creating the `TerraformDeployment` target type. Once you have that, might as well wire it in to the `experimental-deploy` goal (especially since that's most of the value of Terraform). 
Also it looks like we weren't fetching dependencies (on other modules) when building up the files to run Terraform commands. Now that happens.

I feel like I'm not being efficient in this MR with the way I bundle the (pants-inferred) dependencies together with everything, since there's this ever-growing ball of files. LMK if we've got a better way.