### PR TITLE
Additional mentions and tweaks in 2.17's "What's new"

### DIFF
--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -16,7 +16,10 @@ The `scie-pants` launcher has numerous benefits, such as:
 See the [Pants  installation
 instructions](https://www.pantsbuild.org/docs/installation) for additional information on how to migrate to `scie-pants.`
 
-Related to this, pants' distribution model is changing, and 2.17 will be the last version that includes the universal (cross-platform) `pants` PEX on the GitHub Release. For future releases, smaller per-platform PEXes will be attached instead.
+Related to this, pants' distribution model is changing, and 2.17 will be the last version where:
+
+* the `pantsbuild.pants` package is published to PyPI. Use [the `pants_requirements` target](https://www.pantsbuild.org/v2.17/docs/reference-pants_requirements) for installing the requisite packages for plugins, rather than `python_requirement` or similar.
+* the universal (cross-platform) `pants` PEX is published to GitHub Releases. For future releases, smaller per-platform PEXes will be attached instead.
 
 #### Performance
 

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -51,8 +51,6 @@ Rules should now request output types which do not need an input type via the ne
 example, rules can now write `await Get(ChosenLocalEnvironmentName)`. Certain request types which exists only to
 work around the previous lack of such synax are now deprecated in favor of the one argument `Get()` form.
 
-`DigestSubset` is now symlink-aware.
-
 ## 2.17.0rc3 (Aug 13, 2023)
 
 ### User API Changes

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -31,8 +31,16 @@ Theo Ribeiro. Please note that the Javascript backend is still incomplete, is be
 has critical bugs_. Despite that, the Pants maintainers would appreciate any feedback from the community to help
 guide our development efforts.
 
-Enable the `pants.backend.experimental.javascript` backend to try out this support. Please file issues at
-https://github.com/pantsbuild/pants/issues/new/choose for any issues encountered.
+Supported goals are:
+
+* `test`: Letting you run tests via runners installed with the package manager of your choice.
+* `package` goal, either to run a customized `package.json` script that produces an artifact via `node_build_script`, or to pack a tarball for npm-registry publication via the `npm_distribution` target.
+* `tailor`: Generates build file targets for `*.js`, `*.test.js` and `package.json` files.
+* `generate-lockfile`: Creates the lockfile in the format matching a projects package manager.
+
+The backend supports all package managers provided by `corepack`. `yarn@v2` and [PlugNPlay](https://yarnpkg.com/features/pnp) is not supported.
+
+Enable the `pants.backend.experimental.javascript` backend to try out this support. Please [file issues](https://github.com/pantsbuild/pants/issues/new/choose) for any issues encountered, and follow along [the stabilization ticket on github](https://github.com/pantsbuild/pants/issues/19240).
 
 #### New: Taplo TOML Formatter
 

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -10,17 +10,17 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/doc
 
 ### Overall
 
-The [`scie-pants` launcher binary](https://github.com/pantsbuild/scie-pants) is now the recommended way to run Pants.
+The [`pants` launcher binary](https://github.com/pantsbuild/scie-pants) (aka `scie-pants`) is now the recommended way to run Pants.
 Use of a `./pants` shell script in a repository is deprecated.
 
-The `scie-pants` launcher has numerous benefits, such as:
+The `pants` launcher has numerous benefits, such as:
 
 * automatically download and maintain a Python distribution for running Pants
 * run `pants` from any directory within a repository and not just the build root
 * far less overhead when starting commands (up to 4-5×)
 
 See the [Pants  installation
-instructions](https://www.pantsbuild.org/docs/installation) for additional information on how to migrate to `scie-pants.`
+instructions](https://www.pantsbuild.org/docs/installation) for additional information on how to migrate to the `pants` launcher binary.
 
 Related to this, pants' distribution model is changing, and 2.17 will be the last version where:
 

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -18,6 +18,12 @@ instructions](https://www.pantsbuild.org/docs/installation) for additional infor
 
 Related to this, pants' distribution model is changing, and 2.17 will be the last version that includes the universal (cross-platform) `pants` PEX on the GitHub Release. For future releases, smaller per-platform PEXes will be attached instead.
 
+#### Performance
+
+As mentioned above, the new launcher binary reduces start-up overhead.
+
+Large files are now cached as standalone files on disk, rather than stored directly in the internal database pants uses for cache (but still under the `~/.cache/pants/lmdb_store` directory). This improves performance for manipulating these files, especially when the cache directory and sandbox temporary directory are on the same file system and thus allow hard-linking.
+
 ### Backends
 
 #### Python

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -36,6 +36,10 @@ The `python_awslambda` or `python_google_cloud_function` targets now support a n
 
 The default value for the `[python].interpreter_constraints` option was deprecated in 2.16 and is now removed: `pants.toml` must provide this option. We recommend constraining to a single interpreter minor version if you can, for instance: `interpreter_constraints = ['==3.11.*']`. See [the Interpreter Compatibility docs for more details](https://www.pantsbuild.org/v2.17/docs/python-interpreter-compatibility).
 
+#### Docker
+
+The Docker backend now supports authenticating with registries via the `DOCKER_HOST`, `DOCKER_CONFIG` and `DOCKER_CERT_PATH` environment variables.
+
 #### New: Javascript (experimental!)
 
 Pants now has _very early_ experimental support for Javascript thanks to ongoing efforts by Tobias Nilsson and

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -24,7 +24,9 @@ Python dependencies are now analyzed via an intrinsic rule implemented in Rust f
 over the prior Python implementation of the rule. See [#18854](https://github.com/pantsbuild/pants/pull/18854) for
 discusion of the performance improvements.
 
-When exporting `python_distribution` targets, they can be installed as editable installs in the exports.
+Exported mutable virtualenvs can now include [PEP-660](https://peps.python.org/pep-0660/) editable installs of `python_distribution` targets.
+To enable this feature for a resolve, add that resolve's name to the `[export].py_editables_in_resolves` list in `pants.toml`.
+See [#18639](https://github.com/pantsbuild/pants/pull/18639) for details on Pants' PEP-660 implementation.
 
 The default `pip` Pants uses under the hood has changed from 20.3.4 to 23.1.2. This newer `pip` has better dependency resolution performance in many cases, but may give different results than the earlier `pip`. Of course those results will still be correct in the sense that they will be compatible with your requirements and constraints.
 

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -34,6 +34,8 @@ The default `pip` Pants uses under the hood has changed from 20.3.4 to 23.1.2. T
 
 The `python_awslambda` or `python_google_cloud_function` targets now support a new 'zip' layout, as recommended by the cloud vendors. This layout gives smaller packages and faster cold starts than the existing Lambdex layout, and will become the default in 2.18. See the docs [for `python_awslambda`](https://www.pantsbuild.org/v2.17/docs/awslambda-python#migrating-from-pants-216-and-earlier) and [for `python_google_cloud_function`](https://www.pantsbuild.org/v2.17/docs/google-cloud-function-python#migrating-from-pants-216-and-earlier).
 
+The default value for the `[python].interpreter_constraints` option was deprecated in 2.16 and is now removed: `pants.toml` must provide this option. We recommend constraining to a single interpreter minor version if you can, for instance: `interpreter_constraints = ['==3.11.*']`. See [the Interpreter Compatibility docs for more details](https://www.pantsbuild.org/v2.17/docs/python-interpreter-compatibility).
+
 #### New: Javascript (experimental!)
 
 Pants now has _very early_ experimental support for Javascript thanks to ongoing efforts by Tobias Nilsson and

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -2,6 +2,12 @@
 
 ## What's New
 
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/docs/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/docs/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
 ### Overall
 
 The [`scie-pants` launcher binary](https://github.com/pantsbuild/scie-pants) is now the recommended way to run Pants.

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -22,6 +22,8 @@ When exporting `python_distribution` targets, they can be installed as editable 
 
 The default `pip` Pants uses under the hood has changed from 20.3.4 to 23.1.2. This newer `pip` has better dependency resolution performance in many cases, but may give different results than the earlier `pip`. Of course those results will still be correct in the sense that they will be compatible with your requirements and constraints.
 
+The `python_awslambda` or `python_google_cloud_function` targets now support a new 'zip' layout, as recommended by the cloud vendors. This layout gives smaller packages and faster cold starts than the existing Lambdex layout, and will become the default in 2.18. See the docs [for `python_awslambda`](https://www.pantsbuild.org/v2.17/docs/awslambda-python#migrating-from-pants-216-and-earlier) and [for `python_google_cloud_function`](https://www.pantsbuild.org/v2.17/docs/google-cloud-function-python#migrating-from-pants-216-and-earlier).
+
 #### New: Javascript (experimental!)
 
 Pants now has _very early_ experimental support for Javascript thanks to ongoing efforts by Tobias Nilsson and

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -78,6 +78,8 @@ Rules should now request output types which do not need an input type via the ne
 example, rules can now write `await Get(ChosenLocalEnvironmentName)`. Certain request types which exists only to
 work around the previous lack of such synax are now deprecated in favor of the one argument `Get()` form.
 
+The `PythonBinary` type is now deprecated, use `PythonBuildStandalone` instead.
+
 ## 2.17.0rc3 (Aug 13, 2023)
 
 ### User API Changes

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -21,7 +21,7 @@ Related to this, pants' distribution model is changing, and 2.17 will be the las
 * the `pantsbuild.pants` package is published to PyPI. Use [the `pants_requirements` target](https://www.pantsbuild.org/v2.17/docs/reference-pants_requirements) for installing the requisite packages for plugins, rather than `python_requirement` or similar.
 * the universal (cross-platform) `pants` PEX is published to GitHub Releases. For future releases, smaller per-platform PEXes will be attached instead.
 
-#### Performance
+### Performance
 
 As mentioned above, the new launcher binary reduces start-up overhead.
 

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -16,6 +16,8 @@ The `scie-pants` launcher has numerous benefits, such as:
 See the [Pants  installation
 instructions](https://www.pantsbuild.org/docs/installation) for additional information on how to migrate to `scie-pants.`
 
+Related to this, pants' distribution model is changing, and 2.17 will be the last version that includes the universal (cross-platform) `pants` PEX on the GitHub Release. For future releases, smaller per-platform PEXes will be attached instead.
+
 ### Backends
 
 #### Python

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -5,9 +5,15 @@
 ### Overall
 
 The [`scie-pants` launcher binary](https://github.com/pantsbuild/scie-pants) is now the recommended way to run Pants.
-Use of a `./pants` shell script in a repository is deprecated. Among other benefits, the `scie-pants` launcher is able
-to automatically download and maintain a Python distribution for running Pants. It also allows you to run `pants`
-from any directory within a repository and not just the build root. See the [Pants  installation
+Use of a `./pants` shell script in a repository is deprecated.
+
+The `scie-pants` launcher has numerous benefits, such as:
+
+* automatically download and maintain a Python distribution for running Pants
+* run `pants` from any directory within a repository and not just the build root
+* far less overhead when starting commands (up to 4-5×)
+
+See the [Pants  installation
 instructions](https://www.pantsbuild.org/docs/installation) for additional information on how to migrate to `scie-pants.`
 
 ### Backends

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -22,14 +22,6 @@ When exporting `python_distribution` targets, they can be installed as editable 
 
 The default `pip` Pants uses under the hood has changed from 20.3.4 to 23.1.2. This newer `pip` has better dependency resolution performance in many cases, but may give different results than the earlier `pip`. Of course those results will still be correct in the sense that they will be compatible with your requirements and constraints.
 
-#### Shell
-
-The behavior of the `workdir` field on several shell-backend target types including `shell_command` has been
-updated to refer to the repository's build root when an empty string is set.
-
-For the `adhoc_tool` target type, the `stdout` and `stderr` fields are now specified relative to the applicable
-workdir and also support absolute paths.
-
 #### New: Javascript (experimental!)
 
 Pants now has _very early_ experimental support for Javascript thanks to ongoing efforts by Tobias Nilsson and


### PR DESCRIPTION
This adds a few additional notes to the "What's new" for 2.17, based on some comments in #19168, as well as a skim of the release notes from 2.17.0rc0 and newer.

This also includes an explicit call out for the new sponsorship strategy.