### PR TITLE
docs: Improve the help string for the global option 'PANTS_CONCURRENT'.

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -952,9 +952,10 @@ class BootstrapOptions:
         default=False,
         help=softwrap(
             """
-            Enable concurrent runs of Pants. Without this enabled, Pants will
+            Enable concurrent runs of Pants. With this enabled, Pants will
             start up all concurrent invocations (e.g. in other terminals) without pantsd.
-            Enabling this option requires parallel Pants invocations to block on the first.
+            As a result, enabling this option will increase the per-run startup cost, but
+            will not block subsequent invocations.
             """
         ),
     )


### PR DESCRIPTION
Previously the text made it seem as if enabling PANTS_CONCURRENT would force the use of pantsd and make concurrent invocations blocking, when in reality it's the other way around.