### PR TITLE
Avoid requiring Python when trying to install Python (using Pyenv)

### DIFF
--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -8,13 +8,13 @@ from pants.backend.python.util_rules.pex import PythonProvider
 from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.python.util_rules.pex_environment import PythonExecutable
 from pants.core.goals.run import RunRequest
+from pants.core.util_rules.adhoc_binaries import PythonBuildStandaloneBinary
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     ExternalToolRequest,
     TemplatedExternalTool,
 )
 from pants.core.util_rules.external_tool import rules as external_tools_rules
-from pants.core.util_rules.system_binaries import PythonBinary
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import CreateDigest, FileContent
 from pants.engine.internals.native_engine import Digest, MergeDigests
@@ -120,7 +120,7 @@ async def get_pyenv_install_info(
     pyenv_subsystem: PyenvPythonProviderSubsystem,
     pyenv_env_aware: PyenvPythonProviderSubsystem.EnvironmentAware,
     platform: Platform,
-    python_binary: PythonBinary,
+    bootstrap_python: PythonBuildStandaloneBinary,
 ) -> RunRequest:
     env_vars, pyenv = await MultiGet(
         Get(
@@ -147,7 +147,7 @@ async def get_pyenv_install_info(
                         DEST="$PYENV_ROOT"/versions/$1
                         if [ ! -f "$DEST"/DONE ]; then
                             mkdir -p "$DEST" 2>/dev/null || true
-                            {python_binary.path} install_python_shim.py $1
+                            {bootstrap_python.path} install_python_shim.py $1
                         fi
                         echo "$DEST"/bin/python
                         """
@@ -204,6 +204,7 @@ async def get_pyenv_install_info(
             "TMPDIR": "{chroot}/tmpdir",
             **installation_env_vars,
         },
+        immutable_input_digests=bootstrap_python.immutable_input_digests,
         append_only_caches=PYENV_APPEND_ONLY_CACHES,
     )
 


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/19160 by switching `PythonBinary` input type to `PythonBuildStandaloneBinary`