### PR TITLE
python: remove run_goal_use_sandbox field from python_test target

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -936,7 +936,6 @@ class SkipPythonTestsField(BoolField):
 _PYTHON_TEST_MOVED_FIELDS = (
     PythonTestsDependenciesField,
     PythonResolveField,
-    PythonRunGoalUseSandboxField,
     PythonTestsTimeoutField,
     PythonTestsXdistConcurrencyField,
     PythonTestsBatchCompatibilityTagField,


### PR DESCRIPTION
Experiment