### PR TITLE
Fix secondary ownership warning semantics

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -11,7 +11,7 @@ import logging
 import os.path
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Any, Iterable, Iterator, NamedTuple, Sequence, Type, cast
+from typing import Any, Iterable, Iterator, NamedTuple, NewType, Sequence, Type, cast
 
 from pants.base.deprecated import warn_or_error
 from pants.base.specs import AncestorGlobSpec, RawSpecsWithoutFileOwners, RecursiveGlobSpec
@@ -896,7 +896,15 @@ class OwnersRequest:
     match_if_owning_build_file_included_in_sources: bool = False
 
 
-class Owners(Collection[Address]):
+# NB: This was changed from:
+# class Owners(Collection[Address]):
+#     pass
+# In https://github.com/pantsbuild/pants/pull/19191 to facilitate surgical warning of deprecation
+# of SecondaryOwnerMixin. After the Deprecation ends, it can be changed back.
+IsPrimary = NewType("IsPrimary", bool)
+
+
+class Owners(FrozenDict[Address, IsPrimary]):
     pass
 
 
@@ -951,7 +959,7 @@ async def find_owners(
     )
     live_candidate_tgts, deleted_candidate_tgts = await MultiGet(live_get, deleted_get)
 
-    matching_addresses: OrderedSet[Address] = OrderedSet()
+    result = {}
     unmatched_sources = set(owners_request.sources)
     for live in (True, False):
         candidate_tgts: Sequence[Target]
@@ -976,6 +984,8 @@ async def find_owners(
             matching_files = set(
                 candidate_tgt.get(SourcesField).filespec_matcher.matches(list(sources_set))
             )
+            is_primary = bool(matching_files)
+
             # Also consider secondary ownership, meaning it's not a `SourcesField` field with
             # primary ownership, but the target still should match the file. We can't use
             # `tgt.get()` because this is a mixin, and there technically may be >1 field.
@@ -986,8 +996,9 @@ async def find_owners(
             )
             for secondary_owner_field in secondary_owner_fields:
                 matching_files.update(
-                    *secondary_owner_field.filespec_matcher.matches(list(sources_set))
+                    secondary_owner_field.filespec_matcher.matches(list(sources_set))
                 )
+
             if not matching_files and not (
                 owners_request.match_if_owning_build_file_included_in_sources
                 and bfa.rel_path in sources_set
@@ -995,7 +1006,7 @@ async def find_owners(
                 continue
 
             unmatched_sources -= matching_files
-            matching_addresses.add(candidate_tgt.address)
+            result[candidate_tgt.address] = IsPrimary(is_primary)
 
     if (
         unmatched_sources
@@ -1005,7 +1016,7 @@ async def find_owners(
             [PurePath(path) for path in unmatched_sources], owners_request.owners_not_found_behavior
         )
 
-    return Owners(matching_addresses)
+    return Owners(result)
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -516,7 +516,7 @@ def _warn_deprecated_secondary_owner_semantics(
             ):
                 break
         else:
-            problematic_target_specs.add(field_sets[0].address.spec)
+            problematic_target_specs.update(field_set.address.spec for field_set in field_sets)
 
     if problematic_target_specs:
         warn_or_error(

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -507,7 +507,7 @@ def _warn_deprecated_secondary_owner_semantics(
         for path in matched_paths:
             path_to_field_sets[path].append(field_set)
 
-    problematic_target_specs = set()
+    problematic_target_specs = set[str]()
     for path, field_sets in path_to_field_sets.items():
         for field_set in field_sets:
             if any(

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -490,8 +490,7 @@ class AmbiguousImplementationsException(Exception):
 # NB: Remove when SecondaryOwnerMixin is removed
 def _maybe_warn_deprecated_secondary_owner_semantics(
     addresses_from_nonfile_specs: Addresses,
-    addresses_from_file_specs: Addresses,
-    owners_info: Owners,
+    owners_from_filespecs: Owners,
     matched_addresses: collections.abc.Set[Address],
 ):
     """Warn about deprecated semantics of implicitly referring to a target through "Secondary
@@ -506,8 +505,8 @@ def _maybe_warn_deprecated_secondary_owner_semantics(
     problematic_target_specs = {
         address.spec
         for address in matched_addresses
-        if address in addresses_from_file_specs
-        and not owners_info[address]
+        if address in owners_from_filespecs
+        and not owners_from_filespecs[address]
         and address not in addresses_from_nonfile_specs
     }
 
@@ -588,11 +587,6 @@ async def find_valid_field_sets_for_target_roots(
                         Addresses,
                         RawSpecsWithoutFileOwners,
                         RawSpecsWithoutFileOwners.from_raw_specs(specs.includes),
-                    ),
-                    Get(
-                        Addresses,
-                        RawSpecsWithOnlyFileOwners,
-                        RawSpecsWithOnlyFileOwners.from_raw_specs(specs.includes),
                     ),
                     Get(
                         Owners,

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -507,7 +507,7 @@ def _warn_deprecated_secondary_owner_semantics(
         for path in matched_paths:
             path_to_field_sets[path].append(field_set)
 
-    problematic_target_specs: set[str] = ()
+    problematic_target_specs: set[str] = set()
     for path, field_sets in path_to_field_sets.items():
         for field_set in field_sets:
             if any(

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -507,7 +507,7 @@ def _warn_deprecated_secondary_owner_semantics(
         for path in matched_paths:
             path_to_field_sets[path].append(field_set)
 
-    problematic_target_specs = set[str]()
+    problematic_target_specs: set[str] = ()
     for path, field_sets in path_to_field_sets.items():
         for field_set in field_sets:
             if any(

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -1132,3 +1132,7 @@ def test_secondary_owner_warning(caplog) -> None:
     assert len(caplog.records) == 1
     assert "secondary1" not in caplog.text
     assert "secondary2" in caplog.text
+
+    result = run_rule([RecursiveGlobSpec("")])
+    assert len(caplog.records) == 0
+    assert result.mapping


### PR DESCRIPTION
Fixes #19174 by boiling the criteria to warn down to:

1. The Address/Target/FieldSet is matched due __only__ to `SecondaryOwnerMixin`
2. It was matched due to a file spec (literal or glob)
3. It wasn't matched due ton address spec
    - This is just to handle the corner case where it was matched due to file and address

In order to facilitate 1., `Owner` and `find_owner` have been (temporarily) modified. Additionally, the rule that goes from `RawSpecsWithOnlyFileOwners` -> `Addresses` has been split to return `Owners`, with an additional rule added to complete the graph (`Owners` -> `Addresses`).

Then 2 and 3 are facilitated by just requesting the addresses based on the include specs.