### PR TITLE
tests: refactor go tests to not depend on each other

### DIFF
--- a/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
+++ b/src/python/pants/backend/go/util_rules/go_bootstrap_test.py
@@ -1,34 +1,15 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import json
 from pathlib import Path
 from textwrap import dedent
-from typing import Mapping
 
 from pants.backend.go.util_rules.go_bootstrap import GoBootstrap, compatible_go_version
 from pants.backend.go.util_rules.go_bootstrap import rules as go_bootstrap_rules
-from pants.core.util_rules.asdf_test import fake_asdf_root, materialize_indices
+from pants.backend.go.util_rules.testutil import EXPECTED_VERSION, mock_go_binary
+from pants.core.util_rules.testutil import fake_asdf_root, materialize_indices
 from pants.engine.env_vars import CompleteEnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
-
-EXPECTED_VERSION = "1.17"
-EXPECTED_VERSION_NEXT_RELEASE = "1.18"
-
-
-def mock_go_binary(*, version_output: str, env_output: Mapping[str, str]) -> str:
-    """Return a bash script that emulates `go version` and `go env`."""
-    return dedent(
-        f"""\
-        #!/bin/bash
-
-        if [[ "$1" == version ]]; then
-            echo '{version_output}'
-        else
-            echo '{json.dumps(env_output)}'
-        fi
-        """
-    )
 
 
 def test_expand_search_paths() -> None:

--- a/src/python/pants/backend/go/util_rules/goroot_test.py
+++ b/src/python/pants/backend/go/util_rules/goroot_test.py
@@ -7,13 +7,13 @@ from pathlib import Path
 
 import pytest
 
