### PR TITLE
Require scie-pants 0.9.2 or newer, for new distribution model

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -110,7 +110,7 @@ class PantsRunner:
                 current_version_text = (
                     f"The current version of the `pants` launcher binary is {scie_pants_version}"
                     if scie_pants_version
-                    else f"Run `PANTS_BOOTSTRAP_VERSION=report pants` to see the current version of the `pants` launcher binary"
+                    else "Run `PANTS_BOOTSTRAP_VERSION=report pants` to see the current version of the `pants` launcher binary"
                 )
                 warn_or_error(
                     "2.18.0.dev6",

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -87,7 +87,11 @@ class PantsRunner:
             stdout_fileno=stdout_fileno,
             stderr_fileno=stderr_fileno,
         ):
-            if "SCIE" not in os.environ and "NO_SCIE_WARNING" not in os.environ:
+            run_via_scie = "SCIE" in os.environ
+            enable_scie_warning = "NO_SCIE_WARNING" not in os.environ
+            scie_pants_version = os.environ.get("SCIE_PANTS_VERSION")
+
+            if not run_via_scie and enable_scie_warning:
                 raise RuntimeError(
                     softwrap(
                         f"""
@@ -97,9 +101,10 @@ class PantsRunner:
                     ),
                 )
 
-            scie_pants_version = os.environ.get("SCIE_PANTS_VERSION")
-            if (
+            if run_via_scie and (
+                # either scie-pants is too old to communicate its version:
                 scie_pants_version is None
+                # or the version itself is too old:
                 or Version(scie_pants_version) < MINIMUM_SCIE_PANTS_VERSION
             ):
                 current_version_text = (


### PR DESCRIPTION
This updates Pants to require and check for the scie-pants launcher binary version: we need version 0.9 or earlier, to have support for the new distribution model. This syncs with https://github.com/pantsbuild/scie-pants/pull/246 (which will become scie-pants 0.9.2 / 0.9.3), which sets the `SCIE_PANTS_VERSION` environment variable when running pants.

This will be cherry-picked back as far as we support, to help users upgrade their launcher earlier.

Fixes #19600 