### PR TITLE
Allow requesters of `TargetRootsToFieldSets` to turn off the secondary ownership warning (Cherry-pick of #19721)

### DIFF
--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -233,6 +233,7 @@ async def _find_what_to_run(
             RunFieldSet,
             goal_description=goal_description,
             no_applicable_targets_behavior=NoApplicableTargetsBehavior.error,
+            warn_on_deprecated_secondary_owner_semantics=False,
         ),
     )
 

--- a/src/python/pants/engine/internals/specs_rules.py
+++ b/src/python/pants/engine/internals/specs_rules.py
@@ -578,7 +578,7 @@ async def find_valid_field_sets_for_target_roots(
             logger.warning(str(no_applicable_exception))
 
     # NB: Remove when SecondaryOwnerMixin is removed
-    if targets_to_applicable_field_sets:
+    if targets_to_applicable_field_sets and request.warn_on_deprecated_secondary_owner_semantics:
         _maybe_warn_deprecated_secondary_owner_semantics(
             # NB: All of these should be memoized, so it's not inappropriate to request simply for warning sake.
             *(

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1537,6 +1537,7 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
     field_set_superclass: Type[_FS]
     goal_description: str
     no_applicable_targets_behavior: NoApplicableTargetsBehavior
+    warn_on_deprecated_secondary_owner_semantics: bool
     shard: int
     num_shards: int
 
@@ -1546,12 +1547,18 @@ class TargetRootsToFieldSetsRequest(Generic[_FS]):
         *,
         goal_description: str,
         no_applicable_targets_behavior: NoApplicableTargetsBehavior,
+        warn_on_deprecated_secondary_owner_semantics: bool = True,
         shard: int = 0,
         num_shards: int = -1,
     ) -> None:
         object.__setattr__(self, "field_set_superclass", field_set_superclass)
         object.__setattr__(self, "goal_description", goal_description)
         object.__setattr__(self, "no_applicable_targets_behavior", no_applicable_targets_behavior)
+        object.__setattr__(
+            self,
+            "warn_on_deprecated_secondary_owner_semantics",
+            warn_on_deprecated_secondary_owner_semantics,
+        )
         object.__setattr__(self, "shard", shard)
         object.__setattr__(self, "num_shards", num_shards)
 


### PR DESCRIPTION
This change adds `warn_on_deprecated_secondary_owner_semantics` to `TargetRootsToFieldSets` (defaulting to `True`) and then has `run` set it to `False` (since `run` does its own filtering).

The other (non-`run`) goals that request this type are `deploy`, `package`, `publish`, and `test`. All of which should be operating on multiple targets, and therefore should issue the warning.

Before:
```console
josh@cephandrius:~/work/pants$ pants run build-support/bin/terraform_tool_versions.py
14:45:12.64 ^[[33m[WARN]^[[0m DEPRECATED: indirectly referring to a target by using a corresponding file argument, when the target owning the file isn't applicable is scheduled to be removed in version 2.18.0.dev1.

Refer to the following targets by their addresses:

  * build-support/bin:terraform_tool_versions
```

After:
```console
josh@cephandrius:~/work/pants$ pants run build-support/bin/terraform_tool_versions.py
... (No warning)
josh@cephandrius:~/work/pants$ pants package build-support/bin/terraform_tool_versions.py
14:45:12.64 ^[[33m[WARN]^[[0m DEPRECATED: indirectly referring to a target by using a corresponding file argument, when the target owning the file isn't applicable is scheduled to be removed in version 2.18.0.dev1.

Refer to the following targets by their addresses:

  * build-support/bin:terraform_tool_versions
```
