### PR TITLE
Require scie-pants 0.9.2 or newer, for new distribution model (Cherry-pick of #19654)

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -8,6 +8,8 @@ import warnings
 from dataclasses import dataclass
 from typing import List, Mapping
 
+from packaging.version import Version
+
 from pants.base.deprecated import warn_or_error
 from pants.base.exception_sink import ExceptionSink
 from pants.base.exiter import ExitCode
@@ -20,6 +22,10 @@ from pants.util.docutil import bin_name, doc_url
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+# Pants 2.18 is using a new distribution model, that's only supported in 0.9.0 (this is 0.9.2,
+# because _detecting_ the version is only supported from 0.9.2), so people should upgrade
+MINIMUM_SCIE_PANTS_VERSION = Version("0.9.2")
 
 
 @dataclass(frozen=True)
@@ -83,7 +89,11 @@ class PantsRunner:
         ):
             # N.B. We inline imports to speed up the python thin client run, and avoids importing
             # engine types until after the runner has had a chance to set __PANTS_BIN_NAME.
-            if "SCIE" not in os.environ and "NO_SCIE_WARNING" not in os.environ:
+            run_via_scie = "SCIE" in os.environ
+            enable_scie_warning = "NO_SCIE_WARNING" not in os.environ
+            scie_pants_version = os.environ.get("SCIE_PANTS_VERSION")
+
+            if not run_via_scie and enable_scie_warning:
                 warn_or_error(
                     "2.18.0.dev0",
                     f"Running Pants in an external Python interpreter via a `{bin_name()}` script",
@@ -91,6 +101,27 @@ class PantsRunner:
                         f"""
                         The `pants` launcher binary is now the approved way of running Pants.
                         See {doc_url("installation")} for details.
+                        """
+                    ),
+                )
+
+            if run_via_scie and (
+                # either scie-pants is too old to communicate its version:
+                scie_pants_version is None
+                # or the version itself is too old:
+                or Version(scie_pants_version) < MINIMUM_SCIE_PANTS_VERSION
+            ):
+                current_version_text = (
+                    f"The current version of the `pants` launcher binary is {scie_pants_version}"
+                    if scie_pants_version
+                    else "Run `PANTS_BOOTSTRAP_VERSION=report pants` to see the current version of the `pants` launcher binary"
+                )
+                warn_or_error(
+                    "2.18.0.dev6",
+                    f"using a `pants` launcher binary older than {MINIMUM_SCIE_PANTS_VERSION}",
+                    softwrap(
+                        f"""
+                        {current_version_text}, and see {doc_url("installation")} for how to upgrade.
                         """
                     ),
                 )


### PR DESCRIPTION
This updates Pants to require and check for the scie-pants launcher binary version: we need version 0.9 or earlier, to have support for the new distribution model. This syncs with https://github.com/pantsbuild/scie-pants/pull/246 (which will become scie-pants 0.9.2 / 0.9.3), which sets the `SCIE_PANTS_VERSION` environment variable when running pants.

This will be cherry-picked back as far as we support, to help users upgrade their launcher earlier.

Fixes #19600 
