### PR TITLE
Remove references to PyPI/`pantsbuild.pants` wheels in docs (Cherry-pick of #19924)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,6 @@ See the [getting started](https://www.pantsbuild.org/docs/getting-started) docum
 
 # Credits
 
-We release to [PyPI](https://pypi.org/pypi)
-
-[![version](https://img.shields.io/pypi/v/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
-[![license](https://img.shields.io/pypi/l/pantsbuild.pants.svg)](https://pypi.org/pypi/pantsbuild.pants)
-
 Linux ARM64 CI resources provided by [Works on ARM](https://www.arm.com/markets/computing-infrastructure/works-on-arm).
 
 macOS CI resources provided by [MacStadium](https://www.macstadium.com/).

--- a/docs/markdown/Contributions/releases/release-process.md
+++ b/docs/markdown/Contributions/releases/release-process.md
@@ -1,7 +1,7 @@
 ---
 title: "Release process"
 slug: "release-process"
-excerpt: "How to release a new version of `pantsbuild.pants` and its plugins."
+excerpt: "How to release a new version of Pants and its plugins."
 hidden: false
 createdAt: "2020-05-16T22:36:48.334Z"
 ---
@@ -206,6 +206,8 @@ Run this script as a basic smoke test:
 ```
 
 You should also [check PyPI](https://pypi.org/pypi/pantsbuild.pants) to ensure everything looks good. Click "Release history" to find the version you released, then click it and confirm the changelog is correct on the "Project description" page and that the `macOS` and `manylinux` wheels show up in the "Download files" page. 
+
+You should also check [GitHub Releases](https://github.com/pantsbuild/pants/releases) to ensure everything looks good. Find the version you released, then click it and confirm that the "Assets" list includes PEXes for macOS and Linux.
 
 Step 6: Announce the change
 ---------------------------

--- a/docs/markdown/Releases/upgrade-tips.md
+++ b/docs/markdown/Releases/upgrade-tips.md
@@ -9,7 +9,7 @@ createdAt: "2020-05-16T22:53:24.499Z"
 >
 > Change the `pants_version` option in the `[GLOBAL]` scope in your pants.toml to upgrade.
 >
-> You can see all releases at <https://pypi.org/project/pantsbuild.pants/#history>.
+> You can see all releases at <https://github.com/pantsbuild/pants/releases>.
 
 Upgrade one minor release at a time
 -----------------------------------

--- a/docs/markdown/Using Pants/restricted-internet-access.md
+++ b/docs/markdown/Using Pants/restricted-internet-access.md
@@ -12,13 +12,9 @@ In such cases, users are typically still able to access internal proxies and ser
 Installing Pants
 ----------------
 
-The `pants` script from [Installing Pants](doc:installation) uses PyPI to download and install the wheel `pantsbuild.pants` and all of Pants's dependencies. 
+The `pants` launcher from [Installing Pants](doc:installation) uses GitHub Releases to download and install a PEX including Pants and all its dependencies.
 
-If you cannot access PyPI directly, you may have an internal mirror or custom Python package repository. If so, you can ensure that `pantsbuild.pants` and all of its dependencies are available in that repository, and modify your `pants` script to bootstrap from it.
-
-Otherwise, you may instead download Pants as a PEX binary from <https://github.com/pantsbuild/pants/releases>. After downloading the PEX artifact, you can rename the file to `pants`, run `chmod +x pants`, then run `pants --version` like you normally would. 
-
-You may want to check the binary into version control so that everyone in your organization can use it. To upgrade to a new Pants release, update the `pants_version` option in `pants.toml` and download the newest release from <https://github.com/pantsbuild/pants/releases>.
+If you cannot access GitHub directly, you will need to follow the instructions for firewalls/restricted internet access for [the launcher itself](https://github.com/pantsbuild/scie-pants).
 
 Setting up a Certificate Authority
 ----------------------------------


### PR DESCRIPTION
This updates our docs to refer to the new release process, using GitHub Releases, instead of PyPI. The `pantsbuild.pants` package becomes somewhat of an implementation detail too, so I've adjusted these too.

Also, the docs previously referred to the universal PEX we published to GitHub Releases which we no longer do (#19450), and thus references to it are removed too.
