### PR TITLE
Automate GitHub release creation, with wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,9 +302,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
-    - if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
-        == 'true'
-      name: Publish GitHub Release
+    - name: Publish GitHub Release
       run: gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
   release_info:
     if: github.repository_owner == 'pantsbuild'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Build wheels (Linux-ARM64)
     needs:
-    - determine_ref
+    - release_info
     runs-on:
     - self-hosted
     - Linux
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-        ref: ${{ needs.determine_ref.outputs.build-ref }}
+        ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
@@ -71,7 +71,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Build wheels (Linux-x86_64)
     needs:
-    - determine_ref
+    - release_info
     runs-on:
     - ubuntu-20.04
     steps:
@@ -79,7 +79,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-        ref: ${{ needs.determine_ref.outputs.build-ref }}
+        ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Configure Git
       run: git config --global safe.directory "$GITHUB_WORKSPACE"
     - name: Install rustup
@@ -128,7 +128,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Build wheels (macOS10-15-x86_64)
     needs:
-    - determine_ref
+    - release_info
     runs-on:
     - self-hosted
     - macOS-10.15-X64
@@ -137,7 +137,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-        ref: ${{ needs.determine_ref.outputs.build-ref }}
+        ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
@@ -187,7 +187,7 @@ jobs:
     if: github.repository_owner == 'pantsbuild'
     name: Build wheels (macOS11-ARM64)
     needs:
-    - determine_ref
+    - release_info
     runs-on:
     - self-hosted
     - macOS-11-ARM64
@@ -196,7 +196,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-        ref: ${{ needs.determine_ref.outputs.build-ref }}
+        ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
@@ -239,37 +239,22 @@ jobs:
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
     timeout-minutes: 90
-  determine_ref:
-    if: github.repository_owner == 'pantsbuild'
-    name: Determine the ref to build
-    outputs:
-      build-ref: ${{ steps.determine_ref.outputs.build-ref }}
-      is-release: ${{ steps.determine_ref.outputs.is-release }}
-    runs-on: ubuntu-latest
-    steps:
-    - env:
-        REF: ${{ github.event.inputs.ref }}
-      id: determine_ref
-      name: Determine ref to build
-      run: "if [[ -n \"$REF\" ]]; then\n    ref=\"$REF\"\nelse\n    ref=\"${GITHUB_REF#refs/tags/}\"\
-        \nfi\necho \"build-ref=${ref}\" >> $GITHUB_OUTPUT\nif [[ \"${ref}\" =~ ^release_.+$\
-        \ ]]; then\n    echo \"is-release=true\" >> $GITHUB_OUTPUT\nfi\n"
   publish:
-    if: github.repository_owner == 'pantsbuild' && needs.determine_ref.outputs.is-release
+    if: github.repository_owner == 'pantsbuild' && needs.release_info.outputs.is-release
       == 'true'
     needs:
     - build_wheels_linux_x86_64
     - build_wheels_linux_arm64
     - build_wheels_macos10_15_x86_64
     - build_wheels_macos11_arm64
-    - determine_ref
+    - release_info
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Pants at Release Tag
       uses: actions/checkout@v3
       with:
         fetch-depth: '0'
-        ref: ${{ needs.determine_ref.outputs.build-ref }}
+        ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Set up Python 3.9
       uses: actions/setup-python@v4
       with:
@@ -282,7 +267,7 @@ jobs:
       run: ./pants run src/python/pants_release/release.py -- fetch-and-stabilize
         --dest=dest/pypi_release
     - name: Create Release -> Commit Mapping
-      run: 'tag="${{ needs.determine_ref.outputs.build-ref }}"
+      run: 'tag="${{ needs.release_info.outputs.build-ref }}"
 
         commit="$(git rev-parse ${tag}^{commit})"
 
