### PR TITLE
Handle `from foo import *` wildcard imports in Rust dep inference parser

### DIFF
--- a/src/rust/engine/dep_inference/src/python/mod.rs
+++ b/src/rust/engine/dep_inference/src/python/mod.rs
@@ -162,17 +162,13 @@ impl ImportCollector<'_> {
     }
   }
 
-  /// Various different styles of references to modules.
-  ///
-  /// NB. this diverges slightly from the core tree-sitter grammar by calling base module reference
-  /// (the part that always exists) "module_name", with "name" only used to refer to the extra bit
-  /// in `from ... import ...`:
+  /// Handle different styles of references to modules/imports
   ///
   /// ```python
-  /// import $base_name
-  /// from $base_name import * # (the * node is passed as imported_name too)
-  /// from $base_name import $imported_name
-  /// "$base_name"
+  /// import $base
+  /// "$base"  # string import
+  /// from $base import *  # (the * node is passed as `imported` too)
+  /// from $base import $imported
   /// ```
   fn insert_import(
     &mut self,

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -536,7 +536,7 @@ fn syntax_errors_and_other_fun() {
 
   assert_imports("imprt a", &[]);
   assert_imports("form a import b", &["b"]);
-  assert_imports("import .b", &[]);
+  assert_imports("import .b", &["."]);
   assert_imports("import a....b", &["a....b"]);
   assert_imports("import a.", &[]);
   assert_imports("import *", &[]);

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -40,6 +40,7 @@ fn simple_imports() {
   assert_imports("import a.b", &["a.b"]);
   assert_imports("import a as x", &["a"]);
   assert_imports("from a import b", &["a.b"]);
+  assert_imports("from a import *", &["a"]);
   assert_imports("from a.b import c", &["a.b.c"]);
   assert_imports("from a.b import c.d", &["a.b.c.d"]);
   assert_imports("from a.b import c, d, e", &["a.b.c", "a.b.d", "a.b.e"]);
@@ -86,6 +87,11 @@ from a.b import (
   assert_imports("from ....a import b.c", &["....a.b.c"]);
   assert_imports("from ....a import b, c", &["....a.b", "....a.c"]);
   assert_imports("from ....a import b as d, c", &["....a.b", "....a.c"]);
+
+  assert_imports("from .a import *", &[".a"]);
+  assert_imports("from . import *", &["."]);
+  assert_imports("from ..a import *", &["..a"]);
+  assert_imports("from .. import *", &[".."]);
 
   assert_imports(
     "class X: def method(): if True: while True: class Y: def f(): import a",
@@ -489,8 +495,11 @@ fn assert_relative_imports(filename: &str, code: &str, resolved_imports: &[&str]
 fn relative_imports_resolution() {
   let filename = "foo/bar/baz.py";
   assert_relative_imports(filename, "from . import b", &["foo.bar.b"]);
+  assert_relative_imports(filename, "from . import *", &["foo.bar"]);
   assert_relative_imports(filename, "from .a import b", &["foo.bar.a.b"]);
+  assert_relative_imports(filename, "from .a import *", &["foo.bar.a"]);
   assert_relative_imports(filename, "from .. import b", &["foo.b"]);
+  assert_relative_imports(filename, "from .. import *", &["foo"]);
   assert_relative_imports(filename, "from ..a import b", &["foo.a.b"]);
   assert_relative_imports(filename, "from .. import b.c", &["foo.b.c"]);
   assert_relative_imports(filename, "from ..a import b.c", &["foo.a.b.c"]);

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -109,6 +109,7 @@ fn pragma_ignore() {
   assert_imports("import a.b  # pants: no-infer-dep", &[]);
   assert_imports("import a.b as d  # pants: no-infer-dep", &[]);
   assert_imports("from a import b  # pants: no-infer-dep", &[]);
+  assert_imports("from a import *  # pants: no-infer-dep", &[]);
   assert_imports("from a import b, c  # pants: no-infer-dep", &[]);
   assert_imports("from a import b, c as d  # pants: no-infer-dep", &[]);
   assert_imports(
@@ -186,6 +187,12 @@ fn pragma_ignore() {
         as \
         dd,  # pants: no-infer-dep
     )",
+    &[],
+  );
+  assert_imports(
+    r"
+    from a.b import \
+        *  # pants: no-infer-dep",
     &[],
   );
 }
@@ -532,11 +539,16 @@ fn syntax_errors_and_other_fun() {
   assert_imports("import .b", &[]);
   assert_imports("import a....b", &["a....b"]);
   assert_imports("import a.", &[]);
+  assert_imports("import *", &[]);
   assert_imports("from a import", &[]);
   assert_imports("from a imp x", &[]);
   assert_imports("from from import a as .as", &[]);
   assert_imports("from a import ......g", &["a.g"]);
   assert_imports("from a. import b", &[]);
+  assert_imports("from a import *, b", &["a"]);
+  assert_imports("from a import b, *", &["a.b"]);
+  assert_imports("from a import (*)", &[]);
+  assert_imports("from * import b", &["b"]);
   assert_imports("try:...\nexcept:import a", &["a"]);
   assert_imports("try:...\nexcept 1:import a", &["a"]);
   assert_imports("try:...\nexcept x=1:import a", &["a"]);

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -541,10 +541,13 @@ fn syntax_errors_and_other_fun() {
   assert_imports("import a.", &[]);
   assert_imports("import *", &[]);
   assert_imports("from a import", &[]);
+  assert_imports("from a import;", &["a."]);
+  assert_imports("from a import ()", &["a."]);
   assert_imports("from a imp x", &[]);
   assert_imports("from from import a as .as", &[]);
   assert_imports("from a import ......g", &["a.g"]);
   assert_imports("from a. import b", &[]);
+  assert_imports("from a as c import b as d", &["a.b"]);
   assert_imports("from a import *, b", &["a"]);
   assert_imports("from a import b, *", &["a.b"]);
   assert_imports("from a import (*)", &[]);


### PR DESCRIPTION
This fixes #19248 by implementing explicit handling for `*` wildcard imports in the Rust-based Python dependency inference parser.

The commits are somewhat individually reviewable:

1. switching how the `insert_import` arguments are consumed from the syntax tree, for `from ... import ...` statements in particular:
   - before: `name` and `module_name` correspond to `import $name`, `"$name"`, `from $module_name import $name`
   - after: `base` and `imported` correspond to `import $base`, `"$base"`, `from $base import $imported`
   - This is in particular flipping the last one, and changes whether the `from ...` part is the optional arg (before) or not (after).
   - The motivation is that there's more functional similarities between the `from ...` part and a plain `import ...` statement, than between the `import ...` part and a plain `import ...` statement, despite the superficial similarities of it! (`from foo import bar` is a little like `import foo as __secret; bar = __secret.bar`.)
2. Add some tests that fail
3. Fix the bug
4. (and others) some tweaks, including defence-in-depth against similar problems happening in future