### PR TITLE
Add cherry-pick PRs to their milestone for better visibility

### DIFF
--- a/build-support/bin/cherry_pick.sh
+++ b/build-support/bin/cherry_pick.sh
@@ -89,7 +89,7 @@ for MILESTONE in $MILESTONES; do
   # spend time cloning the whole history
   git_fetch_with_depth 1 "$MILESTONE" || continue
 
-  PR_CREATE_CMD=(gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --body-file "$BODY_FILE")
+  PR_CREATE_CMD=(gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --body-file "$BODY_FILE" --milestone "$MILESTONE")
   while IFS= read -r REVIEWER; do PR_CREATE_CMD+=(--reviewer "$REVIEWER"); done <<< "$REVIEWERS"
   # NB: Add the author in case someone else creates the PR
   PR_CREATE_CMD+=(--reviewer "$(gh pr view "$PR_NUM" --json author --jq '.author.login')")


### PR DESCRIPTION
This adjusts the cherry picking to create the PRs with a milestone attached, so that they're surfaced in the milestone views like https://github.com/pantsbuild/pants/milestone/58, alongside any pending issues and not-yet-cherrypicked PRs.

In particular, if a PR is going to be cherry-picked, it'll have the milestone attached and be visible in that view (and any issues it's fixing may also have it tagged)... but once PR merges to `main`, it and any associated issues will be closed. This means they disappear from the milestone view, but there's still work remaining to actually fix them for that milestone: landing the cherry-pick. Pending cherry-pick PRs _can_ be discovered by doing [a search like `base:2.17.x`](https://github.com/pantsbuild/pants/pulls?q=is%3Apr+is%3Aopen+base%3A2.17.x), but it's nice to have only one place to check (the milestone view) rather than needing to remember to also construct that search manually.

This is a response to https://github.com/pantsbuild/pants/pull/19110 sitting around for a while and delaying 2.16, due to flaky CI failures: it was hard to notice.

See also https://pantsbuild.slack.com/archives/C0D7TNJHL/p1685929902870459 / https://chat.pantsbuild.org/t/12317552/looks-like-https-github-com-pantsbuild-pants-pull-19110-neve#4a387fb1-fc0c-4395-9160-74adf8ab7944

(This will cause some conflicts with #19230, but this PR is a quick win that's easily ported over.)