### PR TITLE
Fix coursier download for arm64, bumps default to v2.1.6

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -109,22 +109,24 @@ class CoursierSubsystem(TemplatedExternalTool):
     name = "coursier"
     help = "A dependency resolver for the Maven ecosystem. (https://get-coursier.io/)"
 
-    default_version = "v2.1.0-M5-18-gfebf9838c"
+    default_version = "v2.1.6"
     default_known_versions = [
+        "v2.1.6|macos_arm64 |746b3e346fa2c0107fdbc8a627890d495cb09dee4f8dcc87146bdb45941088cf|20829782|https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.6/cs-aarch64-apple-darwin.gz",
+        "v2.1.6|linux_arm64 |33330ca433781c9db9458e15d2d32e5d795de3437771647e26835e8b1391af82|20899290|https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.6/cs-aarch64-pc-linux.gz",
+        "v2.1.6|linux_x86_64|af7234f8802107f5e1130307ef8a5cc90262d392f16ddff7dce27a4ed0ddd292|20681688",
+        "v2.1.6|macos_x86_64|36a5d42a0724be2ac39d0ebd8869b985e3d58ceb121bc60389ee2d6d7408dd56|20037412",
         "v2.1.0-M5-18-gfebf9838c|linux_arm64 |d4ad15ba711228041ad8a46d848c83c8fbc421d7b01c415d8022074dd609760f|19264005",
         "v2.1.0-M5-18-gfebf9838c|linux_x86_64|3e1a1ad1010d5582e9e43c5a26b273b0147baee5ebd27d3ac1ab61964041c90b|19551533",
-        "v2.1.0-M5-18-gfebf9838c|macos_arm64 |d13812c5a5ef4c9b3e25cc046d18addd09bacd149f95b20a14e4d2a73e358ecf|18826510",
         "v2.1.0-M5-18-gfebf9838c|macos_x86_64|d13812c5a5ef4c9b3e25cc046d18addd09bacd149f95b20a14e4d2a73e358ecf|18826510",
         "v2.0.16-169-g194ebc55c|linux_arm64 |da38c97d55967505b8454c20a90370c518044829398b9bce8b637d194d79abb3|18114472",
         "v2.0.16-169-g194ebc55c|linux_x86_64|4c61a634c4bd2773b4543fe0fc32210afd343692891121cddb447204b48672e8|18486946",
-        "v2.0.16-169-g194ebc55c|macos_arm64 |15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
         "v2.0.16-169-g194ebc55c|macos_x86_64|15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
     ]
     default_url_template = (
         "https://github.com/coursier/coursier/releases/download/{version}/cs-{platform}.gz"
     )
     default_url_platform_mapping = {
-        "macos_arm64": "x86_64-apple-darwin",
+        "macos_arm64": "aarch64-apple-darwin",
         "macos_x86_64": "x86_64-apple-darwin",
         "linux_arm64": "aarch64-pc-linux",
         "linux_x86_64": "x86_64-pc-linux",


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/19480

Coursier [recommends](https://get-coursier.io/docs/cli-installation#native-launcher) using https://github.com/VirtusLab/coursier-m1/releases for Arm64 for both Linux and MacOS.

https://github.com/coursier/coursier Does not have Arm64 artifacts in more recent releases and never had them for MacOS.

## Intended changes

- Bumps the default version to 2.1.6. The existing default known versions `v2.1.0-M5-18-gfebf9838c` and `v2.0.16-169-g194ebc55c` are not available at VirtusLab/coursier-m1 so we have to add a new version anyway. Chose the latest version listed in https://get-coursier.io/versions at the time of this writing.
- Remove default support for downloading `v2.1.0-M5-18-gfebf9838c` and `v2.0.16-169-g194ebc55c` for MacOS arm64.   It only worked with Rosetta, which is strange to consider as "working".

## Testing

So far I've just tested locally on my M1 mac. With this change, coursier download works fine.