### PR TITLE
python: add default module mapping of scikit-video Python package

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -234,6 +234,7 @@ DEFAULT_MODULE_MAPPING = {
     "randomwords": ("random_words",),
     "scikit-image": ("skimage",),
     "scikit-learn": ("sklearn",),
+    "scikit-video": ("skvideo",),
     "sseclient-py": ("sseclient",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
     "snowflake-connector-python": ("snowflake.connector",),


### PR DESCRIPTION
Saw a [post](https://www.reddit.com/r/Python/comments/153oomg/comment/jslq9ax/) by a Pants user mentioning that they had to add the module mapping, so updating our default mappings so that no one needs to add more code to their BUILD files :) 

An example of the import: http://www.scikit-video.org/stable/examples/io2.html#ioexampleimages