### PR TITLE
Add `bash` to list of tools for GH CLI

### DIFF
--- a/3rdparty/tools/gh/BUILD
+++ b/3rdparty/tools/gh/BUILD
@@ -42,7 +42,7 @@ shell_source(
 shell_command(
     name="extracted-gh",
     command="./extract.sh",
-    tools=["tar", "gzip", "zip", "mv", "mkdir"],
+    tools=["tar", "gzip", "zip", "mv", "mkdir", "bash"],
     execution_dependencies=[":downloaded-gh", ":extract.sh"],
     output_directories=["gh"],
 )


### PR DESCRIPTION
Techincally this shouldn't be needed as we know the script will be run with bash, but otherwise there's an error.

(This worked when I tested it, but then `shellcheck` wanted me to add the she-bang :unamused:)