### PR TITLE
Catch google artifact registry gotcha

### DIFF
--- a/docs/markdown/Docker/docker.md
+++ b/docs/markdown/Docker/docker.md
@@ -311,7 +311,7 @@ Most authentication mechanisms will also require tools exposed on the `$PATH` to
 [docker]
 env_vars = ["DOCKER_CONFIG=%(homedir)s/.docker"]
 tools = [
-  "docker-credential-gcr",
+  "docker-credential-gcr", # or docker-credential-gcloud when using artifact registry
   "dirname",
   "readlink",
   "python3",


### PR DESCRIPTION
The command referenced in the docker config is `gcloud` which is a suffix for `docker-credential-gcloud`. This can be a significant gotcha when first trying to set up docker publishing.

Since I was asked to submit this as a PR, do you also want me to update the relevant "suggest edit" section?