### PR TITLE
Discover Scala REPL main class and coordinates

### DIFF
--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
-from pants.backend.scala.util_rules.versions import ScalaArtifactsForVersionRequest, ScalaArtifactsForVersionResult
+from pants.backend.scala.util_rules.versions import (
+    ScalaArtifactsForVersionRequest,
+    ScalaArtifactsForVersionResult,
+)
 from pants.core.goals.repl import ReplImplementation, ReplRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import Addresses
@@ -15,7 +18,7 @@ from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
 
@@ -44,7 +47,9 @@ async def create_scala_repl_request(
         ToolClasspath,
         ToolClasspathRequest(
             prefix="__toolcp",
-            artifact_requirements=ArtifactRequirements.from_coordinates(scala_artifacts.all_coordinates),
+            artifact_requirements=ArtifactRequirements.from_coordinates(
+                scala_artifacts.all_coordinates
+            ),
         ),
     )
 

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -17,7 +17,13 @@ class ScalaArtifactsForVersionRequest:
 class ScalaArtifactsForVersionResult:
     compiler_coordinate: Coordinate
     library_coordinate: Coordinate
+    reflect_coordinate: Coordinate | None
     compiler_main: str
+    repl_main: str
+
+    @property
+    def all_coordinates(self) -> tuple[Coordinate, ...]:
+        return (self.compiler_coordinate, self.library_coordinate, self.reflect_coordinate)
 
 
 @rule
@@ -38,6 +44,7 @@ async def resolve_scala_artifacts_for_version(
                 version=request.scala_version,
             ),
             compiler_main="dotty.tools.dotc.Main",
+            repl_main="dotty.tools.repl.Main"
         )
 
     return ScalaArtifactsForVersionResult(
@@ -51,7 +58,13 @@ async def resolve_scala_artifacts_for_version(
             artifact="scala-library",
             version=request.scala_version,
         ),
+        reflect_coordinate=Coordinate(
+            group="org.scala-lang",
+            artifact="scala-reflect",
+            version=request.scala_version,
+        ),
         compiler_main="scala.tools.nsc.Main",
+        repl_main="scala.tools.nsc.MainGenericRunner"
     )
 
 

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -23,7 +23,10 @@ class ScalaArtifactsForVersionResult:
 
     @property
     def all_coordinates(self) -> tuple[Coordinate, ...]:
-        return (self.compiler_coordinate, self.library_coordinate, self.reflect_coordinate)
+        coords = [self.compiler_coordinate, self.library_coordinate]
+        if self.reflect_coordinate:
+            coords.append(self.reflect_coordinate)
+        return tuple(coords)
 
 
 @rule
@@ -43,8 +46,9 @@ async def resolve_scala_artifacts_for_version(
                 artifact="scala3-library_3",
                 version=request.scala_version,
             ),
+            reflect_coordinate=None,
             compiler_main="dotty.tools.dotc.Main",
-            repl_main="dotty.tools.repl.Main"
+            repl_main="dotty.tools.repl.Main",
         )
 
     return ScalaArtifactsForVersionResult(
@@ -64,7 +68,7 @@ async def resolve_scala_artifacts_for_version(
             version=request.scala_version,
         ),
         compiler_main="scala.tools.nsc.Main",
-        repl_main="scala.tools.nsc.MainGenericRunner"
+        repl_main="scala.tools.nsc.MainGenericRunner",
     )
 
 


### PR DESCRIPTION
Small change to make the Scala REPL able to discover the required dependencies and be compatible with Scala 3.

[ci skip-build-wheels]
[ci skip-rust]