### PR TITLE
Upgrade the default pip to v23.1.2. (Cherry-pick of #19538)

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -229,7 +229,7 @@ class PythonSetup(Subsystem):
         ),
     )
     pip_version = EnumOption(
-        default=PipVersion.V20_3_4,
+        default=PipVersion.V23_1_2,
         help=softwrap(
             """
             Use this version of Pip for resolving requirements and generating lockfiles.


### PR DESCRIPTION
Users frequently suffer from slow backtracking behavior in older pip.
