### PR TITLE
Stop publishing to PyPI (Cherry-pick of #19714)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -369,18 +369,6 @@ jobs:
         python-version: '3.9'
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
-    - env:
-        GH_REPO: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      name: Download wheels
-      run: gh release download ${{ needs.release_info.outputs.build-ref }} -p '*.whl'
-        --dir dest/pypi_release
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages-dir: dest/pypi_release
-        password: ${{ secrets.PANTSBUILD_PYPI_API_TOKEN }}
-        skip-existing: true
     - name: Generate announcement
       run: './pants run src/python/pants_release/generate_release_announcement.py                         --
         --output-dir=${{ runner.temp }}

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1086,10 +1086,8 @@ def cache_comparison_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
 
 
 def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
-    """Builds and releases a git ref to S3, and (if the ref is a release tag) to PyPI."""
     inputs, env = workflow_dispatch_inputs([WorkflowInput("REF", "string")])
 
-    pypi_release_dir = "dest/pypi_release"
     helper = Helper(Platform.LINUX_X86_64)
     wheels_jobs = build_wheels_jobs(
         needs=["release_info"], for_deploy_ref=gha_expr("needs.release_info.outputs.build-ref")
@@ -1188,23 +1186,6 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                 },
                 *helper.setup_primary_python(),
                 *helper.expose_all_pythons(),
-                {
-                    "name": "Download wheels",
-                    "run": f"gh release download {gha_expr('needs.release_info.outputs.build-ref')} -p '*.whl' --dir {pypi_release_dir}",
-                    "env": {
-                        "GH_TOKEN": "${{ github.token }}",
-                        "GH_REPO": "${{ github.repository }}",
-                    },
-                },
-                {
-                    "name": "Publish to PyPI",
-                    "uses": "pypa/gh-action-pypi-publish@release/v1",
-                    "with": {
-                        "password": gha_expr("secrets.PANTSBUILD_PYPI_API_TOKEN"),
-                        "packages-dir": pypi_release_dir,
-                        "skip-existing": True,
-                    },
-                },
                 {
                     "name": "Generate announcement",
                     "run": dedent(


### PR DESCRIPTION
![It's done](https://media.giphy.com/media/3oKIPf3C7HqqYBVcCk/giphy-downsized.gif)

The final nail in the coffin of our new release process of consuming all artifacts from GitHub Release assets, stop publishing `pantsbuild.pants` and `pantsbuild.pants.testutil` to PyPI. So long and thanks for all the fish!
