### PR TITLE
Backport `make_pr.sh` to 2.15.x

### DIFF
--- a/build-support/cherry_pick/make_pr.sh
+++ b/build-support/cherry_pick/make_pr.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -e
+
+function fail {
+  printf '%s\n' "$1" >&2
+  exit "${2-1}"
+}
+
+if [[ -z $(which gh 2> /dev/null) ]]; then
+  fail "Requires the GitHub CLI: https://cli.github.com/"
+fi
+
+if [[ -z $(which jq 2> /dev/null) ]]; then
+  fail "Requires JQ: https://github.com/jqlang/jq"
+fi
+
+PR_NUM=$1
+MILESTONE=$2
+BRANCH_NAME=$3
+
+PR_INFO=$(gh pr view "$PR_NUM" --json title,labels,reviews,body,author)
+
+TITLE=$(echo "$PR_INFO" | jq -r .title)
+AUTHOR=$(echo "$PR_INFO" | jq -r .author.login)
+CATEGORY_LABEL=$(echo "$PR_INFO" | jq -r '.labels[] | select(.name|test("category:.")).name')
+REVIEWERS="$(echo "$PR_INFO" | jq -r '.reviews[].author.login' | tr '\n' ',')$AUTHOR"
+
+BODY_FILE=$(mktemp "/tmp/github.cherrypick.$PR_NUM.XXXXXX")
+echo "$PR_INFO" | jq -r .body > "$BODY_FILE"
+
+ADDITIONAL_ARGS=()
+if [ -n "$BRANCH_NAME" ]; then
+  ADDITIONAL_ARGS=(--head "$BRANCH_NAME")
+fi
+
+gh pr create \
+  --base "$MILESTONE" \
+  --title "$TITLE (Cherry-pick of #$PR_NUM)" \
+  --label "$CATEGORY_LABEL" \
+  --milestone "$MILESTONE" \
+  --body-file "$BODY_FILE" \
+  --reviewer "$REVIEWERS" \
+  "${ADDITIONAL_ARGS[@]}"
+rm "$BODY_FILE"


### PR DESCRIPTION
Partial cherry pick of https://github.com/pantsbuild/pants/commit/d6f6373ad2443672d7cc82f807e0a3f535a073cb and cherry-pick of https://github.com/pantsbuild/pants/commit/68be3f016fabd1df5565a0797176cef397111e50

Needed for users to run it on the branch, which part of the instructions when auto-cherry-picking fails.