### PR TITLE
upgrade to Rust v1.72.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 
@@ -258,7 +258,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 
@@ -126,7 +126,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 
@@ -228,7 +228,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 
@@ -435,7 +435,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 
@@ -500,7 +500,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.71.1-*
+        path: '~/.rustup/toolchains/1.72.0-*
 
           ~/.rustup/update-hashes
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.72.0"
 components = [
   "cargo",
   "clippy",

--- a/src/rust/engine/fs/src/glob_matching.rs
+++ b/src/rust/engine/fs/src/glob_matching.rs
@@ -527,7 +527,7 @@ trait GlobMatchingImplementation<E: Display + Send + Sync + 'static>: Vfs<E> {
       // Get all the inputs which didn't transitively expand to any files.
       let matching_inputs = sources
         .iter()
-        .zip(matched.into_iter())
+        .zip(matched)
         .filter_map(
           |(source, matched)| {
             if matched {

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -69,8 +69,8 @@ impl Config {
     files
       .iter()
       .map(Config::parse)
-      .fold(Ok(Config::default()), |acc, parse_result| {
-        acc.and_then(|config| parse_result.map(|parsed| config.merge(parsed)))
+      .try_fold(Config::default(), |config, parse_result| {
+        parse_result.map(|parsed| config.merge(parsed))
       })
   }
 

--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -203,7 +203,7 @@ async fn credentials_for_image(
   //
   // https://github.com/distribution/distribution/blob/e5d5810851d1f17a5070e9b6f940d8af98ea3c29/reference/reference.go#L4-L26
   let Some((server, _)) = image.split_once('/') else {
-    return Ok(None)
+    return Ok(None);
   };
   let server = server.to_owned();
 
@@ -211,8 +211,11 @@ async fn credentials_for_image(
     .spawn_blocking(
       move || {
         // Resolve the server as a DNS name to confirm that it is actually a registry.
-        let Ok(_) = (server.as_ref(), 80).to_socket_addrs().or_else(|_| server.to_socket_addrs()) else {
-          return Ok(None)
+        let Ok(_) = (server.as_ref(), 80)
+          .to_socket_addrs()
+          .or_else(|_| server.to_socket_addrs())
+        else {
+          return Ok(None);
         };
 
         // TODO: https://github.com/keirlawson/docker_credential/issues/7 means that this will only
@@ -404,8 +407,10 @@ impl<'a> process_execution::CommandRunner for CommandRunner<'a> {
         let (container_id, named_caches) = {
           let ProcessExecutionStrategy::Docker(image) = &req.execution_environment.strategy else {
             return Err(ProcessError::Unclassified(
-                "The Docker execution strategy was not set on the Process, but \
-                 the Docker CommandRunner was used.".to_owned()))
+              "The Docker execution strategy was not set on the Process, but \
+                 the Docker CommandRunner was used."
+                .to_owned(),
+            ));
           };
 
           self

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -590,7 +590,9 @@ async fn check_action_cache(
       let response = provider
         .get_action_result(action_digest, context)
         .and_then(|action_result| async move {
-          let Some(action_result) = action_result else { return Ok(None) };
+          let Some(action_result) = action_result else {
+            return Ok(None);
+          };
 
           let response = populate_fallible_execution_result(
             store.clone(),

--- a/src/rust/engine/src/externs/address.rs
+++ b/src/rust/engine/src/externs/address.rs
@@ -256,7 +256,10 @@ impl AddressInput {
   fn file_to_address(&self) -> PyResult<Address> {
     let Some(target_component) = self.target_component.as_ref() else {
       // Use the default target in the same directory as the file.
-      match (self.path_component.parent(), self.path_component.file_name()) {
+      match (
+        self.path_component.parent(),
+        self.path_component.file_name(),
+      ) {
         (Some(spec_path), Some(relative_file_path)) if !spec_path.as_os_str().is_empty() => {
           return Address::__new__(
             spec_path.to_owned(),

--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -228,10 +228,10 @@ impl Field {
     }
 
     let Some(removal_hint) = Self::cls_removal_hint(cls)? else {
-        return Err(PyValueError::new_err(
-            "You specified `removal_version` for {cls:?}, but not the class \
-             property `removal_hint`."
-        ))
+      return Err(PyValueError::new_err(
+        "You specified `removal_version` for {cls:?}, but not the class \
+             property `removal_hint`.",
+      ));
     };
 
     let alias = Self::cls_alias(cls)?;

--- a/src/rust/engine/task_executor/src/lib.rs
+++ b/src/rust/engine/task_executor/src/lib.rs
@@ -250,7 +250,9 @@ impl Executor {
   /// This method has no effect for "borrowed" Executors: see the `Executor` rustdoc.
   ///
   pub fn shutdown(&self, timeout: Duration) {
-    let Some(runtime) = self.runtime.lock().take() else { return };
+    let Some(runtime) = self.runtime.lock().take() else {
+      return;
+    };
 
     let start = Instant::now();
     runtime.shutdown_timeout(timeout + Duration::from_millis(250));


### PR DESCRIPTION
Upgrade to Rust v1.72.0. See the [blog post for more information](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html).

Changes:
- Fixed two clippy lints which triggered.
- `cargo fmt` reformatted some code including usages of `let foo = ... else { }`.