### PR TITLE
Always have coloured output and then strip later for pytest, helm unittest, shunit2

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -80,7 +80,7 @@ async def clangformat_fmt(request: ClangFormatRequest.Batch, clangformat: ClangF
             level=LogLevel.DEBUG,
         ),
     )
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/backend/helm/test/unittest.py
+++ b/src/python/pants/backend/helm/test/unittest.py
@@ -53,6 +53,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+from pants.util.strutil import Simplifier
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,9 @@ async def setup_helm_unittest(
     process = HelmProcess(
         argv=[
             unittest_subsystem.plugin_name,
-            *(("--color",) if unittest_subsystem.color else ()),
+            # Always include colors and strip them out for display below (if required), for better cache
+            # hit rates
+            "--color",
             *(("--strict",) if field_set.strict.value else ()),
             *(("--update-snapshot",) if request.update_snapshots else ()),
             "--output-type",
@@ -194,6 +197,7 @@ async def setup_helm_unittest(
 async def run_helm_unittest(
     batch: HelmUnitTestRequest.Batch[HelmUnitTestFieldSet, Any],
     test_subsystem: TestSubsystem,
+    unittest_subsystem: HelmUnitTestSubsystem,
 ) -> TestResult:
     field_set = batch.single_element
 
@@ -223,6 +227,7 @@ async def run_helm_unittest(
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=reports,
+        output_simplifier=Simplifier(strip_formatting=not unittest_subsystem.color),
     )
 
 

--- a/src/python/pants/backend/java/lint/google_java_format/rules.py
+++ b/src/python/pants/backend/java/lint/google_java_format/rules.py
@@ -94,7 +94,7 @@ async def google_java_format_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 @rule

--- a/src/python/pants/backend/javascript/lint/prettier/rules.py
+++ b/src/python/pants/backend/javascript/lint/prettier/rules.py
@@ -70,7 +70,7 @@ async def prettier_fmt(request: PrettierFmtRequest.Batch, prettier: Prettier) ->
             level=LogLevel.DEBUG,
         ),
     )
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/backend/kotlin/lint/ktlint/rules.py
+++ b/src/python/pants/backend/kotlin/lint/ktlint/rules.py
@@ -79,7 +79,7 @@ async def ktlint_fmt(
         ),
     )
 
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 @rule

--- a/src/python/pants/backend/openapi/lint/openapi_format/rules.py
+++ b/src/python/pants/backend/openapi/lint/openapi_format/rules.py
@@ -47,7 +47,7 @@ async def run_openapi_format(
         ),
     )
 
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -249,7 +249,6 @@ async def setup_pytest_for_target(
     coverage_config: CoverageConfig,
     coverage_subsystem: CoverageSubsystem,
     test_extra_env: TestExtraEnv,
-    global_options: GlobalOptions,
 ) -> TestSetup:
     addresses = tuple(field_set.address for field_set in request.field_sets)
 
