### PR TITLE
Add `act` to Pants (all in BUILD) and smoke test our workflows

### DIFF
--- a/.github/workflows/BUILD
+++ b/.github/workflows/BUILD
@@ -1,0 +1,3 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+files(sources=["*.yaml"])

--- a/.github/workflows/BUILD
+++ b/.github/workflows/BUILD
@@ -1,3 +1,4 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 files(sources=["*.yaml"])

--- a/.github/workflows/tests/BUILD
+++ b/.github/workflows/tests/BUILD
@@ -9,14 +9,9 @@
 shell_sources(name="tests")
 
 
-def _run_test(filename):
-    filepath = build_file_dir() / filename
-    return f"chmod +x {filepath} && {filepath}"
-
-
 experimental_test_shell_command(
     name="Test workflow_dispatch dryrun",
-    command=_run_test("smoke_test_all_using_dryrun.sh"),
+    command=f"bash { build_file_dir() / 'smoke_test_all_using_dryrun.sh'}",
     tools=["chmod"],
     execution_dependencies=[
         "//build-support/bin/act:act-at-root",

--- a/.github/workflows/tests/BUILD
+++ b/.github/workflows/tests/BUILD
@@ -1,0 +1,28 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This contains various smoke tests for out GitHub Actions workflows.
+# These aren't meant to be comprehensive, as they can be quite expensive to run. However, they are
+# still useful as they can expose bugs before the action is run in "prod".
+
+
+shell_sources(name="tests")
+
+
+def _run_test(filename):
+    filepath = build_file_dir() / filename
+    return f"chmod +x {filepath} && {filepath}"
+
+
+experimental_test_shell_command(
+    name="Test workflow_dispatch dryrun",
+    command=_run_test("smoke_test_all_using_dryrun.sh"),
+    tools=["chmod"],
+    execution_dependencies=[
+        "//build-support/bin/act:act-at-root",
+        "./smoke_test_all_using_dryrun.sh",
+        ".github/workflows:workflows",
+    ],
+    workdir="/",
+    timeout=120,
+)

--- a/.github/workflows/tests/BUILD
+++ b/.github/workflows/tests/BUILD
@@ -5,17 +5,11 @@
 # These aren't meant to be comprehensive, as they can be quite expensive to run. However, they are
 # still useful as they can expose bugs before the action is run in "prod".
 
-
-shell_sources(name="tests")
-
-
 experimental_test_shell_command(
     name="Test workflow_dispatch dryrun",
-    command=f"bash { build_file_dir() / 'smoke_test_all_using_dryrun.sh'}",
-    tools=["chmod"],
+    command="./act workflow_dispatch --dryrun",
     execution_dependencies=[
         "//build-support/bin/act:act-at-root",
-        "./smoke_test_all_using_dryrun.sh",
         ".github/workflows:workflows",
     ],
     workdir="/",

--- a/.github/workflows/tests/smoke_test_all_using_dryrun.sh
+++ b/.github/workflows/tests/smoke_test_all_using_dryrun.sh
@@ -1,1 +1,4 @@
+#!/usr/bin/env bash
+set -eu
+
 ./act workflow_dispatch --dryrun

--- a/.github/workflows/tests/smoke_test_all_using_dryrun.sh
+++ b/.github/workflows/tests/smoke_test_all_using_dryrun.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-set -eu
-
-./act workflow_dispatch --dryrun

--- a/.github/workflows/tests/smoke_test_all_using_dryrun.sh
+++ b/.github/workflows/tests/smoke_test_all_using_dryrun.sh
@@ -1,0 +1,1 @@
+./act workflow_dispatch --dryrun

--- a/build-support/bin/act/.actrc
+++ b/build-support/bin/act/.actrc
@@ -1,0 +1,1 @@
+-P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/build-support/bin/act/BUILD
+++ b/build-support/bin/act/BUILD
@@ -1,0 +1,64 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# This contains all the plumbing in order to get https://github.com/nektos/act working in a sandbox
+# and in `run`.
+# To run `act`, use `pants run build-support/bin/act -- --version` (or whatever args you want).
+
+file(
+    name="downloaded-act",
+    source=per_platform(
+        macos_x86_64=http_source(
+            url="https://github.com/nektos/act/releases/download/v0.2.46/act_Darwin_x86_64.tar.gz",
+            len=6289585,
+            sha256="503bd4560afa3394fac87c404d4b34d1b422b8bb136b7f4ddaab27d08367700a",
+            filename="act.tar.gz",
+        ),
+        macos_arm64=http_source(
+            url="https://github.com/nektos/act/releases/download/v0.2.46/act_Darwin_arm64.tar.gz",
+            len=6015670,
+            sha256="6e5aae98192747d9430625cf0ac42e9fbcdbd9bc5e2558eb0297d0e2f9f2b2a8",
+            filename="act.tar.gz",
+        ),
+        linux_x86_64=http_source(
+            url="https://github.com/nektos/act/releases/download/v0.2.46/act_Linux_x86_64.tar.gz",
+            len=6079499,
+            sha256="19d5cdf534f892c1b62c32765c3982e2eb1334d66de4cc7e4a0e568cc0256f44",
+            filename="act.tar.gz",
+        ),
+        linux_arm64=http_source(
+            url="https://github.com/nektos/act/releases/download/v0.2.46/act_Linux_arm64.tar.gz",
+            len=5544514,
+            sha256="06418ca7430df409940812afe343c00118d7df889b11422232ff31a32a32b737",
+            filename="act.tar.gz",
+        ),
+    ),
+)
+
+shell_command(
+    name="extracted-act",
+    command="tar -xf act.tar.gz",
+    tools=["tar", "gzip"],
+    execution_dependencies=[":downloaded-act"],
+    output_directories=["act"],
+)
+
+file(
+    name=".actrc",
+    source=".actrc",
+)
+
+relocated_files(
+    name="act-at-root",
+    files_targets=[":extracted-act", ":.actrc"],
+    src=f"{build_file_dir()}",
+    dest="",
+)
+
+run_shell_command(
+    name="act",
+    # NB: Use XDG_CONFIG_DIRS so the .actrc gets loaded from the sandbox
+    command="XDG_CONFIG_DIRS=${CHROOT}:$XDG_CONFIG_DIRS {chroot}/act $@",
+    workdir="/",
+    execution_dependencies=[":act-at-root"],
+)

--- a/pants.toml
+++ b/pants.toml
@@ -64,6 +64,8 @@ pants_ignore.add = [
   "!/pants.pex",
   # Ignore node modules for docs processing tools
   "/docs/node_modules",
+  # We have Pants stuff in here
+  "!.github/",
 ]
 
 build_ignore.add = [


### PR DESCRIPTION
This is groundwork for/from https://github.com/pantsbuild/pants/pull/19230.

Not only can we have devs run `act` now (without having to install it :smile: (kudos to @chrisjrn 's work in adhoc/shell) but we can smoke test our workflows.

My local testing using `act` has actually bore much fruit. Several bugs were caught that existed solely in the YAML file itself. A history of the `workflows` file shows PRs that mirror my own findings: It's damn hard to test actions. Although this addition represents semi-significant cognitive burden of `act` and what goes into smoke testing, I think it's worth it to avoid the large churn that comes with authoring/editing actions. And I want to author more actions (because automation is bae).

So, here's the foundation :smile: 