### PR TITLE
Fix the `warn_or_error` on 2.18.x for the rust parser

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -185,11 +185,11 @@ async def parse_python_dependencies(
     # We operate on PythonSourceField, which should be one file.
     assert len(stripped_sources.snapshot.files) == 1
 
-    if not python_infer_subsystem.options.is_default("use_rust_parser"):
+    if not python_infer_subsystem.use_rust_parser:
         # NB: In 2.19, we remove the option altogether and remove the old code.
         warn_or_error(
             removal_version="2.19.0.dev0",
-            entity="Explicitly providing [python-infer].use_rust_parser",
+            entity="Setting [python-infer].use_rust_parser to false",
             hint=softwrap(
                 f"""
                 Read the help for [python-infer].use_rust_parser


### PR DESCRIPTION
As per our deprecation policy, here's the expected flow:
- `2.17.x` -> warn if you're not setting the value, default to `False`
- `2.18.x` -> warn if you ARE setting the value, and you're setting it to `False`. Default to `True`.
- `2.19.x` -> there's only one codepath