### PR TITLE
A few fixes for the auto-cherry-pick script

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -31,8 +31,7 @@ jobs:
       - run: npm install ./build-support/cherry_pick
       - id: get-prereqs
         name: Get Cherry-Pick prerequisites
-        # NB: See https://github.com/actions/github-script/pull/397
-        uses: thejcannon/github-script@7ed0cc648959192a3868f0de9862110d7922b7cc
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
           allow-empty-token: true
@@ -84,14 +83,13 @@ jobs:
     name: Post-Pick Actions
     needs: [cherry_picker, prerequisites]
     runs-on: ubuntu-latest
-    if: always()
+    if: success() || failure()
     steps:
       - name: Check out code
         uses: actions/checkout@v3
       - run: npm install ./build-support/cherry_pick
       - name: Run Script
-        # NB: See https://github.com/actions/github-script/pull/397
-        uses: thejcannon/github-script@7ed0cc648959192a3868f0de9862110d7922b7cc
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
           allow-empty-token: true

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -34,7 +34,6 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
-          allow-empty-token: true
           script: |
             const Helper = require('./build-support/cherry_pick/helper.js');
             const helper = new Helper({octokit: github, context, core});
@@ -92,7 +91,6 @@ jobs:
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
-          allow-empty-token: true
           script: |
             const Helper = require('./build-support/cherry_pick/helper.js');
             const helper = new Helper({octokit: github, context, core});

--- a/.github/workflows/tests/auto_cherry_picker_smoke_test.py
+++ b/.github/workflows/tests/auto_cherry_picker_smoke_test.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
 import subprocess
 from textwrap import dedent
 
@@ -50,27 +51,62 @@ def stub_helper():
         )
 
 
-def test_auto_cherry_pick():
-    result = subprocess.run(
+def run_act(*extra_args) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
         [
             "./act",
-            "workflow_dispatch",
             "-W",
             ".github/workflows/auto-cherry-picker.yaml",
             "--input",
             "PR_number=17295",
             "--env",
             "GITHUB_REPOSITORY=pantsbuild/pants",
+            "--secret",
+            "WORKER_PANTS_CHERRY_PICK_PAT=SUPER-SECRET",
+            *extra_args,
         ],
         text=True,
         capture_output=True,
         check=False,
     )
+
+
+def test_auto_cherry_pick__workflow_dispatch():
+    result = run_act(
+        "workflow_dispatch",
+    )
     stdout = result.stdout
-    print(stdout)
     assert "make_pr.sh 12345 2.16.x" in stdout
     assert "make_pr.sh 12345 2.17.x" in stdout
     assert (
         'cherry_picked_finished: ABCDEF12345 [{"milestone":"2.16.x","branch_name":"cherry-pick-12345-to-2.16.x"},{"milestone":"2.17.x","branch_name":"cherry-pick-12345-to-2.17.x"}]'
         in stdout
     )
+
+
+def test_auto_cherry_pick__PR_merged(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps({"pull_request": {"merged": True, "labels": [{"name": "needs-cherrypick"}]}})
+    )
+
+    result = run_act("pull_request_target", "--eventpath", str(event_path))
+    stdout = result.stdout
+    assert "make_pr.sh 12345 2.16.x" in stdout
+    assert "make_pr.sh 12345 2.17.x" in stdout
+    assert (
+        'cherry_picked_finished: ABCDEF12345 [{"milestone":"2.16.x","branch_name":"cherry-pick-12345-to-2.16.x"},{"milestone":"2.17.x","branch_name":"cherry-pick-12345-to-2.17.x"}]'
+        in stdout
+    )
+
+
+@pytest.mark.xfail(reason="https://github.com/nektos/act/issues/1482")
+def test_auto_cherry_pick__PR_doesnt_match(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"merged": True, "labels": []}}))
+
+    result = run_act("pull_request_target", "--eventpath", str(event_path))
+    stdout = result.stdout
+    print(stdout)
+    assert not result.stderr
+    # @TODO: Assert we didn't try and run _anything_. See https://github.com/pantsbuild/pants/issues/19305


### PR DESCRIPTION
A few fixes:
- Stop using `if: always()`. As I'm understanding it, this will force the job to run, even if prerequisites didn't run (I'm thinking this is for, like critical teardown jobs/steps). Instead use `if: success() || failure()`, which is suggested in the docs. As I understand there are (at least?) 4 states: `success`, `failure`, `skipped`, and `cancelled`.
- Used upstream `github-script` since we no longer talk to the web
  - This fixes https://github.com/pantsbuild/pants/issues/19305 (I think)
- Pass a dummy PAT
- Add a new test for PR event
- Add a new xfail test that should be testing the bugfix, but unfortunately `act` has a bug

So, can't test that this fixes it, but the suggestion comes from GitHub directly: https://docs.github.com/en/actions/learn-github-actions/expressions#always