### PR TITLE
Backport to 2.17: docs: set EnvironmentBehavior in plugin Goal examples (#19590)

### DIFF
--- a/docs/markdown/Tutorials/advanced-plugin-concepts.md
+++ b/docs/markdown/Tutorials/advanced-plugin-concepts.md
@@ -519,6 +519,7 @@ class ProjectVersionSubsystem(GoalSubsystem):
 
 class ProjectVersionGoal(Goal):
     subsystem_cls = ProjectVersionSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 class InvalidProjectVersionString(ValueError):

--- a/docs/markdown/Tutorials/create-a-new-goal.md
+++ b/docs/markdown/Tutorials/create-a-new-goal.md
@@ -126,6 +126,7 @@ class ProjectVersionSubsystem(GoalSubsystem):
 
 class ProjectVersionGoal(Goal):
     subsystem_cls = ProjectVersionSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule
@@ -345,6 +346,7 @@ class ProjectVersionSubsystem(GoalSubsystem):
 
 class ProjectVersionGoal(Goal):
     subsystem_cls = ProjectVersionSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-goal-rules.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-goal-rules.md
@@ -39,6 +39,7 @@ class HelloWorldSubsystem(GoalSubsystem):
 
 class HelloWorld(Goal):
     subsystem_cls = HelloWorldSubsystem
+    environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
 @goal_rule


### PR DESCRIPTION
Per the plugin upgrade guide, this become mandatory in 2.17