### PR TITLE
add type annotation in goal.py

### DIFF
--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -54,7 +54,7 @@ class GoalSubsystem(Subsystem):
 
     @classproperty
     @abstractmethod
-    def name(cls):
+    def name(cls) -> str:
         """The name used to select the corresponding Goal on the commandline and the options_scope
         for its options."""
 


### PR DESCRIPTION
When I define a new Subsystem like so…
```
class HelloWorldSubsystem(Outputting, GoalSubsystem):
    name = "hello-world"
    help = "An example goal."
```
…I get red squiggles in VS Code and an error message:
```
Expression of type "Literal['hello-world']" cannot be assigned to declared type "None"
  Type cannot be assigned to type "None"
```
I don't like red squiggles, and this makes them go away.