### PR TITLE
Remove `tensorboard` mapping from our default mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -241,7 +241,6 @@ DEFAULT_MODULE_MAPPING = {
     "snowflake-sqlalchemy": ("snowflake.sqlalchemy",),
     "strawberry-graphql": ("strawberry",),
     "streamlit-aggrid": ("st_aggrid",),
-    "tensorboard": ("torch.utils.tensorboard",),
     "unleashclient": ("UnleashClient",),
     "websocket-client": ("websocket",),
 }


### PR DESCRIPTION
`torch.utils.tensorboard` imports `tensorboard` (or dies trying). The original intent is "if a file imports it, it should receive a dependency on `tensorboard`". Unfortunately the actual behavior is that _only_ tensorboard is inferred (and not `torch`). Worse, an import from `tensorboard` is now ambiguous (because it's missing from the value).

So we'll remove it and cherry-pick to 2.17.x (when it was introduced). Later we can fix the underlying issue of being able to model an import mapping to multiple packages.

See https://github.com/pantsbuild/pants/issues/19672