### PR TITLE
Pin `test_package_pex_environment`'s image to a particular sha (Cherry-pick of #19324)

### DIFF
--- a/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_build_context_test.py
@@ -393,7 +393,8 @@ def test_packaged_pex_environment(rule_runner: RuleRunner) -> None:
                 """
               docker_environment(
                 name="python_38",
-                image="python:3.8",
+                image="python:3.8-buster@sha256:bc4b9fb034a871b285bea5418cedfcaa9d2ab5590fb5fb6f0c42aaebb2e2c911",
+                platform="linux_x86_64",
                 python_bootstrap_search_path=["<PATH>"],
               )
 
@@ -428,8 +429,8 @@ def test_packaged_pex_environment(rule_runner: RuleRunner) -> None:
     rule_runner.write_digest(context.digest, path_prefix="contents")
     with zipfile.ZipFile(os.path.join(rule_runner.build_root, "contents", pex_file), "r") as zf:
         assert json.loads(zf.read("PEX-INFO"))["distributions"].keys() == {
+            "psutil-5.9.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
             "psutil-5.9.2-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-            "psutil-5.9.2-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
         }
 
 


### PR DESCRIPTION
This pins the docker image used in `src/python/pants/backend/docker/util_rules/docker_build_context_test.py:test_packaged_pex_environment` to https://hub.docker.com/layers/library/python/3.8-buster/images/sha256-bc4b9fb034a871b285bea5418cedfcaa9d2ab5590fb5fb6f0c42aaebb2e2c911?context=explore, which is (at the time of writing) the most recent `3.8-buster` image.

This test has recently started failing with an error when building `psutil`:

```
E         psutil/_psutil_common.c:9:10: fatal error: Python.h: No such file or directory
E             9 | #include <Python.h>
E               |          ^~~~~~~~~~
E         compilation terminated.
E         error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
E         ----------------------------------------
E         ERROR: Failed building wheel for psutil
```

The failure correlates with the change in base image (from buster to bookworm) https://github.com/docker-library/python/pull/822, which seems to have been published at 2023-06-14T23:05Z (https://hub.docker.com/layers/library/python/3.8/images/sha256-b904ee5365f53d19de5ff11c1ce96a616224a55306d55e3cf29a11e969a3a7e0?context=explore).

This change, that pins to the older image, seems to fix the problem.

This fixes https://pantsbuild.slack.com/archives/C0D7TNJHL/p1686790197387729
