### PR TITLE
Upload local Pants PEXs to release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,11 +44,7 @@ jobs:
     - env:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -61,6 +57,21 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
+    - env:
+        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Pants PEX
+      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
+        dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        '
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -103,11 +114,7 @@ jobs:
         go-version: 1.19.5
     - env: {}
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -120,6 +127,20 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
+    - env: {}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Pants PEX
+      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
+        dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        '
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -162,11 +183,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -179,6 +196,21 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Pants PEX
+      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
+        dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        '
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -221,11 +253,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch arm64
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -238,6 +266,21 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
+    - env:
+        ARCHFLAGS: -arch arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
+    - if: needs.release_info.outputs.is-release == 'true'
+      name: Upload Pants PEX
+      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
+        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
+
+        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
+        dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+        '
     timeout-minutes: 90
   determine_ref:
     if: github.repository_owner == 'pantsbuild'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,22 +45,22 @@ jobs:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-Linux-ARM64
+        name: logs-wheels-and-pex-Linux-ARM64
         path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
       run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
@@ -115,21 +115,21 @@ jobs:
     - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env: {}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-Linux-x86_64
+        name: logs-wheels-and-pex-Linux-x86_64
         path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env: {}
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
       run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
@@ -184,22 +184,22 @@ jobs:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-macOS10-15-x86_64
+        name: logs-wheels-and-pex-macOS10-15-x86_64
         path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
       run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
