### PR TITLE
Update FaaS docs for 2.18, including Lambda layers

### DIFF
--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -201,24 +201,16 @@ Then, use  `pants package project:lambda`, and upload the resulting `project/lam
 Migrating from Pants 2.16 and earlier
 -------------------------------------
 
-Pants has implemented a new way to package Lambda functions in 2.17, resulting in smaller packages and faster cold starts. This involves some changes:
+Pants has implemented a new way to package Lambda functions in 2.17, which is now the default in 2.18, resulting in smaller packages and faster cold starts. This involves some changes:
 
 - In Pants 2.16 and earlier, Pants used the [Lambdex](https://github.com/pantsbuild/lambdex) project. First, Pants would convert your code into a [Pex file](doc:pex-files) and then use Lambdex to adapt this to be better understood by AWS by adding a shim handler at the path `lambdex_handler.handler`. This shim handler first triggers the Pex initialization to choose and unzip dependencies, during the "INIT" phase.
-- In Pants 2.17, the use of Lambdex is deprecated, in favour of choosing the appropriate dependencies ahead of time, as described above, without needing to do this on each cold start. This results in a zip file laid out in the format recommended by AWS, and includes a re-export of the handler at the path `lambda_function.handler`.
-- In Pants 2.18, the new behaviour will become the default behaviour.
+- In Pants 2.17, the use of Lambdex was deprecated, in favour of choosing the appropriate dependencies ahead of time, as described above, without needing to do this on each cold start. This results in a zip file laid out in the format recommended by AWS, and includes a re-export of the handler at the path `lambda_function.handler`.
+- In Pants 2.18, the new behaviour is now the default behaviour. Layers can now be built using Pants, and this addition includes renaming the `python_awslambda` target to `python_aws_lambda_function`.
 - In Pants 2.19, the old Lambdex behaviour will be entirely removed.
 
-Any existing `python_awslambda` targets will change how they are built. Migrating has three steps:
+When upgrading to Pants 2.18, any existing `python_awslambda` functions will need to be renamed to `python_aws_lambda_function`, which can be done via `pants update-build-files ::`. Additional changes may be required:
 
-1. opt-in to the new behaviour in Pants 2.17
-2. package the new targets
-3. upload those packages to AWS, and update the configured handler from `lambdex_handler.handler` (old) to `lambda_function.handler` (new)
+- If you already use Pants 2.17 and set `layout = "zip"` in the `[lambdex]` section of `pants.toml`, you already use the new behaviour: nice one! All you need to do is delete the whole `[lambdex]` section.
+- If you use Pants 2.16 or earlier, or use Pants 2.17 with `layout = "lambdex"`, upgrading will change how these targets are built. To migrate, we suggest you first migrate to using `layout = "zip"` in Pants 2.17, by [following its instructions](/v2.17/docs/awslambda-python#migrating-from-pants-216-and-earlier), and upgrade to Pants 2.18 after that.
 
-To opt-in to the new behaviour in Pants 2.17, add the following to the end of your `pants.toml`:
-
-``` toml pants.toml
-[lambdex]
-layout = "zip"
-```
-
-To temporarily continue using the old behaviour in Pants 2.17, instead set `layout = "lambdex"`. This will not be supported in Pants 2.19. If you encounter a bug with `layout = "zip"`, [please let us know](https://github.com/pantsbuild/pants/issues/new/choose). If you require advanced PEX features, [switch to using `pex_binary` directly](#advanced-using-pex-directly).
+If you encounter a bug with the new behaviour, [please let us know](https://github.com/pantsbuild/pants/issues/new/choose). If you require advanced PEX features, [switch to using `pex_binary` directly](#advanced-using-pex-directly).

--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -24,7 +24,7 @@ backend_packages.add = [
 ]
 ```
 
-This adds the new `python_awslambda` target, which you can confirm by running `pants help python_awslambda`
+This adds the new `python_aws_lambda_function` target, which you can confirm by running `pants help python_aws_lambda_function`
 
 Step 2: Define a `python_aws_lambda_function` target
 ----------------------------------------------------
