### PR TITLE
Discover Scala REPL main class and coordinates (Cherry-pick of #19189)

### DIFF
--- a/src/python/pants/backend/scala/goals/repl.py
+++ b/src/python/pants/backend/scala/goals/repl.py
@@ -4,6 +4,10 @@
 from __future__ import annotations
 
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
+from pants.backend.scala.util_rules.versions import (
+    ScalaArtifactsForVersionRequest,
+    ScalaArtifactsForVersionResult,
+)
 from pants.core.goals.repl import ReplImplementation, ReplRequest
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import Addresses
@@ -14,7 +18,7 @@ from pants.engine.target import CoarsenedTargets
 from pants.engine.unions import UnionRule
 from pants.jvm.classpath import Classpath
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
 
@@ -36,28 +40,15 @@ async def create_scala_repl_request(
     jdk = max(environs, key=lambda j: j.jre_major_version)
 
     scala_version = scala_subsystem.version_for_resolve(user_classpath.resolve.name)
+    scala_artifacts = await Get(
+        ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(scala_version)
+    )
     tool_classpath = await Get(
         ToolClasspath,
         ToolClasspathRequest(
             prefix="__toolcp",
             artifact_requirements=ArtifactRequirements.from_coordinates(
-                [
-                    Coordinate(
-                        group="org.scala-lang",
-                        artifact="scala-compiler",
-                        version=scala_version,
-                    ),
-                    Coordinate(
-                        group="org.scala-lang",
-                        artifact="scala-library",
-                        version=scala_version,
-                    ),
-                    Coordinate(
-                        group="org.scala-lang",
-                        artifact="scala-reflect",
-                        version=scala_version,
-                    ),
-                ]
+                scala_artifacts.all_coordinates
             ),
         ),
     )
@@ -77,7 +68,7 @@ async def create_scala_repl_request(
         args=[
             *jdk.args(bash, tool_classpath.classpath_entries(), chroot="{chroot}"),
             "-Dscala.usejavacp=true",
-            "scala.tools.nsc.MainGenericRunner",
+            scala_artifacts.repl_main,
             "-classpath",
             ":".join(user_classpath.args(prefix=user_classpath_prefix)),
         ],

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -17,7 +17,16 @@ class ScalaArtifactsForVersionRequest:
 class ScalaArtifactsForVersionResult:
     compiler_coordinate: Coordinate
     library_coordinate: Coordinate
+    reflect_coordinate: Coordinate | None
     compiler_main: str
+    repl_main: str
+
+    @property
+    def all_coordinates(self) -> tuple[Coordinate, ...]:
+        coords = [self.compiler_coordinate, self.library_coordinate]
+        if self.reflect_coordinate:
+            coords.append(self.reflect_coordinate)
+        return tuple(coords)
 
 
 @rule
@@ -37,7 +46,9 @@ async def resolve_scala_artifacts_for_version(
                 artifact="scala3-library_3",
                 version=request.scala_version,
             ),
+            reflect_coordinate=None,
             compiler_main="dotty.tools.dotc.Main",
+            repl_main="dotty.tools.repl.Main",
         )
 
     return ScalaArtifactsForVersionResult(
@@ -51,7 +62,13 @@ async def resolve_scala_artifacts_for_version(
             artifact="scala-library",
             version=request.scala_version,
         ),
+        reflect_coordinate=Coordinate(
+            group="org.scala-lang",
+            artifact="scala-reflect",
+            version=request.scala_version,
+        ),
         compiler_main="scala.tools.nsc.Main",
+        repl_main="scala.tools.nsc.MainGenericRunner",
     )
 
 


### PR DESCRIPTION
Small change to make the Scala REPL able to discover the required dependencies and be compatible with Scala 3.

[ci skip-build-wheels]
[ci skip-rust]
