### PR TITLE
Terraform lockfiles

### DIFF
--- a/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-lockfiles.md
+++ b/docs/markdown/Writing Plugins/common-plugin-tasks/plugin-lockfiles.md
@@ -1,0 +1,129 @@
+---
+title: "Add lockfiles"
+slug: "plugins-lockfiles-goal"
+excerpt: "How to add lockfiles and the `generate-lockfiles` and `export` goals."
+hidden: false
+createdAt: "2023-08-013T00:00:00.000Z"
+---
+Lockfiles are a way to pin to exact versions of dependencies, often including hashes to guarantee integrity between the version pinned and the version downloaded.
+
+This guide will walk you through implementing lockfiles, hooking them into the `generate-lockfiles` goal, and implementing the `export` goal which will allow you to export dependencies for use outside of Pants.
+
+# 1. Expose your lockfiles to Pants
+
+Create subclasses of `KnownUserResolveNamesRequest` to inform Pants about which resolves exist, and a subclass of `RequestedUserResolveNames` for Pants to request those resolves later. Implement the resolve-finding logic in a Rule from your subclass of `KnownUserResolveNamesRequest` to `KnownUserResolveNames`. Set `KnownResolveNames.requested_resolve_names_cls` to your subclass of `RequestedUserResolveNames`. 
+
+```python
+from pants.core.goals.generate_lockfiles import KnownUserResolveNamesRequest, RequestedUserResolveNames, KnownUserResolveNames
+from pants.engine.rules import rule
+from pants.engine.target import AllTargets
+
+
+class KnownTerraformResolveNamesRequest(KnownUserResolveNamesRequest):
+    pass
+
+
+class RequestedTerraformResolveNames(RequestedUserResolveNames):
+    pass
+
+
+@rule
+async def identify_user_resolves_from_terraform_files(
+        _: KnownTerraformResolveNamesRequest,
+        all_targets: AllTargets,
+) -> KnownUserResolveNames:
+    ...
+    return KnownUserResolveNames(
+        ...,
+        requested_resolve_names_cls=RequestedTerraformResolveNames
+    )
+```
+
+# 2. Connect resolve names to requests to generate lockfiles
+
+Create a subclass of `GenerateLockfile`, (TODO: Why). Then create a rule from your subclass of `RequestedUserResolveNames` to `UserGenerateLockfiles`. Pants will use this rule to convert from a user's request to export a resolve by name into the information needed to export the resolve.
+
+```python
+from dataclasses import dataclass
+
+from pants.backend.terraform.target_types import TerraformDeploymentTarget
+from pants.core.goals.generate_lockfiles import GenerateLockfile, UserGenerateLockfiles
+from pants.engine.rules import rule
+
+
+@dataclass(frozen=True)
+class GenerateTerraformLockfile(GenerateLockfile):
+    target: TerraformDeploymentTarget
+
+
+@rule
+async def setup_user_lockfile_requests(
+        requested: RequestedTerraformResolveNames,
+) -> UserGenerateLockfiles:
+    ...
+    return UserGenerateLockfiles(
+        [
+            GenerateTerraformLockfile(
+                ...
+            )
+        ]
+    )
+```
+
+# 3. Generate lockfiles
+
+Create a rule from your subclass of `GenerateLockfile` to `GenerateLockfileResult`. This rule generates the lockfile. In the common case that you're running a process to generate this lockfile, you can use the `Process.output_files` to gather those files from the execution sandbox.
+
+```python
+from pants.backend.terraform.tool import TerraformProcess
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.engine.internals.selectors import Get
+from pants.engine.process import ProcessResult
+from pants.engine.rules import rule
+
+
+@rule
+async def generate_lockfile_from_sources(
+        request: GenerateTerraformLockfile,
+) -> GenerateLockfileResult:
+    ...
+
+    result = await Get(
+        ProcessResult,
+        TerraformProcess(...),
+    )
+
+    return GenerateLockfileResult(result.output_digest, request.resolve_name, request.lockfile_dest)
+
+```
+
+# 4. Register rules
+
+At the bottom of the file, let Pants know what your rules and types do. Update your plugin's `register.py` to tell Pants about them/
+
+```python pants-plugins/terraform/lockfiles.py
+
+
+from pants.core.goals.generate_lockfiles import GenerateLockfile, KnownUserResolveNamesRequest, RequestedUserResolveNames
+from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateLockfile, GenerateTerraformLockfile),
+        UnionRule(KnownUserResolveNamesRequest, KnownTerraformResolveNamesRequest),
+        UnionRule(RequestedUserResolveNames, RequestedTerraformResolveNames),
+    )
+```
+
+```python pants-plugins/terraform/register.py
+from terraform import lockfiles
+
+def rules():
+    return [
+        ...,
+        *lockfiles.rules()
+    ]
+```

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -11,13 +11,19 @@ from pants.backend.terraform.target_types import (
     TerraformBackendTarget,
     TerraformDeploymentTarget,
     TerraformModuleTarget,
+    TerraformVarFileTarget,
 )
 from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget]
