### PR TITLE
async-ify some of the bootstrap logic

### DIFF
--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -783,6 +783,7 @@ async fn main() {
           .value_of_t::<usize>("batch-api-size-limit")
           .expect("Bad batch-api-size-limit flag"),
       })
+      .await
       .expect("Error making remote store"),
     None => local_only_store,
   };

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -412,31 +412,33 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
         }
 
         (
-          local_only.into_with_remote(RemoteOptions {
-            cas_address: cas_address.to_owned(),
-            instance_name: top_match
-              .value_of("remote-instance-name")
-              .map(str::to_owned),
-            tls_config,
-            headers,
-            chunk_size_bytes,
-            // This deadline is really only in place because otherwise DNS failures
-            // leave this hanging forever.
-            //
-            // Make fs_util have a very long deadline (because it's not configurable,
-            // like it is inside pants).
-            rpc_timeout: Duration::from_secs(30 * 60),
-            rpc_retries: top_match
-              .value_of_t::<usize>("rpc-attempts")
-              .expect("Bad rpc-attempts flag"),
-            rpc_concurrency_limit: top_match
-              .value_of_t::<usize>("rpc-concurrency-limit")
-              .expect("Bad rpc-concurrency-limit flag"),
-            capabilities_cell_opt: None,
-            batch_api_size_limit: top_match
-              .value_of_t::<usize>("batch-api-size-limit")
-              .expect("Bad batch-api-size-limit flag"),
-          }),
+          local_only
+            .into_with_remote(RemoteOptions {
+              cas_address: cas_address.to_owned(),
+              instance_name: top_match
+                .value_of("remote-instance-name")
+                .map(str::to_owned),
+              tls_config,
+              headers,
+              chunk_size_bytes,
+              // This deadline is really only in place because otherwise DNS failures
+              // leave this hanging forever.
+              //
+              // Make fs_util have a very long deadline (because it's not configurable,
+              // like it is inside pants).
+              rpc_timeout: Duration::from_secs(30 * 60),
+              rpc_retries: top_match
+                .value_of_t::<usize>("rpc-attempts")
+                .expect("Bad rpc-attempts flag"),
+              rpc_concurrency_limit: top_match
+                .value_of_t::<usize>("rpc-concurrency-limit")
+                .expect("Bad rpc-concurrency-limit flag"),
+              capabilities_cell_opt: None,
+              batch_api_size_limit: top_match
+                .value_of_t::<usize>("batch-api-size-limit")
+                .expect("Bad batch-api-size-limit flag"),
+            })
+            .await,
           true,
         )
       }

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -373,12 +373,12 @@ impl Store {
   /// Add remote storage to a Store. If it is missing a value which it tries to load, it will
   /// attempt to back-fill its local storage from the remote storage.
   ///
-  pub fn into_with_remote(self, remote_options: RemoteOptions) -> Result<Store, String> {
+  pub async fn into_with_remote(self, remote_options: RemoteOptions) -> Result<Store, String> {
     Ok(Store {
       local: self.local,
-      remote: Some(RemoteStore::new(remote::ByteStore::from_options(
-        remote_options,
-      )?)),
+      remote: Some(RemoteStore::new(
+        remote::ByteStore::from_options(remote_options).await?,
+      )),
       immutable_inputs_base: self.immutable_inputs_base,
     })
   }

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -104,9 +104,9 @@ impl ByteStore {
     }
   }
 
-  pub fn from_options(options: RemoteOptions) -> Result<ByteStore, String> {
+  pub async fn from_options(options: RemoteOptions) -> Result<ByteStore, String> {
     let instance_name = options.instance_name.clone();
-    let provider = Arc::new(reapi::Provider::new(options)?);
+    let provider = Arc::new(reapi::Provider::new(options).await?);
     Ok(ByteStore::new(instance_name, provider))
   }
 

--- a/src/rust/engine/fs/store/src/remote/reapi.rs
+++ b/src/rust/engine/fs/store/src/remote/reapi.rs
@@ -66,7 +66,7 @@ impl std::error::Error for ByteStoreError {}
 impl Provider {
   // TODO: Consider extracting these options to a struct with `impl Default`, similar to
   // `super::LocalOptions`.
-  pub fn new(mut options: RemoteOptions) -> Result<Provider, String> {
+  pub async fn new(mut options: RemoteOptions) -> Result<Provider, String> {
     let tls_client_config = if options.cas_address.starts_with("https://") {
       Some(options.tls_config.try_into()?)
     } else {
@@ -77,7 +77,8 @@ impl Provider {
       &options.cas_address,
       tls_client_config.as_ref(),
       &mut options.headers,
-    )?;
+    )
+    .await?;
     let http_headers = headers_to_http_header_map(&options.headers)?;
     let channel = layered_service(
       tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),

--- a/src/rust/engine/fs/store/src/remote_tests.rs
+++ b/src/rust/engine/fs/store/src/remote_tests.rs
@@ -39,6 +39,7 @@ async fn smoke_test_from_options_reapi_provider() {
     capabilities_cell_opt: None,
     batch_api_size_limit: crate::tests::STORE_BATCH_API_SIZE_LIMIT,
   })
+  .await
   .unwrap();
 
   let mut missing_set = HashSet::new();

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -114,7 +114,7 @@ fn remote_options(
 ///
 /// Create a new store with a remote CAS.
 ///
-fn new_store<P: AsRef<Path>>(dir: P, cas_address: &str) -> Store {
+async fn new_store<P: AsRef<Path>>(dir: P, cas_address: &str) -> Store {
   Store::local_only(task_executor::Executor::new(), dir)
     .unwrap()
     .into_with_remote(remote_options(
@@ -122,6 +122,7 @@ fn new_store<P: AsRef<Path>>(dir: P, cas_address: &str) -> Store {
       None,
       BTreeMap::new(),
     ))
+    .await
     .unwrap()
 }
 
@@ -143,7 +144,11 @@ async fn load_file_prefers_local() {
 
   let cas = new_cas(1024);
   assert_eq!(
-    load_file_bytes(&new_store(dir.path(), &cas.address()), testdata.digest()).await,
+    load_file_bytes(
+      &new_store(dir.path(), &cas.address()).await,
+      testdata.digest()
+    )
+    .await,
     Ok(testdata.bytes())
   );
   assert_eq!(0, cas.read_request_count());
@@ -168,6 +173,7 @@ async fn load_directory_prefers_local() {
   let cas = new_cas(1024);
   assert_eq!(
     new_store(dir.path(), &cas.address())
+      .await
       .load_directory(testdir.digest(),)
       .await
       .unwrap(),
@@ -184,7 +190,11 @@ async fn load_file_falls_back_and_backfills() {
 
   let cas = new_cas(1024);
   assert_eq!(
-    load_file_bytes(&new_store(dir.path(), &cas.address()), testdata.digest()).await,
+    load_file_bytes(
+      &new_store(dir.path(), &cas.address()).await,
+      testdata.digest()
+    )
+    .await,
     Ok(testdata.bytes()),
     "Read from CAS"
   );
@@ -214,9 +224,12 @@ async fn load_file_falls_back_and_backfills_for_huge_file() {
     .build();
 
   assert_eq!(
-    load_file_bytes(&new_store(dir.path(), &cas.address()), testdata.digest())
-      .await
-      .unwrap(),
+    load_file_bytes(
+      &new_store(dir.path(), &cas.address()).await,
+      testdata.digest()
+    )
+    .await
+    .unwrap(),
     testdata.bytes()
   );
   assert_eq!(1, cas.read_request_count());
@@ -241,6 +254,7 @@ async fn load_directory_falls_back_and_backfills() {
 
   assert_eq!(
     new_store(dir.path(), &cas.address())
+      .await
       .load_directory(testdir.digest(),)
       .await
       .unwrap(),
@@ -279,6 +293,7 @@ async fn load_recursive_directory() {
     .build();
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_downloaded(
       HashSet::new(),
       HashSet::from([recursive_testdir_digest.clone()]),
@@ -316,7 +331,7 @@ async fn load_file_missing_is_none() {
 
   let cas = new_empty_cas();
   let result = load_file_bytes(
-    &new_store(dir.path(), &cas.address()),
+    &new_store(dir.path(), &cas.address()).await,
     TestData::roland().digest(),
   )
   .await;
@@ -330,6 +345,7 @@ async fn load_directory_missing_errors() {
 
   let cas = new_empty_cas();
   let result = new_store(dir.path(), &cas.address())
+    .await
     .load_directory(TestDirectory::containing_roland().digest())
     .await;
   assert!(matches!(result, Err(StoreError::MissingDigest { .. })),);
@@ -343,7 +359,7 @@ async fn load_file_remote_error_is_error() {
   let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::cas_always_errors();
   let error = load_file_bytes(
-    &new_store(dir.path(), &cas.address()),
+    &new_store(dir.path(), &cas.address()).await,
     TestData::roland().digest(),
   )
   .await
@@ -368,6 +384,7 @@ async fn load_directory_remote_error_is_error() {
   let _ = WorkunitStore::setup_for_tests();
   let cas = StubCAS::cas_always_errors();
   let error = new_store(dir.path(), &cas.address())
+    .await
     .load_directory(TestData::roland().digest())
     .await
     .expect_err("Want error");
@@ -438,6 +455,7 @@ async fn malformed_remote_directory_is_error() {
 
   let cas = new_cas(1024);
   new_store(dir.path(), &cas.address())
+    .await
     .load_directory(testdata.digest())
     .await
     .expect_err("Want error");
@@ -476,6 +494,7 @@ async fn non_canonical_remote_directory_is_error() {
     )
     .build();
   new_store(dir.path(), &cas.address())
+    .await
     .load_directory(directory_digest)
     .await
     .expect_err("Want error");
@@ -503,9 +522,12 @@ async fn wrong_remote_file_bytes_is_error() {
       TestDirectory::containing_roland().bytes(),
     )
     .build();
-  load_file_bytes(&new_store(dir.path(), &cas.address()), testdata.digest())
-    .await
-    .expect_err("Want error");
+  load_file_bytes(
+    &new_store(dir.path(), &cas.address()).await,
+    testdata.digest(),
+  )
+  .await
+  .expect_err("Want error");
 
   assert_eq!(
     crate::local_tests::load_file_bytes(
@@ -530,9 +552,12 @@ async fn wrong_remote_directory_bytes_is_error() {
       TestDirectory::containing_roland().bytes(),
     )
     .build();
-  load_file_bytes(&new_store(dir.path(), &cas.address()), testdir.digest())
-    .await
-    .expect_err("Want error");
+  load_file_bytes(
+    &new_store(dir.path(), &cas.address()).await,
+    testdir.digest(),
+  )
+  .await
+  .expect_err("Want error");
 
   assert_eq!(
     crate::local_tests::load_file_bytes(
@@ -668,6 +693,7 @@ async fn uploads_files() {
   assert_eq!(cas.blobs.lock().get(&testdata.fingerprint()), None);
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdata.digest()])
     .await
     .expect("Error uploading file");
@@ -699,6 +725,7 @@ async fn uploads_directories_recursively() {
   assert_eq!(cas.blobs.lock().get(&testdir.fingerprint()), None);
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest()])
     .await
     .expect("Error uploading directory");
@@ -731,6 +758,7 @@ async fn uploads_files_recursively_when_under_three_digests_ignoring_items_alrea
     .expect("Error storing file locally");
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdata.digest()])
     .await
     .expect("Error uploading file");
@@ -743,6 +771,7 @@ async fn uploads_files_recursively_when_under_three_digests_ignoring_items_alrea
   assert_eq!(cas.blobs.lock().get(&testdir.fingerprint()), None);
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest()])
     .await
     .expect("Error uploading directory");
@@ -777,6 +806,7 @@ async fn does_not_reupload_file_already_in_cas_when_requested_with_three_other_d
     .expect("Error storing file locally");
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![roland.digest()])
     .await
     .expect("Error uploading big file");
@@ -790,6 +820,7 @@ async fn does_not_reupload_file_already_in_cas_when_requested_with_three_other_d
   assert_eq!(cas.blobs.lock().get(&testdir.fingerprint()), None);
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest(), catnip.digest()])
     .await
     .expect("Error uploading directory");
@@ -816,6 +847,7 @@ async fn does_not_reupload_big_file_already_in_cas() {
     .expect("Error storing file locally");
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![extra_big_file_digest()])
     .await
     .expect("Error uploading directory");
@@ -827,6 +859,7 @@ async fn does_not_reupload_big_file_already_in_cas() {
   );
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![extra_big_file_digest()])
     .await
     .expect("Error uploading directory");
@@ -848,6 +881,7 @@ async fn upload_missing_files() {
   assert_eq!(cas.blobs.lock().get(&testdata.fingerprint()), None);
 
   let error = new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdata.digest()])
     .await
     .expect_err("Want error");
@@ -871,6 +905,7 @@ async fn upload_succeeds_for_digests_which_only_exist_remotely() {
 
   // The data does not exist locally, but already exists remotely: succeed.
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdata.digest()])
     .await
     .unwrap();
@@ -892,6 +927,7 @@ async fn upload_missing_file_in_directory() {
   assert_eq!(cas.blobs.lock().get(&testdir.fingerprint()), None);
 
   let error = new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest()])
     .await
     .expect_err("Want error");
@@ -918,6 +954,7 @@ async fn uploading_digest_with_wrong_size_is_error() {
   let wrong_digest = Digest::new(testdata.fingerprint(), testdata.len() + 1);
 
   new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![wrong_digest])
     .await
     .expect_err("Expect error uploading file");
@@ -956,6 +993,7 @@ async fn instance_name_upload() {
       Some("dark-tower".to_owned()),
       BTreeMap::new(),
     ))
+    .await
     .unwrap();
 
   store_with_remote
@@ -980,6 +1018,7 @@ async fn instance_name_download() {
       Some("dark-tower".to_owned()),
       BTreeMap::new(),
     ))
+    .await
     .unwrap();
 
   assert_eq!(
@@ -1020,6 +1059,7 @@ async fn auth_upload() {
   let store_with_remote = Store::local_only(task_executor::Executor::new(), dir.path())
     .unwrap()
     .into_with_remote(remote_options(cas.address(), None, headers))
+    .await
     .unwrap();
 
   store_with_remote
@@ -1042,6 +1082,7 @@ async fn auth_download() {
   let store_with_remote = Store::local_only(task_executor::Executor::new(), dir.path())
     .unwrap()
     .into_with_remote(remote_options(cas.address(), None, headers))
+    .await
     .unwrap();
 
   assert_eq!(
@@ -1477,6 +1518,7 @@ async fn returns_upload_summary_on_empty_cas() {
     .await
     .expect("Error storing file locally");
   let mut summary = new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest()])
     .await
     .expect("Error uploading file");
@@ -1527,6 +1569,7 @@ async fn summary_does_not_count_things_in_cas() {
 
   // Store testroland first, which should return a summary of one file
   let mut data_summary = new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testroland.digest()])
     .await
     .expect("Error uploading file");
@@ -1547,6 +1590,7 @@ async fn summary_does_not_count_things_in_cas() {
   // It should see the digest of testroland already in cas,
   // and not report it in uploads.
   let mut dir_summary = new_store(dir.path(), &cas.address())
+    .await
     .ensure_remote_has_recursive(vec![testdir.digest()])
     .await
     .expect("Error uploading directory");
@@ -1600,7 +1644,7 @@ async fn explicitly_overwrites_already_existing_file() {
     .directory(&contents_dir)
     .file(&cas_file)
     .build();
-  let store = new_store(tempfile::tempdir().unwrap(), &cas.address());
+  let store = new_store(tempfile::tempdir().unwrap(), &cas.address()).await;
 
   store
     .materialize_directory(

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -266,6 +266,7 @@ mod tests {
       None,
       &mut headers,
     )
+    .await
     .unwrap();
 
     let channel = Channel::balance_list(vec![endpoint].into_iter());

--- a/src/rust/engine/grpc_util/src/lib.rs
+++ b/src/rust/engine/grpc_util/src/lib.rs
@@ -94,7 +94,7 @@ lazy_static! {
 }
 
 /// Create a Tonic `Endpoint` from a string containing a schema and IP address/name.
-pub fn create_endpoint(
+pub async fn create_endpoint(
   addr: &str,
   tls_config_opt: Option<&ClientConfig>,
   headers: &mut BTreeMap<String, String>,

--- a/src/rust/engine/process_execution/remote/src/remote.rs
+++ b/src/rust/engine/process_execution/remote/src/remote.rs
@@ -159,7 +159,7 @@ impl Drop for RunningOperation {
 
 impl CommandRunner {
   /// Construct a new CommandRunner
-  pub fn new(
+  pub async fn new(
     execution_address: &str,
     instance_name: Option<String>,
     process_cache_namespace: Option<String>,
@@ -186,7 +186,8 @@ impl CommandRunner {
       execution_address,
       tls_client_config.as_ref().filter(|_| execution_use_tls),
       &mut execution_headers,
-    )?;
+    )
+    .await?;
     let execution_http_headers = headers_to_http_header_map(&execution_headers)?;
     let execution_channel = layered_service(
       tonic::transport::Channel::balance_list(vec![execution_endpoint].into_iter()),

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -136,11 +136,11 @@ impl CommandRunner {
     }
   }
 
-  pub fn from_provider_options(
+  pub async fn from_provider_options(
     runner_options: RemoteCacheRunnerOptions,
     provider_options: RemoteCacheProviderOptions,
   ) -> Result<Self, String> {
-    let provider = Arc::new(reapi::Provider::new(provider_options)?);
+    let provider = Arc::new(reapi::Provider::new(provider_options).await?);
 
     Ok(Self::new(runner_options, provider))
   }

--- a/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
@@ -24,7 +24,7 @@ pub struct Provider {
 }
 
 impl Provider {
-  pub fn new(
+  pub async fn new(
     RemoteCacheProviderOptions {
       instance_name,
       action_cache_address,
@@ -44,7 +44,8 @@ impl Provider {
       &action_cache_address,
       tls_client_config.as_ref(),
       &mut headers,
-    )?;
+    )
+    .await?;
     let http_headers = headers_to_http_header_map(&headers)?;
     let channel = layered_service(
       tonic::transport::Channel::balance_list(vec![endpoint].into_iter()),

--- a/src/rust/engine/process_execution/remote/src/remote_cache/reapi_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache/reapi_tests.rs
@@ -9,7 +9,7 @@ use protos::gen::build::bazel::remote::execution::v2 as remexec;
 
 use super::{reapi::Provider, ActionCacheProvider, RemoteCacheProviderOptions};
 
-fn new_provider(cas: &StubCAS) -> Provider {
+async fn new_provider(cas: &StubCAS) -> Provider {
   Provider::new(RemoteCacheProviderOptions {
     instance_name: None,
     action_cache_address: cas.address(),
@@ -18,13 +18,14 @@ fn new_provider(cas: &StubCAS) -> Provider {
     concurrency_limit: 256,
     rpc_timeout: Duration::from_secs(2),
   })
+  .await
   .unwrap()
 }
 
 #[tokio::test]
 async fn get_action_result_existing() {
   let cas = StubCAS::empty();
-  let provider = new_provider(&cas);
+  let provider = new_provider(&cas).await;
 
   let action_digest = Digest::of_bytes(b"get_action_cache test");
   let action_result = remexec::ActionResult {
@@ -48,7 +49,7 @@ async fn get_action_result_existing() {
 #[tokio::test]
 async fn get_action_result_missing() {
   let cas = StubCAS::empty();
-  let provider = new_provider(&cas);
+  let provider = new_provider(&cas).await;
 
   let action_digest = Digest::of_bytes(b"update_action_cache test");
 
@@ -63,7 +64,7 @@ async fn get_action_result_missing() {
 #[tokio::test]
 async fn get_action_result_grpc_error() {
   let cas = StubCAS::builder().ac_always_errors().build();
-  let provider = new_provider(&cas);
+  let provider = new_provider(&cas).await;
 
   let action_digest = Digest::of_bytes(b"get_action_result_grpc_error test");
 
@@ -81,7 +82,7 @@ async fn get_action_result_grpc_error() {
 #[tokio::test]
 async fn update_action_cache() {
   let cas = StubCAS::empty();
-  let provider = new_provider(&cas);
+  let provider = new_provider(&cas).await;
 
   let action_digest = Digest::of_bytes(b"update_action_cache test");
   let action_result = remexec::ActionResult {
@@ -103,7 +104,7 @@ async fn update_action_cache() {
 #[tokio::test]
 async fn update_action_cache_grpc_error() {
   let cas = StubCAS::builder().ac_always_errors().build();
-  let provider = new_provider(&cas);
+  let provider = new_provider(&cas).await;
 
   let action_digest = Digest::of_bytes(b"update_action_cache_grpc_error test");
   let action_result = remexec::ActionResult {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -1273,7 +1273,7 @@ pub async fn make_execute_request(
   };
 
   if let Some(timeout) = req.timeout {
-    action.timeout = Some(prost_types::Duration::from(timeout));
+    action.timeout = Some(prost_types::Duration::try_from(timeout).unwrap());
   }
 
   let execute_request = remexec::ExecuteRequest {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -252,19 +252,21 @@ async fn main() {
         );
       }
 
-      local_only_store.into_with_remote(RemoteOptions {
-        cas_address: cas_server.to_owned(),
-        instance_name: args.remote_instance_name.clone(),
-        tls_config: grpc_util::tls::Config::new_without_mtls(root_ca_certs),
-        headers,
-        chunk_size_bytes: args.upload_chunk_bytes,
-        rpc_timeout: Duration::from_secs(30),
-        rpc_retries: args.store_rpc_retries,
-        rpc_concurrency_limit: args.store_rpc_concurrency,
+      local_only_store
+        .into_with_remote(RemoteOptions {
+          cas_address: cas_server.to_owned(),
+          instance_name: args.remote_instance_name.clone(),
+          tls_config: grpc_util::tls::Config::new_without_mtls(root_ca_certs),
+          headers,
+          chunk_size_bytes: args.upload_chunk_bytes,
+          rpc_timeout: Duration::from_secs(30),
+          rpc_retries: args.store_rpc_retries,
+          rpc_concurrency_limit: args.store_rpc_concurrency,
 
-        capabilities_cell_opt: None,
-        batch_api_size_limit: args.store_batch_api_size_limit,
-      })
+          capabilities_cell_opt: None,
+          batch_api_size_limit: args.store_batch_api_size_limit,
+        })
+        .await
     }
     (None, None) => Ok(local_only_store),
     _ => panic!("Can't specify --server without --cas-server"),
@@ -313,6 +315,7 @@ async fn main() {
         args.execution_rpc_concurrency,
         None,
       )
+      .await
       .expect("Failed to make remote command runner");
 
       let command_runner_box: Box<dyn process_execution::CommandRunner> = {
@@ -341,6 +344,7 @@ async fn main() {
               rpc_timeout: Duration::from_secs(2),
             },
           )
+          .await
           .expect("Failed to make remote cache command runner"),
         )
       };

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -144,7 +144,7 @@ impl From<&LocalStoreOptions> for store::LocalOptions {
 }
 
 impl Core {
-  fn make_store(
+  async fn make_store(
     executor: &Executor,
     local_store_options: &LocalStoreOptions,
     local_execution_root_dir: &Path,
@@ -165,18 +165,20 @@ impl Core {
         .as_ref()
         .ok_or("Remote store required, but none configured")?
         .clone();
-      local_only.into_with_remote(RemoteOptions {
-        cas_address,
-        instance_name: remoting_opts.instance_name.clone(),
-        tls_config: grpc_util::tls::Config::new_without_mtls(root_ca_certs.clone()),
-        headers: remoting_opts.store_headers.clone(),
-        chunk_size_bytes: remoting_opts.store_chunk_bytes,
-        rpc_timeout: remoting_opts.store_rpc_timeout,
-        rpc_retries: remoting_opts.store_rpc_retries,
-        rpc_concurrency_limit: remoting_opts.store_rpc_concurrency,
-        capabilities_cell_opt,
-        batch_api_size_limit: remoting_opts.store_batch_api_size_limit,
-      })
+      local_only
+        .into_with_remote(RemoteOptions {
+          cas_address,
+          instance_name: remoting_opts.instance_name.clone(),
+          tls_config: grpc_util::tls::Config::new_without_mtls(root_ca_certs.clone()),
+          headers: remoting_opts.store_headers.clone(),
+          chunk_size_bytes: remoting_opts.store_chunk_bytes,
+          rpc_timeout: remoting_opts.store_rpc_timeout,
+          rpc_retries: remoting_opts.store_rpc_retries,
+          rpc_concurrency_limit: remoting_opts.store_rpc_concurrency,
+          capabilities_cell_opt,
+          batch_api_size_limit: remoting_opts.store_batch_api_size_limit,
+        })
+        .await
     } else {
       Ok(local_only)
     }
@@ -186,7 +188,7 @@ impl Core {
   /// Make the innermost / leaf runner. Will have concurrency control and process pooling, but
   /// will not have caching.
   ///
-  fn make_leaf_runner(
+  async fn make_leaf_runner(
     full_store: &Store,
     local_runner_store: &Store,
     executor: &Executor,
@@ -269,21 +271,24 @@ impl Core {
       // We always create the remote execution runner if it is globally enabled, but it may not
       // actually be used thanks to the `SwitchedCommandRunner` below. Only one of local execution
       // or remote execution will be used for any particular process.
-      let remote_execution_runner = Box::new(remote::remote::CommandRunner::new(
-        // We unwrap because global_options.py will have already validated this is defined.
-        remoting_opts.execution_address.as_ref().unwrap(),
-        instance_name,
-        process_cache_namespace,
-        remoting_opts.append_only_caches_base_path.clone(),
-        root_ca_certs.clone(),
-        remoting_opts.execution_headers.clone(),
-        full_store.clone(),
-        executor.clone(),
-        remoting_opts.execution_overall_deadline,
-        Duration::from_millis(100),
-        remoting_opts.execution_rpc_concurrency,
-        capabilities_cell_opt,
-      )?);
+      let remote_execution_runner = Box::new(
+        remote::remote::CommandRunner::new(
+          // We unwrap because global_options.py will have already validated this is defined.
+          remoting_opts.execution_address.as_ref().unwrap(),
+          instance_name,
+          process_cache_namespace,
+          remoting_opts.append_only_caches_base_path.clone(),
+          root_ca_certs.clone(),
+          remoting_opts.execution_headers.clone(),
+          full_store.clone(),
+          executor.clone(),
+          remoting_opts.execution_overall_deadline,
+          Duration::from_millis(100),
+          remoting_opts.execution_rpc_concurrency,
+          capabilities_cell_opt,
+        )
+        .await?,
+      );
       let remote_execution_runner = Box::new(bounded::CommandRunner::new(
         executor,
         remote_execution_runner,
@@ -310,7 +315,7 @@ impl Core {
   /// The given cache read/write flags override the relevant cache flags to allow this method
   /// to be called with all cache reads disabled, regardless of their configured values.
   ///
-  fn make_cached_runner(
+  async fn make_cached_runner(
     mut runner: Arc<dyn CommandRunner>,
     full_store: &Store,
     executor: &Executor,
@@ -325,28 +330,31 @@ impl Core {
     local_cache_write: bool,
   ) -> Result<Arc<dyn CommandRunner>, String> {
     if remote_cache_read || remote_cache_write {
-      runner = Arc::new(remote_cache::CommandRunner::from_provider_options(
-        RemoteCacheRunnerOptions {
-          inner: runner,
-          instance_name: instance_name.clone(),
-          process_cache_namespace: process_cache_namespace.clone(),
-          executor: executor.clone(),
-          store: full_store.clone(),
-          cache_read: remote_cache_read,
-          cache_write: remote_cache_write,
-          warnings_behavior: remoting_opts.cache_warnings_behavior,
-          cache_content_behavior: remoting_opts.cache_content_behavior,
-          append_only_caches_base_path: remoting_opts.append_only_caches_base_path.clone(),
-        },
-        RemoteCacheProviderOptions {
-          instance_name,
-          action_cache_address: remoting_opts.store_address.clone().unwrap(),
-          root_ca_certs: root_ca_certs.clone(),
-          headers: remoting_opts.store_headers.clone(),
-          concurrency_limit: remoting_opts.cache_rpc_concurrency,
-          rpc_timeout: remoting_opts.cache_rpc_timeout,
-        },
-      )?);
+      runner = Arc::new(
+        remote_cache::CommandRunner::from_provider_options(
+          RemoteCacheRunnerOptions {
+            inner: runner,
+            instance_name: instance_name.clone(),
+            process_cache_namespace: process_cache_namespace.clone(),
+            executor: executor.clone(),
+            store: full_store.clone(),
+            cache_read: remote_cache_read,
+            cache_write: remote_cache_write,
+            warnings_behavior: remoting_opts.cache_warnings_behavior,
+            cache_content_behavior: remoting_opts.cache_content_behavior,
+            append_only_caches_base_path: remoting_opts.append_only_caches_base_path.clone(),
+          },
+          RemoteCacheProviderOptions {
+            instance_name,
+            action_cache_address: remoting_opts.store_address.clone().unwrap(),
+            root_ca_certs: root_ca_certs.clone(),
+            headers: remoting_opts.store_headers.clone(),
+            concurrency_limit: remoting_opts.cache_rpc_concurrency,
+            rpc_timeout: remoting_opts.cache_rpc_timeout,
+          },
+        )
+        .await?,
+      );
     }
 
     if local_cache_read || local_cache_write {
@@ -366,7 +374,7 @@ impl Core {
   ///
   /// Creates the stack of CommandRunners for the purposes of backtracking.
   ///
-  fn make_command_runners(
+  async fn make_command_runners(
     full_store: &Store,
     local_runner_store: &Store,
     executor: &Executor,
@@ -394,14 +402,16 @@ impl Core {
       exec_strategy_opts,
       remoting_opts,
       capabilities_cell_opt,
-    )?;
+    )
+    .await?;
 
     let remote_cache_read = exec_strategy_opts.remote_cache_read;
     let remote_cache_write = exec_strategy_opts.remote_cache_write;
     let local_cache_read_write = exec_strategy_opts.local_cache;
 
-    let make_cached_runner = |should_cache_read: bool| -> Result<Arc<dyn CommandRunner>, String> {
-      Self::make_cached_runner(
+    // The first attempt is always with all caches.
+    let mut runners = {
+      let cached_runner = Self::make_cached_runner(
         leaf_runner.clone(),
         full_store,
         executor,
@@ -410,19 +420,35 @@ impl Core {
         process_cache_namespace.clone(),
         root_ca_certs,
         remoting_opts,
-        remote_cache_read && should_cache_read,
+        remote_cache_read,
         remote_cache_write,
-        local_cache_read_write && should_cache_read,
+        local_cache_read_write,
         local_cache_read_write,
       )
-    };
+      .await?;
 
-    // The first attempt is always with all caches.
-    let mut runners = vec![make_cached_runner(true)?];
+      vec![cached_runner]
+    };
     // If any cache is both readable and writable, we additionally add a backtracking attempt which
     // disables all cache reads.
     if (remote_cache_read && remote_cache_write) || local_cache_read_write {
-      runners.push(make_cached_runner(false)?);
+      let disabled_cached_runner = Self::make_cached_runner(
+        leaf_runner.clone(),
+        full_store,
+        executor,
+        local_cache,
+        instance_name.clone(),
+        process_cache_namespace.clone(),
+        root_ca_certs,
+        remoting_opts,
+        false,
+        remote_cache_write,
+        false,
+        local_cache_read_write,
+      )
+      .await?;
+
+      runners.push(disabled_cached_runner);
     }
 
     Ok(runners)
@@ -461,7 +487,7 @@ impl Core {
     Ok(certs)
   }
 
-  pub fn new(
+  pub async fn new(
     executor: Executor,
     tasks: Tasks,
     types: Types,
@@ -518,6 +544,7 @@ impl Core {
       &root_ca_certs,
       capabilities_cell_opt.clone(),
     )
+    .await
     .map_err(|e| format!("Could not initialize Store: {e:?}"))?;
 
     let local_cache = PersistentCache::new(
@@ -561,7 +588,8 @@ impl Core {
       &exec_strategy_opts,
       &remoting_opts,
       capabilities_cell_opt,
-    )?;
+    )
+    .await?;
     log::debug!("Using {command_runners:?} for process execution.");
 
     let graph = Arc::new(InvalidatableGraph(Graph::new(executor.clone())));

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -701,22 +701,25 @@ fn scheduler_create(
   let core = py_executor
     .0
     .enter(|| {
-      Core::new(
-        py_executor.0.clone(),
-        tasks,
-        types,
-        intrinsics,
-        build_root,
-        ignore_patterns,
-        use_gitignore,
-        watch_filesystem,
-        local_execution_root_dir,
-        named_caches_dir,
-        ca_certs_path,
-        local_store_options.0.clone(),
-        remoting_options.0.clone(),
-        exec_strategy_opts.0.clone(),
-      )
+      py_executor.0.block_on(async {
+        Core::new(
+          py_executor.0.clone(),
+          tasks,
+          types,
+          intrinsics,
+          build_root,
+          ignore_patterns,
+          use_gitignore,
+          watch_filesystem,
+          local_execution_root_dir,
+          named_caches_dir,
+          ca_certs_path,
+          local_store_options.0.clone(),
+          remoting_options.0.clone(),
+          exec_strategy_opts.0.clone(),
+        )
+        .await
+      })
     })
     .map_err(PyValueError::new_err)?;
   Ok(PyScheduler(Scheduler::new(core)))


### PR DESCRIPTION
`grpc_util::create_endpoint` will be `async` once https://github.com/pantsbuild/pants/pull/19517 lands to upgrade the `tonic` crate. This PR splits out the boring changes to change all callers in the call stack above `grpc_util::create_endpoint` to also be `async` which will simplify the other PR.