### PR TITLE
Add missed fixes for semgrep backend

### DIFF
--- a/src/python/pants/backend/tools/semgrep/rules_test.py
+++ b/src/python/pants/backend/tools/semgrep/rules_test.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import PurePath
 
 import pytest
 
@@ -14,7 +14,9 @@ from pants.engine.fs import Paths
 
 
 def configs(strs: dict[str, set[str]]) -> AllSemgrepConfigs:
-    return AllSemgrepConfigs({Path(d): {Path(f) for f in files} for d, files in strs.items()})
+    return AllSemgrepConfigs(
+        {PurePath(d): {PurePath(f) for f in files} for d, files in strs.items()}
+    )
 
 
 @pytest.mark.parametrize(
@@ -128,4 +130,4 @@ def test_all_semgrep_configs_ancestor_configs(
 ):
     result = config.ancestor_configs(address)
 
-    assert set(result) == {Path(p) for p in expected}
+    assert set(result) == {PurePath(p) for p in expected}

--- a/src/python/pants/backend/tools/semgrep/subsystem.py
+++ b/src/python/pants/backend/tools/semgrep/subsystem.py
@@ -31,7 +31,7 @@ class SemgrepSubsystem(PythonToolBase):
     name = "Semgrep"
     options_scope = "semgrep"
     help = softwrap(
-        """\
+        """
         Lightweight static analysis for many languages. Find bug variants with patterns that look
         like source code. (https://semgrep.dev/)
 
@@ -60,7 +60,7 @@ class SemgrepSubsystem(PythonToolBase):
     force = BoolOption(
         default=False,
         help=softwrap(
-            """\
+            """
             If true, semgrep is always run, even if the input files haven't changed. This can be
             used to run cloud rulesets like `pants lint --semgrep-force
             --semgrep-args='--config=p/python' ::`. Without `--semgrep-force`, using the cloud


### PR DESCRIPTION
Two fixes from #18593 that I pushed to the wrong branch, and didn't notice before merging that PR:

- Use `PurePath` instead of `Path`: https://github.com/pantsbuild/pants/pull/18593#discussion_r1307751390
- Avoid escaping the newline for `softwrap`: https://github.com/pantsbuild/pants/pull/18593#discussion_r1307811816