### PR TITLE
Add a GitHub Actions Cache remote cache backend

### DIFF
--- a/docs/markdown/Using Pants/remote-caching-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution.md
@@ -13,7 +13,7 @@ By default, Pants executes processes in a local [environment](doc:environments) 
 
 2. "Remote execution" where Pants offloads execution of processes to a remote server (and consumes cached results from that remote server)
 
-Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server.
+Pants does this by using the "Remote Execution API" to converse with the remote cache or remote execution server. Pants also [supports some additional providers](doc:remote-caching) other than Remote Execution API that provide only remote caching, without execution.
 
 What is Remote Execution API?
 -----------------------------

--- a/docs/markdown/Using Pants/remote-caching-execution/remote-caching.md
+++ b/docs/markdown/Using Pants/remote-caching-execution/remote-caching.md
@@ -7,20 +7,26 @@ createdAt: "2021-03-19T21:40:24.451Z"
 What is remote caching?
 =======================
 
-Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server that complies with the [Remote Execution API](https://github.com/bazelbuild/remote-apis) standard ("REAPI"), rather than only using your machine's local Pants cache. This allows Pants to share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
+Remote caching allows Pants to store and retrieve the results of process execution to and from a remote server, rather than only using your machine's local Pants cache. This allows Pants to efficiently share a cache across different runs and different machines, for example, all of your CI workers sharing the same fine-grained cache.
 
-Setup
-=====
+Pants supports several remote caching providers:
+
+- [Remote Execution API](https://github.com/bazelbuild/remote-apis) ("REAPI"), which also supports [remote execution](doc:remote-execution)
+- GitHub Actions Cache
+- Local file system
+
+Remote Execution API
+====================
 
 Server
 ------
 
-Remote caching requires the availability of a REAPI-compatible cache. See the [REAPI server compatibility guide](doc:remote-caching-execution#server-compatibility) for more information.
+See the [REAPI server compatibility guide](doc:remote-caching-execution#server-compatibility) for more information about REAPI-compatible caches.
 
 Pants Configuration
 -------------------
 
-After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results. 
+After you have either set up a REAPI cache server or obtained access to one, the next step is to point Pants to it so that Pants will use it to read and write process results.
 
 For the following examples, assume that the REAPI server is running on `cache.corp.example.com` at port 8980 and that it is on an internal network. Also assume that the name of the REAPI instance is "main." At a minimum, you will need to configure `pants.toml` as follows:
 
@@ -33,6 +39,64 @@ remote_instance_name = "main"
 ```
 
 If the endpoint is using TLS, then the `remote_store_address` option would be specified with the  `grpcs://` scheme, i.e. `"grpcs://cache.corp.example.com:8980"`.
+
+GitHub Actions Cache
+====================
+
+GitHub Actions provides built-in caching service which Pants supports using for sharing caches across GitHub Actions runs (not with machines outside of GitHub Actions). It is typically used via the `actions/cache` action to cache whole directories and files, but Pants can use the same functionality for fine-grained caching.
+
+> 🚧 GitHub Actions Cache support is still experimental
+>
+> Support for this cache provider is still under development, with more refinement required. Please [let us know](doc:getting-help) if you use it and encounter errors or warnings.
+
+Workflow
+--------
+
+The values of the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` environment variables need to be provided to Pants via the `[GLOBAL].remote_store_address` and `[GLOBAL].remote_store_headers` options respectively. They are only provided to action calls (not shell steps that use `run: ...`). Include a step like the following in your jobs, which sets those options via environment variables, before executing any Pants commands:
+
+```yaml
+- name: Configure Pants caching to GitHub Actions Cache
+  uses: actions/github-script@v6
+  with:
+    script: |
+      core.exportVariable('PANTS_REMOTE_STORE_ADDRESS', 'experimental:github-actions-cache+' + (process.env.ACTIONS_CACHE_URL || ''));
+      core.exportVariable('PANTS_REMOTE_STORE_HEADERS', `+{'authorization':'Bearer ${process.env.ACTIONS_RUNTIME_TOKEN || ''}'}`);
+```
+
+Pants Configuration
+-------------------
+
+Once the GitHub values are configured, Pants will read the environment variables. You will also need to configure pants to read and write to the cache only while in CI, such as [via a `pants.ci.toml` configuration file](doc:using-pants-in-ci#configuring-pants-for-ci-pantscitoml-optional):
+
+```toml
+[GLOBAL]
+# GitHub Actions cache URL and token are set via environment variables
+remote_cache_read = true
+remote_cache_write = true
+```
+
+If desired, you can also set `remote_instance_name` to a string that's included as a prefix on each cache key, which will be then be displayed in the 'Actions' > 'Caches' UI.
+
+Local file system
+=================
+
+Pants can cache "remotely" to a local file system path, which can be used for a networked mount cache, without having to pay the cost of storing Pants' local cache on the network mount too. This can also be used for testing/validation.
+
+> 🚧 Local file system caching support is still experimental
+>
+> Support for this cache provider is still under development, with more refinement required. Please [let us know](doc:getting-help) if you use it and encounter errors or warnings.
+
+Pants Configuration
+-------------------
+
+To read and write the cache to `/path/to/cache`, you will need to configure `pants.toml` as follows:
+
+```toml
+[GLOBAL]
+remote_store_address = "experimental:file:///path/to/cache"
+remote_cache_read = true
+remote_cache_write = true
+```
 
 Reference
 =========

--- a/docs/markdown/Using Pants/remote-caching-execution/remote-caching.md
+++ b/docs/markdown/Using Pants/remote-caching-execution/remote-caching.md
@@ -43,7 +43,7 @@ If the endpoint is using TLS, then the `remote_store_address` option would be sp
 GitHub Actions Cache
 ====================
 
-GitHub Actions provides built-in caching service which Pants supports using for sharing caches across GitHub Actions runs (not with machines outside of GitHub Actions). It is typically used via the `actions/cache` action to cache whole directories and files, but Pants can use the same functionality for fine-grained caching.
+GitHub Actions provides a built-in caching service which Pants supports using for sharing caches across GitHub Actions runs (not with machines outside of GitHub Actions). It is typically used via the `actions/cache` action to cache whole directories and files, but Pants can use the same functionality for fine-grained caching.
 
 > 🚧 GitHub Actions Cache support is still experimental
 >

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -280,6 +280,21 @@ _REMOTE_ADDRESS_SCHEMES = (
             """
         ),
     ),
+    _RemoteAddressScheme(
+        schemes=("github-actions-cache+http", "github-actions-cache+https"),
+        supports_execution=False,
+        experimental=True,
+        description=softwrap(
+            f"""
+            Use the GitHub Actions Cache for fine-grained caching. This requires extracting
+            `ACTIONS_CACHE_URL` (passing it in `[GLOBAL].remote_store_address`) and
+            `ACTIONS_RUNTIME_TOKEN` (storing it in a file and passing
+            `[GLOBAL].remote_oauth_bearer_token_path` or setting `[GLOBAL].remote_store_headers` to
+            include `authorization: Bearer {{token...}}`). See
+            {doc_url('remote-caching#github-actions-cache')} for more details.
+            """
+        ),
+    ),
 )
 
 

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -395,7 +395,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "testutil",
- "time 0.3.20",
+ "time",
  "tokio",
  "tokio-stream",
  "workunit_store",
@@ -498,18 +498,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "winapi",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1050,7 +1049,7 @@ dependencies = [
  "task_executor",
  "tempfile",
  "testutil",
- "time 0.3.20",
+ "time",
  "tokio",
  "tokio-retry",
  "tokio-util 0.7.8",
@@ -2249,9 +2248,8 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad95e460e5976ab1b74f398ab856c59f8417b3dd32202329e3491dcbe3a6b84"
+version = "0.40.0"
+source = "git+https://github.com/apache/incubator-opendal?rev=97bcef60eb0b515bd2442ab5b671080766fa35eb#97bcef60eb0b515bd2442ab5b671080766fa35eb"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -3323,7 +3321,7 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "time 0.3.20",
+ "time",
 ]
 
 [[package]]
@@ -3659,17 +3657,6 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -4155,12 +4142,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -254,7 +254,11 @@ notify = { git = "https://github.com/pantsbuild/notify", rev = "276af0f3c5f300bf
 num_cpus = "1"
 num_enum = "0.5"
 once_cell = "1.18"
-opendal = { version = "0.39.0", default-features = false }
+opendal = { version = "0.39.0", default-features = false, features = [
+  "services-memory",
+  "services-fs",
+  "services-ghac",
+] }
 os_pipe = "1.1"
 parking_lot = "0.12"
 peg = "0.8"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -254,7 +254,10 @@ notify = { git = "https://github.com/pantsbuild/notify", rev = "276af0f3c5f300bf
 num_cpus = "1"
 num_enum = "0.5"
 once_cell = "1.18"
-opendal = { version = "0.39.0", default-features = false, features = [
+# TODO: this is waiting for several changes to be released (likely in 0.41):
+# https://github.com/apache/incubator-opendal/pull/3163
+# https://github.com/apache/incubator-opendal/pull/3177
+opendal = { git = "https://github.com/apache/incubator-opendal", rev = "97bcef60eb0b515bd2442ab5b671080766fa35eb", default-features = false, features = [
   "services-memory",
   "services-fs",
   "services-ghac",

--- a/src/rust/engine/fs/store/Cargo.toml
+++ b/src/rust/engine/fs/store/Cargo.toml
@@ -41,10 +41,7 @@ tower-service = { workspace = true }
 tryfuture = { path = "../../tryfuture" }
 uuid = { workspace = true, features = ["v4"] }
 workunit_store = { path = "../../workunit_store" }
-opendal = { workspace = true, default-features = false, features = [
-  "services-memory",
-  "services-fs",
-] }
+opendal = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -82,8 +82,10 @@ async fn choose_provider(options: RemoteOptions) -> Result<Arc<dyn ByteStoreProv
       options,
     )?))
   } else if let Some(url) = address.strip_prefix("github-actions-cache+") {
-    // TODO: this is relying on python validating that it was set as
-    // `github-actions-cache+https://...`
+    // This is relying on python validating that it was set as `github-actions-cache+https://...` so
+    // incorrect values could easily slip through here and cause downstream confusion. We're
+    // intending to change the approach (https://github.com/pantsbuild/pants/issues/19902) so this
+    // is tolerable for now.
     Ok(Arc::new(base_opendal::Provider::github_actions_cache(
       url,
       "byte-store".to_owned(),

--- a/src/rust/engine/fs/store/src/remote.rs
+++ b/src/rust/engine/fs/store/src/remote.rs
@@ -81,6 +81,14 @@ async fn choose_provider(options: RemoteOptions) -> Result<Arc<dyn ByteStoreProv
       "byte-store".to_owned(),
       options,
     )?))
+  } else if let Some(url) = address.strip_prefix("github-actions-cache+") {
+    // TODO: this is relying on python validating that it was set as
+    // `github-actions-cache+https://...`
+    Ok(Arc::new(base_opendal::Provider::github_actions_cache(
+      url,
+      "byte-store".to_owned(),
+      options,
+    )?))
   } else {
     Err(format!(
       "Cannot initialise remote byte store provider with address {address}, as the scheme is not supported",

--- a/src/rust/engine/fs/store/src/remote/base_opendal.rs
+++ b/src/rust/engine/fs/store/src/remote/base_opendal.rs
@@ -178,12 +178,7 @@ impl ByteStoreProvider for Provider {
 
     let path = self.path(digest.hash);
 
-    let mut writer = match self
-      .operator
-      .writer_with(&path)
-      .content_length(digest.size_bytes as u64)
-      .await
-    {
+    let mut writer = match self.operator.writer(&path).await {
       Ok(writer) => writer,
       // The item already exists, i.e. these bytes have already been stored. For example,
       // concurrent executions that are caching the same bytes. This makes the assumption that

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -106,8 +106,10 @@ async fn choose_provider(
       remote_options,
     )?))
   } else if let Some(url) = address.strip_prefix("github-actions-cache+") {
-    // TODO: this is relying on python validating that it was set as
-    // `github-actions-cache+https://...`
+    // This is relying on python validating that it was set as `github-actions-cache+https://...` so
+    // incorrect values could easily slip through here and cause downstream confusion. We're
+    // intending to change the approach (https://github.com/pantsbuild/pants/issues/19902) so this
+    // is tolerable for now.
     Ok(Arc::new(base_opendal::Provider::github_actions_cache(
       url,
       "action-cache".to_owned(),

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -105,6 +105,14 @@ async fn choose_provider(
       "action-cache".to_owned(),
       remote_options,
     )?))
+  } else if let Some(url) = address.strip_prefix("github-actions-cache+") {
+    // TODO: this is relying on python validating that it was set as
+    // `github-actions-cache+https://...`
+    Ok(Arc::new(base_opendal::Provider::github_actions_cache(
+      url,
+      "action-cache".to_owned(),
+      remote_options,
+    )?))
   } else {
     Err(format!(
       "Cannot initialise remote action cache provider with address {address}, as the scheme is not supported",


### PR DESCRIPTION
This adds support for remote caching to the Github Actions Cache, by setting `remote_store_address = "experimental:github-actions-cache+https://..."`. This is implemented as just another OpenDAL (#19827) provider.

As written, this requires the `ACTIONS_CACHE_URL` and `ACTIONS_RUNTIME_TOKEN` values to be massaged into the appropriate pants configuration. I've included basic docs for how to do this. This set-up can/should be packaged into the `init-pants` action in future, but for now, we're in experimental-land.

There's various ways in which this can be improved, but I think it's helpful to have a "real world" example of a remote cache beyond the `file://` one to be able to guide the refactoring, plus good to start testing this earlier. Thus, I'd like to land this, and do them as follow-up:

- better docs/help (always!), particularly on the `using-pants-in-ci` docs page, which I haven't updated here
- now that I've implemented this, I don't like my `<provider>+<scheme>://...` proposal from #19827. I think it'd be better to have a separate `remote_store_provider = "experimental-github-actions-cache"` (or `"reapi"`, etc.) option and `remote_store_address` is just the raw URL (with the provider validating it can understand the URL, of course)
- it'd be good to be able to pass the token in in a simpler way, I'm thinking there could be a `remote_oauth_bearer_token` option literally, which is expected (and suggested in docs) to be passed as the `PANTS_REMOTE_OAUTH_BEARER_TOKEN` env var, in addition to `remote_oauth_bearer_token_path`

These are tracked in #19902 (and all of the others in that issue would be good too, but weren't as acutely surfaced by this change, I'll start chipping away at it once this is in).

This is awkward to test. My plan, not implemented here, is to somehow tee up a dedicated set of tests to run within https://github.com/nektos/act somehow. For now, we'll have to go with manual testing, e.g. this specific PR is validated by https://github.com/huonw/pants-cache-github-actions-poc/actions/runs/6298908094/job/17119702612#step:11:983

This is the first example of something useful user-facing for #11149. This doesn't close it, I'll wait until we have a blob store like S3 too.

The commits are individually reviewable.

(Replaces #17840.)
