### PR TITLE
Rename `python_awslambda` to `python_aws_lambda_function`

### DIFF
--- a/docs/markdown/Python/python-goals/python-test-goal.md
+++ b/docs/markdown/Python/python-goals/python-test-goal.md
@@ -449,7 +449,7 @@ You can include the result of `pants package` in your test through the `runtime_
 
 This allows you to test your packaging pipeline by simply running `pants test ::`, without needing custom integration test scripts.
 
-To depend on a built package, use the `runtime_package_dependencies` field on the `python_test` / `python_tests` target, which is a list of addresses to targets that can be built with `pants package`, such as `pex_binary`, `python_awslambda`, and `archive` targets. Pants will build the package before running your test, and insert the file into the test's chroot. It will use the same name it would normally use with `pants package`, except without the `dist/` prefix (set by the `output_path` field).
+To depend on a built package, use the `runtime_package_dependencies` field on the `python_test` / `python_tests` target, which is a list of addresses to targets that can be built with `pants package`, such as `pex_binary`, `python_aws_lambda_function`, and `archive` targets. Pants will build the package before running your test, and insert the file into the test's chroot. It will use the same name it would normally use with `pants package`, except without the `dist/` prefix (set by the `output_path` field).
 
 For example:
 

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -353,7 +353,7 @@ You can include the result of `pants package` in your test through the `runtime_
 
 This allows you to test your packaging pipeline by simply running `pants test ::`, without needing custom integration test scripts.
 
-To depend on a built package, use the `runtime_package_dependencies` field on the `shunit2_test` / `shunit2_tests` targets, which is a list of addresses to targets that can be built with `pants package`, such as [`pex_binary`](doc:python-package-goal), [`python_awslambda`](doc:awslambda-python), and [`archive`](doc:resources) targets. Pants will build the package before running your test, and insert the file into the test's chroot. It will use the same name it would normally use with `pants package`, except without the `dist/` prefix.
+To depend on a built package, use the `runtime_package_dependencies` field on the `shunit2_test` / `shunit2_tests` targets, which is a list of addresses to targets that can be built with `pants package`, such as [`pex_binary`](doc:python-package-goal), [`python_aws_lambda_function`](doc:awslambda-python), and [`archive`](doc:resources) targets. Pants will build the package before running your test, and insert the file into the test's chroot. It will use the same name it would normally use with `pants package`, except without the `dist/` prefix.
 
 For example:
 

--- a/docs/markdown/Using Pants/assets.md
+++ b/docs/markdown/Using Pants/assets.md
@@ -80,8 +80,8 @@ Note that we open the file with its full path, including the `src/python` prefix
 
 > 🚧 `file` targets are not included with binaries like `pex_binary`
 > 
-> Pants will not include dependencies on `file` / `files` targets when creating binaries like `pex_binary` and `python_awslambda` via `pants package`. Filesystem APIs like Python's `open()` are relative to the current working directory, and they would try to read the files from where the binary is executed, rather than reading from the binary itself.
 > 
+> Pants will not include dependencies on `file` / `files` targets when creating binaries like `pex_binary` and `python_aws_lambda_function` via `pants package`. Filesystem APIs like Python's `open()` are relative to the current working directory, and they would try to read the files from where the binary is executed, rather than reading from the binary itself.
 > Instead, use `resource` / `resources` targets or an `archive` target.
 
 When to use each asset target type
@@ -97,11 +97,11 @@ Use `file` / `files` for files that aren't tightly coupled to any specific code,
 
 When writing tests, it is also often more convenient to open a file than to load a resource.
 
-|                       | `resource`                                                                                      | `file`                                                |
-| :-------------------- | :---------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
-| **Runtime path**      | Relative to source root                                                                         | Relative to repo root                                 |
-| **Loading mechanism** | Language's package loader, relative to package                                                  | Language's file loading idioms, relative to repo root |
-| **Use with**          | Targets that produce binaries, such as `pex_binary`, `python_distribution`, `python_awslambda`. | `archive` targets, tests                              |
+|                       | `resource`                                                                                                | `file`                                                |
+|:----------------------|:----------------------------------------------------------------------------------------------------------|:------------------------------------------------------|
+| **Runtime path**      | Relative to source root                                                                                   | Relative to repo root                                 |
+| **Loading mechanism** | Language's package loader, relative to package                                                            | Language's file loading idioms, relative to repo root |
+| **Use with**          | Targets that produce binaries, such as `pex_binary`, `python_distribution`, `python_aws_lambda_function`. | `archive` targets, tests                              |
 
 `relocated_files`
 -----------------
