### PR TITLE
Bump PEX to 2.1.147

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ fasteners==0.16.3
 freezegun==1.2.1
 ijson==3.1.4
 packaging==21.3
-pex==2.1.137
+pex==2.1.147
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.1.137",
+//     "pex==2.1.147",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -909,21 +909,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5031c3b283d63470faeaf82d0fc1344e6f71b3ad4ac4ca34572a42bae6dfc4b8",
-              "url": "https://files.pythonhosted.org/packages/e8/6e/eadca769b580a93d10caeca29d17397565672cf8b675991ccbf959c75476/pex-2.1.137-py2.py3-none-any.whl"
+              "hash": "ed4965277875c9256ee3fc7daaad3375216c0f0aba00b6b951f31c002a27a4c6",
+              "url": "https://files.pythonhosted.org/packages/6b/71/c86c5f4de096e237ca87848aa86564c00e2807b1ff10466ca77aa042c1d8/pex-2.1.147-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "cb0ce6cf64757dd5ba4f34c4607ab485f7909e6c24cd479ca28ce52205f0edeb",
-              "url": "https://files.pythonhosted.org/packages/a8/06/26c731fbf11fad3b1dff7b1d535636c65d8d630eabc981ca025d2e7b5cfb/pex-2.1.137.tar.gz"
+              "hash": "a13ccc3136eafa9aca344f218415ac46f871043f826bf335a55ba9a520728e9e",
+              "url": "https://files.pythonhosted.org/packages/73/0b/3c336b565f241f0237e0ba09512231c3f83ab0f8e6ca9afc2c1a9e5455bd/pex-2.1.147.tar.gz"
             }
           ],
           "project_name": "pex",
           "requires_dists": [
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
-          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.12,>=2.7",
-          "version": "2.1.137"
+          "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.13,>=2.7",
+          "version": "2.1.147"
         },
         {
           "artifacts": [

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -35,7 +35,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.137"
+    default_version = "v2.1.147"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.135,<3.0"
 
@@ -46,8 +46,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "faad51a6a108fba9d40b2a10e82a2646fccbaf8c3d9be47818f4bffae02d94b8",
-                    "4098329",
+                    "090df7f6f40c0cdf1ee4f948aa815c56371f8af8f1932781a7113d1665968728",
+                    "4195878",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
This PR bumps PEX from 2.1.137 to 2.1.147.

This brings a bunch of bug fixes:

- various improvements for the `__pex__` import hook, and `--venv` PEXes (and their interaction)
- deterministic file order on different operating/file systems
- eCryptFS support
- better handling of sdist build errors for some versions of `pip-2020-resolver`

There's also a few new features:

- support for Python 3.12 and pip 23.2
- additional args for adding source files beyond just `-D`/`--sources-directories`
- a `--use-pip-config` argument to let pip read its various configuration env vars and files


Changelog starts at https://github.com/pantsbuild/pex/blob/813666627fa089878be729e6eda68a3ee49197fd/CHANGES.md#21147