### PR TITLE
Add visibility rules for the python_test targets

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -55,3 +55,23 @@ pex_binary(
 # use `entry_points` to link to the actual native code, so clang/gcc do not need to build any
 # native code. This is just a dummy file.
 resources(name="resources", sources=["py.typed", "dummy.c"])
+
+__dependencies_rules__(
+    (
+        # test modules should not depend on other test modules
+        (python_tests, python_test),
+        "?<python_tests>",
+        "?<python_test>",
+        "//BUILD_ROOT:files",
+        "//pants.toml:files",
+        "conftest.py",
+        "pants/**",
+        "pants-plugins/**",
+        "tests/**",
+        "testprojects/**",
+        "<python_requirement>",
+        "<python_requirements>",
+        "?*",
+    ),
+    ("*", "*"),
+)


### PR DESCRIPTION
I'd like to introduce a few visibility rules that should help us with the time spent running tests. 

With the current state, making a change to a test module that other test modules import from (usually a helper function or two), would cause tests from both modules to be run. This is not always necessary, so a better solution would be to move helpers into a separate module to let both test modules depend on that instead.

Example:

```
$ git --no-pager diff --name-only
src/python/pants/jvm/test/junit_test.py

$ pants --changed-since=HEAD --changed-dependents=transitive list
src/python/pants/backend/kotlin/test:tests
src/python/pants/backend/kotlin/test/junit_test.py:tests
src/python/pants/jvm/test/junit_test.py:tests
```

If we make `src/python/pants/backend/kotlin/test/junit_test.py` stop depending on `src/python/pants/jvm/test/junit_test.py`, then:

```
$ git --no-pager diff --name-only
src/python/pants/jvm/test/junit_test.py

$ pants --changed-since=HEAD --changed-dependents=transitive list                               
src/python/pants/jvm/test/junit_test.py:tests
```

This would, for instance, mean that any changes to a test module (addition of a new test, for instance) would not trigger running tests in another test module wasting time and resources.

---

These are the violations currently found:

```
$ pants lint --only=visibility ::                           
11:49:18.04 [WARN] Dependency rule violation for src/python/pants/backend/terraform/dependencies_test.py:tests's dependency on src/python/pants/backend/terraform/goals/deploy_test.py:tests
11:49:18.04 [WARN] Dependency rule violation for src/python/pants/core/subsystems/python_bootstrap_test.py:tests's dependency on src/python/pants/core/util_rules/asdf_test.py:tests
11:49:18.04 [WARN] Dependency rule violation for src/python/pants/engine/internals/synthetic_targets_test.py:tests's dependency on src/python/pants/engine/internals/specs_rules_test.py:tests
11:49:18.05 [WARN] Dependency rule violation for src/python/pants/jvm/package/war_test.py:tests's dependency on src/python/pants/jvm/shading/rules_integration_test.py:tests
11:49:18.05 [WARN] Dependency rule violation for src/python/pants/backend/go/util_rules/go_bootstrap_test.py:tests's dependency on src/python/pants/core/util_rules/asdf_test.py:tests
11:49:18.05 [WARN] Dependency rule violation for src/python/pants/backend/go/util_rules/goroot_test.py:tests's dependency on src/python/pants/backend/go/util_rules/go_bootstrap_test.py:tests
11:49:18.05 [WARN] Dependency rule violation for src/python/pants/backend/helm/util_rules/post_renderer_test.py:tests's dependency on src/python/pants/backend/helm/util_rules/renderer_test.py:tests
11:49:18.06 [WARN] Dependency rule violation for src/python/pants/backend/kotlin/test/junit_test.py:tests's dependency on src/python/pants/backend/kotlin/compile/kotlinc_test.py:tests
11:49:18.06 [WARN] Dependency rule violation for src/python/pants/backend/kotlin/test/junit_test.py:tests's dependency on src/python/pants/jvm/test/junit_test.py:tests
```

In this PR, I add the rules with the warning only. Once it's merged, I'll refactor the violating test modules and adjust the rule to treat violations as errors failing a build.