### PR TITLE
add force-exclude to ruff args

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -65,7 +65,7 @@ async def run_ruff(
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
     # `--force-exclude` applies file excludes from config to files provided explicitly
-    initial_args = ("--force-exclude", "--fix") if request.is_fix else ("--force-exclude",)
+    initial_args = ("--force-exclude",) + (( "--fix",) if request.is_fix else ())
 
     result = await Get(
         FallibleProcessResult,

--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -64,7 +64,7 @@ async def run_ruff(
     )
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
-    # We must set `--force-exclude` so ruff applies excludes from config as designed by ruff
+    # `--force-exclude` applies file excludes from config to files provided explicitly
     initial_args = ("--force-exclude", "--fix") if request.is_fix else ("--force-exclude",)
 
     result = await Get(

--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -65,7 +65,7 @@ async def run_ruff(
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
     # `--force-exclude` applies file excludes from config to files provided explicitly
-    initial_args = ("--force-exclude",) + (( "--fix",) if request.is_fix else ())
+    initial_args = ("--force-exclude",) + (("--fix",) if request.is_fix else ())
 
     result = await Get(
         FallibleProcessResult,

--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -64,7 +64,8 @@ async def run_ruff(
     )
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
-    initial_args = ("--force-exclude","--fix",) if request.is_fix else ("--force-exclude",)
+    # We must set `--force-exclude` so ruff applies excludes from config as designed by ruff
+    initial_args = ("--force-exclude", "--fix") if request.is_fix else ("--force-exclude",)
 
     result = await Get(
         FallibleProcessResult,

--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -64,7 +64,7 @@ async def run_ruff(
     )
 
     conf_args = [f"--config={ruff.config}"] if ruff.config else []
-    initial_args = ("--fix",) if request.is_fix else ()
+    initial_args = ("--force-exclude","--fix",) if request.is_fix else ("--force-exclude",)
 
     result = await Get(
         FallibleProcessResult,


### PR DESCRIPTION
as suggested by @benjyw in [this issue](https://github.com/pantsbuild/pants/issues/19786) here is a small PR to pass the `--force-exclude` command line arg to `ruff`.

ATTENTION please, I'm new to pants and I literally just changed the source files as visible in this PR. No further testing etc. done since I don't know yet how to approach this including running pants locally from my fork.

I still hope it helps and I'm of course willing to continue on the PR and improve it accordingly.