### PR TITLE
docs: fix code examples for `setting-up-ide` and `interpreter-compatibility` docs

### DIFF
--- a/docs/markdown/Python/python/python-interpreter-compatibility.md
+++ b/docs/markdown/Python/python/python-interpreter-compatibility.md
@@ -55,6 +55,7 @@ python_sources(
         "py2.py": {"interpreter_constraints": ["==2.7.*"]},
         # You can use a tuple for multiple files:
         ("common.py", "f.py"): {"interpreter_constraints": ["==2.7.*"]},
+    }
 )
 ```
 

--- a/docs/markdown/Using Pants/setting-up-an-ide.md
+++ b/docs/markdown/Using Pants/setting-up-an-ide.md
@@ -24,8 +24,8 @@ In VSCode, the Python extension will look for a file named `.env` in the current
 For Python, to generate the `.env` file containing all the source roots, you can use something like this:
 
 ```shell
-$ ROOTS=$(pants roots --roots-sep=';')
-$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join(\"${ROOTS}\".split(';')) + ':\$PYTHONPATH\"')" > .env
+$ ROOTS=$(pants roots)
+$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join('''${ROOTS}'''.split('\n')) + ':\$PYTHONPATH\"')" > .env
 ```
 
 See [Use of the PYTHONPATH variable](https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable) to learn more about using the `PYTHONPATH` variable in VSCode.

--- a/docs/markdown/Using Pants/setting-up-an-ide.md
+++ b/docs/markdown/Using Pants/setting-up-an-ide.md
@@ -24,8 +24,8 @@ In VSCode, the Python extension will look for a file named `.env` in the current
 For Python, to generate the `.env` file containing all the source roots, you can use something like this:
 
 ```shell
-$ ROOTS=$(pants roots --roots-sep=' ')
-$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join(\"${ROOTS}\".split()) + ':\$PYTHONPATH\"')" > .env
+$ ROOTS=$(pants roots --roots-sep=';')
+$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join(\"${ROOTS}\".split(';')) + ':\$PYTHONPATH\"')" > .env
 ```
 
 See [Use of the PYTHONPATH variable](https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable) to learn more about using the `PYTHONPATH` variable in VSCode.


### PR DESCRIPTION
## Setting Up IDE Doc Issue

Currently, in the `docs/markdown/Using Pants/setting-up-an-ide.md` page, the project instructs users to run

```shell
$ ROOTS=$(pants roots --roots-sep=' ')
$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join(\"${ROOTS}\".split()) + ':\$PYTHONPATH\"')" > .env
```

However, for some reason, the command `pants roots --roots-sep=' '` is not working for the `' '` character. This PR makes a small fix to this issue changing the `' '` character to the default `'\n'` by removing the `--roots-sep=` argument and changing how the `ROOTS` environment variable is split.

```bash
$ ROOTS=$(pants roots)
$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join('''${ROOTS}'''.split('\n')) + ':\$PYTHONPATH\"')" > .env
```

Alternatively, if we want to maintain the `roots-sep` argument, so users know it exists, we can change it from `' '` to a non whitespace character, such as `';'` and that also seems to work.

## Interpreter Compatibility Doc Issue

Another small issue is in `docs/markdown/Python/python/python-interpreter-compatibility.md` in the example:

```python
python_sources(
    name="lib",
    overrides={
        "py2.py": {"interpreter_constraints": ["==2.7.*"]},
        # You can use a tuple for multiple files:
        ("common.py", "f.py"): {"interpreter_constraints": ["==2.7.*"]},
)
```

This example is missing an `}`. This PR also addresses this small issue.