### PR TITLE
WIP: Use Pants to build Pants and run Pants

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -32,6 +32,7 @@ python_requirements(
 # the breakpoint will cause dep inference to add this dep on the remote debugger client.
 python_requirement(name="pydevd-pycharm", requirements=["pydevd-pycharm==203.5419.8"])
 
+
 __dependents_rules__(
     (  # Only the explorer server may depend on these libraries
         (

--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -32,7 +32,6 @@ python_requirements(
 # the breakpoint will cause dep inference to add this dep on the remote debugger client.
 python_requirement(name="pydevd-pycharm", requirements=["pydevd-pycharm==203.5419.8"])
 
-
 __dependents_rules__(
     (  # Only the explorer server may depend on these libraries
         (

--- a/3rdparty/tools/protoc/BUILD
+++ b/3rdparty/tools/protoc/BUILD
@@ -1,0 +1,40 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+file(
+    name="compressed-protoc",
+    source=per_platform(
+        linux_arm64=http_source(
+            url="https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-aarch_64.zip",
+            len=2971115,
+            sha256="77a5a41f3e9712af6a35de13143b9b2b77f075aa1ab18a63cca4483b30f6e3cd",
+            filename="protoc.zip",
+        ),
+        linux_x86_64=http_source(
+            url="https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-linux-x86_64.zip",
+            len=3005508,
+            sha256="fc793561283d9ea6813fb757ae54f1afea6770afcd930904bdf3e590910420aa",
+            filename="protoc.zip",
+        ),
+        macos_arm64=http_source(
+            url="https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-osx-aarch_64.zip",
+            len=2089053,
+            sha256="cca53adb73a6686dd60bb3b0da33961e6b9dab1f833c851b5e1bb7b5df02b36f",
+            filename="protoc.zip",
+        ),
+        macos_x86_64=http_source(
+            url="https://github.com/protocolbuffers/protobuf/releases/download/v24.3/protoc-24.3-osx-x86_64.zip",
+            len=2121387,
+            sha256="13b45cdcde9b2101e982de897d5490cfd81dfa181605749c23982379ba0e3288",
+            filename="protoc.zip",
+        ),
+    ),
+)
+
+shell_command(
+    name="protoc",
+    command="unzip protoc.zip -d protoc",
+    tools=["unzip"],
+    execution_dependencies=[":compressed-protoc"],
+    output_directories=["protoc"],
+)

--- a/3rdparty/tools/python3/BUILD
+++ b/3rdparty/tools/python3/BUILD
@@ -1,0 +1,40 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+file(
+    name="compressed-python-build-standalone-3.9",
+    source=per_platform(
+        linux_arm64=http_source(
+            url="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
+            len=23583066,
+            sha256="f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
+            filename="python-build-standalone.tar.gz",
+        ),
+        linux_x86_64=http_source(
+            url="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            len=25738357,
+            sha256="2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
+            filename="python-build-standalone.tar.gz",
+        ),
+        macos_arm64=http_source(
+            url="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz",
+            len=16634170,
+            sha256="c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd",
+            filename="python-build-standalone.tar.gz",
+        ),
+        macos_x86_64=http_source(
+            url="https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz",
+            len=16908516,
+            sha256="3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
+            filename="python-build-standalone.tar.gz",
+        ),
+    ),
+)
+
+shell_command(
+    name="python3",
+    command="tar -xzf python-build-standalone.tar.gz",
+    tools=["tar", "gzip"],
+    execution_dependencies=[":compressed-python-build-standalone-3.9"],
+    output_directories=["python"],
+)

--- a/3rdparty/tools/rust/BUILD
+++ b/3rdparty/tools/rust/BUILD
@@ -1,0 +1,112 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# NB: TO get the links/hashes go to https://static.rust-lang.org/manifests.txt, then for the relevant
+# TOML for the version, go to that URL.
+
+file(
+    name="compressed-cargo",
+    source=per_platform(
+        linux_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-aarch64-unknown-linux-gnu.tar.gz",
+            len=13144016,
+            sha256="ae2414ed0e30340fa2994e1c4b4e809c2bb1a3c054de395540f5ec1aa1b35072",
+            filename="cargo.tar.gz",
+        ),
+        linux_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-x86_64-unknown-linux-gnu.tar.gz",
+            len=13011632,
+            sha256="bdd0589277041b7e6375e2782f9ce197f454f735642f118acb3a2d8e422770a4",
+            filename="cargo.tar.gz",
+        ),
+        macos_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-aarch64-apple-darwin.tar.gz",
+            len=9236959,
+            sha256="fc5d3c2f618fd691b6d61e8f845648c2b4d4b0981fab4d5f563615fa4673bfa7",
+            filename="cargo.tar.gz",
+        ),
+        macos_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/cargo-1.72.0-x86_64-apple-darwin.tar.gz",
+            len=9880166,
+            sha256="a16f7c17a24a57c5990b104271524c33320da0006446aabeaa25eb0e718dd450",
+            filename="cargo.tar.gz",
+        ),
+    ),
+)
+
+file(
+    name="compressed-rustc",
+    source=per_platform(
+        linux_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rustc-1.72.0-aarch64-unknown-linux-gnu.tar.gz",
+            len=152371343,
+            sha256="3a2d1a5b5b713615162dcaa6319b6ad65ab4b951f90557dfb1e5c54f2a64c4ee",
+            filename="rustc.tar.gz",
+        ),
+        linux_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rustc-1.72.0-x86_64-unknown-linux-gnu.tar.gz",
+            len=119891076,
+            sha256="f414557b12f2a7a61fabf152b4b9d6cb436ff15698e64a3111bca1a94be97a3e",
+            filename="rustc.tar.gz",
+        ),
+        macos_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rustc-1.72.0-aarch64-apple-darwin.tar.gz",
+            len=96788681,
+            sha256="8314d30747d95e62345d46b682bf490fa1b397d194294fae917bf72a6eda9709",
+            filename="rustc.tar.gz",
+        ),
+        macos_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rustc-1.72.0-x86_64-apple-darwin.tar.gz",
+            len=92090616,
+            sha256="93d50e6d828214b6a97086a10193f5cbbf64e84f240196849e96b7ceef2d224a",
+            filename="rustc.tar.gz",
+        ),
+    ),
+)
+
+file(
+    name="compressed-rust-std",
+    source=per_platform(
+        linux_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rust-std-1.72.0-aarch64-unknown-linux-gnu.tar.gz",
+            len=64875725,
+            sha256="dd504733d3d8939b448ee93247d62d7fb09316b54c2f247b3c9f4709bf70784d",
+            filename="rust-std.tar.gz",
+        ),
+        linux_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rust-std-1.72.0-x86_64-unknown-linux-gnu.tar.gz",
+            len=46275300,
+            sha256="89f6f6ef25e7e754940c54cc0584bfdb83e1df75019d5aa126e3fa66c2921b15",
+            filename="rust-std.tar.gz",
+        ),
+        macos_arm64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rust-std-1.72.0-aarch64-apple-darwin.tar.gz",
+            len=40654475,
+            sha256="24d7a92bed5a1841933cb6a6ec12050c750c766c840460f45de843c1e164ea59",
+            filename="rust-std.tar.gz",
+        ),
+        macos_x86_64=http_source(
+            url="https://static.rust-lang.org/dist/2023-08-24/rust-std-1.72.0-x86_64-apple-darwin.tar.gz",
+            len=43014050,
+            sha256="1d408dd46105b6f5256a00f4b116a8e385089a9647b7189497daf1a2dd728a19",
+            filename="rust-std.tar.gz",
+        ),
+    ),
+)
+
+shell_command(
+    name="rust-toolchain",
+    command="""
+        mkdir rust-toolchain
+        for TARBALL in cargo.tar.gz rustc.tar.gz rust-std.tar.gz; do
+            tar -xzf $TARBALL --strip-components=2 -C rust-toolchain
+        done
+    """,
+    tools=["tar", "gzip", "mkdir"],
+    execution_dependencies=[
+        ":compressed-cargo",
+        ":compressed-rustc",
+        ":compressed-rust-std",
+    ],
+    output_directories=["rust-toolchain"],
+)

