### PR TITLE
default_module_mapping: add snowflake-sqlalchemy

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -238,6 +238,7 @@ DEFAULT_MODULE_MAPPING = {
     "sseclient-py": ("sseclient",),
     "setuptools": ("easy_install", "pkg_resources", "setuptools"),
     "snowflake-connector-python": ("snowflake.connector",),
+    "snowflake-sqlalchemy": ("snowflake.sqlalchemy",),
     "strawberry-graphql": ("strawberry",),
     "streamlit-aggrid": ("st_aggrid",),
     "tensorboard": ("torch.utils.tensorboard",),


### PR DESCRIPTION
Looks like there is no mapping for snowflake-sqlalchemy, this PR adds it.

SF repo: https://github.com/snowflakedb/snowflake-sqlalchemy/tree/main/src/snowflake

[ci skip-rust]
[ci skip-build-wheels]
