### PR TITLE
Mark python_aws_lambda_layer as packageable

### DIFF
--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -145,5 +145,6 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(PackageFieldSet, PythonAwsLambdaFieldSet),
+        UnionRule(PackageFieldSet, PythonAwsLambdaLayerFieldSet),
         *faas_rules(),
     ]


### PR DESCRIPTION
In yet more follow up to #19123 and #19550 for #18880, this ensures the `PythonAwsLambdaLayerFieldSet` is part of the `PackageFieldSet` union, so that `pants package path/to:some-layer` actually works.

I clearly didn't test this properly in #19123 or #19550, but now I have: in a separate repo `PANTS_SOURCE=~/... pants package path/to:some-layer` produces `dist/path.to/some-layer.zip`, with the expected contents. 🎉 