### PR TITLE
Use hardlinking when possible for mypy cache (Cherry-pick of #19633)

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -39,7 +39,13 @@ from pants.backend.python.util_rules.python_sources import (
 from pants.base.build_root import BuildRoot
 from pants.core.goals.check import REPORT_DIR, CheckRequest, CheckResult, CheckResults
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.core.util_rules.system_binaries import CpBinary, MkdirBinary, MvBinary, ReadlinkBinary
+from pants.core.util_rules.system_binaries import (
+    CpBinary,
+    LnBinary,
+    MkdirBinary,
+    MktempBinary,
+    MvBinary,
+)
 from pants.engine.collection import Collection
 from pants.engine.fs import CreateDigest, Digest, FileContent, MergeDigests, RemovePrefix
 from pants.engine.process import FallibleProcessResult, Process
@@ -133,9 +139,10 @@ async def mypy_typecheck_partition(
     mypy: MyPy,
     python_setup: PythonSetup,
     mkdir: MkdirBinary,
+    mktemp: MktempBinary,
     cp: CpBinary,
     mv: MvBinary,
-    readlink: ReadlinkBinary,
+    ln: LnBinary,
     global_options: GlobalOptions,
 ) -> CheckResult:
     # MyPy requires 3.5+ to run, but uses the typed-ast library to work with 2.7, 3.4, 3.5, 3.6,
@@ -258,11 +265,20 @@ async def mypy_typecheck_partition(
                             # db, as it issues at least 2 single-row queries per source file at different
                             # points in time (therefore SQLite's own safety guarantees don't apply).
                             #
-                            # To workaround this we make a copy of the db from the append_only_cache,
-                            # run MyPy on it, then move the updated cache back to the append_only_cache.
-                            # This is multiprocess-safe as mv on the same filesystem is an atomic "rename",
-                            # and any processes copying the "old" file will still have valid file
-                            # descriptors for the "old" file.
+                            # Our workaround depends on whether we can hardlink between the sandbox
+                            # and cache or not.
+                            #
+                            # If we can hardlink (this means the two sides of the link are on the
+                            # same filesystem), then after mypy runs, we hardlink from the sandbox
+                            # back to the named cache.
+                            #
+                            # If we can't hardlink, we resort to copying the result next to the
+                            # cache under a temporary name, and finally doing an atomic mv from the
+                            # tempfile to the real one.
+                            #
+                            # In either case, the result is an atomic replacement of the "old" named
+                            # cache db, such that old references (via opened file descriptors) are
+                            # still valid, but new references use the new contents.
                             #
                             # There is a chance of multiple processes thrashing on the cache, leaving
                             # it in a state that doesn't reflect reality at the current point in time,
@@ -278,28 +294,21 @@ async def mypy_typecheck_partition(
                             # for different versions) and uses a one-process-at-a-time daemon by default,
                             # multiple MyPy processes operating on a single db cache should be rare.
 
-                            {mkdir.path} -p {run_cache_dir}/{py_version} > /dev/null 2>&1 || true
-                            {cp.path} {mypy_cache_dir}/{py_version}/cache.db {run_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
+                            NAMED_CACHE_DIR="{mypy_cache_dir}/{py_version}"
+                            NAMED_CACHE_DB="$NAMED_CACHE_DIR/cache.db"
+                            SANDBOX_CACHE_DIR="{run_cache_dir}/{py_version}"
+                            SANDBOX_CACHE_DB="$SANDBOX_CACHE_DIR/cache.db"
+
+                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" > /dev/null 2>&1
+                            {cp.path} "$NAMED_CACHE_DB" "$SANDBOX_CACHE_DB" > /dev/null 2>&1
 
                             {' '.join((shell_quote(arg) for arg in argv))}
                             EXIT_CODE=$?
 
-                            get_device_id() {{
-                                TEST_PATH=$({readlink.path} -f "$1")
-                                stat -c "%d" "$TEST_PATH" 2>/dev/null || stat -f "%d" "$TEST_PATH" 2>/dev/null
-                            }}
-                            {mkdir.path} -p {mypy_cache_dir}/{py_version} > /dev/null 2>&1 || true
-                            SANDBOX_DEVID=$(get_device_id "{run_cache_dir}")
-                            NAMED_CACHE_DEVID=$(get_device_id "{mypy_cache_dir}")
-
-                            if [ "$SANDBOX_DEVID" = "$NAMED_CACHE_DEVID" ]; then
-                                # Same device, just `mv`
-                                {mv.path} {run_cache_dir}/{py_version}/cache.db {mypy_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
-                            else
-                                # Different devices, `cp` into a tempfile, then `mv`
-                                TMP_CACHE=$(mktemp "{mypy_cache_dir}/{py_version}/cache.db.tmp.XXXXXX")
-                                {cp.path} {run_cache_dir}/{py_version}/cache.db $TMP_CACHE > /dev/null 2>&1 || true
-                                {mv.path} $TMP_CACHE {mypy_cache_dir}/{py_version}/cache.db > /dev/null 2>&1 || true
+                            if ! {ln.path} "$SANDBOX_CACHE_DB" "$NAMED_CACHE_DB" > /dev/null 2>&1; then
+                                TMP_CACHE=$({mktemp.path} "$SANDBOX_CACHE_DB.tmp.XXXXXX")
+                                {cp.path} "$SANDBOX_CACHE_DB" "$TMP_CACHE" > /dev/null 2>&1
+                                {mv.path} "$TMP_CACHE" "$NAMED_CACHE_DB" > /dev/null 2>&1
                             fi
 
                             exit $EXIT_CODE

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -334,6 +334,10 @@ class MkdirBinary(BinaryPath):
     pass
 
 
+class MktempBinary(BinaryPath):
+    pass
+
+
 class TouchBinary(BinaryPath):
     pass
 
@@ -343,6 +347,10 @@ class CpBinary(BinaryPath):
 
 
 class MvBinary(BinaryPath):
+    pass
+
+
+class LnBinary(BinaryPath):
     pass
 
 
@@ -702,6 +710,14 @@ async def find_mkdir() -> MkdirBinary:
     return MkdirBinary(first_path.path, first_path.fingerprint)
 
 
+@rule(desc="Finding the `mktempt` binary", level=LogLevel.DEBUG)
+async def find_mktemp() -> MktempBinary:
+    request = BinaryPathRequest(binary_name="mktemp", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="create temporary files/directories")
+    return MktempBinary(first_path.path, first_path.fingerprint)
+
+
 @rule(desc="Finding the `touch` binary", level=LogLevel.DEBUG)
 async def find_touch() -> TouchBinary:
     request = BinaryPathRequest(binary_name="touch", search_path=SEARCH_PATHS)
@@ -724,6 +740,14 @@ async def find_mv() -> MvBinary:
     paths = await Get(BinaryPaths, BinaryPathRequest, request)
     first_path = paths.first_path_or_raise(request, rationale="move files")
     return MvBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `ln` binary", level=LogLevel.DEBUG)
+async def find_ln() -> LnBinary:
+    request = BinaryPathRequest(binary_name="ln", search_path=SEARCH_PATHS)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="link files")
+    return LnBinary(first_path.path, first_path.fingerprint)
 
 
 @rule(desc="Finding the `chmod` binary", level=LogLevel.DEBUG)


### PR DESCRIPTION
As surfaced by @jsirois in https://github.com/pantsbuild/pants/pull/19610#discussion_r1298951404, as a way of making the mypy cache "atomic" in all scenarios, we'll attempt a hardlink and fall back to copying/moving.
