### PR TITLE
generate toml for reference-docs

### DIFF
--- a/build-support/bin/docs_templates/single_option_reference.md.mustache
+++ b/build-support/bin/docs_templates/single_option_reference.md.mustache
@@ -4,6 +4,11 @@
 
   <code>{{comma_separated_display_args}}</code><br>
   <code>{{env_var}}</code><br>
+  {{#toml}}
+  ```toml pants.toml
+  {{{toml}}}
+  ```
+  {{/toml}}
 </div>
 <div style="padding-left: 2em;">
 {{#comma_separated_choices}}
@@ -22,4 +27,3 @@ Can be overriden by field `{{target_field_name}}` on `local_environment`, `docke
 {{/target_field_name}}
 </div>
 <br>
-

--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -367,7 +367,7 @@ class ReferenceGenerator:
             toml_lines.append(f"{config_key} = [")
             val = val[2:-2]
             for item in val.split(", "):
-                toml_lines.append(f"  {item},")
+                toml_lines.append(f"    {item},")
             toml_lines.append("]")
         else:
             toml_lines.append(f"[{scope}]")

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -104,6 +104,7 @@ class OptionHelpInfo:
     """
 
     display_args: tuple[str, ...]
+    scope: str
     comma_separated_display_args: str
     scoped_cmd_line_args: tuple[str, ...]
     unscoped_cmd_line_args: tuple[str, ...]
@@ -1033,6 +1034,7 @@ class HelpInfoExtracter:
         ret = OptionHelpInfo(
             display_args=tuple(display_args),
             comma_separated_display_args=", ".join(display_args),
+            scope=self._scope,
             scoped_cmd_line_args=tuple(scoped_cmd_line_args),
             unscoped_cmd_line_args=tuple(unscoped_cmd_line_args),
             env_var=env_var,


### PR DESCRIPTION
Fixes #19705.

Adds a `toml` snippet to each configuration option in the reference.

Not quite sure how to validate this across the hundreds of files generated -- I've looked at a few ones for examples of enums, bools, lists, maps, and scalars. Not sure what other fun things might happen, or what kind of weird setup might exist in other places.

Open questions:
- Should each config add the header? I think *yes* for clarity, but it does add a *lot* of extra lines to some pages.

---
<img width="518" alt="image" src="https://github.com/pantsbuild/pants/assets/8234817/645e2942-26a2-4b3a-9460-c1565b106d28">
<img width="492" alt="image" src="https://github.com/pantsbuild/pants/assets/8234817/58c5bef0-a84c-4fbf-a92f-7d3236f74e99">
<img width="817" alt="image" src="https://github.com/pantsbuild/pants/assets/8234817/6fc14e14-e884-4ecb-9618-9e20467fef11">
