### PR TITLE
Ignore all empty string CLI args

### DIFF
--- a/src/python/pants/option/arg_splitter.py
+++ b/src/python/pants/option/arg_splitter.py
@@ -164,9 +164,13 @@ class ArgSplitter:
             # Use builtin goal as default scope for args.
             return builtin_goal or scope_info.scope
 
-        self._unconsumed_args = list(reversed(args))
-        # The first token is the binary name, so skip it.
-        self._unconsumed_args.pop()
+        self._unconsumed_args = [
+            arg
+            # The first token is the binary name, so skip it:
+            for arg in reversed(args[1:])
+            # Ignore empty strings, they never mean anything:
+            if arg != ""
+        ]
 
         def assign_flag_to_scope(flg: str, default_scope: str) -> None:
             flag_scope, descoped_flag = self._descope_flag(flg, default_scope=default_scope)

--- a/src/python/pants/option/arg_splitter_test.py
+++ b/src/python/pants/option/arg_splitter_test.py
@@ -198,6 +198,40 @@ def goal_split_test(command_line: str, **expected):
                 expected_specs=["check.java"],
             ),
         ),
+        # empty args should be ignored everywhere...
+        (
+            "./pants '' test --debug ::",
+            dict(
+                expected_goals=["test"],
+                expected_scope_to_flags={"": [], "test": ["--debug"]},
+                expected_specs=["::"],
+            ),
+        ),
+        (
+            "./pants test '' --debug ::",
+            dict(
+                expected_goals=["test"],
+                expected_scope_to_flags={"": [], "test": ["--debug"]},
+                expected_specs=["::"],
+            ),
+        ),
+        (
+            "./pants test --debug '' ::",
+            dict(
+                expected_goals=["test"],
+                expected_scope_to_flags={"": [], "test": ["--debug"]},
+                expected_specs=["::"],
+            ),
+        ),
+        # ... except if one somehow end up as the binary name:
+        (
+            "'' test --debug ::",
+            dict(
+                expected_goals=["test"],
+                expected_scope_to_flags={"": [], "test": ["--debug"]},
+                expected_specs=["::"],
+            ),
+        ),
     ],
 )
 def test_valid_arg_splits(


### PR DESCRIPTION
Fixes pantsbuild/scie-pants#249 

Notes to @huonw :

- scie-pants fix in pantsbuild/scie-pants#250 
- In theory I think an empty string always does nothing (e.g. passing nothing to an arg should be `pants --foo=` not `pants --foo ''`), but maybe a plugin could observe the difference?