### PR TITLE
Demonstrate using semgrep to detect pathlib.Path (and textwrap.dedent)

### DIFF
--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -1,0 +1,16 @@
+rules:
+  - id: use-pure-path
+    patterns:
+      - pattern: pathlib.Path
+    message: >-
+      Don't use pathlib.Path, use pathlib.PurePath instead: file IO should happen via the engine, not Python
+    languages:
+      - python
+    severity: ERROR
+    paths:
+      # this only matters in code that runs as part of `pants ...`
+      exclude:
+        - "*_test.py"
+      include:
+        - src/python/pants/
+        - pants-plugins/

--- a/.semgrep.yml
+++ b/.semgrep.yml
@@ -14,3 +14,19 @@ rules:
       include:
         - src/python/pants/
         - pants-plugins/
+
+  - id: use-pants-softwrap
+    patterns:
+      - pattern: textwrap.dedent
+    message: >-
+      Don't use `textwrap.dedent`, use `pants.util.strutil.softwrap` instead
+    languages:
+      - python
+    severity: ERROR
+    paths:
+      # this only matters in code that runs as part of `pants ...`
+      exclude:
+        - "*_test.py"
+      include:
+        - src/python/pants/
+        - pants-plugins/

--- a/pants.toml
+++ b/pants.toml
@@ -32,6 +32,7 @@ backend_packages.add = [
   "pants.backend.experimental.scala",
   "pants.backend.experimental.scala.lint.scalafmt",
   "pants.backend.experimental.scala.debug_goals",
+  "pants.backend.experimental.tools.semgrep",
   "pants.backend.experimental.tools.workunit_logger",
   "pants.backend.experimental.visibility",
   "pants.backend.tools.preamble",


### PR DESCRIPTION
Riffing on https://github.com/pantsbuild/pants/pull/18593#discussion_r1308058613, this demonstrates how we might lint against using `pathlib.Path` in pants code (since we should be using `pathlib.PurePath`, that doesn't support IO).

This also plops in an equivalent version of the PNT20 flake8 lint about `textwrap.dedent` (https://github.com/pantsbuild/pants/blob/cb63bba66817677a1dcb862c150e6fc7ca9f96dd/build-support/flake8/dedent_use_checker.py).

I'm amused that I made an easily-semgrepable mistake when adding semgrep!