### PR TITLE
Expose current `BUILD` files globals to macros

### DIFF
--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -420,7 +420,7 @@ class Parser:
             exec(code, global_symbols)
         except NameError as e:
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
-            original = e.args[0].capitalize()
+            original = e.args[0][0].upper() + e.args[0][1:]
             help_str = softwrap(
                 f"""
                 If you expect to see more symbols activated in the below list, refer to

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -3,6 +3,9 @@
 
 from __future__ import annotations
 
+from textwrap import dedent
+from typing import Any
+
 import pytest
 
 from pants.build_graph.build_file_aliases import BuildFileAliases
@@ -83,7 +86,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             )
         assert str(exc.value) == softwrap(
             f"""
-            Name 'FAKE' is not defined.
+            dir/BUILD:1: Name 'FAKE' is not defined.
 
             {dym}If you expect to see more symbols activated in the below list, refer to
             {doc_url('enabling-backends')} for all available backends to activate.
@@ -128,3 +131,62 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
 @pytest.mark.parametrize("symbol", ["a", "bad", "BAD", "a___b_c", "a231", "áç"])
 def test_extract_symbol_from_name_error(symbol: str) -> None:
     assert _extract_symbol_from_name_error(NameError(f"name '{symbol}' is not defined")) == symbol
+
+
+def test_unrecognized_symbol_in_prelude(
+    defaults_parser_state: BuildFileDefaultsParserState,
+) -> None:
+    build_file_aliases = BuildFileAliases(
+        objects={"obj": 0},
+        context_aware_object_factories={"caof": lambda parse_context: lambda _: None},
+    )
+    parser = Parser(
+        build_root="",
+        registered_target_types=RegisteredTargetTypes({}),
+        union_membership=UnionMembership({}),
+        object_aliases=build_file_aliases,
+        ignore_unrecognized_symbols=False,
+    )
+    prelude: dict[str, Any] = {}
+    exec(
+        compile(
+            dedent(
+                """\
+                # This macro references some undefined symbol...
+                def macro():
+                    return NonExisting
+                """
+            ),
+            "preludes/bad.py",
+            "exec",
+            dont_inherit=True,
+        ),
+        {},
+        prelude,
+    )
+    prelude_symbols = BuildFilePreludeSymbols.create(prelude, ())
+
+    with pytest.raises(ParseError) as exc:
+        parser.parse(
+            filepath="dir/BUILD",
+            build_file_content="macro()",
+            extra_symbols=prelude_symbols,
+            env_vars=EnvironmentVars({}),
+            is_bootstrap=False,
+            defaults=defaults_parser_state,
+            dependents_rules=None,
+            dependencies_rules=None,
+        )
+    assert str(exc.value) == softwrap(
+        f"""
+        preludes/bad.py:3:macro: Name 'NonExisting' is not defined.
+
+        Did you mean macro?
+
+        If you expect to see more symbols activated in the below list, refer to
+        {doc_url('enabling-backends')} for all available backends to activate.
+
+        All registered symbols: ['__defaults__', '__dependencies_rules__', '__dependents_rules__',
+        'build_file_dir', 'caof', 'env', 'macro', 'obj']
+        """
+    )

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -20,6 +20,7 @@ from pants.engine.unions import UnionMembership
 from pants.testutil.pytest_util import no_exception
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
+from pants.util.strutil import softwrap
 
 
 @pytest.fixture
@@ -72,7 +73,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
         with pytest.raises(ParseError) as exc:
             parser.parse(
                 "dir/BUILD",
-                "fake",
+                "FAKE",
                 prelude_symbols,
                 EnvironmentVars({}),
                 False,
@@ -80,14 +81,16 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
                 dependents_rules=None,
                 dependencies_rules=None,
             )
-        assert str(exc.value) == (
-            f"Name 'fake' is not defined.\n\n{dym}"
-            "If you expect to see more symbols activated in the below list,"
-            f" refer to {doc_url('enabling-backends')} for all available"
-            " backends to activate.\n\n"
-            "All registered symbols: ['__defaults__', '__dependencies_rules__', "
-            f"'__dependents_rules__', 'build_file_dir', 'caof', 'env', {fmt_extra_sym}"
-            "'obj', 'prelude', 'tgt']"
+        assert str(exc.value) == softwrap(
+            f"""
+            Name 'FAKE' is not defined.
+
+            {dym}If you expect to see more symbols activated in the below list, refer to
+            {doc_url('enabling-backends')} for all available backends to activate.
+
+            All registered symbols: [{fmt_extra_sym}'__defaults__', '__dependencies_rules__',
+            '__dependents_rules__', 'build_file_dir', 'caof', 'env', 'obj', 'prelude', 'tgt']
+            """
         )
 
         with no_exception():
@@ -102,7 +105,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             )
             parser.parse(
                 "dir/BUILD",
-                "fake",
+                "FAKE",
                 prelude_symbols,
                 EnvironmentVars({}),
                 False,
@@ -111,14 +114,14 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
                 dependencies_rules=None,
             )
 
-    test_targs = ["fake1", "fake2", "fake3", "fake4", "fake5"]
+    test_targs = ["FAKE1", "FAKE2", "FAKE3", "FAKE4", "FAKE5"]
 
     perform_test([], "")
-    dym_one = "Did you mean fake1?\n\n"
+    dym_one = "Did you mean FAKE1?\n\n"
     perform_test(test_targs[:1], dym_one)
-    dym_two = "Did you mean fake2 or fake1?\n\n"
+    dym_two = "Did you mean FAKE2 or FAKE1?\n\n"
     perform_test(test_targs[:2], dym_two)
-    dym_many = "Did you mean fake5, fake4, or fake3?\n\n"
+    dym_many = "Did you mean FAKE5, FAKE4, or FAKE3?\n\n"
     perform_test(test_targs, dym_many)
 
 


### PR DESCRIPTION
It came up in [slack](https://pantsbuild.slack.com/archives/C046T6T9U/p1686300047969839) ([linen](https://chat.pantsbuild.org/t/12325392/can-macros-access-global-variables-from-the-root-of-the-call#8e0110cd-740b-45f9-9af5-a4dc628cc25f)) a question about accessing global symbols declared in the current BUILD file.

Although this may be a sign of bad design to need this, it was not too difficult to support. (also, the error message is confusing as **, as it suggests it should work by including the BUILD file globals in the output for registered symbols).

As such I submit this PR as POC and for discussion.

There are three commits in this PR, and if we decide to not support accessing the current BUILD files globals from macros, the first two commits still has good improvements for error reporting in case of unknown symbols (by including the location of the error properly).

If we do decide to keep all of it, I'll add a few lines to the docs before proceeding.

--

From a prelude (macro file) you may access the current BUILD files global from a `BUILD` scope.

Adjusted example from the above linked thread: (added `BUILD.` prefix to the variable reference in the macro):
```python
def my_special_wrapper(**kwargs):
    real_target(something=BUILD.MY_SPECIAL_GLOBAL_VARIABLE, **kwargs)
```
> and a BUILD file with something like
```python

MY_SPECIAL_GLOBAL_VARIABLE = "something"

my_special_wrapper()
```
