### PR TITLE
docs: use Python 3.11+ as example (Cherry-pick of #18565)

### DIFF
--- a/docs/markdown/Python/python/python-interpreter-compatibility.md
+++ b/docs/markdown/Python/python/python-interpreter-compatibility.md
@@ -12,7 +12,7 @@ Configure your default Python interpreter compatibility constraints in `pants.to
 
 ```toml pants.toml
 [python]
-interpreter_constraints = ["CPython==3.8.*"]
+interpreter_constraints = ["CPython==3.11.*"]
 ```
 
 The value can be any valid Requirement-style strings. You can use multiple strings to OR constraints, and use commas within each string to AND constraints. For example:


### PR DESCRIPTION
3.11 is the current stable release of Python, and 3.8 is end-of-life soon.

Using a newer version than 3.8 also side-steps issues on Apple Silicon Macs, which require 3.9 (https://www.pantsbuild.org/docs/prerequisites#macos)
