### PR TITLE
Fetch shellcheck from vscode-shellcheck for M1 support (Cherry-pick of #19945)

### DIFF
--- a/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shellcheck/subsystem.py
@@ -20,18 +20,21 @@ class Shellcheck(TemplatedExternalTool):
 
     default_version = "v0.8.0"
     default_known_versions = [
-        "v0.8.0|macos_arm64 |e065d4afb2620cc8c1d420a9b3e6243c84ff1a693c1ff0e38f279c8f31e86634|4049756",
-        "v0.8.0|macos_x86_64|e065d4afb2620cc8c1d420a9b3e6243c84ff1a693c1ff0e38f279c8f31e86634|4049756",
-        "v0.8.0|linux_arm64 |9f47bbff5624babfa712eb9d64ece14c6c46327122d0c54983f627ae3a30a4ac|2996468",
-        "v0.8.0|linux_x86_64|ab6ee1b178f014d1b86d1e24da20d1139656c8b0ed34d2867fbb834dad02bf0a|1403852",
+        "v0.8.0|macos_arm64 |36dffd536b801c8bab2e9fa468163037e0c7f7e0a05298e5ad6299b4dde67e31|14525367",
+        "v0.8.0|macos_x86_64|4e93a76ee116b2f08c88e25011830280ad0d61615d8346364a4ea564b29be3f0|6310442",
+        "v0.8.0|linux_arm64 |8f4810485425636eadce2ec23441fd29d5b1b58d239ffda0a5faf8dd499026f5|4884430",
+        "v0.8.0|linux_x86_64|01d181787ffe63ebb0a2293f63bdc8455c5c30d3a6636320664bfa278424638f|2082242",
     ]
 
+    # We use this third party source since it has pre-compiled binaries for both x86 and aarch.
+    # It is recommended by shellcheck
+    # https://github.com/koalaman/shellcheck/blob/90d3172dfec30a7569f95b32479ae97af73b8b2e/README.md?plain=1#L236-L237
     default_url_template = (
-        "https://github.com/koalaman/shellcheck/releases/download/{version}/shellcheck-"
-        "{version}.{platform}.tar.xz"
+        "https://github.com/vscode-shellcheck/shellcheck-binaries/releases/download/{version}/shellcheck-"
+        "{version}.{platform}.tar.gz"
     )
     default_url_platform_mapping = {
-        "macos_arm64": "darwin.x86_64",
+        "macos_arm64": "darwin.aarch64",
         "macos_x86_64": "darwin.x86_64",
         "linux_arm64": "linux.aarch64",
         "linux_x86_64": "linux.x86_64",
@@ -52,7 +55,7 @@ class Shellcheck(TemplatedExternalTool):
     )
 
     def generate_exe(self, _: Platform) -> str:
-        return f"./shellcheck-{self.version}/shellcheck"
+        return "./shellcheck"
 
     def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
         # Refer to https://www.mankier.com/1/shellcheck#RC_Files for how config files are


### PR DESCRIPTION
Fixes #18589 

https://github.com/pantsbuild/pants/issues/18589#issuecomment-1737616128
> Shellcheck is available from VSCode: https://github.com/vscode-shellcheck/shellcheck-binaries/releases
> 
> and this is the recommendation of shellcheck itself:
> 
> https://github.com/koalaman/shellcheck/blob/90d3172dfec30a7569f95b32479ae97af73b8b2e/README.md?plain=1#L236-L237
> 
> > There are currently no official binaries for Apple Silicon, but third party builds are available via [ShellCheck for Visual Studio Code](https://github.com/vscode-shellcheck/shellcheck-binaries/releases).
> 

## Testing

This has fixed shellcheck in my local env without the need for rosetta.
