### PR TITLE
Don't gpg-sign PyPI uploads in our release process.

### DIFF
--- a/build-support/bin/release.py
+++ b/build-support/bin/release.py
@@ -66,10 +66,6 @@ _known_packages = [
     "pantsbuild.pants.testinfra",
 ]
 
-_expected_owners = {"benjyw", "John.Sirois", "stuhood"}
-
-_expected_maintainers = {"EricArellano", "illicitonion", "wisechengyi", "kaos"}
-
 
 # Disable the Pants repository-internal internal_plugins.test_lockfile_fixtures plugin because
 # otherwise inclusion of that plugin will fail due to its `pytest` import not being included in the pex.
@@ -824,14 +820,6 @@ def build_pex(fetch: bool) -> None:
         dest = stable_dest
     green(f"Built {dest}")
 
-    # We filter out Pants options like `PANTS_CONFIG_FILES` and disable certain internal backends.
-    env = {k: v for k, v in env.items() if not k.startswith("PANTS_")}
-    env.update(DISABLED_BACKENDS_CONFIG)
-    # NB: Set `--concurrent` so that if this script is running under `pantsd`, the validation
-    # won't kill it.
-    subprocess.run([dest, "--concurrent", "--version"], env=env, check=True)
-    green(f"Validated {dest}")
-
 
 # -----------------------------------------------------------------------------------------------
 # Fetch and stabilize the versions of wheels for publishing
@@ -961,9 +949,6 @@ def upload_wheels_via_twine() -> None:
         [
             str(CONSTANTS.twine_venv_dir / "bin/twine"),
             "upload",
-            "--sign",
-            f"--sign-with={get_pgp_program_name()}",
-            f"--identity={get_pgp_key_id()}",
             "--skip-existing",  # Makes the upload idempotent.
             str(CONSTANTS.deploy_pants_wheel_dir / CONSTANTS.pants_stable_version / "*.whl"),
         ],

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -94,7 +94,7 @@ Update the release page in `src/python/pants/notes` for this release series, e.g
 
 Run `git fetch --all --tags` to be sure you have the latest release tags available locally.
 
-From the `main` branch, run `pants run build-support/bin/changelog.py -- --prior 2.9.0.dev0 --new 2.9.0.dev1` with the relevant versions. 
+From the `main` branch, run `./pants run build-support/bin/changelog.py -- --prior 2.9.0.dev0 --new 2.9.0.dev1` with the relevant versions.
 
 This will generate the sections to copy into the release notes. Delete any empty sections. Do not paste the `Internal` section into the notes file. Instead, paste into a comment on the prep PR.
 
@@ -112,7 +112,7 @@ You are encouraged to fix typos and tweak change descriptions for clarity to use
 
 ### 2. Update `CONTRIBUTORS.md`
 
-Run `pants run build-support/bin/contributors.py`
+Run `./pants run build-support/bin/contributors.py`
 
 Take note of any new contributors since the last release so that you can give a shoutout in the announcement email.
 
@@ -172,7 +172,7 @@ On the relevant release branch, run `npx rdme docs docs/markdown --version v<pan
 
 ### Regenerate the references
 
-Still on the relevant release branch, run `pants run build-support/bin/generate_docs.py -- --sync --api-key <key>` with your key from <https://dash.readme.com/project/pants/v2.8/api-key>.
+Still on the relevant release branch, run `./pants run build-support/bin/generate_docs.py -- --sync --api-key <key>` with your key from <https://dash.readme.com/project/pants/v2.8/api-key>.
 
 ### `stable` releases - Update the default docsite
 
@@ -212,7 +212,13 @@ After the [`Release` job](https://github.com/pantsbuild/pants/actions/workflows/
 PANTS_PEX_RELEASE=STABLE ./pants run build-support/bin/release.py -- build-universal-pex
 ```
 
-Then go to <https://github.com/pantsbuild/pants/tags>, find your release's tag, click `Edit tag`, and upload the PEX located at `dist/pex.pants.<version>.pex`.
+Then:
+
+- Go to <https://github.com/pantsbuild/pants/tags>, find your release's tag and click `Create release from tag`.
+- If this is not the latest stable release, deselect "Set as the latest release".
+- If this is not a stable release, select "Set as a pre-release".
+- Attach the PEX located at `dist/pex.pants.<version>.pex`.
+- Click "Publish release"
 
 Step 5: Test the release
 ------------------------
@@ -243,7 +249,7 @@ pants run ./build-support/bin/contributors.py -- -s <tag>
 
 > ❗️ Update the links in these templates!
 > 
-> When copy pasting these templates, please always check that all versions match the relevant release. When adding a link, use "Test this link" to ensure that it loads properly.
+> When copy-pasting these templates, please always check that all versions match the relevant release. When adding a link, use "Test this link" to ensure that it loads properly.
 
 #### Dev release
 


### PR DESCRIPTION
As of 5/23/2023 PyPI ignores these signatures, and the
releaser gets an email saying as much.

See here for details: 
https://blog.pypi.org/posts/2023-05-23-removing-pgp/

Also:
- Don't attempt to run the release pex for validation, as it only
  runs on x86_64 (at least currently), so that validation fails on
  Apple Silicon machines, which are increasingly commonly used by releasers.
- Remove unused expected owners/maintainers lists.
- Some tweaks to the release instructions.