### PR TITLE
Pin CI to Python 3.9.18 specifically

### DIFF
--- a/.github/workflows/cache_comparison.yaml
+++ b/.github/workflows/cache_comparison.yaml
@@ -11,10 +11,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -363,10 +363,10 @@ jobs:
       with:
         fetch-depth: '0'
         ref: ${{ needs.release_info.outputs.build-ref }}
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Generate announcement

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -113,10 +113,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -215,10 +215,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 10
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Install Protoc
       uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9
       with:
@@ -611,10 +611,10 @@ jobs:
         \                 --max_size 30\necho \"PANTS_REMOTE_STORE_ADDRESS=grpc://localhost:9092\" >> \"$GITHUB_ENV\"\necho\
         \ \"PANTS_REMOTE_CACHE_READ=true\" >> \"$GITHUB_ENV\"\necho \"PANTS_REMOTE_CACHE_WRITE=${CACHE_WRITE}\" >> \"$GITHUB_ENV\"\
         \n"
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
@@ -786,10 +786,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -877,10 +877,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -968,10 +968,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1059,10 +1059,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1150,10 +1150,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1241,10 +1241,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1332,10 +1332,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1423,10 +1423,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1514,10 +1514,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1605,10 +1605,10 @@ jobs:
         echo "${HOME}/.thrift" >> $GITHUB_PATH
 
         '
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries
@@ -1663,10 +1663,10 @@ jobs:
       with:
         distribution: adopt
         java-version: '11'
-    - name: Set up Python 3.9
+    - name: Set up Python 3.9.18
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.9.18
     - name: Expose Pythons
       uses: pantsbuild/actions/expose-pythons@627a8ce25d972afa03da1641be9261bbbe0e3ffe
     - name: Download native binaries

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -78,9 +78,9 @@ NATIVE_FILES = [
     f"{NATIVE_FILES_COMMON_PREFIX}/engine/internals/native_engine.so.metadata",
 ]
 
-# We don't specify a patch version so that we get the latest, which comes pre-installed:
-#  https://github.com/actions/setup-python#available-versions-of-python
-PYTHON_VERSION = "3.9"
+# We specify a patch version because Github runners upgrade their versions incrementally: some
+# runners might be on 3.9.17 while others are on 3.9.18
+PYTHON_VERSION = "3.9.18"
 
 DONT_SKIP_RUST = "needs.classify_changes.outputs.rust == 'true'"
 DONT_SKIP_WHEELS = "needs.classify_changes.outputs.release == 'true'"


### PR DESCRIPTION
This fixes #19781 by pinning CI to use exactly 3.9.18, not just 3.9 in general, so that all jobs use the same patch version. Before this, the patch version could differ, and that would change the engine hash (as computed by `calculate_engine_hash.sh`), leading to jobs attempting to rebuild the engine.

GitHub seems to upgrade the Python versions across runners in phases, meaning `actions/setup-python` with a version specifier of `3.9` will sometimes be 3.9.17, and sometimes 3.9.18. When the the engine is built with one version, and then a test job has a different version, the test job would notice the mismatch in engine hash and start rebuilding the Rust engine. See #19780 for verification of this.

This explains why CI has been failing inconsistently: sometimes we get lucky and all jobs run with the same Python version, but often we don't.

This is one approach to fixing #19781. #19784 is probably a better approach, if it is valid.

(Only one of this and #19784 needs to merge.)