### PR TITLE
`scandir` returns `Stat`s relative to its directory.

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -473,7 +473,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
               .ok_or_else(|| format!("File being saved must have parent but {path:?} did not"))?,
           );
           let file = posix_fs
-            .stat_sync(PathBuf::from(path.file_name().unwrap()))
+            .stat_sync(Path::new(path.file_name().unwrap()))
             .unwrap()
             .ok_or_else(|| format!("Tried to save file {path:?} but it did not exist"))?;
           match file {

--- a/src/rust/engine/fs/src/gitignore.rs
+++ b/src/rust/engine/fs/src/gitignore.rs
@@ -129,7 +129,7 @@ mod tests {
 
   async fn read_mock_files(input: Vec<PathBuf>, posix_fs: &Arc<PosixFS>) -> Vec<Stat> {
     input
-      .into_iter()
+      .iter()
       .map(|p| posix_fs.stat_sync(p).unwrap().unwrap())
       .collect()
   }

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -419,8 +419,8 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
     symlink_behavior: SymlinkBehavior,
     link_depth: LinkDepth,
   ) -> Result<Vec<(PathStat, LinkDepth)>, E> {
-    // List the directory.
-    let dir_listing = self.scandir(canonical_dir).await?;
+    // List the directory to create relative Stats.
+    let dir_listing = self.scandir(canonical_dir.clone()).await?;
 
     // Match any relevant Stats, and join them into PathStats.
     let path_stats = future::try_join_all(
@@ -446,10 +446,11 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
         .map(|(stat_symbolic_path, stat)| {
           let context = self.clone();
           let exclude = exclude.clone();
+          let stat = stat.within(&canonical_dir.0);
           async move {
             // Canonicalize matched PathStats, and filter paths that are ignored by local excludes.
             // Context ("global") ignore patterns are applied during `scandir`.
-            if exclude.is_ignored(stat) {
+            if exclude.is_ignored(&stat) {
               Ok(None)
             } else {
               match stat {
@@ -463,25 +464,17 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
 
                   if let SymlinkBehavior::Aware = symlink_behavior {
                     return Ok(Some((
-                      PathStat::link(stat_symbolic_path, l.clone()),
+                      PathStat::link(stat_symbolic_path, l),
                       link_depth + 1,
                     )));
                   }
 
-                  let dest = context
-                    .canonicalize_link(stat_symbolic_path, l.clone())
-                    .await?;
+                  let dest = context.canonicalize_link(stat_symbolic_path, l).await?;
 
                   Ok(dest.map(|ps| (ps, link_depth + 1)))
                 }
-                Stat::Dir(d) => Ok(Some((
-                  PathStat::dir(stat_symbolic_path, d.clone()),
-                  link_depth,
-                ))),
-                Stat::File(f) => Ok(Some((
-                  PathStat::file(stat_symbolic_path, f.clone()),
-                  link_depth,
-                ))),
+                Stat::Dir(d) => Ok(Some((PathStat::dir(stat_symbolic_path, d), link_depth))),
+                Stat::File(f) => Ok(Some((PathStat::file(stat_symbolic_path, f), link_depth))),
               }
             }
           }

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -178,6 +178,23 @@ impl Stat {
   pub fn link(path: PathBuf, target: PathBuf) -> Stat {
     Stat::Link(Link { path, target })
   }
+
+  pub fn within(&self, directory: &Path) -> Stat {
+    match self {
+      Stat::Dir(Dir(p)) => Stat::Dir(Dir(directory.join(p))),
+      Stat::File(File {
+        path,
+        is_executable,
+      }) => Stat::File(File {
+        path: directory.join(path),
+        is_executable: *is_executable,
+      }),
+      Stat::Link(Link { path, target }) => Stat::Link(Link {
+        path: directory.join(path),
+        target: target.to_owned(),
+      }),
+    }
+  }
 }
 
 #[derive(Clone, Debug, DeepSizeOf, Eq, Hash, PartialEq)]
@@ -404,7 +421,6 @@ impl PosixFS {
 
   fn scandir_sync(&self, dir_relative_to_root: &Dir) -> Result<DirectoryListing, io::Error> {
     let dir_abs = self.root.0.join(&dir_relative_to_root.0);
-    let root = self.root.0.clone();
     let mut stats: Vec<Stat> = dir_abs
       .read_dir()?
       .map(|readdir| {
@@ -422,14 +438,18 @@ impl PosixFS {
             }
           };
         PosixFS::stat_internal(
-          &root,
-          dir_relative_to_root.0.join(dir_entry.file_name()),
+          &dir_abs.join(dir_entry.file_name()),
           file_type,
           compute_metadata,
         )
       })
       .filter_map(|s| match s {
-        Ok(Some(s)) if !self.ignore.is_ignored(&s) => {
+        Ok(Some(s))
+          if !self.ignore.is_ignored_path(
+            &dir_relative_to_root.0.join(s.path()),
+            matches!(s, Stat::Dir(_)),
+          ) =>
+        {
           // It would be nice to be able to ignore paths before stat'ing them, but in order to apply
           // git-style ignore patterns, we need to know whether a path represents a directory.
           Some(Ok(s))
@@ -482,7 +502,7 @@ impl PosixFS {
   }
 
   ///
-  /// Makes a Stat for path_for_stat relative to absolute_path_to_root.
+  /// Makes a Stat for path_to_stat relative to its containing directory.
   ///
   /// This method takes both a `FileType` and a getter for `Metadata` because on Unixes,
   /// directory walks cheaply return the `FileType` without extra syscalls, but other
@@ -490,64 +510,61 @@ impl PosixFS {
   /// Dirs and Links.
   ///
   fn stat_internal<F>(
-    absolute_path_to_root: &Path,
-    path_for_stat: PathBuf,
+    path_to_stat: &Path,
     file_type: std::fs::FileType,
     compute_metadata: F,
   ) -> Result<Option<Stat>, io::Error>
   where
     F: FnOnce() -> Result<std::fs::Metadata, io::Error>,
   {
-    if !path_for_stat.is_relative() {
+    let Some(file_name) = path_to_stat.file_name() else {
+      return Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "Argument path_to_stat to PosixFS::stat must have a file name.",
+      ));
+    };
+    if !path_to_stat.is_absolute() {
       return Err(io::Error::new(
         io::ErrorKind::InvalidInput,
         format!(
-          "Argument path_for_stat to PosixFS::stat must be relative path, got {path_for_stat:?}"
+          "Argument path_to_stat to PosixFS::stat must be absolute path, got {path_to_stat:?}"
         ),
       ));
     }
-    // TODO: Make this an instance method, and stop having to check this every call.
-    if !absolute_path_to_root.is_absolute() {
-      return Err(io::Error::new(
-        io::ErrorKind::InvalidInput,
-        format!(
-          "Argument absolute_path_to_root to PosixFS::stat must be absolute path, got {absolute_path_to_root:?}"
-        ),
-      ));
-    }
+    let path = file_name.to_owned().into();
     if file_type.is_symlink() {
       Ok(Some(Stat::Link(Link {
-        path: path_for_stat.clone(),
-        target: std::fs::read_link(absolute_path_to_root.join(path_for_stat))?,
+        path,
+        target: std::fs::read_link(path_to_stat)?,
       })))
     } else if file_type.is_file() {
       let is_executable = compute_metadata()?.permissions().mode() & 0o100 == 0o100;
       Ok(Some(Stat::File(File {
-        path: path_for_stat,
+        path,
         is_executable: is_executable,
       })))
     } else if file_type.is_dir() {
-      Ok(Some(Stat::Dir(Dir(path_for_stat))))
+      Ok(Some(Stat::Dir(Dir(path))))
     } else {
       Ok(None)
     }
   }
 
+  ///
+  /// Returns a Stat relative to its containing directory.
+  ///
   /// NB: This method is synchronous because it is used to stat all files in a directory as one
   /// blocking operation as part of `scandir_sync` (as recommended by the `tokio` documentation, to
   /// avoid many small spawned tasks).
-  pub fn stat_sync(&self, relative_path: PathBuf) -> Result<Option<Stat>, io::Error> {
-    let abs_path = self.root.0.join(&relative_path);
+  ///
+  pub fn stat_sync(&self, relative_path: &Path) -> Result<Option<Stat>, io::Error> {
+    let abs_path = self.root.0.join(relative_path);
     let metadata = match self.symlink_behavior {
-      SymlinkBehavior::Aware => fs::symlink_metadata(abs_path),
-      SymlinkBehavior::Oblivious => fs::metadata(abs_path),
+      SymlinkBehavior::Aware => fs::symlink_metadata(&abs_path),
+      SymlinkBehavior::Oblivious => fs::metadata(&abs_path),
     };
     metadata
-      .and_then(|metadata| {
-        PosixFS::stat_internal(&self.root.0, relative_path, metadata.file_type(), || {
-          Ok(metadata)
-        })
-      })
+      .and_then(|metadata| PosixFS::stat_internal(&abs_path, metadata.file_type(), || Ok(metadata)))
       .or_else(|err| match err.kind() {
         io::ErrorKind::NotFound => Ok(None),
         _ => Err(err),
@@ -599,11 +616,10 @@ impl Vfs<String> for DigestTrie {
   }
 
   async fn scandir(&self, dir: Dir) -> Result<Arc<DirectoryListing>, String> {
-    // TODO(#14890): Change interface to take a reference to an Entry, and to avoid absolute paths.
-    // That would avoid both the need to handle this root case, and the need to recurse in `entry`
-    // down into children.
-    let directory = if dir.0.components().next().is_none() {
-      directory::Directory::new(directory::Name::new(""), self.entries().into())
+    // TODO(#14890): Change interface to take a reference to an Entry. That would avoid both the
+    // need to handle this root case, and the need to recurse in `entry` down into children.
+    let entries = if dir.0.components().next().is_none() {
+      self.entries()
     } else {
       let entry = self
         .entry(&dir.0)?
@@ -621,25 +637,23 @@ impl Vfs<String> for DigestTrie {
             dir.0.display()
           ))
         }
-        directory::Entry::Directory(d) => d.clone(),
+        directory::Entry::Directory(d) => d.tree().entries(),
       }
     };
 
     Ok(Arc::new(DirectoryListing(
-      directory
-        .tree()
-        .entries()
+      entries
         .iter()
         .map(|child| match child {
           directory::Entry::File(f) => Stat::File(File {
-            path: dir.0.join(f.name().as_ref()),
+            path: f.name().as_ref().into(),
             is_executable: f.is_executable(),
           }),
           directory::Entry::Symlink(s) => Stat::Link(Link {
-            path: dir.0.join(s.name().as_ref()),
+            path: s.name().as_ref().into(),
             target: s.target().to_path_buf(),
           }),
-          directory::Entry::Directory(d) => Stat::Dir(Dir(dir.0.join(d.name().as_ref()))),
+          directory::Entry::Directory(d) => Stat::Dir(Dir(d.name().as_ref().into())),
         })
         .collect(),
     )))


### PR DESCRIPTION
The `scandir` node (which currently holds `Stat` entries relative to the build root) was 28% of memory usage for one use case on #19053.

This change moves to holding `Stat`s relative to their containing directory.

The performance difference is negligible, but the memory usage of the `scandir` node for `./pants dependencies ::` in `pantsbuild/pants` drops by 32% (562754 -> 382163), and deeper / wider directory structures should notice a larger difference.