### PR TITLE
javascript: Assign a default name to root nodejs resolves

### DIFF
--- a/src/python/pants/backend/javascript/goals/lockfile.py
+++ b/src/python/pants/backend/javascript/goals/lockfile.py
@@ -13,7 +13,8 @@ from pants.backend.javascript.nodejs_project_environment import (
     NodeJsProjectEnvironmentProcess,
 )
 from pants.backend.javascript.package_json import PackageJsonTarget
-from pants.backend.javascript.resolve import NodeJSProjectResolves, UserChosenNodeJSResolveAliases
+from pants.backend.javascript.resolve import NodeJSProjectResolves
+from pants.backend.javascript.subsystems.nodejs import UserChosenNodeJSResolveAliases
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfile,
     GenerateLockfileResult,

--- a/src/python/pants/backend/javascript/goals/lockfile_test.py
+++ b/src/python/pants/backend/javascript/goals/lockfile_test.py
@@ -20,7 +20,7 @@ from pants.backend.javascript.package_json import (
     PackageJsonForGlobs,
     PackageJsonTarget,
 )
-from pants.backend.javascript.resolve import UserChosenNodeJSResolveAliases
+from pants.backend.javascript.subsystems.nodejs import UserChosenNodeJSResolveAliases
 from pants.core.goals.generate_lockfiles import (
     GenerateLockfileResult,
     KnownUserResolveNames,

--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -16,7 +16,7 @@ from pants.backend.javascript.package_json import (
     PnpmWorkspaces,
 )
 from pants.backend.javascript.subsystems import nodejs
-from pants.backend.javascript.subsystems.nodejs import NodeJS
+from pants.backend.javascript.subsystems.nodejs import NodeJS, UserChosenNodeJSResolveAliases
 from pants.core.util_rules import stripped_source_files
 from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
 from pants.engine.collection import Collection
@@ -25,7 +25,7 @@ from pants.engine.internals.selectors import Get
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import softwrap
+from pants.util.strutil import bullet_list, softwrap
 
 
 @dataclass(frozen=True)
@@ -123,7 +123,11 @@ class NodeJSProject:
 
     @classmethod
     def from_tentative(
-        cls, project: _TentativeProject, nodejs: NodeJS, pnpm_workspaces: PnpmWorkspaces
+        cls,
+        project: _TentativeProject,
+        nodejs: NodeJS,
+        pnpm_workspaces: PnpmWorkspaces,
+        resolve_names: UserChosenNodeJSResolveAliases,
     ) -> NodeJSProject:
         root_ws = project.root_workspace()
         package_manager: str | None = None
@@ -163,7 +167,7 @@ class NodeJSProject:
         return NodeJSProject(
             root_dir=project.root_dir,
             workspaces=project.workspaces,
-            default_resolve_name=project.default_resolve_name,
+            default_resolve_name=project.default_resolve_name or "nodejs-default",
             package_manager=package_manager_command,
             package_manager_version=package_manager_version,
             pnpm_workspace=pnpm_workspaces.for_root(project.root_dir),
@@ -206,7 +210,10 @@ async def _get_default_resolve_name(path: str) -> str:
 
 @rule
 async def find_node_js_projects(
-    package_workspaces: AllPackageJson, pnpm_workspaces: PnpmWorkspaces, nodejs: NodeJS
+    package_workspaces: AllPackageJson,
+    pnpm_workspaces: PnpmWorkspaces,
+    nodejs: NodeJS,
+    resolve_names: UserChosenNodeJSResolveAliases,
 ) -> AllNodeJSProjects:
     project_paths = (
         ProjectPaths(pkg.root_dir, ["", *pkg.workspaces])
@@ -224,9 +231,42 @@ async def find_node_js_projects(
         for paths in project_paths
     }
     merged_projects = _merge_workspaces(node_js_projects)
-    return AllNodeJSProjects(
-        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces) for p in merged_projects
+    all_projects = AllNodeJSProjects(
+        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces, resolve_names)
+        for p in merged_projects
     )
+    _ensure_resolve_names_are_unique(all_projects, resolve_names)
+
+    return all_projects
+
+
+_AMBIGUOUS_RESOLVE_SOLUTIONS = [
+    f"Configure [{NodeJS.options_scope}].resolves to grant the package.json directories different names.",
+    "Make one package a workspace of the other.",
+    "Re-configure your source root(s).",
+]
+
+
+def _ensure_resolve_names_are_unique(
+    all_projects: AllNodeJSProjects, resolve_names: UserChosenNodeJSResolveAliases
+) -> None:
+    seen: dict[str, NodeJSProject] = {}
+    for project in all_projects:
+        resolve_name = resolve_names.get(project.root_dir, project.default_resolve_name)
+        seen_project = seen.get(resolve_name)
+        if seen_project:
+            raise ValueError(
+                softwrap(
+                    f"""
+                    Projects with root directories '{project.root_dir}' and '{seen_project.root_dir}'
+                    have the same resolve name {resolve_name}. This will cause ambiguities.
+
+                    To disambiguate, either:\n\n
+                    {bullet_list(_AMBIGUOUS_RESOLVE_SOLUTIONS)}
+                    """
+                )
+            )
+        seen[resolve_name] = project
 
 
 def _project_to_parents(

--- a/src/python/pants/backend/javascript/nodejs_project.py
+++ b/src/python/pants/backend/javascript/nodejs_project.py
@@ -127,7 +127,6 @@ class NodeJSProject:
         project: _TentativeProject,
         nodejs: NodeJS,
         pnpm_workspaces: PnpmWorkspaces,
-        resolve_names: UserChosenNodeJSResolveAliases,
     ) -> NodeJSProject:
         root_ws = project.root_workspace()
         package_manager: str | None = None
@@ -232,8 +231,7 @@ async def find_node_js_projects(
     }
     merged_projects = _merge_workspaces(node_js_projects)
     all_projects = AllNodeJSProjects(
-        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces, resolve_names)
-        for p in merged_projects
+        NodeJSProject.from_tentative(p, nodejs, pnpm_workspaces) for p in merged_projects
     )
     _ensure_resolve_names_are_unique(all_projects, resolve_names)
 

--- a/src/python/pants/backend/javascript/nodejs_project_test.py
+++ b/src/python/pants/backend/javascript/nodejs_project_test.py
@@ -82,6 +82,7 @@ def test_root_package_json_is_supported(rule_runner: RuleRunner) -> None:
     )
     projects = rule_runner.request(AllNodeJSProjects, [])
     assert {project.root_dir for project in projects} == {"", "src/js/bar"}
