### PR TITLE
Dont allow running `start_release.py` for 2.17.x (or earlier)

### DIFF
--- a/src/python/pants_release/start_release.py
+++ b/src/python/pants_release/start_release.py
@@ -110,11 +110,11 @@ def main() -> None:
         die(
             softwrap(
                 """
-            This script shouldn't be used for releases pre-2.18.x.
-            Follow the release docs for the relevant release.
+                This script shouldn't be used for releases pre-2.18.x.
+                Follow the release docs for the relevant release.
 
-            E.g. https://www.pantsbuild.org/v2.17/docs/release-process
-            """
+                E.g. https://www.pantsbuild.org/v2.17/docs/release-process
+                """
             )
         )
 

--- a/src/python/pants_release/start_release.py
+++ b/src/python/pants_release/start_release.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 import github
 from packaging.version import Version
-from pants_release.common import CONTRIBUTORS_PATH, VERSION_PATH, sorted_contributors
+from pants_release.common import CONTRIBUTORS_PATH, VERSION_PATH, die, sorted_contributors
 from pants_release.git import git, git_fetch, github_repo
 
 from pants.util.strutil import softwrap
@@ -105,6 +105,18 @@ def commit_and_pr(
 def main() -> None:
     args = create_parser().parse_args()
     logging.basicConfig(level=args.log_level)
+
+    if args.new < Version("2.18.0.dev0"):
+        die(
+            softwrap(
+                """
+            This script shouldn't be used for releases pre-2.18.x.
+            Follow the release docs for the relevant release.
+
+            E.g. https://www.pantsbuild.org/v2.17/docs/release-process
+            """
+            )
+        )
 
     # connect to github first, to fail faster if credentials are wrong, etc.
     gh_repo = github_repo() if args.publish else None


### PR DESCRIPTION
This script is expected to be able to be used on `main` for all branches, but unfortunately that's not true for 2.17.x or earleier (due to https://github.com/pantsbuild/pants/pull/19668)