@@ -317,6 +302,34 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
+  release_info:
+    if: github.repository_owner == 'pantsbuild'
+    name: Determine the ref to build
+    outputs:
+      build-ref: ${{ steps.get_info.outputs.build-ref }}
+      is-release: ${{ steps.get_info.outputs.is-release }}
+    runs-on: ubuntu-latest
+    steps:
+    - env:
+        REF: ${{ github.event.inputs.ref }}
+      id: get_info
+      name: Determine ref to build
+      run: "if [[ -n \"$REF\" ]]; then\n    ref=\"$REF\"\nelse\n    ref=\"${GITHUB_REF#refs/tags/}\"\
+        \nfi\necho \"build-ref=${ref}\" >> $GITHUB_OUTPUT\nif [[ \"${ref}\" =~ ^release_.+$\
+        \ ]]; then\n    echo \"is-release=true\" >> $GITHUB_OUTPUT\nfi\n"
+    - if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
+        == 'true'
+      name: Make GitHub Release
+      run: "GH_RELEASE_ARGS=(\"--notes\" \"\")\nif [[ \"${{ steps.get_info.outputs.is-release\
+        \ }}\" == \"true\" ]]; then\n    GH_RELEASE_ARGS+=(\"--title\" \"${{ steps.get_info.outputs.build-ref\
+        \ }}\")\n    RELEASE_TAG=\"${{ steps.get_info.outputs.build-ref }}\"\n   \
+        \ if [[ ${RELEASE_TAG#release_} =~ [[:alpha:]] ]]; then\n        GH_RELEASE_ARGS+=(\"\
+        --prerelease\")\n    fi\nelse\n    GH_RELEASE_ARGS+=(\"--title\" \"dev_${{\
+        \ steps.get_info.outputs.build-ref }}\")\n    GH_RELEASE_ARGS+=(\"--prerelease\"\
+        )\nfi\n\n# NB: This could be a re-run of a release, in the event a job/step\
+        \ failed.\nif ! gh release view ${{ steps.get_info.outputs.build-ref }} ;\
+        \ then\n    gh release create \"${{ steps.get_info.outputs.build-ref }}\"\
+        \ \"${GH_RELEASE_ARGS[@]}\"\nfi\n"
 name: Release
 'on':
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -320,16 +320,24 @@ jobs:
     - if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
         == 'true'
       name: Make GitHub Release
-      run: "GH_RELEASE_ARGS=(\"--notes\" \"\")\nif [[ \"${{ steps.get_info.outputs.is-release\
-        \ }}\" == \"true\" ]]; then\n    GH_RELEASE_ARGS+=(\"--title\" \"${{ steps.get_info.outputs.build-ref\
-        \ }}\")\n    RELEASE_TAG=\"${{ steps.get_info.outputs.build-ref }}\"\n   \
-        \ if [[ ${RELEASE_TAG#release_} =~ [[:alpha:]] ]]; then\n        GH_RELEASE_ARGS+=(\"\
-        --prerelease\")\n    fi\nelse\n    GH_RELEASE_ARGS+=(\"--title\" \"dev_${{\
-        \ steps.get_info.outputs.build-ref }}\")\n    GH_RELEASE_ARGS+=(\"--prerelease\"\
-        )\nfi\n\n# NB: This could be a re-run of a release, in the event a job/step\
-        \ failed.\nif ! gh release view ${{ steps.get_info.outputs.build-ref }} ;\
-        \ then\n    gh release create \"${{ steps.get_info.outputs.build-ref }}\"\
-        \ \"${GH_RELEASE_ARGS[@]}\"\nfi\n"
+      run: "                        RELEASE_TAG=${{ steps.get_info.outputs.build-ref\
+        \ }}\n                        RELEASE_VERSION=\"${RELEASE_TAG#release_}\"\n\
+        \n                        # NB: This could be a re-run of a release, in the\
+        \ event a job/step failed.\n                        if gh release view $RELEASE_TAG\
+        \ ; then\n                            exit 0\n                        fi\n\
+        \n                        GH_RELEASE_ARGS=(\"--notes\" \"\")\n           \
+        \             GH_RELEASE_ARGS+=(\"--title\" \"$RELEASE_TAG\")\n          \
+        \              if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n          \
+        \                  GH_RELEASE_ARGS+=(\"--prerelease\")\n                 \
+        \       else\n                            STABLE_RELEASE_TAGS=$(gh api -X\
+        \ GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name |\
+        \ sub(\"^release_\"; \"\")')\n                            LATEST_TAG=$(echo\
+        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\n' | sort --version-sort\
+        \ | tail -n 1)\n                            if [[ $RELEASE_TAG == $LATEST_TAG\
+        \ ]]; then\n                                GH_RELEASE_ARGS+=(\"--latest\"\
+        )\n                            fi\n                        fi\n\n        \
+        \                gh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
+        \n"
 name: Release
 'on':
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -310,7 +310,7 @@ jobs:
         '
   release_info:
     if: github.repository_owner == 'pantsbuild'
