### PR TITLE
Add taplo to the release (Cherry-pick of #19258)

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -84,6 +84,7 @@ target(
         "src/python/pants/backend/shell/lint/shellcheck",
         "src/python/pants/backend/shell/lint/shfmt",
         "src/python/pants/backend/tools/preamble",
+        "src/python/pants/backend/tools/taplo",
         "src/python/pants/backend/url_handlers/s3",
         "src/python/pants/core",
     ],


### PR DESCRIPTION
Per the thread here: https://pantsbuild.slack.com/archives/C0D7TNJHL/p1685984488435849?thread_ts=1685983060.055239&cid=C0D7TNJHL after merging the Taplo formatter with #18865 it wasn't added to the release dependencies. This adds the backend to the file.
