### PR TITLE
Add path to cache key for Rust dep inference, for relative imports (cherry-pick of #19630)

### DIFF
--- a/src/rust/engine/protos/protos/pants/cache.proto
+++ b/src/rust/engine/protos/protos/pants/cache.proto
@@ -17,6 +17,27 @@ message CacheKey {
   build.bazel.remote.execution.v2.Digest digest = 2;
 }
 
+message DependencyInferenceRequest {
+  build.bazel.remote.execution.v2.Digest input_file_digest = 1;
+  oneof metadata {
+    JavascriptInferenceMetadata js = 2;
+  }
+  // Ensure using this as a cache key reflects everything that might influence the output: inference
+  // implementation inside Pants, and the input's file location (if there's any relative imports)
+  string impl_hash = 3;
+  string input_file_path = 4;
+}
+
+
+message JavascriptInferenceMetadata {
+  message ImportPattern {
+    string pattern = 1;
+    repeated string replacements = 2;
+  }
+  string package_root = 1;
+  repeated ImportPattern import_patterns = 2;
+}
+
 // A URL and Digest tuple, which is itself digested and used as a CacheKey. ObservedURLs
 // collectively represent the set of digests that we have ever observed for a particular URL:
 // their cache value is always empty.


### PR DESCRIPTION
This adds the file path for the file being dependency-inferred to the cache key for the Rust dep inference. Without this, the same file contents appearing multiple times in different places will give the wrong results for relative imports, because the dep inference process mashes together the file path and the relative import.

The circumstances here seem most likely to occur in the real world if a file is moved, with the inference results from before the move reused for the file _after_ the move too.

I've tested this manually on the reproducer in https://github.com/pantsbuild/pants/issues/19618#issuecomment-1685631591, in addition to comparing the before (fails) and after (passes) behaviour of the new test.

To try to make this code more resilient to this sort of mistake, I've removed the top level `PreparedInferenceRequest.path` key, in favour of using the new `input_file_path` on the request protobuf struct, at the cost of an additional `String` -> `PathBuf` conversion when doing the inference.

Fixes #19618 

This is a cherry pick of #19630, but is essentially a slightly weird rewrite that partially cherry-picks #19001 too, by copying over the whole `DependencyInferenceRequest` protobuf type as is (even with some fields that are unused) because that's the easiest way to generate appropriate bytes for turning into the digest for use in the cache-key. I think it's okay to have this "weird" behaviour in the 2.17 branch, with the real/normal code in main/2.18?