@@ -33,7 +33,7 @@ First, add your lambda function in a Python file like you would [normally do wit
 
 Then, in your BUILD file, make sure that you have a `python_source` or `python_sources` target with the handler file included in the `sources` field. You can use [`pants tailor ::`](doc:initial-configuration#5-generate-build-files) to automate this.
 
-Add a `python_awslambda` target and define the `runtime` and `handler` fields. The `runtime` should be one of the values from <https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html>. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
+Add a `python_aws_lambda_function` target and define the `runtime` and `handler` fields. The `runtime` should be one of the values from <https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html>. The `handler` has the form `handler_file.py:handler_func`, which Pants will convert into a well-formed entry point. Alternatively, you can set `handler` to the format `path.to.module:handler_func`.
 
 For example:
 
@@ -41,7 +41,7 @@ For example:
 # The default `sources` field will include our handler file.
 python_sources(name="lib")
 
-python_awslambda(
+python_aws_lambda_function(
     name="lambda",
     runtime="python3.8",
     # Pants will convert this to `project.lambda_example:example_handler`.
@@ -64,7 +64,7 @@ You can optionally set the `output_path` field to change the generated zip file'
 Step 3: Run `package`
 ---------------------
 
-Now run `pants package` on your `python_awslambda` target to create a zipped file.
+Now run `pants package` on your `python_aws_lambda_function` target to create a zipped file.
 
 For example:
 
@@ -105,7 +105,7 @@ CMD ["lambda_function.handler"]
 ```python project/BUILD
 python_sources()
 
-python_awslambda(
+python_aws_lambda_function(
     name="lambda",
     runtime="python3.8",
     handler="main.py:lambda_handler"
@@ -136,7 +136,7 @@ This split means making a change to first-party sources only requires rebuilding
 ```python project/BUILD
 python_sources(name="lib")
 
-python_awslambda(
+python_aws_lambda_function(
     name="function",
     runtime="python3.8",
     handler="lambda_example.py:example_handler",
@@ -208,7 +208,7 @@ Pants has implemented a new way to package Lambda functions in 2.17, which is no
 - In Pants 2.18, the new behaviour is now the default behaviour. Layers can now be built using Pants, and this addition includes renaming the `python_awslambda` target to `python_aws_lambda_function`.
 - In Pants 2.19, the old Lambdex behaviour will be entirely removed.
 
-When upgrading to Pants 2.18, any existing `python_awslambda` functions will need to be renamed to `python_aws_lambda_function`, which can be done via `pants update-build-files ::`. Additional changes may be required:
+When upgrading to Pants 2.18, any existing `python_awslambda` targets will need to be renamed to `python_aws_lambda_function`, which can be done via `pants update-build-files ::`. Additional changes may be required:
 
 - If you already use Pants 2.17 and set `layout = "zip"` in the `[lambdex]` section of `pants.toml`, you already use the new behaviour: nice one! All you need to do is delete the whole `[lambdex]` section.
 - If you use Pants 2.16 or earlier, or use Pants 2.17 with `layout = "lambdex"`, upgrading will change how these targets are built. To migrate, we suggest you first migrate to using `layout = "zip"` in Pants 2.17, by [following its instructions](/v2.17/docs/awslambda-python#migrating-from-pants-216-and-earlier), and upgrade to Pants 2.18 after that.

--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -26,19 +26,8 @@ backend_packages.add = [
 
 This adds the new `python_awslambda` target, which you can confirm by running `pants help python_awslambda`
 
-> 🚧 Set `layout = "zip"` for Pants 2.17
->
-> Pants 2.17 is transitioning to a new, better layout, but defaults to the old Lambdex layout for backwards compatibility. To silence the warnings and be ready for Pants 2.18, add the following to the end of your `pants.toml`:
->
-> ```toml pants.toml
-> [lambdex]
-> layout = "zip"
-> ```
->
-> If you have existing `python_awslambda` targets, this will change the handler from `lambdex_handler.handler` to `lambda_function.handler` (see [below](#migrating-from-pants-216-and-earlier) for more details).
-
-Step 2: Define a `python_awslambda` target
-------------------------------------------
+Step 2: Define a `python_aws_lambda_function` target
+----------------------------------------------------
 
 First, add your lambda function in a Python file like you would [normally do with AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/python-handler.html). Specifically, create a function `def my_handler_name(event, context)` with the name you want.
 

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -118,24 +118,16 @@ Then, use  `pants package project:gcf`, and upload the resulting `project/gcf.pe
 Migrating from Pants 2.16 and earlier
 -------------------------------------
 
-Pants has implemented a new way to package Google Cloud Functions in 2.17, resulting in smaller packages and faster cold starts. This involves some changes:
+Pants has implemented a new way to package Google Cloud Functions in 2.17, which is now the default in 2.18, resulting in smaller packages and faster cold starts. This involves some changes:
 
 - In Pants 2.16 and earlier, Pants used the [Lambdex](https://github.com/pantsbuild/lambdex) project. First, Pants would convert your code into a [Pex file](doc:pex-files) and then use Lambdex to adapt this to be better understood by GCF by adding a shim handler. This shim handler first triggers the Pex initialization to choose and unzip dependencies, during initialization.
-- In Pants 2.17, the use of Lambdex is deprecated, in favour of choosing the appropriate dependencies ahead of time, as described above, without needing to do this on each cold start. This results in a zip file laid out in the format recommended by GCF, and includes a re-export of the handler.
-- In Pants 2.18, the new behaviour will become the default behaviour.
+- In Pants 2.17, the use of Lambdex was deprecated, in favour of choosing the appropriate dependencies ahead of time, as described above, without needing to do this on each cold start. This results in a zip file laid out in the format recommended by GCF, and includes a re-export of the handler.
+- In Pants 2.18, the new behaviour is now the default behaviour.
 - In Pants 2.19, the old Lambdex behaviour will be entirely removed.
 
-Any existing `python_google_cloud_function` targets will change how they are built. Migrating has three steps:
+When upgrading to Pants 2.18, some changes may be required:
 
-1. opt-in to the new behaviour in Pants 2.17
-2. package the new targets
-3. upload those packages to GCF (the existing handler configuration should still work)
+- If you already use Pants 2.17 and set `layout = "zip"` in the `[lambdex]` section of `pants.toml`, you already use the new behaviour: nice one! All you need to do is delete the whole `[lambdex]` section.
+- If you use Pants 2.16 or earlier, or use Pants 2.17 with `layout = "lambdex"`, upgrading will change how these targets are built. To migrate, we suggest you first migrate to using `layout = "zip"` in Pants 2.17, by [following its instructions](/v2.17/docs/google-cloud-function-python#migrating-from-pants-216-and-earlier), and upgrade to Pants 2.18 after that.
 
-To opt-in to the new behaviour in Pants 2.17, set:
-
-``` toml pants.toml
-[lambdex]
-layout = "zip"
-```
-
-To temporarily continue using the old behaviour in Pants 2.17, instead set `layout = "lambdex"`. This will not be supported in Pants 2.19. If you encounter a bug with `layout = "zip"`, [please let us know](https://github.com/pantsbuild/pants/issues/new/choose). If you require advanced PEX features, [switch to using `pex_binary` directly](#advanced-using-pex-directly).
+If you encounter a bug with the new behaviour, [please let us know](https://github.com/pantsbuild/pants/issues/new/choose). If you require advanced PEX features, [switch to using `pex_binary` directly](#advanced-using-pex-directly).

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -27,15 +27,6 @@ backend_packages.add = [
 
 This adds the new `python_google_cloud_function` target, which you can confirm by running `pants help python_google_cloud_function `
 
-> 🚧 Set `layout = "zip"` for Pants 2.17
->
-> Pants 2.17 is transitioning to a new, better layout, but defaults to the old Lambdex layout for backwards compatibility (see [below](#migrating-from-pants-216-and-earlier) for more details). To silence the warnings and be ready for Pants 2.18, add the following to the end of your `pants.toml`:
->
-> ```toml pants.toml
-> [lambdex]
-> layout = "zip"
-> ```
-
 Step 2: Define a `python_google_cloud_function ` target
 -------------------------------------------------------
 


### PR DESCRIPTION
This updates the AWS Lambda and Google Cloud Functions documentation to be appropriate for Pants 2.18, which includes:

- updates for the migration from Lambdex to 'native'/zip (continuing #19067 and #19122)
- describing how to build a Lambda layer (documenting #19123)
- updating the AWS Lambda docs for renaming from `python_awslambda` to `python_aws_lambda_function` (finishing off #19216)