### PR TITLE
Require no post-download validation for remote->FSDB

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -257,9 +257,12 @@ impl RemoteStore {
     let remote_store = self.store.clone();
     self
       .maybe_download(digest, async move {
-        let store_into_fsdb =
-          f_remote.is_none() && ByteStore::should_use_fsdb(entry_type, digest.size_bytes);
+        let store_into_fsdb = ByteStore::should_use_fsdb(entry_type, digest.size_bytes);
         if store_into_fsdb {
+          assert!(
+            f_remote.is_none(),
+            "Entries to be stored in FSDB should never need validation via f_remote, found {digest:?} of type {entry_type:?} that does"
+          );
           local_store
             .get_file_fsdb()
             .write_using(digest.hash, |file| {

--- a/src/rust/engine/testutil/src/data.rs
+++ b/src/rust/engine/testutil/src/data.rs
@@ -1,6 +1,7 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 use grpc_util::prost::MessageExt;
+use hashing::EMPTY_DIGEST;
 use protos::gen::build::bazel::remote::execution::v2 as remexec;
 
 #[derive(Clone)]
@@ -249,6 +250,25 @@ impl TestDirectory {
           ..remexec::FileNode::default()
         },
       ],
+      ..remexec::Directory::default()
+    };
+    TestDirectory { directory }
+  }
+
+  // Directory structure
+  //
+  // 100k empty files: /00000.ext up to /99999.ext
+  pub fn many_files() -> TestDirectory {
+    let files = (0..100000)
+      .map(|idx| remexec::FileNode {
+        name: format!("{idx:05}.ext"),
+        digest: Some(EMPTY_DIGEST.into()),
+        is_executable: false,
+        ..remexec::FileNode::default()
+      })
+      .collect();
+    let directory = remexec::Directory {
+      files,
       ..remexec::Directory::default()
     };
     TestDirectory { directory }


### PR DESCRIPTION
This adjusts `RemoteStore::download_digest_to_local` to enforce that the `f_remote` validation function is never provided for digests that should be stored in FSDB. This is no-functionality-change, just refactoring things to be slightly clearer and more future-proof.

Previously, this code was conditionalising whether something should be stored in FSDB on _more_ than just the type/size, which _could_ have led to bugs: if we were downloading a digest that should be stored in FSDB, but pass `f_remote = Some(...)`, `download_digest_to_local` would instead store it in LMDB, and future look-ups of the digest (which don't know about `f_remote`) would look in FSDB and fail to find it.

However, in practice, we only ever pass `f_remote` in `Store::load_directory`, and directories are never stored in the FSDB, even if they're huge, so the extra condition was not changing behaviour. This PR is making the assumption/behaviour/luck here more explicit, and adds a test validating the behaviour of huge directory digests too.

This came out of my investigation of #19748, and, I think, eliminates directories as potential cause of the issues there.