### PR TITLE
Refine run_shell_command docs (Cherry-pick of #19413)

### DIFF
--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -90,6 +90,9 @@ class AdhocToolOutputDependenciesField(AdhocToolDependenciesField):
         To enable legacy use cases, if `{AdhocToolExecutionDependenciesField.alias}` is `None`,
         these dependencies will be materialized in the execution sandbox. This behavior is
         deprecated, and will be removed in version 2.17.0.dev0.
+
+        See also `{AdhocToolExecutionDependenciesField.alias}` and
+        `{AdhocToolRunnableDependenciesField.alias}`.
         """
     )
 
@@ -111,6 +114,9 @@ class AdhocToolExecutionDependenciesField(SpecialCasedDependencies):
 
         If this field is specified, dependencies from `{AdhocToolOutputDependenciesField.alias}`
         will not be added to the execution sandbox.
+
+        See also `{AdhocToolOutputDependenciesField.alias}` and
+        `{AdhocToolRunnableDependenciesField.alias}`.
         """
     )
 
@@ -122,7 +128,7 @@ class AdhocToolRunnableDependenciesField(SpecialCasedDependencies):
 
     help = help_text(
         lambda: f"""
-        The execution dependencies for this command.
+        The runnable dependencies for this command.
 
         Dependencies specified here are those required to exist on the `PATH` to make the command
         complete successfully (interpreters specified in a `#!` command, etc). Note that these

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -309,8 +309,36 @@ class ShellCommandExecutionDependenciesField(AdhocToolExecutionDependenciesField
     pass
 
 
+class RunShellCommandExecutionDependenciesField(ShellCommandExecutionDependenciesField):
+    help = help_text(
+        lambda: f"""
+        The execution dependencies for this command.
+
+        Dependencies specified here are those required to make the command complete successfully
+        (e.g. file inputs, packages compiled from other targets, etc), but NOT required to make
+        the outputs of the command useful.
+
+        See also `{RunShellCommandRunnableDependenciesField.alias}`.
+        """
+    )
+
+
 class ShellCommandRunnableDependenciesField(AdhocToolRunnableDependenciesField):
     pass
+
+
+class RunShellCommandRunnableDependenciesField(ShellCommandRunnableDependenciesField):
+    help = help_text(
+        lambda: f"""
+        The runnable dependencies for this command.
+
+        Dependencies specified here are those required to exist on the `PATH` to make the command
+        complete successfully (interpreters specified in a `#!` command, etc). Note that these
+        dependencies will be made available on the `PATH` with the name of the target.
+
+        See also `{RunShellCommandExecutionDependenciesField.alias}`.
+        """
+    )
 
 
 class ShellCommandSourcesField(MultipleSourcesField):
@@ -421,8 +449,8 @@ class ShellCommandRunTarget(Target):
     deprecated_alias_removal_version = "2.18.0.dev0"
     core_fields = (
         *COMMON_TARGET_FIELDS,
-        ShellCommandExecutionDependenciesField,
-        ShellCommandRunnableDependenciesField,
+        RunShellCommandExecutionDependenciesField,
+        RunShellCommandRunnableDependenciesField,
         ShellCommandCommandField,
         RunShellCommandWorkdirField,
     )


### PR DESCRIPTION
This fixes #19347 by excluding references to the not-used `output_dependencies` field in the documentation of the various dependencies fields of `run_shell_command`, as well as making some minor improvements to the docs of `adhoc_tool` and `shell_command`.
