### PR TITLE
Add 'cattrs' module to 'cattrs' package entry in default_module_mapping.py

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -66,7 +66,7 @@ DEFAULT_MODULE_MAPPING = {
     "azure-synapse-accesscontrol": ("azure.synapse.accesscontrol",),
     "beautifulsoup4": ("bs4",),
     "bitvector": ("BitVector",),
-    "cattrs": ("cattr",),
+    "cattrs": ("cattr", "cattrs"),
     "django-admin-cursor-paginator": ("admin_cursor_paginator",),
     "django-cors-headers": ("corsheaders",),
     "django-csp": ("csp",),


### PR DESCRIPTION
Fixes issue #19761. The Python module mappings file had an entry for the cattrs PyPi package that only included the cattr module name, and not the (now canonical) cattrs module name.