### PR TITLE
Allow loading flake8 configuration from pyproject.toml

### DIFF
--- a/3rdparty/python/flake8-requirements.txt
+++ b/3rdparty/python/flake8-requirements.txt
@@ -2,3 +2,4 @@ flake8>=5.0.4,<7
 flake8-2020>=1.7.0,<2
 flake8-no-implicit-concat
 flake8-comprehensions>=3.10.0,<4.0
+flake8-pyproject>=1.2.3


### PR DESCRIPTION
This commit works around the fact that flake8 doesn't support reading its configuration from pyproject.toml.
The flake8-pyproject plugin allows us to do just that and put all our Python linters-related configurations in one place.