### PR TITLE
Upgrade Helm unittest

### DIFF
--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -9,7 +9,6 @@ from pants.backend.helm.util_rules.tool import (
     ExternalHelmPluginBinding,
     ExternalHelmPluginRequest,
 )
-from pants.base.deprecated import deprecated
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -40,9 +39,6 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         "0.2.8|macos_x86_64|1dc95699320894bdebf055c4f4cc084c2cfa0133d3cb7fd6a4c0adca94df5c96|18161928",
         "0.2.8|macos_arm64 |436e3167c26f71258b96e32c2877b4f97c051064db941de097cf3db2fc861342|17621648",
     ]
-    legacy_url_template: ClassVar[
-        str
-    ] = "https://github.com/quintush/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
     default_url_template = "https://github.com/helm-unittest/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
     default_url_platform_mapping = {
         "linux_arm64": "linux-arm64",
@@ -50,6 +46,11 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
         "macos_arm64": "macos-arm64",
         "macos_x86_64": "macos-amd64",
     }
+
+    # TODO Remove after dropping support for the legacy tool
+    legacy_url_template: ClassVar[
+        str
+    ] = "https://github.com/quintush/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
 
     color = BoolOption(
         "--color",
@@ -65,14 +66,12 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
     skip = SkipOption("test")
 
     @property
-    @deprecated("2.19.dev0")
-    def is_legacy(self) -> bool:
+    def _is_legacy(self) -> bool:
         version_parts = self.version.split(".")
         return len(version_parts) >= 2 and version_parts[1] == "2"
 
-    @deprecated("2.19.dev0")
     def generate_url(self, plat: Platform) -> str:
-        if self.is_legacy:
+        if self._is_legacy:
             platform = self.url_platform_mapping.get(plat.value, "")
             return self.legacy_url_template.format(version=self.version, platform=platform)
         return super().generate_url(plat)

--- a/src/python/pants/backend/helm/subsystems/unittest.py
+++ b/src/python/pants/backend/helm/subsystems/unittest.py
@@ -2,12 +2,14 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from enum import Enum
+from typing import ClassVar
 
 from pants.backend.helm.util_rules.tool import (
     ExternalHelmPlugin,
     ExternalHelmPluginBinding,
     ExternalHelmPluginRequest,
 )
+from pants.base.deprecated import deprecated
 from pants.engine.platform import Platform
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
@@ -25,16 +27,23 @@ class HelmUnitTestReportFormat(Enum):
 class HelmUnitTestSubsystem(ExternalHelmPlugin):
     options_scope = "helm-unittest"
     plugin_name = "unittest"
-    help = "BDD styled unit test framework for Kubernetes Helm charts as a Helm plugin. (https://github.com/quintush/helm-unittest)"
+    help = "BDD styled unit test framework for Kubernetes Helm charts as a Helm plugin. (https://github.com/helm-unittest)"
 
-    default_version = "0.2.8"
+    default_version = "0.3.3"
     default_known_versions = [
+        "0.3.3|linux_x86_64|8ebe20f77012a5d4e7139760cabe36dd1ea38e40b26f57de3f4165d96bd486ff|21685365",
+        "0.3.3|linux_arm64 |7f5e4426428cb9678f971576103df410e6fa38dd19b87fce4729f5217bd5c683|19944514",
+        "0.3.3|macos_x86_64|b2298a513b3cb6482ba2e42079c93ad18be8a31a230bd4dffdeb01ec2881d0f5|21497144",
+        "0.3.3|macos_arm64 |2365f5b3a99e6fc83218457046378b14039a3992e9ae96a4192bc2e43a33c742|20479438",
         "0.2.8|linux_x86_64|d7c452559ad4406a1197435394fbcffe51198060de1aa9b4cb6feaf876776ba0|18299096",
         "0.2.8|linux_arm64 |c793e241b063f0540ad9b4acc0a02e5a101bd9daea5bdf4d8562e9b2337fedb2|16943867",
         "0.2.8|macos_x86_64|1dc95699320894bdebf055c4f4cc084c2cfa0133d3cb7fd6a4c0adca94df5c96|18161928",
         "0.2.8|macos_arm64 |436e3167c26f71258b96e32c2877b4f97c051064db941de097cf3db2fc861342|17621648",
     ]
-    default_url_template = "https://github.com/quintush/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
+    legacy_url_template: ClassVar[
+        str
+    ] = "https://github.com/quintush/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
+    default_url_template = "https://github.com/helm-unittest/helm-unittest/releases/download/v{version}/helm-unittest-{platform}-{version}.tgz"
     default_url_platform_mapping = {
         "linux_arm64": "linux-arm64",
         "linux_x86_64": "linux-amd64",
@@ -54,6 +63,19 @@ class HelmUnitTestSubsystem(ExternalHelmPlugin):
     )
 
     skip = SkipOption("test")
+
+    @property
+    @deprecated("2.19.dev0")
+    def is_legacy(self) -> bool:
+        version_parts = self.version.split(".")
+        return len(version_parts) >= 2 and version_parts[1] == "2"
+
+    @deprecated("2.19.dev0")
+    def generate_url(self, plat: Platform) -> str:
+        if self.is_legacy:
+            platform = self.url_platform_mapping.get(plat.value, "")
+            return self.legacy_url_template.format(version=self.version, platform=platform)
+        return super().generate_url(plat)
 
     def generate_exe(self, _: Platform) -> str:
         return "./untt"

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -126,15 +126,14 @@ async def run_helm_unittest(
         ProcessCacheScope.PER_SESSION if test_subsystem.force else ProcessCacheScope.SUCCESSFUL
     )
 
-    strict = field_set.strict.value
     process_result = await Get(
         FallibleProcessResult,
         HelmProcess(
             argv=[
                 unittest_subsystem.plugin_name,
-                "--helm3",
+                *(("--helm3",) if unittest_subsystem.is_legacy else ()),
                 *(("--color",) if unittest_subsystem.color else ()),
-                *(("--strict",) if strict else ()),
+                *(("--strict",) if field_set.strict.value else ()),
                 "--output-type",
                 unittest_subsystem.output_type.value,
                 "--output-file",

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -113,7 +113,6 @@ def test_simple_success_with_legacy_tool(rule_runner: RuleRunner) -> None:
     field_set = HelmUnitTestFieldSet.create(target)
 
     result = rule_runner.request(TestResult, [HelmUnitTestRequest.Batch("", (field_set,), None)])
-    print(result.stdout)
 
     assert result.exit_code == 0
     assert result.xml_results and result.xml_results.files

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -79,6 +79,47 @@ def test_simple_success(rule_runner: RuleRunner) -> None:
     assert result.xml_results.files == (f"{target.address.path_safe_spec}.xml",)
 
 
+def test_simple_success_with_legacy_tool(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": "helm_chart(name='mychart')",
+            "Chart.yaml": HELM_CHART_FILE,
+            "values.yaml": HELM_VALUES_FILE,
+            "templates/_helpers.tpl": HELM_TEMPLATE_HELPERS_FILE,
+            "templates/service.yaml": K8S_SERVICE_TEMPLATE,
+            "tests/BUILD": "helm_unittest_test(name='test', source='service_test.yaml')",
+            "tests/service_test.yaml": dedent(
+                """\
+                suite: test service
+                templates:
+                  - service.yaml
+                values:
+                  - ../values.yaml
+                tests:
+                  - it: should work
+                    asserts:
+                      - isKind:
+                          of: Service
+                      - equal:
+                          path: spec.type
+                          value: ClusterIP
+                """
+            ),
+        }
+    )
+
+    rule_runner.set_options(["--helm-unittest-version=0.2.8"])
+    target = rule_runner.get_target(Address("tests", target_name="test"))
+    field_set = HelmUnitTestFieldSet.create(target)
+
+    result = rule_runner.request(TestResult, [HelmUnitTestRequest.Batch("", (field_set,), None)])
+    print(result.stdout)
+
+    assert result.exit_code == 0
+    assert result.xml_results and result.xml_results.files
+    assert result.xml_results.files == (f"{target.address.path_safe_spec}.xml",)
+
+
 def test_simple_failure(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -340,7 +340,7 @@ class TemplatedExternalTool(ExternalTool, TemplatedExternalToolOptionsMixin):
     The platform mapping dict is optional.
     """
 
-    def generate_url(self, plat: Platform):
+    def generate_url(self, plat: Platform) -> str:
         platform = self.url_platform_mapping.get(plat.value, "")
         return self.url_template.format(version=self.version, platform=platform)
 


### PR DESCRIPTION
Fixes #19219

Upgrades Helm unittest while keeping support for the previous version in case users need to downgrade due potential incompatibilities.