### PR TITLE
turn `path/BUILD` into `path` in the `tailor` goal

### DIFF
--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -10,9 +10,10 @@ import os
 from abc import ABCMeta
 from collections import defaultdict
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable, Iterator, Mapping, cast
 
-from pants.base.specs import AncestorGlobSpec, RawSpecs, Specs
+from pants.base.specs import AncestorGlobSpec, DirLiteralSpec, FileLiteralSpec, RawSpecs, Specs
 from pants.build_graph.address import Address
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.console import Console
@@ -571,6 +572,35 @@ async def edit_build_files(
     return EditedBuildFiles(new_digest, tuple(sorted(created)), tuple(sorted(updated)))
 
 
+def spec_with_build_to_dir(spec: RawSpecs, build_file_name: str) -> RawSpecs:
+    """Convert a spec like `path/to/BUILD` into `path/to`, which is probably the intention."""
+
+    def resolve(s: str) -> str:
+        path = Path(s)
+        if path.name == build_file_name:
+            return path.parent.as_posix()
+        else:
+            return s
+
+    # handles existing BUILD files
+    new_file_literals = [FileLiteralSpec(resolve(e.file)) for e in spec.file_literals]
+
+    # If the BUILD file doesn't exist (possible because it was deleted)
+    # it will appear as a dir_literal
+    new_dir_literals = [DirLiteralSpec(resolve(e.directory)) for e in spec.dir_literals]
+    return dataclasses.replace(
+        spec, dir_literals=tuple(new_dir_literals), file_literals=tuple(new_file_literals)
+    )
+
+
+def resolve_specs_with_build(specs: Specs, build_file_name: str) -> Specs:
+    """Convert Specs with specs like `path/to/BUILD` into `path/to`, which is probably the
+    intention."""
+    new_includes = spec_with_build_to_dir(specs.includes, build_file_name)
+    new_ignores = spec_with_build_to_dir(specs.ignores, build_file_name)
+    return dataclasses.replace(specs, includes=new_includes, ignores=new_ignores)
+
+
 @goal_rule
 async def tailor(
     tailor_subsystem: TailorSubsystem,
@@ -580,7 +610,11 @@ async def tailor(
     specs: Specs,
     build_file_options: BuildFileOptions,
 ) -> TailorGoal:
+    print(specs)
     tailor_subsystem.validate_build_file_name(build_file_options.patterns)
+
+    specs = resolve_specs_with_build(specs, tailor_subsystem.build_file_name)
+
     if not specs:
         if not specs.includes.from_change_detection:
             logger.warning(
@@ -593,6 +627,7 @@ async def tailor(
                       * `{bin_name()} tailor ::` to run on everything
                       * `{bin_name()} tailor dir::` to run on `dir` and subdirs
                       * `{bin_name()} tailor dir` to run on `dir`
+                      * `{bin_name()} tailor dir/{tailor_subsystem.build_file_name}` to run on `dir`
                       * `{bin_name()} --changed-since=HEAD tailor` to only run on changed and new files
                     """
                 )

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -597,26 +597,35 @@ def test_resolve_specs_targetting_build_files(build_file_name) -> None:
             description_of_origin="CLI arguments",
             dir_literals=(DirLiteralSpec(f"src/{build_file_name}"), DirLiteralSpec("src/dir")),
             dir_globs=(DirGlobSpec("src/other/"),),
-            file_literals=(FileLiteralSpec(f"src/exists/{build_file_name}"),),
+            file_literals=(FileLiteralSpec(f"src/exists/{build_file_name}.suffix"),),
         ),
         ignores=RawSpecs(
             description_of_origin="CLI arguments",
             dir_literals=(DirLiteralSpec(f"bad/{build_file_name}"), DirLiteralSpec("bad/dir")),
             dir_globs=(DirGlobSpec("bad/other/"),),
-            file_literals=(FileLiteralSpec(f"bad/exists/{build_file_name}"),),
+            file_literals=(FileLiteralSpec(f"bad/exists/{build_file_name}.suffix"),),
         ),
     )
-    resolved = resolve_specs_with_build(specs, build_file_name)
+    build_file_patterns = (build_file_name, f"{build_file_name}.*")
+    resolved = resolve_specs_with_build(specs, build_file_patterns)
 
-    assert resolved.includes.file_literals == (FileLiteralSpec("src/exists"),)
-    assert resolved.ignores.file_literals == (FileLiteralSpec("bad/exists"),)
+    assert resolved.includes.file_literals == tuple()
+    assert resolved.ignores.file_literals == tuple()
 
-    assert resolved.includes.dir_literals == (DirLiteralSpec("src"), DirLiteralSpec("src/dir"))
-    assert resolved.ignores.dir_literals == (DirLiteralSpec("bad"), DirLiteralSpec("bad/dir"))
+    assert resolved.includes.dir_literals == (
+        DirLiteralSpec("src/exists"),
+        DirLiteralSpec("src"),
+        DirLiteralSpec("src/dir"),
+    )
+    assert resolved.ignores.dir_literals == (
+        DirLiteralSpec("bad/exists"),
+        DirLiteralSpec("bad"),
+        DirLiteralSpec("bad/dir"),
+    )
 
     assert resolved.includes.dir_globs == (
         DirGlobSpec("src/other/"),
-    ), "did not passthrough other target"
+    ), "did not passthrough other spec type"
     assert resolved.ignores.dir_globs == (
         DirGlobSpec("bad/other/"),
-    ), "did not passthrough other target"
+    ), "did not passthrough other spec type"

--- a/src/python/pants/core/goals/tailor_test.py
+++ b/src/python/pants/core/goals/tailor_test.py
@@ -10,6 +10,7 @@ from textwrap import dedent
 
 import pytest
 
+from pants.base.specs import DirGlobSpec, DirLiteralSpec, FileLiteralSpec, RawSpecs, Specs
 from pants.core.goals import tailor
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -25,6 +26,7 @@ from pants.core.goals.tailor import (
     default_sources_for_target_type,
     has_source_or_sources_field,
     make_content_str,
+    resolve_specs_with_build,
 )
 from pants.core.util_rules import source_files
 from pants.engine.fs import DigestContents, FileContent, PathGlobs, Paths
@@ -586,3 +588,35 @@ def test_filter_by_ignores() -> None:
         ),
     )
     assert set(result) == set(valid_ptgts)
+
+
+@pytest.mark.parametrize("build_file_name", ["BUILD", "OTHER_NAME"])
+def test_resolve_specs_targetting_build_files(build_file_name) -> None:
+    specs = Specs(
+        includes=RawSpecs(
+            description_of_origin="CLI arguments",
+            dir_literals=(DirLiteralSpec(f"src/{build_file_name}"), DirLiteralSpec("src/dir")),
+            dir_globs=(DirGlobSpec("src/other/"),),
+            file_literals=(FileLiteralSpec(f"src/exists/{build_file_name}"),),
+        ),
+        ignores=RawSpecs(
+            description_of_origin="CLI arguments",
+            dir_literals=(DirLiteralSpec(f"bad/{build_file_name}"), DirLiteralSpec("bad/dir")),
+            dir_globs=(DirGlobSpec("bad/other/"),),
+            file_literals=(FileLiteralSpec(f"bad/exists/{build_file_name}"),),
+        ),
+    )
+    resolved = resolve_specs_with_build(specs, build_file_name)
+
+    assert resolved.includes.file_literals == (FileLiteralSpec("src/exists"),)
+    assert resolved.ignores.file_literals == (FileLiteralSpec("bad/exists"),)
+
+    assert resolved.includes.dir_literals == (DirLiteralSpec("src"), DirLiteralSpec("src/dir"))
+    assert resolved.ignores.dir_literals == (DirLiteralSpec("bad"), DirLiteralSpec("bad/dir"))
+
+    assert resolved.includes.dir_globs == (
+        DirGlobSpec("src/other/"),
+    ), "did not passthrough other target"
+    assert resolved.ignores.dir_globs == (
+        DirGlobSpec("bad/other/"),
+    ), "did not passthrough other target"


### PR DESCRIPTION
Transforms a request to `pants tailor /path/to/BUILD` into `pants tailor /path/to` which is probably what people want.

The wrinkle is that if the BUILD file exists, we need to turn a FileLiteralSpec into DirLiteralSpec.

closes https://github.com/pantsbuild/pants/issues/17868