### PR TITLE
Add test for nested no-infer-dep in Rust Python dep inference

### DIFF
--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -195,6 +195,48 @@ fn pragma_ignore() {
         *  # pants: no-infer-dep",
     &[],
   );
+  // Imports nested within other constructs
+  assert_imports(
+    r"
+    if x:
+        import a  # pants: no-infer-dep
+    ",
+    &[],
+  );
+  assert_imports(
+    r"
+    if x:
+        import a  # pants: no-infer-dep
+        import b
+    ",
+    &["b"],
+  );
+  assert_imports(
+    r"
+    class X: def method(): if True: while True: class Y: def f(): import a  # pants: no-infer-dep
+    ",
+    &[],
+  );
+  assert_imports(
+    r"
+    if x:
+        import \
+            a  # pants: no-infer-dep
+    ",
+    &[],
+  );
+
+  // https://github.com/pantsbuild/pants/issues/19751
+  assert_imports(
+    r"
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from a import ClassA  # pants: no-infer-dep
+
+    print('Hello, world!')",
+    &["typing.TYPE_CHECKING"],
+  );
 }
 
 #[test]


### PR DESCRIPTION
This closes #19751 by adding some tests for it. We're pretty sure the real fix was in #19293, but only incidentally, so this PR makes sure we've got a regression test specifically for #19751.

I've marked the test for cherrypicking so that we confirm that this is fixed in the earlier releases too.