### PR TITLE
Tweak getting-help docs

### DIFF
--- a/docs/markdown/Getting Help/getting-help.md
+++ b/docs/markdown/Getting Help/getting-help.md
@@ -7,20 +7,19 @@ createdAt: "2020-03-23T21:37:03.235Z"
 ---
 The [Pants community](doc:the-pants-community) is friendly, welcoming, and passionate about improving the craft of software engineering. If you need help with anything Pants-related, you've come to the right place.  We'd love to hear from you!
 
+Slack
+-----
+
+The best place to become acquainted with Pants community members, exchange informal chat and ask quick questions is at the project's Slack. You can join using [this link](https://docs.google.com/forms/d/e/1FAIpQLSf9zgf-MXRnVDJbrVEST3urqneq7LCcy0zw8qU-GH4hPMn52A/viewform?usp=sf_link).
+
+We encourage you to introduce yourself in the `#welcome` channel!
+
 Discussions
 ----
 
-The best place to ask technical questions or hold design discussions is via the project's [GitHub Discussions](https://github.com/pantsbuild/pants). While questions, feedback, and design discussions are equally welcome on Slack, *we encourage you to choose Discussions whenever it's likely other users would benefit from persistent access to the conversation*. GitHub Discussions is indexed by search engines, and its content is retained long-term, so this is opportunity to help your fellow Pants users by making it easier for folks to discover supplementary technical information beyond the [docs](https://pantsbuild.org/docs).
+The best place to ask deeper technical questions or hold design discussions is via the project's [GitHub Discussions](https://github.com/pantsbuild/pants). While questions, feedback, and design discussions are equally welcome on Slack, *we encourage you to choose Discussions whenever it's likely other users would benefit from persistent access to the conversation*. GitHub Discussions is indexed by search engines, and its content is retained long-term, so this is opportunity to help your fellow Pants users by making it easier for folks to discover supplementary technical information beyond the [docs](https://pantsbuild.org/docs).
 
 We encourage you to introduce yourself in the [`"welcome"`](https://github.com/pantsbuild/pants/discussions/categories/-welcome) category!
-
-
-Community Chat
------
-
-The best place to become acquainted with Pants community members and exchange informal chat is at the project's Slack. You can join using [this link](https://docs.google.com/forms/d/e/1FAIpQLSf9zgf-MXRnVDJbrVEST3urqneq7LCcy0zw8qU-GH4hPMn52A/viewform?usp=sf_link). *We use Slack's basic tier, which expires messages after a couple months, so usage is best suited to the more ephemeral or informal conversations that are unlikely to have long-term archival value.*
-
-We encourage you to introduce yourself in the `#welcome` channel!
 
 
 Blog

--- a/docs/markdown/Introduction/sponsorship.md
+++ b/docs/markdown/Introduction/sponsorship.md
@@ -2,7 +2,7 @@
 title: "Sponsoring Pants"
 slug: "sponsorship"
 excerpt: "How to support the Pants project financially."
-hidden: true
+hidden: false
 createdAt: "2023-07-05T18:06:00.000Z"
 ---
 
@@ -18,6 +18,8 @@ Corporate Sponsorship
 =====================
 
 Corporate sponsorships are formal agreements with the Pants Build organization. Sponsors receive regular access to project maintainers, privileged support channels, and listings and acknowledgements on our website.
+
+To inquire about corporate sponsorship, please reach out to Benjy Weinberger on [Slack](doc:getting-help#slack).
 
 The corporate sponsorship tiers are:
 


### PR DESCRIPTION
- Change the heading from "Community Chat" back to "Slack".
   This is more evocative, and more specific, and also fixes
   many links we had to the #slack anchor on this page that
   were silently broken when we changed the heading.

- Remove stale reference to the Slack basic plan, now that
   we're on the premium offering.

- Reorder the sections to put Slack ahead of discussions, since
   it is the first port of entry.
    
    Also, make the sponsorships page public.