-    name: Determine the ref to build
+    name: Create draft release and output info
     outputs:
       build-ref: ${{ steps.get_info.outputs.build-ref }}
       is-release: ${{ steps.get_info.outputs.is-release }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -320,23 +320,17 @@ jobs:
     - if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
         == 'true'
       name: Make GitHub Release
-      run: "                        RELEASE_TAG=${{ steps.get_info.outputs.build-ref\
-        \ }}\n                        RELEASE_VERSION=\"${RELEASE_TAG#release_}\"\n\
-        \n                        # NB: This could be a re-run of a release, in the\
-        \ event a job/step failed.\n                        if gh release view $RELEASE_TAG\
-        \ ; then\n                            exit 0\n                        fi\n\
-        \n                        GH_RELEASE_ARGS=(\"--notes\" \"\")\n           \
-        \             GH_RELEASE_ARGS+=(\"--title\" \"$RELEASE_TAG\")\n          \
-        \              if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n          \
-        \                  GH_RELEASE_ARGS+=(\"--prerelease\")\n                 \
-        \       else\n                            STABLE_RELEASE_TAGS=$(gh api -X\
-        \ GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name |\
-        \ sub(\"^release_\"; \"\")')\n                            LATEST_TAG=$(echo\
-        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\n' | sort --version-sort\
-        \ | tail -n 1)\n                            if [[ $RELEASE_TAG == $LATEST_TAG\
-        \ ]]; then\n                                GH_RELEASE_ARGS+=(\"--latest\"\
-        )\n                            fi\n                        fi\n\n        \
-        \                gh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
+      run: "RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}\nRELEASE_VERSION=\"\
+        ${RELEASE_TAG#release_}\"\n\n# NB: This could be a re-run of a release, in\
+        \ the event a job/step failed.\nif gh release view $RELEASE_TAG ; then\n \
+        \   exit 0\nfi\n\nGH_RELEASE_ARGS=(\"--notes\" \"\")\nGH_RELEASE_ARGS+=(\"\
+        --title\" \"$RELEASE_TAG\")\nif [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
+        \    GH_RELEASE_ARGS+=(\"--prerelease\")\nelse\n    STABLE_RELEASE_TAGS=$(gh\
+        \ api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name\
+        \ | sub(\"^release_\"; \"\")')\n    LATEST_TAG=$(echo \"$STABLE_RELEASE_TAGS\
+        \ $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort | tail -n 1)\n    if\
+        \ [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n        GH_RELEASE_ARGS+=(\"--latest\"\
+        )\n    fi\nfi\n\ngh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
         \n"
 name: Release
 'on':

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -302,6 +302,10 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
+    - if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
+        == 'true'
+      name: Publish GitHub Release
+      run: gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
   release_info:
     if: github.repository_owner == 'pantsbuild'
     name: Determine the ref to build
@@ -325,13 +329,14 @@ jobs:
         \ the event a job/step failed.\nif gh release view $RELEASE_TAG ; then\n \
         \   exit 0\nfi\n\nGH_RELEASE_ARGS=(\"--notes\" \"\")\nGH_RELEASE_ARGS+=(\"\
         --title\" \"$RELEASE_TAG\")\nif [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
-        \    GH_RELEASE_ARGS+=(\"--prerelease\")\nelse\n    STABLE_RELEASE_TAGS=$(gh\
-        \ api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name\
-        \ | sub(\"^release_\"; \"\") | select(test(\"^[0-9.]+$\"))')\n    LATEST_TAG=$(echo\
-        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort\
-        \ | tail -n 1)\n    if [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n        GH_RELEASE_ARGS+=(\"\
-        --latest\")\n    fi\nfi\n\ngh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
-        \n"
+        \    GH_RELEASE_ARGS+=(\"--prerelease\")\n    GH_RELEASE_ARGS+=(\"--latest=false\"\
+        )\nelse\n    STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases\
+        \ --jq '.[].tag_name | sub(\"^release_\"; \"\") | select(test(\"^[0-9.]+$\"\
+        ))')\n    LATEST_TAG=$(echo \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' '\
+        \ '\\n' | sort --version-sort | tail -n 1)\n    if [[ $RELEASE_TAG == $LATEST_TAG\
+        \ ]]; then\n        GH_RELEASE_ARGS+=(\"--latest=true\")\n    else\n     \
+        \   GH_RELEASE_ARGS+=(\"--latest=false\")\n    fi\nfi\n\ngh release create\
+        \ \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\" --draft\n"
 name: Release
 'on':
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -303,7 +303,11 @@ jobs:
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
     - name: Publish GitHub Release
-      run: gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
+      run: 'gh release upload ${{ needs.release_info.outputs.build-ref }} dest/pypi_release
+
+        gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
+
+        '
   release_info:
     if: github.repository_owner == 'pantsbuild'
     name: Determine the ref to build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -327,10 +327,10 @@ jobs:
         --title\" \"$RELEASE_TAG\")\nif [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
         \    GH_RELEASE_ARGS+=(\"--prerelease\")\nelse\n    STABLE_RELEASE_TAGS=$(gh\
         \ api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name\
-        \ | sub(\"^release_\"; \"\")')\n    LATEST_TAG=$(echo \"$STABLE_RELEASE_TAGS\
-        \ $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort | tail -n 1)\n    if\
-        \ [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n        GH_RELEASE_ARGS+=(\"--latest\"\
-        )\n    fi\nfi\n\ngh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
+        \ | sub(\"^release_\"; \"\") | select(test(\"^[0-9.]+$\"))')\n    LATEST_TAG=$(echo\
+        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort\
+        \ | tail -n 1)\n    if [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n        GH_RELEASE_ARGS+=(\"\
+        --latest\")\n    fi\nfi\n\ngh release create \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\"\
         \n"
 name: Release
 'on':

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -207,9 +207,7 @@ PANTS_PEX_RELEASE=STABLE ./pants run src/python/pants_release/release.py -- buil
 
 Then:
 
-- Go to <https://github.com/pantsbuild/pants/tags>, find your release's tag and click `Create release from tag`.
-- If this is not the latest stable release, deselect "Set as the latest release".
-- If this is not a stable release, select "Set as a pre-release".
+- Go to <https://github.com/pantsbuild/pants/releases>, find your release.
 - Attach the PEX located at `dist/pex.pants.<version>.pex`.
 - Click "Publish release"
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1073,7 +1073,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                         if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then
                             GH_RELEASE_ARGS+=("--prerelease")
                         else
-                            STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "")')
+                            STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "") | select(test("^[0-9.]+$"))')
                             LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\\n' | sort --version-sort | tail -n 1)
                             if [[ $RELEASE_TAG == $LATEST_TAG ]]; then
                                 GH_RELEASE_ARGS+=("--latest")

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1033,7 +1033,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
     wheels_job_names = tuple(wheels_jobs.keys())
     jobs = {
         "release_info": {
-            "name": "Determine the ref to build",
+            "name": "Create draft release and output info",
             "runs-on": "ubuntu-latest",
             "if": IS_PANTS_OWNER,
             "steps": [

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1170,7 +1170,12 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 ),
                 {
                     "name": "Publish GitHub Release",
-                    "run": "gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false",
+                    "run": dedent(
+                        f"""\
+                        gh release upload {gha_expr("needs.release_info.outputs.build-ref") } {pypi_release_dir}
+                        gh release edit {gha_expr("needs.release_info.outputs.build-ref") } --draft=false
+                        """
+                    ),
                 },
             ],
         },

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1074,7 +1074,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                             GH_RELEASE_ARGS+=("--prerelease")
                         else
                             STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "")')
-                            LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\n' | sort --version-sort | tail -n 1)
+                            LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\\n' | sort --version-sort | tail -n 1)
                             if [[ $RELEASE_TAG == $LATEST_TAG ]]; then
                                 GH_RELEASE_ARGS+=("--latest")
                             fi

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1170,7 +1170,6 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 ),
                 {
                     "name": "Publish GitHub Release",
-                    "if": f"{IS_PANTS_OWNER} && steps.get_info.outputs.is-release == 'true'",
                     "run": "gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false",
                 },
             ],


### PR DESCRIPTION
This change makes it so the "release" job creates the GitHub release automatically, and also uploads the wheels to the release.

Note that the "latest release" tag is supposedly automatically deduced based on the ["date and version"](https://cli.github.com/manual/gh_release_create). Unfortunately, my testing showed that `release_2.17.2` was marked "latest" when released after `2.18.0` (although I was using a single commit for every tag)