### PR TITLE
add module mapping for launchdarkly-server-sdk

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -112,6 +112,7 @@ DEFAULT_MODULE_MAPPING = {
     "jack-client": ("jack",),
     "kafka-python": ("kafka",),
     "lark-parser": ("lark",),
+    "launchdarkly-server-sdk": ("ldclient"),
     "mail-parser": ("mailparser",),
     "mysql-connector-python": ("mysql.connector",),
     "opencv-python": ("cv2",),

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -112,7 +112,7 @@ DEFAULT_MODULE_MAPPING = {
     "jack-client": ("jack",),
     "kafka-python": ("kafka",),
     "lark-parser": ("lark",),
-    "launchdarkly-server-sdk": ("ldclient"),
+    "launchdarkly-server-sdk": ("ldclient",),
     "mail-parser": ("mailparser",),
     "mysql-connector-python": ("mysql.connector",),
     "opencv-python": ("cv2",),


### PR DESCRIPTION
This PR adds a [module mapping](https://www.pantsbuild.org/docs/python-third-party-dependencies#use-modules-and-module_mapping-when-the-module-name-is-not-standard) for the [`launchdarkly-server-sdk`](https://pypi.org/project/launchdarkly-server-sdk/) module - used in code, the module is named [`ldclient`](https://github.com/launchdarkly/python-server-sdk/tree/main/ldclient) ([usage docs](https://docs.launchdarkly.com/sdk/server-side/python#getting-started)).

This is my first time making a PR on this project, if there's anything else I should do for this please let me know.