@@ -152,7 +152,7 @@ archive(
 
 The format can be `zip`, `tar`, `tar.xz`, `tar.gz`, or `tar.bz2`.
 
-The `packages` field is a list of targets that can be built using `pants package`, such as `pex_binary`, `python_awslambda`, and even other `archive` targets. Pants will build the packages as if you had run `pants package`. It will include the results in your archive using the same name they would normally have, but without the `dist/` prefix.
+The `packages` field is a list of targets that can be built using `pants package`, such as `pex_binary`, `python_aws_lambda_function`, and even other `archive` targets. Pants will build the packages as if you had run `pants package`. It will include the results in your archive using the same name they would normally have, but without the `dist/` prefix.
 
 The `files` field is a list of `file`, `files`, and `relocated_files` targets. See [resources](doc:resources) for more details.
 

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -57,8 +57,8 @@ class PythonAwsLambdaLayerFieldSet(_BaseFieldSet):
     include_sources: PythonAwsLambdaIncludeSources
 
 
-@rule(desc="Create Python AWS Lambda", level=LogLevel.DEBUG)
-async def package_python_awslambda(
+@rule(desc="Create Python AWS Lambda Function", level=LogLevel.DEBUG)
+async def package_python_aws_lambda_function(
     field_set: PythonAwsLambdaFieldSet,
     lambdex: Lambdex,
 ) -> BuiltPackage:

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -193,7 +193,9 @@ def test_create_hello_world_lambda_with_lambdex(
         ".deps/mureq-0.2.0-py3-none-any.whl/mureq/__init__.py" in names
     ), "third-party dep `mureq` must be included"
     if sys.platform == "darwin":
-        assert "`python_aws_lambda_function` targets built on macOS may fail to build." in caplog.text
+        assert (
+            "`python_aws_lambda_function` targets built on macOS may fail to build." in caplog.text
+        )
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -154,14 +154,14 @@ def test_create_hello_world_lambda_with_lambdex(
                 python_sources(name='lib')
 
                 file(name="platform", source="platform.json")
-                python_awslambda(
+                python_aws_lambda_function(
                     name='lambda',
                     dependencies=[':lib'],
                     handler='foo.bar.hello_world:handler',
                     runtime='python3.7',
                     complete_platforms=[':platform'],
                 )
-                python_awslambda(
+                python_aws_lambda_function(
                     name='slimlambda',
                     include_requirements=False,
                     dependencies=[':lib'],
@@ -193,7 +193,7 @@ def test_create_hello_world_lambda_with_lambdex(
         ".deps/mureq-0.2.0-py3-none-any.whl/mureq/__init__.py" in names
     ), "third-party dep `mureq` must be included"
     if sys.platform == "darwin":
-        assert "`python_awslambda` targets built on macOS may fail to build." in caplog.text
+        assert "`python_aws_lambda_function` targets built on macOS may fail to build." in caplog.text
 
     zip_file_relpath, content = create_python_awslambda(
         rule_runner,
@@ -247,7 +247,7 @@ def test_warn_files_targets_with_lambdex(rule_runner: PythonRuleRunner, caplog) 
                     dependencies=['assets:files', 'assets:relocated', 'assets:resources'],
                 )
 
-                python_awslambda(
+                python_aws_lambda_function(
                     name='lambda',
                     dependencies=[':lib'],
                     handler='foo.bar.hello_world:handler',
@@ -271,7 +271,7 @@ def test_warn_files_targets_with_lambdex(rule_runner: PythonRuleRunner, caplog) 
     assert caplog.records
     assert "src.py.project/lambda.zip" == zip_file_relpath
     assert (
-        "The target src/py/project:lambda (`python_awslambda`) transitively depends on"
+        "The target src/py/project:lambda (`python_aws_lambda_function`) transitively depends on"
         in caplog.text
     )
     assert "assets/f.txt:files" in caplog.text
@@ -295,12 +295,12 @@ def test_create_hello_world_lambda(rule_runner: PythonRuleRunner) -> None:
                 python_requirement(name="mureq", requirements=["mureq==0.2"])
                 python_sources()
 
-                python_awslambda(
+                python_aws_lambda_function(
                     name='lambda',
                     handler='foo.bar.hello_world:handler',
                     runtime="python3.7",
                 )
-                python_awslambda(
+                python_aws_lambda_function(
                     name='slimlambda',
                     include_requirements=False,
                     handler='foo.bar.hello_world:handler',

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -153,8 +153,11 @@ class _AWSLambdaBaseTarget(Target):
 
 
 class PythonAWSLambda(_AWSLambdaBaseTarget):
-    # TODO: rename to python_aws_lambda_function
-    alias = "python_awslambda"
+    alias = "python_aws_lambda_function"
+
+    deprecated_alias = "python_awslambda"
+    deprecated_alias_removal_version = "2.19.0.dev0"
+
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,
         PythonFaaSDependencies,

--- a/src/python/pants/backend/awslambda/python/target_types_test.py
+++ b/src/python/pants/backend/awslambda/python/target_types_test.py
@@ -64,24 +64,24 @@ def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
             "project/platform-py37.json": "",
             "project/BUILD": dedent(
                 """\
-                python_awslambda(
+                python_aws_lambda_function(
                     name='runtime',
                     handler='project.app:func',
                     runtime='python3.7',
                 )
                 file(name="python37", source="platform-py37.json")
-                python_awslambda(
+                python_aws_lambda_function(
                     name='complete_platforms',
                     handler='project.app:func',
                     complete_platforms=[':python37'],
                 )
-                python_awslambda(
+                python_aws_lambda_function(
                     name='both',
                     handler='project.app:func',
                     runtime='python3.7',
                     complete_platforms=[':python37'],
                 )
-                python_awslambda(
+                python_aws_lambda_function(
                     name='neither',
                     handler='project.app:func',
                 )
@@ -110,7 +110,7 @@ def test_at_least_one_target_platform(rule_runner: RuleRunner) -> None:
             re.escape(
                 softwrap(
                     """
-                    InvalidTargetException: The `python_awslambda` target project:neither must
+                    InvalidTargetException: The `python_aws_lambda_function` target project:neither must
                     specify either a `runtime` or `complete_platforms` or both.
                     """
                 )

--- a/src/python/pants/backend/python/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/python/dependency_inference/subsystem.py
@@ -127,7 +127,7 @@ class PythonInferSubsystem(Subsystem):
         help=softwrap(
             """
             Infer dependencies on targets' entry points, e.g. `pex_binary`'s
-            `entry_point` field, `python_awslambda`'s `handler` field and
+            `entry_point` field, `python_aws_lambda_function`'s `handler` field and
             `python_distribution`'s `entry_points` field.
             """
         ),

--- a/src/python/pants/backend/python/subsystems/lambdex.py
+++ b/src/python/pants/backend/python/subsystems/lambdex.py
@@ -34,9 +34,10 @@ class Lambdex(PythonToolBase):
         default=LambdexLayout.ZIP,
         help=softwrap(
             """
-            Explicitly control the layout used for `python_awslambda` and
-            `python_google_cloud_function` targets. This option exists for the transition from
-            Lambdex-based layout to the plain zip layout, as recommended by cloud vendors.
+            Explicitly control the layout used for `python_aws_lambda_function` (formerly
+            `python_awslambda`) and `python_google_cloud_function` targets. This option exists for
+            the transition from Lambdex-based layout to the plain zip layout, as recommended by
+            cloud vendors.
             """
         ),
         removal_version="2.19.0.dev0",
@@ -47,9 +48,10 @@ class Lambdex(PythonToolBase):
             the recommended layout.
 
             If you have `layout = "lambdex"`, removing the section will switch any
-            `python_awslambda` and `python_google_cloud_function` targets to using the `zip` layout,
-            as recommended by cloud vendors.  (If you are using `python_awslambda`, you will need to
-            also update the handlers configured in the cloud from `lambdex_handler.handler` to
+            `python_aws_lambda_function` (formerly `python_awslambda`) and
+            `python_google_cloud_function` targets to using the `zip` layout, as recommended by
+            cloud vendors.  (If you are using `python_aws_lambda_function`, you will need to also
+            update the handlers configured in the cloud from `lambdex_handler.handler` to
             `lambda_function.handler`.)
 
             See the docs for more details:

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -200,7 +200,7 @@ def test_infer_handler_dependency(rule_runner: RuleRunner, caplog) -> None:
 
     # Test that using a file path results in ignoring all targets which are not an ancestor. We can
     # do this because we know the file name must be in the current directory or subdir of the
-    # `python_awslambda`.
+    # `python_aws_lambda_function`.
     assert_inferred(
         Address("project", target_name="another_root__file_used"),
         expected=Address(

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -1069,7 +1069,7 @@ class RuntimePackageDependenciesField(SpecialCasedDependencies):
         have, but without the `--distdir` prefix (e.g. `dist/`).
 
         You can include anything that can be built by `{bin_name()} package`, e.g. a `pex_binary`,
-        `python_awslambda`, or an `archive`.
+        `python_aws_lambda_function`, or an `archive`.
         """
     )
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -736,7 +736,7 @@ class ArchivePackagesField(SpecialCasedDependencies):
         `["project:app"]`.\n\nPants will build the assets as if you had run `{bin_name()} package`.
         It will include the results in your archive using the same name they would normally have,
         but without the `--distdir` prefix (e.g. `dist/`).\n\nYou can include anything that can
-        be built by `{bin_name()} package`, e.g. a `pex_binary`, `python_awslambda`, or even another
+        be built by `{bin_name()} package`, e.g. a `pex_binary`, `python_aws_lambda_function`, or even another
         `archive`.
         """
     )

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -405,7 +405,7 @@ class NoApplicableTargetsException(Exception):
         # command only works if at least one of the targets has a SourcesField field.
         #
         # NB: Even with the "secondary owners" mechanism - used by target types like `pex_binary`
-        # and `python_awslambda` to still work with file args - those targets will not show the
+        # and `python_aws_lambda_function` to still work with file args - those targets will not show the
         # associated files when using filedeps.
         filedeps_goal_works = any(
             tgt.class_has_field(SourcesField, union_membership) for tgt in applicable_target_types


### PR DESCRIPTION
This renames the `python_awslambda` target to `python_aws_lambda_function`. This is to reduce ambiguity now that Pants has support for building layers via `python_aws_lambda_layer` (#19123), in addition to functions, and also aligns with the `python_google_cloud_function` target too.

This change has a single release deprecation since it's easy to fix, and keeps it inline with the layout switch over (e.g. #19122), but it's also easy to keep around for longer.

This PR essentially just does a search and replace on the documentation, it doesn't update the docs to include info about layers. I'm working on that separately.