### PR TITLE
Prepare store::remote::ByteStore for other providers

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -42,7 +42,7 @@ use log::{debug, error, warn};
 use parking_lot::Mutex;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use protos::require_digest;
-use store::{Store, StoreError};
+use store::{RemoteOptions, Store, StoreError};
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::task;
 use tokio_stream::wrappers::SignalStream;
@@ -767,22 +767,22 @@ async fn main() {
     Store::local_only(runtime.clone(), store_path).expect("Error making local store.");
   let store = match args.value_of("server-address") {
     Some(address) => local_only_store
-      .into_with_remote(
-        address,
-        args.value_of("remote-instance-name").map(str::to_owned),
-        tls::Config::new_without_mtls(root_ca_certs),
+      .into_with_remote(RemoteOptions {
+        cas_address: address.to_owned(),
+        instance_name: args.value_of("remote-instance-name").map(str::to_owned),
+        tls_config: tls::Config::new_without_mtls(root_ca_certs),
         headers,
-        4 * 1024 * 1024,
-        std::time::Duration::from_secs(5 * 60),
-        1,
-        args
+        chunk_size_bytes: 4 * 1024 * 1024,
+        rpc_timeout: std::time::Duration::from_secs(5 * 60),
+        rpc_retries: 1,
+        rpc_concurrency_limit: args
           .value_of_t::<usize>("rpc-concurrency-limit")
           .expect("Bad rpc-concurrency-limit flag"),
-        None,
-        args
+        capabilities_cell_opt: None,
+        batch_api_size_limit: args
           .value_of_t::<usize>("batch-api-size-limit")
           .expect("Bad batch-api-size-limit flag"),
-      )
+      })
       .expect("Error making remote store"),
     None => local_only_store,
   };

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -48,7 +48,8 @@ use protos::require_digest;
 use serde_derive::Serialize;
 use std::collections::{BTreeMap, BTreeSet};
 use store::{
-  Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest, SubsetParams, UploadSummary,
+  RemoteOptions, Snapshot, SnapshotOps, Store, StoreError, StoreFileByDigest, SubsetParams,
+  UploadSummary,
 };
 use workunit_store::WorkunitStore;
 
@@ -342,7 +343,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
       .map_err(|e| format!("Failed to open/create store for directory {store_dir:?}: {e}"))?;
     let (store_result, store_has_remote) = match top_match.value_of("server-address") {
       Some(cas_address) => {
-        let chunk_size = top_match
+        let chunk_size_bytes = top_match
           .value_of_t::<usize>("chunk-bytes")
           .expect("Bad chunk-bytes flag");
 
@@ -411,31 +412,31 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         }
 
         (
-          local_only.into_with_remote(
-            cas_address,
-            top_match
+          local_only.into_with_remote(RemoteOptions {
+            cas_address: cas_address.to_owned(),
+            instance_name: top_match
               .value_of("remote-instance-name")
               .map(str::to_owned),
             tls_config,
             headers,
-            chunk_size,
+            chunk_size_bytes,
             // This deadline is really only in place because otherwise DNS failures
             // leave this hanging forever.
             //
             // Make fs_util have a very long deadline (because it's not configurable,
             // like it is inside pants).
-            Duration::from_secs(30 * 60),
-            top_match
+            rpc_timeout: Duration::from_secs(30 * 60),
+            rpc_retries: top_match
               .value_of_t::<usize>("rpc-attempts")
               .expect("Bad rpc-attempts flag"),
-            top_match
+            rpc_concurrency_limit: top_match
               .value_of_t::<usize>("rpc-concurrency-limit")
               .expect("Bad rpc-concurrency-limit flag"),
-            None,
-            top_match
+            capabilities_cell_opt: None,
+            batch_api_size_limit: top_match
               .value_of_t::<usize>("batch-api-size-limit")
               .expect("Bad batch-api-size-limit flag"),
-          ),
+          }),
           true,
         )
       }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -376,8 +376,7 @@ impl Store {
   pub fn into_with_remote(self, remote_options: RemoteOptions) -> Result<Store, String> {
     Ok(Store {
       local: self.local,
-      remote: Some(RemoteStore::new(remote::ByteStore::new(
-        remote_options.instance_name.clone(),
+      remote: Some(RemoteStore::new(remote::ByteStore::from_options(
         remote_options,
       )?)),
       immutable_inputs_base: self.immutable_inputs_base,

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -37,7 +37,7 @@ mod snapshot_ops_tests;
 mod snapshot_tests;
 pub use crate::snapshot_ops::{SnapshotOps, SubsetParams};
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::fmt::{self, Debug, Display};
 use std::fs::OpenOptions;
 use std::fs::Permissions as FSPermissions;
@@ -64,7 +64,7 @@ use parking_lot::Mutex;
 use prost::Message;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 use protos::require_digest;
-use remexec::{ServerCapabilities, Tree};
+use remexec::Tree;
 use serde_derive::Serialize;
 use sharded_lmdb::DEFAULT_LEASE_TIME;
 #[cfg(target_os = "macos")]
@@ -84,6 +84,7 @@ mod local;
 pub mod local_tests;
 
 mod remote;
+pub use remote::RemoteOptions;
 #[cfg(test)]
 mod remote_tests;
 
@@ -372,32 +373,12 @@ impl Store {
   /// Add remote storage to a Store. If it is missing a value which it tries to load, it will
   /// attempt to back-fill its local storage from the remote storage.
   ///
-  pub fn into_with_remote(
-    self,
-    cas_address: &str,
-    instance_name: Option<String>,
-    tls_config: grpc_util::tls::Config,
-    headers: BTreeMap<String, String>,
-    chunk_size_bytes: usize,
-    rpc_timeout: Duration,
-    rpc_retries: usize,
-    rpc_concurrency_limit: usize,
-    capabilities_cell_opt: Option<Arc<OnceCell<ServerCapabilities>>>,
-    batch_api_size_limit: usize,
-  ) -> Result<Store, String> {
+  pub fn into_with_remote(self, remote_options: RemoteOptions) -> Result<Store, String> {
     Ok(Store {
       local: self.local,
       remote: Some(RemoteStore::new(remote::ByteStore::new(
-        cas_address,
-        instance_name,
-        tls_config,
-        headers,
-        chunk_size_bytes,
-        rpc_timeout,
-        rpc_retries,
-        rpc_concurrency_limit,
-        capabilities_cell_opt,
-        batch_api_size_limit,
+        remote_options.instance_name.clone(),
+        remote_options,
       )?)),
       immutable_inputs_base: self.immutable_inputs_base,
     })

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -20,6 +20,8 @@ use workunit_store::{in_workunit, ObservationMetric};
 use crate::StoreError;
 
 mod reapi;
+#[cfg(test)]
+mod reapi_tests;
 
 pub type ByteSource = Arc<(dyn Fn(Range<usize>) -> Bytes + Send + Sync + 'static)>;
 

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -117,10 +117,10 @@ impl ByteStore {
   pub async fn store_buffered<WriteToBuffer, WriteResult>(
     &self,
     digest: Digest,
-    mut write_to_buffer: WriteToBuffer,
+    write_to_buffer: WriteToBuffer,
   ) -> Result<(), StoreError>
   where
-    WriteToBuffer: FnMut(std::fs::File) -> WriteResult,
+    WriteToBuffer: FnOnce(std::fs::File) -> WriteResult,
     WriteResult: Future<Output = Result<(), StoreError>>,
   {
     let write_buffer = tempfile::tempfile().map_err(|e| {

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -94,12 +94,20 @@ impl LoadDestination for Vec<u8> {
 }
 
 impl ByteStore {
-  pub fn new(instance_name: Option<String>, options: RemoteOptions) -> Result<ByteStore, String> {
-    let provider = Arc::new(reapi::Provider::new(options)?);
-    Ok(ByteStore {
+  pub fn new(
+    instance_name: Option<String>,
+    provider: Arc<dyn ByteStoreProvider + 'static>,
+  ) -> ByteStore {
+    ByteStore {
       instance_name,
       provider,
-    })
+    }
+  }
+
+  pub fn from_options(options: RemoteOptions) -> Result<ByteStore, String> {
+    let instance_name = options.instance_name.clone();
+    let provider = Arc::new(reapi::Provider::new(options)?);
+    Ok(ByteStore::new(instance_name, provider))
   }
 
   pub(crate) fn chunk_size_bytes(&self) -> usize {

--- a/src/rust/engine/fs/store/src/remote/reapi.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi.rs
@@ -1,11 +1,11 @@
 // Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use std::cmp::min;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::fmt;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use async_oncecell::OnceCell;
 use async_trait::async_trait;
@@ -26,6 +26,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tonic::{Code, Request, Status};
 use workunit_store::{Metric, ObservationMetric};
+
+use crate::RemoteOptions;
 
 use super::{ByteSource, ByteStoreProvider, LoadDestination};
 
@@ -64,32 +66,24 @@ impl std::error::Error for ByteStoreError {}
 impl Provider {
   // TODO: Consider extracting these options to a struct with `impl Default`, similar to
   // `super::LocalOptions`.
-  pub fn new(
-    cas_address: &str,
-    instance_name: Option<String>,
-    tls_config: grpc_util::tls::Config,
-    mut headers: BTreeMap<String, String>,
-    chunk_size_bytes: usize,
-    rpc_timeout: Duration,
-    rpc_retries: usize,
-    rpc_concurrency_limit: usize,
-    capabilities_cell_opt: Option<Arc<OnceCell<ServerCapabilities>>>,
-    batch_api_size_limit: usize,
-  ) -> Result<Provider, String> {
-    let tls_client_config = if cas_address.starts_with("https://") {
-      Some(tls_config.try_into()?)
+  pub fn new(mut options: RemoteOptions) -> Result<Provider, String> {
+    let tls_client_config = if options.cas_address.starts_with("https://") {
+      Some(options.tls_config.try_into()?)
     } else {
       None
     };
 
-    let endpoint =
-      grpc_util::create_endpoint(cas_address, tls_client_config.as_ref(), &mut headers)?;
-    let http_headers = headers_to_http_header_map(&headers)?;
+    let endpoint = grpc_util::create_endpoint(
+      &options.cas_address,
+      tls_client_config.as_ref(),
+      &mut options.headers,
+    )?;
+    let http_headers = headers_to_http_header_map(&options.headers)?;
     let channel = layered_service(
       tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),
-      rpc_concurrency_limit,
+      options.rpc_concurrency_limit,
       http_headers,
-      Some((rpc_timeout, Metric::RemoteStoreRequestTimeouts)),
+      Some((options.rpc_timeout, Metric::RemoteStoreRequestTimeouts)),
     );
 
     let byte_stream_client = Arc::new(ByteStreamClient::new(channel.clone()));
@@ -99,14 +93,16 @@ impl Provider {
     let capabilities_client = Arc::new(CapabilitiesClient::new(channel));
 
     Ok(Provider {
-      instance_name,
-      chunk_size_bytes,
-      _rpc_attempts: rpc_retries + 1,
+      instance_name: options.instance_name,
+      chunk_size_bytes: options.chunk_size_bytes,
+      _rpc_attempts: options.rpc_retries + 1,
       byte_stream_client,
       cas_client,
-      capabilities_cell: capabilities_cell_opt.unwrap_or_else(|| Arc::new(OnceCell::new())),
+      capabilities_cell: options
+        .capabilities_cell_opt
+        .unwrap_or_else(|| Arc::new(OnceCell::new())),
       capabilities_client,
-      batch_api_size_limit,
+      batch_api_size_limit: options.batch_api_size_limit,
     })
   }
 

--- a/src/rust/engine/fs/store/src/remote/reapi_tests.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi_tests.rs
@@ -120,6 +120,30 @@ async fn load_grpc_error() {
   )
 }
 
+#[tokio::test]
+async fn load_existing_wrong_digest_error() {
+  let testdata = TestData::roland();
+  let cas = StubCAS::builder()
+    .unverified_content(
+      TestData::roland().fingerprint(),
+      Bytes::from_static(b"not roland"),
+    )
+    .build();
+
+  let provider = new_provider(&cas);
+  let mut destination = Vec::new();
+
+  let error = provider
+    .load(testdata.digest(), &mut destination)
+    .await
+    .expect_err("Want error");
+
+  assert!(
+    error.contains("Remote CAS gave wrong digest"),
+    "Bad error message, got: {error}"
+  )
+}
+
 fn assert_cas_store(
   cas: &StubCAS,
   fingerprint: Fingerprint,

--- a/src/rust/engine/fs/store/src/remote/reapi_tests.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi_tests.rs
@@ -1,0 +1,276 @@
+// Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use grpc_util::tls;
+use hashing::{Digest, Fingerprint};
+use mock::StubCAS;
+use testutil::data::TestData;
+
+use crate::remote::{ByteStoreProvider, RemoteOptions};
+use crate::tests::{big_file_bytes, big_file_fingerprint, new_cas};
+use crate::MEGABYTES;
+
+use super::reapi::Provider;
+use super::ByteSource;
+
+fn remote_options(
+  cas_address: String,
+  chunk_size_bytes: usize,
+  batch_api_size_limit: usize,
+) -> RemoteOptions {
+  RemoteOptions {
+    cas_address,
+    instance_name: None,
+    tls_config: tls::Config::default(),
+    headers: BTreeMap::new(),
+    chunk_size_bytes,
+    rpc_timeout: Duration::from_secs(5),
+    rpc_retries: 1,
+    rpc_concurrency_limit: 256,
+    capabilities_cell_opt: None,
+    batch_api_size_limit,
+  }
+}
+
+fn new_provider(cas: &StubCAS) -> Provider {
+  Provider::new(remote_options(
+    cas.address(),
+    10 * MEGABYTES,
+    crate::tests::STORE_BATCH_API_SIZE_LIMIT,
+  ))
+  .unwrap()
+}
+
+fn byte_source(bytes: Bytes) -> ByteSource {
+  Arc::new(move |r| bytes.slice(r))
+}
+
+async fn load_test(chunk_size: usize) {
+  let testdata = TestData::roland();
+  let cas = new_cas(chunk_size);
+
+  let provider = new_provider(&cas);
+  let mut destination = Vec::new();
+
+  let found = provider
+    .load(testdata.digest(), &mut destination)
+    .await
+    .unwrap();
+
+  assert!(found);
+  assert_eq!(destination, testdata.bytes());
+}
+
+#[tokio::test]
+async fn load_existing_less_than_one_chunk() {
+  load_test(TestData::roland().bytes().len() + 1).await;
+}
+
+#[tokio::test]
+async fn load_existing_exactly_one_chunk() {
+  load_test(TestData::roland().bytes().len()).await;
+}
+
+#[tokio::test]
+async fn load_existing_multiple_chunks_exact() {
+  load_test(1).await;
+}
+
+#[tokio::test]
+async fn load_existing_multiple_chunks_nonfactor() {
+  load_test(9).await;
+}
+
+#[tokio::test]
+async fn load_missing() {
+  let testdata = TestData::roland();
+  let cas = StubCAS::empty();
+  let provider = new_provider(&cas);
+  let mut destination = Vec::new();
+
+  let found = provider
+    .load(testdata.digest(), &mut destination)
+    .await
+    .unwrap();
+
+  assert!(!found);
+  assert_eq!(destination, Vec::new());
+}
+
+#[tokio::test]
+async fn load_grpc_error() {
+  let testdata = TestData::roland();
+  let cas = StubCAS::cas_always_errors();
+
+  let provider = new_provider(&cas);
+  let mut destination = Vec::new();
+
+  let error = provider
+    .load(testdata.digest(), &mut destination)
+    .await
+    .expect_err("Want error");
+
+  assert!(
+    error.contains("StubCAS is configured to always fail"),
+    "Bad error message, got: {error}"
+  )
+}
+
+fn assert_cas_store(
+  cas: &StubCAS,
+  fingerprint: Fingerprint,
+  bytes: Bytes,
+  chunks: usize,
+  chunk_size: usize,
+) {
+  let blobs = cas.blobs.lock();
+  assert_eq!(blobs.get(&fingerprint), Some(&bytes));
+
+  let write_message_sizes = cas.write_message_sizes.lock();
+  assert_eq!(write_message_sizes.len(), chunks);
+  for &size in write_message_sizes.iter() {
+    assert!(
+      size <= chunk_size,
+      "Size {} should have been <= {}",
+      size,
+      chunk_size
+    );
+  }
+}
+
+#[tokio::test]
+async fn store_bytes_one_chunk() {
+  let testdata = TestData::roland();
+  let cas = StubCAS::empty();
+  let provider = new_provider(&cas);
+
+  provider
+    .store_bytes(testdata.digest(), byte_source(testdata.bytes()))
+    .await
+    .unwrap();
+
+  assert_cas_store(&cas, testdata.fingerprint(), testdata.bytes(), 1, 1024)
+}
+#[tokio::test]
+async fn store_bytes_multiple_chunks() {
+  let cas = StubCAS::empty();
+  let chunk_size = 10 * 1024;
+  let provider = Provider::new(remote_options(
+    cas.address(),
+    chunk_size,
+    0, // disable batch API, force streaming API
+  ))
+  .unwrap();
+
+  let all_the_henries = big_file_bytes();
+  let fingerprint = big_file_fingerprint();
+  let digest = Digest::new(fingerprint, all_the_henries.len());
+
+  provider
+    .store_bytes(digest, byte_source(all_the_henries.clone()))
+    .await
+    .unwrap();
+
+  assert_cas_store(&cas, fingerprint, all_the_henries, 98, chunk_size)
+}
+
+#[tokio::test]
+async fn store_bytes_empty_file() {
+  let testdata = TestData::empty();
+  let cas = StubCAS::empty();
+  let provider = new_provider(&cas);
+
+  provider
+    .store_bytes(testdata.digest(), byte_source(testdata.bytes()))
+    .await
+    .unwrap();
+
+  assert_cas_store(&cas, testdata.fingerprint(), testdata.bytes(), 1, 1024)
+}
+
+#[tokio::test]
+async fn store_bytes_grpc_error() {
+  let testdata = TestData::roland();
+  let cas = StubCAS::cas_always_errors();
+  let provider = new_provider(&cas);
+
+  let error = provider
+    .store_bytes(testdata.digest(), byte_source(testdata.bytes()))
+    .await
+    .expect_err("Want err");
+  assert!(
+    error.contains("StubCAS is configured to always fail"),
+    "Bad error message, got: {error}"
+  );
+}
+
+#[tokio::test]
+async fn store_bytes_connection_error() {
+  let testdata = TestData::roland();
+  let provider = Provider::new(remote_options(
+    "http://doesnotexist.example".to_owned(),
+    10 * MEGABYTES,
+    crate::tests::STORE_BATCH_API_SIZE_LIMIT,
+  ))
+  .unwrap();
+
+  let error = provider
+    .store_bytes(testdata.digest(), byte_source(testdata.bytes()))
+    .await
+    .expect_err("Want err");
+  assert!(
+    error.contains("Unavailable: \"error trying to connect: dns error"),
+    "Bad error message, got: {error}"
+  );
+}
+
+#[tokio::test]
+async fn list_missing_digests_none_missing() {
+  let cas = new_cas(1024);
+
+  let provider = new_provider(&cas);
+
+  assert_eq!(
+    provider
+      .list_missing_digests(&mut vec![TestData::roland().digest()].into_iter())
+      .await,
+    Ok(HashSet::new())
+  )
+}
+
+#[tokio::test]
+async fn list_missing_digests_some_missing() {
+  let cas = StubCAS::empty();
+
+  let provider = new_provider(&cas);
+  let digest = TestData::roland().digest();
+
+  let mut digest_set = HashSet::new();
+  digest_set.insert(digest);
+
+  assert_eq!(
+    provider
+      .list_missing_digests(&mut vec![digest].into_iter())
+      .await,
+    Ok(digest_set)
+  )
+}
+
+#[tokio::test]
+async fn list_missing_digests_grpc_error() {
+  let cas = StubCAS::cas_always_errors();
+  let provider = new_provider(&cas);
+
+  let error = provider
+    .list_missing_digests(&mut vec![TestData::roland().digest()].into_iter())
+    .await
+    .expect_err("Want error");
+  assert!(
+    error.contains("StubCAS is configured to always fail"),
+    "Bad error message, got: {error}"
+  );
+}

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -146,21 +146,18 @@ async fn list_missing_digests_error() {
 }
 
 fn new_byte_store(cas: &StubCAS) -> ByteStore {
-  ByteStore::new(
-    None,
-    RemoteOptions {
-      cas_address: cas.address(),
-      instance_name: None,
-      tls_config: tls::Config::default(),
-      headers: BTreeMap::new(),
-      chunk_size_bytes: 10 * MEGABYTES,
-      rpc_timeout: Duration::from_secs(5),
-      rpc_retries: 1,
-      rpc_concurrency_limit: 256,
-      capabilities_cell_opt: None,
-      batch_api_size_limit: crate::tests::STORE_BATCH_API_SIZE_LIMIT,
-    },
-  )
+  ByteStore::from_options(RemoteOptions {
+    cas_address: cas.address(),
+    instance_name: None,
+    tls_config: tls::Config::default(),
+    headers: BTreeMap::new(),
+    chunk_size_bytes: 10 * MEGABYTES,
+    rpc_timeout: Duration::from_secs(5),
+    rpc_retries: 1,
+    rpc_concurrency_limit: 256,
+    capabilities_cell_opt: None,
+    batch_api_size_limit: crate::tests::STORE_BATCH_API_SIZE_LIMIT,
+  })
   .unwrap()
 }
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -7,12 +7,12 @@ use bytes::Bytes;
 use grpc_util::tls;
 use hashing::Digest;
 use mock::StubCAS;
-use testutil::data::{TestData, TestDirectory};
+use testutil::data::TestData;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use workunit_store::WorkunitStore;
 
 use crate::remote::{ByteStore, RemoteOptions};
-use crate::tests::{big_file_bytes, big_file_fingerprint, new_cas};
+use crate::tests::new_cas;
 use crate::MEGABYTES;
 
 #[tokio::test]
@@ -71,32 +71,6 @@ async fn missing_file() {
 }
 
 #[tokio::test]
-async fn load_directory() {
-  let cas = new_cas(10);
-  let testdir = TestDirectory::containing_roland();
-
-  assert_eq!(
-    load_directory_proto_bytes(&new_byte_store(&cas), testdir.digest()).await,
-    Ok(Some(testdir.bytes()))
-  );
-}
-
-#[tokio::test]
-async fn missing_directory() {
-  let _ = WorkunitStore::setup_for_tests();
-  let cas = StubCAS::empty();
-
-  assert_eq!(
-    load_directory_proto_bytes(
-      &new_byte_store(&cas),
-      TestDirectory::containing_roland().digest()
-    )
-    .await,
-    Ok(None)
-  );
-}
-
-#[tokio::test]
 async fn load_file_grpc_error() {
   let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::cas_always_errors();
@@ -107,67 +81,6 @@ async fn load_file_grpc_error() {
   assert!(
     error.contains("StubCAS is configured to always fail"),
     "Bad error message, got: {error}"
-  )
-}
-
-#[tokio::test]
-async fn load_directory_grpc_error() {
-  let _ = WorkunitStore::setup_for_tests();
-  let cas = StubCAS::cas_always_errors();
-
-  let error = load_directory_proto_bytes(
-    &new_byte_store(&cas),
-    TestDirectory::containing_roland().digest(),
-  )
-  .await
-  .expect_err("Want error");
-  assert!(
-    error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {error}"
-  )
-}
-
-#[tokio::test]
-async fn fetch_less_than_one_chunk() {
-  let testdata = TestData::roland();
-  let cas = new_cas(testdata.bytes().len() + 1);
-
-  assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
-    Ok(Some(testdata.bytes()))
-  )
-}
-
-#[tokio::test]
-async fn fetch_exactly_one_chunk() {
-  let testdata = TestData::roland();
-  let cas = new_cas(testdata.bytes().len());
-
-  assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
-    Ok(Some(testdata.bytes()))
-  )
-}
-
-#[tokio::test]
-async fn fetch_multiple_chunks_exact() {
-  let testdata = TestData::roland();
-  let cas = new_cas(1);
-
-  assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
-    Ok(Some(testdata.bytes()))
-  )
-}
-
-#[tokio::test]
-async fn fetch_multiple_chunks_nonfactor() {
-  let testdata = TestData::roland();
-  let cas = new_cas(9);
-
-  assert_eq!(
-    load_file_bytes(&new_byte_store(&cas), testdata.digest()).await,
-    Ok(Some(testdata.bytes()))
   )
 }
 
@@ -204,62 +117,6 @@ fn remote_options(
 }
 
 #[tokio::test]
-async fn write_file_multiple_chunks() {
-  let _ = WorkunitStore::setup_for_tests();
-  let cas = StubCAS::empty();
-
-  let store = ByteStore::new(
-    None,
-    remote_options(
-      cas.address(),
-      10 * 1024,
-      0, // disable batch API, force streaming API
-    ),
-  )
-  .unwrap();
-
-  let all_the_henries = big_file_bytes();
-
-  let fingerprint = big_file_fingerprint();
-
-  assert_eq!(store.store_bytes(all_the_henries.clone()).await, Ok(()));
-
-  let blobs = cas.blobs.lock();
-  assert_eq!(blobs.get(&fingerprint), Some(&all_the_henries));
-
-  let write_message_sizes = cas.write_message_sizes.lock();
-  assert_eq!(
-    write_message_sizes.len(),
-    98,
-    "Wrong number of chunks uploaded"
-  );
-  for size in write_message_sizes.iter() {
-    assert!(
-      size <= &(10 * 1024),
-      "Size {} should have been <= {}",
-      size,
-      10 * 1024
-    );
-  }
-}
-
-#[tokio::test]
-async fn write_empty_file() {
-  let _ = WorkunitStore::setup_for_tests();
-  let empty_file = TestData::empty();
-  let cas = StubCAS::empty();
-
-  let store = new_byte_store(&cas);
-  assert_eq!(store.store_bytes(empty_file.bytes()).await, Ok(()));
-
-  let blobs = cas.blobs.lock();
-  assert_eq!(
-    blobs.get(&empty_file.fingerprint()),
-    Some(&empty_file.bytes())
-  );
-}
-
-#[tokio::test]
 async fn write_file_errors() {
   let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::cas_always_errors();
@@ -271,28 +128,6 @@ async fn write_file_errors() {
     .expect_err("Want error");
   assert!(
     error.contains("StubCAS is configured to always fail"),
-    "Bad error message, got: {error}"
-  );
-}
-
-#[tokio::test]
-async fn write_connection_error() {
-  let _ = WorkunitStore::setup_for_tests();
-  let store = ByteStore::new(
-    None,
-    remote_options(
-      "http://doesnotexist.example".to_owned(),
-      10 * 1024 * 1024,
-      super::tests::STORE_BATCH_API_SIZE_LIMIT,
-    ),
-  )
-  .unwrap();
-  let error = store
-    .store_bytes(TestData::roland().bytes())
-    .await
-    .expect_err("Want error");
-  assert!(
-    error.contains("Unavailable: \"error trying to connect: dns error"),
     "Bad error message, got: {error}"
   );
 }
@@ -357,17 +192,6 @@ fn new_byte_store(cas: &StubCAS) -> ByteStore {
   .unwrap()
 }
 
-pub async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
-  load_bytes(store, digest).await
-}
-
-pub async fn load_directory_proto_bytes(
-  store: &ByteStore,
-  digest: Digest,
-) -> Result<Option<Bytes>, String> {
-  load_bytes(store, digest).await
-}
-
-async fn load_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
+async fn load_file_bytes(store: &ByteStore, digest: Digest) -> Result<Option<Bytes>, String> {
   store.load_bytes(digest).await
 }

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -14,7 +14,7 @@ use crate::remote::{ByteSource, ByteStore, ByteStoreProvider, LoadDestination};
 use crate::MEGABYTES;
 
 #[tokio::test]
-async fn loads_file() {
+async fn load_bytes_existing() {
   let _ = WorkunitStore::setup_for_tests();
   let testdata = TestData::roland();
   let store = new_byte_store(&testdata);
@@ -26,7 +26,7 @@ async fn loads_file() {
 }
 
 #[tokio::test]
-async fn loads_huge_file_via_temp_file() {
+async fn load_file_existing() {
   // 5MB of data
   let testdata = TestData::new(&"12345".repeat(MEGABYTES));
 
@@ -54,7 +54,7 @@ async fn loads_huge_file_via_temp_file() {
 }
 
 #[tokio::test]
-async fn missing_file() {
+async fn load_bytes_missing() {
   let _ = WorkunitStore::setup_for_tests();
   let (store, _) = empty_byte_store();
 
@@ -65,7 +65,7 @@ async fn missing_file() {
 }
 
 #[tokio::test]
-async fn load_file_grpc_error() {
+async fn load_bytes_provider_error() {
   let _ = WorkunitStore::setup_for_tests();
   let store = byte_store_always_error_provider();
 
@@ -73,7 +73,7 @@ async fn load_file_grpc_error() {
 }
 
 #[tokio::test]
-async fn write_file_one_chunk() {
+async fn store_bytes() {
   let _ = WorkunitStore::setup_for_tests();
   let testdata = TestData::roland();
 
@@ -85,7 +85,7 @@ async fn write_file_one_chunk() {
 }
 
 #[tokio::test]
-async fn write_file_errors() {
+async fn store_bytes_provider_error() {
   let _ = WorkunitStore::setup_for_tests();
   let store = byte_store_always_error_provider();
   assert_error(store.store_bytes(TestData::roland().bytes()).await)
@@ -120,7 +120,7 @@ async fn list_missing_digests_some_missing() {
 }
 
 #[tokio::test]
-async fn list_missing_digests_error() {
+async fn list_missing_digests_provider_error() {
   let _ = WorkunitStore::setup_for_tests();
   let store = byte_store_always_error_provider();
 

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -236,6 +236,23 @@ async fn list_missing_digests_provider_error() {
   )
 }
 
+#[tokio::test]
+async fn file_as_load_destination_reset() {
+  let mut file = mk_tempfile().await;
+  file.write_all(b"initial").await.unwrap();
+
+  file.reset().await.unwrap();
+  assert_file_contents(file, "").await;
+}
+
+#[tokio::test]
+async fn vec_as_load_destination_reset() {
+  let mut vec: Vec<u8> = b"initial".to_vec();
+
+  vec.reset().await.unwrap();
+  assert_eq!(vec, []);
+}
+
 fn new_byte_store(data: &TestData) -> ByteStore {
   let provider = TestProvider::new();
   provider.add(data.bytes());

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use rustls::{ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError};
 use webpki::DNSNameRef;
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Config {
   pub root_ca_certs: Option<Vec<u8>>,
   pub mtls: Option<MtlsConfig>,
@@ -79,6 +79,7 @@ impl TryFrom<Config> for ClientConfig {
   }
 }
 
+#[derive(Clone)]
 pub struct MtlsConfig {
   /// PEM bytes of the private key used for MTLS.
   pub key: Vec<u8>,
@@ -86,6 +87,7 @@ pub struct MtlsConfig {
   pub cert_chain: Vec<u8>,
 }
 
+#[derive(Clone)]
 pub enum CertificateCheck {
   Enabled,
   DangerouslyDisabled,

--- a/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
@@ -16,7 +16,7 @@ use grpc_util::tls;
 use hashing::{Digest, EMPTY_DIGEST};
 use mock::StubCAS;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
-use store::Store;
+use store::{RemoteOptions, Store};
 use testutil::data::{TestData, TestDirectory, TestTree};
 use workunit_store::{RunId, RunningWorkunit, WorkunitStore};
 
@@ -105,18 +105,18 @@ impl StoreSetup {
     let store_dir = store_temp_dir.path().join("store_dir");
     let store = Store::local_only(executor.clone(), store_dir)
       .unwrap()
-      .into_with_remote(
-        &cas.address(),
-        None,
-        tls::Config::default(),
-        BTreeMap::new(),
-        10 * 1024 * 1024,
-        Duration::from_secs(1),
-        1,
-        256,
-        None,
-        4 * 1024 * 1024,
-      )
+      .into_with_remote(RemoteOptions {
+        cas_address: cas.address(),
+        instance_name: None,
+        tls_config: tls::Config::default(),
+        headers: BTreeMap::new(),
+        chunk_size_bytes: 10 * 1024 * 1024,
+        rpc_timeout: Duration::from_secs(1),
+        rpc_retries: 1,
+        rpc_concurrency_limit: 256,
+        capabilities_cell_opt: None,
+        batch_api_size_limit: 4 * 1024 * 1024,
+      })
       .unwrap();
     Self {
       store,


### PR DESCRIPTION
This does preparatory refactoring towards #11149 (and probably also #19049), by adjusting `store::remote::ByteStore` in a few ways to make it easier to plop in new 'providers':

- package the various options for creating a provider into a struct, and a bunch of mechanical refactoring to use that struct
- improved tests:
  - explicit tests for the REAPI provider
  - more extensive exercising of the `ByteStore` interface, including extra tests for combinations like "`load_file` when digest is missing", and (to me) more logical test names
  - testing the 'normal' `ByteStore` interface via fully in-memory simple `Provider` instead of needing to run the `StubCAS`
  - testing some more things at lower levels, like the REAPI provider doing hash verification, the `LoadDestination::reset` methods doing the right thing and `ByteStore::store_buffered`

The commits are mostly individually reviewable, although I'd recommend having a sense of the big picture as described above before going through them one-by-one.

After this, the next steps towards #11149 will be:

1. do something similar for the action cache
2. implement new providers, with some sort of factory function for going from `RemoteOptions` to an appropriate `Arc<dyn ByteStoreProvider + 'static>`
3. expose settings to select and configure those new providers