### PR TITLE
tests: refactor kotlin tests to not depend on other tests

### DIFF
--- a/src/python/pants/backend/kotlin/compile/kotlinc_test.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc_test.py
@@ -13,6 +13,7 @@ from internal_plugins.test_lockfile_fixtures.lockfile_fixture import (
 from pants.backend.kotlin.compile import kotlinc_plugins
 from pants.backend.kotlin.compile.kotlinc import CompileKotlinSourceRequest
 from pants.backend.kotlin.compile.kotlinc import rules as kotlinc_rules
+from pants.backend.kotlin.compile.testutil import _KOTLIN_VERSION, KOTLIN_STDLIB_REQUIREMENTS
 from pants.backend.kotlin.dependency_inference.rules import rules as kotlin_dep_inf_rules
 from pants.backend.kotlin.goals.check import KotlincCheckRequest
 from pants.backend.kotlin.goals.check import rules as kotlin_check_rules
@@ -67,14 +68,6 @@ def rule_runner() -> RuleRunner:
     )
     rule_runner.set_options(args=[], env_inherit=PYTHON_BOOTSTRAP_ENV)
     return rule_runner
-
-
-_KOTLIN_VERSION = "1.6.20"
-KOTLIN_STDLIB_REQUIREMENTS = [
-    f"org.jetbrains.kotlin:kotlin-stdlib:{_KOTLIN_VERSION}",
-    f"org.jetbrains.kotlin:kotlin-reflect:{_KOTLIN_VERSION}",
-    f"org.jetbrains.kotlin:kotlin-script-runtime:{_KOTLIN_VERSION}",
-]
 
 
 @pytest.fixture

--- a/src/python/pants/backend/kotlin/compile/testutil.py
+++ b/src/python/pants/backend/kotlin/compile/testutil.py
@@ -1,0 +1,10 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+_KOTLIN_VERSION = "1.6.20"
+KOTLIN_STDLIB_REQUIREMENTS = [
+    f"org.jetbrains.kotlin:kotlin-stdlib:{_KOTLIN_VERSION}",
+    f"org.jetbrains.kotlin:kotlin-reflect:{_KOTLIN_VERSION}",
+    f"org.jetbrains.kotlin:kotlin-script-runtime:{_KOTLIN_VERSION}",
+]

--- a/src/python/pants/backend/kotlin/test/junit_test.py
+++ b/src/python/pants/backend/kotlin/test/junit_test.py
@@ -14,7 +14,7 @@ from internal_plugins.test_lockfile_fixtures.lockfile_fixture import (
 from pants.backend.java.compile.javac import rules as javac_rules
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.backend.kotlin.compile import kotlinc, kotlinc_plugins
-from pants.backend.kotlin.compile.kotlinc_test import KOTLIN_STDLIB_REQUIREMENTS
+from pants.backend.kotlin.compile.testutil import KOTLIN_STDLIB_REQUIREMENTS
 from pants.backend.kotlin.dependency_inference.rules import rules as kotlin_dep_inf_rules
 from pants.backend.kotlin.subsystems.kotlin import DEFAULT_KOTLIN_VERSION
 from pants.backend.kotlin.target_types import KotlinJunitTestsGeneratorTarget
@@ -34,7 +34,7 @@ from pants.jvm.strip_jar import strip_jar
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.test.junit import JunitTestRequest
 from pants.jvm.test.junit import rules as jvm_junit_rules
-from pants.jvm.test.junit_test import run_junit_test
+from pants.jvm.test.testutil import run_junit_test
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner

--- a/src/python/pants/jvm/test/testutil.py
+++ b/src/python/pants/jvm/test/testutil.py
@@ -1,0 +1,31 @@
+# Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from pants.core.goals.test import TestResult
+from pants.engine.internals.native_engine import Address
+from pants.jvm.test.junit import JunitTestFieldSet, JunitTestRequest
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
+
+
+def run_junit_test(
+    rule_runner: RuleRunner,
+    target_name: str,
+    relative_file_path: str,
+    *,
+    extra_args: Iterable[str] | None = None,
+    env: Mapping[str, str] | None = None,
+) -> TestResult:
+    args = [
+        "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
+        *(extra_args or ()),
+    ]
+    rule_runner.set_options(args, env=env, env_inherit=PYTHON_BOOTSTRAP_ENV)
+    tgt = rule_runner.get_target(
+        Address(spec_path="", target_name=target_name, relative_file_path=relative_file_path)
+    )
+    return rule_runner.request(
+        TestResult, [JunitTestRequest.Batch("", (JunitTestFieldSet.create(tgt),), None)]
+    )


### PR DESCRIPTION
With https://github.com/pantsbuild/pants/pull/19506 merged, PRs are coming that refactor tests modules so that they don't depend on each other. This will help with the build time as changes to a test module should not cause running tests from another test module (just because they happen to import some helper).