### PR TITLE
Immediately invalidate written files in write_digest (Cherry-pick of #19903)

### DIFF
--- a/src/rust/engine/fs/src/directory.rs
+++ b/src/rust/engine/fs/src/directory.rs
@@ -608,6 +608,17 @@ impl DigestTrie {
     symlinks
   }
 
+  /// The paths of all "leaf" nodes of the DigestTrie: empty directories, files, or symlinks.
+  pub fn leaf_paths(&self) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    self.walk(SymlinkBehavior::Aware, &mut |path, entry| match entry {
+      Entry::Directory(d) if d.tree.0.is_empty() => paths.push(path.to_owned()),
+      Entry::Directory(_) => {}
+      Entry::File(_) | Entry::Symlink(_) => paths.push(path.to_owned()),
+    });
+    paths
+  }
+
   /// Visit every node in the tree, calling the given function with the path to the Node, and its
   /// entries.
   /// NOTE: if SymlinkBehavior::Oblivious, `f` will never be called with a `SymlinkEntry`.

--- a/src/rust/engine/fs/src/directory_tests.rs
+++ b/src/rust/engine/fs/src/directory_tests.rs
@@ -370,3 +370,25 @@ fn walk_too_many_links_subdir() {
     vec!["".to_string(), "a".to_string()],
   );
 }
+
+#[test]
+fn leaf_paths() {
+  let file = PathBuf::from("parent/file.txt");
+  let link = PathBuf::from("parent/link");
+  let empty_dir = PathBuf::from("empty_dir");
+  let tree = make_tree(vec![
+    TypedPath::File {
+      path: &file,
+      is_executable: false,
+    },
+    TypedPath::Link {
+      path: &link,
+      target: Path::new("file.txt"),
+    },
+    TypedPath::Dir(&empty_dir),
+  ]);
+
+  let leaf_paths = tree.leaf_paths();
+
+  assert_eq!(leaf_paths, vec![empty_dir, file, link])
+}

--- a/src/rust/engine/src/context.rs
+++ b/src/rust/engine/src/context.rs
@@ -23,7 +23,7 @@ use fs::{GitignoreStyleExcludes, PosixFS};
 use futures::FutureExt;
 use graph::{Graph, InvalidationResult};
 use hashing::Digest;
-use log::info;
+use log::{log, Level};
 use parking_lot::Mutex;
 // use docker::docker::{self, DOCKER, IMAGE_PULL_CACHE};
 use docker::docker;
@@ -40,7 +40,7 @@ use remote::{self, remote_cache};
 use rule_graph::RuleGraph;
 use store::{self, ImmutableInputs, RemoteOptions, Store};
 use task_executor::Executor;
-use watch::{Invalidatable, InvalidationWatcher};
+use watch::{Invalidatable, InvalidateCaller, InvalidationWatcher};
 use workunit_store::{Metric, RunningWorkunit};
 
 // The reqwest crate has no support for ingesting multiple certificates in a single file,
