### PR TITLE
Don't override the ICs in the pants script on MacOS Silicon.

### DIFF
--- a/pants
+++ b/pants
@@ -26,10 +26,6 @@ source "${HERE}/build-support/common.sh"
 PY="$(determine_python)"
 export PY
 
-if is_macos_arm; then
-  export PANTS_PYTHON_INTERPRETER_CONSTRAINTS="${PANTS_PYTHON_INTERPRETER_CONSTRAINTS:-"['==3.9.*']"}"
-fi
-
 # Exposes:
 # + activate_pants_venv: Activate a virtualenv for pants requirements, creating it if needed.
 # shellcheck source=build-support/pants_venv


### PR DESCRIPTION
We used to need this because pants ran on Python 3.7-3.9
generally, but only on 3.9 on MacOS Silicon.

It is no longer necessary to do so, since the repo-wide ICs
are 3.9.* anyway now.

Setting this is not harmless, as it would override the ICs in
other repos when running from sources with PANTS_SOURCE=.