+    return [
+        TerraformModuleTarget,
+        TerraformBackendTarget,
+        TerraformVarFileTarget,
+        TerraformDeploymentTarget,
+    ]
 
 
 def rules():

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -7,13 +7,17 @@ from pants.backend.terraform.goals import check, deploy
 from pants.backend.terraform.goals import lockfiles as terraform_lockfile
 from pants.backend.terraform.goals import tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
-from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformDeploymentTarget,
+    TerraformModuleTarget,
+)
 from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModuleTarget, TerraformDeploymentTarget]
+    return [TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget]
 
 
 def rules():

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -3,7 +3,9 @@
 
 from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.terraform import dependencies, dependency_inference, tool
-from pants.backend.terraform.goals import check, deploy, tailor
+from pants.backend.terraform.goals import check, deploy
+from pants.backend.terraform.goals import lockfiles as terraform_lockfile
+from pants.backend.terraform.goals import tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
 from pants.backend.terraform.target_types import rules as target_types_rules
@@ -25,5 +27,6 @@ def rules():
         *tool.rules(),
         *tffmt_rules(),
         *deploy.rules(),
+        *terraform_lockfile.rules(),
         *python_lockfile.rules(),
     ]

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Tuple
 
-from pants.backend.terraform.partition import partition_files_by_directory
 from pants.backend.terraform.target_types import (
     TerraformBackendConfigField,
     TerraformDependenciesField,
@@ -14,29 +13,16 @@ from pants.backend.terraform.target_types import (
 from pants.backend.terraform.tool import TerraformProcess
 from pants.backend.terraform.utils import terraform_arg, terraform_relpath
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.internals.native_engine import (
-    EMPTY_DIGEST,
-    Address,
-    AddressInput,
-    Digest,
-    MergeDigests,
-)
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import collect_rules, rule
-from pants.engine.target import (
-    DependenciesRequest,
-    SourcesField,
-    Targets,
-    WrappedTarget,
-    WrappedTargetRequest,
-)
+from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
 
 
 @dataclass(frozen=True)
 class TerraformDependenciesRequest:
-    source_files: SourceFiles
-    directories: Tuple[str, ...]
+    chdir: str
     backend_config: SourceFiles
     dependencies_files: SourceFiles
 
@@ -58,7 +44,7 @@ async def get_terraform_providers(
         args.append(
             terraform_arg(
                 "-backend-config",
-                terraform_relpath(req.directories[0], req.backend_config.files[0]),
+                terraform_relpath(req.chdir, req.backend_config.files[0]),
             )
         )
         backend_digest = req.backend_config.snapshot.digest
@@ -71,31 +57,27 @@ async def get_terraform_providers(
         Digest,
         MergeDigests(
             [
-                req.source_files.snapshot.digest,
                 backend_digest,
                 req.dependencies_files.snapshot.digest,
             ]
         ),
     )
 
-    # TODO: Does this need to be a MultiGet? I think we will now always get one directory
-    fetched_deps = await MultiGet(
-        Get(
-            FallibleProcessResult,
-            TerraformProcess(
-                args=tuple(args),
-                input_digest=with_backend_config,
-                output_files=(".terraform.lock.hcl",),
-                output_directories=(".terraform",),
-                description="Run `terraform init` to fetch dependencies",
-                chdir=directory,
-            ),
-        )
-        for directory in req.directories
+    fetched_deps = await Get(
+        FallibleProcessResult,
+        TerraformProcess(
+            args=tuple(args),
+            input_digest=with_backend_config,
+            output_files=(".terraform.lock.hcl",),
+            output_directories=(".terraform",),
+            description="Run `terraform init` to fetch dependencies",
+            chdir=req.chdir,
+        ),
     )
 
     return TerraformDependenciesResponse(
-        tuple(zip(req.directories, (x.output_digest for x in fetched_deps)))
+        ((req.chdir, fetched_deps.output_digest),)
+        # tuple(zip(req.directories, (x.output_digest for x in fetched_deps)))
     )
 
 
@@ -118,37 +100,21 @@ class TerraformInitResponse:
 
 @rule
 async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse:
-    address_input = request.root_module.to_address_input()
-    module_address = await Get(Address, AddressInput, address_input)
-    module = await Get(
-        WrappedTarget,
-        WrappedTargetRequest(
-            module_address, description_of_origin=address_input.description_of_origin
-        ),
+    module_dependencies = await Get(
+        TransitiveTargets, TransitiveTargetsRequest((request.dependencies.address,))
     )
 
-    root_dependencies, module_dependencies = await MultiGet(
-        Get(Targets, DependenciesRequest(request.dependencies)),
-        Get(Targets, DependenciesRequest(module.target.get(TerraformDependenciesField))),
-    )
-
-    source_files, backend_config, dependencies_files = await MultiGet(
-        Get(SourceFiles, SourceFilesRequest([module.target.get(SourcesField)])),
+    backend_config, dependencies_files = await MultiGet(
         Get(SourceFiles, SourceFilesRequest([request.backend_config])),
         Get(
             SourceFiles,
-            SourceFilesRequest(
-                [tgt.get(SourcesField) for tgt in (*root_dependencies, *module_dependencies)]
-            ),
+            SourceFilesRequest([tgt.get(SourcesField) for tgt in module_dependencies.dependencies]),
         ),
     )
-    files_by_directory = partition_files_by_directory(source_files.files)
-
     fetched_deps = await Get(
         TerraformDependenciesResponse,
         TerraformDependenciesRequest(
-            source_files,
-            tuple(files_by_directory.keys()),
+            request.root_module.address.spec_path,
             backend_config,
             dependencies_files,
             initialise_backend=request.initialise_backend,
@@ -159,14 +125,14 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
 
     sources_and_deps = await Get(
         Digest,
-        MergeDigests(
-            [source_files.snapshot.digest, merged_fetched_deps, dependencies_files.snapshot.digest]
-        ),
+        MergeDigests([merged_fetched_deps, dependencies_files.snapshot.digest]),
     )
 
-    assert len(files_by_directory) == 1, "Multiple directories found, unable to identify a root"
-    chdir, files = next(iter(files_by_directory.items()))
-    return TerraformInitResponse(sources_and_deps, tuple(files), chdir)
+    return TerraformInitResponse(
+        sources_and_deps,
+        dependencies_files.files,  # TODO: I think this includes the wrong files (all the dependencies, not just TF ones). It's now a bit muddled which files are actually TF files
+        request.root_module.address.spec_path,
+    )
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -131,7 +131,11 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
     )
 
     if request.backend_config.value:
-        backend_address = await Get(Address, AddressInput, to_address_input(request.backend_config))
+        backend_address = await Get(
+            Address,
+            AddressInput,
+            to_address_input(request.backend_config.value, request.backend_config),
+        )
         backend_target = await Get(
             WrappedTarget,
             WrappedTargetRequest(backend_address, description_of_origin="Terraform initialisation"),

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import dataclasses
 import json
 import textwrap
 from pathlib import Path
@@ -64,8 +65,64 @@ def test_init_terraform(rule_runner: RuleRunner, standard_deployment: StandardDe
         ".terraform/providers/registry.terraform.io/hashicorp/null/*/*/terraform-provider-null*",
     ), "Did not find expected provider"
 
-    # Assert lockfile is included
+    # Assert lockfile is generated and included
     assert find_file(initialised_files, ".terraform.lock.hcl"), "Did not find expected provider"
+
+
+def test_init_terraform_uses_lockfiles(
+    rule_runner: RuleRunner, standard_deployment: StandardDeployment
+) -> None:
+    """Test that we can use generated lockfiles."""
+    requested_version = "3.2.0"
+
+    terraform_lockfile = textwrap.dedent(
+        f"""\
+        provider "registry.terraform.io/hashicorp/null" {{
+          version     = "3.2.0"
+          constraints = "~> {requested_version}"
+          hashes = [
+            "h1:pfjuwssoCoBDRbutlVLAP8wiDrkQ3G4d3rs+f7uSh2A=",
+            "zh:1d88ea3af09dcf91ad0aaa0d3978ca8dcb49dc866c8615202b738d73395af6b5",
+            "zh:3844db77bfac2aca43aaa46f3f698c8e5320a47e838ee1318408663449547e7e",
+            "zh:538fadbd87c576a332b7524f352e6004f94c27afdd3b5d105820d328dc49c5e3",
+            "zh:56def6f00fc2bc9c3c265b841ce71e80b77e319de7b0f662425b8e5e7eb26846",
+            "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+            "zh:8fce56e5f1d13041d8047a1d0c93f930509704813a28f8d39c2b2082d7eebf9f",
+            "zh:989e909a5eca96b8bdd4a0e8609f1bd525949fd226ae870acedf2da0c55b0451",
+            "zh:99ddc34ad13e04e9c3477f5422fbec20fc13395ff940720c287bfa5c546d2fbc",
+            "zh:b546666da4b4b60c0eec23faab7f94dc900e48f66b5436fc1ac0b87c6709ef04",
+            "zh:d56643cb08cba6e074d70c4af37d5de2bd7c505f81d866d6d47c9e1d28ec65d1",
+            "zh:f39ac5ff9e9d00e6a670bce6825529eded4b0b4966abba36a387db5f0712d7ba",
+            "zh:fe102389facd09776502327352be99becc1ac09e80bc287db84a268172be641f",
+          ]
+        }}"""
+    )
+
+    deployment_with_lockfile = dataclasses.replace(
+        standard_deployment,
+        files={**standard_deployment.files, **{"src/tf/.terraform.lock.hcl": terraform_lockfile}},
+    )
+
+    initialised_files = _do_init_terraform(
+        rule_runner, deployment_with_lockfile, initialise_backend=True
+    )
+
+    # Assert lockfile is not regenerated
+    result_lockfile = find_file(initialised_files, ".terraform.lock.hcl")
+    assert result_lockfile, "Did not find lockfile"
+    assert (
+        f'version     = "{requested_version}"' in result_lockfile.content.decode()
+    ), "version in lockfile has changed, we should not have regenerated the lockfile"
+
+    # Assert dependencies are initialised to the older version
+    result_provider = find_file(
+        initialised_files,
+        ".terraform/providers/registry.terraform.io/hashicorp/null/*/*/terraform-provider-null*",
+    )
+    assert result_provider, "Did not find any providers, did we initialise them successfully?"
+    assert (
+        requested_version in result_provider.path
+    ), "initialised provider did not have our requested version, did the lockfile show up and did we regenerate it?"
 
 
 def test_init_terraform_without_backends(

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -12,6 +12,7 @@ from pants.backend.terraform.testutil import (
     StandardDeployment,
     rule_runner_with_auto_approve,
     standard_deployment,
+    terraform_lockfile,
 )
 from pants.engine.fs import DigestContents, FileContent
 from pants.engine.internals.native_engine import Address
@@ -74,29 +75,6 @@ def test_init_terraform_uses_lockfiles(
 ) -> None:
     """Test that we can use generated lockfiles."""
     requested_version = "3.2.0"
-
-    terraform_lockfile = textwrap.dedent(
-        f"""\
-        provider "registry.terraform.io/hashicorp/null" {{
-          version     = "3.2.0"
-          constraints = "~> {requested_version}"
-          hashes = [
-            "h1:pfjuwssoCoBDRbutlVLAP8wiDrkQ3G4d3rs+f7uSh2A=",
-            "zh:1d88ea3af09dcf91ad0aaa0d3978ca8dcb49dc866c8615202b738d73395af6b5",
-            "zh:3844db77bfac2aca43aaa46f3f698c8e5320a47e838ee1318408663449547e7e",
-            "zh:538fadbd87c576a332b7524f352e6004f94c27afdd3b5d105820d328dc49c5e3",
-            "zh:56def6f00fc2bc9c3c265b841ce71e80b77e319de7b0f662425b8e5e7eb26846",
-            "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-            "zh:8fce56e5f1d13041d8047a1d0c93f930509704813a28f8d39c2b2082d7eebf9f",
-            "zh:989e909a5eca96b8bdd4a0e8609f1bd525949fd226ae870acedf2da0c55b0451",
-            "zh:99ddc34ad13e04e9c3477f5422fbec20fc13395ff940720c287bfa5c546d2fbc",
-            "zh:b546666da4b4b60c0eec23faab7f94dc900e48f66b5436fc1ac0b87c6709ef04",
-            "zh:d56643cb08cba6e074d70c4af37d5de2bd7c505f81d866d6d47c9e1d28ec65d1",
-            "zh:f39ac5ff9e9d00e6a670bce6825529eded4b0b4966abba36a387db5f0712d7ba",
-            "zh:fe102389facd09776502327352be99becc1ac09e80bc287db84a268172be641f",
-          ]
-        }}"""
-    )
 
     deployment_with_lockfile = dataclasses.replace(
         standard_deployment,

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -159,13 +159,14 @@ async def infer_terraform_deployment_dependencies(
     root_module_address_input = request.field_set.root_module.to_address_input()
     root_module = await Get(Address, AddressInput, root_module_address_input)
 
-    # # TODO: This leads to a dependency on self. Can we do something about it?
+    # TODO: add depenendency on the vars files
+    #  The use of this target_name here leads to a dependency on self.
+    #  Is there a way to avoid the reference? Would generating targets for the vars files help?
     # var_files_names = request.field_set.var_files.value
-    # print(request.field_set.address.spec_path)
     # var_files_addresses = [
     #     Address(
     #         spec_path=request.field_set.address.spec_path,
-    #         target_name="a",
+    #         target_name=request.field_set.address.target_name,
     #         relative_file_path=v,
     #     ) for v in var_files_names
     # ]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -157,7 +157,9 @@ class InferTerraformDeploymentDependenciesRequest(InferDependenciesRequest):
 async def infer_terraform_deployment_dependencies(
     request: InferTerraformDeploymentDependenciesRequest,
 ) -> InferredDependencies:
-    root_module_address_input = to_address_input(request.field_set.root_module)
+    root_module_address_input = to_address_input(
+        request.field_set.root_module.value, request.field_set.root_module
+    )
     root_module = await Get(Address, AddressInput, root_module_address_input)
 
     deps = [root_module]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -9,10 +9,14 @@ from pants.backend.python.subsystems.python_tool_base import PythonToolRequireme
 from pants.backend.python.target_types import EntryPoint
 from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
 from pants.backend.python.util_rules.pex import rules as pex_rules
-from pants.backend.terraform.target_types import TerraformModuleSourcesField
+from pants.backend.terraform.target_types import (
+    TerraformDeploymentFieldSet,
+    TerraformModuleSourcesField,
+)
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
 from pants.engine.fs import CreateDigest, Digest, FileContent
+from pants.engine.internals.native_engine import Address, AddressInput
 from pants.engine.internals.selectors import Get
 from pants.engine.process import Process, ProcessResult
 from pants.engine.rules import collect_rules, rule
@@ -139,9 +143,45 @@ async def infer_terraform_module_dependencies(
     return InferredDependencies(terraform_module_addresses)
 
 
+@dataclass(frozen=True)
+class TerraformDeploymentDependenciesInferenceFieldSet(TerraformDeploymentFieldSet):
+    pass
+
+
+class InferTerraformDeploymentDependenciesRequest(InferDependenciesRequest):
+    infer_from = TerraformDeploymentDependenciesInferenceFieldSet
+
+
+@rule
+async def infer_terraform_deployment_dependencies(
+    request: InferTerraformDeploymentDependenciesRequest,
+) -> InferredDependencies:
+    root_module_address_input = request.field_set.root_module.to_address_input()
+    root_module = await Get(Address, AddressInput, root_module_address_input)
+
+    # # TODO: This leads to a dependency on self. Can we do something about it?
+    # var_files_names = request.field_set.var_files.value
+    # print(request.field_set.address.spec_path)
+    # var_files_addresses = [
+    #     Address(
+    #         spec_path=request.field_set.address.spec_path,
+    #         target_name="a",
+    #         relative_file_path=v,
+    #     ) for v in var_files_names
+    # ]
+
+    return InferredDependencies(
+        [
+            root_module,
+            # *var_files_addresses,
+        ]
+    )
+
+
 def rules():
     return [
         *collect_rules(),
         *pex_rules(),
         UnionRule(InferDependenciesRequest, InferTerraformModuleDependenciesRequest),
+        UnionRule(InferDependenciesRequest, InferTerraformDeploymentDependenciesRequest),
     ]

--- a/src/python/pants/backend/terraform/dependency_inference.py
+++ b/src/python/pants/backend/terraform/dependency_inference.py
@@ -12,6 +12,7 @@ from pants.backend.python.util_rules.pex import rules as pex_rules
 from pants.backend.terraform.target_types import (
     TerraformDeploymentFieldSet,
     TerraformModuleSourcesField,
+    to_address_input,
 )
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.base.specs import DirGlobSpec, RawSpecs
@@ -156,8 +157,10 @@ class InferTerraformDeploymentDependenciesRequest(InferDependenciesRequest):
 async def infer_terraform_deployment_dependencies(
     request: InferTerraformDeploymentDependenciesRequest,
 ) -> InferredDependencies:
-    root_module_address_input = request.field_set.root_module.to_address_input()
+    root_module_address_input = to_address_input(request.field_set.root_module)
     root_module = await Get(Address, AddressInput, root_module_address_input)
+
+    deps = [root_module]
 
     # TODO: add depenendency on the vars files
     #  The use of this target_name here leads to a dependency on self.
@@ -170,13 +173,13 @@ async def infer_terraform_deployment_dependencies(
     #         relative_file_path=v,
     #     ) for v in var_files_names
     # ]
+    # backend_target_name = request.field_set.backend_config.value
+    # if backend_target_name:
+    #     deps += [
+    #         await Get(Address, AddressInput, backend_target_name)
+    #     ]
 
-    return InferredDependencies(
-        [
-            root_module,
-            # *var_files_addresses,
-        ]
-    )
+    return InferredDependencies(deps)
 
 
 def rules():

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -49,8 +49,8 @@ async def terraform_check(
             TerraformProcess(
                 args=("validate",),
                 input_digest=deployment.sources_and_deps,
-                output_files=tuple(deployment.terraform_files),
-                description=f"Run `terraform fmt` on {pluralize(len(deployment.terraform_files), 'file')}.",
+                output_files=tuple(deployment.terraform_files.files),
+                description=f"Run `terraform fmt` on {pluralize(len(deployment.terraform_files.files), 'file')}.",
                 chdir=deployment.chdir,
             ),
         )

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -15,6 +15,7 @@ from pants.backend.terraform.target_types import (
     TerraformDeploymentFieldSet,
     TerraformDeploymentTarget,
     TerraformModuleTarget,
+    TerraformVarFileTarget,
 )
 from pants.core.goals.check import CheckResult, CheckResults
 from pants.core.util_rules import external_tool, source_files
@@ -28,7 +29,12 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
+        target_types=[
+            TerraformModuleTarget,
+            TerraformBackendTarget,
+            TerraformVarFileTarget,
+            TerraformDeploymentTarget,
+        ],
         rules=[
             *external_tool.rules(),
             *check.rules(),

--- a/src/python/pants/backend/terraform/goals/check_test.py
+++ b/src/python/pants/backend/terraform/goals/check_test.py
@@ -11,6 +11,7 @@ from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.goals import check
 from pants.backend.terraform.goals.check import TerraformCheckRequest
 from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
     TerraformDeploymentFieldSet,
     TerraformDeploymentTarget,
     TerraformModuleTarget,
@@ -27,7 +28,7 @@ from pants.testutil.rule_runner import QueryRule, RuleRunner
 @pytest.fixture()
 def rule_runner() -> RuleRunner:
     return RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
         rules=[
             *external_tool.rules(),
             *check.rules(),

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -97,6 +97,7 @@ async def generate_lockfile_from_sources(
             lockfile_request.target[TerraformBackendConfigField],
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
+            upgrade=True,
         ),
     )
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -1,0 +1,122 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Union
+
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
+from pants.backend.terraform.target_types import (
+    TerraformBackendConfigField,
+    TerraformDependenciesField,
+    TerraformDeploymentTarget,
+    TerraformRootModuleField,
+)
+from pants.backend.terraform.tool import TerraformProcess
+from pants.core.goals.generate_lockfiles import (
+    GenerateLockfile,
+    GenerateLockfileResult,
+    KnownUserResolveNames,
+    KnownUserResolveNamesRequest,
+    RequestedUserResolveNames,
+    UserGenerateLockfiles,
+)
+from pants.engine.addresses import Addresses
+from pants.engine.internals.native_engine import Address
+from pants.engine.internals.selectors import Get
+from pants.engine.process import ProcessResult
+from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.target import AllTargets, Targets
+from pants.engine.unions import UnionRule
+
+
+@dataclass(frozen=True)
+class GenerateTerraformLockfile(GenerateLockfile):
+    target: TerraformDeploymentTarget
+
+
+class KnownTerraformResolveNamesRequest(KnownUserResolveNamesRequest):
+    pass
+
+
+class RequestedTerraformResolveNames(RequestedUserResolveNames):
+    pass
+
+
+@rule
+async def identify_user_resolves_from_terraform_files(
+    _: KnownTerraformResolveNamesRequest,
+    all_targets: AllTargets,
+) -> KnownUserResolveNames:
+    known_terraform_module_dirs = []
+    for tgt in all_targets:
+        if tgt.has_field(TerraformRootModuleField):
+            known_terraform_module_dirs.append(tgt.residence_dir)
+
+    return KnownUserResolveNames(
+        names=tuple(known_terraform_module_dirs),
+        option_name="[terraform].resolves",
+        requested_resolve_names_cls=RequestedTerraformResolveNames,
+    )
+
+
+@rule
+async def setup_user_lockfile_requests(
+    requested: RequestedTerraformResolveNames,
+) -> UserGenerateLockfiles:
+    [tgt] = await Get(Targets, Addresses([Address(requested[0])]))
+    assert isinstance(tgt, TerraformDeploymentTarget)
+
+    return UserGenerateLockfiles(
+        [
+            GenerateTerraformLockfile(
+                target=tgt,
+                resolve_name=requested[0],
+                lockfile_dest=(Path(tgt.residence_dir) / ".terraform.lock.hcl").as_posix(),
+                diff=False,
+            )
+        ]
+    )
+
+
+@rule
+async def generate_lockfile_from_sources(
+    lockfile_request: GenerateTerraformLockfile,
+) -> GenerateLockfileResult:
+    """Generate a Terraform lockfile by running `terraform providers lock` on the sources."""
+
+    initialised_terraform = await Get(
+        TerraformInitResponse,
+        TerraformInitRequest(
+            lockfile_request.target[TerraformRootModuleField],
+            lockfile_request.target[TerraformBackendConfigField],
+            lockfile_request.target[TerraformDependenciesField],
+            initialise_backend=False,
+        ),
+    )
+
+    result = await Get(
+        ProcessResult,
+        TerraformProcess(
+            args=(
+                "providers",
+                "lock",
+            ),
+            input_digest=initialised_terraform.sources_and_deps,
+            output_files=(".terraform.lock.hcl",),
+            description=f"Update terraform lockfile for {lockfile_request.resolve_name}",
+            chdir=initialised_terraform.chdir,
+        ),
+    )
+
+    return GenerateLockfileResult(
+        result.output_digest, lockfile_request.resolve_name, lockfile_request.lockfile_dest
+    )
+
+
+def rules() -> Iterable[Union[Rule, UnionRule]]:
+    return (
+        *collect_rules(),
+        UnionRule(GenerateLockfile, GenerateTerraformLockfile),
+        UnionRule(KnownUserResolveNamesRequest, KnownTerraformResolveNamesRequest),
+        UnionRule(RequestedUserResolveNames, RequestedTerraformResolveNames),
+    )

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -62,24 +62,24 @@ async def identify_user_resolves_from_terraform_files(
 async def setup_user_lockfile_requests(
     requested: RequestedTerraformResolveNames,
 ) -> UserGenerateLockfiles:
-    targets_in_dir = await Get(
+    targets_in_dirs = await Get(
         Targets,
         RawSpecs(
             description_of_origin="setup Terraform lockfiles",
-            dir_globs=(DirGlobSpec(requested[0]),),
+            dir_globs=tuple(DirGlobSpec(d) for d in requested),
         ),
     )
-    [tgt] = [t for t in targets_in_dir if isinstance(t, TerraformDeploymentTarget)]
-    assert isinstance(tgt, TerraformDeploymentTarget)
+    deployment_targets = [t for t in targets_in_dirs if isinstance(t, TerraformDeploymentTarget)]
 
     return UserGenerateLockfiles(
         [
             GenerateTerraformLockfile(
                 target=tgt,
-                resolve_name=requested[0],
+                resolve_name=tgt.residence_dir,
                 lockfile_dest=(Path(tgt.residence_dir) / ".terraform.lock.hcl").as_posix(),
                 diff=False,
             )
+            for tgt in deployment_targets
         ]
     )
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -6,7 +6,7 @@ from typing import Iterable, Union
 
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.target_types import (
-    TerraformBackendConfigField,
+    TerraformBackendTargetField,
     TerraformDependenciesField,
     TerraformDeploymentTarget,
     TerraformRootModuleField,
@@ -94,7 +94,7 @@ async def generate_lockfile_from_sources(
         TerraformInitResponse,
         TerraformInitRequest(
             lockfile_request.target[TerraformRootModuleField],
-            lockfile_request.target[TerraformBackendConfigField],
+            lockfile_request.target[TerraformBackendTargetField],
             lockfile_request.target[TerraformDependenciesField],
             initialise_backend=False,
             upgrade=True,

--- a/src/python/pants/backend/terraform/goals/lockfiles_test.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles_test.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.terraform.testutil import (
+    StandardDeployment,
+    rule_runner_with_auto_approve,
+    standard_deployment,
+    terraform_lockfile,
+    terraform_lockfile_regenerated,
+)
+from pants.core.goals.generate_lockfiles import GenerateLockfilesGoal
+from pants.testutil.rule_runner import RuleRunner
+
+rule_runner = rule_runner_with_auto_approve
+standard_deployment = standard_deployment
+
+
+@pytest.mark.parametrize("existing_lockfile", [False, True])
+def test_integration_generate_lockfile(
+    rule_runner: RuleRunner, standard_deployment: StandardDeployment, existing_lockfile: bool
+) -> None:
+    rule_runner.write_files(standard_deployment.files)
+    if existing_lockfile:
+        rule_runner.write_files({"src/tf/.terraform.lock.hcl": terraform_lockfile})
+
+    result = rule_runner.run_goal_rule(
+        GenerateLockfilesGoal,
+        global_args=[*rule_runner.options_bootstrapper.args],
+        args=["--generate-lockfiles-resolve=src/tf"],
+    )
+
+    # assert Pants things we succeeded
+    assert result.exit_code == 0
+
+    # assert Terraform wrote the lockfile
+    lockfile_contents = rule_runner.read_file("src/tf/.terraform.lock.hcl")
+    assert lockfile_contents == terraform_lockfile_regenerated

--- a/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
@@ -11,6 +11,7 @@ from pants.backend.terraform.target_types import (
     TerraformDeploymentTarget,
     TerraformFieldSet,
     TerraformModuleTarget,
+    TerraformVarFileTarget,
 )
 from pants.core.goals.lint import LintResult
 from pants.core.util_rules import source_files
@@ -21,7 +22,12 @@ from pants.testutil.rule_runner import RuleRunner
 
 def test_run_tfsec():
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
+        target_types=[
+            TerraformModuleTarget,
+            TerraformBackendTarget,
+            TerraformVarFileTarget,
+            TerraformDeploymentTarget,
+        ],
         rules=[
             *tfsec_rules(),
             *tool.rules(),

--- a/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
@@ -7,6 +7,7 @@ from pants.backend.terraform.lint.tffmt.tffmt import PartitionMetadata
 from pants.backend.terraform.lint.tfsec.rules import rules as tfsec_rules
 from pants.backend.terraform.lint.tfsec.tfsec import TfSecRequest
 from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
     TerraformDeploymentTarget,
     TerraformFieldSet,
     TerraformModuleTarget,
@@ -20,7 +21,7 @@ from pants.testutil.rule_runner import RuleRunner
 
 def test_run_tfsec():
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
         rules=[
             *tfsec_rules(),
             *tool.rules(),

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -15,6 +15,7 @@ from pants.backend.terraform.target_types import (
     TerraformBackendTarget,
     TerraformDeploymentTarget,
     TerraformModuleTarget,
+    TerraformVarFileTarget,
 )
 from pants.core.goals import deploy
 from pants.core.goals.deploy import DeployProcess
@@ -29,7 +30,12 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner_with_auto_approve() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
+        target_types=[
+            TerraformModuleTarget,
+            TerraformBackendTarget,
+            TerraformVarFileTarget,
+            TerraformDeploymentTarget,
+        ],
         rules=[
             *dependency_inference.rules(),
             *dependencies.rules(),
@@ -66,11 +72,12 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                 """
                 terraform_deployment(
                     name="stg",
-                    var_files=["stg.tfvars"],
+                    var_files=[":stg_vars"],
                     backend_config=":stg_tfbackend",
                     root_module=":mod",
                 )
                 terraform_backend(name="stg_tfbackend", source="stg.tfbackend")
+                terraform_var_files(name="stg_vars", sources=["stg.tfvars"])
                 terraform_module(name="mod")
             """
             ),

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -11,7 +11,11 @@ from pants.backend.terraform.dependencies import TerraformInitRequest, Terraform
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
 from pants.backend.terraform.goals.lockfiles import rules as terraform_lockfile_rules
-from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformDeploymentTarget,
+    TerraformModuleTarget,
+)
 from pants.core.goals import deploy
 from pants.core.goals.deploy import DeployProcess
 from pants.core.register import rules as core_rules
@@ -25,7 +29,7 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner_with_auto_approve() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        target_types=[TerraformModuleTarget, TerraformBackendTarget, TerraformDeploymentTarget],
         rules=[
             *dependency_inference.rules(),
             *dependencies.rules(),
@@ -63,9 +67,10 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                 terraform_deployment(
                     name="stg",
                     var_files=["stg.tfvars"],
-                    backend_config="stg.tfbackend",
+                    backend_config=":stg_tfbackend",
                     root_module=":mod",
                 )
+                terraform_backend(name="stg_tfbackend", source="stg.tfbackend")
                 terraform_module(name="mod")
             """
             ),

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -10,6 +10,7 @@ from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
+from pants.backend.terraform.goals.lockfiles import rules as terraform_lockfile_rules
 from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
 from pants.core.goals import deploy
 from pants.core.goals.deploy import DeployProcess
@@ -30,6 +31,7 @@ def rule_runner_with_auto_approve() -> RuleRunner:
             *dependencies.rules(),
             *tool.rules(),
             *terraform_deploy_rules(),
+            *terraform_lockfile_rules(),
             *source_files.rules(),
             *deploy.rules(),
             *core_rules(),
@@ -89,3 +91,51 @@ def standard_deployment(tmpdir) -> StandardDeployment:
         },
         state_file,
     )
+
+
+terraform_lockfile = """\
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.0"
+  constraints = "~> 3.2.0"
+  hashes = [
+    "h1:pfjuwssoCoBDRbutlVLAP8wiDrkQ3G4d3rs+f7uSh2A=",
+    "zh:1d88ea3af09dcf91ad0aaa0d3978ca8dcb49dc866c8615202b738d73395af6b5",
+    "zh:3844db77bfac2aca43aaa46f3f698c8e5320a47e838ee1318408663449547e7e",
+    "zh:538fadbd87c576a332b7524f352e6004f94c27afdd3b5d105820d328dc49c5e3",
+    "zh:56def6f00fc2bc9c3c265b841ce71e80b77e319de7b0f662425b8e5e7eb26846",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fce56e5f1d13041d8047a1d0c93f930509704813a28f8d39c2b2082d7eebf9f",
+    "zh:989e909a5eca96b8bdd4a0e8609f1bd525949fd226ae870acedf2da0c55b0451",
+    "zh:99ddc34ad13e04e9c3477f5422fbec20fc13395ff940720c287bfa5c546d2fbc",
+    "zh:b546666da4b4b60c0eec23faab7f94dc900e48f66b5436fc1ac0b87c6709ef04",
+    "zh:d56643cb08cba6e074d70c4af37d5de2bd7c505f81d866d6d47c9e1d28ec65d1",
+    "zh:f39ac5ff9e9d00e6a670bce6825529eded4b0b4966abba36a387db5f0712d7ba",
+    "zh:fe102389facd09776502327352be99becc1ac09e80bc287db84a268172be641f",
+  ]
+}"""
+
+# TODO: pin upper bound so this doesn't break with a new release of the provider
+terraform_lockfile_regenerated = """\
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.1"
+  constraints = "~> 3.2.0"
+  hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+"""

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -73,6 +73,12 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                     backend "local" {
                         path = "/tmp/will/not/exist"
                     }
+                    required_providers {
+                        null = {
+                          source = "hashicorp/null"
+                          version = "~>3.2.0" # there are later versions, so we can lock it to this version to check lockfile use
+                        }
+                    }
                 }
                 variable "var0" {}
                 resource "null_resource" "dep" {}

--- a/src/python/pants/backend/terraform/tool.py
+++ b/src/python/pants/backend/terraform/tool.py
@@ -273,8 +273,13 @@ async def setup_terraform_process(
     def prepend_paths(paths: Tuple[str, ...]) -> Tuple[str, ...]:
         return tuple((Path(request.chdir) / path).as_posix() for path in paths)
 
+    def normalise_chdir(chdir: str) -> str:
+        if not chdir:
+            chdir = "."
+        return shlex.quote(chdir)
+
     return Process(
-        argv=("__terraform/terraform", f"-chdir={shlex.quote(request.chdir)}") + request.args,
+        argv=("__terraform/terraform", f"-chdir={normalise_chdir(request.chdir)}") + request.args,
         input_digest=request.input_digest,
         immutable_input_digests=immutable_input_digests,
         output_files=prepend_paths(request.output_files),


### PR DESCRIPTION
Generate and consume Terraform lockfiles!

Supported features:
- Create Terraform lockfile
- Use Terraform lockfile for deployments, checks, &c.

Unsupported features:
- Using the same lockfile for multiple deployments (although Terraform itself doesn't support this either)
- Export Terraform dependencies
- Lockfiles treated as dependencies of deployments