+    assert {project.default_resolve_name for project in projects} == {"nodejs-default", "js.bar"}
 
 
 def test_parses_project_with_workspaces(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/javascript/resolve.py
+++ b/src/python/pants/backend/javascript/resolve.py
@@ -15,7 +15,7 @@ from pants.backend.javascript.package_json import (
     OwningNodePackageRequest,
     PackageJsonSourceField,
 )
-from pants.backend.javascript.subsystems.nodejs import NodeJS
+from pants.backend.javascript.subsystems.nodejs import UserChosenNodeJSResolveAliases
 from pants.build_graph.address import Address
 from pants.engine.fs import PathGlobs
 from pants.engine.internals.selectors import Get
@@ -23,7 +23,6 @@ from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import Target, WrappedTarget, WrappedTargetRequest
 from pants.engine.unions import UnionRule
 from pants.util.frozendict import FrozenDict
-from pants.util.logging import LogLevel
 
 
 @dataclass(frozen=True)
@@ -76,10 +75,6 @@ class NodeJSProjectResolves(FrozenDict[str, NodeJSProject]):
     pass
 
 
-class UserChosenNodeJSResolveAliases(FrozenDict[str, str]):
-    pass
-
-
 @rule
 async def resolve_to_projects(
     all_projects: AllNodeJSProjects, user_chosen_resolves: UserChosenNodeJSResolveAliases
@@ -104,11 +99,6 @@ async def resolve_to_first_party_node_package(
     return FirstPartyNodePackageResolves(
         (resolve, by_dir[project.root_dir]) for resolve, project in resolves.items()
     )
-
-
-@rule(level=LogLevel.DEBUG)
-async def user_chosen_resolve_aliases(nodejs: NodeJS) -> UserChosenNodeJSResolveAliases:
-    return UserChosenNodeJSResolveAliases((value, key) for key, value in nodejs.resolves.items())
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -601,6 +601,15 @@ async def setup_node_tool_process(
     )
 
 
+class UserChosenNodeJSResolveAliases(FrozenDict[str, str]):
+    pass
+
+
+@rule(level=LogLevel.DEBUG)
+async def user_chosen_resolve_aliases(nodejs: NodeJS) -> UserChosenNodeJSResolveAliases:
+    return UserChosenNodeJSResolveAliases((value, key) for key, value in nodejs.resolves.items())
+
+
 def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),

--- a/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs_tool_test.py
@@ -85,7 +85,10 @@ def test_resolve_dictates_version(
         }
     )
     rule_runner.set_options(
-        ["--cowsay-install-from-resolve=", f"--nodejs-package-manager={package_manager}"],
+        [
+            "--cowsay-install-from-resolve=nodejs-default",
+            f"--nodejs-package-manager={package_manager}",
+        ],
         env_inherit={"PATH"},
     )
     tool = rule_runner.request(CowsayTool, [])

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -243,7 +243,7 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
             },
             (
                 f"--source-root-patterns=['{LIB_1_PACKAGE}', '{LIB_2_PACKAGE}', '/']",
-                "--pyright-install-from-resolve=",  # See: https://github.com/pantsbuild/pants/issues/18924
+                "--pyright-install-from-resolve=nodejs-default",
             ),
             id="from_resolve_at_root",
         ),


### PR DESCRIPTION
Also validate the resolve names, ensuring they are 1:1 with project
roots.

Fixes https://github.com/pantsbuild/pants/issues/18924