### PR TITLE
Use `ambiguity-resolution` for Python protobuf/grpc dependency inference

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -9,14 +9,22 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufGrpcToggleField,
 )
 from pants.backend.codegen.utils import find_python_runtime_library_or_raise_error
-from pants.backend.python.dependency_inference.module_mapper import ThirdPartyPythonModuleMapping
+from pants.backend.python.dependency_inference.module_mapper import (
+    PythonModuleOwners,
+    PythonModuleOwnersRequest,
+)
+from pants.backend.python.dependency_inference.subsystem import (
+    AmbiguityResolution,
+    PythonInferSubsystem,
+)
 from pants.backend.python.subsystems.python_tool_base import PythonToolRequirementsBase
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, InferDependenciesRequest, InferredDependencies
 from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.option.subsystem import Subsystem
+from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.docutil import doc_url
 from pants.util.strutil import help_text, softwrap
 
@@ -96,17 +104,33 @@ async def infer_dependencies(
     request: InferPythonProtobufDependencies,
     python_protobuf: PythonProtobufSubsystem,
     python_setup: PythonSetup,
-    # TODO(#12946): Make this a lazy Get once possible.
-    module_mapping: ThirdPartyPythonModuleMapping,
+    python_infer_subsystem: PythonInferSubsystem,
 ) -> InferredDependencies:
     if not python_protobuf.infer_runtime_dependency:
         return InferredDependencies([])
 
     resolve = request.field_set.python_resolve.normalized_value(python_setup)
 
