### PR TITLE
Undo pyenv install marking files as RO (Cherry-pick of #19645)

### DIFF
--- a/src/python/pants/backend/python/providers/pyenv/rules.py
+++ b/src/python/pants/backend/python/providers/pyenv/rules.py
@@ -187,10 +187,6 @@ async def get_pyenv_install_info(
                             shutil.rmtree(SPECIFIC_VERSION_PATH, ignore_errors=True)
 
                             subprocess.run(["{pyenv.exe}", "install", SPECIFIC_VERSION], check=True)
-                            # Removing write perms helps ensure users aren't accidentally modifying
-                            # Python or the site-packages
-                            subprocess.run(["chmod", "-R", "-w", str(SPECIFIC_VERSION_PATH)], check=True)
-                            subprocess.run(["chmod", "+w", str(SPECIFIC_VERSION_PATH)], check=True)
                             DONEFILE_PATH.touch()
 
                         if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/19515

The original change was a precaution to ensure the cached environment was read-only, but as the ticket points out this makes cache-wiping a headache and it isn't clear marking as read-only gains us anything.