@@ -684,8 +684,20 @@ impl Core {
 
 pub struct InvalidatableGraph(Graph<NodeKey>);
 
+fn caller_to_logging_info(caller: InvalidateCaller) -> (Level, &'static str) {
+  match caller {
+    // An external invalidation is driven by some other pants operation, and thus isn't as
+    // interesting, there's likely to be output about that action already, hence this can be logged
+    // quieter.
+    InvalidateCaller::External => (Level::Debug, "external"),
+    // A notify invalidation may have been triggered by a user-driven action that isn't otherwise
+    // visible in logs (e.g. file editing, branch switching), hence log it louder.
+    InvalidateCaller::Notify => (Level::Info, "notify"),
+  }
+}
+
 impl Invalidatable for InvalidatableGraph {
-  fn invalidate(&self, paths: &HashSet<PathBuf>, caller: &str) -> usize {
+  fn invalidate(&self, paths: &HashSet<PathBuf>, caller: InvalidateCaller) -> usize {
     let InvalidationResult { cleared, dirtied } = self.invalidate_from_roots(false, move |node| {
       if let Some(fs_subject) = node.fs_subject() {
         paths.contains(fs_subject)
@@ -693,19 +705,28 @@ impl Invalidatable for InvalidatableGraph {
         false
       }
     });
-    info!(
+    let (level, caller) = caller_to_logging_info(caller);
+    log!(
+      level,
       "{} invalidation: cleared {} and dirtied {} nodes for: {:?}",
-      caller, cleared, dirtied, paths
+      caller,
+      cleared,
+      dirtied,
+      paths
     );
     cleared + dirtied
   }
 
-  fn invalidate_all(&self, caller: &str) -> usize {
+  fn invalidate_all(&self, caller: InvalidateCaller) -> usize {
     let InvalidationResult { cleared, dirtied } =
       self.invalidate_from_roots(false, |node| node.fs_subject().is_some());
-    info!(
+    let (level, caller) = caller_to_logging_info(caller);
+    log!(
+      level,
       "{} invalidation: cleared {} and dirtied {} nodes for all paths",
-      caller, cleared, dirtied
+      caller,
+      cleared,
+      dirtied
     );
     cleared + dirtied
   }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -1659,6 +1659,7 @@ fn write_digest(
     let lifted_digest = nodes::lift_directory_digest(digest).map_err(PyValueError::new_err)?;
 
     // Python will have already validated that path_prefix is a relative path.
+    let path_prefix = Path::new(&path_prefix);
     let mut destination = PathBuf::new();
     destination.push(&core.build_root);
     destination.push(path_prefix);
@@ -1674,17 +1675,34 @@ fn write_digest(
     }
 
     block_in_place_and_wait(py, || async move {
-      core
-        .store()
+      let store = core.store();
+      store
         .materialize_directory(
           destination.clone(),
           &core.build_root,
-          lifted_digest,
+          lifted_digest.clone(),
           true, // Force everything we write to be mutable
           &BTreeSet::new(),
           fs::Permissions::Writable,
         )
-        .await
+        .await?;
+
+      // Invalidate all the paths we've changed within `path_prefix`: both the paths we cleared and
+      // the files we've just written to.
+      let snapshot = store::Snapshot::from_digest(store, lifted_digest).await?;
+      let written_paths = snapshot.tree.leaf_paths();
+      let written_paths = written_paths.iter().map(|p| p as &Path);
+
+      let cleared_paths = clear_paths.iter().map(Path::new);
+
+      let changed_paths = written_paths
+        .chain(cleared_paths)
+        .map(|p| path_prefix.join(p))
+        .collect();
+
+      py_scheduler.0.invalidate_paths(&changed_paths);
+
+      Ok(())
     })
     .map_err(possible_store_missing_digest)
   })

--- a/src/rust/engine/src/scheduler.rs
+++ b/src/rust/engine/src/scheduler.rs
@@ -20,7 +20,7 @@ use crate::session::{ObservedValueResult, Root, Session};
 
 use graph::LastObserved;
 use ui::ConsoleUI;
-use watch::Invalidatable;
+use watch::{Invalidatable, InvalidateCaller};
 
 pub enum ExecutionTermination {
   // Raised as a vanilla keyboard interrupt on the python side.
@@ -99,14 +99,17 @@ impl Scheduler {
   /// Invalidate the invalidation roots represented by the given Paths.
   ///
   pub fn invalidate_paths(&self, paths: &HashSet<PathBuf>) -> usize {
-    self.core.graph.invalidate(paths, "external")
+    self
+      .core
+      .graph
+      .invalidate(paths, InvalidateCaller::External)
   }
 
   ///
   /// Invalidate all filesystem dependencies in the graph.
   ///
   pub fn invalidate_all_paths(&self) -> usize {
-    self.core.graph.invalidate_all("external")
+    self.core.graph.invalidate_all(InvalidateCaller::External)
   }
 
   ///

--- a/src/rust/engine/watch/src/lib.rs
+++ b/src/rust/engine/watch/src/lib.rs
@@ -259,10 +259,10 @@ impl InvalidationWatcher {
 
     if flag == Some(Flag::Rescan) {
       debug!("notify queue overflowed: invalidating all paths");
-      invalidatable.invalidate_all("notify");
+      invalidatable.invalidate_all(InvalidateCaller::Notify);
     } else if !paths.is_empty() {
       debug!("notify invalidating {:?} because of {:?}", paths, ev.kind);
-      invalidatable.invalidate(&paths, "notify");
+      invalidatable.invalidate(&paths, InvalidateCaller::Notify);
     }
   }
 
@@ -325,9 +325,14 @@ impl InvalidationWatcher {
   }
 }
 
+pub enum InvalidateCaller {
+  External,
+  Notify,
+}
+
 pub trait Invalidatable: Send + Sync + 'static {
-  fn invalidate(&self, paths: &HashSet<PathBuf>, caller: &str) -> usize;
-  fn invalidate_all(&self, caller: &str) -> usize;
+  fn invalidate(&self, paths: &HashSet<PathBuf>, caller: InvalidateCaller) -> usize;
+  fn invalidate_all(&self, caller: InvalidateCaller) -> usize;
 }
 
 ///

--- a/src/rust/engine/watch/src/tests.rs
+++ b/src/rust/engine/watch/src/tests.rs
@@ -1,6 +1,6 @@
 // Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
-use crate::{Invalidatable, InvalidationWatcher};
+use crate::{Invalidatable, InvalidateCaller, InvalidationWatcher};
 
 use std::collections::HashSet;
 use std::fs::create_dir;
@@ -154,14 +154,14 @@ impl TestInvalidatable {
 }
 
 impl Invalidatable for TestInvalidatable {
-  fn invalidate(&self, paths: &HashSet<PathBuf>, _caller: &str) -> usize {
+  fn invalidate(&self, paths: &HashSet<PathBuf>, _caller: InvalidateCaller) -> usize {
     let invalidated = paths.len();
     let mut calls = self.calls.lock();
     calls.push(paths.clone());
     invalidated
   }
 
-  fn invalidate_all(&self, _caller: &str) -> usize {
+  fn invalidate_all(&self, _caller: InvalidateCaller) -> usize {
     unimplemented!();
   }
 }


### PR DESCRIPTION
This ensures that files changed by `write_digest` are immediately flagged as changed/invalidated, for any follow-on processing, by invalidating them in the graph as part of the write.

Previously, `write_digest` just changed files directly, and we were relying on file-change notifications to make the graph aware of those changes, but this is racy: a command like `pants fmt lint ::` will write any formatting changes as part of `fmt` and immediately run `lint`, hopefully on those files... if the `lint` call happens soon enough, it'll run before the graph is aware of the changed files, and give incorrect results.

This fixes #19897

