### PR TITLE
Register the `python_aws_lambda_layer` target type

### DIFF
--- a/src/python/pants/backend/awslambda/python/register.py
+++ b/src/python/pants/backend/awslambda/python/register.py
@@ -7,7 +7,7 @@ See https://www.pantsbuild.org/docs/awslambda-python.
 """
 
 from pants.backend.awslambda.python import rules as python_rules
-from pants.backend.awslambda.python.target_types import PythonAWSLambda
+from pants.backend.awslambda.python.target_types import PythonAWSLambda, PythonAWSLambdaLayer
 from pants.backend.awslambda.python.target_types import rules as target_types_rules
 from pants.backend.python.subsystems import lambdex
 
@@ -17,4 +17,4 @@ def rules():
 
 
 def target_types():
-    return [PythonAWSLambda]
+    return [PythonAWSLambda, PythonAWSLambdaLayer]


### PR DESCRIPTION
This ensures the `python_aws_lambda_layer` target type exists when activating the `pants.backend.awslambda.python` backend. This was missed from #19123, oops!