### PR TITLE
Remove `src/python/pants/bin:pants`

### DIFF
--- a/src/python/pants/BUILD
+++ b/src/python/pants/BUILD
@@ -37,7 +37,7 @@ python_distribution(
         # N.B.: Must match [python] interpreter_constraints in pants.toml.
         python_requires="==3.9.*",
     ),
-    entry_points={"console_scripts": {"pants": "src/python/pants/bin:pants"}},
+    entry_points={"console_scripts": {"pants": "pants.bin.pants_loader:main"}},
 )
 
 pex_binary(

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -91,17 +91,6 @@ target(
     ],
 )
 
-# This binary's entry_point is used by the pantsbuild.pants sdist to setup a binary for
-# pip installers, ie: it is why this works to get `pants` on your PATH:
-# $ pip install pantsbuild.pants
-# $ pants
-pex_binary(
-    name="pants",
-    entry_point="pants.bin.pants_loader:main",
-    dependencies=[":pants_loader"],
-    strip_pex_env=False,
-)
-
 resources(
     name="native_client",
     sources=["native_client"],


### PR DESCRIPTION
I found this poking around. We don't want people doing `pip install pantsbuild.pants`. Also it's completely superfluous because we have the `python_distribution` with the `entry_point`. So double-whammy.