### PR TITLE
Increase timeouts on some frequent offenders

### DIFF
--- a/src/python/pants/backend/adhoc/BUILD
+++ b/src/python/pants/backend/adhoc/BUILD
@@ -4,6 +4,6 @@ python_sources()
 python_tests(
     name="tests",
     overrides={
-        "run_system_binary_integration_test.py": dict(timeout=120),
+        "run_system_binary_integration_test.py": dict(timeout=180),
     },
 )

--- a/src/python/pants/backend/docker/target_types_test.py
+++ b/src/python/pants/backend/docker/target_types_test.py
@@ -25,6 +25,11 @@ from pants.engine.internals.native_engine import Address
             os.path.expanduser("~/home/path"),
         ),
     ],
+    ids=[
+        "absolute_path",
+        "relative_path",
+        "homedir_path",
+    ],
 )
 def test_secret_path_resolvement(src: str, expected: str):
     Path.cwd().joinpath("pants.toml").write_text("")

--- a/src/python/pants/backend/python/goals/BUILD
+++ b/src/python/pants/backend/python/goals/BUILD
@@ -31,7 +31,7 @@ python_tests(
             "tags": ["platform_specific_behavior"],
             "timeout": 300,
         },
-        "run_pex_binary_integration_test.py": {"timeout": 600},
+        "run_pex_binary_integration_test.py": {"timeout": 660},
         "run_python_source_integration_test.py": {"timeout": 180},
         "package_dists_integration_test.py": {
             "dependencies": ["testprojects/src/python:native_directory"],

--- a/src/python/pants/build_graph/BUILD
+++ b/src/python/pants/build_graph/BUILD
@@ -2,4 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
-python_tests(name="tests")
+python_tests(
+    name="tests",
+    overrides={
+        "subproject_integration_test.py": {"timeout": 180},
+    },
+)

--- a/src/python/pants/init/BUILD
+++ b/src/python/pants/init/BUILD
@@ -17,6 +17,6 @@ python_sources(
 python_tests(
     name="tests",
     overrides={
-        "load_backends_integration_test.py": {"timeout": 800},
+        "load_backends_integration_test.py": {"timeout": 900},
     },
 )


### PR DESCRIPTION
I did some janky analysis of the historic data on test runs to identify tests that timed out.
These ones came up most frequently, so I've bumped their timeouts up as a temporary measure.
(This MR also gives some tests stable names so it's easier to track them across executions)