### PR TITLE
Revert "javascript: Assign a default name to root nodejs resolves (#1…

### DIFF
--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -16,7 +16,7 @@ from pants.backend.javascript.package_json import (
     PnpmWorkspaces,
 )
 from pants.backend.javascript.subsystems import nodejs
-from pants.backend.javascript.subsystems.nodejs import NodeJS, UserChosenNodeJSResolveAliases
+from pants.backend.javascript.subsystems.nodejs import NodeJS
 from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
 from pants.engine.collection import Collection
@@ -25,7 +25,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import bullet_list, softwrap
+from pants.util.strutil import softwrap
 
 
 @dataclass(frozen=True)
@@ -123,11 +123,7 @@ class NodeJSProject:
 
     @classmethod
     def from_tentative(
-        cls,
-        project: _TentativeProject,
-        nodejs: NodeJS,
-        pnpm_workspaces: PnpmWorkspaces,
-        resolve_names: UserChosenNodeJSResolveAliases,
+        cls, project: _TentativeProject, nodejs: NodeJS, pnpm_workspaces: PnpmWorkspaces
     ) -> NodeJSProject:
         root_ws = project.root_workspace()
         package_manager: str | None = None
@@ -167,7 +163,7 @@ class NodeJSProject:
         return NodeJSProject(
             root_dir=project.root_dir,
             workspaces=project.workspaces,
-            default_resolve_name=project.default_resolve_name or "nodejs-default",
+            default_resolve_name=project.default_resolve_name,
             package_manager=package_manager_command,
             package_manager_version=package_manager_version,
             pnpm_workspace=pnpm_workspaces.for_root(project.root_dir),
@@ -210,10 +206,7 @@ async def _get_default_resolve_name(path: str) -> str:
 
 @rule
 async def find_node_js_projects(
-    package_workspaces: AllPackageJson,
-    pnpm_workspaces: PnpmWorkspaces,
-    nodejs: NodeJS,
-    resolve_names: UserChosenNodeJSResolveAliases,
+    package_workspaces: AllPackageJson, pnpm_workspaces: PnpmWorkspaces, nodejs: NodeJS
 ) -> AllNodeJSProjects:
     project_paths = (
         ProjectPaths(pkg.root_dir, ["", *pkg.workspaces])
@@ -231,42 +224,9 @@ async def find_node_js_projects(
         for paths in project_paths
     }
     merged_projects = _merge_workspaces(node_js_projects)
-    all_projects = AllNodeJSProjects(
-        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces, resolve_names)
-        for p in merged_projects
+    return AllNodeJSProjects(
+        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces) for p in merged_projects
     )
-    _ensure_resolve_names_are_unique(all_projects, resolve_names)
-
-    return all_projects
-
-
-_AMBIGUOUS_RESOLVE_SOLUTIONS = [
-    f"Configure [{NodeJS.options_scope}].resolves to grant the package.json directories different names.",
-    "Make one package a workspace of the other.",
-    "Re-configure your source root(s).",
-]
-
-
-def _ensure_resolve_names_are_unique(
-    all_projects: AllNodeJSProjects, resolve_names: UserChosenNodeJSResolveAliases
-) -> None:
-    seen: dict[str, NodeJSProject] = {}
-    for project in all_projects:
-        resolve_name = resolve_names.get(project.root_dir, project.default_resolve_name)
-        seen_project = seen.get(resolve_name)
-        if seen_project:
-            raise ValueError(
-                softwrap(
-                    f"""
-                    Projects with root directories '{project.root_dir}' and '{seen_project.root_dir}'
-                    have the same resolve name {resolve_name}. This will cause ambiguities.
-
-                    To disambiguate, either:\n\n
-                    {bullet_list(_AMBIGUOUS_RESOLVE_SOLUTIONS)}
-                    """
-                )
-            )
-        seen[resolve_name] = project
 
 
 def _project_to_parents(

--- a/src/python/pants/backend/javascript/nodejs_project_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_test.py
@@ -82,7 +82,6 @@ def test_root_package_json_is_supported(rule_runner: RuleRunner) -> None:
     )
     projects = rule_runner.request(AllNodeJSProjects, [])
     assert {project.root_dir for project in projects} == {"", "src/js/bar"}
-    assert {project.default_resolve_name for project in projects} == {"nodejs-default", "js.bar"}
 
 
 def test_parses_project_with_workspaces(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
…9047)"

This reverts commit 0aedb6b3559240c120ad3e09ee99a83b821e7351.

contains breaking change:
```
Error: 3.20 [ERROR] Failed to load the pants.backend.experimental.javascript.register backend: ImportError("cannot import name 'UserChosenNodeJSResolveAliases' from 'pants.backend.javascript.subsystems.nodejs' (/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/subsystems/nodejs.py)")
Traceback (most recent call last):
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/init/extension_loader.py", line 141, in load_backend
    module = importlib.import_module(backend_module)
  File "/home/gha/.pyenv/versions/3.9.13/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/experimental/javascript/register.py", line 9, in <module>
    from pants.backend.javascript.goals import lockfile, tailor, test
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/goals/lockfile.py", line 9, in <module>
    from pants.backend.javascript import nodejs_project_environment
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/nodejs_project_environment.py", line 9, in <module>
    from pants.backend.javascript import package_json, resolve
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/resolve.py", line 9, in <module>
    from pants.backend.javascript import nodejs_project
  File "/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/nodejs_project.py", line 19, in <module>
    from pants.backend.javascript.subsystems.nodejs import NodeJS, UserChosenNodeJSResolveAliases
ImportError: cannot import name 'UserChosenNodeJSResolveAliases' from 'pants.backend.javascript.subsystems.nodejs' (/home/gha/actions-runner1/_work/pants/pants/src/python/pants/backend/javascript/subsystems/nodejs.py)
```