### PR TITLE
Automate GitHub Release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -337,6 +337,13 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       name: Deploy commit mapping to S3
       run: ./pants run src/python/pants_release/deploy_to_s3.py -- --scope tags/pantsbuild.pants
+    - name: Get release notes
+      run: 'REF="${{ needs.release_info.outputs.build-ref }}"
+
+        ./pants run src/python/pants_release/get_release_notes.py -- ${REF#"release_"}
+        > notes.txt",
+
+        '
     - env:
         GH_REPO: ${{ github.repository }}
         GH_TOKEN: ${{ github.token }}
@@ -344,6 +351,7 @@ jobs:
       run: 'gh release upload ${{ needs.release_info.outputs.build-ref }} dest/pypi_release/*
 
         gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
+        --notes-file notes.txt
 
         '
   release_info:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1194,6 +1194,15 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     scope="tags/pantsbuild.pants",
                 ),
                 {
+                    "name": "Get release notes",
+                    "run": dedent(
+                        """\
+                        REF="${{ needs.release_info.outputs.build-ref }}"
+                        ./pants run src/python/pants_release/get_release_notes.py -- ${REF#"release_"} > notes.txt",
+                        """
+                    ),
+                },
+                {
                     "name": "Publish GitHub Release",
                     "env": {
                         "GH_TOKEN": "${{ github.token }}",
@@ -1202,7 +1211,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     "run": dedent(
                         f"""\
                         gh release upload {gha_expr("needs.release_info.outputs.build-ref") } {pypi_release_dir}/*
-                        gh release edit {gha_expr("needs.release_info.outputs.build-ref") } --draft=false
+                        gh release edit {gha_expr("needs.release_info.outputs.build-ref") } --draft=false --notes-file notes.txt
                         """
                     ),
                 },

--- a/src/python/pants_release/get_release_notes.py
+++ b/src/python/pants_release/get_release_notes.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def main(version: str) -> str:
+    maj, min = version.split(".")[:2]
+    notes_path = Path("src/python/pants/notes", maj).with_suffix(f".{min}.x.md")
+    notes_contents = notes_path.read_text()
+    for section in notes_contents.split("\n## "):
+        if section.startswith(version):
+            section = section.replace("##", "#")
+            return section.split("\n", 2)[-1]
+
+    raise Exception(f"Couldn't find section for version {version} in {notes_path}")
+
+
+if __name__ == "__main__":
+    body = main(sys.argv[1])
+    print(body)


### PR DESCRIPTION
Do the easy thing of just stripping the release notes out of the relevant `notes/` file and use that to populate the GitHub Release notes.

The addition of `get_release_notes` would need to be cherry-picked, but not the Action yml. I'll do this manually to 2.16 and 2.17 branches.
(Alternatively we could try using the `run` step with the `python` shell, but I haven't had great luck with that. Or we could try porting the logic to Bash)