### PR TITLE
Fetch tags in the `publish` job (Cherry-pick of #19875)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -362,6 +362,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: '0'
+        fetch-tags: true
         ref: ${{ needs.release_info.outputs.build-ref }}
     - name: Set up Python 3.9
       uses: actions/setup-python@v4

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1182,6 +1182,7 @@ def release_jobs_and_inputs() -> tuple[Jobs, dict[str, Any]]:
                         # clone the repo, we're not so big as to need to optimize this.
                         "fetch-depth": "0",
                         "ref": f"{gha_expr('needs.release_info.outputs.build-ref')}",
+                        "fetch-tags": True,
                     },
                 },
                 *helper.setup_primary_python(),


### PR DESCRIPTION
This is needed for `changelog.py` to operate
