### PR TITLE
Remove top-level dependency on `ansicolors`

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -312,7 +312,7 @@ async def mypy_typecheck_partition(
         "MYPY_FORCE_COLOR": "1",
         # Mypy needs to know the terminal so it can use appropriate escape sequences. ansi is a
         # reasonable lowest common denominator for the sort of escapes mypy uses (NB. TERM=xterm
-        # uses some additional codes that pants.util.strip_color doesn't remove).
+        # uses some additional codes that pants.util.colors.strip_color doesn't remove).
         "TERM": "ansi",
         # Force a fixed terminal width. This is effectively infinite, disabling mypy's
         # builtin truncation and line wrapping. Terminals do an acceptable job of soft-wrapping

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -312,7 +312,7 @@ async def mypy_typecheck_partition(
         "MYPY_FORCE_COLOR": "1",
         # Mypy needs to know the terminal so it can use appropriate escape sequences. ansi is a
         # reasonable lowest common denominator for the sort of escapes mypy uses (NB. TERM=xterm
-        # uses some additional codes that colors.strip_color doesn't remove).
+        # uses some additional codes that pants.util.strip_color doesn't remove).
         "TERM": "ansi",
         # Force a fixed terminal width. This is effectively infinite, disabling mypy's
         # builtin truncation and line wrapping. Terminals do an acceptable job of soft-wrapping

--- a/src/python/pants/core/goals/check.py
+++ b/src/python/pants/core/goals/check.py
@@ -8,8 +8,6 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, ClassVar, Generic, Iterable, TypeVar, cast
 
-import colors
-
 from pants.core.goals.lint import REPORT_DIR as REPORT_DIR  # noqa: F401
 from pants.core.goals.multi_tool_goal_helper import (
     OnlyOption,
@@ -28,6 +26,7 @@ from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, QueryRule, collect_rules, goal_rule
 from pants.engine.target import FieldSet, FilteredTargets
 from pants.engine.unions import UnionMembership, union
+from pants.util.colors import strip_color
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.meta import classproperty
@@ -57,7 +56,7 @@ class CheckResult:
     ) -> CheckResult:
         def prep_output(s: bytes) -> str:
             chroot = strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
-            formatting = cast(str, colors.strip_color(chroot)) if strip_formatting else chroot
+            formatting = strip_color(chroot) if strip_formatting else chroot
             return formatting
 
         return CheckResult(

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -232,7 +232,7 @@ class LockfileDiffPrinter(MaybeColor):
         yield from self.output_reqs("Removed dependencies", diff.removed, color="magenta")
 
     def style(self, text: str, *, color: str, **kwargs) -> str:
-        return cast(str, getattr(self, color)(text, **kwargs))
+        return cast(str, getattr(self, f"maybe_{color}")(text, **kwargs))
 
     def title(self, text: str) -> str:
         heading = f"== {text:^60} =="

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -218,7 +218,7 @@ class LockfileDiffPrinter(MaybeColor):
         if not output:
             return
         self.console.print_stderr(
-            self.style(" " * 66, underline=True)
+            self.style(" " * 66, color="default", underline=True)
             + f"\nLockfile diff: {diff.path} [{diff.resolve_name}]\n"
             + output
         )
@@ -236,7 +236,9 @@ class LockfileDiffPrinter(MaybeColor):
 
     def title(self, text: str) -> str:
         heading = f"== {text:^60} =="
-        return self.style("\n".join((" " * len(heading), heading, "")), underline=True)
+        return self.style(
+            "\n".join((" " * len(heading), heading, "")), color="default", underline=True
+        )
 
     def output_reqs(self, heading: str, reqs: LockfilePackages, **kwargs) -> Iterator[str]:
         if not reqs:
@@ -270,7 +272,7 @@ class LockfileDiffPrinter(MaybeColor):
         (None, dict(color="magenta")),
     )
 
-    def get_bump_attrs(self, prev: PackageVersion, curr: PackageVersion) -> dict[str, str]:
+    def get_bump_attrs(self, prev: PackageVersion, curr: PackageVersion) -> dict[str, str | bool]:
         for key, attrs in self._BUMPS:
             if key is None or getattr(prev, key, None) != getattr(curr, key, None):
                 return attrs

--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -218,25 +218,25 @@ class LockfileDiffPrinter(MaybeColor):
         if not output:
             return
         self.console.print_stderr(
-            self.style(" " * 66, style="underline")
+            self.style(" " * 66, underline=True)
             + f"\nLockfile diff: {diff.path} [{diff.resolve_name}]\n"
             + output
         )
 
     def output_sections(self, diff: LockfileDiff) -> Iterator[str]:
         if self.include_unchanged:
-            yield from self.output_reqs("Unchanged dependencies", diff.unchanged, fg="blue")
+            yield from self.output_reqs("Unchanged dependencies", diff.unchanged, color="blue")
         yield from self.output_changed("Upgraded dependencies", diff.upgraded)
         yield from self.output_changed("!! Downgraded dependencies !!", diff.downgraded)
-        yield from self.output_reqs("Added dependencies", diff.added, fg="green", style="bold")
-        yield from self.output_reqs("Removed dependencies", diff.removed, fg="magenta")
+        yield from self.output_reqs("Added dependencies", diff.added, color="green", bold=True)
+        yield from self.output_reqs("Removed dependencies", diff.removed, color="magenta")
 
-    def style(self, text: str, **kwargs) -> str:
-        return cast(str, self.maybe_color(text, **kwargs))
+    def style(self, text: str, *, color: str, **kwargs) -> str:
+        return cast(str, getattr(self, color)(text, **kwargs))
 
     def title(self, text: str) -> str:
         heading = f"== {text:^60} =="
-        return self.style("\n".join((" " * len(heading), heading, "")), style="underline")
+        return self.style("\n".join((" " * len(heading), heading, "")), underline=True)
 
     def output_reqs(self, heading: str, reqs: LockfilePackages, **kwargs) -> Iterator[str]:
         if not reqs:
@@ -244,7 +244,7 @@ class LockfileDiffPrinter(MaybeColor):
 
         yield self.title(heading)
         for name, version in reqs.items():
-            name_s = self.style(f"{name:30}", fg="yellow")
+            name_s = self.style(f"{name:30}", color="yellow")
             version_s = self.style(str(version), **kwargs)
             yield f"  {name_s} {version_s}"
 
@@ -256,18 +256,18 @@ class LockfileDiffPrinter(MaybeColor):
         label = "-->"
         for name, (prev, curr) in reqs.items():
             bump_attrs = self.get_bump_attrs(prev, curr)
-            name_s = self.style(f"{name:30}", fg="yellow")
-            prev_s = self.style(f"{str(prev):10}", fg="cyan")
+            name_s = self.style(f"{name:30}", color="yellow")
+            prev_s = self.style(f"{str(prev):10}", color="cyan")
             bump_s = self.style(f"{label:^7}", **bump_attrs)
             curr_s = self.style(str(curr), **bump_attrs)
             yield f"  {name_s} {prev_s} {bump_s} {curr_s}"
 
     _BUMPS = (
-        ("major", dict(fg="red", style="bold")),
-        ("minor", dict(fg="yellow")),
-        ("micro", dict(fg="green")),
+        ("major", dict(color="red", bold=True)),
+        ("minor", dict(color="yellow")),
+        ("micro", dict(color="green")),
         # Default style
-        (None, dict(fg="magenta")),
+        (None, dict(color="magenta")),
     )
 
     def get_bump_attrs(self, prev: PackageVersion, curr: PackageVersion) -> dict[str, str]:

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -13,8 +13,6 @@ from enum import Enum
 from io import BytesIO
 from typing import DefaultDict, cast
 
-from colors import green, red
-
 from pants.backend.build_files.fix.deprecations import renamed_fields_rules, renamed_targets_rules
 from pants.backend.build_files.fix.deprecations.base import FixedBUILDFile
 from pants.backend.build_files.fmt.black.register import BlackRequest
@@ -47,6 +45,7 @@ from pants.engine.internals.parser import ParseError
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.unions import UnionMembership, UnionRule, union
 from pants.option.option_types import BoolOption, EnumOption
+from pants.util.colors import green, red
 from pants.util.docutil import bin_name, doc_url
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
-from typing import DefaultDict, cast
+from typing import DefaultDict
 
 from pants.backend.build_files.fix.deprecations import renamed_fields_rules, renamed_targets_rules
 from pants.backend.build_files.fix.deprecations.base import FixedBUILDFile
@@ -93,10 +93,10 @@ class RewrittenBuildFileRequest(EngineAwareParameter):
             raise ParseError(f"Failed to parse {self.path}: {e}")
 
     def red(self, s: str) -> str:
-        return cast(str, red(s)) if self.colors_enabled else s
+        return red(s) if self.colors_enabled else s
 
     def green(self, s: str) -> str:
-        return cast(str, green(s)) if self.colors_enabled else s
+        return green(s) if self.colors_enabled else s
 
 
 class DeprecationFixerRequest(RewrittenBuildFileRequest):

--- a/src/python/pants/engine/console.py
+++ b/src/python/pants/engine/console.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import sys
 from typing import Callable, TextIO
 
-from colors import blue, cyan, green, magenta, red, yellow
-
 from pants.engine.engine_aware import SideEffecting
 from pants.engine.internals.scheduler import SchedulerSession
+from pants.util.colors import blue, cyan, green, magenta, red, yellow
 
 
 class Console(SideEffecting):

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -3,7 +3,7 @@
 
 from typing import List
 
-from pants.util.colors import cyan, default, green, magenta, orange, red, yellow
+from pants.util.colors import blue, cyan, default, green, magenta, orange, red, yellow
 
 
 class MaybeColor:
@@ -16,6 +16,7 @@ class MaybeColor:
             return x
 
         self.maybe_default = default if color else noop
+        self.maybe_blue = blue if color else noop
         self.maybe_cyan = cyan if color else noop
         self.maybe_green = green if color else noop
         self.maybe_orange = orange if color else noop

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -3,12 +3,7 @@
 
 from typing import List
 
-from colors import color as ansicolor
-from colors import cyan, green, magenta, red, yellow
-
-
-def _orange(s: str, **kwargs):
-    return ansicolor(s, "orange", **kwargs)
+from pants.util.colors import cyan, green, magenta, orange, red, yellow
 
 
 class MaybeColor:
@@ -20,10 +15,9 @@ class MaybeColor:
         def noop(x, **_):
             return x
 
-        self.maybe_color = ansicolor if color else noop
         self.maybe_cyan = cyan if color else noop
         self.maybe_green = green if color else noop
-        self.maybe_orange = _orange if color else noop
+        self.maybe_orange = orange if color else noop
         self.maybe_red = red if color else noop
         self.maybe_magenta = magenta if color else noop
         self.maybe_yellow = yellow if color else noop

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -12,7 +12,7 @@ class MaybeColor:
     def __init__(self, color: bool) -> None:
         self._color = color
 
-        def noop(x, **_):
+        def noop(x, bold: bool = False, underline: bool = False):
             return x
 
         self.maybe_cyan = cyan if color else noop

--- a/src/python/pants/help/maybe_color.py
+++ b/src/python/pants/help/maybe_color.py
@@ -3,7 +3,7 @@
 
 from typing import List
 
-from pants.util.colors import cyan, green, magenta, orange, red, yellow
+from pants.util.colors import cyan, default, green, magenta, orange, red, yellow
 
 
 class MaybeColor:
@@ -15,6 +15,7 @@ class MaybeColor:
         def noop(x, bold: bool = False, underline: bool = False):
             return x
 
+        self.maybe_default = default if color else noop
         self.maybe_cyan = cyan if color else noop
         self.maybe_green = green if color else noop
         self.maybe_orange = orange if color else noop

--- a/src/python/pants/util/colors.py
+++ b/src/python/pants/util/colors.py
@@ -34,8 +34,6 @@ def _ansi_color(r: int, g: int, b: int) -> Callable[[Callable[_P, None]], Callab
 def blue(s: str, *, bold: bool = False, underline: bool = False):
     """Clear skies, tranquil oceans, and sapphires gleaming with brilliance."""
 
-if TYPE_CHECKING:
-    reveal_type(blue)
 
 @_ansi_color(0, 255, 255)
 def cyan(s: str, *, bold: bool = False, underline: bool = False):

--- a/src/python/pants/util/colors.py
+++ b/src/python/pants/util/colors.py
@@ -17,13 +17,15 @@ def strip_color(s: str) -> str:
 _P = ParamSpec("_P")
 
 
-def _ansi_color(r: int, g: int, b: int) -> Callable[[Callable[_P, None]], Callable[_P, str]]:
+def _ansi_color(*rgb) -> Callable[[Callable[_P, None]], Callable[_P, str]]:
+    codes = ""
+    if rgb:
+        codes = "2;" + ";".join(str(n) for n in rgb)
+
     def decorator(func: Callable[_P, None]) -> Callable[_P, str]:
         @functools.wraps(func)
         def wrapper(s: str, *, bold: bool = False, underline: bool = False) -> str:
-            return (
-                f"\x1b[{'1;' if bold else ''}{'4;' if underline else ''}38;2;{r};{g};{b}m{s}\x1b[0m"
-            )
+            return f"\x1b[{'1;' if bold else ''}{'4;' if underline else ''}38;{codes}m{s}\x1b[0m"
 
         return wrapper  # type: ignore
 
@@ -63,3 +65,8 @@ def red(s: str, *, bold: bool = False, underline: bool = False):
 @_ansi_color(255, 255, 0)
 def yellow(s: str, *, bold: bool = False, underline: bool = False):
     """Sunshine, golden fields of daffodils, and the cheerful vibrancy of lemon zest."""
+
+
+@_ansi_color()
+def default(s: str, *, bold: bool = False, underline: bool = False):
+    """Initial state, conventional choice, and the pre-established configuration."""

--- a/src/python/pants/util/colors.py
+++ b/src/python/pants/util/colors.py
@@ -1,0 +1,65 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+# See https://en.wikipedia.org/wiki/ANSI_escape_code#24-bit
+
+import functools
+import re
+from typing import Callable
+
+from typing_extensions import ParamSpec
+
+
+def strip_color(s: str) -> str:
+    """Remove ANSI color/style sequences from a string."""
+    return re.sub("\x1b\\[(.*?m)", "", s)
+
+
+_P = ParamSpec("_P")
+
+
+def _ansi_color(r: int, g: int, b: int) -> Callable[[Callable[_P, None]], Callable[_P, str]]:
+    def decorator(func: Callable[_P, None]) -> Callable[_P, str]:
+        @functools.wraps(func)
+        def wrapper(s: str, *, bold: bool = False, underline: bool = False) -> str:
+            return (
+                f"\x1b[{'1;' if bold else ''}{'4;' if underline else ''}38;2;{r};{g};{b}m{s}\x1b[0m"
+            )
+
+        return wrapper
+
+    return decorator
+
+
+@_ansi_color(0, 0, 255)
+def blue(s: str, *, bold: bool = False, underline: bool = False):
+    """Clear skies, tranquil oceans, and sapphires gleaming with brilliance."""
+
+
+@_ansi_color(0, 255, 255)
+def cyan(s: str, *, bold: bool = False, underline: bool = False):
+    """Tropical waters, verdant foliage, and the vibrant plumage of exotic birds."""
+
+
+@_ansi_color(0, 128, 0)
+def green(s: str, *, bold: bool = False, underline: bool = False):
+    """Fresh leaves, lush meadows, and emerald gemstones."""
+
+
+@_ansi_color(255, 0, 255)
+def magenta(s: str, *, bold: bool = False, underline: bool = False):
+    """Blooming flowers, radiant sunsets, and the bold intensity of fuchsia."""
+
+
+@_ansi_color(255, 165, 0)
+def orange(s: str, *, bold: bool = False, underline: bool = False):
+    """Zest of ripe citrus fruits, fiery autumn leaves, and the energetic glow of a setting sun.."""
+
+
+@_ansi_color(255, 0, 0)
+def red(s: str, *, bold: bool = False, underline: bool = False):
+    """Fiery sunsets, vibrant roses, and the exhilarating energy of blazing flames."""
+
+
+@_ansi_color(255, 255, 0)
+def yellow(s: str, *, bold: bool = False, underline: bool = False):
+    """Sunshine, golden fields of daffodils, and the cheerful vibrancy of lemon zest."""

--- a/src/python/pants/util/colors.py
+++ b/src/python/pants/util/colors.py
@@ -4,7 +4,7 @@
 
 import functools
 import re
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 from typing_extensions import ParamSpec
 

--- a/src/python/pants/util/colors.py
+++ b/src/python/pants/util/colors.py
@@ -4,7 +4,7 @@
 
 import functools
 import re
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 from typing_extensions import ParamSpec
 
@@ -25,7 +25,7 @@ def _ansi_color(r: int, g: int, b: int) -> Callable[[Callable[_P, None]], Callab
                 f"\x1b[{'1;' if bold else ''}{'4;' if underline else ''}38;2;{r};{g};{b}m{s}\x1b[0m"
             )
 
-        return wrapper
+        return wrapper  # type: ignore
 
     return decorator
 
@@ -34,6 +34,8 @@ def _ansi_color(r: int, g: int, b: int) -> Callable[[Callable[_P, None]], Callab
 def blue(s: str, *, bold: bool = False, underline: bool = False):
     """Clear skies, tranquil oceans, and sapphires gleaming with brilliance."""
 
+if TYPE_CHECKING:
+    reveal_type(blue)
 
 @_ansi_color(0, 255, 255)
 def cyan(s: str, *, bold: bool = False, underline: bool = False):
@@ -52,7 +54,7 @@ def magenta(s: str, *, bold: bool = False, underline: bool = False):
 
 @_ansi_color(255, 165, 0)
 def orange(s: str, *, bold: bool = False, underline: bool = False):
-    """Zest of ripe citrus fruits, fiery autumn leaves, and the energetic glow of a setting sun.."""
+    """Zest of ripe citrus fruits, fiery autumn leaves, and the energetic glow of a setting sun."""
 
 
 @_ansi_color(255, 0, 0)


### PR DESCRIPTION
(First PR towards https://github.com/pantsbuild/pants/issues/19282)

Removes the top-level dependence on `ansicolors` by shifting the code we need into our own utility (the code is simple enough that providing ansicolors through a Pex, or using a native function provided by the engine is unnecessary).

```console
$ pants dependents 3rdparty/python#ansicolors
3rdparty/python:python
testprojects/src/python/hello/greet/greet.py
testprojects/src/python/native/setup.py:lib
tests/python/pants_test/pantsd/pantsd_integration_test_base.py:pantsd_integration_test_base
```

(NOTE `ansicolors` most likely will still be a transitive dependency, this is just step 1)