### PR TITLE
Implement Helm chart versioning

### DIFF
--- a/docs/markdown/Helm/helm-overview.md
+++ b/docs/markdown/Helm/helm-overview.md
@@ -113,6 +113,44 @@ Built Helm chart artifact: testprojects.src.helm.example/example/example-0.2.0.t
 
 The final output folder can customised using the `output_path` field in the `helm_chart` target. Run `pants help helm_chart` for more information.
 
+### Helm chart version
+
+Helm charts are versioned artifacts with the value of the `version` field in `Chart.yaml` determining the actual version of the chart. Pants needs to know the version of a first party chart to be able to build packages and correctly stablish the dependencies among them. By default, Pants will use the value in `Chart.yaml` as the given version of a chart but it also supports overring that value via the `version` field in the `helm_chart` target.
+
+For example, a chart defined as such:
+
+```python src/helm/example/BUILD
+helm_chart()
+```
+```yaml src/helm/example/Chart.yaml
+apiVersion: v2
+description: Example Helm chart
+name: example
+version: 0.1.0
+```
+
+Will be understood to have version `0.1.0` (as read from the Chart.yaml) file. However, if we specify a version in `helm_chart` as follows:
+
+```python src/helm/example/BUILD
+helm_chart(version="1.0.0")
+```
+```yaml src/helm/example/Chart.yaml
+apiVersion: v2
+description: Example Helm chart
+name: example
+version: 0.1.0
+```
+
+Now the value in `Chart.yaml` will be ignored and the chart will be understood to have version `1.0.0`.
+
+Because Pants has support for interpolating values in the target fields, we can also make this version value more dynamic as follows:
+
+```python src/helm/example/BUILD
+helm_chart(version=f"{env('HELM_CHART_VERSION')}")
+```
+
+Now the version value for this chart will be what has been set as the value of the environment variable `HELM_CHART_VERSION`.
+
 Helm Unit tests
 ===============
 
@@ -384,7 +422,7 @@ Managing Chart Dependencies
 
 Helm charts can depend on other charts, whether first-party charts defined in the same repo, or third-party charts published in a registry. Pants uses this dependency information to know when work needs to be re-run. 
 
-> 📘 Chart.yaml version
+> 📘 Chart.yaml API version
 > 
 > To benefit from Pants dependency management and inference in your Helm charts, you will need to use `apiVersion: v2` in your `Chart.yaml` file.
 

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -184,6 +184,18 @@ class HelmChartRepositoryField(StringField):
     )
 
 
+class HelmChartVersionField(StringField):
+    alias = "version"
+    help = help_text(
+        """
+        Version number for the given Helm chart.
+
+        When specified, the version provided in the source Chart.yaml file will be overriden by the value
+        given to this field.
+        """
+    )
+
+
 class HelmChartTarget(Target):
     alias = "helm_chart"
     core_fields = (
@@ -194,6 +206,7 @@ class HelmChartTarget(Target):
         HelmChartOutputPathField,
         HelmChartLintStrictField,
         HelmChartRepositoryField,
+        HelmChartVersionField,
         HelmRegistriesField,
         HelmSkipPushField,
         HelmSkipLintField,
@@ -212,6 +225,7 @@ class HelmChartFieldSet(FieldSet):
     sources: HelmChartSourcesField
     dependencies: HelmChartDependenciesField
     description: DescriptionField
+    version: HelmChartVersionField
 
 
 class AllHelmChartTargets(Targets):

--- a/src/python/pants/backend/helm/util_rules/chart.py
+++ b/src/python/pants/backend/helm/util_rules/chart.py
@@ -186,6 +186,9 @@ async def get_helm_chart(request: HelmChartRequest, subsystem: HelmSubsystem) ->
         Get(HelmChartMetadata, HelmChartMetaSourceField, request.field_set.chart),
     )
 
+    if request.field_set.version.value:
+        chart_info = dataclasses.replace(chart_info, version=request.field_set.version.value)
+
     subcharts_digest = EMPTY_DIGEST
     subcharts = await _find_charts_by_targets(
         dependencies, description_of_origin=f"the `helm_chart` {request.field_set.address}"


### PR DESCRIPTION
As mentioned in the following Slack conversations:
- https://pantsbuild.slack.com/archives/C046T6T9U/p1655829023778059?thread_ts=1655829019.142379&cid=C046T6T9U
- https://pantsbuild.slack.com/archives/C046T6T9U/p1682361743285239

Some users are interested on overriding the version value of first party charts. This PR provides with the ability of doing so via a field in the `helm_chart` target which could be made dynamic by using string interpolation and environment variables.