### PR TITLE
Include scala_artifact classpath rule

### DIFF
--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -14,8 +14,8 @@ from pants.backend.scala.compile.scalac_plugins import (
     ScalaPluginsRequest,
     ScalaPluginTargetsForTarget,
 )
-from pants.backend.scala.resolve.artifact import rules as scala_artifact_rules
 from pants.backend.scala.compile.scalac_plugins import rules as scalac_plugins_rules
+from pants.backend.scala.resolve.artifact import rules as scala_artifact_rules
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
 from pants.backend.scala.target_types import ScalaFieldSet, ScalaGeneratorFieldSet, ScalaSourceField

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -14,6 +14,7 @@ from pants.backend.scala.compile.scalac_plugins import (
     ScalaPluginsRequest,
     ScalaPluginTargetsForTarget,
 )
+from pants.backend.scala.resolve.artifact import rules as scala_artifact_rules
 from pants.backend.scala.compile.scalac_plugins import rules as scalac_plugins_rules
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.subsystems.scalac import Scalac
@@ -246,6 +247,7 @@ def rules():
     return [
         *collect_rules(),
         *jvm_compile_rules(),
+        *scala_artifact_rules(),
         *scalac_plugins_rules(),
         *versions.rules(),
         UnionRule(ClasspathEntryRequest, CompileScalaSourceRequest),


### PR DESCRIPTION
Follow up from #19187, as previous missed including the rules that allow the `scala_artifact` target be part of dependencies.

[ci skip-build-wheels]
[ci skip-rust]