### PR TITLE
Add `GH_REPO` to jobs with `gh` calls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,7 @@ jobs:
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
@@ -133,6 +134,7 @@ jobs:
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
@@ -205,6 +207,7 @@ jobs:
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
@@ -277,6 +280,7 @@ jobs:
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
@@ -354,6 +358,7 @@ jobs:
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       name: Publish GitHub Release
       run: 'gh release upload ${{ needs.release_info.outputs.build-ref }} dest/pypi_release
@@ -377,6 +382,7 @@ jobs:
         \nfi\necho \"build-ref=${ref}\" >> $GITHUB_OUTPUT\nif [[ \"${ref}\" =~ ^release_.+$\
         \ ]]; then\n    echo \"is-release=true\" >> $GITHUB_OUTPUT\nfi\n"
     - env:
+        GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
       if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
         == 'true'

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -864,7 +864,10 @@ def build_wheels_job(
                         {
                             "name": "Upload Pants PEX",
                             "if": "needs.release_info.outputs.is-release == 'true'",
-                            "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
+                            "env": {
+                                "GH_TOKEN": "${{ github.token }}",
+                                "GH_REPO": "${{ github.repository }}",
+                            },
                             "run": dedent(
                                 """\
                                 LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')")
@@ -1065,7 +1068,10 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 {
                     "name": "Make GitHub Release",
                     "if": f"{IS_PANTS_OWNER} && steps.get_info.outputs.is-release == 'true'",
-                    "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
+                    "env": {
+                        "GH_TOKEN": "${{ github.token }}",
+                        "GH_REPO": "${{ github.repository }}",
+                    },
                     "run": dedent(
                         """\
                         RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}
@@ -1178,7 +1184,10 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 ),
                 {
                     "name": "Publish GitHub Release",
-                    "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
+                    "env": {
+                        "GH_TOKEN": "${{ github.token }}",
+                        "GH_REPO": "${{ github.repository }}",
+                    },
                     "run": dedent(
                         f"""\
                         gh release upload {gha_expr("needs.release_info.outputs.build-ref") } {pypi_release_dir}

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -864,7 +864,7 @@ def build_wheels_job(
                         {
                             "name": "Upload Pants PEX",
                             "if": "needs.release_info.outputs.is-release == 'true'",
-                            "env": {"GH_TOKEN": "${{ github.token }}"},
+                            "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
                             "run": dedent(
                                 """\
                                 LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')")
@@ -1065,7 +1065,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 {
                     "name": "Make GitHub Release",
                     "if": f"{IS_PANTS_OWNER} && steps.get_info.outputs.is-release == 'true'",
-                    "env": {"GH_TOKEN": "${{ github.token }}"},
+                    "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
                     "run": dedent(
                         """\
                         RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}
@@ -1178,7 +1178,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 ),
                 {
                     "name": "Publish GitHub Release",
-                    "env": {"GH_TOKEN": "${{ github.token }}"},
+                    "env": {"GH_TOKEN": "${{ github.token }}", "GH_REPO": "${{ github.repository }}"},
                     "run": dedent(
                         f"""\
                         gh release upload {gha_expr("needs.release_info.outputs.build-ref") } {pypi_release_dir}


### PR DESCRIPTION
This change adds `GH_REPO: ${{ github.repository }}` env variables to all jobs which calls `gh`. Although not strictly necessary if the job checks out the repo, setting it universally is more robust and is easy.