### PR TITLE
Raise AddressCollision error for Docker registries

### DIFF
--- a/src/python/pants/backend/docker/registries.py
+++ b/src/python/pants/backend/docker/registries.py
@@ -24,6 +24,15 @@ class DockerRegistryOptionsNotFoundError(DockerRegistryError):
         )
 
 
+class DockerRegistryAddressCollisionError(DockerRegistryError):
+    def __init__(self, first, second):
+        message = f"Registry addresses must be unique: {first.alias}, {second.alias}. "
+        "Check that each registry in [docker] configuration has a unique "
+        "`address` field."
+
+        super().__init__(message)
+
+
 @dataclass(frozen=True)
 class DockerRegistryOptions:
     address: str
@@ -49,6 +58,9 @@ class DockerRegistryOptions:
         )
 
     def register(self, registries: dict[str, DockerRegistryOptions]) -> None:
+        if self.address in registries:
+            collision = registries[self.address]
+            raise DockerRegistryAddressCollisionError(collision, self)
         registries[self.address] = self
         if self.alias:
             registries[f"@{self.alias}"] = self

--- a/src/python/pants/backend/docker/registries_test.py
+++ b/src/python/pants/backend/docker/registries_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from pants.backend.docker.registries import (
     DockerRegistries,
+    DockerRegistryAddressCollisionError,
     DockerRegistryOptions,
     DockerRegistryOptionsNotFoundError,
 )
@@ -96,3 +97,15 @@ def test_repository() -> None:
     )
     (reg1,) = registries.get("@reg1")
     assert reg1.repository == "{name}/foo"
+
+
+def test_registries_must_be_unique() -> None:
+    with pytest.raises(DockerRegistryAddressCollisionError) as e:
+        DockerRegistries.from_dict(
+            {
+                "reg1": {"address": "mydomain:port"},
+                "reg2": {"address": "mydomain:port"},
+            }
+        )
+
+    assert e.match("Registry addresses must be unique: reg1, reg2.")


### PR DESCRIPTION
Previously, docker registries with the same address would overwrite one another during `register`.

That confused me when I was trying to use registries to group image targets. This commit causes `register` to raise DockerRegistryAddressCollisionError if a user tries to create two registries with the same address.