### PR TITLE
Save CI test reports to S3.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,8 +54,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-Linux-ARM64
-        path: .pants.d/pants.log
+        name: logs-wheels-Linux-ARM64
+        path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -113,8 +113,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-wheels-Linux-x86_64
+        path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -172,8 +172,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-macOS10-15-x86_64
-        path: .pants.d/pants.log
+        name: logs-wheels-macOS10-15-x86_64
+        path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -231,8 +231,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-macOS11-ARM64
-        path: .pants.d/pants.log
+        name: logs-wheels-macOS11-ARM64
+        path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -672,7 +672,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -758,7 +758,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -844,7 +844,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -930,7 +930,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1016,7 +1016,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1102,7 +1102,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1188,7 +1188,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1274,7 +1274,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1360,7 +1360,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1446,7 +1446,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1532,7 +1532,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1586,7 +1586,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -76,8 +76,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-Linux-ARM64
-        path: .pants.d/pants.log
+        name: logs-bootstrap-Linux-ARM64
+        path: .pants.d/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -161,8 +161,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-bootstrap-Linux-x86_64
+        path: .pants.d/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -258,8 +258,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-bootstrap-macOS11-x86_64
-        path: .pants.d/pants.log
+        name: logs-bootstrap-macOS11-x86_64
+        path: .pants.d/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -325,8 +325,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-Linux-ARM64
-        path: .pants.d/pants.log
+        name: logs-wheels-Linux-ARM64
+        path: .pants.d/*.log
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -379,8 +379,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-wheels-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -434,8 +434,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-macOS10-15-x86_64
-        path: .pants.d/pants.log
+        name: logs-wheels-macOS10-15-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -489,8 +489,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-wheels-macOS11-ARM64
-        path: .pants.d/pants.log
+        name: logs-wheels-macOS11-ARM64
+        path: .pants.d/*.log
     timeout-minutes: 90
   check_labels:
     if: github.repository_owner == 'pantsbuild'
@@ -585,8 +585,8 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-lint-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-lint-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 30
   merge_ok:
     if: always()
@@ -667,12 +667,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-Linux-ARM64
-        path: .pants.d/pants.log
+        name: logs-python-test-Linux-ARM64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_0:
     env: {}
@@ -744,12 +753,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-0_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-0_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_1:
     env: {}
@@ -821,12 +839,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-1_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-1_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_2:
     env: {}
@@ -898,12 +925,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-2_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-2_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_3:
     env: {}
@@ -975,12 +1011,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-3_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-3_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_4:
     env: {}
@@ -1052,12 +1097,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-4_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-4_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_5:
     env: {}
@@ -1129,12 +1183,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-5_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-5_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_6:
     env: {}
@@ -1206,12 +1269,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-6_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-6_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_7:
     env: {}
@@ -1283,12 +1355,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-7_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-7_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_8:
     env: {}
@@ -1360,12 +1441,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-8_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-8_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_9:
     env: {}
@@ -1437,12 +1527,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-9_10-Linux-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-9_10-Linux-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
   test_python_macos11_x86_64:
     env:
@@ -1482,12 +1581,21 @@ jobs:
 
         '
     - continue-on-error: true
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      if: always()
+      name: Upload test reports
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/2023-06-07/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}                       --path=
+
+        '
+    - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: pants-log-python-test-macOS11-x86_64
-        path: .pants.d/pants.log
+        name: logs-python-test-macOS11-x86_64
+        path: .pants.d/*.log
     timeout-minutes: 90
 name: Pull Request CI
 'on':

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -672,7 +672,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -758,7 +759,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -844,7 +846,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -930,7 +933,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1016,7 +1020,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1102,7 +1107,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1188,7 +1194,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1274,7 +1281,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1360,7 +1368,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1446,7 +1455,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1532,7 +1542,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true
@@ -1586,7 +1597,8 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/2023-06-07/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/$(git
+        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
 
         '
     - continue-on-error: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -672,8 +672,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-ARM64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -759,8 +762,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -846,8 +852,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -933,8 +942,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1020,8 +1032,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1107,8 +1122,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1194,8 +1212,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1281,8 +1302,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1368,8 +1392,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1455,8 +1482,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1542,8 +1572,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/Linux-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true
@@ -1597,8 +1630,11 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: './build-support/bin/copy_to_s3.py                       --src-prefix=dist/test/reports                       --dst-prefix=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/$(git
-        show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}                       --path=""
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+
+        echo "Uploading test reports to ${S3_DST}"
+
+        ./build-support/bin/copy_to_s3.py                   --src-prefix=dist/test/reports                   --dst-prefix=${S3_DST}                   --path=""
 
         '
     - continue-on-error: true

--- a/build-support/bin/deploy_to_s3.py
+++ b/build-support/bin/deploy_to_s3.py
@@ -40,7 +40,8 @@ def perform_deploy(*, aws_cli_symlink_path: str | None = None, scope: str | None
         src_prefix="dist/deploy",
         dst_prefix="s3://binaries.pantsbuild.org",
         path=scope or "",
-        dst_region="us-east-1",
+        region="us-east-1",
+        acl="public-read",
         aws_cli_symlink_path=aws_cli_symlink_path,
     )
 

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
@@ -552,7 +551,6 @@ class Helper:
         }
 
     def upload_test_reports(self) -> Step:
-        date_str = datetime.now(timezone.utc).date().isoformat()
         # The path doesn't include job ID, as we want to aggregate test reports across all
         # jobs/shards in a workflow.  We do, however, qualify by run attempt, so we capture
         # separate reports for tests that flake between attempts on the same workflow run.
@@ -560,8 +558,8 @@ class Helper:
             "test/reports/"
             + self.platform_name()
             + "/"
-            + date_str
-            + "/${GITHUB_REF_NAME//\\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}"
+            + "$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/"
+            + "${GITHUB_REF_NAME//\\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}"
         )
         return {
             "name": "Upload test reports",

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 from textwrap import dedent
@@ -545,8 +546,38 @@ class Helper:
             "if": "always()",
             "continue-on-error": True,
             "with": {
-                "name": f"pants-log-{name.replace('/', '_')}-{self.platform_name()}",
-                "path": ".pants.d/pants.log",
+                "name": f"logs-{name.replace('/', '_')}-{self.platform_name()}",
+                "path": ".pants.d/*.log",
+            },
+        }
+
+    def upload_test_reports(self) -> Step:
+        date_str = datetime.now(timezone.utc).date().isoformat()
+        # The path doesn't include job ID, as we want to aggregate test reports across all
+        # jobs/shards in a workflow.  We do, however, qualify by run attempt, so we capture
+        # separate reports for tests that flake between attempts on the same workflow run.
+        s3_path = (
+            "test/reports/"
+            + self.platform_name()
+            + "/"
+            + date_str
+            + "/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+        )
+        return {
+            "name": "Upload test reports",
+            "if": "always()",
+            "continue-on-error": True,
+            "run": dedent(
+                f"""\
+                    ./build-support/bin/copy_to_s3.py \
+                      --src-prefix=dist/test/reports \
+                      --dst-prefix=s3://logs.pantsbuild.org/{s3_path} \
+                      --path=
+                    """
+            ),
+            "env": {
+                "AWS_SECRET_ACCESS_KEY": f"{gha_expr('secrets.AWS_SECRET_ACCESS_KEY')}",
+                "AWS_ACCESS_KEY_ID": f"{gha_expr('secrets.AWS_ACCESS_KEY_ID')}",
             },
         }
 
@@ -685,6 +716,7 @@ def test_jobs(
                 "name": human_readable_step_name,
                 "run": pants_args_str,
             },
+            helper.upload_test_reports(),
             helper.upload_log_artifacts(name=log_name),
         ],
     }

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -561,7 +561,7 @@ class Helper:
             + self.platform_name()
             + "/"
             + date_str
-            + "/${GITHUB_REF}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}"
+            + "/${GITHUB_REF_NAME//\\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}"
         )
         return {
             "name": "Upload test reports",
@@ -572,7 +572,7 @@ class Helper:
                     ./build-support/bin/copy_to_s3.py \
                       --src-prefix=dist/test/reports \
                       --dst-prefix=s3://logs.pantsbuild.org/{s3_path} \
-                      --path=
+                      --path=""
                     """
             ),
             "env": {

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,6 +1,9 @@
 [GLOBAL]
 colors = true
 
+[test]
+report = true
+
 [pytest]
 args = ["--no-header", "--noskip", "-vv"]
 


### PR DESCRIPTION
This will let us gather data on test performance/flakiness/timeouts. 

The first commit is the interesting one. The second is just the regenerated yaml files.