### PR TITLE
Remove `PANTS_SHA` from docs

### DIFF
--- a/docs/markdown/Getting Started/getting-started/installation.md
+++ b/docs/markdown/Getting Started/getting-started/installation.md
@@ -44,17 +44,6 @@ If you have difficulty installing Pants, see our [getting help](doc:getting-help
 > SCIE_BOOT=update pants
 > ```
 
-Running Pants from unreleased builds
-------------------------------------
-
-To use an unreleased build of Pants from the [pantsbuild/pants](https://github.com/pantsbuild/pants) main branch, locate the main branch SHA, set `PANTS_SHA=<SHA>` in the environment, and run `pants` as usual:
-
-```
-PANTS_SHA=8553e8cbc5a1d9da3f84dcfc5e7bf3139847fb5f pants --version
-```
-
-If a particular SHA does not have built wheels, you can either wait for [the next release from the relevant branch](doc:release-strategy), ping a maintainer [in Slack](doc:getting-help), or file a Github issue mentioning the SHA that you would like to test.
-
 Running Pants from sources
 --------------------------
 


### PR DESCRIPTION
This is deprecated and eventually removed from `scie-pants`, let's not suggest it to users anymore.