### PR TITLE
Use Pants-sandboxed GH in wheel-build jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,8 +71,8 @@ jobs:
 
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
 
-        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
-        dist/src.python.pants/pants.$LOCAL_TAG.pex
+        pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
+        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
 
         '
     timeout-minutes: 90
@@ -143,8 +143,8 @@ jobs:
 
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
 
-        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
-        dist/src.python.pants/pants.$LOCAL_TAG.pex
+        pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
+        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
 
         '
     timeout-minutes: 90
@@ -216,8 +216,8 @@ jobs:
 
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
 
-        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
-        dist/src.python.pants/pants.$LOCAL_TAG.pex
+        pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
+        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
 
         '
     timeout-minutes: 90
@@ -289,8 +289,8 @@ jobs:
 
         mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
 
-        gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }}
-        dist/src.python.pants/pants.$LOCAL_TAG.pex
+        pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
+        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
 
         '
     timeout-minutes: 90

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -872,7 +872,7 @@ def build_wheels_job(
                                 """\
                                 LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')")
                                 mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-                                gh release upload --no-clobber ${{ needs.release_info.outputs.build-ref }} dist/src.python.pants/pants.$LOCAL_TAG.pex
+                                pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref }} dist/src.python.pants/pants.$LOCAL_TAG.pex
                                 """
                             ),
                         }


### PR DESCRIPTION
This change switches the step that uploads wheels to the GH Release to use a `pants run` GH CLI, since some of them are run in containers that don't contain GH CLI.

