### PR TITLE
Introduce by-name `@rule` call syntax

### DIFF
--- a/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules_test.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/renamed_fields_rules_test.py
@@ -37,7 +37,7 @@ def test_determine_renamed_fields() -> None:
         moved_fields = (DeprecatedField, OkayField)
 
     registered_targets = RegisteredTargetTypes.create([Tgt, TgtGenerator])
-    result = determine_renamed_field_types(registered_targets, UnionMembership({}))
+    result = determine_renamed_field_types.rule.func(registered_targets, UnionMembership({}))  # type: ignore[attr-defined]
     deprecated_fields = FrozenDict({DeprecatedField.deprecated_alias: DeprecatedField.alias})
     assert result.target_field_renames == FrozenDict(
         {k: deprecated_fields for k in (TgtGenerator.alias, Tgt.alias, Tgt.deprecated_alias)}
@@ -60,7 +60,7 @@ def test_determine_renamed_fields() -> None:
 )
 def test_rename_deprecated_field_types_noops(lines: list[str]) -> None:
     content = "\n".join(lines).encode("utf-8")
-    result = fix_single(
+    result = fix_single.rule.func(  # type: ignore[attr-defined]
         RenameFieldsInFileRequest("BUILD", content=content),
         RenamedFieldTypes.from_dict({"target": {"deprecated_name": "new_name"}}),
     )
@@ -77,7 +77,7 @@ def test_rename_deprecated_field_types_noops(lines: list[str]) -> None:
     ),
 )
 def test_rename_deprecated_field_types_rewrite(lines: list[str], expected: list[str]) -> None:
-    result = fix_single(
+    result = fix_single.rule.func(  # type: ignore[attr-defined]
         RenameFieldsInFileRequest("BUILD", content="\n".join(lines).encode("utf-8")),
         RenamedFieldTypes.from_dict({"tgt1": {"deprecated_name": "new_name"}}),
     )

--- a/src/python/pants/backend/build_files/fix/deprecations/renamed_targets_rules_test.py
+++ b/src/python/pants/backend/build_files/fix/deprecations/renamed_targets_rules_test.py
@@ -29,7 +29,7 @@ from pants.util.frozendict import FrozenDict
 )
 def test_rename_deprecated_target_types_noops(lines: list[str]) -> None:
     content = "\n".join(lines).encode("utf-8")
-    result = fix_single(
+    result = fix_single.rule.func(  # type: ignore[attr-defined]
         RenameTargetsInFileRequest("BUILD", content=content),
         RenamedTargetTypes(FrozenDict({"deprecated_name": "new_name"})),
     )
@@ -46,7 +46,7 @@ def test_rename_deprecated_target_types_noops(lines: list[str]) -> None:
     ),
 )
 def test_rename_deprecated_target_types_rewrite(lines: list[str], expected: list[str]) -> None:
