### PR TITLE
Fix unwanted line break in remote-caching-execution.md

### DIFF
--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -52,8 +52,7 @@ As a more lightweight solution - for caching only - Pants can use a server provi
 
 Bazel Remote Cache supports local disk, S3, GCS, and Azure Blob storage options - needing only a single lightweight Docker container.
 
-There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but
-they have not, to our knowledge, been tested with Pants.  Let us know if you have any experience with them!
+There are a few [other](https://github.com/bazelbuild/remote-apis) systems and services in this space, but they have not, to our knowledge, been tested with Pants.  Let us know if you have any experience with them!
 
 Resources
 =========


### PR DESCRIPTION
The line break rendered

# Before
![image](https://github.com/pantsbuild/pants/assets/20454870/5369c57c-27a8-43d0-a90f-273b2ca501ce)

# After
![image](https://github.com/pantsbuild/pants/assets/20454870/496c9238-bf4c-4099-b435-a1edf68338a4)

