### PR TITLE
Trigger cheeseshop build on release success

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -346,6 +346,12 @@ jobs:
         gh release edit ${{ needs.release_info.outputs.build-ref }} --draft=false
 
         '
+    - env:
+        GH_TOKEN: ${{ secrets.WORKER_PANTS_CHEESESHOP_TRIGGER_PAT }}
+      name: Trigger cheeseshop build
+      run: 'gh api "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -X POST
+
+        '
   release_info:
     if: github.repository_owner == 'pantsbuild'
     name: Create draft release and output info

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -349,7 +349,8 @@ jobs:
     - env:
         GH_TOKEN: ${{ secrets.WORKER_PANTS_CHEESESHOP_TRIGGER_PAT }}
       name: Trigger cheeseshop build
-      run: 'gh api "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -X POST
+      run: 'gh api -X POST "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -F
+        event_type=github-pages
 
         '
   release_info:

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1213,7 +1213,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                     },
                     "run": dedent(
                         """\
-                        gh api "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -X POST
+                        gh api -X POST "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -F event_type=github-pages
                         """
                     ),
                 },

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1206,6 +1206,17 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                         """
                     ),
                 },
+                {
+                    "name": "Trigger cheeseshop build",
+                    "env": {
+                        "GH_TOKEN": "${{ secrets.WORKER_PANTS_CHEESESHOP_TRIGGER_PAT }}",
+                    },
+                    "run": dedent(
+                        """\
+                        gh api "/repos/pantsbuild/wheels.pantsbuild.org/dispatches" -X POST
+                        """
+                    ),
+                },
             ],
         },
     }


### PR DESCRIPTION
This change just adds an additional step after marking the release public, which triggers a `repository_dispatch` event to re-generate and publish the new cheeseshop index for all wheels.