-    result = fix_single(
+    result = fix_single.rule.func(  # type: ignore[attr-defined]
         RenameTargetsInFileRequest("BUILD", content="\n".join(lines).encode("utf-8")),
         RenamedTargetTypes(FrozenDict({"deprecated_name": "new_name"})),
     )

--- a/src/python/pants/core/goals/run.py
+++ b/src/python/pants/core/goals/run.py
@@ -7,7 +7,7 @@ import logging
 from abc import ABCMeta
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar, Iterable, Mapping, Optional, Tuple, TypeVar, Union
+from typing import Any, ClassVar, Iterable, Mapping, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import final
 
@@ -311,7 +311,7 @@ def _run_in_sandbox_behavior_rule(cls: type[RunFieldSet]) -> Iterable:
     async def run_request_not_hermetic(request: RunFieldSet) -> RunInSandboxRequest:
         return await _run_request(request)
 
-    default_rules = {
+    default_rules: dict[RunInSandboxBehavior, list[Any]] = {
         RunInSandboxBehavior.NOT_SUPPORTED: [not_supported],
         RunInSandboxBehavior.RUN_REQUEST_HERMETIC: [run_request_hermetic],
         RunInSandboxBehavior.RUN_REQUEST_NOT_HERMETIC: [run_request_not_hermetic],

--- a/src/python/pants/core/goals/run_test.py
+++ b/src/python/pants/core/goals/run_test.py
@@ -90,7 +90,7 @@ def single_target_run(
     workspace = Workspace(rule_runner.scheduler, _enforce_effects=False)
 
     with mock_console(rule_runner.options_bootstrapper) as (console, _):
-        res = run_rule_with_mocks(
+        return run_rule_with_mocks(
             run,
             rule_args=[
                 create_goal_subsystem(RunSubsystem, args=[], cleanup=True, debug_adapter=False),
@@ -137,7 +137,6 @@ def single_target_run(
                 },
             ),
         )
-        return cast(Run, res)
 
 
 def test_normal_run(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -353,7 +353,7 @@ def test_resolve_environment_name_local_and_docker_fallbacks(monkeypatch) -> Non
                 ),
             ],
         ).val
-        return result  # type: ignore[no-any-return]
+        return result
 
     def create_local_tgt(
         *, compatible_platforms: list[Platform] | None = None, fallback: bool = False

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -733,6 +733,30 @@ class PyGeneratorResponseBreak:
 _Output = TypeVar("_Output")
 _Input = TypeVar("_Input")
 
+class PyGeneratorResponseCall:
+    @overload
+    def __init__(self) -> None: ...
+    @overload
+    def __init__(
+        self,
+        input_arg0: dict[Any, type],
+    ) -> None: ...
+    @overload
+    def __init__(self, input_arg0: _Input) -> None: ...
+    @overload
+    def __init__(
+        self,
+        input_arg0: type[_Input],
+        input_arg1: _Input,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        input_arg0: type[_Input] | _Input,
+        input_arg1: _Input | None = None,
+    ) -> None: ...
+    def set_output_type(self, output_type: type) -> None: ...
+
 class PyGeneratorResponseGet(Generic[_Output]):
     output_type: type[_Output]
     input_types: Sequence[type]

--- a/src/python/pants/engine/internals/rule_visitor.py
+++ b/src/python/pants/engine/internals/rule_visitor.py
@@ -278,7 +278,6 @@ class _AwaitableCollector(ast.NodeVisitor):
                 for input_type, input_node in zip(input_type_nodes, input_nodes)
             )
         else:
-            print(f">>> call_node.keywords: {call_node.keywords}")
             raise parse_error(
                 self._format(
                     call_node,

--- a/src/python/pants/engine/internals/rule_visitor.py
+++ b/src/python/pants/engine/internals/rule_visitor.py
@@ -271,6 +271,7 @@ class _AwaitableCollector(ast.NodeVisitor):
             len(call_node.keywords) == 1
             and not call_node.keywords[0].arg
             and isinstance(implicitly_call := call_node.keywords[0].value, ast.Call)
+            and self._lookup(implicitly_call.func).__name__ == "implicitly"
         ):
             input_nodes, input_type_nodes = self._get_inputs(implicitly_call.args)
             input_types = tuple(

--- a/src/python/pants/engine/internals/rule_visitor.py
+++ b/src/python/pants/engine/internals/rule_visitor.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Iterator, List, get_type_hints
+from typing import Any, Callable, Iterator, List, Sequence, get_type_hints
 
 import typing_extensions
 
@@ -193,7 +193,30 @@ class _AwaitableCollector(ast.NodeVisitor):
             )
         return resolved
 
-    def _get_awaitable(self, call_node: ast.Call, is_effect: bool) -> AwaitableConstraints:
+    def _get_inputs(self, input_nodes: Sequence[Any]) -> tuple[Sequence[Any], List[Any]]:
+        if not input_nodes:
+            return input_nodes, []
+        if len(input_nodes) != 1:
+            return input_nodes, [self._lookup(input_nodes[0])]
+
+        input_constructor = input_nodes[0]
+        if isinstance(input_constructor, ast.Call):
+            cls_or_func = self._lookup(input_constructor.func)
+            try:
+                type_ = (
+                    _lookup_return_type(cls_or_func, check=True)
+                    if not isinstance(cls_or_func, type)
+                    else cls_or_func
+                )
+            except TypeError as e:
+                raise RuleTypeError(self._missing_type_error(input_constructor, str(e))) from e
+            return [input_constructor.func], [type_]
+        elif isinstance(input_constructor, ast.Dict):
+            return input_constructor.values, [self._lookup(v) for v in input_constructor.values]
+        else:
+            return input_nodes, [self._lookup(n) for n in input_nodes]
+
+    def _get_legacy_awaitable(self, call_node: ast.Call, is_effect: bool) -> AwaitableConstraints:
         get_args = call_node.args
         parse_error = partial(GetParseError, get_args=get_args, source_file_name=self.source_file)
 
@@ -209,33 +232,10 @@ class _AwaitableCollector(ast.NodeVisitor):
         output_node = get_args[0]
         output_type = self._lookup(output_node)
 
-        input_nodes = get_args[1:]
-        input_types: List[Any]
-        if not input_nodes:
-            input_types = []
-        elif len(input_nodes) == 1:
-            input_constructor = input_nodes[0]
-            if isinstance(input_constructor, ast.Call):
-                cls_or_func = self._lookup(input_constructor.func)
-                try:
-                    type_ = (
-                        _lookup_return_type(cls_or_func, check=True)
-                        if not isinstance(cls_or_func, type)
-                        else cls_or_func
-                    )
-                except TypeError as e:
-                    raise RuleTypeError(self._missing_type_error(input_constructor, str(e))) from e
-                input_nodes = [input_constructor.func]
-                input_types = [type_]
-            elif isinstance(input_constructor, ast.Dict):
-                input_nodes = input_constructor.values
-                input_types = [self._lookup(v) for v in input_constructor.values]
-            else:
-                input_types = [self._lookup(n) for n in input_nodes]
-        else:
-            input_types = [self._lookup(input_nodes[0])]
+        input_nodes, input_types = self._get_inputs(get_args[1:])
 
         return AwaitableConstraints(
+            None,
             self._check_constraint_arg_type(output_type, output_node),
             tuple(
                 self._check_constraint_arg_type(input_type, input_node)
@@ -244,14 +244,70 @@ class _AwaitableCollector(ast.NodeVisitor):
             is_effect,
         )
 
+    def _get_byname_awaitable(
+        self, rule_func: Callable, call_node: ast.Call
+    ) -> AwaitableConstraints:
+        parse_error = partial(
+            GetParseError, get_args=call_node.args, source_file_name=self.source_file
+        )
+
+        output_type = _lookup_return_type(rule_func, check=True)
+
+        if call_node.args:
+            raise parse_error(
+                self._format(
+                    call_node,
+                    (
+                        f"Expected no positional arguments (got {len(call_node.args)}), and "
+                        "a `**implicitly(..)` application."
+                    ),
+                )
+            )
+
+        input_types: tuple[type, ...]
+        if not call_node.keywords:
+            input_types = ()
+        elif (
+            len(call_node.keywords) == 1
+            and not call_node.keywords[0].arg
+            and isinstance(implicitly_call := call_node.keywords[0].value, ast.Call)
+        ):
+            input_nodes, input_type_nodes = self._get_inputs(implicitly_call.args)
+            input_types = tuple(
+                self._check_constraint_arg_type(input_type, input_node)
+                for input_type, input_node in zip(input_type_nodes, input_nodes)
+            )
+        else:
+            print(f">>> call_node.keywords: {call_node.keywords}")
+            raise parse_error(
+                self._format(
+                    call_node,
+                    "Expected an `**implicitly(..)` application as the only input.",
+                )
+            )
+
+        return AwaitableConstraints(
+            rule_func,
+            output_type,
+            input_types,
+            # TODO: Extract this from the callee? Currently only intrinsics can be Effects, so need
+            # to figure out their new syntax first.
+            is_effect=False,
+        )
+
     def visit_Call(self, call_node: ast.Call) -> None:
         func = self._lookup(call_node.func)
         if func is not None:
             if isinstance(func, type) and issubclass(func, Awaitable):
+                # Is a `Get`/`Effect`.
                 self.awaitables.append(
-                    self._get_awaitable(call_node, is_effect=issubclass(func, Effect))
+                    self._get_legacy_awaitable(call_node, is_effect=issubclass(func, Effect))
                 )
+            elif inspect.isfunction(func) and getattr(func, "rule", None):
+                # Is a direct `@rule` call.
+                self.awaitables.append(self._get_byname_awaitable(func, call_node))
             elif inspect.iscoroutinefunction(func) or _returns_awaitable(func):
+                # Is a call to a "rule helper".
                 self.awaitables.extend(collect_awaitables(func))
 
         self.generic_visit(call_node)

--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -11,7 +11,7 @@ import pytest
 from pants.base.exceptions import RuleTypeError
 from pants.engine.internals.rule_visitor import collect_awaitables
 from pants.engine.internals.selectors import Get, GetParseError, MultiGet
-from pants.engine.rules import rule_helper
+from pants.engine.rules import implicitly, rule, rule_helper
 from pants.util.strutil import softwrap
 
 # The visitor inspects the module for definitions.
@@ -126,6 +126,23 @@ def test_get_no_index_call_no_subject_call_allowed() -> None:
         get_type: type = Get  # noqa: F841
 
     assert_awaitables(rule, [])
+
+
+def test_byname() -> None:
+    @rule
+    def rule1(arg: int) -> int:
+        return arg
+
+    @rule
+    async def rule2() -> int:
+        return 2
+
+    async def rule3() -> int:
+        one = await rule1(**implicitly(int(1)))
+        two = await rule2()
+        return one + two
+
+    assert_awaitables(rule3, [(int, int), (int, [])])
 
 
 def test_rule_helpers_free_functions() -> None:

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -10,9 +10,8 @@ from typing import Any
 import pytest
 
 from pants.base.exceptions import IncorrectProductError
-from pants.engine.internals.engine_testutil import remove_locations_from_traceback
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.rules import Get, rule
+from pants.engine.rules import Get, implicitly, rule
 from pants.engine.unions import UnionRule, union
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
@@ -45,11 +44,11 @@ def test_use_params() -> None:
     # Confirm that we can pass in Params in order to provide multiple inputs to an execution.
     a, b = A(), B()
     result_str = rule_runner.request(str, [a, b])
-    assert result_str == consumes_a_and_b(a, b)
+    assert result_str == consumes_a_and_b.rule.func(a, b)  # type: ignore[attr-defined]
 
     # And confirm that a superset of Params is also accepted.
     result_str = rule_runner.request(str, [a, b, b"bytes aren't used by any rules"])
-    assert result_str == consumes_a_and_b(a, b)
+    assert result_str == consumes_a_and_b.rule.func(a, b)  # type: ignore[attr-defined]
 
     # But not a subset.
     expected_msg = "No installed QueryRules can compute str given input Params(A), but"
@@ -97,10 +96,7 @@ def test_transitive_params(transitive_params_rule_runner: RuleRunner) -> None:
     # Test that C can be provided and implicitly converted into a B with transitive_b_c() to satisfy
     # the selectors of consumes_a_and_b().
     a, c = A(), C()
-    result_str = transitive_params_rule_runner.request(str, [a, c])
-    assert remove_locations_from_traceback(result_str) == remove_locations_from_traceback(
-        consumes_a_and_b(a, transitive_b_c(c))
-    )
+    assert transitive_params_rule_runner.request(str, [a, c])
 
     # Test that an inner Get in transitive_coroutine_rule() is able to resolve B from C due to
     # the existence of transitive_b_c().
@@ -125,6 +121,40 @@ def test_strict_equals() -> None:
     # to the same value, triggering an error. Instead, the engine additionally includes the
     # type of a value in equality.
     assert A() == rule_runner.request(A, [1, True])
+
+
+# -----------------------------------------------------------------------------------------------
+# Test direct @rule calls
+# -----------------------------------------------------------------------------------------------
+
+
+@rule
+async def b(i: int) -> B:
+    return B()
+
+
+@rule
+def c() -> C:
+    return C()
+
+
+@rule
+async def a() -> A:
+    _ = await b(**implicitly(int(1)))
+    _ = await c()
+    return A()
+
+
+def test_direct_call() -> None:
+    rule_runner = RuleRunner(
+        rules=[
+            a,
+            b,
+            c,
+            QueryRule(A, []),
+        ]
+    )
+    assert rule_runner.request(A, [])
 
 
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/rules.py
+++ b/src/python/pants/engine/rules.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import inspect
 import sys
 from dataclasses import dataclass
@@ -10,7 +11,9 @@ from enum import Enum
 from types import FrameType, ModuleType
 from typing import (
     Any,
+    Awaitable,
     Callable,
+    Coroutine,
     Iterable,
     Mapping,
     Optional,
@@ -18,6 +21,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
     get_type_hints,
     overload,
 )
@@ -28,7 +32,7 @@ from pants.base.deprecated import deprecated
 from pants.engine.engine_aware import SideEffecting
 from pants.engine.goal import Goal
 from pants.engine.internals.rule_visitor import collect_awaitables
-from pants.engine.internals.selectors import AwaitableConstraints
+from pants.engine.internals.selectors import AwaitableConstraints, Call
 from pants.engine.internals.selectors import Effect as Effect  # noqa: F401
 from pants.engine.internals.selectors import Get as Get  # noqa: F401
 from pants.engine.internals.selectors import MultiGet as MultiGet  # noqa: F401
@@ -41,10 +45,34 @@ from pants.util.strutil import softwrap
 PANTS_RULES_MODULE_KEY = "__pants_rules__"
 
 
+def implicitly(*args) -> dict[str, Any]:
+    # NB: This function does not have a `TypedDict` return type, because the `@rule` decorator
+    # cannot adjust the type of the `@rule` function to include a keyword argument (keyword
+    # arguments are not supported by PEP-612).
+    return {"__implicitly": Call(*args)}
+
+
 class RuleType(Enum):
     rule = "rule"
     goal_rule = "goal_rule"
     uncacheable_rule = "_uncacheable_rule"
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
+SyncRuleT = Callable[P, R]
+AsyncRuleT = Callable[P, Awaitable[R]]
+RuleDecorator = Callable[[Union[SyncRuleT, AsyncRuleT]], AsyncRuleT]
+
+
+def _rule_call_trampoline(output_type: type, func: Callable[P, R]) -> Callable[P, R]:
+    @functools.wraps(func)  # type: ignore
+    async def wrapper(*args, __implicitly: Call | None = None, **kwargs):
+        call = __implicitly or Call()
+        call.set_output_type(output_type)
+        return await call
+
+    return cast(Callable[P, R], wrapper)
 
 
 def _make_rule(
@@ -58,7 +86,7 @@ def _make_rule(
     canonical_name: str,
     desc: Optional[str],
     level: LogLevel,
-) -> Callable[[Callable], Callable]:
+) -> RuleDecorator:
     """A @decorator that declares that a particular static function may be used as a TaskRule.
 
     :param rule_type: The specific decorator used to declare the rule.
@@ -77,23 +105,29 @@ def _make_rule(
     if rule_type == RuleType.goal_rule and not is_goal_cls:
         raise TypeError("An `@goal_rule` must return a subclass of `engine.goal.Goal`.")
 
-    def wrapper(func):
-        if not inspect.isfunction(func):
+    def wrapper(original_func):
+        if not inspect.isfunction(original_func):
             raise ValueError("The @rule decorator must be applied innermost of all decorators.")
 
-        awaitables = FrozenOrderedSet(collect_awaitables(func))
+        awaitables = FrozenOrderedSet(collect_awaitables(original_func))
 
         validate_requirements(func_id, parameter_types, awaitables, cacheable)
 
         # Set our own custom `__line_number__` dunder so that the engine may visualize the line number.
-        func.__line_number__ = func.__code__.co_firstlineno
+        original_func.__line_number__ = original_func.__code__.co_firstlineno
 
+        func = _rule_call_trampoline(return_type, original_func)
+
+        # NB: The named definition of the rule ends up wrapped in a trampoline to handle memoization
+        # and implicit arguments for direct by-name calls. But the `TaskRule` takes a reference to
+        # the original unwrapped function, which avoids the need for a special protocol when the
+        # engine invokes a @rule under memoization.
         func.rule = TaskRule(
             return_type,
             parameter_types,
             awaitables,
             masked_types,
-            func,
+            original_func,
             canonical_name=canonical_name,
             desc=desc,
             level=level,
@@ -165,7 +199,7 @@ PRIVATE_RULE_DECORATOR_ARGUMENTS = {
 IMPLICIT_PRIVATE_RULE_DECORATOR_ARGUMENTS = {"rule_type", "cacheable"}
 
 
-def rule_decorator(func, **kwargs) -> Callable:
+def rule_decorator(func: SyncRuleT | AsyncRuleT, **kwargs) -> AsyncRuleT:
     if not inspect.isfunction(func):
         raise ValueError("The @rule decorator expects to be placed on a function.")
 
@@ -312,7 +346,7 @@ def validate_requirements(
             )
 
 
-def inner_rule(*args, **kwargs) -> Callable:
+def inner_rule(*args, **kwargs) -> AsyncRuleT | RuleDecorator:
     if len(args) == 1 and inspect.isfunction(args[0]):
         return rule_decorator(*args, **kwargs)
     else:
@@ -323,11 +357,26 @@ def inner_rule(*args, **kwargs) -> Callable:
         return wrapper
 
 
-def rule(*args, **kwargs) -> Callable:
+@overload
+def rule(func: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, Coroutine[Any, Any, R]]:
+    ...
+
+
+@overload
+def rule(func: Callable[P, R]) -> Callable[P, Coroutine[Any, Any, R]]:
+    ...
+
+
+@overload
+def rule(func: None = None, **kwargs: Any) -> RuleDecorator:
+    ...
+
+
+def rule(*args, **kwargs):
     return inner_rule(*args, **kwargs, rule_type=RuleType.rule, cacheable=True)
 
 
-def goal_rule(*args, **kwargs) -> Callable:
+def goal_rule(*args, **kwargs) -> AsyncRuleT | RuleDecorator:
     if "level" not in kwargs:
         kwargs["level"] = LogLevel.DEBUG
     return inner_rule(*args, **kwargs, rule_type=RuleType.goal_rule, cacheable=False)
@@ -335,12 +384,8 @@ def goal_rule(*args, **kwargs) -> Callable:
 
 # This has a "private" name, as we don't (yet?) want it to be part of the rule API, at least
 # until we figure out the implications, and have a handle on the semantics and use-cases.
-def _uncacheable_rule(*args, **kwargs) -> Callable:
+def _uncacheable_rule(*args, **kwargs) -> AsyncRuleT | RuleDecorator:
     return inner_rule(*args, **kwargs, rule_type=RuleType.uncacheable_rule, cacheable=False)
-
-
-P = ParamSpec("P")
-R = TypeVar("R")
 
 
 def _rule_helper_decorator(func: Callable[P, R], _public: bool = False) -> Callable[P, R]:

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -315,22 +315,22 @@ class TestRuleArgumentAnnotation:
         def a_named_rule(a: int, b: str) -> bool:
             return False
 
-        assert a_named_rule.rule is not None
+        assert a_named_rule.rule is not None  # type: ignore[attr-defined]
         assert (
-            a_named_rule.rule.canonical_name
+            a_named_rule.rule.canonical_name  # type: ignore[attr-defined]
             == "pants.engine.rules_test.TestRuleArgumentAnnotation.test_annotations_kwargs.a_named_rule"
         )
-        assert a_named_rule.rule.desc is None
-        assert a_named_rule.rule.level == LogLevel.INFO
+        assert a_named_rule.rule.desc is None  # type: ignore[attr-defined]
+        assert a_named_rule.rule.level == LogLevel.INFO  # type: ignore[attr-defined]
 
         @rule(canonical_name="something_different", desc="Human readable desc")
         def another_named_rule(a: int, b: str) -> bool:
             return False
 
-        assert a_named_rule.rule is not None
-        assert another_named_rule.rule.canonical_name == "something_different"
-        assert another_named_rule.rule.desc == "Human readable desc"
-        assert another_named_rule.rule.level == LogLevel.TRACE
+        assert a_named_rule.rule is not None  # type: ignore[attr-defined]
+        assert another_named_rule.rule.canonical_name == "something_different"  # type: ignore[attr-defined]
+        assert another_named_rule.rule.desc == "Human readable desc"  # type: ignore[attr-defined]
+        assert another_named_rule.rule.level == LogLevel.TRACE  # type: ignore[attr-defined]
 
     def test_bogus_rules(self) -> None:
         with pytest.raises(UnrecognizedRuleArgument):
@@ -351,7 +351,7 @@ class TestRuleArgumentAnnotation:
         def some_goal_rule() -> Example:
             return Example(exit_code=0)
 
-        name = some_goal_rule.rule.canonical_name
+        name = some_goal_rule.rule.canonical_name  # type: ignore[attr-defined]
         assert name == "some_other_name"
 
 
@@ -1058,7 +1058,7 @@ def test_param_type_overrides() -> None:
     async def dont_injure_humans(param1: str, param2, param3: list) -> A:
         return A()
 
-    assert dont_injure_humans.rule.input_selectors == (int, dict, list)
+    assert dont_injure_humans.rule.input_selectors == (int, dict, list)  # type: ignore[attr-defined]
 
     with pytest.raises(ValueError, match="paramX"):
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -67,6 +67,7 @@ def fmt_rule(
     line_sep = "\n" if multiline else " "
     optional_line_sep = "\n" if multiline else ""
 
+    rule = rule.rule.func  # type: ignore[attr-defined]
     type_hints = get_type_hints(rule)
     product = type_hints.pop("return").__name__
     params = f",{line_sep}".join(t.__name__ for t in type_hints.values())

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -202,7 +202,7 @@ class Subsystem(metaclass=_SubsystemMeta):
             input_selectors=(),
             input_gets=(
                 AwaitableConstraints(
-                    output_type=ScopedOptions, input_types=(Scope,), is_effect=False
+                    callee=None, output_type=ScopedOptions, input_types=(Scope,), is_effect=False
                 ),
             ),
             masked_types=(),
@@ -232,6 +232,7 @@ class Subsystem(metaclass=_SubsystemMeta):
             input_selectors=(cls, EnvironmentTarget),
             input_gets=(
                 AwaitableConstraints(
+                    callee=None,
                     output_type=EnvironmentVars,
                     input_types=(EnvironmentVarsRequest,),
                     is_effect=False,

--- a/src/python/pants/source/source_root_test.py
+++ b/src/python/pants/source/source_root_test.py
@@ -3,7 +3,7 @@
 
 import os
 from pathlib import PurePath
-from typing import Iterable, Optional, cast
+from typing import Iterable, Optional
 
 import pytest
 
@@ -45,20 +45,17 @@ def _find_root(
         return Paths(files=tuple(), dirs=tuple())
 
     def _do_find_root(src_root_req: SourceRootRequest) -> OptionalSourceRoot:
-        return cast(
-            OptionalSourceRoot,
-            run_rule_with_mocks(
-                get_optional_source_root,
-                rule_args=[src_root_req, source_root_config],
-                mock_gets=[
-                    MockGet(
-                        output_type=OptionalSourceRoot,
-                        input_types=(SourceRootRequest,),
-                        mock=_do_find_root,
-                    ),
-                    MockGet(output_type=Paths, input_types=(PathGlobs,), mock=_mock_fs_check),
-                ],
-            ),
+        return run_rule_with_mocks(
+            get_optional_source_root,
+            rule_args=[src_root_req, source_root_config],
+            mock_gets=[
+                MockGet(
+                    output_type=OptionalSourceRoot,
+                    input_types=(SourceRootRequest,),
+                    mock=_do_find_root,
+                ),
+                MockGet(output_type=Paths, input_types=(PathGlobs,), mock=_mock_fs_check),
+            ],
         )
 
     source_root = _do_find_root(SourceRootRequest(PurePath(path))).source_root

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -15,11 +15,11 @@ from io import StringIO
 from pathlib import Path, PurePath
 from pprint import pformat
 from tempfile import mkdtemp
-from types import CoroutineType, GeneratorType
 from typing import (
     Any,
     Callable,
     Coroutine,
+    Generator,
     Generic,
     Iterable,
     Iterator,
@@ -694,6 +694,8 @@ def run_rule_with_mocks(
 
     task_rule = getattr(rule, "rule", None)
 
+    func: Callable[..., Coroutine[Any, Any, _O]] | Callable[..., _O]
+
     # Perform additional validation on `@rule` that the correct args are provided. We don't have
     # an easy way to do this for `@rule_helper` yet.
     if task_rule:
@@ -708,10 +710,15 @@ def run_rule_with_mocks(
                 f"{pformat(task_rule.input_gets)}\ngot:\n"
                 f"{pformat(mock_gets)}"
             )
+        # Access the original function, rather than the trampoline that we would get by calling
+        # it directly.
+        func = task_rule.func
+    else:
+        func = rule
 
-    res = rule(*(rule_args or ()))
-    if not isinstance(res, (CoroutineType, GeneratorType)):
-        return res  # type: ignore[misc,return-value]
+    res = func(*(rule_args or ()))
+    if not isinstance(res, (Coroutine, Generator)):
+        return res
 
     def get(res: Get | Effect):
         provider = next(
@@ -746,9 +753,9 @@ def run_rule_with_mocks(
             if isinstance(res, (Get, Effect)):
                 rule_input = get(res)
             elif type(res) in (tuple, list):
-                rule_input = [get(g) for g in res]  # type: ignore[attr-defined]
+                rule_input = [get(g) for g in res]  # type: ignore[union-attr]
             else:
-                return res  # type: ignore[misc,return-value]
+                return res  # type: ignore[return-value]
         except StopIteration as e:
             return e.value  # type: ignore[no-any-return]
 

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -83,10 +83,6 @@ fn native_engine(py: Python, m: &PyModule) -> PyO3Result<()> {
   m.add_class::<PyThreadLocals>()?;
   m.add_class::<PyTypes>()?;
 
-  m.add_class::<externs::PyGeneratorResponseBreak>()?;
-  m.add_class::<externs::PyGeneratorResponseGet>()?;
-  m.add_class::<externs::PyGeneratorResponseGetMulti>()?;
-
   m.add_function(wrap_pyfunction!(stdio_initialize, m)?)?;
   m.add_function(wrap_pyfunction!(stdio_thread_console_set, m)?)?;
   m.add_function(wrap_pyfunction!(stdio_thread_console_color_mode_set, m)?)?;

--- a/src/rust/engine/src/externs/mod.rs
+++ b/src/rust/engine/src/externs/mod.rs
@@ -39,6 +39,11 @@ pub mod workunits;
 
 pub fn register(py: Python, m: &PyModule) -> PyResult<()> {
   m.add_class::<PyFailure>()?;
+  m.add_class::<PyGeneratorResponseBreak>()?;
+  m.add_class::<PyGeneratorResponseCall>()?;
+  m.add_class::<PyGeneratorResponseGet>()?;
+  m.add_class::<PyGeneratorResponseGetMulti>()?;
+
   m.add("EngineError", py.get_type::<EngineError>())?;
   m.add("IntrinsicError", py.get_type::<IntrinsicError>())?;
   m.add(
@@ -281,6 +286,10 @@ pub fn generator_send(
       Value::new(b.0.clone_ref(py)),
       TypeId::new(b.0.as_ref(py).get_type()),
     ))
+  } else if let Ok(call) = response.extract::<PyRef<PyGeneratorResponseCall>>() {
+    // TODO: When we begin using https://github.com/pantsbuild/pants/pull/19755, this will likely
+    // use a different syntax.
+    Ok(GeneratorResponse::Get(call.take()?))
   } else if let Ok(get) = response.extract::<PyRef<PyGeneratorResponseGet>>() {
     Ok(GeneratorResponse::Get(get.take()?))
   } else if let Ok(get_multi) = response.extract::<PyRef<PyGeneratorResponseGetMulti>>() {
@@ -332,6 +341,124 @@ impl PyGeneratorResponseBreak {
   }
 }
 
+/// Interprets the `Get` and `implicitly(..)` syntax, which reduces to two optional positional
+/// arguments, and results in input types and inputs.
+#[allow(clippy::type_complexity)]
+fn interpret_get_inputs(
+  py: Python,
+  input_arg0: Option<&PyAny>,
+  input_arg1: Option<&PyAny>,
+) -> PyResult<(SmallVec<[TypeId; 2]>, SmallVec<[Key; 2]>)> {
+  match (input_arg0, input_arg1) {
+    (None, None) => Ok((smallvec![], smallvec![])),
+    (None, Some(_)) => Err(PyAssertionError::new_err(
+      "input_arg1 set, but input_arg0 was None. This should not happen with PyO3.",
+    )),
+    (Some(input_arg0), None) => {
+      if input_arg0.is_instance_of::<PyType>() {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the shorthand form \
+            Get(OutputType, InputType(constructor args)), the second argument should be \
+            a constructor call, rather than a type, but given {input_arg0}."
+        )));
+      }
+      if let Ok(d) = input_arg0.downcast::<PyDict>() {
+        let mut input_types = SmallVec::new();
+        let mut inputs = SmallVec::new();
+        for (value, declared_type) in d.iter() {
+          input_types.push(TypeId::new(declared_type.downcast::<PyType>().map_err(
+            |_| {
+              PyTypeError::new_err(
+                "Invalid Get. Because the second argument was a dict, we expected the keys of the \
+            dict to be the Get inputs, and the values of the dict to be the declared \
+            types of those inputs.",
+              )
+            },
+          )?));
+          inputs.push(INTERNS.key_insert(py, value.into())?);
+        }
+        Ok((input_types, inputs))
+      } else {
+        Ok((
+          smallvec![TypeId::new(input_arg0.get_type())],
+          smallvec![INTERNS.key_insert(py, input_arg0.into())?],
+        ))
+      }
+    }
+    (Some(input_arg0), Some(input_arg1)) => {
+      let declared_type = input_arg0.downcast::<PyType>().map_err(|_| {
+        let input_arg0_type = input_arg0.get_type();
+        PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, \
+          input), the second argument must be a type, but given `{input_arg0}` of type \
+          {input_arg0_type}."
+        ))
+      })?;
+
+      if input_arg1.is_instance_of::<PyType>() {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. Because you are using the longhand form \
+          Get(OutputType, InputType, input), the third argument should be \
+          an object, rather than a type, but given {input_arg1}."
+        )));
+      }
+
+      let actual_type = input_arg1.get_type();
+      if !declared_type.is(actual_type) && !is_union(py, declared_type)? {
+        return Err(PyTypeError::new_err(format!(
+          "Invalid Get. The third argument `{input_arg1}` must have the exact same type as the \
+          second argument, {declared_type}, but had the type {actual_type}."
+        )));
+      }
+
+      Ok((
+        smallvec![TypeId::new(declared_type)],
+        smallvec![INTERNS.key_insert(py, input_arg1.into())?],
+      ))
+    }
+  }
+}
+
+#[pyclass(subclass)]
+pub struct PyGeneratorResponseCall {
+  output_type: Option<TypeId>,
+  input_types: SmallVec<[TypeId; 2]>,
+  inputs: SmallVec<[Key; 2]>,
+}
+
+#[pymethods]
+impl PyGeneratorResponseCall {
+  #[new]
+  fn __new__(py: Python, input_arg0: Option<&PyAny>, input_arg1: Option<&PyAny>) -> PyResult<Self> {
+    let (input_types, inputs) = interpret_get_inputs(py, input_arg0, input_arg1)?;
+
+    Ok(Self {
+      output_type: None,
+      input_types,
+      inputs,
+    })
+  }
+
+  fn set_output_type(&mut self, output_type: &PyType) {
+    self.output_type = Some(TypeId::new(output_type))
+  }
+}
+
+impl PyGeneratorResponseCall {
+  fn take(&self) -> Result<Get, String> {
+    if let Some(output_type) = self.output_type {
+      Ok(Get {
+        output: output_type,
+        // TODO: Similar to `PyGeneratorResponseGet::take`, this should avoid these clones.
+        input_types: self.input_types.clone(),
+        inputs: self.inputs.clone(),
+      })
+    } else {
+      Err("Cannot convert a Call into a Get until its output_type has been set.".to_owned())
+    }
+  }
+}
+
 // Contains a `RefCell<Option<Get>>` in order to allow us to `take` the content without cloning.
 #[pyclass(subclass)]
 pub struct PyGeneratorResponseGet(RefCell<Option<Get>>);
@@ -364,76 +491,7 @@ impl PyGeneratorResponseGet {
     })?;
     let output = TypeId::new(product);
 
-    let (input_types, inputs) = match (input_arg0, input_arg1) {
-      (None, None) => (smallvec![], smallvec![]),
-      (None, Some(_)) => {
-        return Err(PyAssertionError::new_err(
-          "input_arg1 set, but input_arg0 was None. This should not happen with PyO3.",
-        ))
-      }
-      (Some(input_arg0), None) => {
-        if input_arg0.is_instance_of::<PyType>() {
-          return Err(PyTypeError::new_err(format!(
-            "Invalid Get. Because you are using the shorthand form \
-            Get(OutputType, InputType(constructor args)), the second argument should be \
-            a constructor call, rather than a type, but given {input_arg0}."
-          )));
-        }
-        if let Ok(d) = input_arg0.downcast::<PyDict>() {
-          let mut input_types = SmallVec::new();
-          let mut inputs = SmallVec::new();
-          for (value, declared_type) in d.iter() {
-            input_types.push(TypeId::new(declared_type.downcast::<PyType>().map_err(
-              |_| {
-                PyTypeError::new_err(
-              "Invalid Get. Because the second argument was a dict, we expected the keys of the \
-            dict to be the Get inputs, and the values of the dict to be the declared \
-            types of those inputs.",
-            )
-              },
-            )?));
-            inputs.push(INTERNS.key_insert(py, value.into())?);
-          }
-          (input_types, inputs)
-        } else {
-          (
-            smallvec![TypeId::new(input_arg0.get_type())],
-            smallvec![INTERNS.key_insert(py, input_arg0.into())?],
-          )
-        }
-      }
-      (Some(input_arg0), Some(input_arg1)) => {
-        let declared_type = input_arg0.downcast::<PyType>().map_err(|_| {
-          let input_arg0_type = input_arg0.get_type();
-          PyTypeError::new_err(format!(
-            "Invalid Get. Because you are using the longhand form Get(OutputType, InputType, \
-          input), the second argument must be a type, but given `{input_arg0}` of type \
-          {input_arg0_type}."
-          ))
-        })?;
-
-        if input_arg1.is_instance_of::<PyType>() {
-          return Err(PyTypeError::new_err(format!(
-            "Invalid Get. Because you are using the longhand form \
-          Get(OutputType, InputType, input), the third argument should be \
-          an object, rather than a type, but given {input_arg1}."
-          )));
-        }
-
-        let actual_type = input_arg1.get_type();
-        if !declared_type.is(actual_type) && !is_union(py, declared_type)? {
-          return Err(PyTypeError::new_err(format!(
-            "Invalid Get. The third argument `{input_arg1}` must have the exact same type as the \
-          second argument, {declared_type}, but had the type {actual_type}."
-          )));
-        }
-
-        (
-          smallvec![TypeId::new(declared_type)],
-          smallvec![INTERNS.key_insert(py, input_arg1.into())?],
-        )
-      }
-    };
+    let (input_types, inputs) = interpret_get_inputs(py, input_arg0, input_arg1)?;
 
     Ok(Self(RefCell::new(Some(Get {
       output,


### PR DESCRIPTION
As discussed on #18905, and sketched on #19730, this change introduces a call-by-name syntax for `@rules`.

```python
@rule
async def b(i: int) -> B: ...

@rule
def c() -> C: ...

@rule
async def a() -> A:
    _ = await b(**implicitly(int(1)))
    _ = await c()
    return A()
```

As demonstrated in the tests, direct calls to `@rules` are translated into an `await Call`, which is currently implemented using `Get`. That means that (currently), the actual `@rule` name which is specified is not used in graph solving. @benjyw's work on #19755 (and further work on #19730) will allow us to pin rule graph solving to the called `@rule` name.

Positional arguments to rules are not yet supported (since the new arguments would need to be accounted for in rule graph solving, and at runtime), and will be followup work.