### PR TITLE
upgrade Rust to v1.71.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -163,7 +163,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 
@@ -233,7 +233,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 
@@ -116,7 +116,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 
@@ -213,7 +213,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 
@@ -403,7 +403,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 
@@ -458,7 +458,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.70.0-*
+        path: '~/.rustup/toolchains/1.71.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.70.0"
+channel = "1.71.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -160,7 +160,7 @@ impl Scheduler {
         items.extend(t.params.keys().map(|k| k.to_value()));
         items.push(v.clone().try_into().unwrap());
       }
-      let mut entry = sizes.entry(k.workunit_name()).or_insert_with(|| (0, 0));
+      let entry = sizes.entry(k.workunit_name()).or_insert_with(|| (0, 0));
       entry.0 += 1;
       entry.1 += {
         std::mem::size_of_val(k)


### PR DESCRIPTION
Upgrade Rust to v1.71.0. The only code change in the PR is to fix "mut unnecessary" error message which this version now detects unlike earlier compiler versions.

Changes in Rust v1.71.0 can be [found here](https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html).

