### PR TITLE
Pass the Python's `immutable_input_digests` when running a PEX

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -1147,6 +1147,9 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
     append_only_caches = (
         request.pex.python.append_only_caches if request.pex.python else FrozenDict({})
     )
+    immutable_input_digests = (
+        request.pex.python.immutable_input_digests if request.pex.python else FrozenDict({})
+    )
     return Process(
         argv,
         description=request.description,
@@ -1160,7 +1163,10 @@ async def setup_pex_process(request: PexProcess, pex_environment: PexEnvironment
             **complete_pex_env.append_only_caches,
             **append_only_caches,
         },
-        immutable_input_digests=pex_environment.bootstrap_python.immutable_input_digests,
+        immutable_input_digests={
+            **pex_environment.bootstrap_python.immutable_input_digests,
+            **immutable_input_digests,
+        },
         timeout_seconds=request.timeout_seconds,
         execution_slot_variable=request.execution_slot_variable,
         concurrency_available=request.concurrency_available,

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -96,14 +96,14 @@ class PythonExecutable(BinaryPath, EngineAwareReturnType):
     """The BinaryPath of a Python executable for user code, along with some extras."""
 
     append_only_caches: FrozenDict[str, str] = FrozenDict({})
-    immutable_input_digests: FrozenDict[str, str] = FrozenDict({})
+    immutable_input_digests: FrozenDict[str, Digest] = FrozenDict({})
 
     def __init__(
         self,
         path: str,
         fingerprint: str | None = None,
         append_only_caches: Mapping[str, str] = FrozenDict({}),
-        immutable_input_digests: Mapping[str, str] = FrozenDict({}),
+        immutable_input_digests: Mapping[str, Digest] = FrozenDict({}),
     ) -> None:
         object.__setattr__(self, "append_only_caches", FrozenDict(append_only_caches))
         object.__setattr__(self, "immutable_input_digests", FrozenDict(immutable_input_digests))


### PR DESCRIPTION
Fixes #19381