### PR TITLE
Remove dependency on `importlib_resources`

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -8,7 +8,6 @@ ansicolors==1.1.8
 chevron==0.14.0
 fasteners==0.16.3
 freezegun==1.2.1
-importlib_resources==5.0.*
 ijson==3.1.4
 packaging==21.3
 pex==2.1.137

--- a/src/python/pants/util/resources.py
+++ b/src/python/pants/util/resources.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 
-import importlib
+import importlib.resources
 from itertools import chain
-
 
 
 def read_resource(package_or_module: str, resource: str) -> bytes:

--- a/src/python/pants/util/resources.py
+++ b/src/python/pants/util/resources.py
@@ -5,7 +5,6 @@
 import importlib
 from itertools import chain
 
-import importlib_resources as resources
 
 
 def read_resource(package_or_module: str, resource: str) -> bytes:
@@ -25,7 +24,7 @@ def read_resource(package_or_module: str, resource: str) -> bytes:
         package = ".".join(chain((package_,), resource_parts[:-1]))
         resource = resource_parts[-1]
 
-    return resources.read_binary(package, resource)
+    return importlib.resources.files(package).joinpath(resource).read_bytes()
 
 
 def read_sibling_resource(sibling_name: str, resource: str) -> bytes:


### PR DESCRIPTION
Now that we know we're at Python 3.9+ we no longer need the backport.