### PR TITLE
upgrade to Rust v1.70.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -142,7 +142,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 
@@ -201,7 +201,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 
@@ -116,7 +116,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 
@@ -213,7 +213,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 
@@ -404,7 +404,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 
@@ -459,7 +459,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.69.0-*
+        path: '~/.rustup/toolchains/1.70.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to Rust v1.70.0. [Release Notes](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)