@@ -254,22 +254,22 @@ jobs:
         ARCHFLAGS: -arch arm64
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-macOS11-ARM64
+        name: logs-wheels-and-pex-macOS11-ARM64
         path: .pants.d/*.log
     - env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        ARCHFLAGS: -arch arm64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
       run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -316,17 +316,17 @@ jobs:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-Linux-ARM64
+        name: logs-wheels-and-pex-Linux-ARM64
         path: .pants.d/*.log
-    - env:
-        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -370,16 +370,16 @@ jobs:
     - env: {}
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env: {}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-Linux-x86_64
+        name: logs-wheels-and-pex-Linux-x86_64
         path: .pants.d/*.log
-    - env: {}
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -424,17 +424,17 @@ jobs:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-macOS10-15-x86_64
+        name: logs-wheels-and-pex-macOS10-15-x86_64
         path: .pants.d/*.log
-    - env:
-        ARCHFLAGS: -arch x86_64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -479,17 +479,17 @@ jobs:
         ARCHFLAGS: -arch arm64
       name: Build wheels
       run: ./pants run src/python/pants_release/release.py -- build-wheels
+    - env:
+        ARCHFLAGS: -arch arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     - continue-on-error: true
       if: always()
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-wheels-macOS11-ARM64
+        name: logs-wheels-and-pex-macOS11-ARM64
         path: .pants.d/*.log
-    - env:
-        ARCHFLAGS: -arch arm64
-      name: Build Pants PEX
-      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   check_labels:
     if: github.repository_owner == 'pantsbuild'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -315,11 +315,7 @@ jobs:
     - env:
         PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -327,6 +323,10 @@ jobs:
       with:
         name: logs-wheels-Linux-ARM64
         path: .pants.d/*.log
+    - env:
+        PANTS_CONFIG_FILES: +['pants.ci.toml','pants.ci.aarch64.toml']
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -369,11 +369,7 @@ jobs:
         go-version: 1.19.5
     - env: {}
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -381,6 +377,9 @@ jobs:
       with:
         name: logs-wheels-Linux-x86_64
         path: .pants.d/*.log
+    - env: {}
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -424,11 +423,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch x86_64
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -436,6 +431,10 @@ jobs:
       with:
         name: logs-wheels-macOS10-15-x86_64
         path: .pants.d/*.log
+    - env:
+        ARCHFLAGS: -arch x86_64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -479,11 +478,7 @@ jobs:
     - env:
         ARCHFLAGS: -arch arm64
       name: Build wheels
-      run: './pants run src/python/pants_release/release.py -- build-local-pex
-
-        ./pants run src/python/pants_release/release.py -- build-wheels
-
-        '
+      run: ./pants run src/python/pants_release/release.py -- build-wheels
     - continue-on-error: true
       if: always()
       name: Upload pants.log
@@ -491,6 +486,10 @@ jobs:
       with:
         name: logs-wheels-macOS11-ARM64
         path: .pants.d/*.log
+    - env:
+        ARCHFLAGS: -arch arm64
+      name: Build Pants PEX
+      run: ./pants package src/python/pants:pants-pex
     timeout-minutes: 90
   check_labels:
     if: github.repository_owner == 'pantsbuild'

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -196,24 +196,8 @@ Then, run:
 
 This will tag the release with your PGP key, and push the tag to origin, which will kick off a [`Release` job](https://github.com/pantsbuild/pants/actions/workflows/release.yaml) to build the wheels and publish them to PyPI.
 
-Step 4: Release a Pants PEX
----------------------------
 
-After the [`Release` job](https://github.com/pantsbuild/pants/actions/workflows/release.yaml) for your tag has completed, you should additionally build and publish the "universal" PEX to Github.
-
-```bash
-PANTS_PEX_RELEASE=STABLE ./pants run src/python/pants_release/release.py -- build-universal-pex
-```
-
-Then:
-
-- Go to <https://github.com/pantsbuild/pants/tags>, find your release's tag and click `Create release from tag`.
-- If this is not the latest stable release, deselect "Set as the latest release".
-- If this is not a stable release, select "Set as a pre-release".
-- Attach the PEX located at `dist/pex.pants.<version>.pex`.
-- Click "Publish release"
-
-Step 5: Test the release
+Step 4: Test the release
 ------------------------
 
 Run this script as a basic smoke test:
@@ -224,7 +208,7 @@ Run this script as a basic smoke test:
 
 You should also [check PyPI](https://pypi.org/pypi/pantsbuild.pants) to ensure everything looks good. Click "Release history" to find the version you released, then click it and confirm the changelog is correct on the "Project description" page and that the `macOS` and `manylinux` wheels show up in the "Download files" page. 
 
-Step 6: Announce the change
+Step 5: Announce the change
 ---------------------------
 
 Announce the release to:

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -45,7 +45,9 @@ pex_binary(
     dependencies=[":pants-packaged"],
     script="pants",
     execution_mode="venv",
+    shebang="/usr/bin/env python",
     strip_pex_env=False,
+    layout="zipapp",
 )
 
 # NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building

--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -40,6 +40,14 @@ python_distribution(
     entry_points={"console_scripts": {"pants": "src/python/pants/bin:pants"}},
 )
 
+pex_binary(
+    name="pants-pex",
+    dependencies=[":pants-packaged"],
+    script="pants",
+    execution_mode="venv",
+    strip_pex_env=False,
+)
+
 # NB: we use `dummy.c` to avoid clang/gcc complaining `error: no input files` when building
 # `:pants-packaged`. We don't actually need to use any meaningful file here, though, because we
 # use `entry_points` to link to the actual native code, so clang/gcc do not need to build any

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -852,13 +852,13 @@ def build_wheels_job(
                     "run": "./pants run src/python/pants_release/release.py -- build-wheels",
                     "env": helper.platform_env(),
                 },
-                helper.upload_log_artifacts(name="wheels"),
-                *([deploy_to_s3("Deploy wheels to S3")] if for_deploy_ref else []),
                 {
                     "name": "Build Pants PEX",
                     "run": "./pants package src/python/pants:pants-pex",
                     "env": helper.platform_env(),
                 },
+                helper.upload_log_artifacts(name="wheels-and-pex"),
+                *([deploy_to_s3("Deploy wheels to S3")] if for_deploy_ref else []),
                 *(
                     [
                         {

--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -32,7 +32,7 @@ from pants_release.reversion import reversion
 
 from pants.util.contextutil import temporary_dir
 from pants.util.memo import memoized_property
-from pants.util.strutil import softwrap, strip_prefix
+from pants.util.strutil import softwrap
 
 # -----------------------------------------------------------------------------------------------
 # Pants package definitions
@@ -497,35 +497,6 @@ def create_twine_venv() -> None:
         shutil.rmtree(CONSTANTS.twine_venv_dir)
     bin_dir = create_venv(CONSTANTS.twine_venv_dir)
     subprocess.run([bin_dir / "pip", "install", "--quiet", "twine"], check=True)
-
-
-@contextmanager
-def download_pex_bin() -> Iterator[Path]:
-    """Download PEX and return the path to the binary."""
-    try:
-        pex_version = next(
-            strip_prefix(ln, "pex==").rstrip()
-            for ln in Path("3rdparty/python/requirements.txt").read_text().splitlines()
-            if ln.startswith("pex==")
-        )
-    except (FileNotFoundError, StopIteration) as exc:
-        die(
-            softwrap(
-                f"""
-                Could not find a requirement starting with `pex==` in
-                3rdparty/python/requirements.txt: {repr(exc)}
-                """
-            )
-        )
-
-    with temporary_dir() as tempdir:
-        resp = requests.get(
-            f"https://github.com/pantsbuild/pex/releases/download/v{pex_version}/pex"
-        )
-        resp.raise_for_status()
-        result = Path(tempdir, "pex")
-        result.write_bytes(resp.content)
-        yield result
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -710,85 +710,6 @@ def build_fs_util() -> None:
     green(f"Built fs_util at {dest_dir / 'fs_util'}.")
 
 
-# TODO: We should be using `./pants package` and `pex_binary` for this...If Pants is lacking in
-#  capabilities, we should improve Pants. When porting, using `runtime_package_dependencies` to do
-#  the validation.
-def build_pex(fetch: bool) -> None:
-    stable = os.environ.get("PANTS_PEX_RELEASE", "") == "STABLE"
-    if fetch:
-        # TODO: Support macos and linux arm64.
-        extra_pex_args = [
-            "--python-shebang",
-            "/usr/bin/env python",
-            *(f"--platform={plat}-cp-39-cp39" for plat in ("linux_x86_64", "macosx_11.0_x86_64")),
-        ]
-        pex_name = f"pants.{CONSTANTS.pants_unstable_version}.pex"
-        banner(f"Building {pex_name} by fetching wheels.")
-    else:
-        # TODO: Support macos and linux arm64. Will require qualifying the pex name with the arch.
-        major, minor = sys.version_info[:2]
-        extra_pex_args = [
-            f"--interpreter-constraint=CPython=={major}.{minor}.*",
-            f"--python={sys.executable}",
-        ]
-        plat = os.uname()[0].lower()
-        py = f"cp{major}{minor}"
-        pex_name = f"pants.{CONSTANTS.pants_unstable_version}.{plat}-{py}.pex"
-        banner(f"Building {pex_name} by building wheels.")
-
-    if CONSTANTS.deploy_dir.exists():
-        shutil.rmtree(CONSTANTS.deploy_dir)
-    CONSTANTS.deploy_dir.mkdir(parents=True)
-
-    if fetch:
-        fetch_prebuilt_wheels(CONSTANTS.deploy_dir, include_3rdparty=True)
-        check_pants_wheels_present(CONSTANTS.deploy_dir)
-        if stable:
-            stable_wheel_dir = CONSTANTS.deploy_pants_wheel_dir / CONSTANTS.pants_stable_version
-            reversion_prebuilt_wheels(str(stable_wheel_dir))
-    else:
-        build_pants_wheels()
-        build_3rdparty_wheels()
-
-    # We need to both run Pex and the Pants PEX we build with it with clean environments since we
-    # ourselves may be running via `./pants run ...` which injects confounding environment variables
-    # like PEX_EXTRA_SYS_PATH, PEX_PATH and PEX_ROOT that need not or should not apply to these
-    # sub-processes.
-    env = {k: v for k, v in os.environ.items() if not k.startswith("PEX_")}
-
-    dest = Path("dist") / pex_name
-    with download_pex_bin() as pex_bin:
-        subprocess.run(
-            [
-                sys.executable,
-                str(pex_bin),
-                "-o",
-                str(dest),
-                "--no-build",
-                "--no-pypi",
-                "--disable-cache",
-                "-f",
-                str(CONSTANTS.deploy_pants_wheel_dir / CONSTANTS.pants_unstable_version),
-                "-f",
-                str(CONSTANTS.deploy_3rdparty_wheel_dir / CONSTANTS.pants_unstable_version),
-                "--no-strip-pex-env",
-                "--console-script=pants",
-                *extra_pex_args,
-                f"pantsbuild.pants=={CONSTANTS.pants_unstable_version}",
-                "--venv",
-            ],
-            env=env,
-            check=True,
-        )
-
-    if stable:
-        stable_dest = CONSTANTS.deploy_dir / "pex" / f"pants.{CONSTANTS.pants_stable_version}.pex"
-        stable_dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.rename(stable_dest)
-        dest = stable_dest
-    green(f"Built {dest}")
-
-
 # -----------------------------------------------------------------------------------------------
 # Fetch and stabilize the versions of wheels for publishing
 # -----------------------------------------------------------------------------------------------
@@ -1108,8 +1029,6 @@ def create_parser() -> argparse.ArgumentParser:
     subparsers.add_parser("test-release")
     subparsers.add_parser("build-wheels")
     subparsers.add_parser("build-fs-util")
-    subparsers.add_parser("build-local-pex")
-    subparsers.add_parser("build-universal-pex")
     subparsers.add_parser("validate-freshness")
     subparsers.add_parser("list-prebuilt-wheels")
     subparsers.add_parser("check-pants-wheels")
@@ -1128,10 +1047,6 @@ def main() -> None:
         build_all_wheels()
     if args.command == "build-fs-util":
         build_fs_util()
-    if args.command == "build-local-pex":
-        build_pex(fetch=False)
-    if args.command == "build-universal-pex":
-        build_pex(fetch=True)
     if args.command == "validate-freshness":
         prompt_artifact_freshness()
     if args.command == "list-prebuilt-wheels":


### PR DESCRIPTION
From https://github.com/pantsbuild/pants/discussions/19443 and fixes https://github.com/pantsbuild/pants/issues/18434 (lol)

This change does 2 things:
- Eliminates the PEX building from `release.py` in favor of just `./pants package src/python/pants:pants-pex`. It isn't universal, but we're moving away from the universal PEX.
- Tweaks CI to package this PEX, and if this is a release, upload the PEX to the GitHub release
- (plus docs changes)