### PR TITLE
Improve dep inference versioning scheme (Cherry-pick of #19790)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "dep_inference"
-version = "0.0.1"
+version = "2.17.0"
 dependencies = [
  "fnv",
  "serde",

--- a/src/rust/engine/dep_inference/Cargo.toml
+++ b/src/rust/engine/dep_inference/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-version = "0.0.1"
+version = "2.17.0"
 edition = "2021"
 name = "dep_inference"
 authors = [ "Pants Build <pantsbuild@gmail.com>" ]


### PR DESCRIPTION
https://github.com/pantsbuild/pants/pull/19293 needs to be cherry-picked back to 2.17.x and 2.18.x, but the version that should be specified isn't clear.
We could copy `0.0.2`, but if any change landed on `main` but not cherry-picked backwards that version is incorrect.

So, I'm changing the versioning scheme to embed the latest-major-changes-branch into the version which forces cherry-picking to fail and the human should bump the destination branch's patch number
