### PR TITLE
Move .pids under .pants.d by default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-Linux-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
       run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
@@ -137,7 +137,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
       run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
@@ -228,7 +228,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-macOS10-15-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
       run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\
@@ -312,7 +312,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-macOS11-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - if: needs.release_info.outputs.is-release == 'true'
       name: Upload Wheel and Pex
       run: "PANTS_VER=$(PEX_INTERPRETER=1 dist/src.python.pants/pants-pex.pex -c \"\

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-bootstrap-Linux-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -176,7 +176,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-bootstrap-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -280,7 +280,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-bootstrap-macOS11-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
@@ -352,7 +352,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-Linux-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
@@ -412,7 +412,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   build_wheels_macos10_15_x86_64:
     env:
@@ -479,7 +479,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-macOS10-15-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   build_wheels_macos11_arm64:
     env:
@@ -546,7 +546,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-wheels-and-pex-macOS11-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   check_labels:
     if: github.repository_owner == 'pantsbuild'
@@ -642,7 +642,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-lint-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 30
   merge_ok:
     if: always()
@@ -741,7 +741,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-Linux-ARM64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_0:
     env:
@@ -832,7 +832,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-0_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_1:
     env:
@@ -923,7 +923,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-1_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_2:
     env:
@@ -1014,7 +1014,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-2_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_3:
     env:
@@ -1105,7 +1105,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-3_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_4:
     env:
@@ -1196,7 +1196,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-4_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_5:
     env:
@@ -1287,7 +1287,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-5_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_6:
     env:
@@ -1378,7 +1378,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-6_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_7:
     env:
@@ -1469,7 +1469,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-7_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_8:
     env:
@@ -1560,7 +1560,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-8_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_linux_x86_64_9:
     env:
@@ -1651,7 +1651,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-9_10-Linux-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
   test_python_macos11_x86_64:
     env:
