### PR TITLE
Fix S3 URL Handler for good (Cherry-pick of #19285)

### DIFF
--- a/src/python/pants/backend/url_handlers/s3/integration_test.py
+++ b/src/python/pants/backend/url_handlers/s3/integration_test.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import sys
+from http.client import HTTPMessage
 from http.server import BaseHTTPRequestHandler
 from types import SimpleNamespace
 
@@ -47,6 +48,8 @@ def monkeypatch_botocore(monkeypatch):
         fake_session = object()
         fake_creds = SimpleNamespace(access_key="ACCESS", secret_key="SECRET", token=None)
         botocore.session = SimpleNamespace(get_session=lambda: fake_session)
+        # NB: HTTPHeaders is just a simple subclass of HTTPMessage
+        botocore.compat = SimpleNamespace(HTTPHeaders=HTTPMessage)
 
         def fake_resolver_creator(session):
             assert session is fake_session

--- a/src/python/pants/backend/url_handlers/s3/register.py
+++ b/src/python/pants/backend/url_handlers/s3/register.py
@@ -64,7 +64,7 @@ class S3DownloadFile:
 
 @rule
 async def download_from_s3(request: S3DownloadFile, aws_credentials: AWSCredentials) -> Digest:
-    from botocore import auth, exceptions  # pants: no-infer-dep
+    from botocore import auth, compat, exceptions  # pants: no-infer-dep
 
     # NB: The URL for auth is expected to be in path-style
     path_style_url = "https://s3"
@@ -74,11 +74,7 @@ async def download_from_s3(request: S3DownloadFile, aws_credentials: AWSCredenti
     if request.query:
         path_style_url += f"?{request.query}"
 
-    headers: dict[str, str] = {}
-    if aws_credentials.creds.token:
-        # Workaround https://github.com/boto/botocore/pull/2948
-        headers["X-Amz-Security-Token"] = ""
-
+    headers = compat.HTTPHeaders()
     http_request = SimpleNamespace(
         url=path_style_url,
         headers=headers,


### PR DESCRIPTION
See https://github.com/boto/botocore/blob/0c833f28b1d87883c7aeb4aed8a05860af1ec34a/botocore/compat.py#L37 this type should work in all cases.

I tried both locally and in my CI (token auth)

Also UGH :sweat: 
