### PR TITLE
upgrade to Rust v1.71.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 
@@ -252,7 +252,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 
@@ -126,7 +126,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 
@@ -228,7 +228,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 
@@ -433,7 +433,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 
@@ -498,7 +498,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.0-*
+        path: '~/.rustup/toolchains/1.71.1-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.0"
+channel = "1.71.1"
 components = [
   "cargo",
   "clippy",


### PR DESCRIPTION
Upgrade to [Rust v1.71.1](https://blog.rust-lang.org/2023/08/03/Rust-1.71.1.html).

That version of Rust was issued to fix some minor regressions from v1.71.0 and to fix [a security issue with Cargo](https://blog.rust-lang.org/2023/08/03/cve-2023-38497.html) not respecting the configured umask which could allow attackers on the system to write into the Cargo cache.