@@ -355,7 +354,11 @@ async def setup_pytest_for_target(
     # Don't forget to keep "Customize Pytest command line options per target" section in
     # docs/markdown/Python/python-goals/python-test-goal.md up to date when changing
     # which flags are added to `pytest_args`.
-    pytest_args = [f"--color={'yes' if global_options.colors else 'no'}"]
+    pytest_args = [
+        # Always include colors and strip them out for display below (if required), for better cache
+        # hit rates
+        "--color=yes"
+    ]
     output_files = []
 
     results_file_name = None
@@ -501,6 +504,7 @@ async def partition_python_tests(
 async def run_python_tests(
     batch: PyTestRequest.Batch[PythonTestFieldSet, TestMetadata],
     test_subsystem: TestSubsystem,
+    global_options: GlobalOptions,
 ) -> TestResult:
     setup = await Get(
         TestSetup, TestSetupRequest(batch.elements, batch.partition_metadata, is_debug=False)
@@ -548,6 +552,7 @@ async def run_python_tests(
         coverage_data=coverage_data,
         xml_results=xml_results_snapshot,
         extra_output=extra_output_snapshot,
+        output_simplifier=global_options.output_simplifier(),
     )
 
 

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -202,7 +202,7 @@ def test_passing(rule_runner: PythonRuleRunner, major_minor_interpreter: str) ->
     )
     assert result.xml_results is not None
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
 
 
 def test_failing(rule_runner: PythonRuleRunner) -> None:
@@ -220,7 +220,7 @@ def test_failing(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, [tgt])
     assert result.exit_code == 1
-    assert f"{PACKAGE}/tests.py F" in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py F" in result.stdout_simplified_str
 
 
 def test_dependencies(rule_runner: PythonRuleRunner) -> None:
@@ -278,7 +278,7 @@ def test_dependencies(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, [tgt])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
 
 
 @skip_unless_python37_and_python39_present
@@ -312,7 +312,7 @@ def test_uses_correct_python_version(rule_runner: PythonRuleRunner) -> None:
     )
     result = run_pytest(rule_runner, [py39_tgt], test_debug_adapter=False)
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
 
 
 def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
@@ -333,7 +333,7 @@ def test_passthrough_args(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, [tgt], extra_args=["--pytest-args='-k test_run_me'"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
     assert b"collected 2 items / 1 deselected / 1 selected" in result.stdout_bytes
 
 
@@ -474,7 +474,7 @@ def test_extra_output(rule_runner: PythonRuleRunner) -> None:
         ],
     )
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
     assert result.extra_output is not None
     digest_contents = rule_runner.request(DigestContents, [result.extra_output.digest])
     paths = {dc.path for dc in digest_contents}
@@ -494,7 +494,7 @@ def test_coverage(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, [tgt], extra_args=["--test-use-coverage"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py ." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py ." in result.stdout_simplified_str
     assert result.coverage_data is not None
 
 
@@ -516,7 +516,7 @@ def test_conftest_dependency_injection(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="tests.py"))
     result = run_pytest(rule_runner, [tgt], extra_args=["--pytest-args='-s'"])
     assert result.exit_code == 0
-    assert f"{PACKAGE}/tests.py In conftest!\n." in result.stdout_bytes.decode()
+    assert f"{PACKAGE}/tests.py In conftest!\n." in result.stdout_simplified_str
 
 
 def test_execution_slot_variable(rule_runner: PythonRuleRunner) -> None:
@@ -539,7 +539,7 @@ def test_execution_slot_variable(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address(PACKAGE, relative_file_path="test_concurrency_slot.py"))
     result = run_pytest(rule_runner, [tgt], extra_args=["--pytest-execution-slot-var=SLOT"])
     assert result.exit_code == 1
-    assert re.search(r"Value of slot is \d+", result.stdout_bytes.decode())
+    assert re.search(r"Value of slot is \d+", result.stdout_simplified_str)
 
 
 def test_extra_env_vars(rule_runner: PythonRuleRunner) -> None:
@@ -948,7 +948,7 @@ def test_batched_passing(rule_runner: PythonRuleRunner, major_minor_interpreter:
     )
     assert result.xml_results is not None
     assert result.exit_code == 0
-    stdout_text = result.stdout_bytes.decode()
+    stdout_text = result.stdout_simplified_str
     assert f"{PACKAGE}/test_1.py ." in stdout_text
     assert f"{PACKAGE}/test_2.py ." in stdout_text
 
@@ -972,6 +972,6 @@ def test_batched_failing(rule_runner: PythonRuleRunner) -> None:
     )
     result = run_pytest(rule_runner, targets)
     assert result.exit_code == 1
-    stdout_text = result.stdout_bytes.decode()
+    stdout_text = result.stdout_simplified_str
     assert f"{PACKAGE}/test_1.py ." in stdout_text
     assert f"{PACKAGE}/test_2.py F" in stdout_text

--- a/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
+++ b/src/python/pants/backend/python/goals/pytest_runner_integration_test.py
@@ -824,7 +824,7 @@ def test_debug_adaptor_request_argv(rule_runner: PythonRuleRunner) -> None:
         "127.0.0.1:5678",
         "-c",
         unittest.mock.ANY,
-        "--color=no",
+        "--color=yes",
         "tests/python/pants_test/test_foo.py",
     )
 