+    locality = None
+    if python_infer_subsystem.ambiguity_resolution == AmbiguityResolution.by_source_root:
+        source_root = await Get(
+            SourceRoot, SourceRootRequest, SourceRootRequest.for_address(request.field_set.address)
+        )
+        locality = source_root.path
+
+    addresses_for_protobuf = await Get(
+        PythonModuleOwners,
+        PythonModuleOwnersRequest(
+            "google.protobuf",
+            resolve=resolve,
+            locality=locality,
+        ),
+    )
+
+    print(addresses_for_protobuf, locality)
     result = [
         find_python_runtime_library_or_raise_error(
-            module_mapping,
+            addresses_for_protobuf,
             request.field_set.address,
             "google.protobuf",
             resolve=resolve,
@@ -118,9 +142,19 @@ async def infer_dependencies(
     ]
 
     if request.field_set.grpc_toggle.value:
+        addresses_for_grpc = await Get(
+            PythonModuleOwners,
+            PythonModuleOwnersRequest(
+                "grpc",
+                resolve=resolve,
+                locality=locality,
+            ),
+        )
+
+        print(addresses_for_grpc, locality)
         result.append(
             find_python_runtime_library_or_raise_error(
-                module_mapping,
+                addresses_for_grpc,
                 request.field_set.address,
                 # Note that the library is called `grpcio`, but the module is `grpc`.
                 "grpc",

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -127,7 +127,6 @@ async def infer_dependencies(
         ),
     )
 
-    print(addresses_for_protobuf, locality)
     result = [
         find_python_runtime_library_or_raise_error(
             addresses_for_protobuf,

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem_test.py
@@ -79,13 +79,28 @@ def test_find_protobuf_python_requirement() -> None:
     )
 
     # If multiple from the same resolve, error.
-    rule_runner.write_files({"grpc2/BUILD": "python_requirement(requirements=['grpc'])"})
+    rule_runner.write_files({"xyz/grpc2/BUILD": "python_requirement(requirements=['grpc'])"})
     with engine_error(
-        AmbiguousPythonCodegenRuntimeLibrary, contains="['grpc1:grpc1', 'grpc2:grpc2']"
+        AmbiguousPythonCodegenRuntimeLibrary, contains="['grpc1:grpc1', 'xyz/grpc2:grpc2']"
     ):
         rule_runner.request(InferredDependencies, [request])
-    rule_runner.write_files({"proto2/BUILD": "python_requirement(requirements=['protobuf'])"})
+    rule_runner.write_files({"xyz/proto2/BUILD": "python_requirement(requirements=['protobuf'])"})
     with engine_error(
-        AmbiguousPythonCodegenRuntimeLibrary, contains="['proto1:proto1', 'proto2:proto2']"
+        AmbiguousPythonCodegenRuntimeLibrary, contains="['proto1:proto1', 'xyz/proto2:proto2']"
     ):
         rule_runner.request(InferredDependencies, [request])
+
+    # If multiple from the same resolve, error unless locality is enabled.
+    rule_runner.set_options(
+        [
+            "--python-resolves={'python-default': '', 'another': ''}",
+            "--python-enable-resolves",
+            # Turn off python synthetic lockfile targets to make the test simpler.
+            "--no-python-enable-lockfile-targets",
+            "--python-infer-ambiguity-resolution=by_source_root",
+        ]
+    )
+
+    assert rule_runner.request(InferredDependencies, [request]) == InferredDependencies(
+        [Address("proto1"), Address("grpc1")]
+    )

--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -3,10 +3,7 @@
 
 from __future__ import annotations
 
-from pants.backend.python.dependency_inference.module_mapper import (
-    ModuleProviderType,
-    PythonModuleOwners,
-)
+from pants.backend.python.dependency_inference.module_mapper import PythonModuleOwners
 from pants.engine.addresses import Address
 from pants.util.docutil import doc_url
 from pants.util.strutil import softwrap

--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from pants.backend.python.dependency_inference.module_mapper import (
     ModuleProviderType,
-    ThirdPartyPythonModuleMapping,
+    PythonModuleOwners,
 )
 from pants.engine.addresses import Address
 from pants.util.docutil import doc_url
@@ -21,7 +21,7 @@ class AmbiguousPythonCodegenRuntimeLibrary(Exception):
 
 
 def find_python_runtime_library_or_raise_error(
-    module_mapping: ThirdPartyPythonModuleMapping,
+    module_owners: PythonModuleOwners,
     codegen_address: Address,
     runtime_library_module: str,
     *,
@@ -31,15 +31,11 @@ def find_python_runtime_library_or_raise_error(
     recommended_requirement_url: str,
     disable_inference_option: str,
 ) -> Address:
-    addresses = [
-        possible_module_provider.provider.addr
-        for possible_module_provider in module_mapping.providers_for_module(
-            runtime_library_module, resolve=resolve
-        )
-        if possible_module_provider.provider.typ == ModuleProviderType.IMPL
-    ]
-    if len(addresses) == 1:
-        return addresses[0]
+    addresses = module_owners.unambiguous
+    if module_owners.unambiguous:
+        return module_owners.unambiguous[0]
+
+    addresses = module_owners.ambiguous
 
     for_resolve_str = f" for the resolve '{resolve}'" if resolves_enabled else ""
     if not addresses:
@@ -98,7 +94,9 @@ def find_python_runtime_library_or_raise_error(
             {sorted(addr.spec for addr in addresses)}
 
             To fix, remove one of these `python_requirement` targets{for_resolve_str} so that
-            there is no ambiguity and Pants can infer a dependency. {alternative_solution}
+            there is no ambiguity and Pants can infer a dependency. It
+            might also help to set
+            `[python-infer].ambiguity-resolution = "by_source_root"`. {alternative_solution}
             """
         )
     )

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -490,7 +490,6 @@ async def map_module_to_address(
                 continue
             providers_with_shortest_relative_path: list[ModuleProvider] = []
             shortest_relative_path_len = 9999
-            print(shortest_relative_path_len, providers)
             for provider in providers:
                 common_ancestor_len = len(
                     os.path.relpath(request.locality, provider.addr.spec_path).split(os.path.sep)

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -488,19 +488,18 @@ async def map_module_to_address(
             providers = val[1]
             if len(providers) < 2:
                 continue
-            providers_with_shortest_relative_path: list[ModuleProvider] = []
-            shortest_relative_path_len = 9999
+            providers_with_closest_common_ancestor: list[ModuleProvider] = []
+            closest_common_ancestor_len = 0
             for provider in providers:
                 common_ancestor_len = len(
-                    os.path.relpath(request.locality, provider.addr.spec_path).split(os.path.sep)
+                    os.path.commonpath([request.locality, provider.addr.spec_path])
                 )
-
-                if common_ancestor_len < shortest_relative_path_len:
-                    shortest_relative_path_len = common_ancestor_len
-                    providers_with_shortest_relative_path = []
-                if common_ancestor_len == shortest_relative_path_len:
-                    providers_with_shortest_relative_path.append(provider)
-            providers[:] = providers_with_shortest_relative_path
+                if common_ancestor_len > closest_common_ancestor_len:
+                    closest_common_ancestor_len = common_ancestor_len
+                    providers_with_closest_common_ancestor = []
+                if common_ancestor_len == closest_common_ancestor_len:
+                    providers_with_closest_common_ancestor.append(provider)
+            providers[:] = providers_with_closest_common_ancestor
 
     remaining_providers: list[ModuleProvider] = list(
         itertools.chain(*[val[1] for val in type_to_closest_providers.values()])

--- a/src/python/pants/backend/python/dependency_inference/module_mapper.py
+++ b/src/python/pants/backend/python/dependency_inference/module_mapper.py
@@ -488,18 +488,20 @@ async def map_module_to_address(
             providers = val[1]
             if len(providers) < 2:
                 continue
-            providers_with_closest_common_ancestor: list[ModuleProvider] = []
-            closest_common_ancestor_len = 0
+            providers_with_shortest_relative_path: list[ModuleProvider] = []
+            shortest_relative_path_len = 9999
+            print(shortest_relative_path_len, providers)
             for provider in providers:
                 common_ancestor_len = len(
-                    os.path.commonpath([request.locality, provider.addr.spec_path])
+                    os.path.relpath(request.locality, provider.addr.spec_path).split(os.path.sep)
                 )
-                if common_ancestor_len > closest_common_ancestor_len:
-                    closest_common_ancestor_len = common_ancestor_len
-                    providers_with_closest_common_ancestor = []
-                if common_ancestor_len == closest_common_ancestor_len:
-                    providers_with_closest_common_ancestor.append(provider)
-            providers[:] = providers_with_closest_common_ancestor
+
+                if common_ancestor_len < shortest_relative_path_len:
+                    shortest_relative_path_len = common_ancestor_len
+                    providers_with_shortest_relative_path = []
+                if common_ancestor_len == shortest_relative_path_len:
+                    providers_with_shortest_relative_path.append(provider)
+            providers[:] = providers_with_shortest_relative_path
 
     remaining_providers: list[ModuleProvider] = list(
         itertools.chain(*[val[1] for val in type_to_closest_providers.values()])


### PR DESCRIPTION
Currently, enabling `[python-infer].ambiguity_resolution = "by_source_root"` does not apply to protobuf dependencies, so one is stuck even if the regular imports are resolved. That leads to an error like this:

```
AmbiguousPythonCodegenRuntimeLibrary: Multiple `python_requirement` targets were found with the module `grpc` 
in your project for the resolve 'base', so it is ambiguous which to use for the runtime library for the Python code 
generated from the the target src/proto/hive:hive_v1_base: ['//:base#grpcio', 'src/py/auth:requirements-base#grpcio']
```
This PR helps solve this case as well, and also hints at users that this option exists[^1].

HOWEVER; I do not think what I'm doing here (or rather what locality does in general) is *right*, semantically. I think that we need no metric at all as long as resolves and lockfiles are used. Please tell me I'm wrong if this reasoning is invalid. But if we have resolves (and lockfiles) that to me implies that we can *only* run if lockfile-generation succeeded. If lockfile-generation succeeded that implies that all target for a specific dependency inside the resolve *agreed* to the point where a single version was found, and thus *any* target will be equally functional. The only ranking needed in that case is one that ensures we pick the "right" target to ensure cache consistency.

For now, I did opt to change the locality metric: Instead of checking the common path; I check the delta -- how many edits (by segments) we would need to make to get from the source root to the target, then pick the shortest one. I think as long as both paths are relative this is a better metric, but I'm happy to discuss it. In particular, it disambiguates the test-case I wrote for the protobuf fix, where the current variant says they are equal because the source root is also the root, so common path is `.`.

See [this thread on Slack](https://pantsbuild.slack.com/archives/C046T6T9U/p1695726211969259) for full context.

(Side note: Have some completely unrelated test issues locally, will see if that repros on CI... Some pex code I've definitely not touched or affected.) 

[^1]: I also wanted to add the hint to the regular dependency ambiguity warning, but that lives in Engine which made passing the hint inelegant. Might be some good way of achieving that too.