--- a/pants.toml
+++ b/pants.toml
@@ -1,4 +1,5 @@
 [GLOBAL]
+pants_version = "2.18.0a0"
 print_stacktrace = true
 
 # Enable our custom loose-source plugins.
@@ -36,9 +37,9 @@ backend_packages.add = [
   "pants.backend.experimental.visibility",
   "pants.backend.tools.preamble",
   "pants.backend.tools.taplo",
-  "pants_explorer.server",
-  "internal_plugins.releases",
-  "internal_plugins.test_lockfile_fixtures",
+  #"pants_explorer.server",
+  #"internal_plugins.releases",
+  #"internal_plugins.test_lockfile_fixtures",
 ]
 plugins = [
   "hdrhistogram", # For use with `--stats-log`.
@@ -68,6 +69,7 @@ pants_ignore.add = [
   "/docs/node_modules",
   # We have Pants stuff in here
   "!.github/",
+  "!/src/rust/engine/.cargo",
 ]
 
 build_ignore.add = [
@@ -81,10 +83,6 @@ unmatched_build_file_globs = "error"
 # network codepaths is needed. See:
 #   https://github.com/pantsbuild/pants/issues/16096.
 cache_content_behavior = "fetch"
-
-[DEFAULT]
-# Tell `scie-pants` to use our `./pants` bootstrap script.
-delegate_bootstrap = true
 
 [anonymous-telemetry]
 enabled = true

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,5 @@
 [toolchain]
+# NB: If you change this, change 3rdparty/tools/cargo/BUILD as well
 channel = "1.72.0"
 components = [
   "cargo",

--- a/src/rust/engine/BUILD
+++ b/src/rust/engine/BUILD
@@ -1,0 +1,39 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+_RELEASE = env("MODE") == "release"
+_RUST_MODE = "--release" if _RELEASE else ""
+_OUTPUT_DIR = "release" if _RELEASE else "debug"
+
+files(
+    name="rust_sources",
+    sources=[
+        "Cargo.lock",
+        "build.rs",
+        "**/Cargo.toml",
+        "**/*.rs",
+        "**/*.proto",
+        ".cargo/config",
+    ],
+)
+
+shell_sources(name="shell")
+
+shell_command(
+    name="engine-and-client",
+    command=f"./sandboxed_cargo.sh build {_RUST_MODE} --features=extension-module -p engine -p client",
+    execution_dependencies=[
+        "./sandboxed_cargo.sh:shell",
+        ":rust_sources",
+        "3rdparty/tools/protoc:protoc",
+        "3rdparty/tools/python3:python3",
+        "3rdparty/tools/rust:rust-toolchain",
+    ],
+    extra_env_vars=["CHROOT={chroot}", "MODE"],
+    tools=["cc", "ld", "as", "ar"],
+    output_files=[
+        f"target/{_OUTPUT_DIR}/libengine.so",
+        f"target/{_OUTPUT_DIR}/pants",
+    ],
+    timeout=600,
+)

--- a/src/rust/engine/sandboxed_cargo.sh
+++ b/src/rust/engine/sandboxed_cargo.sh
@@ -1,0 +1,9 @@
+# THis simply exists because `shell_command` at the time of writing doesn't know how to merge `PATH`
+# from the rule's env and the `extra_env_vars`.
+
+PYTHON_PATH=${CHROOT}/3rdparty/tools/python3/python/bin
+RUST_TOOLCHAIN_PATH=${CHROOT}/3rdparty/tools/rust/rust-toolchain/bin
+PROTOC_PATH=${CHROOT}/3rdparty/tools/protoc/protoc/bin
+
+PATH=$PATH:$PYTHON_PATH:$RUST_TOOLCHAIN_PATH:$PROTOC_PATH
+cargo "$@"


### PR DESCRIPTION
This change fixes https://github.com/pantsbuild/pants/issues/18688 by introducing the necessary targets to compile the engine at the least granular level. This is done in a way that requires only `build-essentials` installed on the system (supposedly).

The components that comprise this are:
- A Python toolchain used by PyO3. This is provided via Python Build Standalone
- The `protoc` Protobuf Compiler binary
- A Rust toolchain, comprised of `cargo`, `rustc` and `rust-std` all blended together

Then, the rest is just wiring these pieces up in a `shell_sources` and off it goes!