### PR TITLE
Switch auto-cherry-picker conditions

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   prerequisites:
     name: Gather Prerequisites
-    if: (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-cherrypick') ) || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'needs-cherrypick') )
     runs-on: ubuntu-latest
     outputs:
       pr_num: ${{ steps.get-prereqs.outputs.pr_num }}


### PR DESCRIPTION
Benjy had a skipped run on `workflow_dispatch`: https://github.com/pantsbuild/pants/actions/runs/5476540434

I'm wondering if the LHS failed to evaluate,m so I'm swapping the sides to see if that fixes it.

Note this PR should be cherry-picked but I'm not going to label it, so I can test out the manual trigger.