### PR TITLE
Add workflow for generating and uploading cheeseshop

### DIFF
--- a/.github/workflows/rebuild_whl_index.yml
+++ b/.github/workflows/rebuild_whl_index.yml
@@ -1,0 +1,30 @@
+name: Rebuild Wheel Index
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+
+concurrency: ${{ github.workflow }}  # Only run one at a time
+jobs:
+  rebuild:
+    name: Gather Prerequisites
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    env:
+      MODE: DEBUG
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Rebuild
+        run: ./pants run src/python/pants_release/rebuild_whl_index.py > s3/index.html
+      - name: Upload to S3
+        run: |
+          ./pants run src/python/pants_release/copy_to_s3.py -- \
+            --src-prefix s3 \
+            --dest-prefix s3://binaries.pantsbuild.org/v2-cheeseshop/simple \
+            --path ""
+        env:
+            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/src/python/pants_release/rebuild_whl_index.py
+++ b/src/python/pants_release/rebuild_whl_index.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants_release.git import github_repo
+
+
+def main() -> str:
+    gh_repo = github_repo()
+    releases = gh_repo.get_releases()
+    index = "\n".join(
+        [
+            "<html>",
+            "<body>",
+            "<h1>Links for Pantsbuild Wheels</h1>",
+            *(
+                f'<a href="{asset.browser_download_url}">{asset.name}</a>'
+                for release in releases
+                if release.tag_name.startswith("release_2")
+                for asset in release.assets
+                if asset.name.endswith(".whl")
+            ),
+            "</body>",
+            "</html>",
+        ]
+    )
+    return index
+
+
+if __name__ == "__main__":
+    print(main())


### PR DESCRIPTION
This change allows us a nice public-facing simple `--find-links` HTML page which serves links to all v2 GitHub Release Asset wheels.

- Added a script to generate the full HTML from scraping GitHub
- Added a workflow which calls the script and uploads to S3