### PR TITLE
Improve dep inference versioning scheme

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "dep_inference"
-version = "0.0.2"
+version = "2.18.0"
 dependencies = [
  "fnv",
  "hex",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -303,7 +303,7 @@ uuid = "1.1.2"
 walkdir = "2"
 webpki = "0.22"
 
-# NB: If a change to these versions requires cache busting, bump ther version of
+# NB: If a change to these versions requires cache busting, bump the version of
 # `src/rust/engine/dep_inference/Cargo.toml`.
 tree-sitter = "0.20.10"
 tree-sitter-javascript = "0.20.0"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -297,11 +297,14 @@ tonic-build = "0.9"
 tower = "0.4"
 tower-layer = "0.3"
 tower-service = "0.3"
-tree-sitter = "0.20.10"
-tree-sitter-javascript = "0.20.0"
-tree-sitter-python = "0.20.4"
 uname = "0.1.1"
 url = "2.4"
 uuid = "1.1.2"
 walkdir = "2"
 webpki = "0.22"
+
+# NB: If a change to these versions requires cache busting, bump ther version of
+# `src/rust/engine/dep_inference/Cargo.toml`.
+tree-sitter = "0.20.10"
+tree-sitter-javascript = "0.20.0"
+tree-sitter-python = "0.20.4"

--- a/src/rust/engine/dep_inference/Cargo.toml
+++ b/src/rust/engine/dep_inference/Cargo.toml
@@ -1,5 +1,14 @@
 [package]
-version = "0.0.2"
+# NB: The Major/Minor is loosely tied to Pants version of the latest breaking change.
+# The patch version should be incremented every time a breaking change is cherry-picked.
+# So when you're making a change on `main`:
+# - Set this to main's Major/Minor.0 if it isn't already
+# - Otherwise, increment the patch number
+# Then when/if you cherry-pick and it fails, simply increment the patch number on the target branch.
+#
+# (A "breaking change" is one that changes the behavior of dependency parsing. This version is
+# embedded in the local cache. Therefore if behavior changes, the cache should be busted)
+version = "2.18.0"
 edition = "2021"
 name = "dep_inference"
 authors = ["Pants Build <pantsbuild@gmail.com>"]
@@ -9,8 +18,6 @@ publish = false
 hex = { workspace = true }
 sha2 = { workspace = true }
 walkdir = { workspace = true }
-
-# NB: If a change to these versions requires cache busting, bump this package's version
 tree-sitter = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-python = { workspace = true }
@@ -21,8 +28,6 @@ protos = { path = "../protos" }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 itertools = { workspace = true }
-
-# NB: If a change to these versions requires cache busting, bump this package's version
 tree-sitter = { workspace = true }
 tree-sitter-javascript = { workspace = true }
 tree-sitter-python = { workspace = true }


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/19293 needs to be cherry-picked back to 2.17.x and 2.18.x, but the version that should be specified isn't clear.
We could copy `0.0.2`, but if any change landed on `main` but not cherry-picked backwards that version is incorrect.

So, I'm changing the versioning scheme to embed the latest-major-changes-branch into the version which forces cherry-picking to fail and the human should bump the destination branch's patch number