### PR TITLE
paths: allow finding paths between addresses that expand to multiple targets

### DIFF
--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from collections import deque
+from dataclasses import dataclass
 from typing import Iterable
 
 from pants.base.specs import Specs
@@ -12,11 +13,12 @@ from pants.base.specs_parser import SpecsParser
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     AlwaysTraverseDeps,
     Dependencies,
     DependenciesRequest,
+    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -83,6 +85,49 @@ def find_paths_breadth_first(
             visited_edges.add(current_edge)
 
 
+@dataclass
+class SpecsPaths:
+    paths: list[list[str]]
+
+
+@dataclass(frozen=True)
+class RootDestinationPair:
+    root: Target
+    destination: Target
+
+
+@rule(desc="Get paths between root and destination.")
+async def get_paths_between_root_and_destination(pair: RootDestinationPair) -> SpecsPaths:
+    transitive_targets = await Get(
+        TransitiveTargets,
+        TransitiveTargetsRequest(
+            [pair.root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
+        ),
+    )
+
+    adjacent_targets_per_target = await MultiGet(
+        Get(
+            Targets,
+            DependenciesRequest(
+                tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
+            ),
+        )
+        for tgt in transitive_targets.closure
+    )
+
+    transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
+    adjacency_lists = dict(zip(transitive_targets_closure_addresses, adjacent_targets_per_target))
+
+    spec_paths = []
+    for path in find_paths_breadth_first(
+        adjacency_lists, pair.root.address, pair.destination.address
+    ):
+        spec_path = [address.spec for address in path]
+        spec_paths.append(spec_path)
+
+    return SpecsPaths(paths=spec_paths)
+
+
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
     path_from = paths_subsystem.from_
@@ -117,37 +162,16 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
 
     all_spec_paths = []
     for root in from_tgts:
-        for destination in to_tgts:
-            spec_paths = []
-            transitive_targets = await Get(  # noqa: PNT30: experiment
-                TransitiveTargets,
-                TransitiveTargetsRequest(
-                    [root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
-                ),
+        spec_paths = await MultiGet(  # noqa: PNT30: keep iterating in for loop
+            Get(
+                SpecsPaths,
+                RootDestinationPair,
+                RootDestinationPair(destination=destination, root=root),
             )
-
-            adjacent_targets_per_target = await MultiGet(  # noqa: PNT30: experiment
-                Get(
-                    Targets,
-                    DependenciesRequest(
-                        tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
-                    ),
-                )
-                for tgt in transitive_targets.closure
-            )
-
-            transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
-            adjacency_lists = dict(
-                zip(transitive_targets_closure_addresses, adjacent_targets_per_target)
-            )
-
-            for path in find_paths_breadth_first(
-                adjacency_lists, root.address, destination.address
-            ):
-                spec_path = [address.spec for address in path]
-                spec_paths.append(spec_path)
-
-            all_spec_paths.extend(spec_paths)
+            for destination in to_tgts
+        )
+        for spec_path in spec_paths:
+            all_spec_paths.extend(spec_path.paths)
 
     with paths_subsystem.output(console) as write_stdout:
         write_stdout(json.dumps(all_spec_paths, indent=2) + "\n")

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from collections import deque
+from dataclasses import dataclass
 from typing import Iterable
 
 from pants.base.specs import Specs
@@ -12,11 +13,12 @@ from pants.base.specs_parser import SpecsParser
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
 from pants.engine.target import (
     AlwaysTraverseDeps,
     Dependencies,
     DependenciesRequest,
+    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -83,6 +85,75 @@ def find_paths_breadth_first(
             visited_edges.add(current_edge)
 
 
+@dataclass
+class SpecsPaths:
+    paths: list[list[str]]
+
+
+@dataclass
+class SpecsPathsCollection:
+    spec_paths: list[SpecsPaths]
+
+
+@dataclass(frozen=True)
+class RootDestinationPair:
+    root: Target
+    destination: Target
+
+
+@dataclass(frozen=True)
+class RootDestinationsPair:
+    root: Target
+    destinations: Targets
+
+
+@rule(desc="Get paths between root and destination.")
+async def get_paths_between_root_and_destination(pair: RootDestinationPair) -> SpecsPaths:
+    transitive_targets = await Get(
+        TransitiveTargets,
+        TransitiveTargetsRequest(
+            [pair.root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
+        ),
+    )
+
+    adjacent_targets_per_target = await MultiGet(
+        Get(
+            Targets,
+            DependenciesRequest(
+                tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
+            ),
+        )
+        for tgt in transitive_targets.closure
+    )
+
+    transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
+    adjacency_lists = dict(zip(transitive_targets_closure_addresses, adjacent_targets_per_target))
+
+    spec_paths = []
+    for path in find_paths_breadth_first(
+        adjacency_lists, pair.root.address, pair.destination.address
+    ):
+        spec_path = [address.spec for address in path]
+        spec_paths.append(spec_path)
+
+    return SpecsPaths(paths=spec_paths)
+
+
+@rule("Get paths between root and multiple destinations.")
+async def get_paths_between_root_and_destinations(
+    pair: RootDestinationsPair,
+) -> SpecsPathsCollection:
+    spec_paths = await MultiGet(
+        Get(
+            SpecsPaths,
+            RootDestinationPair,
+            RootDestinationPair(destination=destination, root=pair.root),
+        )
+        for destination in pair.destinations
+    )
+    return SpecsPathsCollection(spec_paths=list(spec_paths))
+
+
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
     path_from = paths_subsystem.from_
@@ -116,38 +187,18 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
     )
 
     all_spec_paths = []
-    for root in from_tgts:
-        for destination in to_tgts:
-            spec_paths = []
-            transitive_targets = await Get(  # noqa: PNT30: ignore
-                TransitiveTargets,
-                TransitiveTargetsRequest(
-                    [root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
-                ),
-            )
+    spec_paths = await MultiGet(
+        Get(
+            SpecsPathsCollection,
+            RootDestinationsPair,
+            RootDestinationsPair(root=root, destinations=to_tgts),
+        )
+        for root in from_tgts
+    )
 
-            adjacent_targets_per_target = await MultiGet(  # noqa: PNT30: ignore
-                Get(
-                    Targets,
-                    DependenciesRequest(
-                        tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
-                    ),
-                )
-                for tgt in transitive_targets.closure
-            )
-
-            transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
-            adjacency_lists = dict(
-                zip(transitive_targets_closure_addresses, adjacent_targets_per_target)
-            )
-
-            for path in find_paths_breadth_first(
-                adjacency_lists, root.address, destination.address
-            ):
-                spec_path = [address.spec for address in path]
-                spec_paths.append(spec_path)
-
-            all_spec_paths.extend(spec_paths)
+    for spec_path in spec_paths:
+        for path in (p.paths for p in spec_path.spec_paths):
+            all_spec_paths.extend(path)
 
     with paths_subsystem.output(console) as write_stdout:
         write_stdout(json.dumps(all_spec_paths, indent=2) + "\n")

--- a/src/python/pants/backend/project_info/paths.py
+++ b/src/python/pants/backend/project_info/paths.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 from collections import deque
-from dataclasses import dataclass
 from typing import Iterable
 
 from pants.base.specs import Specs
@@ -13,12 +12,11 @@ from pants.base.specs_parser import SpecsParser
 from pants.engine.addresses import Address
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, Outputting
-from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule, rule
+from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
 from pants.engine.target import (
     AlwaysTraverseDeps,
     Dependencies,
     DependenciesRequest,
-    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -85,75 +83,6 @@ def find_paths_breadth_first(
             visited_edges.add(current_edge)
 
 
-@dataclass
-class SpecsPaths:
-    paths: list[list[str]]
-
-
-@dataclass
-class SpecsPathsCollection:
-    specpaths: list[SpecsPaths]
-
-
-@dataclass(frozen=True)
-class RootDestinationPair:
-    root: Target
-    destination: Target
-
-
-@dataclass(frozen=True)
-class RootDestinationsPair:
-    root: Target
-    destinations: Targets
-
-
-@rule(desc="Get paths between root and destination.")
-async def get_paths_between_root_and_destination(pair: RootDestinationPair) -> SpecsPaths:
-    transitive_targets = await Get(
-        TransitiveTargets,
-        TransitiveTargetsRequest(
-            [pair.root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
-        ),
-    )
-
-    adjacent_targets_per_target = await MultiGet(
-        Get(
-            Targets,
-            DependenciesRequest(
-                tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
-            ),
-        )
-        for tgt in transitive_targets.closure
-    )
-
-    transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
-    adjacency_lists = dict(zip(transitive_targets_closure_addresses, adjacent_targets_per_target))
-
-    spec_paths = []
-    for path in find_paths_breadth_first(
-        adjacency_lists, pair.root.address, pair.destination.address
-    ):
-        spec_path = [address.spec for address in path]
-        spec_paths.append(spec_path)
-
-    return SpecsPaths(paths=spec_paths)
-
-
-@rule
-async def get_paths_between_root_and_all_destinations(
-    pair: RootDestinationsPair,
-) -> SpecsPathsCollection:
-    spec_paths = await MultiGet(
-        Get(
-            SpecsPaths,
-            RootDestinationPair,
-            RootDestinationPair(destination=destination, root=pair.root),
-        )
-        for destination in pair.destinations
-    )
-    return SpecsPathsCollection(specpaths=list(spec_paths))
-
-
 @goal_rule
 async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
     path_from = paths_subsystem.from_
@@ -187,18 +116,38 @@ async def paths(console: Console, paths_subsystem: PathsSubsystem) -> PathsGoal:
     )
 
     all_spec_paths = []
-    spec_paths = await MultiGet(
-        Get(
-            SpecsPathsCollection,
-            RootDestinationsPair,
-            RootDestinationsPair(root=root, destinations=to_tgts),
-        )
-        for root in from_tgts
-    )
+    for root in from_tgts:
+        for destination in to_tgts:
+            spec_paths = []
+            transitive_targets = await Get(  # noqa: PNT30: ignore
+                TransitiveTargets,
+                TransitiveTargetsRequest(
+                    [root.address], should_traverse_deps_predicate=AlwaysTraverseDeps()
+                ),
+            )
 
-    for spec_path in spec_paths:
-        for path in (p.paths for p in spec_path.specpaths):
-            all_spec_paths.extend(path)
+            adjacent_targets_per_target = await MultiGet(  # noqa: PNT30: ignore
+                Get(
+                    Targets,
+                    DependenciesRequest(
+                        tgt.get(Dependencies), should_traverse_deps_predicate=AlwaysTraverseDeps()
+                    ),
+                )
+                for tgt in transitive_targets.closure
+            )
+
+            transitive_targets_closure_addresses = (t.address for t in transitive_targets.closure)
+            adjacency_lists = dict(
+                zip(transitive_targets_closure_addresses, adjacent_targets_per_target)
+            )
+
+            for path in find_paths_breadth_first(
+                adjacency_lists, root.address, destination.address
+            ):
+                spec_path = [address.spec for address in path]
+                spec_paths.append(spec_path)
+
+            all_spec_paths.extend(spec_paths)
 
     with paths_subsystem.output(console) as write_stdout:
         write_stdout(json.dumps(all_spec_paths, indent=2) + "\n")


### PR DESCRIPTION
The `paths` goal currently expects a single `from` and a single `to` address. This works great for finding all paths in the dependency graph between two individual targets, e.g. a `python_source` or a `python_requirement`. Attempting to find all paths between multiple targets in a directory, however, would fail with an error:

```
$ pants paths --from=src/python/pants/backend/adhoc --to=src/python/pants/backend/project_info
...
pants.build_graph.address.ResolveError: Expected a single target, but was given multiple targets.

Did you mean one of these?

  * src/python/pants/backend/adhoc/__init__.py
  * src/python/pants/backend/adhoc/adhoc_tool.py
  * src/python/pants/backend/adhoc/run_system_binary.py
  * src/python/pants/backend/adhoc/target_types.py
```

This can be solved by running the `paths` goal multiple times, of course, by listing the targets in a directory and then using `paths` goal in a for loop (Bash/Python). This is very expensive, however, as making a Pants call is known to have an overhead (pantsd/scheduler/etc). It's a whole lot cheaper to get all the paths in a single Pants call. 

---

Being able to find all paths between multiple targets would help answering the following questions:

1. How is this Python module connected to a Python package, if at all? 

One can find out if the module is accessing the package by doing `dependencies --transitive` for the module of interest and see if there are any modules from the package of concern. If there's a single module listed, then doing just another manual `paths` invocation is fine. However, if there are multiple modules listed, you'd have to run `paths` for each of them which is, again, very expensive.

2. How tightly are two Python packages connected?

For example, you may want to estimate the refactoring efforts (to make two packages not depend on each other) and for this you need to see how many paths exist between two packages. Currently, obtaining the dependency graph for individual files in one shot (as `{moduleA: [deps], moduleB: [deps]}`) is not possible with Pants (I've solved this with a [plugin](https://pypi.org/project/pants-plugin-dep-graph/)), so you need to run dependencies, transitively for every file of interest, which again has an overhead (one file - one Pants call). Running `pants paths --from=src/libraryA:: --to=src/appB::` would provide all the necessary information in one shot.

3. Dependency grapth analytics. Dumping all the paths in the repo, e.g. between sources and tests, one can find the source modules that has most paths leading to tests (so perhaps needs to be split?), find too long paths (code architecture smell if a module leads to another module through 10+ modules steps?), and many more.

---

After the changes made, these commands produce identical results (i.e. it doesn't matter if a directory is passed or an address (with single or double colon notation):

```
$ pants paths --from=src/python/pants/backend/adhoc --to=src/python/pants/backend/project_info > all.json 
$ pants paths --from=src/python/pants/backend/adhoc:: --to=src/python/pants/backend/project_info:: > all-recursive.json
$ diff all.json all-recursive.json; echo $?
0
```

Running this command consistently takes about 45-50s with nested for loop (the final suggested implementation).

```
pants --no-pantsd --no-local-cache paths --to=src/python/pants/engine/target.py --from=src/python/pants/backend:: > all.json
```

I've experimented using `MultiGet` with multiple rules (please see commit [2](https://github.com/pantsbuild/pants/pull/19482/commits/d4015f590ebac780a6dc41129c232b000de1c393) and [3](https://github.com/pantsbuild/pants/pull/19482/commits/075d18b7ab974052a57929acbcf7d348bbf4a7f8)), but the performance was identical. I therefore suggest to keep the for loops in place for simplicity purposes. Of course happy to switch to a full or partial rule-based implementation, if desired.

---

The paths are still printed in the ASC order based on the length, however, they are grouped. I think if a user dumps multiple paths, the order doesn't have any meaning any longer so we don't have to sort them in any particular way and should keep the current behavior in place.

An example of the output:

```
$ ./pants_from_sources paths --from=tests:: --to=cheeseshop/repository::
  [
    "tests/repository/test_repository.py:tests",
    "cheeseshop/repository/parsing/exceptions.py"
  ],
  [
    "tests/repository/test_repository.py:tests",
    "cheeseshop/repository/repository.py",
    "cheeseshop/repository/parsing/exceptions.py"
  ],
  [
    "tests/repository/test_repository.py:tests",
    "cheeseshop/repository/repository.py",
    "cheeseshop/repository/package.py",
    "cheeseshop/repository/parsing/casts.py",
    "cheeseshop/repository/parsing/exceptions.py"
  ],
  [
    "tests/repository/parsing/test_casts.py:tests",
    "cheeseshop/repository/parsing/casts.py"
  ],
  [
    "tests/repository/parsing/test_casts.py:tests",
    "cheeseshop/repository/parsing/exceptions.py"
  ],
  [
    "tests/repository/parsing/test_casts.py:tests",
    "cheeseshop/repository/parsing/casts.py",
    "cheeseshop/repository/parsing/exceptions.py"
  ]
]
```

---

As a little stress test experiment, I've run:

```

$ pants paths --from=src/python/pants/backend:: --to=src/python/pants/engine:: > huge.json 
(took 11 mins)

$ jq length huge.json                                                                                                                                           
1704925
```