### PR TITLE
Add additional public repos to test, fix backend.ai

### DIFF
--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -560,9 +560,9 @@ jobs:
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
-      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis::`
+      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::`
         with repo-default version (baseline)'
-      run: ' pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis::'
+      run: ' pants test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::'
     - env:
         PANTS_VERSION: ''
       if: success() || failure()
@@ -591,10 +591,10 @@ jobs:
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()
-      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis::`
+      name: 'Run `test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::`
         with ${{ github.event.inputs.pants_version }}'
       run: '${{ github.event.inputs.extra_env }} pants test :: -tests/agent/docker::
-        -tests/client/integration:: -tests/common/redis::'
+        -tests/client/integration:: -tests/common/redis_helper::'
     - env:
         PANTS_VERSION: ${{ github.event.inputs.pants_version }}
       if: success() || failure()

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -4,6 +4,91 @@
 
 
 jobs:
+  AlexTereshenkov_cheeseshop-query:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    name: AlexTereshenkov/cheeseshop-query
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 10
+        repository: AlexTereshenkov/cheeseshop-query
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Pants on
+      run: '
+
+        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
+        | bash -
+
+        echo "$HOME/bin" | tee -a $GITHUB_PATH
+
+        '
+    - name: Check for pants.ci.toml
+      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
+        \ | tee -a $GITHUB_ENV\nfi\n"
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `version` with repo-default version (baseline)
+      run: ' pants version'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `tailor --check update-build-files --check ::` with repo-default version
+        (baseline)
+      run: ' pants tailor --check update-build-files --check ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `lint check ::` with repo-default version (baseline)
+      run: ' pants lint check ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `test ::` with repo-default version (baseline)
+      run: ' pants test ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `package ::` with repo-default version (baseline)
+      run: ' pants package ::'
+    - if: success() || failure()
+      name: Kill pantsd
+      run: pkill -f pantsd
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `version` with ${{ github.event.inputs.pants_version }}
+      run: ${{ github.event.inputs.extra_env }} pants version
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
+        }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
+        --check ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `test ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants test ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `package ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants package ::'
   Ars-Linguistica_mlconjug3:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -1522,6 +1522,91 @@ jobs:
       if: success() || failure()
       name: Run `test ::` with ${{ github.event.inputs.pants_version }}
       run: '${{ github.event.inputs.extra_env }} pants test ::'
+  pantsbuild_scie-pants:
+    env:
+      PANTS_REMOTE_CACHE_READ: 'false'
+      PANTS_REMOTE_CACHE_WRITE: 'false'
+    name: pantsbuild/scie-pants
+    permissions: {}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 10
+        repository: pantsbuild/scie-pants
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Pants on
+      run: '
+
+        curl --proto ''=https'' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh
+        | bash -
+
+        echo "$HOME/bin" | tee -a $GITHUB_PATH
+
+        '
+    - name: Check for pants.ci.toml
+      run: "\nif [[ -f pants.ci.toml ]]; then\n    echo \"PANTS_CONFIG_FILES=pants.ci.toml\"\
+        \ | tee -a $GITHUB_ENV\nfi\n"
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `version` with repo-default version (baseline)
+      run: ' pants version'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `tailor --check update-build-files --check ::` with repo-default version
+        (baseline)
+      run: ' pants tailor --check update-build-files --check ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `lint check ::` with repo-default version (baseline)
+      run: ' pants lint check ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `test ::` with repo-default version (baseline)
+      run: ' pants test ::'
+    - env:
+        PANTS_VERSION: ''
+      if: success() || failure()
+      name: Run `package ::` with repo-default version (baseline)
+      run: ' pants package ::'
+    - if: success() || failure()
+      name: Kill pantsd
+      run: pkill -f pantsd
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `version` with ${{ github.event.inputs.pants_version }}
+      run: ${{ github.event.inputs.extra_env }} pants version
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `tailor --check update-build-files --check ::` with ${{ github.event.inputs.pants_version
+        }}
+      run: '${{ github.event.inputs.extra_env }} pants tailor --check update-build-files
+        --check ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `lint check ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants lint check ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `test ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants test ::'
+    - env:
+        PANTS_VERSION: ${{ github.event.inputs.pants_version }}
+      if: success() || failure()
+      name: Run `package ::` with ${{ github.event.inputs.pants_version }}
+      run: '${{ github.event.inputs.extra_env }} pants package ::'
 name: Public repos tests
 'on':
   workflow_dispatch:

--- a/.github/workflows/public_repos.yaml
+++ b/.github/workflows/public_repos.yaml
@@ -523,10 +523,10 @@ jobs:
       with:
         fetch-depth: 10
         repository: lablup/backend.ai
-    - name: Set up Python 3.11.3
+    - name: Set up Python 3.11.4
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11.3
+        python-version: 3.11.4
     - name: Pants on
       run: '
 

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1396,7 +1396,7 @@ PUBLIC_REPOS = [
         goals=[
             DefaultGoals.tailor_update_build_files,
             DefaultGoals.lint_check,
-            "test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis::",
+            "test :: -tests/agent/docker:: -tests/client/integration:: -tests/common/redis_helper::",
             DefaultGoals.package,
         ],
     ),

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1367,6 +1367,8 @@ PUBLIC_REPOS = [
         # skip check
         goals=[DefaultGoals.tailor_update_build_files, "lint ::", DefaultGoals.test],
     ),
+    # other pants' managed repos
+    Repo(name="pantsbuild/scie-pants", python_version="3.9"),
     # public repos
     Repo(name="AlexTereshenkov/cheeseshop-query", python_version="3.9"),
     Repo(name="Ars-Linguistica/mlconjug3", goals=[DefaultGoals.package]),

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1368,6 +1368,7 @@ PUBLIC_REPOS = [
         goals=[DefaultGoals.tailor_update_build_files, "lint ::", DefaultGoals.test],
     ),
     # public repos
+    Repo(name="AlexTereshenkov/cheeseshop-query", python_version="3.9"),
     Repo(name="Ars-Linguistica/mlconjug3", goals=[DefaultGoals.package]),
     Repo(
         name="fucina/treb",

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1389,7 +1389,7 @@ PUBLIC_REPOS = [
     Repo(name="komprenilo/liga", python_version="3.9", goals=[DefaultGoals.package]),
     Repo(
         name="lablup/backend.ai",
-        python_version="3.11.3",
+        python_version="3.11.4",
         setup_commands="mkdir .tmp",
         goals=[
             DefaultGoals.tailor_update_build_files,


### PR DESCRIPTION
This makes a few tweaks to the public repos testing experiment from #19161:

- add https://github.com/pantsbuild/scie-pants (currently fails, but will be fixed by #258, and #259 is related too)
- add https://github.com/AlexTereshenkov/cheeseshop-query (works!)
- adjusts lablup/backend.ai for some upstream changes: install Python 3.11.4 to match its ICs, and change a file path (currently fails, but seemingly due to upstream issues)

https://github.com/pantsbuild/pants/actions/runs/5998411580 shows a run of Pants 2.16.0, including these new repos. The failures there seem to fall into three categories:

- #19269
- upstream not working (i.e. even the 'baseline' run failing) for "simple" reasons (scie-pants, and backend.ai fall into this category)
- breaking changes between the upstream's pants version and 2.16.0, mostly the PEX minimum version
