### PR TITLE
Add build platform and hosts options to docker_image target

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -20,6 +20,7 @@ from pants.backend.docker.registries import DockerRegistries, DockerRegistryOpti
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMixin,
+    DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
     DockerImageContextRootField,
@@ -326,6 +327,8 @@ def get_build_options(
             )
             yield from target[field_type].options(format)
         elif issubclass(field_type, DockerBuildOptionFieldValueMixin):
+            yield from target[field_type].options()
+        elif issubclass(field_type, DockerBuildOptionFieldMultiValueMixin):
             yield from target[field_type].options()
         elif issubclass(field_type, DockerBuildOptionFlagFieldMixin):
             yield from target[field_type].options()

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -312,6 +312,7 @@ def get_build_options(
     context: DockerBuildContext,
     field_set: DockerPackageFieldSet,
     global_target_stage_option: str | None,
+    global_build_hosts_options: dict | None,
     target: Target,
 ) -> Iterator[str]:
     # Build options from target fields inheriting from DockerBuildOptionFieldMixin
@@ -325,7 +326,7 @@ def get_build_options(
                 source=source,
                 error_cls=DockerImageOptionValueError,
             )
-            yield from target[field_type].options(format)
+            yield from target[field_type].options(format, global_build_hosts_options)
         elif issubclass(field_type, DockerBuildOptionFieldValueMixin):
             yield from target[field_type].options()
         elif issubclass(field_type, DockerBuildOptionFieldMultiValueMixin):
@@ -416,6 +417,7 @@ async def build_docker_image(
                 context=context,
                 field_set=field_set,
                 global_target_stage_option=options.build_target_stage,
+                global_build_hosts_options=options.build_hosts,
                 target=wrapped_target.target,
             )
         ),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1010,6 +1010,43 @@ def test_docker_build_ssh_option(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_docker_build_hosts_option(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  extra_build_hosts={"docker": "10.180.0.1", "docker2": "10.180.0.2"},
+                )
+                """
+            ),
+        }
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "build",
+            "--add-host",
+            "docker:10.180.0.1",
+            "--add-host",
+            "docker2:10.180.0.2",
+            "--pull=False",
+            "--tag",
+            "img1:latest",
+            "--file",
+            "docker/test/Dockerfile",
+            ".",
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        process_assertions=check_docker_proc,
+    )
+
+
 def test_docker_build_network_option(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -168,6 +168,7 @@ def assert_build(
         opts.setdefault("default_context_root", "")
         opts.setdefault("build_args", [])
         opts.setdefault("build_target_stage", None)
+        opts.setdefault("build_hosts", None)
         opts.setdefault("build_verbose", False)
         opts.setdefault("env_vars", [])
 
@@ -1011,6 +1012,12 @@ def test_docker_build_ssh_option(rule_runner: RuleRunner) -> None:
 
 
 def test_docker_build_hosts_option(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(
+        [],
+        env={
+            "PANTS_DOCKER_BUILD_HOSTS": '{"global": "9.9.9.9"}',
+        },
+    )
     rule_runner.write_files(
         {
             "docker/test/BUILD": dedent(
@@ -1028,6 +1035,8 @@ def test_docker_build_hosts_option(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "build",
+            "--add-host",
+            "global:9.9.9.9",
             "--add-host",
             "docker:10.180.0.1",
             "--add-host",

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1044,6 +1044,40 @@ def test_docker_build_network_option(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_docker_build_platform_option(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  build_platform=["linux/amd64", "linux/arm64", "linux/arm/v7"],
+                )
+                """
+            ),
+        }
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "build",
+            "--platform=linux/amd64,linux/arm64,linux/arm/v7",
+            "--pull=False",
+            "--tag",
+            "img1:latest",
+            "--file",
+            "docker/test/Dockerfile",
+            ".",
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        process_assertions=check_docker_proc,
+    )
+
+
 def test_docker_build_labels_option(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -175,6 +175,22 @@ class DockerOptions(Subsystem):
             """
         ),
     )
+    build_hosts = DictOption[str](
+        default={},
+        help=softwrap(
+            f"""
+            Hosts entries to be added to the `/etc/hosts` file in all built images.
+
+            Example:
+
+                [{options_scope}]
+                build_hosts = {{"docker": "10.180.0.1", "docker2": "10.180.0.2"}}
+
+            Use the `extra_build_hosts` field on a `docker_image` target for additional
+            image specific host entries.
+            """
+        ),
+    )
     build_verbose = BoolOption(
         default=False,
         help="Whether to log the Docker output to the console. If false, only the image ID is logged.",

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -271,6 +271,23 @@ class DockerImageBuildImageLabelsOptionField(DockerBuildOptionFieldMixin, DictSt
             yield f"{label}={value_formatter(value)}"
 
 
+class DockerImageBuildImageExtraHostsField(DockerBuildOptionFieldMixin, DictStringToStringField):
+    alias = "extra_build_hosts"
+    help = help_text(
+        f"""
+        Extra hosts entries to be added to a container's `/etc/hosts` file.
+
+        #TODO:
+        Use `[docker].build_hosts` to set default host entries for all images.
+        """
+    )
+    docker_build_option = "--add-host"
+
+    def option_values(self, value_formatter: OptionValueFormatter) -> Iterator[str]:
+        for label, value in (self.value or {}).items():
+            yield f"{label}:{value_formatter(value)}"
+
+
 class DockerImageBuildSecretsOptionField(
     AsyncFieldMixin, DockerBuildOptionFieldMixin, DictStringToStringField
 ):
@@ -440,6 +457,7 @@ class DockerImageTarget(Target):
         DockerImageRegistriesField,
         DockerImageRepositoryField,
         DockerImageBuildImageLabelsOptionField,
+        DockerImageBuildImageExtraHostsField,
         DockerImageBuildSecretsOptionField,
         DockerImageBuildSSHOptionField,
         DockerImageSkipPushField,

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -350,6 +350,18 @@ class DockerBuildOptionFieldValueMixin(Field):
             yield f"{self.docker_build_option}={self.value}"
 
 
+class DockerBuildOptionFieldMultiValueMixin(StringSequenceField):
+    """Inherit this mixin class to provide options in the form of `--flag=value1,value2` to `docker
+    build`."""
+
+    docker_build_option: ClassVar[str]
+
+    @final
+    def options(self) -> Iterator[str]:
+        if self.value:
+            yield f"{self.docker_build_option}={','.join(list(self.value))}"
+
+
 class DockerImageBuildPullOptionField(DockerBuildOptionFieldValueMixin, BoolField):
     alias = "pull"
     default = False
@@ -402,6 +414,19 @@ class DockerImageBuildNetworkOptionField(DockerBuildOptionFieldValueMixin, Strin
     docker_build_option = "--network"
 
 
+class DockerImageBuildPlatformOptionField(
+    DockerBuildOptionFieldMultiValueMixin, StringSequenceField
+):
+    alias = "build_platform"
+    default = None
+    help = help_text(
+        """
+        Set the target platform(s) for the build.
+        """
+    )
+    docker_build_option = "--platform"
+
+
 class DockerImageTarget(Target):
     alias = "docker_image"
     core_fields = (
@@ -422,6 +447,7 @@ class DockerImageTarget(Target):
         DockerImageBuildPullOptionField,
         DockerImageBuildSquashOptionField,
         DockerImageBuildNetworkOptionField,
+        DockerImageBuildPlatformOptionField,
         OutputPathField,
         RestartableField,
     )


### PR DESCRIPTION
For #19350.

I plan to add the `--no-cache` option (global & for each image) next to complete that issue. 