### PR TITLE
Add Python 3.12 to the default interpreter universe

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -64,7 +64,17 @@ class PythonSetup(Subsystem):
     options_scope = "python"
     help = "Options for Pants's Python backend."
 
-    default_interpreter_universe = ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11"]
+    default_interpreter_universe = [
+        "2.7",
+        "3.5",
+        "3.6",
+        "3.7",
+        "3.8",
+        "3.9",
+        "3.10",
+        "3.11",
+        "3.12",
+    ]
 
     _interpreter_constraints = StrListOption(
         default=None,


### PR DESCRIPTION
[PEP 693](https://peps.python.org/pep-0693/) gives an expected release date for 3.12.0 of 2023-10-02, which is about 6 weeks away. This suggests it's likely that either Pants 2.17 or 2.18 will be the current Pants release when 3.12.0 comes out... This patch anticipates this, and ensures Pants users are ready to start using 3.12.0 immediately, easily, without having to override the `[python] interpreter_versions_universe = ...` setting.

I'm not sure if changing this value has consequences beyond just making more options available; let me know! I also don't know what `category:` label this should have.