### PR TITLE
Fix typoed artifact name in Lambda docs (Cherry-pick of #19739)

### DIFF
--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -196,7 +196,7 @@ def example_handler(event, context):
     print("Hello AWS!")
 ```
 
-Then, use  `pants package project:lambda`, and upload the resulting `project/lambdex.pex` to AWS.  The handler will need to be configured in AWS as `__pex__.lambda_example.example_handler` (assuming `project` is a [source root](doc:source-roots)).
+Then, use  `pants package project:lambda`, and upload the resulting `project/lambda.pex` to AWS.  The handler will need to be configured in AWS as `__pex__.lambda_example.example_handler` (assuming `project` is a [source root](doc:source-roots)).
 
 Migrating from Pants 2.16 and earlier
 -------------------------------------


### PR DESCRIPTION
Small typo in #19180: the target name is `lambda`, and hence the PEX name will be `lambda.pex`, not `lambdex.pex`.
