### PR TITLE
Run the deploy_to_s3.py script via Pants.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
-      run: ./src/python/pants_release/deploy_to_s3.py
+      run: ./pants run src/python/pants_release/deploy_to_s3.py
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -119,7 +119,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
-      run: ./src/python/pants_release/deploy_to_s3.py
+      run: ./pants run src/python/pants_release/deploy_to_s3.py
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -178,7 +178,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
-      run: ./src/python/pants_release/deploy_to_s3.py
+      run: ./pants run src/python/pants_release/deploy_to_s3.py
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -237,7 +237,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
-      run: ./src/python/pants_release/deploy_to_s3.py
+      run: ./pants run src/python/pants_release/deploy_to_s3.py
     timeout-minutes: 90
   determine_ref:
     if: github.repository_owner == 'pantsbuild'
@@ -303,7 +303,7 @@ jobs:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy commit mapping to S3
-      run: ./src/python/pants_release/deploy_to_s3.py --scope tags/pantsbuild.pants
+      run: ./pants run src/python/pants_release/deploy_to_s3.py --scope tags/pantsbuild.pants
 name: Release
 'on':
   push:

--- a/src/python/pants_release/common.py
+++ b/src/python/pants_release/common.py
@@ -1,22 +1,6 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-"""Utils for scripts to interface with the outside world.
-
-NB: We intentionally only use the standard library here, rather than using
-Pants code and/or 3rd-party dependencies like `colors`, to ensure that all
-scripts that import this file may still be invoked directly, rather than having
-to run via `./pants run`.
-
-We want to allow direct invocation of scripts for these reasons:
-1) Consistency with how we invoke Bash scripts, which notably may _not_ be ran via `./pants run`.
-2) More ergonomic command line arguments, e.g. `./src/python/pants_release/generate_github_workflows.py [args]`,
-   rather than `./pants run src/python/pants_release:generate_github_workflows -- [args]`.
-3) Avoid undesired dependencies on Pants for certain scripts.
-
-Callers of this file, however, are free to dogfood Pants as they'd like, and any script
-may be called via `./pants run` instead of direct invocation if desired.
-"""
 from __future__ import annotations
 
 import time

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -299,7 +299,7 @@ def deploy_to_s3(
     *,
     scope: str | None = None,
 ) -> Step:
-    run = "./src/python/pants_release/deploy_to_s3.py"
+    run = "./pants run src/python/pants_release/deploy_to_s3.py"
     if scope:
         run = f"{run} --scope {scope}"
     return {


### PR DESCRIPTION
To ensure it sees its imports.

There was a naive attempt to have this and other build-support scripts run independently, but that has not been observed or enforced in practice for a long time, and runs counter to good codebase structure anyway.