### PR TITLE
 Pin manylinux image to avoid openssl error

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -368,7 +368,7 @@ jobs:
     timeout-minutes: 90
   build_wheels_linux_x86_64:
     container:
-      image: quay.io/pypa/manylinux2014_x86_64:latest
+      image: quay.io/pypa/manylinux2014_x86_64:2023-08-27-bd7ad21
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'

--- a/build-support/bin/generate_github_workflows.py
+++ b/build-support/bin/generate_github_workflows.py
@@ -764,7 +764,10 @@ def build_wheels_job(platform: Platform, python_versions: list[str]) -> Jobs:
     # the code, install rustup and expose Pythons.
     # TODO: Apply rust caching here.
     if platform == Platform.LINUX_X86_64:
-        container = {"image": "quay.io/pypa/manylinux2014_x86_64:latest"}
+        # Use 2023-08-27-bd7ad21, because at some point `urllib3 >= 2` broke, and that version
+        # was used for the last "working" build.
+        # See https://github.com/pantsbuild/pants/actions/runs/6286401038/job/17069772062
+        container = {"image": "quay.io/pypa/manylinux2014_x86_64:2023-08-27-bd7ad21"}
     elif platform == Platform.LINUX_ARM64:
         # Unfortunately Equinix do not support the CentOS 7 image on the hardware we've been
         # generously given by the Runs on ARM program. Se we have to build in this image.


### PR DESCRIPTION
This fixes the 2.16-series Linux x64 builds by pinning the build container to the last "known" working container (pre Aug 30th).

Note we don't make this change on 2.18.x or later, as this (puzzelingly) only appears for Python 3.7.

(I tested this fix on [pantsbuild/pants/actions/runs/6393992973/job/17354421789](https://github.com/pantsbuild/pants/actions/runs/6393992973/job/17354421789) which was able to run the release helper script (then I cancelled it))