### PR TITLE
Optionally retry failed tests

### DIFF
--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -218,6 +218,16 @@ The default test runners for these CI providers have the following resources. If
 | Circle CI, Linux, free plan  | 2      | 4 GB    | [link](https://circleci.com/docs/2.0/credits/#free-plan)                                                                                    |
 | GitLab, Linux shared runners | 1      | 3.75 GB | [link](https://docs.gitlab.com/ee/user/gitlab_com/#linux-shared-runners)                                                                    |
 
+Tip: automatically retry failed tests
+-------------------------------------
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml
+[test]
+attempts_default = 3
+```
+
 Tip: store Pants logs as artifacts
 ----------------------------------
 

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-test-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-test-goal.md
@@ -256,7 +256,7 @@ result = await Get(FallibleProcessResult, Process, my_test_process)
 Simply wrap the process in types that request the retries:
 ```python
 results = await Get(
-    ProcessResultWithRetries, RunProcWithRetry(my_test_process, retry_count)
+    ProcessResultWithRetries, ProcessWithRetries(my_test_process, retry_count)
 )
 last_result = results.last
 ```

--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-test-goal.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugins-test-goal.md
@@ -243,3 +243,20 @@ async def setup_example_debug_adapter_test(
 ) -> TestDebugAdapterRequest:
     ...
 ```
+
+Automatic retries for tests
+---------------------------
+
+Running the process without retries could look like this:
+
+```python
+result = await Get(FallibleProcessResult, Process, my_test_process)
+```
+
+Simply wrap the process in types that request the retries:
+```python
+results = await Get(
+    ProcessResultWithRetries, RunProcWithRetry(my_test_process, retry_count)
+)
+last_result = results.last
+```

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
@@ -129,11 +129,11 @@ To set environment variables, use the parameter `env: Mapping[str, str]`, like y
 
 The `Effect` will return an `InteractiveProcessResult`, which has a single field `exit_code: int`.
 
-### Retries in case of failure
+### ProcessWithRetries
 
-A `Process` can be retried by wrapping it in a `RunProcWithRetry` and requesting a `ProcessResultWithRetries`. The last result, whether succeeded or failed, is available with the `last` parameter. For example, the following will allow for up to 5 attempts at running `my_process`:
+A `Process` can be retried by wrapping it in a `ProcessWithRetries` and requesting a `ProcessResultWithRetries`. The last result, whether succeeded or failed, is available with the `last` parameter. For example, the following will allow for up to 5 attempts at running `my_process`:
 
 ```python
-results = await Get(ProcessResultWithRetries, RunProcWithRetry(my_process, 5))
+results = await Get(ProcessResultWithRetries, ProcessWithRetries(my_process, 5))
 last_result = results.last
 ```

--- a/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
+++ b/docs/markdown/Writing Plugins/rules-api/rules-api-process.md
@@ -128,3 +128,12 @@ You may either set the parameter `input_digest: Digest`, or you may set `run_in_
 To set environment variables, use the parameter `env: Mapping[str, str]`, like you would with `Process`. You can also set `hermetic_env=False` to inherit the environment variables from the parent `pants` process.
 
 The `Effect` will return an `InteractiveProcessResult`, which has a single field `exit_code: int`.
+
+### Retries in case of failure
+
+A `Process` can be retried by wrapping it in a `RunProcWithRetry` and requesting a `ProcessResultWithRetries`. The last result, whether succeeded or failed, is available with the `last` parameter. For example, the following will allow for up to 5 attempts at running `my_process`:
+
+```python
+results = await Get(ProcessResultWithRetries, RunProcWithRetry(my_process, 5))
+last_result = results.last
+```

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -3,6 +3,7 @@ colors = true
 
 [test]
 report = true
+attempts_default = 3
 
 [pytest]
 args = ["--no-header", "--noskip", "-vv"]

--- a/pants.toml
+++ b/pants.toml
@@ -191,6 +191,7 @@ extra_env_vars = [
   "RUST_BACKTRACE=1",
 ]
 timeout_default = 60
+attempts_default = 3
 
 [mypy]
 install_from_resolve = "mypy"

--- a/pants.toml
+++ b/pants.toml
@@ -191,7 +191,6 @@ extra_env_vars = [
   "RUST_BACKTRACE=1",
 ]
 timeout_default = 60
-attempts_default = 3
 
 [mypy]
 install_from_resolve = "mypy"

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -709,7 +709,7 @@ async def run_go_tests(
         extra_output = await Get(Snapshot, Digest, output_digest)
 
     return TestResult.from_fallible_process_result(
-        process_result=result,
+        process_results=[result],
         address=field_set.address,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -709,7 +709,7 @@ async def run_go_tests(
         extra_output = await Get(Snapshot, Digest, output_digest)
 
     return TestResult.from_fallible_process_result(
-        process_results=[result],
+        process_results=(result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -223,7 +223,7 @@ async def run_helm_unittest(
     reports = await Get(Snapshot, RemovePrefix(reports_digest, setup.reports_output_directory))
 
     return TestResult.from_fallible_process_result(
-        process_result,
+        process_results=[process_result],
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=reports,

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -223,7 +223,7 @@ async def run_helm_unittest(
     reports = await Get(Snapshot, RemovePrefix(reports_digest, setup.reports_output_directory))
 
     return TestResult.from_fallible_process_result(
-        process_results=[process_result],
+        process_results=(process_result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=reports,

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -247,7 +247,7 @@ async def run_javascript_tests(
         )
 
     return TestResult.from_batched_fallible_process_result(
-        result, batch, test.output, coverage_data=coverage_data
+        [result], batch, test.output, coverage_data=coverage_data
     )
 
 

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -247,7 +247,7 @@ async def run_javascript_tests(
         )
 
     return TestResult.from_batched_fallible_process_result(
-        [result], batch, test.output, coverage_data=coverage_data
+        (result,), batch, test.output, coverage_data=coverage_data
     )
 
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -71,6 +71,7 @@ from pants.engine.process import (
     InteractiveProcess,
     Process,
     ProcessCacheScope,
+    RunProcWithRetry,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -509,7 +510,7 @@ async def run_python_tests(
     setup = await Get(
         TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
     )
-    result = await Get(FallibleProcessResult, Process, setup.process)
+    result = await Get(FallibleProcessResult, RunProcWithRetry(setup.process))
 
     def warning_description() -> str:
         description = batch.elements[0].address.spec

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -514,7 +514,7 @@ async def run_python_tests(
     results = await Get(
         ProcessResultWithRetries, RunProcWithRetry(setup.process, HARDCODED_RETRY_COUNT)
     )
-    last_result = results.last  # TODO: report all for digestion
+    last_result = results.last
 
     def warning_description() -> str:
         description = batch.elements[0].address.spec

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -510,9 +510,9 @@ async def run_python_tests(
     setup = await Get(
         TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
     )
-    HARDCODED_RETRY_COUNT = 5  # TODO: get from global option or batch
+
     results = await Get(
-        ProcessResultWithRetries, RunProcWithRetry(setup.process, HARDCODED_RETRY_COUNT)
+        ProcessResultWithRetries, RunProcWithRetry(setup.process, test_subsystem.attempts_default)
     )
     last_result = results.last
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -510,7 +510,7 @@ async def run_python_tests(
     setup = await Get(
         TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
     )
-    result = await Get(FallibleProcessResult, RunProcWithRetry(setup.process))
+    result = await Get(FallibleProcessResult, RunProcWithRetry(setup.process, 0))
 
     def warning_description() -> str:
         description = batch.elements[0].address.spec

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -514,7 +514,7 @@ async def run_python_tests(
     results = await Get(
         ProcessResultWithRetries, RunProcWithRetry(setup.process, HARDCODED_RETRY_COUNT)
     )
-    result = results.last  # TODO: report all for digestion
+    last_result = results.last  # TODO: report all for digestion
 
     def warning_description() -> str:
         description = batch.elements[0].address.spec
@@ -527,7 +527,7 @@ async def run_python_tests(
     coverage_data = None
     if test_subsystem.use_coverage:
         coverage_snapshot = await Get(
-            Snapshot, DigestSubset(result.output_digest, PathGlobs([".coverage"]))
+            Snapshot, DigestSubset(last_result.output_digest, PathGlobs([".coverage"]))
         )
         if coverage_snapshot.files == (".coverage",):
             coverage_data = PytestCoverageData(
@@ -539,24 +539,25 @@ async def run_python_tests(
     xml_results_snapshot = None
     if setup.results_file_name:
         xml_results_snapshot = await Get(
-            Snapshot, DigestSubset(result.output_digest, PathGlobs([setup.results_file_name]))
+            Snapshot, DigestSubset(last_result.output_digest, PathGlobs([setup.results_file_name]))
         )
         if xml_results_snapshot.files != (setup.results_file_name,):
             logger.warning(f"Failed to generate JUnit XML data for {warning_description()}.")
     extra_output_snapshot = await Get(
-        Snapshot, DigestSubset(result.output_digest, PathGlobs([f"{_EXTRA_OUTPUT_DIR}/**"]))
+        Snapshot, DigestSubset(last_result.output_digest, PathGlobs([f"{_EXTRA_OUTPUT_DIR}/**"]))
     )
     extra_output_snapshot = await Get(
         Snapshot, RemovePrefix(extra_output_snapshot.digest, _EXTRA_OUTPUT_DIR)
     )
 
     return TestResult.from_batched_fallible_process_result(
-        result,
+        last_result,
         batch=batch,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
         extra_output=extra_output_snapshot,
+        all_results=results.results,
         output_simplifier=global_options.output_simplifier(),
     )
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -71,7 +71,7 @@ from pants.engine.process import (
     Process,
     ProcessCacheScope,
     ProcessResultWithRetries,
-    RunProcWithRetry,
+    ProcessWithRetries,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
@@ -512,7 +512,8 @@ async def run_python_tests(
     )
 
     results = await Get(
-        ProcessResultWithRetries, RunProcWithRetry(setup.process, test_subsystem.attempts_default)
+        ProcessResultWithRetries,
+        ProcessWithRetries(setup.process, test_subsystem.attempts_default),
     )
     last_result = results.last
 

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -551,13 +551,12 @@ async def run_python_tests(
     )
 
     return TestResult.from_batched_fallible_process_result(
-        last_result,
+        results.results,
         batch=batch,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
         extra_output=extra_output_snapshot,
-        all_results=results.results,
         output_simplifier=global_options.output_simplifier(),
     )
 

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -185,7 +185,7 @@ async def run_scalatest_test(
     xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
 
     return TestResult.from_fallible_process_result(
-        process_results=[process_result],
+        process_results=(process_result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=xml_results,

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -185,7 +185,7 @@ async def run_scalatest_test(
     xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
 
     return TestResult.from_fallible_process_result(
-        process_result,
+        process_results=[process_result],
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=xml_results,

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -71,7 +71,7 @@ async def test_shell_command(
 
     shell_result = await Get(FallibleProcessResult, Process, shell_process)
     return TestResult.from_fallible_process_result(
-        process_results=[shell_result],
+        process_results=(shell_result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
     )

--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -71,7 +71,7 @@ async def test_shell_command(
 
     shell_result = await Get(FallibleProcessResult, Process, shell_process)
     return TestResult.from_fallible_process_result(
-        process_result=shell_result,
+        process_results=[shell_result],
         address=field_set.address,
         output_setting=test_subsystem.output,
     )

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -252,7 +252,7 @@ async def run_tests_with_shunit2(
     setup = await Get(TestSetup, TestSetupRequest(field_set))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return TestResult.from_fallible_process_result(
-        result,
+        process_results=[result],
         address=field_set.address,
         output_setting=test_subsystem.output,
         output_simplifier=global_options.output_simplifier(),

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -252,7 +252,7 @@ async def run_tests_with_shunit2(
     setup = await Get(TestSetup, TestSetupRequest(field_set))
     result = await Get(FallibleProcessResult, Process, setup.process)
     return TestResult.from_fallible_process_result(
-        process_results=[result],
+        process_results=(result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
         output_simplifier=global_options.output_simplifier(),

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -97,7 +97,7 @@ class TestResult(EngineAwareReturnType):
     # True if the core test rules should log that extra output was written.
     log_extra_output: bool = False
     # All results including failed attempts
-    all_results: List[FallibleProcessResult] = field(default_factory=list)
+    process_results: List[FallibleProcessResult] = field(default_factory=list)
 
     output_simplifier: Simplifier = Simplifier()
 
@@ -161,7 +161,7 @@ class TestResult(EngineAwareReturnType):
             xml_results=xml_results,
             extra_output=extra_output,
             log_extra_output=log_extra_output,
-            all_results=process_results,
+            process_results=process_results,
             output_simplifier=output_simplifier,
         )
 
@@ -193,7 +193,7 @@ class TestResult(EngineAwareReturnType):
             log_extra_output=log_extra_output,
             output_simplifier=output_simplifier,
             partition_description=batch.partition_metadata.description,
-            all_results=process_results,
+            process_results=process_results,
         )
 
     @property
@@ -1026,7 +1026,7 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
         result.result_metadata is not None
     ), "Skipped test results should not be outputted in the test summary"
     succeeded = result.exit_code == 0
-    retried = len(result.all_results) > 1
+    retried = len(result.process_results) > 1
 
     if succeeded:
         if not retried:
@@ -1039,7 +1039,7 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
         status = "failed"
 
     if retried:
-        attempt_msg = f" after {len(result.all_results)} attempts"
+        attempt_msg = f" after {len(result.process_results)} attempts"
     else:
         attempt_msg = ""
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -622,6 +622,16 @@ class TestSubsystem(GoalSubsystem):
         advanced=True,
         help="The maximum timeout (in seconds) that may be used on a test target.",
     )
+    attempts_default = IntOption(
+        default=1,
+        help=softwrap(
+            """
+            The number of attempts to run tests, in case of a test failure.
+            Tests that were retried will include the number of attempts in the summary output.
+            """
+        ),
+    )
+
     batch_size = IntOption(
         "--batch-size",
         default=128,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import itertools
 import logging
 from abc import ABC, ABCMeta
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, ClassVar, Iterable, Optional, Sequence, TypeVar, cast
+from typing import Any, ClassVar, Iterable, List, Optional, Sequence, TypeVar, cast
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
@@ -96,6 +96,8 @@ class TestResult(EngineAwareReturnType):
     extra_output: Snapshot | None = None
     # True if the core test rules should log that extra output was written.
     log_extra_output: bool = False
+    # All results including failed attempts
+    all_results: List[FallibleProcessResult] = field(default_factory=list)
 
     output_simplifier: Simplifier = Simplifier()
 
@@ -143,6 +145,7 @@ class TestResult(EngineAwareReturnType):
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
         log_extra_output: bool = False,
+        all_results: List[FallibleProcessResult] | None = None,
         output_simplifier: Simplifier = Simplifier(),
     ) -> TestResult:
         return TestResult(
@@ -158,6 +161,7 @@ class TestResult(EngineAwareReturnType):
             xml_results=xml_results,
             extra_output=extra_output,
             log_extra_output=log_extra_output,
+            all_results=all_results or [process_result],
             output_simplifier=output_simplifier,
         )
 
@@ -171,6 +175,7 @@ class TestResult(EngineAwareReturnType):
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
         log_extra_output: bool = False,
+        all_results: List[FallibleProcessResult] | None = None,
         output_simplifier: Simplifier = Simplifier(),
     ) -> TestResult:
         return TestResult(
@@ -188,6 +193,7 @@ class TestResult(EngineAwareReturnType):
             log_extra_output=log_extra_output,
             output_simplifier=output_simplifier,
             partition_description=batch.partition_metadata.description,
+            all_results=all_results or [process_result],
         )
 
     @property

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -9,7 +9,7 @@ from abc import ABC, ABCMeta
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import PurePath
-from typing import Any, ClassVar, Iterable, List, Optional, Sequence, TypeVar, cast
+from typing import Any, ClassVar, Iterable, Optional, Sequence, Tuple, TypeVar, cast
 
 from pants.core.goals.multi_tool_goal_helper import SkippableSubsystem
 from pants.core.goals.package import BuiltPackage, EnvironmentAwarePackageRequest, PackageFieldSet
@@ -97,7 +97,7 @@ class TestResult(EngineAwareReturnType):
     # True if the core test rules should log that extra output was written.
     log_extra_output: bool = False
     # All results including failed attempts
-    process_results: List[FallibleProcessResult] = field(default_factory=list)
+    process_results: Tuple[FallibleProcessResult, ...] = field(default_factory=tuple)
 
     output_simplifier: Simplifier = Simplifier()
 
@@ -137,7 +137,7 @@ class TestResult(EngineAwareReturnType):
 
     @staticmethod
     def from_fallible_process_result(
-        process_results: List[FallibleProcessResult],
+        process_results: Tuple[FallibleProcessResult, ...],
         address: Address,
         output_setting: ShowOutput,
         *,
@@ -167,7 +167,7 @@ class TestResult(EngineAwareReturnType):
 
     @staticmethod
     def from_batched_fallible_process_result(
-        process_results: List[FallibleProcessResult],
+        process_results: Tuple[FallibleProcessResult, ...],
         batch: TestRequest.Batch[_TestFieldSetT, Any],
         output_setting: ShowOutput,
         *,

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -895,17 +895,15 @@ async def run_tests(
         )
 
     to_test = list(zip(test_batches, environment_names))
-    results = (
-        await MultiGet(  # noqa: PNT30: We only know that we need to rerun the test after we run it
-            Get(
-                TestResult,
-                {
-                    batch: TestRequest.Batch,
-                    environment_name: EnvironmentName,
-                },
-            )
-            for batch, environment_name in to_test
+    results = await MultiGet(
+        Get(
+            TestResult,
+            {
+                batch: TestRequest.Batch,
+                environment_name: EnvironmentName,
+            },
         )
+        for batch, environment_name in to_test
     )
 
     # Print summary.
@@ -1055,8 +1053,7 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
         elapsed_secs = total_elapsed_ms / 1000
         elapsed_print = f"in {elapsed_secs:.2f}s"
 
-    suffix = f"{elapsed_print}{source_desc}"
-    return f"{sigil} {result.description} {status}{attempt_msg} {suffix}."
+    return f"{sigil} {result.description} {status}{attempt_msg} {elapsed_print}{source_desc}."
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -137,7 +137,7 @@ class TestResult(EngineAwareReturnType):
 
     @staticmethod
     def from_fallible_process_result(
-        process_result: FallibleProcessResult,
+        process_results: List[FallibleProcessResult],
         address: Address,
         output_setting: ShowOutput,
         *,
@@ -145,9 +145,9 @@ class TestResult(EngineAwareReturnType):
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
         log_extra_output: bool = False,
-        all_results: List[FallibleProcessResult] | None = None,
         output_simplifier: Simplifier = Simplifier(),
     ) -> TestResult:
+        process_result = process_results[-1]
         return TestResult(
             exit_code=process_result.exit_code,
             stdout_bytes=process_result.stdout,
@@ -161,13 +161,13 @@ class TestResult(EngineAwareReturnType):
             xml_results=xml_results,
             extra_output=extra_output,
             log_extra_output=log_extra_output,
-            all_results=all_results or [process_result],
+            all_results=process_results,
             output_simplifier=output_simplifier,
         )
 
     @staticmethod
     def from_batched_fallible_process_result(
-        process_result: FallibleProcessResult,
+        process_results: List[FallibleProcessResult],
         batch: TestRequest.Batch[_TestFieldSetT, Any],
         output_setting: ShowOutput,
         *,
@@ -175,9 +175,9 @@ class TestResult(EngineAwareReturnType):
         xml_results: Snapshot | None = None,
         extra_output: Snapshot | None = None,
         log_extra_output: bool = False,
-        all_results: List[FallibleProcessResult] | None = None,
         output_simplifier: Simplifier = Simplifier(),
     ) -> TestResult:
+        process_result = process_results[-1]
         return TestResult(
             exit_code=process_result.exit_code,
             stdout_bytes=process_result.stdout,
@@ -193,7 +193,7 @@ class TestResult(EngineAwareReturnType):
             log_extra_output=log_extra_output,
             output_simplifier=output_simplifier,
             partition_description=batch.partition_metadata.description,
-            all_results=all_results or [process_result],
+            all_results=process_results,
         )
 
     @property

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -65,6 +65,7 @@ class Process:
     concurrency_available: int
     cache_scope: ProcessCacheScope
     remote_cache_speculation_delay_millis: int
+    extra: FrozenDict[str, str]
 
     def __init__(
         self,
@@ -86,6 +87,7 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         remote_cache_speculation_delay_millis: int = 0,
+        extra: Mapping[str, str] | None = None,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -142,6 +144,7 @@ class Process:
         object.__setattr__(
             self, "remote_cache_speculation_delay_millis", remote_cache_speculation_delay_millis
         )
+        object.__setattr__(self, "extra", FrozenDict(extra or {}))
 
 
 @dataclass(frozen=True)
@@ -304,8 +307,7 @@ def fallible_to_exec_result_or_raise(
 
 @rule
 async def run_proc_with_retry(req: RunProcWithRetry, attempt: int) -> FallibleProcessResult:
-    proc = req.proc
-    # proc = dataclasses.replace(proc, env=FrozenDict({"PANTS_TEST_ATTEMPT": str(attempt), **proc.env}))
+    proc = dataclasses.replace(req.proc, extra=FrozenDict({"PANTS_TEST_ATTEMPT": str(attempt)}))
     return await Get(FallibleProcessResult, Process, proc)
 
 

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -65,7 +65,7 @@ class Process:
     concurrency_available: int
     cache_scope: ProcessCacheScope
     remote_cache_speculation_delay_millis: int
-    extra: FrozenDict[str, str]
+    attempt: int
 
     def __init__(
         self,
@@ -87,7 +87,7 @@ class Process:
         concurrency_available: int = 0,
         cache_scope: ProcessCacheScope = ProcessCacheScope.SUCCESSFUL,
         remote_cache_speculation_delay_millis: int = 0,
-        extra: Mapping[str, str] | None = None,
+        attempt: int = 0,
     ) -> None:
         """Request to run a subprocess, similar to subprocess.Popen.
 
@@ -144,12 +144,13 @@ class Process:
         object.__setattr__(
             self, "remote_cache_speculation_delay_millis", remote_cache_speculation_delay_millis
         )
-        object.__setattr__(self, "extra", FrozenDict(extra or {}))
+        object.__setattr__(self, "attempt", attempt)
 
 
 @dataclass(frozen=True)
 class RunProcWithRetry:
     proc: Process
+    attempts: int
 
 
 @dataclass(frozen=True)
@@ -307,7 +308,7 @@ def fallible_to_exec_result_or_raise(
 
 @rule
 async def run_proc_with_retry(req: RunProcWithRetry, attempt: int) -> FallibleProcessResult:
-    proc = dataclasses.replace(req.proc, extra=FrozenDict({"PANTS_TEST_ATTEMPT": str(attempt)}))
+    proc = dataclasses.replace(req.proc, attempt=attempt)
     return await Get(FallibleProcessResult, Process, proc)
 
 

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -184,7 +184,7 @@ async def run_junit_test(
     xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
 
     return TestResult.from_fallible_process_result(
-        process_results=[process_result],
+        process_results=(process_result,),
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=xml_results,

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -184,7 +184,7 @@ async def run_junit_test(
     xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
 
     return TestResult.from_fallible_process_result(
-        process_result,
+        process_results=[process_result],
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=xml_results,

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -103,6 +103,7 @@ async fn make_execute_request() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -202,6 +203,7 @@ async fn make_execute_request_with_instance_name() {
       )]),
     },
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -307,6 +309,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let mut want_command = remexec::Command {
@@ -580,6 +583,7 @@ async fn make_execute_request_with_timeout() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -679,6 +683,7 @@ async fn make_execute_request_with_append_only_caches() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {
@@ -833,6 +838,7 @@ async fn make_execute_request_using_immutable_inputs() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -103,7 +103,7 @@ async fn make_execute_request() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let want_command = remexec::Command {
@@ -203,7 +203,7 @@ async fn make_execute_request_with_instance_name() {
       )]),
     },
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let want_command = remexec::Command {
@@ -309,7 +309,7 @@ async fn make_execute_request_with_cache_key_gen_version() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let mut want_command = remexec::Command {
@@ -583,7 +583,7 @@ async fn make_execute_request_with_timeout() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let want_command = remexec::Command {
@@ -683,7 +683,7 @@ async fn make_execute_request_with_append_only_caches() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let want_command = remexec::Command {
@@ -838,7 +838,7 @@ async fn make_execute_request_using_immutable_inputs() {
     cache_scope: ProcessCacheScope::Always,
     execution_environment: make_environment(Platform::Linux_x86_64),
     remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let want_command = remexec::Command {

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -585,6 +585,11 @@ pub struct Process {
 
   pub remote_cache_speculation_delay: std::time::Duration,
 
+  ///
+  /// The attempt number, in the case this Process is being retried.
+  ///
+  /// This is included in hash/eq so it creates a unique node in the runtime graph.
+  ///
   pub attempt: usize,
 }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -585,7 +585,7 @@ pub struct Process {
 
   pub remote_cache_speculation_delay: std::time::Duration,
 
-  pub extra: BTreeMap<String, String>,
+  pub attempt: usize,
 }
 
 impl Process {
@@ -622,7 +622,7 @@ impl Process {
         strategy: ProcessExecutionStrategy::Local,
       },
       remote_cache_speculation_delay: std::time::Duration::from_millis(0),
-      extra: BTreeMap::new(),
+      attempt: 0,
     }
   }
 

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -584,6 +584,8 @@ pub struct Process {
   pub execution_environment: ProcessExecutionEnvironment,
 
   pub remote_cache_speculation_delay: std::time::Duration,
+
+  pub extra: BTreeMap<String, String>,
 }
 
 impl Process {
@@ -620,6 +622,7 @@ impl Process {
         strategy: ProcessExecutionStrategy::Local,
       },
       remote_cache_speculation_delay: std::time::Duration::from_millis(0),
+      extra: BTreeMap::new(),
     }
   }
 

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -569,7 +569,7 @@ async fn make_request_from_flat_args(
     cache_scope: ProcessCacheScope::Always,
     execution_environment,
     remote_cache_speculation_delay: Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
   let metadata = ProcessMetadata {
     instance_name: args.remote_instance_name.clone(),
@@ -659,7 +659,7 @@ async fn extract_request_from_action_digest(
     cache_scope: ProcessCacheScope::Always,
     execution_environment,
     remote_cache_speculation_delay: Duration::from_millis(0),
-    extra: BTreeMap::new(),
+    attempt: 0,
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -569,6 +569,7 @@ async fn make_request_from_flat_args(
     cache_scope: ProcessCacheScope::Always,
     execution_environment,
     remote_cache_speculation_delay: Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
   let metadata = ProcessMetadata {
     instance_name: args.remote_instance_name.clone(),
@@ -658,6 +659,7 @@ async fn extract_request_from_action_digest(
     cache_scope: ProcessCacheScope::Always,
     execution_environment,
     remote_cache_speculation_delay: Duration::from_millis(0),
+    extra: BTreeMap::new(),
   };
 
   let metadata = ProcessMetadata {

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -376,6 +376,8 @@ impl ExecuteProcess {
         .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64,
     );
 
+    let extra = externs::getattr_from_str_frozendict(value, "extra");
+
     Ok(Process {
       argv: externs::getattr(value, "argv").unwrap(),
       env,
@@ -393,6 +395,7 @@ impl ExecuteProcess {
       cache_scope,
       execution_environment: process_config.environment,
       remote_cache_speculation_delay,
+      extra,
     })
   }
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -376,7 +376,7 @@ impl ExecuteProcess {
         .map_err(|e| format!("Failed to get `name` for field: {e}"))? as u64,
     );
 
-    let extra = externs::getattr_from_str_frozendict(value, "extra");
+    let attempt = externs::getattr(value, "attempt").unwrap_or(0);
 
     Ok(Process {
       argv: externs::getattr(value, "argv").unwrap(),
@@ -395,7 +395,7 @@ impl ExecuteProcess {
       cache_scope,
       execution_environment: process_config.environment,
       remote_cache_speculation_delay,
-      extra,
+      attempt,
     })
   }
 


### PR DESCRIPTION
This MR adds the ability to rerun Tests. The implementation adds a field on Process for the attempt number. This uniquifies the Process instance, which means that the Runtime Graph will not deduplicate it and will run it again. A wrapper RunProcessWithRetries is provided to rerun a normal process a number of attempts. `TestResult` is modified to have a tuple of `FallibleProcessResult`s to contain the retries. The output of the test goal then aggregates these to create a "succeeded after k attempts" message, like:
```
✓ src/python/pants/core/goals/testomatic_pass_test.py:batch1 succeeded in 0.56s.
+ src/python/pants/core/goals/testomatic_test.py:batch0 succeeded after 4 attempts in 0.53s.
```
The implementation requires each backend to opt into retries of the test process. This MR only implements it for the pytest backend. Documentation describing RunProcessWithRetries and how to use it to retry tests is added.

The number of retries can be set with the `[test].attempts_default` config setting. This is currently global, but we could extend the machinery to act like the timeout field.

This implementation retries whole batches, and does not rebatch only failed targets. It also doesn't aggregate retried process metadata (currently not easy to get total run time, for example).