### PR TITLE
Use `curl` for uploading wheels

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,20 +61,15 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        GH_REPO: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
-      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
-
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        ./pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
-        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        '
+      run: "LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
+        import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')\"\
+        )\nmv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex\n\
+        \ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
+        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
+        \ }}?name=pants.$LOCAL_TAG.pex \\\n    --data-binary \"@dist/src.python.pants/pants.$LOCAL_TAG.pex\"\
+        \n"
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -133,20 +128,15 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        GH_REPO: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
-      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
-
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        ./pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
-        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        '
+      run: "LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
+        import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')\"\
+        )\nmv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex\n\
+        \ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
+        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
+        \ }}?name=pants.$LOCAL_TAG.pex \\\n    --data-binary \"@dist/src.python.pants/pants.$LOCAL_TAG.pex\"\
+        \n"
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -206,20 +196,15 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        GH_REPO: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
-      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
-
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        ./pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
-        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        '
+      run: "LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
+        import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')\"\
+        )\nmv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex\n\
+        \ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
+        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
+        \ }}?name=pants.$LOCAL_TAG.pex \\\n    --data-binary \"@dist/src.python.pants/pants.$LOCAL_TAG.pex\"\
+        \n"
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -279,20 +264,15 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy wheels to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py
-    - env:
-        GH_REPO: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      if: needs.release_info.outputs.is-release == 'true'
+    - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Pants PEX
-      run: 'LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import
-        sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f''cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}'')")
-
-        mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        ./pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref
-        }} dist/src.python.pants/pants.$LOCAL_TAG.pex
-
-        '
+      run: "LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
+        import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')\"\
+        )\nmv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex\n\
+        \ncurl -L --fail \\\n    -X POST \\\n    -H \"Authorization: Bearer ${{ github.token\
+        \ }}\" \\\n    -H \"Content-Type: application/octet-stream\" \\\n    ${{ needs.release_info.outputs.release-asset-upload-url\
+        \ }}?name=pants.$LOCAL_TAG.pex \\\n    --data-binary \"@dist/src.python.pants/pants.$LOCAL_TAG.pex\"\
+        \n"
     timeout-minutes: 90
   publish:
     if: github.repository_owner == 'pantsbuild' && needs.release_info.outputs.is-release
@@ -372,6 +352,8 @@ jobs:
     outputs:
       build-ref: ${{ steps.get_info.outputs.build-ref }}
       is-release: ${{ steps.get_info.outputs.is-release }}
+      release-asset-upload-url: ${{ steps.make_draft_release.release-asset-upload-url
+        }}
     runs-on: ubuntu-latest
     steps:
     - env:
@@ -384,22 +366,26 @@ jobs:
     - env:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
