### PR TITLE
Fix "failed to create hardlink" error due to multiple mounts on the same device

### DIFF
--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -505,6 +505,9 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
     ("tree", sub_match) => match expect_subcommand(sub_match) {
       ("materialize", args) => {
         let destination = PathBuf::from(args.value_of("destination").unwrap());
+        // NB: We use `destination` as the root directory, because there is no need to
+        // memoize a check for whether some other parent directory is hardlinkable.
+        let destination_root = destination.clone();
         let fingerprint = Fingerprint::from_hex_string(args.value_of("fingerprint").unwrap())?;
         let size_bytes = args
           .value_of("size_bytes")
@@ -522,6 +525,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           store
             .materialize_directory(
               destination,
+              &destination_root,
               output_digest,
               false,
               &BTreeSet::new(),
@@ -535,6 +539,9 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
     ("directory", sub_match) => match expect_subcommand(sub_match) {
       ("materialize", args) => {
         let destination = PathBuf::from(args.value_of("destination").unwrap());
+        // NB: We use `destination` as the root directory, because there is no need to
+        // memoize a check for whether some other parent directory is hardlinkable.
+        let destination_root = destination.clone();
         let fingerprint = Fingerprint::from_hex_string(args.value_of("fingerprint").unwrap())?;
         let size_bytes = args
           .value_of("size_bytes")
@@ -546,6 +553,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           store
             .materialize_directory(
               destination,
+              &destination_root,
               digest,
               false,
               &BTreeSet::new(),

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -77,6 +77,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
               let _ = executor
                 .block_on(store.materialize_directory(
                   dest,
+                  parent_dest_path,
                   digest.clone(),
                   false,
                   &BTreeSet::new(),

--- a/src/rust/engine/fs/store/src/immutable_inputs.rs
+++ b/src/rust/engine/fs/store/src/immutable_inputs.rs
@@ -105,6 +105,7 @@ impl ImmutableInputs {
           .store
           .materialize_directory(
             dest.clone(),
+            self.0.workdir.path(),
             directory_digest,
             false,
             &BTreeSet::new(),

--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -43,7 +43,7 @@ use std::fs::OpenOptions;
 use std::fs::Permissions as FSPermissions;
 use std::future::Future;
 use std::io::Write;
-use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
@@ -389,11 +389,6 @@ impl Store {
   // This default suffix is also hard-coded into the Python options code in global_options.py
   pub fn default_path() -> PathBuf {
     default_cache_path().join("lmdb_store")
-  }
-
-  /// Return the device ID that the local Store is hosted on.
-  pub fn local_filesystem_device(&self) -> u64 {
-    self.local.filesystem_device()
   }
 
   ///
@@ -1174,14 +1169,26 @@ impl Store {
   /// an existing destination directory, meaning that directory and file creation must be
   /// idempotent.
   ///
+  /// If the destination (more specifically, the given parent directory of the destination, for
+  /// memoization purposes) is hardlinkable from the local store, and `!force_mutable`, hardlinks
+  /// may be used for large files which are not listed in `mutable_paths`.
+  ///
   pub async fn materialize_directory(
     &self,
     destination: PathBuf,
+    destination_root: &Path,
     digest: DirectoryDigest,
     force_mutable: bool,
     mutable_paths: &BTreeSet<RelativePath>,
     perms: Permissions,
   ) -> Result<(), StoreError> {
+    if cfg!(debug_assertions) {
+      assert!(
+        destination.starts_with(destination_root),
+        "The destination root must be a parent directory of the destination."
+      )
+    }
+
     // Load the DigestTrie for the digest, and convert it into a mapping between a fully qualified
     // parent path and its children.
     let mut parent_to_child = HashMap::new();
@@ -1201,41 +1208,30 @@ impl Store {
     }
 
     // Create the root, and determine what filesystem it and the store are on.
-    let materializing_to_same_filesystem = {
-      let store_filesystem_device = self.local_filesystem_device();
-      self
-        .local
-        .executor()
-        .spawn_blocking(
-          {
-            let destination = destination.clone();
-            move || {
-              std::fs::create_dir_all(&destination).map_err(|e| {
-                format!("Failed to create directory {}: {e}", destination.display())
-              })?;
-              let dest_device = destination
-                .metadata()
-                .map_err(|e| {
-                  format!(
-                    "Failed to get metadata for destination {}: {e}",
-                    destination.display()
-                  )
-                })?
-                .dev();
-              Ok(dest_device == store_filesystem_device)
-            }
-          },
-          |e| Err(format!("Directory creation task failed: {e}")),
-        )
-        .await?
+    let destination_is_hardlinkable = {
+      let directory_creation_fut = self.local.executor().spawn_blocking(
+        {
+          let destination = destination.clone();
+          move || {
+            std::fs::create_dir_all(&destination)
+              .map_err(|e| format!("Failed to create directory {}: {e}", destination.display()))
+          }
+        },
+        |e| Err(format!("Directory creation task failed: {e}")),
+      );
+      let (_, destination_is_hardlinkable) = tokio::try_join!(
+        directory_creation_fut,
+        self.local.is_hardlinkable_destination(destination_root)
+      )?;
+      destination_is_hardlinkable
     };
 
     self
       .materialize_directory_children(
-        destination.clone(),
+        destination,
         true,
         force_mutable,
-        materializing_to_same_filesystem,
+        destination_is_hardlinkable,
         &parent_to_child,
         &mutable_path_ancestors,
         perms,

--- a/src/rust/engine/fs/store/src/local.rs
+++ b/src/rust/engine/fs/store/src/local.rs
@@ -532,7 +532,6 @@ struct InnerStore {
   file_lmdb: Result<Arc<ShardedLmdb>, String>,
   directory_lmdb: Result<Arc<ShardedLmdb>, String>,
   file_fsdb: ShardedFSDB,
-  executor: task_executor::Executor,
 }
 
 impl ByteStore {
@@ -577,19 +576,14 @@ impl ByteStore {
         )
         .map(Arc::new),
         file_fsdb: ShardedFSDB {
-          executor: executor.clone(),
+          executor: executor,
           root: fsdb_files_root,
           lease_time: options.lease_time,
           dest_initializer: Arc::new(Mutex::default()),
           hardlinkable_destinations: Arc::new(Mutex::default()),
         },
-        executor,
       }),
     })
-  }
-
-  pub fn executor(&self) -> &task_executor::Executor {
-    &self.inner.executor
   }
 
   pub async fn is_hardlinkable_destination(&self, destination: &Path) -> Result<bool, String> {

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1202,6 +1202,7 @@ async fn materialize_missing_directory() {
   store
     .materialize_directory(
       materialize_dir.path().to_owned(),
+      materialize_dir.path(),
       TestDirectory::recursive().directory_digest(),
       false,
       &BTreeSet::new(),
@@ -1236,6 +1237,7 @@ async fn materialize_directory(perms: Permissions, executable_file: bool) {
   store
     .materialize_directory(
       materialize_dir.path().to_owned(),
+      materialize_dir.path(),
       recursive_testdir.directory_digest(),
       false,
       &BTreeSet::new(),
@@ -1699,11 +1701,13 @@ async fn explicitly_overwrites_already_existing_file() {
     .directory(&contents_dir)
     .file(&cas_file)
     .build();
-  let store = new_store(tempfile::tempdir().unwrap(), &cas.address()).await;
+  let store_dir = tempfile::tempdir().unwrap();
+  let store = new_store(store_dir.path(), &cas.address()).await;
 
   store
     .materialize_directory(
       dir_to_write_to.path().to_owned(),
+      dir_to_write_to.path(),
       contents_dir.directory_digest(),
       false,
       &BTreeSet::new(),
@@ -1716,7 +1720,6 @@ async fn explicitly_overwrites_already_existing_file() {
   assert_eq!(file_contents, b"abc123".to_vec());
 }
 
-#[ignore] // see #17754
 #[tokio::test]
 async fn big_file_immutable_link() {
   let materialize_dir = TempDir::new().unwrap();
@@ -1779,6 +1782,7 @@ async fn big_file_immutable_link() {
   store
     .materialize_directory(
       materialize_dir.path().to_owned(),
+      materialize_dir.path(),
       directory_digest,
       false,
       &BTreeSet::from([

--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -467,6 +467,7 @@ impl<'a> process_execution::CommandRunner for CommandRunner<'a> {
         // DOCKER-NOTE: The input root will be bind mounted into the container.
         let exclusive_spawn = prepare_workdir(
           workdir.path().to_owned(),
+          &self.work_dir_base,
           &req,
           req.input_digests.inputs.clone(),
           &self.store,

--- a/src/rust/engine/process_execution/pe_nailgun/src/lib.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/lib.rs
@@ -207,6 +207,7 @@ impl process_execution::CommandRunner for CommandRunner {
         // Prepare the workdir.
         let exclusive_spawn = prepare_workdir(
           nailgun_process.workdir_path().to_owned(),
+          self.nailgun_pool.workdir_base(),
           &client_req,
           client_req.input_digests.inputs.clone(),
           &self.store,

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -77,6 +77,10 @@ impl NailgunPool {
     }
   }
 
+  pub fn workdir_base(&self) -> &Path {
+    &self.workdir_base
+  }
+
   ///
   /// Given a name and a `Process` configuration, return a port of a nailgun server running
   /// under that name and configuration.
@@ -367,6 +371,7 @@ impl NailgunProcess {
     // simpler.
     prepare_workdir(
       workdir.path().to_owned(),
+      workdir_base,
       &startup_options,
       startup_options.input_digests.inputs.clone(),
       store,

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -211,6 +211,7 @@ impl super::CommandRunner for CommandRunner {
         // Prepare the workdir.
         let exclusive_spawn = prepare_workdir(
           workdir.path().to_owned(),
+          &self.work_dir_base,
           &req,
           req.input_digests.inputs.clone(),
           &self.store,
@@ -677,6 +678,7 @@ pub async fn prepare_workdir_digest(
 ///
 pub async fn prepare_workdir(
   workdir_path: PathBuf,
+  workdir_root_path: &Path,
   req: &Process,
   materialized_input_digest: DirectoryDigest,
   store: &Store,
@@ -717,6 +719,7 @@ pub async fn prepare_workdir(
     store
       .materialize_directory(
         workdir_path,
+        workdir_root_path,
         complete_input_digest,
         false,
         &mutable_paths,

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -732,6 +732,7 @@ async fn prepare_workdir_exclusive_relative() {
 
   let exclusive_spawn = local::prepare_workdir(
     work_dir.path().to_owned(),
+    work_dir.path(),
     &process,
     TestDirectory::recursive().directory_digest(),
     &store,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -372,9 +372,13 @@ async fn main() {
   .expect("Error executing");
 
   if let Some(output) = args.materialize_output_to {
+    // NB: We use `destination` as the root directory, because there is no need to
+    // memoize a check for whether some other parent directory is hardlinkable.
+    let output_root = output.clone();
     store
       .materialize_directory(
         output,
+        &output_root,
         result.output_directory,
         false,
         &BTreeSet::new(),

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -372,7 +372,7 @@ async fn main() {
   .expect("Error executing");
 
   if let Some(output) = args.materialize_output_to {
-    // NB: We use `destination` as the root directory, because there is no need to
+    // NB: We use `output` as the root directory, because there is no need to
     // memoize a check for whether some other parent directory is hardlinkable.
     let output_root = output.clone();
     store

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1657,7 +1657,7 @@ fn write_digest(
 
     // Python will have already validated that path_prefix is a relative path.
     let mut destination = PathBuf::new();
-    destination.push(core.build_root.clone());
+    destination.push(&core.build_root);
     destination.push(path_prefix);
 
     for subpath in &clear_paths {
@@ -1675,6 +1675,7 @@ fn write_digest(
         .store()
         .materialize_directory(
           destination.clone(),
+          &core.build_root,
           lifted_digest,
           true, // Force everything we write to be mutable
           &BTreeSet::new(),

--- a/src/rust/engine/src/intrinsics.rs
+++ b/src/rust/engine/src/intrinsics.rs
@@ -669,6 +669,7 @@ fn interactive_process(
       )?;
       prepare_workdir(
         tempdir.path().to_owned(),
+        &context.core.local_execution_root_dir,
         &process,
         process.input_digests.inputs.clone(),
         &context.core.store(),


### PR DESCRIPTION
As described in #18757, the "check that source and dest are on same device" strategy that was introduced in #18153 to decide whether we could hardlink when materializing files was not robust when faced with the same device being mounted in multiple locations.

This change moves to a "create a canary" strategy for deciding when hardlinking between two destinations is legal. Hardlinks are canaried and memoized on a per-destination-root basis, so this strategy might actually be slightly cheaper than the previous one.

Fixes #18757.