### PR TITLE
tests: refactor helm tests to not depend on each other

### DIFF
--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -30,7 +30,7 @@ from pants.backend.helm.util_rules.renderer import (
     HelmDeploymentRequest,
     RenderedHelmFiles,
 )
-from pants.backend.helm.util_rules.renderer_test import _read_file_from_digest
+from pants.backend.helm.util_rules.testutil import _read_file_from_digest
 from pants.backend.helm.util_rules.tool import HelmProcess
 from pants.backend.shell.target_types import ShellCommandRunTarget, ShellSourcesGeneratorTarget
 from pants.backend.shell.util_rules import shell_command

--- a/src/python/pants/backend/helm/util_rules/renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/renderer_test.py
@@ -22,10 +22,9 @@ from pants.backend.helm.util_rules.renderer import (
     RenderedHelmFiles,
     RenderHelmChartRequest,
 )
+from pants.backend.helm.util_rules.testutil import _read_file_from_digest
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.addresses import Address
-from pants.engine.fs import DigestContents, DigestSubset, PathGlobs
-from pants.engine.internals.native_engine import Digest
 from pants.engine.process import InteractiveProcess
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target
@@ -51,12 +50,6 @@ def rule_runner() -> RuleRunner:
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner
-
-
-def _read_file_from_digest(rule_runner: RuleRunner, *, digest: Digest, filename: str) -> str:
-    config_file_digest = rule_runner.request(Digest, [DigestSubset(digest, PathGlobs([filename]))])
-    config_file_contents = rule_runner.request(DigestContents, [config_file_digest])
-    return config_file_contents[0].content.decode("utf-8")
 
 
 _COMMON_WORKSPACE_FILES = {

--- a/src/python/pants/backend/helm/util_rules/testutil.py
+++ b/src/python/pants/backend/helm/util_rules/testutil.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from pants.engine.fs import DigestContents, DigestSubset, PathGlobs
+from pants.engine.internals.native_engine import Digest
+from pants.testutil.rule_runner import RuleRunner
+
+
+def _read_file_from_digest(rule_runner: RuleRunner, *, digest: Digest, filename: str) -> str:
+    config_file_digest = rule_runner.request(Digest, [DigestSubset(digest, PathGlobs([filename]))])
+    config_file_contents = rule_runner.request(DigestContents, [config_file_digest])
+    return config_file_contents[0].content.decode("utf-8")


### PR DESCRIPTION
With https://github.com/pantsbuild/pants/pull/19506 merged, PRs are coming that refactor tests modules so that they don't depend on each other. This will help with the build time as changes to a test module should not cause running tests from another test module (just because they happen to import some helper).