### PR TITLE
Fix global report coverage for namespaced packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ markers = ["platform_specific_behavior"]
 # coverage will gather stats for it, but it doesn't correspond to a real source file,
 # so reporting will fail, unless we omit it here.
 omit = ["src/python/pants/__init__.py"]
-include_namespace_packages = true
 
 [tool.mypy]
 namespace_packages = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ markers = ["platform_specific_behavior"]
 # coverage will gather stats for it, but it doesn't correspond to a real source file,
 # so reporting will fail, unless we omit it here.
 omit = ["src/python/pants/__init__.py"]
+include_namespace_packages = true
 
 [tool.mypy]
 namespace_packages = true

--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -69,6 +69,8 @@ def sources(batched: bool) -> dict[str, str]:
         "src/python/core/BUILD": "python_sources()",
         "src/python/core/__init__.py": "",
         "src/python/core/untested.py": "CONSTANT = 42",
+        "src/python/core/namespace/BUILD": "python_sources()",
+        "src/python/core/namespace/baz.py": "QUX = True",
         "foo/bar.py": "BAZ = True",
         # Test that a `tests/` source root accurately gets coverage data for the `src/`
         # root.
@@ -227,6 +229,7 @@ def test_coverage_global(batched: bool) -> None:
             ---------------------------------------------------------------------------------
             {tmpdir}/foo/bar.py                                            1      1     0%
             {tmpdir}/src/python/core/__init__.py                           0      0   100%
+            {tmpdir}/src/python/core/namespace/baz.py                      1      1     0%
             {tmpdir}/src/python/core/untested.py                           1      1     0%
             {tmpdir}/src/python/project/__init__.py                        0      0   100%
             {tmpdir}/src/python/project/lib.py                             6      0   100%
@@ -239,7 +242,7 @@ def test_coverage_global(batched: bool) -> None:
             {tmpdir}/tests/python/project_test/test_arithmetic.py          3      0   100%
             {tmpdir}/tests/python/project_test/test_multiply.py            3      0   100%
             ---------------------------------------------------------------------------------
-            TOTAL                                                            22      5    77%
+            TOTAL                                                            23      6    74%
             """
         )
         in result.stderr

--- a/src/python/pants/backend/python/goals/coverage_py_integration_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_integration_test.py
@@ -18,6 +18,12 @@ from pants.testutil.python_interpreter_selection import all_major_minor_python_v
 
 def sources(batched: bool) -> dict[str, str]:
     return {
+        "pyproject.toml": dedent(
+            """\
+        [tool.coverage.report]
+        include_namespace_packages = true
+        """
+        ),
         # Only `lib.py` will actually be tested, but we still expect `random.py` t`o show up in
         # the final report correctly.
         "src/python/project/__init__.py": "",
@@ -221,7 +227,9 @@ def test_coverage_fail_under(batched: bool) -> None:
 @pytest.mark.parametrize("batched", (True, False))
 def test_coverage_global(batched: bool) -> None:
     with setup_tmpdir(sources(batched)) as tmpdir:
-        result = run_coverage(tmpdir, "--coverage-py-global-report")
+        result = run_coverage(
+            tmpdir, "--coverage-py-global-report", f"--coverage-py-config={tmpdir}/pyproject.toml"
+        )
     assert (
         dedent(
             f"""\

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -9,6 +9,7 @@ from pants.backend.python.goals.coverage_py import (
     CoverageSubsystem,
     create_or_update_coverage_config,
     get_branch_value_from_config,
+    get_namespace_value_from_config,
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import (
@@ -334,6 +335,105 @@ def test_get_branch_value_from_config() -> None:
                     relative_files: False
                     branch: True
                     foo: bar
+                    """
+            ),
+        )
+        is True
+    )
+
+
+def namespace(path: str, content: str) -> bool:
+    fc = FileContent(path, content.encode())
+    return get_namespace_value_from_config(fc)
+
+
+def test_get_namespace_value_from_config() -> None:
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+        [tool.coverage.report]
+        foo = "bar"
+        """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+        [tool.coverage.report]
+        include_namespace_packages = true
+        """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+            [tool.coverage]
+                [tool.coverage.report]
+                include_namespace_packages = true
+            """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            ".coveragerc",
+            dedent(
+                """\
+                [report]
+                foo: bar
+                """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            ".coveragerc",
+            dedent(
+                """\
+                    [report]
+                    include_namespace_packages: True
+                    """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            "setup.cfg",
+            dedent(
+                """\
+                [coverage:report]
+                foo: bar
+                """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            "setup.cfg",
+            dedent(
+                """\
+                    [coverage:report]
+                    include_namespace_packages: True
                     """
             ),
         )


### PR DESCRIPTION
When configuring Pants to generate global reports for coverage-py, while at the same time configuring coverage-py reports to include namespace packages (added in version 7.0), you still only get the coverage of files that have test coverage.

This is due to the additional process that generates this global report only adds configuration for `tool.coverage.run`, but coverage-py's `run` command also takes into account if `include_namespace_packages` is configured under `tool.coverage.report`.

The issue is fixed by also dumping the `include_namespace_packages` config to the generated `pyproject.toml`.

~I am not sure if there is a better way of doing that, like using the real `pyproject.toml` file instead of generating a separate one.~

~I also found no proper way of using a custom `pyproject.toml` during the integration tests, so the only way I found of passing the `include_namespace_packages` config was to edit the project's configuration file, any suggestions on how to improve that would be welcome.~