### PR TITLE
Fix rules-api docs typos

### DIFF
--- a/docs/markdown/Writing Plugins/rules-api/rules-api-file-system.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-file-system.md
@@ -5,12 +5,12 @@ excerpt: "How to safely interact with the file system in your plugin."
 hidden: false
 createdAt: "2020-07-01T04:40:26.783Z"
 ---
-It is not safe to use functions like `open` or the non-pure operations of `pathlib.Path` like you normally might: this will break caching because they do not hook up to Pants's file watcher. 
+It is not safe to use functions like `open` or the non-pure operations of `pathlib.Path` like you normally might: this will break caching because they do not hook up to Pants's file watcher.
 
 Instead, Pants has several mechanisms to work with the file system in a safe and concurrent way.
 
 > 🚧 Missing certain file operations?
-> 
+>
 > If it would help you to have a certain file operation, please let us know by either opening a new [GitHub issue](https://github.com/pantsbuild/pants/issues) or by messaging us on [Slack](doc:community) in the #plugins room.
 
 Core abstractions: `Digest` and `Snapshot`
@@ -71,7 +71,7 @@ async def demo(...) -> Foo:
 
 The `CreateDigest` constructor expects an iterable including any of these types:
 
-- `FileContent` objects, which represent a file to create. It take a `path: str` parameter, `contents: bytes` parameter, and optional `is_executable: bool` parameter with a default of `False`.
+- `FileContent` objects, which represent a file to create. It takes a `path: str` parameter, `contents: bytes` parameter, and optional `is_executable: bool` parameter with a default of `False`.
 - `Directory` objects, which can be used to create empty directories. It takes a single parameter: `path: str`. You do not need to use this when creating a file inside a certain directory; this is only to create empty directories.
 - `FileEntry` objects, which are handles to existing files from `DigestEntries`. Do not manually create these.
 
@@ -155,15 +155,15 @@ async def demo(...) -> Foo:
 The result will be a sequence of `FileContent` objects, which each have a property `path: str` and a property `content: bytes`. You may want to call `content.decode()` to convert to `str`.
 
 > 🚧 You may not need `DigestContents`
-> 
+>
 > Only use `DigestContents` if you need to read and operate on the content of files directly in your rule.
-> 
+>
 > - If you are running a `Process`, you only need to pass the `Digest` as input and that process will be able to read all the files in its environment. If you only need a list of files included in the digest, use `Get(Snapshot, Digest)`.
-> 
+>
 > - If you just need to manipulate the directory structure of a `Digest`, such as renaming files,  use `DigestEntries` with `CreateDigest` or use `AddPrefix` and `RemovePrefix`. These avoid reading the file content into memory.
 
 > 🚧 Does not handle empty directories in a `Digest`
-> 
+>
 > `DigestContents` does not have a way to represent empty directories in a `Digest` since it is only a sequence of `FileContent` objects. That is, passing the `FileContent` objects to `CreateDigest` will not result in the original `Digest` if there were empty directories in that original `Digest`. Use `DigestEntries` instead if your rule needs to handle empty directories in a `Digest`.
 
 `DigestEntries`: light-weight handles to files
@@ -271,7 +271,7 @@ async def run_my_goal(..., workspace: Workspace) -> MyGoal:
 
 `Workspace` is a special type that can only be requested in `@goal_rule`s because it is only safe to write to disk in a `@goal_rule`. So, a common pattern is for "downstream" rules to return a `Digest` with the contents they want to write to disk, and then the `@goal_rule` aggregating all the results and writing them to disk. For example, for the `fmt` goal, each `FmtResult` includes a `digest` field.
 
-For better performance, avoid calling `workspace.write_digest` multiple times, such as in a `for` loop. Instead, first, merge all the digests, then write them in a single call. 
+For better performance, avoid calling `workspace.write_digest` multiple times, such as in a `for` loop. Instead, first, merge all the digests, then write them in a single call.
 
 Bad:
 
@@ -312,7 +312,7 @@ async def demo(...) -> Foo:
 Often, you will want to download a pre-compiled binary for a tool. When doing this, use `ExternalTool` instead for help with extracting the binary from the download. See [Installing tools](doc:rules-api-installing-tools).
 
 > 🚧 HTTP requests without digests are unsafe
-> 
+>
 > It is not safe to use `DownloadFile` for mutable HTTP requests, as it will never ping the server for updates once it is cached. It is also not safe to use the `requests` library or similar because it will not be cached safely.
-> 
+>
 > You can use a `Process` with uniquely identifying information in its arguments to run `/usr/bin/curl`.

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-goal-rules.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-goal-rules.md
@@ -24,7 +24,7 @@ There are four steps to creating a new [goal](doc:goals) with Pants:
    1. Set the class property `subsystem_cls` to the `GoalSubsystem` from the previous step.
    2. A `Goal` takes a single argument in its constructor, `exit_code: int`. Pants will use this to determine what its own exit code should be.
 3. Define an `@goal_rule`, which must return the `Goal` from the previous step and set its `exit_code`.
-   1. For most goals, simply return `MyGoal(exit_code=0)`. Some goals like `lint` and `test` will instead propagate the error code from the tools they run. 
+   1. For most goals, simply return `MyGoal(exit_code=0)`. Some goals like `lint` and `test` will instead propagate the error code from the tools they run.
 4. Register the `@goal_rule` in a `register.py` file.
 
 ```python pants-plugins/example/hello_world.py
@@ -44,7 +44,7 @@ class HelloWorld(Goal):
 @goal_rule
 async def hello_world() -> HelloWorld:
     return HelloWorld(exit_code=1)
- 
+
 
 def rules():
     return collect_rules()
@@ -115,7 +115,7 @@ from pants.engine.rules import goal_rule
 
 class HelloWorldSubsystem(LineOriented, GoalSubsystem):
     name = "hello-world"
-    help = "An example goal."""
+    help = "An example goal."
 
 ...
 
@@ -156,24 +156,24 @@ helloworld/util:tests
 See [Rules and the Target API](doc:rules-api-and-target-api)  for detailed information on how to use these targets in your rules, including accessing the metadata specified in BUILD files.
 
 > 🚧 Common mistake: requesting the type of target you want in the `@goal_rule` signature
-> 
+>
 > For example, if you are writing a `publish` goal, and you expect to operate on `python_distribution` targets, you might think to request `PythonDistribution` in your `@goal_rule` signature:
-> 
+>
 > ```python
 > @goal_rule
 > def publish(distribution: PythonDistributionTarget, console: Console) -> Publish:
 >    ...
 > ```
-> 
+>
 > This will not work because the engine has no path in the rule graph to resolve a `PythonDistribution` type given the initial input types to the rule graph (the "roots").
-> 
+>
 > Instead, request `Targets`, which will give you all the targets that the user specified on the command line. The engine knows how to resolve this type because it can go from `Specs` -> `Addresses` -> `Targets`.
-> 
+>
 > From here, filter out the relevant targets you want using the Target API (see [Rules and the Target API](doc:rules-api-and-target-api)).
-> 
+>
 > ```python
 > from pants.engine.target import Targets
-> 
+>
 > @goal_rule
 > def publish(targets: Targets, console: Console) -> Publish:
 >    relevant_targets = [
@@ -203,4 +203,4 @@ To convert `SpecsPaths` into a [`Digest`](doc:rules-api-file-system), use `await
 
 > 📘 Name clashing
 >
-> It is very unlikely, but is still possible that adding a custom goal with an unfortunate name may cause issues when certain existing Pants options are passed in the command line. For instance, executing a goal named `local` with a particular option (in this case, the global `local_cache` option), e.g. `pants --no-local-cache local ...` would fail since there's no `--no-cache` flag defined for the `local` goal. 
+> It is very unlikely, but is still possible that adding a custom goal with an unfortunate name may cause issues when certain existing Pants options are passed in the command line. For instance, executing a goal named `local` with a particular option (in this case, the global `local_cache` option), e.g. `pants --no-local-cache local ...` would fail since there's no `--no-cache` flag defined for the `local` goal.

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
@@ -107,7 +107,7 @@ class Shellcheck(ExternalTool):
         return f"./shellcheck-{self.version}/shellcheck"
 ```
 
-You must define the class properties `default_version` and `default_known_version`. `default_known_version` is a list of pipe-separated strings in the form `version|platform|sha256|length`. Use the values you found earlier by running `shasum` and `wc` for sha256 and length, respectively. `platform` should be one of `linux_arm64`, `linux_x86_64`, `macos_arm64`, and `macos_x86_64`.
+You must define the class properties `default_version` and `default_known_versions`. `default_known_versions` is a list of pipe-separated strings in the form `version|platform|sha256|length`. Use the values you found earlier by running `shasum` and `wc` for sha256 and length, respectively. `platform` should be one of `linux_arm64`, `linux_x86_64`, `macos_arm64`, and `macos_x86_64`.
 
 You must also define the methods `generate_url`, which is the URL to make a GET request to download the file, and `generate_exe`, which is the relative path to the binary in the downloaded digest. Both methods take `plat: Platform` as a parameter.
 

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-installing-tools.md
@@ -182,7 +182,7 @@ There are several other optional parameters that may be helpful.
 
 The resulting `Pex` object has a `digest: Digest` field containing the built `.pex` file. This digest should be included in the `input_digest` to the `Process` you run.
 
-Instead of the normal `Get(ProcessResult, Process)`, you should use `Get(ProcessResult, PexProcess)`, which will set up the environment properly for your Pex to execute. There is a predefined rule to go from `PexProcess -> Process`, so `Get(ProcessResult, Process)` will cause the engine to run `PexProcess -> Process -> ProcessResult`.
+Instead of the normal `Get(ProcessResult, Process)`, you should use `Get(ProcessResult, PexProcess)`, which will set up the environment properly for your Pex to execute. There is a predefined rule to go from `PexProcess -> Process`, so `Get(ProcessResult, PexProcess)` will cause the engine to run `PexProcess -> Process -> ProcessResult`.
 
 `PexProcess` requires arguments for `pex: Pex`, `argv: Iterable[str]`, and `description: str`. It has several optional parameters that mirror the arguments to `Process`. If you specify `input_digest`, be careful to first use `Get(Digest, MergeDigests)` on the `pex.digest` and any of the other input digests.
 
@@ -203,10 +203,10 @@ Instead of the normal `Get(ProcessResult, Process)`, you should use `Get(Process
 >     help = "The Black Python code formatter (https://black.readthedocs.io/)."
 >
 >     default_main = ConsoleScript("black")
->     
+>
 >     register_interpreter_constraints = True
 >     default_interpreter_constraints = ["CPython>=3.8,<3.9"]
-> 
+>
 >     default_lockfile_resource = ("pants.backend.python.lint.black", "black.lock")
 >
 >     config = StrOption(


### PR DESCRIPTION
# Documentation Fixes

- Fix missing 's' in variable name.
- Add missing 's' to match plural.
- Fix invalid reference to `Process`.
- Remove extraneous quotes.