### PR TITLE
Fix global report coverage for namespaced packages (Cherry-pick of #19821)

### DIFF
--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -315,6 +315,23 @@ def get_branch_value_from_config(fc: FileContent) -> bool:
     return cp.getboolean(run_section, "branch", fallback=False)
 
 
+def get_namespace_value_from_config(fc: FileContent) -> bool:
+    if PurePath(fc.path).suffix == ".toml":
+        all_config = _parse_toml_config(fc)
+        return bool(
+            all_config.get("tool", {})
+            .get("coverage", {})
+            .get("report", {})
+            .get("include_namespace_packages", False)
+        )
+
+    cp = _parse_ini_config(fc)
+    report_section = "coverage:report" if fc.path in ("tox.ini", "setup.cfg") else "report"
+    if not cp.has_section(report_section):
+        return False
+    return cp.getboolean(report_section, "include_namespace_packages", fallback=False)
+
+
 @rule
 async def create_or_update_coverage_config(coverage: CoverageSubsystem) -> CoverageConfig:
     config_files = await Get(ConfigFiles, ConfigFilesRequest, coverage.config_request)
@@ -383,6 +400,9 @@ async def merge_coverage_data(
         # See https://github.com/pantsbuild/pants/issues/14542 .
         config_contents = await Get(DigestContents, Digest, coverage_config.digest)
         branch = get_branch_value_from_config(config_contents[0]) if config_contents else False
+        namespace_packages = (
+            get_namespace_value_from_config(config_contents[0]) if config_contents else False
+        )
         global_coverage_base_dir = PurePath("__global_coverage__")
         global_coverage_config_path = global_coverage_base_dir / "pyproject.toml"
         global_coverage_config_content = toml.dumps(
@@ -393,7 +413,10 @@ async def merge_coverage_data(
                             "relative_files": True,
                             "source": [source_root.path for source_root in source_roots],
                             "branch": branch,
-                        }
+                        },
+                        "report": {
+                            "include_namespace_packages": namespace_packages,
+                        },
                     }
                 }
             }

--- a/src/python/pants/backend/python/goals/coverage_py_test.py
+++ b/src/python/pants/backend/python/goals/coverage_py_test.py
@@ -9,6 +9,7 @@ from pants.backend.python.goals.coverage_py import (
     CoverageSubsystem,
     create_or_update_coverage_config,
     get_branch_value_from_config,
+    get_namespace_value_from_config,
 )
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.fs import (
@@ -334,6 +335,105 @@ def test_get_branch_value_from_config() -> None:
                     relative_files: False
                     branch: True
                     foo: bar
+                    """
+            ),
+        )
+        is True
+    )
+
+
+def namespace(path: str, content: str) -> bool:
+    fc = FileContent(path, content.encode())
+    return get_namespace_value_from_config(fc)
+
+
+def test_get_namespace_value_from_config() -> None:
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+        [tool.coverage.report]
+        foo = "bar"
+        """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+        [tool.coverage.report]
+        include_namespace_packages = true
+        """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            "pyproject.toml",
+            dedent(
+                """\
+            [tool.coverage]
+                [tool.coverage.report]
+                include_namespace_packages = true
+            """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            ".coveragerc",
+            dedent(
+                """\
+                [report]
+                foo: bar
+                """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            ".coveragerc",
+            dedent(
+                """\
+                    [report]
+                    include_namespace_packages: True
+                    """
+            ),
+        )
+        is True
+    )
+
+    assert (
+        namespace(
+            "setup.cfg",
+            dedent(
+                """\
+                [coverage:report]
+                foo: bar
+                """
+            ),
+        )
+        is False
+    )
+
+    assert (
+        namespace(
+            "setup.cfg",
+            dedent(
+                """\
+                    [coverage:report]
+                    include_namespace_packages: True
                     """
             ),
         )


### PR DESCRIPTION
When configuring Pants to generate global reports for coverage-py, while at the same time configuring coverage-py reports to include namespace packages (added in version 7.0), you still only get the coverage of files that have test coverage.

This is due to the additional process that generates this global report only adds configuration for `tool.coverage.run`, but coverage-py's `run` command also takes into account if `include_namespace_packages` is configured under `tool.coverage.report`.

The issue is fixed by also dumping the `include_namespace_packages` config to the generated `pyproject.toml`.

~I am not sure if there is a better way of doing that, like using the real `pyproject.toml` file instead of generating a separate one.~

~I also found no proper way of using a custom `pyproject.toml` during the integration tests, so the only way I found of passing the `include_namespace_packages` config was to edit the project's configuration file, any suggestions on how to improve that would be welcome.~