-from pants.backend.go.util_rules.go_bootstrap_test import (
+from pants.backend.go.util_rules.goroot import GoRoot
+from pants.backend.go.util_rules.goroot import rules as goroot_rules
+from pants.backend.go.util_rules.testutil import (
     EXPECTED_VERSION,
     EXPECTED_VERSION_NEXT_RELEASE,
     mock_go_binary,
 )
-from pants.backend.go.util_rules.goroot import GoRoot
-from pants.backend.go.util_rules.goroot import rules as goroot_rules
 from pants.core.util_rules.system_binaries import BinaryNotFoundError
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.rules import QueryRule

--- a/src/python/pants/backend/go/util_rules/testutil.py
+++ b/src/python/pants/backend/go/util_rules/testutil.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from textwrap import dedent  # noqa: PNT20
+from typing import Mapping
+
+EXPECTED_VERSION = "1.17"
+EXPECTED_VERSION_NEXT_RELEASE = "1.18"
+
+
+def mock_go_binary(*, version_output: str, env_output: Mapping[str, str]) -> str:
+    """Return a bash script that emulates `go version` and `go env`."""
+    return dedent(
+        f"""\
+        #!/bin/bash
+
+        if [[ "$1" == version ]]; then
+            echo '{version_output}'
+        else
+            echo '{json.dumps(env_output)}'
+        fi
+        """
+    )

--- a/src/python/pants/core/subsystems/python_bootstrap_test.py
+++ b/src/python/pants/core/subsystems/python_bootstrap_test.py
@@ -19,12 +19,12 @@ from pants.core.subsystems.python_bootstrap import (
 from pants.core.subsystems.python_bootstrap import rules as python_bootstrap_rules
 from pants.core.util_rules import asdf
 from pants.core.util_rules.asdf import AsdfToolPathsRequest, AsdfToolPathsResult
-from pants.core.util_rules.asdf_test import fake_asdf_root
 from pants.core.util_rules.environments import EnvironmentTarget, LocalEnvironmentTarget
 from pants.core.util_rules.search_paths import (
     VersionManagerSearchPaths,
     VersionManagerSearchPathsRequest,
 )
+from pants.core.util_rules.testutil import fake_asdf_root
 from pants.engine.addresses import Address
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars
 from pants.engine.rules import QueryRule

--- a/src/python/pants/core/util_rules/asdf_test.py
+++ b/src/python/pants/core/util_rules/asdf_test.py
@@ -2,9 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
-from contextlib import contextmanager
-from pathlib import Path, PurePath
-from typing import Iterable, Mapping, Sequence, TypeVar
+from pathlib import PurePath
+from typing import Mapping
 
 import pytest
 
@@ -17,61 +16,11 @@ from pants.core.util_rules.environments import (
     LocalEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
+from pants.core.util_rules.testutil import fake_asdf_root, materialize_indices
 from pants.engine.addresses import Address
 from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
-from pants.util.contextutil import temporary_dir
-
-_T = TypeVar("_T")
-
-
-def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> tuple[_T, ...]:
-    return tuple(sequence[i] for i in indices)
-
-
-@contextmanager
-def fake_asdf_root(
-    fake_versions: list[str],
-    fake_home_versions: list[int],
-    fake_local_versions: list[int],
-    *,
-    tool_name: str,
-):
-    with temporary_dir() as home_dir, temporary_dir() as asdf_dir:
-        fake_dirs: list[Path] = []
-        fake_version_dirs: list[str] = []
-
-        fake_home_dir = Path(home_dir)
-        fake_tool_versions = fake_home_dir / ".tool-versions"
-        fake_home_versions_str = " ".join(materialize_indices(fake_versions, fake_home_versions))
-        fake_tool_versions.write_text(f"nodejs lts\njava 8\n{tool_name} {fake_home_versions_str}\n")
-
-        fake_asdf_dir = Path(asdf_dir)
-        fake_asdf_plugin_dir = fake_asdf_dir / "plugins" / tool_name
-        fake_asdf_installs_dir = fake_asdf_dir / "installs" / tool_name
-
-        fake_dirs.extend(
-            [fake_home_dir, fake_asdf_dir, fake_asdf_plugin_dir, fake_asdf_installs_dir]
-        )
-
-        for version in fake_versions:
-            fake_version_path = fake_asdf_installs_dir / version / "bin"
-            fake_version_dirs.append(f"{fake_version_path}")
-            fake_dirs.append(fake_version_path)
-
-        for fake_dir in fake_dirs:
-            fake_dir.mkdir(parents=True, exist_ok=True)
-
-        yield (
-            home_dir,
-            asdf_dir,
-            fake_version_dirs,
-            # fake_home_version_dirs
-            materialize_indices(fake_version_dirs, fake_home_versions),
-            # fake_local_version_dirs
-            materialize_indices(fake_version_dirs, fake_local_versions),
-        )
 
 
 def test_get_asdf_dir() -> None:

--- a/src/python/pants/core/util_rules/testutil.py
+++ b/src/python/pants/core/util_rules/testutil.py
@@ -1,0 +1,59 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, Sequence, TypeVar
+
+from pants.util.contextutil import temporary_dir
+
+_T = TypeVar("_T")
+
+
+def materialize_indices(sequence: Sequence[_T], indices: Iterable[int]) -> tuple[_T, ...]:
+    return tuple(sequence[i] for i in indices)
+
+
+@contextmanager
+def fake_asdf_root(
+    fake_versions: list[str],
+    fake_home_versions: list[int],
+    fake_local_versions: list[int],
+    *,
+    tool_name: str,
+):
+    with temporary_dir() as home_dir, temporary_dir() as asdf_dir:
+        fake_dirs: list[Path] = []
+        fake_version_dirs: list[str] = []
+
+        fake_home_dir = Path(home_dir)
+        fake_tool_versions = fake_home_dir / ".tool-versions"
+        fake_home_versions_str = " ".join(materialize_indices(fake_versions, fake_home_versions))
+        fake_tool_versions.write_text(f"nodejs lts\njava 8\n{tool_name} {fake_home_versions_str}\n")
+
+        fake_asdf_dir = Path(asdf_dir)
+        fake_asdf_plugin_dir = fake_asdf_dir / "plugins" / tool_name
+        fake_asdf_installs_dir = fake_asdf_dir / "installs" / tool_name
+
+        fake_dirs.extend(
+            [fake_home_dir, fake_asdf_dir, fake_asdf_plugin_dir, fake_asdf_installs_dir]
+        )
+
+        for version in fake_versions:
+            fake_version_path = fake_asdf_installs_dir / version / "bin"
+            fake_version_dirs.append(f"{fake_version_path}")
+            fake_dirs.append(fake_version_path)
+
+        for fake_dir in fake_dirs:
+            fake_dir.mkdir(parents=True, exist_ok=True)
+
+        yield (
+            home_dir,
+            asdf_dir,
+            fake_version_dirs,
+            # fake_home_version_dirs
+            materialize_indices(fake_version_dirs, fake_home_versions),
+            # fake_local_version_dirs
+            materialize_indices(fake_version_dirs, fake_local_versions),
+        )


### PR DESCRIPTION
With https://github.com/pantsbuild/pants/pull/19506 merged, PRs are coming that refactor tests modules so that they don't depend on each other. This will help with the build time as changes to a test module should not cause running tests from another test module (just because they happen to import some helper).