### PR TITLE
A couple of fixes to cherry-picking and `make_pr.sh`

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -73,11 +73,15 @@ jobs:
           git checkout -b "${{ matrix.branch_name }}" FETCH_HEAD
           git cherry-pick "${{ needs.prerequisites.outputs.merge_commit }}"
           git push -u origin "${{ matrix.branch_name }}"
+
+          # Now we go back to `main` to ensure we're running the latest `make_pr.sh`.
+          # (this only really should matter if we're cherry-picking changed to `make_pr.sh` itself).
+          git checkout main
       - name: Create Cherry-Pick Branch
         env:
           GH_TOKEN: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
         run: |
-          bash build-support/cherry_pick/make_pr.sh "${{ needs.prerequisites.outputs.pr_num }}" "${{ matrix.milestone }}"
+          bash build-support/cherry_pick/make_pr.sh "${{ needs.prerequisites.outputs.pr_num }}" "${{ matrix.milestone }}" "${{ matrix.branch_name }}"
 
   post_pick:
     name: Post-Pick Actions

--- a/.github/workflows/tests/auto_cherry_picker_smoke_test.py
+++ b/.github/workflows/tests/auto_cherry_picker_smoke_test.py
@@ -76,8 +76,8 @@ def test_auto_cherry_pick__workflow_dispatch():
         "workflow_dispatch",
     )
     stdout = result.stdout
-    assert "make_pr.sh 12345 2.16.x" in stdout
-    assert "make_pr.sh 12345 2.17.x" in stdout
+    assert "make_pr.sh 12345 2.16.x cherry-pick-12345-to-2.16.x" in stdout
+    assert "make_pr.sh 12345 2.17.x cherry-pick-12345-to-2.17.x" in stdout
     # NB: Even if one fails, the other should run to completion and fail as well (e.g. continue-on-error)
     # (although act has a bug where it doesn't cancel: https://github.com/nektos/act/issues/1865
     # so we aren't _really_ testing `continue-on-error` until that is fixed)
@@ -97,8 +97,8 @@ def test_auto_cherry_pick__PR_merged(tmp_path):
 
     result = run_act("pull_request_target", "--eventpath", str(event_path))
     stdout = result.stdout
-    assert "make_pr.sh 12345 2.16.x" in stdout
-    assert "make_pr.sh 12345 2.17.x" in stdout
+    assert "make_pr.sh 12345 2.16.x cherry-pick-12345-to-2.16.x" in stdout
+    assert "make_pr.sh 12345 2.17.x cherry-pick-12345-to-2.17.x" in stdout
     assert (
         'cherry_picked_finished: ABCDEF12345 [{"milestone":"2.16.x","branch_name":"cherry-pick-12345-to-2.16.x"},{"milestone":"2.17.x","branch_name":"cherry-pick-12345-to-2.17.x"}]'
         in stdout

--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -19,13 +19,13 @@ MILESTONE=$2
 
 PR_INFO=$(gh pr view "$PR_NUM" --json title,labels,reviews,body,author)
 
-TITLE=$(echo "$PR_INFO" | jq .title)
+TITLE=$(echo "$PR_INFO" | jq -r .title)
 AUTHOR=$(echo "$PR_INFO" | jq -r .author.login)
-CATEGORY_LABEL=$(echo "$PR_INFO" | jq '.labels[] | select(.name|test("category:.")).name')
-REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ' ') $AUTHOR"
+CATEGORY_LABEL=$(echo "$PR_INFO" | jq -r '.labels[] | select(.name|test("category:.")).name')
+REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ' ')$AUTHOR"
 
 BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.XXXXXX")
-echo "$PR_INFO" | jq .body > "$BODY_FILE"
+echo "$PR_INFO" | jq -r .body > "$BODY_FILE"
 
-gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --milestone "$MILESTONE" --body-file "$BODY_FILE" --reviewers "$(echo "$REVIEWERS" | tr ' ' ',')"
+gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --milestone "$MILESTONE" --body-file "$BODY_FILE" --reviewer "$(echo "$REVIEWERS" | tr ' ' ',')"
 rm "$BODY_FILE"

--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -40,5 +40,5 @@ gh pr create \
   --milestone "$MILESTONE" \
   --body-file "$BODY_FILE" \
   --reviewer "$REVIEWERS" \
-  ${ADDITIONAL_ARGS[@]}
+  "${ADDITIONAL_ARGS[@]}"
 rm "$BODY_FILE"

--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -23,7 +23,7 @@ PR_INFO=$(gh pr view "$PR_NUM" --json title,labels,reviews,body,author)
 TITLE=$(echo "$PR_INFO" | jq -r .title)
 AUTHOR=$(echo "$PR_INFO" | jq -r .author.login)
 CATEGORY_LABEL=$(echo "$PR_INFO" | jq -r '.labels[] | select(.name|test("category:.")).name')
-REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ' ')$AUTHOR"
+REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ',')$AUTHOR"
 
 BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.XXXXXX")
 echo "$PR_INFO" | jq -r .body > "$BODY_FILE"
@@ -39,6 +39,6 @@ gh pr create \
   --label "$CATEGORY_LABEL" \
   --milestone "$MILESTONE" \
   --body-file "$BODY_FILE" \
-  --reviewer "$(echo "$REVIEWERS" | tr ' ' ',')" \
+  --reviewer "$REVIEWERS" \
   ${ADDITIONAL_ARGS[@]}
 rm "$BODY_FILE"

--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -16,6 +16,7 @@ fi
 
 PR_NUM=$1
 MILESTONE=$2
+BRANCH_NAME=$3
 
 PR_INFO=$(gh pr view "$PR_NUM" --json title,labels,reviews,body,author)
 
@@ -27,5 +28,17 @@ REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ' ')$AU
 BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.XXXXXX")
 echo "$PR_INFO" | jq -r .body > "$BODY_FILE"
 
-gh pr create --base "$MILESTONE" --title "$TITLE (Cherry-pick of #$PR_NUM)" --label "$CATEGORY_LABEL" --milestone "$MILESTONE" --body-file "$BODY_FILE" --reviewer "$(echo "$REVIEWERS" | tr ' ' ',')"
+ADDITIONAL_ARGS=()
+if [ -n "$BRANCH_NAME" ]; then
+  ADDITIONAL_ARGS=(--head "$BRANCH_NAME")
+fi
+
+gh pr create \
+  --base "$MILESTONE" \
+  --title "$TITLE (Cherry-pick of #$PR_NUM)" \
+  --label "$CATEGORY_LABEL" \
+  --milestone "$MILESTONE" \
+  --body-file "$BODY_FILE" \
+  --reviewer "$(echo "$REVIEWERS" | tr ' ' ',')" \
+  ${ADDITIONAL_ARGS[@]}
 rm "$BODY_FILE"


### PR DESCRIPTION
- Use `jq -r` everywhere to get raw strings, not quoted ones
- Don't add a space before putting the author as a reviewer in `REVIEWERS` so that the space replacement will work correctly
- The right flag is `--reviewer` not `--reviewers`
- Plumbing to allow the cherry picker to pick changes to `make_pr.sh` (namely switching the github action back to using `main` after pushing the branch, and plumbing that through `make_pr.sh`).