### PR TITLE
Use worker pants PAT for checkout during cherry-picking (Cherry-pick of #19713)

### DIFF
--- a/.github/workflows/auto-cherry-picker.yaml
+++ b/.github/workflows/auto-cherry-picker.yaml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.WORKER_PANTS_CHERRY_PICK_PAT }}
       - name: Prepare cherry-pick branch
         if: ${{ !env.ACT }}
         run: |


### PR DESCRIPTION
The default `github.TOKEN` doesn't have permissions to push to `origin` a branch that contains a change to a worfklow file:

```
 ! [remote rejected] cherry-pick-19668-to-2.18.x -> cherry-pick-19668-to-2.18.x (refusing to allow a GitHub App to create or update workflow `.github/workflows/release.yaml` without `workflows` permission)
```

I have ensured that this particular PAT has the necessary permissions in this repo.
