### PR TITLE
add support for mTLS in remote cache usage (Cherry-pick of #19887)

### DIFF
--- a/docs/markdown/Using Pants/remote-caching-execution/remote-execution.md
+++ b/docs/markdown/Using Pants/remote-caching-execution/remote-execution.md
@@ -5,7 +5,7 @@ hidden: false
 createdAt: "2020-11-13T23:44:25.806Z"
 ---
 > 🚧 Remote execution support is still experimental
-> 
+>
 > Remote execution support in Pants comes with several limitations. For example, Pants requires that the server's operating system match the client's operating system. In practice, this means that Pants must be running on Linux because all three major server projects generally only operate on Linux.
 
 What is remote execution?
@@ -91,6 +91,9 @@ remote_execution_address = "grpcs://build.example.com:443"
 remote_instance_name = "main"
 # This is optional, Pants will auto-discover certificates otherwise.
 remote_ca_certs_path = "/etc/ssl/certs/ca-certificates.crt"
+# this allows you to setup client authentication with a certificate and key (mTLS).
+remote_client_certs_path = "/etc/ssl/certs/client-cert.pem"
+remote_client_key_path = "/etc/ssl/certs/client-key.pem"
 ```
 
 Reference

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -197,6 +197,8 @@ class Scheduler:
             execution_process_cache_namespace=execution_options.process_execution_cache_namespace,
             instance_name=execution_options.remote_instance_name,
             root_ca_certs_path=execution_options.remote_ca_certs_path,
+            client_certs_path=execution_options.remote_client_certs_path,
+            client_key_path=execution_options.remote_client_key_path,
             append_only_caches_base_path=execution_options.remote_execution_append_only_caches_base_path,
         )
         py_local_store_options = PyLocalStoreOptions(

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -485,6 +485,8 @@ class ExecutionOptions:
 
     remote_instance_name: str | None
     remote_ca_certs_path: str | None
+    remote_client_certs_path: str | None
+    remote_client_key_path: str | None
 
     keep_sandboxes: KeepSandboxes
     local_cache: bool
@@ -540,6 +542,8 @@ class ExecutionOptions:
             # General remote setup.
             remote_instance_name=dynamic_remote_options.instance_name,
             remote_ca_certs_path=bootstrap_options.remote_ca_certs_path,
+            remote_client_certs_path=bootstrap_options.remote_client_certs_path,
+            remote_client_key_path=bootstrap_options.remote_client_key_path,
             # Process execution setup.
             keep_sandboxes=GlobalOptions.resolve_keep_sandboxes(bootstrap_options),
             local_cache=bootstrap_options.local_cache,
@@ -624,6 +628,8 @@ DEFAULT_EXECUTION_OPTIONS = ExecutionOptions(
     # General remote setup.
     remote_instance_name=None,
     remote_ca_certs_path=None,
+    remote_client_certs_path=None,
+    remote_client_key_path=None,
     # Process execution setup.
     process_total_child_memory_usage=None,
     process_per_child_memory_usage=memory_size(_PER_CHILD_MEMORY_USAGE),
@@ -1404,6 +1410,35 @@ class BootstrapOptions:
             """
         ),
     )
+    remote_client_certs_path = StrOption(
+        default=None,
+        advanced=True,
+        help=softwrap(
+            """
+            Path to a PEM file containing client certificates used for verifying secure connections to
+            `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address` when using
+            client authentication (mTLS).
+
+            If unspecified, will use regular TLS. Requires `remote_client_key_path` to also be
+            specified.
+            """
+        ),
+    )
+
+    remote_client_key_path = StrOption(
+        default=None,
+        advanced=True,
+        help=softwrap(
+            """
+            Path to a PEM file containing a private key used for verifying secure connections to
+            `[GLOBAL].remote_execution_address` and `[GLOBAL].remote_store_address` when using
+            client authentication (mTLS).
+
+            If unspecified, will use regular TLS. Requires `remote_client_certs_path` to also be
+            specified.
+            """
+        ),
+    )
     remote_oauth_bearer_token_path = StrOption(
         default=None,
         advanced=True,
@@ -1846,6 +1881,18 @@ class GlobalOptions(BootstrapOptions, Subsystem):
 
         validate_remote_headers("remote_execution_headers")
         validate_remote_headers("remote_store_headers")
+
+        is_remote_client_key_set = opts.remote_client_key_path is not None
+        is_remote_client_certs_set = opts.remote_client_certs_path is not None
+        if is_remote_client_key_set != is_remote_client_certs_set:
+            raise OptionsError(
+                softwrap(
+                    """
+                    `--remote-client-key-path` and `--remote-client-certs-path` must be specified
+                    together.
+                    """
+                )
+            )
 
         illegal_build_ignores = [i for i in opts.build_ignore if i.startswith("!")]
         if illegal_build_ignores:

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1410,6 +1410,7 @@ dependencies = [
  "hyper-rustls 0.24.1",
  "itertools",
  "lazy_static",
+ "log",
  "parking_lot 0.12.1",
  "pin-project",
  "pin-project-lite",

--- a/src/rust/engine/fs/brfs/src/main.rs
+++ b/src/rust/engine/fs/brfs/src/main.rs
@@ -763,6 +763,14 @@ async fn main() {
 
   let runtime = task_executor::Executor::new();
 
+  let tls_config = match tls::Config::new(root_ca_certs, None) {
+    Ok(tls_config) => tls_config,
+    Err(err) => {
+      error!("Error when creating TLS configuration: {err:?}");
+      std::process::exit(1);
+    }
+  };
+
   let local_only_store =
     Store::local_only(runtime.clone(), store_path).expect("Error making local store.");
   let store = match args.value_of("server-address") {
@@ -770,7 +778,7 @@ async fn main() {
       .into_with_remote(RemoteOptions {
         cas_address: address.to_owned(),
         instance_name: args.value_of("remote-instance-name").map(str::to_owned),
-        tls_config: tls::Config::new_without_mtls(root_ca_certs),
+        tls_config,
         headers,
         chunk_size_bytes: 4 * 1024 * 1024,
         rpc_timeout: std::time::Duration::from_secs(5 * 60),

--- a/src/rust/engine/fs/fs_util/src/main.rs
+++ b/src/rust/engine/fs/fs_util/src/main.rs
@@ -41,7 +41,7 @@ use fs::{
 use futures::future::{self, BoxFuture};
 use futures::FutureExt;
 use grpc_util::prost::MessageExt;
-use grpc_util::tls::{CertificateCheck, MtlsConfig};
+use grpc_util::tls::CertificateCheck;
 use hashing::{Digest, Fingerprint};
 use parking_lot::Mutex;
 use protos::require_digest;
@@ -267,14 +267,14 @@ Destination must not exist before this command is run.",
         )
         .arg(
           Arg::new("mtls-client-certificate-chain-path")
-              .help("Path to certificate chain to use when using MTLS.")
+              .help("Path to certificate chain to use when using mTLS.")
               .takes_value(true)
               .long("mtls-client-certificate-chain-path")
               .required(false)
         )
         .arg(
           Arg::new("mtls-client-key-path")
-              .help("Path to private key to use when using MTLS.")
+              .help("Path to private key to use when using mTLS.")
               .takes_value(true)
               .long("mtls-client-key-path")
               .required(false)
@@ -369,7 +369,7 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
                 "Failed to read mtls-client-certificate-chain-path from {cert_chain_path:?}: {err:?}"
               )
             })?;
-            Some(MtlsConfig { key, cert_chain })
+            Some((cert_chain, key))
           }
           (None, None) => None,
           _ => {
@@ -383,11 +383,9 @@ async fn execute(top_match: &clap::ArgMatches) -> Result<(), ExitError> {
           CertificateCheck::Enabled
         };
 
-        let tls_config = grpc_util::tls::Config {
-          root_ca_certs,
-          mtls,
-          certificate_check,
-        };
+        let mut tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls)?;
+
+        tls_config.certificate_check = certificate_check;
 
         let mut headers = BTreeMap::new();
 

--- a/src/rust/engine/grpc_util/Cargo.toml
+++ b/src/rust/engine/grpc_util/Cargo.toml
@@ -9,18 +9,19 @@ publish = false
 bytes = { workspace = true }
 either = { workspace = true }
 futures = { workspace = true }
-hyper = { workspace = true }
-hyper-rustls = { workspace = true, features = ["http2"] }
 http = { workspace = true }
 http-body = { workspace = true }
+hyper = { workspace = true }
+hyper-rustls = { workspace = true, features = ["http2"] }
 itertools = { workspace = true }
-rustls-native-certs = { workspace = true }
 lazy_static = { workspace = true }
+log = { workspace = true }
 pin-project = { workspace = true }
 pin-project-lite = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
 rustls = { workspace = true, features = ["dangerous_configuration", 'logging'] }
+rustls-native-certs = { workspace = true }
 rustls-pemfile = { workspace = true }
 tokio = { workspace = true, features = ["net", "process", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = { workspace = true }

--- a/src/rust/engine/grpc_util/src/tls.rs
+++ b/src/rust/engine/grpc_util/src/tls.rs
@@ -8,18 +8,34 @@ use tokio_rustls::rustls::{Certificate, ClientConfig, Error, RootCertStore, Serv
 
 #[derive(Default, Clone)]
 pub struct Config {
-  pub root_ca_certs: Option<Vec<u8>>,
+  pub root_ca_certs: Option<Vec<Certificate>>,
   pub mtls: Option<MtlsConfig>,
   pub certificate_check: CertificateCheck,
 }
 
 impl Config {
-  pub fn new_without_mtls(root_ca_certs: Option<Vec<u8>>) -> Self {
-    Self {
+  /// Creates a new config with the given root CA certs and mTLS config.
+  pub fn new<Buf: AsRef<[u8]>>(
+    root_ca_certs: Option<Buf>,
+    mtls: Option<(Buf, Buf)>,
+  ) -> Result<Self, String> {
+    let root_ca_certs = root_ca_certs
+      .map(|certs| {
+        let raw_certs = rustls_pemfile::certs(&mut std::io::Cursor::new(certs.as_ref()))
+          .map_err(|e| format!("Failed to parse TLS certs data: {e:?}"))?;
+        Result::<_, String>::Ok(raw_certs.into_iter().map(rustls::Certificate).collect())
+      })
+      .transpose()?;
+
+    let mtls = mtls
+      .map(|buffers| MtlsConfig::from_pem_buffers(buffers.0.as_ref(), buffers.1.as_ref()))
+      .transpose()?;
+
+    Ok(Self {
       root_ca_certs,
-      mtls: None,
+      mtls,
       certificate_check: CertificateCheck::Enabled,
-    }
+    })
   }
 }
 
@@ -33,71 +49,106 @@ impl TryFrom<Config> for ClientConfig {
     let tls_config = ClientConfig::builder().with_safe_defaults();
 
     // Add the root certificate store.
-    let mut tls_config = match config.certificate_check {
+    let tls_config = match config.certificate_check {
       CertificateCheck::DangerouslyDisabled => {
         let tls_config = tls_config.with_custom_certificate_verifier(Arc::new(NoVerifier));
-        if let Some(MtlsConfig { key, cert_chain }) = config.mtls {
+        if let Some(MtlsConfig { cert_chain, key }) = config.mtls {
           tls_config
-            .with_client_auth_cert(
-              cert_chain_from_pem_bytes(cert_chain)?,
-              der_key_from_pem_bytes(key)?,
-            )
-            .map_err(|err| format!("Error creating MTLS config: {:?}", err))?
+            .with_client_auth_cert(cert_chain, key)
+            .map_err(|err| format!("Error setting client authentication configuration: {err:?}"))?
         } else {
           tls_config.with_no_client_auth()
         }
       }
       CertificateCheck::Enabled => {
-        let tls_config = match config.root_ca_certs {
-          Some(pem_bytes) => {
-            let reader = std::io::Cursor::new(pem_bytes);
-            let mut reader = std::io::BufReader::new(reader);
-            let certs = rustls_pemfile::certs(&mut reader)
-              .map_err(|err| format!("Failed to read PEM certificate: {err}"))?;
-            let mut root_cert_store = RootCertStore::empty();
-            root_cert_store.add_parsable_certificates(&certs);
-            tls_config.with_root_certificates(root_cert_store)
-          }
-          None => {
-            let native_root_certs = rustls_native_certs::load_native_certs().map_err(|err| {
-              format!(
+        let tls_config = {
+          let mut root_cert_store = RootCertStore::empty();
+
+          match config.root_ca_certs {
+            Some(certs) => {
+              for cert in &certs {
+                root_cert_store
+                  .add(cert)
+                  .map_err(|e| format!("failed adding CA cert to store: {e:?}"))?;
+              }
+            }
+            None => {
+              let native_root_certs = rustls_native_certs::load_native_certs().map_err(|err| {
+                format!(
                 "Could not discover root CA cert files to use TLS with remote caching and remote \
             execution. Consider setting `--remote-ca-certs-path` instead to explicitly point to \
             the correct PEM file.\n\n{err}",
               )
-            })?;
-            let mut root_cert_store = RootCertStore::empty();
-            for cert in native_root_certs {
-              root_cert_store.add_parsable_certificates(&[cert.0]);
+              })?;
+
+              for cert in native_root_certs {
+                root_cert_store.add_parsable_certificates(&[cert.0]);
+              }
             }
-            tls_config.with_root_certificates(root_cert_store)
           }
+
+          tls_config.with_root_certificates(root_cert_store)
         };
 
-        if let Some(MtlsConfig { key, cert_chain }) = config.mtls {
+        if let Some(MtlsConfig { cert_chain, key }) = config.mtls {
           tls_config
-            .with_client_auth_cert(
-              cert_chain_from_pem_bytes(cert_chain)?,
-              der_key_from_pem_bytes(key)?,
-            )
-            .map_err(|err| format!("Error creating MTLS config: {:?}", err))?
+            .with_client_auth_cert(cert_chain, key)
+            .map_err(|err| format!("Error setting client authentication configuration: {err:?}"))?
         } else {
           tls_config.with_no_client_auth()
         }
       }
     };
 
-    tls_config.alpn_protocols = vec![b"h2".to_vec()];
     Ok(tls_config)
   }
 }
 
 #[derive(Clone)]
 pub struct MtlsConfig {
-  /// PEM bytes of the private key used for MTLS.
-  pub key: Vec<u8>,
-  /// PEM bytes of the certificate used for MTLS.
-  pub cert_chain: Vec<u8>,
+  /// DER bytes of the certificate used for mTLS.
+  pub cert_chain: Vec<rustls::Certificate>,
+  /// DER bytes of the private key used for mTLS.
+  pub key: rustls::PrivateKey,
+}
+
+impl MtlsConfig {
+  pub fn from_pem_buffers(certs: &[u8], key: &[u8]) -> Result<Self, String> {
+    let cert_chain = rustls_pemfile::certs(&mut std::io::Cursor::new(certs))
+      .map_err(|e| format!("Failed to parse client authentication (mTLS) certs data: {e:?}"))?
+      .into_iter()
+      .map(rustls::Certificate)
+      .collect();
+
+    let keys = rustls_pemfile::read_all(&mut std::io::Cursor::new(key))
+      .map_err(|e| format!("Failed to parse client authentication (mTLS) key data: {e:?}"))?
+      .into_iter()
+      .filter(|item| match item {
+        rustls_pemfile::Item::X509Certificate(_) => {
+          log::warn!("Found x509 certificate in client authentication (mTLS) key data. Ignoring.");
+          false
+        }
+        _ => true,
+      });
+
+    let mut key = None;
+    for item in keys {
+      use rustls_pemfile::Item;
+
+      match item {
+        Item::RSAKey(buf) | Item::PKCS8Key(buf) | Item::ECKey(buf) => {
+          key = Some(rustls::PrivateKey(buf))
+        }
+        Item::X509Certificate(_) => unreachable!("filtered above"),
+        _ => unreachable!("rustls_pemfile::read_all returned an unexpected item"),
+      }
+    }
+
+    let key = key
+      .ok_or_else(|| "No private key found in client authentication (mTLS) key data".to_owned())?;
+
+    Ok(Self { cert_chain, key })
+  }
 }
 
 #[derive(Clone)]
@@ -128,32 +179,53 @@ impl ServerCertVerifier for NoVerifier {
   }
 }
 
-fn cert_chain_from_pem_bytes(cert_chain: Vec<u8>) -> Result<Vec<rustls::Certificate>, String> {
-  rustls_pemfile::certs(&mut cert_chain.as_slice())
-    .and_then(|certs| {
-      certs
-        .into_iter()
-        .map(|cert| Ok(rustls::Certificate(cert)))
-        .collect::<Result<Vec<_>, _>>()
-    })
-    .map_err(|err| format!("Failed to parse certificates from PEM file {err:?}"))
-}
+#[cfg(test)]
+mod test {
+  use super::Config;
+  use std::path::PathBuf;
 
-fn der_key_from_pem_bytes(pem_bytes: Vec<u8>) -> Result<tokio_rustls::rustls::PrivateKey, String> {
-  let key = rustls_pemfile::read_one(&mut pem_bytes.as_slice())
-    .map_err(|err| format!("Failed to read PEM file: {err:?}"))?
-    .ok_or_else(|| "No private key found in PEM file".to_owned())?;
-  use rustls_pemfile::Item;
-  let key = match key {
-    Item::RSAKey(bytes) => bytes,
-    Item::PKCS8Key(bytes) => bytes,
-    Item::X509Certificate(_) => {
-      return Err("Found certificate in PEM file but expected private key".to_owned())
-    }
-    Item::ECKey(_) => {
-      return Err("EC certificate not currently supported. Contact Pantsbuild Slack.".to_owned())
-    }
-    _ => return Err("Unknown entry in PEM file. Contact Pantsbuild Slack.".to_owned()),
-  };
-  Ok(rustls::PrivateKey(key))
+  #[test]
+  fn test_client_auth_cert_resolver_is_unconfigured_no_mtls() {
+    let cert_pem = std::fs::read(
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test-certs")
+        .join("cert.pem"),
+    )
+    .unwrap();
+
+    let config = Config::new(Some(&cert_pem), None).unwrap();
+
+    assert!(config.root_ca_certs.is_some());
+    assert!(config.mtls.is_none());
+
+    let rustls_config: rustls::ClientConfig = config.try_into().unwrap();
+
+    assert!(!rustls_config.client_auth_cert_resolver.has_certs());
+  }
+
+  #[test]
+  fn test_client_auth_cert_resolver_is_configured() {
+    let cert_pem = std::fs::read(
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test-certs")
+        .join("cert.pem"),
+    )
+    .unwrap();
+
+    let key_pem = std::fs::read(
+      PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("test-certs")
+        .join("key.pem"),
+    )
+    .unwrap();
+
+    let config = Config::new(Some(&cert_pem), Some((&cert_pem, &key_pem))).unwrap();
+
+    assert!(config.root_ca_certs.is_some());
+    assert!(config.mtls.is_some());
+
+    let rustls_config: rustls::ClientConfig = config.try_into().unwrap();
+
+    assert!(rustls_config.client_auth_cert_resolver.has_certs());
+  }
 }

--- a/src/rust/engine/process_execution/remote/src/remote.rs
+++ b/src/rust/engine/process_execution/remote/src/remote.rs
@@ -165,6 +165,7 @@ impl CommandRunner {
     process_cache_namespace: Option<String>,
     append_only_caches_base_path: Option<String>,
     root_ca_certs: Option<Vec<u8>>,
+    mtls_data: Option<(Vec<u8>, Vec<u8>)>,
     headers: BTreeMap<String, String>,
     store: Store,
     executor: Executor,
@@ -173,19 +174,18 @@ impl CommandRunner {
     execution_concurrency_limit: usize,
     capabilities_cell_opt: Option<Arc<OnceCell<ServerCapabilities>>>,
   ) -> Result<Self, String> {
-    let execution_use_tls = execution_address.starts_with("https://");
+    let needs_tls = execution_address.starts_with("https://");
 
-    let tls_client_config = if execution_use_tls {
-      Some(grpc_util::tls::Config::new_without_mtls(root_ca_certs).try_into()?)
+    let tls_client_config = if needs_tls {
+      let tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls_data)?;
+      Some(tls_config.try_into()?)
     } else {
       None
     };
 
-    let execution_endpoint = grpc_util::create_channel(
-      execution_address,
-      tls_client_config.as_ref().filter(|_| execution_use_tls),
-    )
-    .await?;
+    let execution_endpoint =
+      grpc_util::create_channel(execution_address, tls_client_config.as_ref()).await?;
+
     let execution_http_headers = headers_to_http_header_map(&headers)?;
     let execution_channel = layered_service(
       execution_endpoint,

--- a/src/rust/engine/process_execution/remote/src/remote_cache.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache.rs
@@ -60,6 +60,7 @@ pub struct RemoteCacheProviderOptions {
   pub instance_name: Option<String>,
   pub action_cache_address: String,
   pub root_ca_certs: Option<Vec<u8>>,
+  pub mtls_data: Option<(Vec<u8>, Vec<u8>)>,
   pub headers: BTreeMap<String, String>,
   pub concurrency_limit: usize,
   pub rpc_timeout: Duration,

--- a/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache/reapi.rs
@@ -29,13 +29,18 @@ impl Provider {
       instance_name,
       action_cache_address,
       root_ca_certs,
+      mtls_data,
       headers,
       concurrency_limit,
       rpc_timeout,
     }: RemoteCacheProviderOptions,
   ) -> Result<Self, String> {
-    let tls_client_config = if action_cache_address.starts_with("https://") {
-      Some(grpc_util::tls::Config::new_without_mtls(root_ca_certs).try_into()?)
+    let needs_tls = action_cache_address.starts_with("https://");
+
+    let tls_client_config = if needs_tls {
+      let tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls_data)?;
+
+      Some(tls_config.try_into()?)
     } else {
       None
     };

--- a/src/rust/engine/process_execution/remote/src/remote_cache/reapi_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache/reapi_tests.rs
@@ -14,6 +14,7 @@ async fn new_provider(cas: &StubCAS) -> Provider {
     instance_name: None,
     action_cache_address: cas.address(),
     root_ca_certs: None,
+    mtls_data: None,
     headers: BTreeMap::new(),
     concurrency_limit: 256,
     rpc_timeout: Duration::from_secs(2),

--- a/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_cache_tests.rs
@@ -166,6 +166,7 @@ async fn create_cached_runner(
         instance_name: None,
         action_cache_address: store_setup.cas.address(),
         root_ca_certs: None,
+        mtls_data: None,
         headers: BTreeMap::default(),
         concurrency_limit: 256,
         rpc_timeout: CACHE_READ_TIMEOUT,
@@ -766,6 +767,8 @@ async fn make_action_result_basic() {
       instance_name: None,
       action_cache_address: cas.address(),
       root_ca_certs: None,
+      mtls_data: None,
+
       headers: BTreeMap::default(),
       concurrency_limit: 256,
       rpc_timeout: CACHE_READ_TIMEOUT,

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -1318,6 +1318,7 @@ async fn sends_headers() {
     None,
     None,
     None,
+    None,
     btreemap! {
       String::from("cat") => String::from("roland"),
       String::from("authorization") => String::from("Bearer catnip-will-get-you-anywhere"),
@@ -1471,6 +1472,7 @@ async fn ensure_inline_stdio_is_stored() {
 
   let cmd_runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -1846,6 +1848,7 @@ async fn execute_missing_file_uploads_if_known() {
     None,
     None,
     None,
+    None,
     BTreeMap::new(),
     store.clone(),
     task_executor::Executor::new(),
@@ -1894,6 +1897,7 @@ async fn execute_missing_file_errors_if_unknown() {
 
   let runner = CommandRunner::new(
     &mock_server.address(),
+    None,
     None,
     None,
     None,
@@ -2601,6 +2605,7 @@ async fn create_command_runner(
   let store = make_store(store_dir.path(), cas, runtime).await;
   let command_runner = CommandRunner::new(
     &execution_address,
+    None,
     None,
     None,
     None,

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -170,6 +170,16 @@ struct Opt {
   #[structopt(long)]
   cas_root_ca_cert_file: Option<PathBuf>,
 
+  /// Path to file containing client certificates for the CAS server.
+  /// If not set, client authentication will not be used when connecting to the CAS server.
+  #[structopt(long)]
+  cas_client_certs_file: Option<PathBuf>,
+
+  /// Path to file containing client key for the CAS server.
+  /// If not set, client authentication will not be used when connecting to the CAS server.
+  #[structopt(long)]
+  cas_client_key_file: Option<PathBuf>,
+
   /// Path to file containing oauth bearer token for communication with the CAS server.
   /// If not set, no authorization will be provided to remote servers.
   #[structopt(long)]
@@ -242,6 +252,24 @@ async fn main() {
         .as_ref()
         .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
 
+      let client_certs = args
+        .cas_client_certs_file
+        .as_ref()
+        .map(|path| std::fs::read(path).expect("Error reading client authentication certs file"));
+
+      let client_key = args
+        .cas_client_key_file
+        .as_ref()
+        .map(|path| std::fs::read(path).expect("Error reading client authentication key file"));
+
+      let mtls_data = match (client_certs, client_key) {
+        (Some(certs), Some(key)) => Some((certs, key)),
+        (None, None) => None,
+        _ => {
+          panic!("Must specify both --cas-client-certs-file and --cas-client-key-file or neither")
+        }
+      };
+
       let mut headers = BTreeMap::new();
       if let Some(ref oauth_path) = args.cas_oauth_bearer_token_path {
         let token =
@@ -252,11 +280,14 @@ async fn main() {
         );
       }
 
+      let tls_config = grpc_util::tls::Config::new(root_ca_certs, mtls_data)
+        .expect("failed parsing root CA certs");
+
       local_only_store
         .into_with_remote(RemoteOptions {
           cas_address: cas_server.to_owned(),
           instance_name: args.remote_instance_name.clone(),
-          tls_config: grpc_util::tls::Config::new_without_mtls(root_ca_certs),
+          tls_config,
           headers,
           chunk_size_bytes: args.upload_chunk_bytes,
           rpc_timeout: Duration::from_secs(30),
@@ -292,6 +323,24 @@ async fn main() {
         .execution_root_ca_cert_file
         .map(|path| std::fs::read(path).expect("Error reading root CA certs file"));
 
+      let client_certs = args
+        .cas_client_certs_file
+        .as_ref()
+        .map(|path| std::fs::read(path).expect("Error reading root client certs file"));
+
+      let client_key = args
+        .cas_client_key_file
+        .as_ref()
+        .map(|path| std::fs::read(path).expect("Error reading client authentication key file"));
+
+      let mtls_data = match (client_certs, client_key) {
+        (Some(certs), Some(key)) => Some((certs, key)),
+        (None, None) => None,
+        _ => {
+          panic!("Must specify both --cas-client-certs-file and --cas-client-key-file or neither")
+        }
+      };
+
       if let Some(oauth_path) = args.execution_oauth_bearer_token_path {
         let token =
           std::fs::read_to_string(oauth_path).expect("Error reading oauth bearer token file");
@@ -307,6 +356,7 @@ async fn main() {
         process_metadata.cache_key_gen_version.clone(),
         None,
         root_ca_certs.clone(),
+        mtls_data.clone(),
         headers.clone(),
         store.clone(),
         executor.clone(),
@@ -339,6 +389,7 @@ async fn main() {
               instance_name: process_metadata.instance_name.clone(),
               action_cache_address: address,
               root_ca_certs,
+              mtls_data,
               headers,
               concurrency_limit: args.cache_rpc_concurrency,
               rpc_timeout: Duration::from_secs(2),

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -320,6 +320,8 @@ impl PyRemotingOptions {
     execution_process_cache_namespace: Option<String>,
     instance_name: Option<String>,
     root_ca_certs_path: Option<PathBuf>,
+    client_certs_path: Option<PathBuf>,
+    client_key_path: Option<PathBuf>,
     append_only_caches_base_path: Option<String>,
   ) -> Self {
     Self(RemotingOptions {
@@ -329,6 +331,8 @@ impl PyRemotingOptions {
       execution_process_cache_namespace,
       instance_name,
       root_ca_certs_path,
+      client_certs_path,
+      client_key_path,
       store_headers,
       store_chunk_bytes,
       store_rpc_retries,


### PR DESCRIPTION
This PR adds support for mTLS when using remote caching. The API is fairly similar to what we've already have, but I've taken the liberty of doing some type cleanups. I also did some refactoring of the tls setup code to move some earliers to parse-time rather than conversion time, and simplify a bit.

I also found a bug with the `alpn` config, which isn't actually valid -- hyper just barfs when that is defined. Not sure how no-one else is hitting that, but it is what it is. Maybe a version/release issue. Comes from here: https://github.com/rustls/hyper-rustls/blob/163b3f539a497ae9c4fa65f55a8133234ef33eb3/src/connector/builder.rs#L46-L51.

I unfortunately don't have any non-mTLS cache to test against, so would love if someone else can test that I haven't broken something there.

(I need to figure out how to easily test-drive this in CI etc; right now I can only validate this works to read/write locally. Otherwise I guess I can test it for real in 2.19 :( )
