### PR TITLE
Require Cargo.lock matches Cargo.toml in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -98,7 +98,7 @@ jobs:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
-      run: ./cargo test --tests -- --nocapture --test-threads=8
+      run: ./cargo test --locked --tests -- --nocapture --test-threads=8
     timeout-minutes: 60
   bootstrap_pants_linux_x86_64:
     env:
@@ -198,7 +198,7 @@ jobs:
 
         ./build-support/bin/check_rust_pre_commit.sh
 
-        ./cargo test --all --tests -- --nocapture
+        ./cargo test --locked --all --tests -- --nocapture
 
         ./cargo check --benches
 
@@ -294,7 +294,7 @@ jobs:
         TMPDIR: ${{ runner.temp }}
       if: needs.classify_changes.outputs.rust == 'true'
       name: Test Rust
-      run: ./cargo test --tests -- --nocapture
+      run: ./cargo test --locked --tests -- --nocapture
     timeout-minutes: 60
   build_wheels_linux_arm64:
     container:

--- a/build-support/bin/check_rust_pre_commit.sh
+++ b/build-support/bin/check_rust_pre_commit.sh
@@ -5,10 +5,10 @@ source build-support/common.sh
 
 if is_macos_arm; then
   echo "* Running \`./cargo clippy\`"
-  ./cargo clippy || exit 1
+  ./cargo clippy --locked || exit 1
 else
   echo "* Running \`./cargo clippy --all\`"
-  ./cargo clippy --all || exit 1
+  ./cargo clippy --locked --all || exit 1
 fi
 
 echo "* Checking formatting of Rust files"

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -612,7 +612,9 @@ def bootstrap_jobs(
         # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
         # pass on GHA MacOS containers.
         step_cmd = helper.wrap_cmd(
-            helper.maybe_append_cargo_test_parallelism("./cargo test --locked --tests -- --nocapture")
+            helper.maybe_append_cargo_test_parallelism(
+                "./cargo test --locked --tests -- --nocapture"
+            )
         )
     elif rust_testing == RustTesting.ALL:
         human_readable_job_name += ", test and lint Rust"

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -612,7 +612,7 @@ def bootstrap_jobs(
         # invalid doc tests in their comments. We do not pass --all as BRFS tests don't
         # pass on GHA MacOS containers.
         step_cmd = helper.wrap_cmd(
-            helper.maybe_append_cargo_test_parallelism("./cargo test --tests -- --nocapture")
+            helper.maybe_append_cargo_test_parallelism("./cargo test --locked --tests -- --nocapture")
         )
     elif rust_testing == RustTesting.ALL:
         human_readable_job_name += ", test and lint Rust"
@@ -623,7 +623,7 @@ def bootstrap_jobs(
             [
                 "./build-support/bin/check_rust_pre_commit.sh",
                 helper.maybe_append_cargo_test_parallelism(
-                    "./cargo test --all --tests -- --nocapture"
+                    "./cargo test --locked --all --tests -- --nocapture"
                 ),
                 "./cargo check --benches",
                 "./cargo doc",


### PR DESCRIPTION
This passes `--locked` to the first interesting cargo invocations, to ensure that the `Cargo.lock` file is up to date with `Cargo.toml`. Without this, if there's been changes to `Cargo.toml` and the user hasn't run a cargo command locally afterwards, those invocation might change the `Cargo.lock` file (e.g. bump versions, add packages) and thus CI runs with an unexpected configuration, that's not recorded in the repo.

(This came up in https://github.com/pantsbuild/scie-pants/pull/290 and I thought to check other Rust repos that are tangentially related.)