@@ -1709,7 +1709,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: logs-python-test-macOS11-x86_64
-        path: .pants.d/*.log
+        path: .pants.d/workdir/*.log
     timeout-minutes: 90
 name: Pull Request CI
 'on':

--- a/.gitignore
+++ b/.gitignore
@@ -22,9 +22,16 @@ __pycache__/
 /.vscode/
 .cache
 .pants.d
+# TODO: We can probably delete these 3. They have not been used in a long time, if ever.
+#  In fact there's a lot of things we can clean up in this .gitignore. It's not harmful
+#  to keep them, but it's nice to keep things tight and avoid questions/confusion.
 .pants.run
 .pants.workdir.file_lock
 .pants.stats
+# TODO: .pids is no longer in use (it is now under .pants.d) but Pants developers switching
+#  to older branches will still see files created under .pids, which will then linger when they
+#  switch back to main. So we keep this in main's .gitignore for a while. We can remove this,
+#  to reduce confusion, once we're no longer developing in branches prior to 2.19.x.
 .pids
 .project
 .settings

--- a/build-support/bin/cache_comparison.py
+++ b/build-support/bin/cache_comparison.py
@@ -85,7 +85,7 @@ def timings_for_build(
     # Build a PEX for the commit, then ensure that `pantsd` is not running.
     checkout(build_commit)
     run(["package", "src/python/pants/bin:pants"], use_pex=False)
-    shutil.rmtree(".pids")
+    shutil.rmtree(".pants.d/pids")
     # Then collect a runtime for each commit in the range.
     cache_namespace = f"cache-comparison-{build_commit}-{time()}"
     return {

--- a/build-support/bin/generate_json_schema.py
+++ b/build-support/bin/generate_json_schema.py
@@ -37,9 +37,9 @@ PYTHON_TO_JSON_TYPE_MAPPING = {
 # This list may need to be extended as more options with environment specific default values are added.
 ENV_SPECIFIC_OPTION_DEFAULTS = {
     "pants_config_files": ["<buildroot>/pants.toml"],
-    "pants_subprocessdir": "<buildroot>/.pids",
+    "pants_subprocessdir": "<buildroot>/.pants.d/pids",
     "pants_distdir": "<buildroot>/dist",
-    "pants_workdir": "<buildroot>/.pants.d",
+    "pants_workdir": "<buildroot>/.pants.d/workdir",
     "local_store_dir": "$XDG_CACHE_HOME/lmdb_store",
     "named_caches_dir": "$XDG_CACHE_HOME/named_caches",
 }

--- a/build-support/python/clean.sh
+++ b/build-support/python/clean.sh
@@ -3,7 +3,7 @@
 PANTS_BASE=$(dirname "$0")/../..
 rm -rf "${HOME}/.pex"
 rm -rf "${HOME}/.cache/pants/pants_dev_deps"
-rm -rf "${PANTS_BASE}/.pants.d"
+rm -rf "${PANTS_BASE}/.pants.d/workdir"
 find "${PANTS_BASE}" -name '*.pyc' -print0 | xargs -0 rm -f
 
 # Legacy:

--- a/docs/markdown/Getting Started/getting-started/initial-configuration.md
+++ b/docs/markdown/Getting Started/getting-started/initial-configuration.md
@@ -62,9 +62,8 @@ If you use Git, we recommend adding these lines to your top-level `.gitignore` f
 
 ```text .gitignore
 # Pants workspace files
-/.pants.*
+/.pants.d
 /dist/
-/.pids
 ```
 
 > 📘 FYI: Pants will ignore all files in your `.gitignore` by default

--- a/docs/markdown/Go/go.md
+++ b/docs/markdown/Go/go.md
@@ -117,7 +117,7 @@ To run a binary, use `pants run path/to/main_pkg:` (note the colon). You can pas
 
 ```
 ❯ pants run cmd/deploy: -- --help
-Usage of /Users/pantsbuild/example/.pants.d/tmpzfh33ggu/cmd.deploy/bin:
+Usage of /Users/pantsbuild/example/.pants.d/workdir/tmpzfh33ggu/cmd.deploy/bin:
       --allow-insecure-auth        allow credentials to be passed unencrypted (i.e., no TLS)
   -A, --auth-token-env string      name of environment variable with auth bearer token
 ...

--- a/docs/markdown/Using Pants/troubleshooting.md
+++ b/docs/markdown/Using Pants/troubleshooting.md
@@ -54,9 +54,9 @@ To start with, first try using `--no-pantsd`. If that doesn't work, you can also
 If `--no-pantsd` worked, you can restart `pantsd`, either by:
 
 - Killing the `pantsd` process associated with your workspace. You can use `ps aux | grep pants` to find the PID, the `kill -9 <pid>`. 
-- Deleting the `<build root>/.pids` directory. 
+- Deleting the `<build root>/.pants.d/pids` directory. 
 
-If this resolves the issue, please report that on the ticket and attach the recent content of the `.pants.d/pantsd/pantsd.log` file.
+If this resolves the issue, please report that on the ticket and attach the recent content of the `.pants.d/workdir/pantsd/pantsd.log` file.
 
 If restarting `pantsd` is not sufficient, you can also use `--no-local-cache` to ignore the persistent caches. If this resolves the issue, then it is possible that the contents of the cache (at `~/.cache/pants`) will be useful for debugging the ticket that you filed: please try to preserve the cache contents until it can be resolved.
 
@@ -161,7 +161,7 @@ You may change any of these options in the `[GLOBAL]` section of your `pants.tom
     "1-2": "`~/.cache/pants/named_caches`",
     "2-0": "`pants_workdir`",
     "2-1": "Stores some project-specific logs; used as a temporary directory when running `pants repl` and `pants run`.  \n  \nThis is not used for caching.  \n  \nThis must be relative to the build root.",
-    "2-2": "`<build_root>/.pants.d/`",
+    "2-2": "`<build_root>/.pants.d/workdir`",
     "3-0": "`pants_distdir`",
     "3-1": "Where Pants writes artifacts to, such as the result of `pants package`.  \n  \nThis is not used for caching; you can delete this folder and still leverage the cache from `local_store_dir`.  \n  \nThis must be relative to the build root.",
     "3-2": "`<build_root>/dist/`"

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -97,7 +97,7 @@ async def handle_bsp_java_options_request(
             classpath=(),
             # TODO: Why is this hardcoded and not under pants_workdir?
             class_directory=build_root.pathlib_path.joinpath(
-                ".pants.d", "bsp", f"{jvm_classes_directory(request.bsp_target_id)}"
+                ".pants.d", "bsp", jvm_classes_directory(request.bsp_target_id)
             ).as_uri(),
         )
     )

--- a/src/python/pants/backend/java/bsp/rules.py
+++ b/src/python/pants/backend/java/bsp/rules.py
@@ -95,8 +95,9 @@ async def handle_bsp_java_options_request(
             target=request.bsp_target_id,
             options=(),
             classpath=(),
+            # TODO: Why is this hardcoded and not under pants_workdir?
             class_directory=build_root.pathlib_path.joinpath(
-                f".pants.d/bsp/{jvm_classes_directory(request.bsp_target_id)}"
+                ".pants.d", "bsp", f"{jvm_classes_directory(request.bsp_target_id)}"
             ).as_uri(),
         )
     )

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -269,7 +269,8 @@ async def bsp_resolve_scala_metadata(
         coursier_java_home = jdk_home
 
     scala_jar_uris = tuple(
-        build_root.pathlib_path.joinpath(".pants.d/bsp").joinpath(p).as_uri()
+        # TODO: Why is this hardcoded and not under pants_workdir?
+        build_root.pathlib_path.joinpath(".pants.d", "bsp").joinpath(p).as_uri()
         for p in scala_runtime.files
     )
 

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -270,7 +270,7 @@ async def bsp_resolve_scala_metadata(
 
     scala_jar_uris = tuple(
         # TODO: Why is this hardcoded and not under pants_workdir?
-        build_root.pathlib_path.joinpath(".pants.d", "bsp").joinpath(p).as_uri()
+        build_root.pathlib_path.joinpath(".pants.d", "bsp", p).as_uri()
         for p in scala_runtime.files
     )
 

--- a/src/python/pants/init/util.py
+++ b/src/python/pants/init/util.py
@@ -43,8 +43,8 @@ def init_workdir(global_options: OptionValueContainer) -> str:
             # Exists and is correct: ensure that the destination exists.
             safe_mkdir(workdir_dst)
     else:
-        # Remove existing physical workdir (.pants.d dir)
+        # Remove existing physical workdir (.pants.d/workdir dir)
         safe_rmtree(workdir_src)
-        # Create both symlink workdir (.pants.d dir) and its destination/physical workdir
+        # Create both symlink workdir (.pants.d/workdir dir) and its destination/physical workdir
         create_symlink_to_clean_workdir()
     return workdir_src

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -999,7 +999,7 @@ class BootstrapOptions:
     pants_workdir = StrOption(
         advanced=True,
         metavar="<dir>",
-        default=lambda _: os.path.join(get_buildroot(), ".pants.d"),
+        default=lambda _: os.path.join(get_buildroot(), ".pants.d", "workdir"),
         daemon=True,
         help="Write intermediate logs and output files to this dir.",
     )
@@ -1024,7 +1024,7 @@ class BootstrapOptions:
     )
     pants_subprocessdir = StrOption(
         advanced=True,
-        default=lambda _: os.path.join(get_buildroot(), ".pids"),
+        default=lambda _: os.path.join(get_buildroot(), ".pants.d", "pids"),
         daemon=True,
         help=softwrap(
             """

--- a/src/python/pants/option/options_bootstrapper_test.py
+++ b/src/python/pants/option/options_bootstrapper_test.py
@@ -59,7 +59,7 @@ class TestOptionsBootstrapper:
                 config=config,
                 env=env,
                 args=args,
-                pants_workdir=workdir or os.path.join(get_buildroot(), ".pants.d"),
+                pants_workdir=workdir or os.path.join(get_buildroot(), ".pants.d", "workdir"),
                 pants_distdir=distdir or os.path.join(get_buildroot(), "dist"),
             )
 

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -255,7 +255,7 @@ class ProcessManager:
         safe_mkdir(self._metadata_base_dir)
         return OwnerPrintingInterProcessFileLock(
             # N.B. This lock can't key into the actual named metadata dir (e.g.
-            # `.pantsd/pids/pantsd/lock` via `ProcessManager._get_metadata_dir_by_name()`)
+            # `.pants.d/pids/pantsd/lock` via `ProcessManager._get_metadata_dir_by_name()`)
             # because of a need to purge the named metadata dir on startup to avoid stale
             # metadata reads.
             os.path.join(self._metadata_base_dir, f".lock.{self._name}")

--- a/src/python/pants/pantsd/process_manager.py
+++ b/src/python/pants/pantsd/process_manager.py
@@ -254,9 +254,10 @@ class ProcessManager:
         """An identity-keyed inter-process lock for safeguarding lifecycle and other operations."""
         safe_mkdir(self._metadata_base_dir)
         return OwnerPrintingInterProcessFileLock(
-            # N.B. This lock can't key into the actual named metadata dir (e.g. `.pids/pantsd/lock`
-            # via `ProcessManager._get_metadata_dir_by_name()`) because of a need to purge
-            # the named metadata dir on startup to avoid stale metadata reads.
+            # N.B. This lock can't key into the actual named metadata dir (e.g.
+            # `.pantsd/pids/pantsd/lock` via `ProcessManager._get_metadata_dir_by_name()`)
+            # because of a need to purge the named metadata dir on startup to avoid stale
+            # metadata reads.
             os.path.join(self._metadata_base_dir, f".lock.{self._name}")
         )
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -377,7 +377,7 @@ class RuleRunner:
 
     @property
     def pants_workdir(self) -> str:
-        return os.path.join(self.build_root, ".pants.d")
+        return os.path.join(self.build_root, ".pants.d", "workdir")
 
     @property
     def target_types(self) -> tuple[type[Target], ...]:

--- a/src/python/pants/vcs/changed_integration_test.py
+++ b/src/python/pants/vcs/changed_integration_test.py
@@ -33,7 +33,7 @@ def repo() -> Iterator[str]:
             ".gitignore": dedent(
                 f"""\
                 {Path(worktree).relative_to(get_buildroot())}
-                .pids
+                .pants.d/pids
                 __pycache__
                 .coverage.*  # For some reason, CI adds these files
                 """

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -552,7 +552,7 @@ class Helper:
             "continue-on-error": True,
             "with": {
                 "name": f"logs-{name.replace('/', '_')}-{self.platform_name()}",
-                "path": ".pants.d/*.log",
+                "path": ".pants.d/workdir/*.log",
             },
         }
 

--- a/src/rust/engine/client/src/client_tests.rs
+++ b/src/rust/engine/client/src/client_tests.rs
@@ -31,7 +31,7 @@ async fn test_client_fingerprint_mismatch() {
   let (build_root, _options_parser, tmpdir) = launch_pantsd();
 
   // Then connect with a different set of options (but with a matching `pants_subprocessdir`, so
-  // that we find the relevant `.pids` directory).
+  // that we find the relevant `.pants.d/pids` directory).
   let options_parser = OptionParser::new(
     Env::new(HashMap::new()),
     Args::new(vec![format!(

--- a/src/rust/engine/pantsd/src/lib.rs
+++ b/src/rust/engine/pantsd/src/lib.rs
@@ -178,7 +178,10 @@ pub fn find_pantsd(
   options_parser: &OptionParser,
 ) -> Result<ConnectionSettings, String> {
   let pants_subprocessdir = option_id!("pants", "subprocessdir");
-  let option_value = options_parser.parse_string(&pants_subprocessdir, ".pids")?;
+  let option_value = options_parser.parse_string(
+    &pants_subprocessdir,
+    Path::new(".pants.d").join("pids").to_str().unwrap(),
+  )?;
   let metadata_dir = {
     let path = PathBuf::from(&option_value.value);
     if path.is_absolute() {
@@ -342,8 +345,9 @@ pub fn fingerprint_compute(
 /// options (because we have redundancy of options definitions between `global_options.py` and what
 /// the Rust native client uses).
 pub fn fingerprinted_options(build_root: &BuildRoot) -> Result<Vec<FingerprintedOption>, String> {
-  let build_root_subdir = |subdir: &str| -> Result<String, String> {
+  let dot_pants_dot_d_subdir = |subdir: &str| -> Result<String, String> {
     build_root
+      .join(".pants.d")
       .join(subdir)
       .into_os_string()
       .into_string()
@@ -363,14 +367,14 @@ pub fn fingerprinted_options(build_root: &BuildRoot) -> Result<Vec<Fingerprinted
     ),
     FingerprintedOption::new(
       option_id!("pants", "workdir"),
-      build_root_subdir(".pants.d")?,
+      dot_pants_dot_d_subdir("workdir")?,
     ),
     // Optional strings are not currently supported by the Rust options parser, but we're only
     // using these for fingerprinting, and so can use a placeholder default.
     FingerprintedOption::new(option_id!("pants", "physical", "workdir", "base"), "<none>"),
     FingerprintedOption::new(
       option_id!("pants", "subprocessdir"),
-      build_root_subdir(".pids")?,
+      dot_pants_dot_d_subdir("pids")?,
     ),
     FingerprintedOption::new(option_id!("logdir"), "<none>"),
     FingerprintedOption::new(option_id!("pantsd"), true),

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -169,7 +169,7 @@ class PantsDaemonIntegrationTestBase(unittest.TestCase):
         self, *, log_level: str = "info", extra_config: dict[str, Any] | None = None
     ) -> Iterator[tuple[str, dict[str, Any], PantsDaemonMonitor]]:
         with temporary_dir(root_dir=os.getcwd()) as dot_pants_dot_d:
-            pid_dir = os.path.join(dot_pants_dot_d, ".pants.d", "pids")
+            pid_dir = os.path.join(dot_pants_dot_d, "pids")
             workdir = os.path.join(dot_pants_dot_d, "workdir")
             print(f"\npantsd log is {workdir}/pantsd/pantsd.log")
             pantsd_config = {

--- a/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
+++ b/tests/python/pants_test/pantsd/pantsd_integration_test_base.py
@@ -168,9 +168,9 @@ class PantsDaemonIntegrationTestBase(unittest.TestCase):
     def pantsd_test_context(
         self, *, log_level: str = "info", extra_config: dict[str, Any] | None = None
     ) -> Iterator[tuple[str, dict[str, Any], PantsDaemonMonitor]]:
-        with temporary_dir(root_dir=os.getcwd()) as workdir_base:
-            pid_dir = os.path.join(workdir_base, ".pids")
-            workdir = os.path.join(workdir_base, ".workdir.pants.d")
+        with temporary_dir(root_dir=os.getcwd()) as dot_pants_dot_d:
+            pid_dir = os.path.join(dot_pants_dot_d, ".pants.d", "pids")
+            workdir = os.path.join(dot_pants_dot_d, "workdir")
             print(f"\npantsd log is {workdir}/pantsd/pantsd.log")
             pantsd_config = {
                 "GLOBAL": {

--- a/tests/python/pants_test/pantsd/test_process_manager.py
+++ b/tests/python/pants_test/pantsd/test_process_manager.py
@@ -351,8 +351,8 @@ def test_process_name_setproctitle_integration(tmp_path: Path) -> None:
     buildroot.mkdir()
     manager_name = "Bob"
     process_name = f"{manager_name} [{buildroot}]"
-    metadata_base_dir = tmp_path / ".pids"
-    metadata_base_dir.mkdir()
+    metadata_base_dir = tmp_path / ".pants.d" / "pids"
+    metadata_base_dir.mkdir(parents=True)
 
     subprocess.check_call(
         args=[


### PR DESCRIPTION
We also make the workdir a subdir of `.pants.d`, so that it's easy to 
nuke it without nuking the pids. These are just changes to default
option values. It is still possible to explicitly set those options so
whatever the user wants.

The structure under `.pants.d` is opaque to end users and not part
of the API, so we have the freedom to do this without a deprecation.

Note that we do *not* move `.pants.d/bsp` under `.pants.d/workdir`.
For whatever reason, `bsp` uses that hardcoded directory, rather
than consulting the pants_workdir option. 

So the end result of this change is that `.pants.d` is no longer the
same thing as the workdir, but a looser "directory Pants writes stuff
under, and that you can safely nuke". There are now three things that
go under that dir: pids, workdir and bsp.
