### PR TITLE
Fix Documentation (InitialConfiguration) go backend

### DIFF
--- a/docs/markdown/Getting Started/getting-started/initial-configuration.md
+++ b/docs/markdown/Getting Started/getting-started/initial-configuration.md
@@ -47,7 +47,7 @@ Most Pants functionality is provided via pluggable [_backends_](doc:enabling-bac
 [GLOBAL]
 ...
 backend_packages = [
-  "pants.backend.go",
+  "pants.backend.experimental.go",
   "pants.backend.python",
   "pants.backend.python.lint.black",
 ]


### PR DESCRIPTION
# What

Update the initial-configuration documentation on https://www.pantsbuild.org/docs/initial-configuration

![image](https://github.com/pantsbuild/pants/assets/9064687/2b757bfb-ebab-47a6-9c07-f60663dedf74)

from `pants.backend.go` -> `pants.backend.experimental.go`

# Why

According to https://www.pantsbuild.org/docs/enabling-backends `pants.backend.experimental.go` is the correct backend name.  Also if you use `pants.backend.go` on `2.17.0` it fails building

```
$ cat pants.toml
[GLOBAL]
pants_version = "2.17.0"
backend_packages = [
  "pants.backend.go",
  "pants.backend.python",
  "pants.backend.python.lint.black",
]

$ pants tailor ::
13:03:35.59 [INFO] waiting for pantsd to start...
13:03:39.18 [INFO] pantsd started
Traceback (most recent call last):
  File "/Users/nobu/Library/Caches/nce/50b60c9f29c54578592fd2b4725722435f65d43cb21e6e2732268b6d5050a09a/bindings/venvs/2.17.0/lib/python3.9/site-packages/pants/init/extension_loader.py", line 141, in load_backend
    module = importlib.import_module(backend_module)
  File "/Users/nobu/Library/Caches/nce/3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz/python/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'pants.backend.go.register'
13:03:39.23 [ERROR] Failed to load the pants.backend.go.register backend: ModuleNotFoundError("No module named 'pants.backend.go.register'")
```

When, I update this to the `experimental` version, it runs tailor correctly

```
 $ cat pants.toml
[GLOBAL]
pants_version = "2.17.0"
backend_packages = [
  "pants.backend.experimental.go",
  "pants.backend.python",
  "pants.backend.python.lint.black",
]
```

```
$ pants tailor ::
13:15:07.47 [INFO] waiting for pantsd to start...
13:15:10.84 [INFO] pantsd started
13:15:11.82 [INFO] Initializing scheduler...
13:15:20.25 [INFO] Scheduler initialized.
```