### PR TITLE
Use the "package_name" variable to fix an UnboundLocalError. (Cherry-pick of #19433)

### DIFF
--- a/src/python/pants/backend/go/goals/package_binary.py
+++ b/src/python/pants/backend/go/goals/package_binary.py
@@ -93,7 +93,7 @@ async def package_go_binary(field_set: GoBinaryFieldSet) -> BuiltPackage:
         raise ValueError(
             f"{GoThirdPartyPackageTarget.alias if main_pkg.is_third_party else GoPackageTarget.alias} "
             f"target `{main_pkg.address}` is used as the main package for {GoBinaryTarget.alias} target "
-            f"`{field_set.address}` but uses package name `{analysis.name}` instead of `main`. Go "
+            f"`{field_set.address}` but uses package name `{package_name}` instead of `main`. Go "
             "requires that main packages actually use `main` as the package name."
         )
 


### PR DESCRIPTION
### Issue
In a case where a go project is probably misconfigured, the `pants run` command may raise an `UnboundLocalError` exception, obscuring the actual reason why the run command failed.

#### Steps to Reproduce
For a project layout:
```
foo/
  src/
    go/
      foo/
        BUILD
        foo.go
  pants
  pants.toml
```
pants.toml:
```toml
[GLOBAL]
pants_version = "2.16.0"

backend_packages = [
  "pants.backend.experimental.go",
]
```

foo.go:
```go
package foo

func main() {
	println("foo")
}
```

BUILD (how the file got like this is irrelevant 😜)
```
go_mod(name="foo0")
go_binary(name="foo1")
go_package(name="foo2")
```

```bash
$ ./pants run src/go/foo:
12:45:44.09 [INFO] Initialization options changed: reinitializing scheduler...
12:45:45.07 [INFO] Scheduler initialized.
12:45:49.78 [ERROR] 1 Exception encountered:

Engine traceback:
  in `run` goal

UnboundLocalError: local variable 'analysis' referenced before assignment
```

With the `--print-stacktrace` option:
```
$ ./pants --print-stacktrace run src/go/foo:foo
10:55:55.85 [INFO] waiting for pantsd to start...
10:56:00.84 [INFO] waiting for pantsd to start...
10:56:05.76 [INFO] waiting for pantsd to start...
10:56:10.76 [INFO] waiting for pantsd to start...
10:56:11.88 [INFO] pantsd started
10:56:13.10 [INFO] Initializing scheduler...
10:56:14.26 [INFO] Scheduler initialized.
10:56:15.76 [ERROR] 1 Exception encountered:

Engine traceback:
  in select
    ..
  in pants.core.goals.run.run
    `run` goal

Traceback (most recent call last):
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/engine/internals/selectors.py", line 623, in native_engine_generator_send
    res = rule.send(arg) if err is None else rule.throw(throw or err)
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/core/goals/run.py", line 292, in run
    request = await (
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/engine/internals/selectors.py", line 118, in __await__
    result = yield self
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/engine/internals/selectors.py", line 623, in native_engine_generator_send
    res = rule.send(arg) if err is None else rule.throw(throw or err)
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/backend/go/goals/run_binary.py", line 15, in create_go_binary_run_request
    binary = await Get(BuiltPackage, PackageFieldSet, field_set)
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/engine/internals/selectors.py", line 118, in __await__
    result = yield self
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/engine/internals/selectors.py", line 623, in native_engine_generator_send
    res = rule.send(arg) if err is None else rule.throw(throw or err)
  File "/Users/sww/.cache/pants/setup/bootstrap-Darwin-x86_64/pants.lrySlP/install/lib/python3.9/site-packages/pants/backend/go/goals/package_binary.py", line 96, in package_go_binary
    f"`{field_set.address}` but uses package name `{analysis.name}` instead of `main`. Go "
UnboundLocalError: local variable 'analysis' referenced before assignment
```

### Validation
After creating the `pants_from_source` [script](https://www.pantsbuild.org/docs/running-pants-from-sources), I reran the run command with the change in this PR:
```
$  ./pants_from_source run src/go/foo:foo
...
11:02:56.74 [ERROR] 1 Exception encountered:

Engine traceback:
  in `run` goal

ValueError: go_package target `src/go/foo:foo2` is used as the main package for go_binary target `src/go/foo:foo` but uses package name `foo` instead of `main`. Go requires that main packages actually use `main` as the package name.