--- a/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/rules.py
@@ -55,7 +55,7 @@ async def add_trailing_comma_fmt(
             level=LogLevel.DEBUG,
         ),
     )
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/autoflake/rules.py
+++ b/src/python/pants/backend/python/lint/autoflake/rules.py
@@ -53,7 +53,7 @@ async def autoflake_fix(request: AutoflakeRequest.Batch, autoflake: Autoflake) -
             level=LogLevel.DEBUG,
         ),
     )
-    return await FixResult.create(request, result, strip_chroot_path=True)
+    return await FixResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/black/rules.py
+++ b/src/python/pants/backend/python/lint/black/rules.py
@@ -62,7 +62,7 @@ async def _run_black(
             level=LogLevel.DEBUG,
         ),
     )
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 @rule

--- a/src/python/pants/backend/python/lint/isort/rules.py
+++ b/src/python/pants/backend/python/lint/isort/rules.py
@@ -105,7 +105,7 @@ async def isort_fmt(
             keep_sandboxes=keep_sandboxes,
         )
 
-    return await FmtResult.create(request, result, strip_chroot_path=True)
+    return await FmtResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/lint/ruff/rules.py
+++ b/src/python/pants/backend/python/lint/ruff/rules.py
@@ -86,7 +86,7 @@ async def ruff_fix(request: RuffFixRequest.Batch, ruff: Ruff) -> FixResult:
     result = await Get(
         FallibleProcessResult, _RunRuffRequest(snapshot=request.snapshot, is_fix=True)
     )
-    return await FixResult.create(request, result, strip_chroot_path=True)
+    return await FixResult.create(request, result)
 
 
 @rule(desc="Lint with ruff", level=LogLevel.DEBUG)
@@ -97,7 +97,7 @@ async def ruff_lint(request: RuffLintRequest.Batch[RuffFieldSet, Any]) -> LintRe
     result = await Get(
         FallibleProcessResult, _RunRuffRequest(snapshot=source_files.snapshot, is_fix=False)
     )
-    return LintResult.create(request, result, strip_chroot_path=True)
+    return LintResult.create(request, result)
 
 
 def rules():

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -368,7 +368,7 @@ async def mypy_typecheck_partition(
         result,
         partition_description=partition.description(),
         report=report,
-        strip_formatting=not global_options.colors,
+        output_simplifier=global_options.output_simplifier(),
     )
 
 

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -161,7 +161,6 @@ async def setup_shunit2_for_target(
     shell_setup: ShellSetup.EnvironmentAware,
     test_subsystem: TestSubsystem,
     test_extra_env: TestExtraEnv,
-    global_options: GlobalOptions,
     shunit2: Shunit2,
     platform: Platform,
 ) -> TestSetup:
@@ -216,7 +215,9 @@ async def setup_shunit2_for_target(
 
     env_dict = {
         "PATH": create_path_env_var(shell_setup.executable_search_path),
-        "SHUNIT_COLOR": "always" if global_options.colors else "none",
+        # Always include colors and strip them out for display below (if required), for better cache
+        # hit rates
+        "SHUNIT_COLOR": "always",
         **test_extra_env.env,
     }
     argv = (
@@ -242,7 +243,9 @@ async def setup_shunit2_for_target(
 
 @rule(desc="Run tests with Shunit2", level=LogLevel.DEBUG)
 async def run_tests_with_shunit2(
-    batch: Shunit2TestRequest.Batch[Shunit2FieldSet, Any], test_subsystem: TestSubsystem
+    batch: Shunit2TestRequest.Batch[Shunit2FieldSet, Any],
+    test_subsystem: TestSubsystem,
+    global_options: GlobalOptions,
 ) -> TestResult:
     field_set = batch.single_element
 
@@ -252,6 +255,7 @@ async def run_tests_with_shunit2(
         result,
         address=field_set.address,
         output_setting=test_subsystem.output,
+        output_simplifier=global_options.output_simplifier(),
     )
 
 

--- a/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
@@ -109,7 +109,7 @@ def test_passing(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 0
-    assert b"Ran 1 test.\n\nOK" in result.stdout_bytes
+    assert "Ran 1 test.\n\nOK" in result.stdout_simplified_str
 
 
 def test_failing(rule_runner: PythonRuleRunner) -> None:
@@ -130,7 +130,7 @@ def test_failing(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 1
-    assert b"Ran 1 test.\n\nFAILED" in result.stdout_bytes
+    assert "Ran 1 test.\n\nFAILED" in result.stdout_simplified_str
 
 
 def test_dependencies(rule_runner: PythonRuleRunner) -> None:
@@ -177,7 +177,7 @@ def test_dependencies(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 0
-    assert b"Ran 1 test.\n\nOK" in result.stdout_bytes
+    assert "Ran 1 test.\n\nOK" in result.stdout_simplified_str
 
 
 def test_subdirectories(rule_runner: PythonRuleRunner) -> None:
@@ -187,7 +187,7 @@ def test_subdirectories(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address("a/b/c", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 0
-    assert b"Ran 1 test.\n\nOK" in result.stdout_bytes
+    assert "Ran 1 test.\n\nOK" in result.stdout_simplified_str
 
 
 @pytest.mark.skip(
@@ -238,7 +238,7 @@ def test_extra_env_vars(rule_runner: PythonRuleRunner) -> None:
         env={"OTHER_VAR": "other_value"},
     )
     assert result.exit_code == 0
-    assert b"Ran 1 test.\n\nOK" in result.stdout_bytes
+    assert "Ran 1 test.\n\nOK" in result.stdout_simplified_str
 
 
 def test_runtime_package_dependency(rule_runner: PythonRuleRunner) -> None:
@@ -268,7 +268,7 @@ def test_runtime_package_dependency(rule_runner: PythonRuleRunner) -> None:
     tgt = rule_runner.get_target(Address("", target_name="t", relative_file_path="tests.sh"))
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 0
-    assert b"Ran 1 test.\n\nOK" in result.stdout_bytes
+    assert "Ran 1 test.\n\nOK" in result.stdout_simplified_str
 
 
 def test_determine_shell_runner(rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/backend/tools/semgrep/rules.py
+++ b/src/python/pants/backend/tools/semgrep/rules.py
@@ -225,7 +225,7 @@ async def lint(
         ),
     )
 
-    return LintResult.create(request, result, strip_formatting=not global_options.colors)
+    return LintResult.create(request, result, output_simplifier=global_options.output_simplifier())
 
 
 def rules() -> Iterable[Rule | UnionRule]:

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -35,6 +35,7 @@ from pants.testutil.option_util import create_options_bootstrapper, create_subsy
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
+from pants.util.strutil import Simplifier
 
 
 class MockMultipleSourcesField(MultipleSourcesField):
@@ -285,42 +286,36 @@ def test_streaming_output_partitions() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    ("strip_chroot_path", "strip_formatting", "expected"),
-    [
-        (False, False, "\033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m"),
-        (False, True, "/var/pants-sandbox-123/red/path.py bold"),
-        (True, False, "\033[0;31mred/path.py\033[0m \033[1mbold\033[0m"),
-        (True, True, "red/path.py bold"),
-    ],
-)
-def test_from_fallible_process_result_output_prepping(
-    strip_chroot_path: bool, strip_formatting: bool, expected: str
-) -> None:
-    result = CheckResult.from_fallible_process_result(
-        FallibleProcessResult(
-            exit_code=0,
-            stdout=b"stdout \033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m",
-            stdout_digest=EMPTY_FILE_DIGEST,
-            stderr=b"stderr \033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m",
-            stderr_digest=EMPTY_FILE_DIGEST,
-            output_digest=EMPTY_DIGEST,
-            metadata=ProcessResultMetadata(
-                0,
-                ProcessExecutionEnvironment(
-                    environment_name=None,
-                    platform=Platform.create_for_localhost().value,
-                    docker_image=None,
-                    remote_execution=False,
-                    remote_execution_extra_platform_properties=[],
-                ),
-                "ran_locally",
-                0,
-            ),
-        ),
-        strip_chroot_path=strip_chroot_path,
-        strip_formatting=strip_formatting,
-    )
+def test_from_fallible_process_result_output_prepping() -> None:
+    # Check that this calls the simplifier.
+    class DistinctiveException(Exception):
+        pass
 
-    assert result.stdout == "stdout " + expected
-    assert result.stderr == "stderr " + expected
+    class SubSimplifier(Simplifier):
+        def simplify(self, v: bytes | str) -> str:
+            raise DistinctiveException()
+
+    with pytest.raises(DistinctiveException):
+        CheckResult.from_fallible_process_result(
+            FallibleProcessResult(
+                exit_code=0,
+                stdout=b"",
+                stdout_digest=EMPTY_FILE_DIGEST,
+                stderr=b"",
+                stderr_digest=EMPTY_FILE_DIGEST,
+                output_digest=EMPTY_DIGEST,
+                metadata=ProcessResultMetadata(
+                    0,
+                    ProcessExecutionEnvironment(
+                        environment_name=None,
+                        platform=Platform.create_for_localhost().value,
+                        docker_image=None,
+                        remote_execution=False,
+                        remote_execution_extra_platform_properties=[],
+                    ),
+                    "ran_locally",
+                    0,
+                ),
+            ),
+            output_simplifier=SubSimplifier(),
+        )

--- a/src/python/pants/core/goals/fix.py
+++ b/src/python/pants/core/goals/fix.py
@@ -37,7 +37,7 @@ from pants.util.collections import partition_sequentially
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import softwrap, strip_v2_chroot_path
+from pants.util.strutil import Simplifier, softwrap
 
 logger = logging.getLogger(__name__)
 
@@ -55,16 +55,13 @@ class FixResult(EngineAwareReturnType):
         request: AbstractFixRequest.Batch,
         process_result: ProcessResult | FallibleProcessResult,
         *,
-        strip_chroot_path: bool = False,
+        output_simplifier: Simplifier = Simplifier(),
     ) -> FixResult:
-        def prep_output(s: bytes) -> str:
-            return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
-
         return FixResult(
             input=request.snapshot,
             output=await Get(Snapshot, Digest, process_result.output_digest),
-            stdout=prep_output(process_result.stdout),
-            stderr=prep_output(process_result.stderr),
+            stdout=output_simplifier.simplify(process_result.stdout),
+            stderr=output_simplifier.simplify(process_result.stderr),
             tool_name=request.tool_name,
         )
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -64,7 +64,7 @@ from pants.option.option_types import BoolOption, EnumOption, IntOption, StrList
 from pants.util.collections import partition_sequentially
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
-from pants.util.memo import memoized
+from pants.util.memo import memoized, memoized_property
 from pants.util.meta import classproperty
 from pants.util.strutil import Simplifier, help_text, softwrap
 
@@ -233,11 +233,11 @@ class TestResult(EngineAwareReturnType):
     def _simplified_output(self, v: bytes) -> str:
         return self.output_simplifier.simplify(v.decode(errors="replace"))
 
-    @property
+    @memoized_property
     def stdout_simplified_str(self) -> str:
         return self._simplified_output(self.stdout_bytes)
 
-    @property
+    @memoized_property
     def stderr_simplified_str(self) -> str:
         return self._simplified_output(self.stderr_bytes)
 

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -233,6 +233,14 @@ class TestResult(EngineAwareReturnType):
     def _simplified_output(self, v: bytes) -> str:
         return self.output_simplifier.simplify(v.decode(errors="replace"))
 
+    @property
+    def stdout_simplified_str(self) -> str:
+        return self._simplified_output(self.stdout_bytes)
+
+    @property
+    def stderr_simplified_str(self) -> str:
+        return self._simplified_output(self.stderr_bytes)
+
     def message(self) -> str:
         if self.exit_code is None:
             return "no tests found."
@@ -246,9 +254,9 @@ class TestResult(EngineAwareReturnType):
             return message
         output = ""
         if self.stdout_bytes:
-            output += f"\n{self._simplified_output(self.stdout_bytes)}"
+            output += f"\n{self.stdout_simplified_str}"
         if self.stderr_bytes:
-            output += f"\n{self._simplified_output(self.stderr_bytes)}"
+            output += f"\n{self.stderr_simplified_str}"
         if output:
             output = f"{output.rstrip()}\n\n"
         return f"{message}{output}"

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -37,7 +37,7 @@ from pants.jvm.resolve.key import CoursierResolveKey
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.util.strutil import strip_v2_chroot_path
+from pants.util.strutil import Simplifier
 
 logger = logging.getLogger(__name__)
 
@@ -338,19 +338,16 @@ class FallibleClasspathEntry(EngineAwareReturnType):
         process_result: FallibleProcessResult,
         output: ClasspathEntry | None,
         *,
-        strip_chroot_path: bool = False,
+        output_simplifier: Simplifier = Simplifier(),
     ) -> FallibleClasspathEntry:
-        def prep_output(s: bytes) -> str:
-            return strip_v2_chroot_path(s) if strip_chroot_path else s.decode()
-
         exit_code = process_result.exit_code
-        stderr = prep_output(process_result.stderr)
+        stderr = output_simplifier.simplify(process_result.stderr)
         return cls(
             description=description,
             result=(CompileResult.SUCCEEDED if exit_code == 0 else CompileResult.FAILED),
             output=output,
             exit_code=exit_code,
-            stdout=prep_output(process_result.stdout),
+            stdout=output_simplifier.simplify(process_result.stdout),
             stderr=stderr,
         )
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -51,7 +51,7 @@ from pants.util.logging import LogLevel
 from pants.util.memo import memoized_classmethod, memoized_property
 from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
 from pants.util.osutil import CPU_COUNT
-from pants.util.strutil import fmt_memory_size, softwrap
+from pants.util.strutil import Simplifier, fmt_memory_size, softwrap
 from pants.version import VERSION
 
 logger = logging.getLogger(__name__)
@@ -2132,6 +2132,15 @@ class GlobalOptions(BootstrapOptions, Subsystem):
     @memoized_property
     def named_caches_dir(self) -> PurePath:
         return Path(self._named_caches_dir).resolve()
+
+    def output_simplifier(self) -> Simplifier:
+        """Create a `Simplifier` instance for use on stdout and stderr that will be shown to a
+        user."""
+        return Simplifier(
+            # it's ~never useful to show the chroot path to a user
+            strip_chroot_path=True,
+            strip_formatting=not self.colors,
+        )
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -172,7 +172,8 @@ def strip_v2_chroot_path(v: bytes | str) -> str:
 class Simplifier:
     """Helper for options for conditionally simplifying a string."""
 
-    strip_chroot_path: bool = False
+    # it's only rarely useful to show a chroot path to a user, hence they're stripped by default
+    strip_chroot_path: bool = True
     """remove all instances of the chroot tmpdir path"""
     strip_formatting: bool = False
     """remove ANSI formatting commands (colors, bold, etc)"""

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import (
+    Simplifier,
     bullet_list,
     comma_separated_list,
     docstring,
@@ -112,6 +113,23 @@ def test_strip_chroot_path() -> None:
     # Confirm we can handle values with no chroot path.
     assert strip_v2_chroot_path("") == ""
     assert strip_v2_chroot_path("hello world") == "hello world"
+
+
+@pytest.mark.parametrize(
+    ("strip_chroot_path", "strip_formatting", "expected"),
+    [
+        (False, False, "\033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m"),
+        (False, True, "/var/pants-sandbox-123/red/path.py bold"),
+        (True, False, "\033[0;31mred/path.py\033[0m \033[1mbold\033[0m"),
+        (True, True, "red/path.py bold"),
+    ],
+)
+def test_simplifier(strip_chroot_path: bool, strip_formatting: bool, expected: str) -> None:
+    simplifier = Simplifier(strip_chroot_path=strip_chroot_path, strip_formatting=strip_formatting)
+    result = simplifier.simplify(
+        b"\033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m"
+    )
+    assert result == expected
 
 
 def test_hard_wrap() -> None:


### PR DESCRIPTION
This tries to increase cache hit rates by having Pytest, Helm unittest and shUnit2 have more consistent command line args/env vars, that don't depend on the value of `[GLOBAL].color` (or other `color` setting): in particular, these processes will now always output with colours under the hood, and Pants post-processes the output based on the flag.

The hope is that this allows more cache hits, particularly remote, where someone might be running locally with colours but a remote tester runs without.

This does a bunch of refactoring to pull out the adhoc colour stripping applied in `CheckResult` etc, and make it more reusable. This will breaks plugins that set the args (maybe we should deprecate them rather than just straight remove?).

Fixes #16526 