### PR TITLE
tests: treat imports from a test module as a build error

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -60,8 +60,8 @@ __dependencies_rules__(
     (
         # test modules should not depend on other test modules
         (python_tests, python_test),
-        "?<python_tests>",
-        "?<python_test>",
+        "!<python_tests>",
+        "!<python_test>",
         "//BUILD_ROOT:files",
         "//pants.toml:files",
         "conftest.py",


### PR DESCRIPTION
With #19506 merged, we have a rule that a test module cannot import from a test module (to remove running running tests when not truly required).

This PR starts treating these violations as errors (not warnings) and violating this rule will lead to build failure. An example error message when attempting to import from a test module:

```
  * src/python/pants/BUILD[!<python_tests>] -> src/python/pants/jvm : DENY
    python_tests src/python/pants/jvm/test/junit_test.py:tests -> python_tests src/python/pants/jvm/util_rules_test.py:tests
```

