### PR TITLE
Add (experimental) named caches field to `shell_command` and `adhoc_tool`

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -152,7 +152,7 @@ async def run_in_sandbox_request(
 
     append_only_caches = {
         **merged_extras.append_only_caches,
-        **target.get(AdhocToolNamedCachesField).value,
+        **(target.get(AdhocToolNamedCachesField).value or {}),
     }
 
     process_request = AdhocProcessRequest(

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -9,6 +9,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
     AdhocToolLogOutputField,
+    AdhocToolNamedCachesField,
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
@@ -149,6 +150,11 @@ async def run_in_sandbox_request(
 
     extra_args = target.get(AdhocToolArgumentsField).value or ()
 
+    append_only_caches = {
+        **merged_extras.append_only_caches,
+        **target.get(AdhocToolNamedCachesField).value,
+    }
+
     process_request = AdhocProcessRequest(
         description=description,
         address=target.address,
@@ -158,7 +164,7 @@ async def run_in_sandbox_request(
         timeout=None,
         input_digest=input_digest,
         immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
-        append_only_caches=FrozenDict.frozen(merged_extras.append_only_caches),
+        append_only_caches=FrozenDict(append_only_caches),
         output_files=output_files,
         output_directories=output_directories,
         fetch_env_vars=target.get(AdhocToolExtraEnvVarsField).value or (),

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -219,7 +219,6 @@ class AdhocToolWorkdirField(StringField):
 
 class AdhocToolNamedCachesField(DictStringToStringField):
     alias = "experimental_named_caches"
-    default = {}
     help = help_text(
         """
         Named caches to construct for the execution.

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -10,6 +10,7 @@ from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     BoolField,
     Dependencies,
+    DictStringToStringField,
     IntField,
     MultipleSourcesField,
     SpecialCasedDependencies,
@@ -212,6 +213,26 @@ class AdhocToolWorkdirField(StringField):
         * Values beginning with `./` are relative to the location of the `BUILD` file.
         * `/` or the empty string specifies the build root.
         * Values beginning with `/` are also relative to the build root.
+        """
+    )
+
+
+class AdhocToolNamedCachesField(DictStringToStringField):
+    alias = "experimental_named_caches"
+    default = {}
+    help = help_text(
+        """
+        Named caches to construct for the execution.
+        See https://www.pantsbuild.org/docs/reference-global#named_caches_dir.
+
+        The keys of the mapping are the directory name to be created in the named caches dir.
+        The values are the name of the symlink (relative to the sandbox root) in the sandbox which
+        points to the subdirectory in the named caches dir
+
+        NOTE: The named caches MUST be handled with great care. Processes accessing the named caches
+        can be run in parallel, and can be cancelled at any point in their execution (and
+        potentially restarted). That means that _every_ operation modifying the contents of the cache
+        MUST be concurrency and cancellation safe.
         """
     )
 

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -11,6 +11,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
     AdhocToolLogOutputField,
+    AdhocToolNamedCachesField,
     AdhocToolOutputDependenciesField,
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
@@ -374,6 +375,10 @@ class ShellCommandTestDependenciesField(ShellCommandExecutionDependenciesField):
     pass
 
 
+class ShellCommandNamedCachesField(AdhocToolNamedCachesField):
+    pass
+
+
 class SkipShellCommandTestsField(BoolField):
     alias = "skip_tests"
     default = False
@@ -396,6 +401,7 @@ class ShellCommandTarget(Target):
         ShellCommandToolsField,
         ShellCommandExtraEnvVarsField,
         ShellCommandWorkdirField,
+        ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
         EnvironmentField,
     )

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -143,7 +143,7 @@ async def _prepare_process_request_from_target(
 
     append_only_caches = {
         **merged_extras.append_only_caches,
-        **shell_command.get(ShellCommandNamedCachesField).value,
+        **(shell_command.get(ShellCommandNamedCachesField).value or {}),
     }
 
     return AdhocProcessRequest(

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -14,6 +14,7 @@ from pants.backend.shell.target_types import (
     ShellCommandExecutionDependenciesField,
     ShellCommandExtraEnvVarsField,
     ShellCommandLogOutputField,
+    ShellCommandNamedCachesField,
     ShellCommandOutputDirectoriesField,
     ShellCommandOutputFilesField,
     ShellCommandOutputRootDirField,
@@ -140,6 +141,11 @@ async def _prepare_process_request_from_target(
     if merged_extras.path:
         extra_env["PATH"] = merged_extras.path
 
+    append_only_caches = {
+        **merged_extras.append_only_caches,
+        **shell_command.get(ShellCommandNamedCachesField).value,
+    }
+
     return AdhocProcessRequest(
         description=description,
         address=shell_command.address,
@@ -151,7 +157,7 @@ async def _prepare_process_request_from_target(
         output_files=output_files,
         output_directories=output_directories,
         fetch_env_vars=shell_command.get(ShellCommandExtraEnvVarsField).value or (),
-        append_only_caches=FrozenDict.frozen(merged_extras.append_only_caches),
+        append_only_caches=FrozenDict(append_only_caches),
         supplied_env_var_values=FrozenDict(extra_env),
         immutable_input_digests=FrozenDict.frozen(merged_extras.immutable_input_digests),
         log_on_process_errors=_LOG_ON_PROCESS_ERRORS,


### PR DESCRIPTION
Part of the effort towards making Pants compile its engine without starting from scratch, and a feature we've probably all mused at some point.

Marked `experimental` because it's completely wild-west right now.