+      id: make_draft_release
       if: github.repository_owner == 'pantsbuild' && steps.get_info.outputs.is-release
         == 'true'
       name: Make GitHub Release
       run: "RELEASE_TAG=${{ steps.get_info.outputs.build-ref }}\nRELEASE_VERSION=\"\
         ${RELEASE_TAG#release_}\"\n\n# NB: This could be a re-run of a release, in\
-        \ the event a job/step failed.\nif gh release view $RELEASE_TAG ; then\n \
-        \   exit 0\nfi\n\nGH_RELEASE_ARGS=(\"--notes\" \"\")\nGH_RELEASE_ARGS+=(\"\
-        --title\" \"$RELEASE_TAG\")\nif [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
-        \    GH_RELEASE_ARGS+=(\"--prerelease\")\n    GH_RELEASE_ARGS+=(\"--latest=false\"\
-        )\nelse\n    STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases\
-        \ --jq '.[].tag_name | sub(\"^release_\"; \"\") | select(test(\"^[0-9.]+$\"\
-        ))')\n    LATEST_TAG=$(echo \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' '\
-        \ '\\n' | sort --version-sort | tail -n 1)\n    if [[ $RELEASE_TAG == $LATEST_TAG\
-        \ ]]; then\n        GH_RELEASE_ARGS+=(\"--latest=true\")\n    else\n     \
-        \   GH_RELEASE_ARGS+=(\"--latest=false\")\n    fi\nfi\n\ngh release create\
-        \ \"$RELEASE_TAG\" \"${GH_RELEASE_ARGS[@]}\" --draft\n"
+        \ the event a job/step failed.\nif ! gh release view $RELEASE_TAG ; then\n\
+        \    GH_RELEASE_ARGS=(\"--notes\" \"\")\n    GH_RELEASE_ARGS+=(\"--title\"\
+        \ \"$RELEASE_TAG\")\n    if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then\n\
+        \        GH_RELEASE_ARGS+=(\"--prerelease\")\n        GH_RELEASE_ARGS+=(\"\
+        --latest=false\")\n    else\n        STABLE_RELEASE_TAGS=$(gh api -X GET -F\
+        \ per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub(\"\
+        ^release_\"; \"\") | select(test(\"^[0-9.]+$\"))')\n        LATEST_TAG=$(echo\
+        \ \"$STABLE_RELEASE_TAGS $RELEASE_TAG\" | tr ' ' '\\n' | sort --version-sort\
+        \ | tail -n 1)\n        if [[ $RELEASE_TAG == $LATEST_TAG ]]; then\n     \
+        \       GH_RELEASE_ARGS+=(\"--latest=true\")\n        else\n            GH_RELEASE_ARGS+=(\"\
+        --latest=false\")\n        fi\n    fi\n\n    gh release create \"$RELEASE_TAG\"\
+        \ \"${GH_RELEASE_ARGS[@]}\" --draft\nfi\n\nASSET_UPLOAD_URL=$(gh release view\
+        \ \"$RELEASE_TAG\" --json uploadUrl --jq '.uploadUrl | sub(\"\\\\{\\\\?.*$\"\
+        ; \"\")')\necho \"release-asset-upload-url=$ASSET_UPLOAD_URL\" >> $GITHUB_OUTPUT\n"
 name: Release
 'on':
   push:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -864,15 +864,21 @@ def build_wheels_job(
                         {
                             "name": "Upload Pants PEX",
                             "if": "needs.release_info.outputs.is-release == 'true'",
-                            "env": {
-                                "GH_TOKEN": "${{ github.token }}",
-                                "GH_REPO": "${{ github.repository }}",
-                            },
+                            # NB: We can't use `gh` or even `./pants run 3rdparty/tools/gh` reliably
+                            #   in this job. Certain variations run on docker images without `gh`,
+                            #   and we could be building on a tag that doesn't have the `pants run <gh>`
+                            #   support. `curl` is a good lowest-common-denominator way to upload the assets.
                             "run": dedent(
                                 """\
                                 LOCAL_TAG=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c "import sys;major, minor = sys.version_info[:2];import os;uname = os.uname();print(f'cp{major}{minor}-{uname.sysname.lower()}_{uname.machine.lower()}')")
                                 mv dist/src.python.pants/pants-pex.pex dist/src.python.pants/pants.$LOCAL_TAG.pex
-                                ./pants run 3rdparty/tools/gh -- release upload --no-clobber ${{ needs.release_info.outputs.build-ref }} dist/src.python.pants/pants.$LOCAL_TAG.pex
+
+                                curl -L --fail \\
+                                    -X POST \\
+                                    -H "Authorization: Bearer ${{ github.token }}" \\
+                                    -H "Content-Type: application/octet-stream" \\
+                                    ${{ needs.release_info.outputs.release-asset-upload-url }}?name=pants.$LOCAL_TAG.pex \\
+                                    --data-binary "@dist/src.python.pants/pants.$LOCAL_TAG.pex"
                                 """
                             ),
                         }
@@ -1067,6 +1073,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 },
                 {
                     "name": "Make GitHub Release",
+                    "id": "make_draft_release",
                     "if": f"{IS_PANTS_OWNER} && steps.get_info.outputs.is-release == 'true'",
                     "env": {
                         "GH_TOKEN": "${{ github.token }}",
@@ -1078,32 +1085,34 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                         RELEASE_VERSION="${RELEASE_TAG#release_}"
 
                         # NB: This could be a re-run of a release, in the event a job/step failed.
-                        if gh release view $RELEASE_TAG ; then
-                            exit 0
-                        fi
-
-                        GH_RELEASE_ARGS=("--notes" "")
-                        GH_RELEASE_ARGS+=("--title" "$RELEASE_TAG")
-                        if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then
-                            GH_RELEASE_ARGS+=("--prerelease")
-                            GH_RELEASE_ARGS+=("--latest=false")
-                        else
-                            STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "") | select(test("^[0-9.]+$"))')
-                            LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\\n' | sort --version-sort | tail -n 1)
-                            if [[ $RELEASE_TAG == $LATEST_TAG ]]; then
-                                GH_RELEASE_ARGS+=("--latest=true")
-                            else
+                        if ! gh release view $RELEASE_TAG ; then
+                            GH_RELEASE_ARGS=("--notes" "")
+                            GH_RELEASE_ARGS+=("--title" "$RELEASE_TAG")
+                            if [[ $RELEASE_VERSION =~ [[:alpha:]] ]]; then
+                                GH_RELEASE_ARGS+=("--prerelease")
                                 GH_RELEASE_ARGS+=("--latest=false")
+                            else
+                                STABLE_RELEASE_TAGS=$(gh api -X GET -F per_page=100 /repos/{owner}/{repo}/releases --jq '.[].tag_name | sub("^release_"; "") | select(test("^[0-9.]+$"))')
+                                LATEST_TAG=$(echo "$STABLE_RELEASE_TAGS $RELEASE_TAG" | tr ' ' '\\n' | sort --version-sort | tail -n 1)
+                                if [[ $RELEASE_TAG == $LATEST_TAG ]]; then
+                                    GH_RELEASE_ARGS+=("--latest=true")
+                                else
+                                    GH_RELEASE_ARGS+=("--latest=false")
+                                fi
                             fi
+
+                            gh release create "$RELEASE_TAG" "${GH_RELEASE_ARGS[@]}" --draft
                         fi
 
-                        gh release create "$RELEASE_TAG" "${GH_RELEASE_ARGS[@]}" --draft
+                        ASSET_UPLOAD_URL=$(gh release view "$RELEASE_TAG" --json uploadUrl --jq '.uploadUrl | sub("\\\\{\\\\?.*$"; "")')
+                        echo "release-asset-upload-url=$ASSET_UPLOAD_URL" >> $GITHUB_OUTPUT
                         """
                     ),
                 },
             ],
             "outputs": {
                 "build-ref": gha_expr("steps.get_info.outputs.build-ref"),
+                "release-asset-upload-url": gha_expr("steps.make_draft_release.release-asset-upload-url"),
                 "is-release": gha_expr("steps.get_info.outputs.is-release"),
             },
         },

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1112,7 +1112,9 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
             ],
             "outputs": {
                 "build-ref": gha_expr("steps.get_info.outputs.build-ref"),
-                "release-asset-upload-url": gha_expr("steps.make_draft_release.release-asset-upload-url"),
+                "release-asset-upload-url": gha_expr(
+                    "steps.make_draft_release.release-asset-upload-url"
+                ),
                 "is-release": gha_expr("steps.get_info.outputs.is-release"),
             },
         },


### PR DESCRIPTION
Ok, given the constraints it's now obvious we can't use `gh` (not in the containers we use to build certain wheels), nor can we use `gh`-provided-by-Pants, as the code checkout will be some tag _before_ the change (and checking out `main` means a rebuild of the engine and possible confusion).

So, switching to `curl` using the code-snippet provided on their [REST API docs](https://docs.github.com/en/rest/releases/assets?apiVersion=2022-11-28#upload-a-release-asset). `curl` is known to be runnable, because an earlier step uses it to download `rustup`.

Additionally, the release job now outputs the upload assets URL so we don't have to look up the release ID. The JSON repsonse looks like: `https://uploads.github.com/repos/pantsbuild/pants/releases/112418611/assets{?name,label}`, so we use the `jq` expression to strip the template bits. I tested the backslash escaping [here](https://github.com/thejcannon/ghatest/actions/runs/5589606931/jobs/10218139198).

Ideally this should be able to be run on older branches :crossed_fingers: 