### PR TITLE
Fix auto-cherry-pick issues discovered when run

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -54,7 +54,7 @@ jobs:
     name: Cherry-Pick
     needs: prerequisites
     runs-on: ubuntu-latest
-    # continue-on-error: true # Don't cancel other jobs if this one fails
+    continue-on-error: true # Don't cancel other jobs if this one fails
     strategy:
       matrix:
         include: ${{ fromJSON(needs.prerequisites.outputs.matrix) }}

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -54,6 +54,7 @@ jobs:
     name: Cherry-Pick
     needs: prerequisites
     runs-on: ubuntu-latest
+    # continue-on-error: true # Don't cancel other jobs if this one fails
     strategy:
       matrix:
         include: ${{ fromJSON(needs.prerequisites.outputs.matrix) }}

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -83,7 +83,8 @@ jobs:
     name: Post-Pick Actions
     needs: [cherry_picker, prerequisites]
     runs-on: ubuntu-latest
-    if: success() || failure()
+    # NB: We don't want to run if the prerequisites job failed or was skipped
+    if: needs.prerequisites.conclusion == "success"
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -84,7 +84,7 @@ jobs:
     needs: [cherry_picker, prerequisites]
     runs-on: ubuntu-latest
     # NB: We don't want to run if the prerequisites job failed or was skipped
-    if: needs.prerequisites.conclusion == "success"
+    if: needs.prerequisites.result == 'success' && (success() || failure())
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/tests/BUILD
+++ b/.github/workflows/tests/BUILD
@@ -8,5 +8,5 @@
 python_tests(
     name="tests",
     dependencies=["//build-support/bin/act:act-at-root"],
-    timeout=120,
+    timeout=180,
 )

--- a/.github/workflows/tests/auto_cherry_picker_smoke_test.py
+++ b/.github/workflows/tests/auto_cherry_picker_smoke_test.py
@@ -37,7 +37,7 @@ def stub_helper():
                     constructor({ octokit, context, core }) {}
                     async get_prereqs() {
                         return {
-                            pr_num: context,
+                            pr_num: 12345,
                             merge_commit: "ABCDEF12345",
                             milestones: ["2.16.x", "2.17.x"],
                         };
@@ -61,7 +61,7 @@ def run_act(*extra_args) -> subprocess.CompletedProcess[str]:
             "-W",
             ".github/workflows/auto-cherry-picker.yaml",
             "--input",
-            "PR_number=12345",
+            "PR_number=17295",
             "--env",
             "GITHUB_REPOSITORY=pantsbuild/pants",
             "--secret",

--- a/.github/workflows/tests/auto_cherry_picker_smoke_test.py
+++ b/.github/workflows/tests/auto_cherry_picker_smoke_test.py
@@ -17,6 +17,9 @@ def stub_make_pr():
                 set -euo pipefail
 
                 echo "make_pr.sh $@"
+                if [ $1 == "2.16.x" ]; then
+                    sleep 10
+                fi
                 # We exit 1 to test we still call the finish job
                 exit 1
                 """
@@ -110,3 +113,8 @@ def test_auto_cherry_pick__PR_doesnt_match(tmp_path):
     print(stdout)
     assert not result.stderr
     # @TODO: Assert we didn't try and run _anything_. See https://github.com/pantsbuild/pants/issues/19305
+
+@pytest.mark.xfail(reason="https://github.com/nektos/act/issues/1865")
+def test_auto_cherry_pick__continue_on_failure():
+    result = run_act("workflow_dispatch")
+    assert "[Auto Cherry-Picker/Cherry-Pick-1       ]   ❌  Failure" not in result.stdout

--- a/build-support/cherry_pick/helper.js
+++ b/build-support/cherry_pick/helper.js
@@ -25,7 +25,7 @@ class CherryPickHelper {
   }
 
   get #run_link() {
-    return `:robot: [Beep Boop here's my run link](${this.context.serverUrl}/${this.context.repo.owner}/${this.context.repo.repo}/actions/runs/${this.context.runId}/jobs/${this.context.job})`;
+    return `:robot: [Beep Boop here's my run link](${this.context.serverUrl}/${this.context.repo.owner}/${this.context.repo.repo}/actions/runs/${this.context.runId})`;
   }
 
   async #add_failed_label() {
@@ -118,7 +118,8 @@ ${this.#run_link}`
     );
 
     let any_failed = false;
-    let comment_body = "";
+    let comment_body =
+      "I tried to automatically cherry-pick this change back to each relevant milestone, so that it is available in those older releases of Pants.\n\n";
     infos.forEach(({ pr_url, milestone, branch_name }) => {
       if (pr_url === undefined) {
         any_failed = true;
@@ -153,17 +154,14 @@ Successfully opened ${pr_url}.`;
       comment_body += "\n\n";
     });
 
-    await this.#add_comment(
-      `I tried to automatically cherry-pick this change back to each relevant milestone, so that it is available in those older releases of Pants.
-
-${comment_body}
-
----
-
-Thanks again for your contributions!
-
-${this.#run_link}`
-    );
+    comment_body += "---\n\n";
+    if (any_failed) {
+      comment_body +=
+        "When you're done manually cherry-picking, please remove the `needs-cherrypick` label on this PR.\n\n";
+    }
+    comment_body += "Thanks again for your contributions!\n\n";
+    comment_body += this.#run_link;
+    await this.#add_comment(comment_body);
     if (any_failed) {
       this.#add_failed_label();
     } else {

--- a/build-support/cherry_pick/helper.test.js
+++ b/build-support/cherry_pick/helper.test.js
@@ -75,7 +75,6 @@ function get_context() {
       repo: REPO,
       number: 19214,
     },
-    job: "9269746089",
     runId: 5148273558,
     workflow: "Auto Cherry-Picker",
   };
@@ -109,7 +108,7 @@ test("get_prereqs fails when no milestone", async () => {
 
 @steve_buscemi: Please add the milestone to the PR and re-run the [Auto Cherry-Picker job](<WORKFLOW_URL>) using the "Run workflow" button.
 
-:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558/jobs/9269746089)`
+:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558)`
   );
   expect(helper.core.setFailed).toBeCalledTimes(1);
 });
@@ -235,13 +234,13 @@ Please note that I cannot re-run CI if a job fails. Please work with your PR app
 
 Successfully opened <URL for 2.17.x>.
 
-
-
 ---
+
+When you're done manually cherry-picking, please remove the \`needs-cherrypick\` label on this PR.
 
 Thanks again for your contributions!
 
-:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558/jobs/9269746089)`
+:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558)`
   );
 });
 
@@ -275,12 +274,10 @@ test("cherry_pick_finished all pass", async () => {
 
 Successfully opened <URL for 2.16.x>.
 
-
-
 ---
 
 Thanks again for your contributions!
 
-:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558/jobs/9269746089)`
+:robot: [Beep Boop here's my run link](https://github.com/pantsbuild/pants/actions/runs/5148273558)`
   );
 });


### PR DESCRIPTION
See https://github.com/pantsbuild/pants/pull/19271#issuecomment-1591546385 for those issues.

Namely:
- Add `continue-on-error` to the cherry pick job so that other cherry-picks don't get cancelled if one fails
- Switch `if: success() || failure()` to now checking if prerequisites job succeeded
  - That way we don't double-comment if that job fails 
- Fix the run link 
- Add a comment (on failure to remove the `needs-cherrypick` label)
