### PR TITLE
Add missing openapi `java` codegen backend

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -49,6 +49,7 @@ target(
         "src/python/pants/backend/experimental/kotlin/debug_goals",
         "src/python/pants/backend/experimental/kotlin/lint/ktlint",
         "src/python/pants/backend/experimental/openapi",
+        "src/python/pants/backend/experimental/openapi/codegen/java",
         "src/python/pants/backend/experimental/openapi/lint/openapi_format",
         "src/python/pants/backend/experimental/openapi/lint/spectral",
         "src/python/pants/backend/experimental/python",


### PR DESCRIPTION
This PR adds the openai `java` codegen backend to [`src/python/pants/bin/BUILD`](https://github.com/pantsbuild/pants/blob/main/src/python/pants/bin/BUILD) introduced in https://github.com/pantsbuild/pants/pull/16862

Closes https://github.com/pantsbuild/pants/issues/19836