### PR TITLE
Add cache-to and cache-from options

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -23,6 +23,8 @@ from pants.backend.docker.target_types import (
     DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
+    DockerImageBuildImageCacheFromField,
+    DockerImageBuildImageCacheToField,
     DockerImageContextRootField,
     DockerImageRegistriesField,
     DockerImageRepositoryField,
@@ -334,6 +336,18 @@ def get_build_options(
             yield from target[field_type].options()
         elif issubclass(field_type, DockerBuildOptionFlagFieldMixin):
             yield from target[field_type].options()
+        elif issubclass(field_type, DockerImageBuildImageCacheToField) or issubclass(
+            field_type, DockerImageBuildImageCacheFromField
+        ):
+            source = InterpolationContext.TextSource(
+                address=target.address, target_alias=target.alias, field_alias=field_type.alias
+            )
+            format = partial(
+                context.interpolation_context.format,
+                source=source,
+                error_cls=DockerImageOptionValueError,
+            )
+            yield from target[field_type].options(format)
 
     # Target stage
     target_stage = None

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1096,6 +1096,74 @@ def test_docker_build_hosts_option(rule_runner: RuleRunner) -> None:
     )
 
 
+def test_docker_cache_to_option(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  cache_to={"type": "local", "dest": "/tmp/docker/pants-test-cache"},
+                )
+                """
+            ),
+        }
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "build",
+            "--cache-to=type=local,dest=/tmp/docker/pants-test-cache",
+            "--pull=False",
+            "--tag",
+            "img1:latest",
+            "--file",
+            "docker/test/Dockerfile",
+            ".",
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        process_assertions=check_docker_proc,
+    )
+
+
+def test_docker_cache_from_option(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  cache_from={"type": "local", "dest": "/tmp/docker/pants-test-cache"},
+                )
+                """
+            ),
+        }
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "build",
+            "--cache-from=type=local,dest=/tmp/docker/pants-test-cache",
+            "--pull=False",
+            "--tag",
+            "img1:latest",
+            "--file",
+            "docker/test/Dockerfile",
+            ".",
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        process_assertions=check_docker_proc,
+    )
+
+
 def test_docker_build_network_option(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -298,7 +298,7 @@ class DockerImageBuildImageExtraHostsField(DockerBuildOptionFieldMixin, DictStri
 
 
 class DockerBuildOptionFieldMultiValueDictMixin(DictStringToStringField):
-    """Inherit this mixin class to provide options in the form of `--flag=key2=value1,key2=value2`
+    """Inherit this mixin class to provide options in the form of `--flag=key1=value1,key2=value2`
     to `docker build`."""
 
     docker_build_option: ClassVar[str]
@@ -347,7 +347,19 @@ class DockerImageBuildImageCacheFromField(
         f"""
         Use an external cache source when building the image.
 
-        See the `cache_to` field help for example usage.
+        Example:
+
+            docker_image(
+                name="example-local-cache-backend",
+                cache_to={{
+                    "type": "local",
+                    "dest": "/tmp/docker-cache/example"
+                }},
+                cache_from={{
+                    "type": "local",
+                    "src": "/tmp/docker-cache/example"
+                }}
+            )
 
         {_interpolation_help.format(kind="Values")}
         """

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -297,6 +297,64 @@ class DockerImageBuildImageExtraHostsField(DockerBuildOptionFieldMixin, DictStri
                 yield f"{label}:{value_formatter(value)}"
 
 
+class DockerBuildOptionFieldMultiValueDictMixin(DictStringToStringField):
+    """Inherit this mixin class to provide options in the form of `--flag=key2=value1,key2=value2`
+    to `docker build`."""
+
+    docker_build_option: ClassVar[str]
+
+    @final
+    def options(self, value_formatter: OptionValueFormatter) -> Iterator[str]:
+        if self.value:
+            yield f"{self.docker_build_option}=" + ",".join(
+                f"{key}={value_formatter(value)}" for key, value in self.value.items()
+            )
+
+
+class DockerImageBuildImageCacheToField(
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+):
+    alias = "cache_to"
+    help = help_text(
+        f"""
+        Export image build cache to an external cache destination.
+
+        Example:
+
+            docker_image(
+                name="example-local-cache-backend",
+                cache_to={{
+                    "type": "local",
+                    "dest": "/tmp/docker-cache/example"
+                }},
+                cache_from={{
+                    "type": "local",
+                    "src": "/tmp/docker-cache/example"
+                }}
+            )
+
+        {_interpolation_help.format(kind="Values")}
+        """
+    )
+    docker_build_option = "--cache-to"
+
+
+class DockerImageBuildImageCacheFromField(
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+):
+    alias = "cache_from"
+    help = help_text(
+        f"""
+        Use an external cache source when building the image.
+
+        See the `cache_to` field help for example usage.
+
+        {_interpolation_help.format(kind="Values")}
+        """
+    )
+    docker_build_option = "--cache-from"
+
+
 class DockerImageBuildSecretsOptionField(
     AsyncFieldMixin, DockerBuildOptionFieldMixin, DictStringToStringField
 ):
@@ -475,6 +533,8 @@ class DockerImageTarget(Target):
         DockerImageBuildSquashOptionField,
         DockerImageBuildNetworkOptionField,
         DockerImageBuildPlatformOptionField,
+        DockerImageBuildImageCacheToField,
+        DockerImageBuildImageCacheFromField,
         OutputPathField,
         RestartableField,
     )


### PR DESCRIPTION
For #15199 and #18287 

A few notes on how to run with this - I'm not sure if it should go in docs or elsewhere? 

For details on the possible cache options, see https://docs.docker.com/build/cache/backends/

## Docker caching

### Setup

Enable buildkit if necessary - this is default in Docker > 19.03
```
export DOCKER_BUILDKIT=1
```

Set buildx as the default builder
```
docker buildx install
```

Create a builder using the Docker container driver (required for using the local file backend) - see https://docs.docker.com/build/drivers/
```
docker buildx create \
  --name container \
  --driver=docker-container \
  container

docker buildx use container
```

### Building with Docker CLI

```
docker build -t pants-cache-test:latest \
  --cache-to type=local,dest=/tmp/docker/pants-test-cache \
  --cache-from type=local,src=/tmp/docker/pants-test-cache .
```

### Building with Pants

Example Docker image target config
```
docker_image(
    name="with-local-cache-backend",
    cache_to={
        "type": "local",
        "dest": "/tmp/docker-cache/pants-example"
    },
    cache_from={
        "type": "local",
        "src": "/tmp/docker-cache/pants-example"
    }
)
```

pants.toml 
```
[docker]
env_vars = [
  "BUILDX_BUILDER"
]
```

Use the `container` builder created earlier
```
export BUILDX_BUILDER=container
```


### Other notes

Pants doesn't work with a non-default Docker context, e.g. `desktop-linux` which seems to be set by Docker desktop on Mac. I had to switch to the default context. 
<img width="1389" alt="image" src="https://github.com/pantsbuild/pants/assets/30220524/ff45100a-3293-4558-a46b-fe530ab554d7">



