### PR TITLE
Stop referring to ~/.cache/pants/setup in CI docs

### DIFF
--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -19,9 +19,7 @@ Directories to cache
 In your CI's config file, we recommend caching these directories:
 
 - `$HOME/.cache/nce` (Linux) or `$HOME/Library/Caches/nce` (macOS)<br>
-  This is the cache directory used by the [Pants launcher binary](doc:installation) to cache its embedded interpreter. Cache this against some static key that you can modify if you want to purge that cache.
-- `$HOME/.cache/pants/setup`<br>
-  This is the Pants bootstrap directory. Cache this against the version, as specified in `pants.toml`.  See the [pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml) repo for an example of how to generate an effective cache key for this directory in GitHub Actions.
+  This is the cache directory used by the [Pants launcher binary](doc:installation) to cache the assets, interpreters and venvs required to run Pants itself. Cache this against the Pants version, as specified in `pants.toml`. See the [pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml) repo for an example of how to generate an effective cache key for this directory in GitHub Actions.
 - `$HOME/.cache/pants/named_caches`<br>
   Caches used by some underlying tools.  Cache this against the inputs to those tools. For the `pants.backend.python` backend, named caches are used by PEX, and therefore its inputs are your lockfiles. Again, see [pantsbuild/example-python](https://github.com/pantsbuild/example-python/blob/main/.github/workflows/pants.yaml) for an example.
 
@@ -50,7 +48,7 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >    fi
 >  }
 >
-> nuke_if_too_big ~/.cache/pants/setup 512
+> nuke_if_too_big ~/.cache/nce 512
 > nuke_if_too_big ~/.cache/pants/named_caches 1024
 > ```
 


### PR DESCRIPTION
This fixes #19497: scie-pants doesn't use the `~/.cache/pants/setup` path at all, as all of its work (including the pants wheels etc.) is cached in the `~/.cache/nce` path.