### PR TITLE
Add more debugging prints to bootstrap code

### DIFF
--- a/build-support/bin/rust/bootstrap_code.sh
+++ b/build-support/bin/rust/bootstrap_code.sh
@@ -50,9 +50,11 @@ function bootstrap_native_code() {
   # Bootstraps the native code only if needed.
   local engine_version_calculated
   engine_version_calculated="$(calculate_current_hash)"
+  echo "engine_version_calculated=$engine_version_calculated"
   local engine_version_in_metadata
   if [[ -f "${NATIVE_ENGINE_RESOURCE_METADATA}" ]]; then
-    engine_version_in_metadata="$(sed -n 's/^engine_version: //p' "${NATIVE_ENGINE_RESOURCE_METADATA}")"
+      engine_version_in_metadata="$(sed -n 's/^engine_version: //p' "${NATIVE_ENGINE_RESOURCE_METADATA}")"
+      echo "engine_version_in_metadata=$engine_version_in_metadata"
   fi
 
   if [[ -f "${NATIVE_ENGINE_RESOURCE}" && -f "${NATIVE_CLIENT_BINARY}" &&
@@ -85,8 +87,8 @@ function bootstrap_native_code() {
 
   # Create the accompanying metadata file.
   local -r metadata_file=$(mktemp -t pants.native_engine.metadata.XXXXXX)
-  echo "engine_version: ${engine_version_calculated}" > "${metadata_file}"
-  echo "repo_version: $(git describe --dirty)" >> "${metadata_file}"
+  echo "engine_version: ${engine_version_calculated}" | tee "${metadata_file}"
+  echo "repo_version: $(git describe --dirty)" | tee -a "${metadata_file}"
 
   # Here we set up a file lock via bash tricks to avoid concurrent `mv` failing.
   if {

--- a/build-support/bin/rust/calculate_engine_hash.sh
+++ b/build-support/bin/rust/calculate_engine_hash.sh
@@ -29,6 +29,7 @@ function calculate_current_hash() {
   # Assumes that PY is set to the path to the interpreter that will be used to build the
   # native engine. We only use this to extract the full Python version, so this can point
   # to a raw interpreter, not necessarily one in a venv with Pants requirements installed.
+  echo "calculate_current_hash" 1>&2
   (
     cd "${REPO_ROOT}" || exit 1
     (
@@ -42,6 +43,6 @@ function calculate_current_hash() {
         "${REPO_ROOT}/build-support/bin/rust" |
         grep -v -E -e "/BUILD$" -e "/[^/]*\.md$" |
         git hash-object --stdin-paths
-    ) | fingerprint_data
+    ) | tee /dev/stderr | fingerprint_data
   )
 }


### PR DESCRIPTION
Attempts to debug why Rust code is being rebuilt in Python test shards in CI, by adding more prints. https://pantsbuild.slack.com/archives/C0D7TNJHL/p1694036554476979