### PR TITLE
Silence the scie-pants version warning when NO_SCIE_WARNING=1

### DIFF
--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -88,39 +88,40 @@ class PantsRunner:
             stderr_fileno=stderr_fileno,
         ):
             run_via_scie = "SCIE" in os.environ
-            enable_scie_warning = "NO_SCIE_WARNING" not in os.environ
+            enable_scie_warnings = "NO_SCIE_WARNING" not in os.environ
             scie_pants_version = os.environ.get("SCIE_PANTS_VERSION")
 
-            if not run_via_scie and enable_scie_warning:
-                raise RuntimeError(
-                    softwrap(
-                        f"""
-                        The `pants` launcher binary is now the only supported way of running Pants.
-                        See {doc_url("installation")} for details.
-                        """
-                    ),
-                )
+            if enable_scie_warnings:
+                if not run_via_scie:
+                    raise RuntimeError(
+                        softwrap(
+                            f"""
+                            The `pants` launcher binary is now the only supported way of running Pants.
+                            See {doc_url("installation")} for details.
+                            """
+                        ),
+                    )
 
-            if run_via_scie and (
-                # either scie-pants is too old to communicate its version:
-                scie_pants_version is None
-                # or the version itself is too old:
-                or Version(scie_pants_version) < MINIMUM_SCIE_PANTS_VERSION
-            ):
-                current_version_text = (
-                    f"The current version of the `pants` launcher binary is {scie_pants_version}"
-                    if scie_pants_version
-                    else "Run `PANTS_BOOTSTRAP_VERSION=report pants` to see the current version of the `pants` launcher binary"
-                )
-                warn_or_error(
-                    "2.18.0.dev6",
-                    f"using a `pants` launcher binary older than {MINIMUM_SCIE_PANTS_VERSION}",
-                    softwrap(
-                        f"""
-                        {current_version_text}, and see {doc_url("installation")} for how to upgrade.
-                        """
-                    ),
-                )
+                if run_via_scie and (
+                    # either scie-pants is too old to communicate its version:
+                    scie_pants_version is None
+                    # or the version itself is too old:
+                    or Version(scie_pants_version) < MINIMUM_SCIE_PANTS_VERSION
+                ):
+                    current_version_text = (
+                        f"The current version of the `pants` launcher binary is {scie_pants_version}"
+                        if scie_pants_version
+                        else "Run `PANTS_BOOTSTRAP_VERSION=report pants` to see the current version of the `pants` launcher binary"
+                    )
+                    warn_or_error(
+                        "2.18.0.dev6",
+                        f"using a `pants` launcher binary older than {MINIMUM_SCIE_PANTS_VERSION}",
+                        softwrap(
+                            f"""
+                            {current_version_text}, and see {doc_url("installation")} for how to upgrade.
+                            """
+                        ),
+                    )
 
             # N.B. We inline imports to speed up the python thin client run, and avoids importing
             # engine types until after the runner has had a chance to set __PANTS_BIN_NAME.


### PR DESCRIPTION
Before this fix, #19654 was causing `pants ...` commands in the pants repo to explode and not work. This fixes it by silencing them in the pants repo, keying off the existing `NO_SCIE_WARNING=1` mechanism.

Running scie-pants in the pants repo goes through a special bootstrap mechanism, that's bootstrapped outside the scie-pants processing on purpose. This in particular means that the scie-pants version check from #19600 / #19654 doesn't work, because it's not invoked via that mechanism. Fortunately, this can just be treated the same as the "am I running in scie-pants at all?" check, looking for the env var set by the pants repo bootstrapper.

The version check has to be strict about the `SCIE_PANTS_VERSION` environment variable, and it cannot just do nothing when that's not set. The goal with this check is to help people using upgrade to scie-pants 0.9+ _before_ Pants 2.18 is released, because Pants 2.18 has a new distribution mechanism that's only supported by scie-pants 0.9+ (this is why we needed to land #19654 last minute, to be in Pants 2.17). scie-pants only sets the environment variable in version 0.9 too, so a user using scie-pants 0.8.0 will be running Pants 2.17 without setting `SCIE_PANTS_VERSION`, and so, to help them upgrade, we have to assume "doesn't exist" = "scie-pants is too old". The pants repo custom bootstrap doesn't set this env var, and hence used to fall into that trap.
