### PR TITLE
Fix "the the" typos in the codebase.

### DIFF
--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -94,7 +94,7 @@ def find_python_runtime_library_or_raise_error(
             f"""
             Multiple `python_requirement` targets were found with the module `{runtime_library_module}`
             in your project{for_resolve_str}, so it is ambiguous which to use for the runtime library
-            for the Python code generated from the the target {codegen_address}:
+            for the Python code generated from the target {codegen_address}:
             {sorted(addr.spec for addr in addresses)}
 
             To fix, remove one of these `python_requirement` targets{for_resolve_str} so that

--- a/src/python/pants/backend/go/util_rules/import_analysis.py
+++ b/src/python/pants/backend/go/util_rules/import_analysis.py
@@ -42,7 +42,7 @@ class GoStdLibPackage:
 
     # Embed configuration.
     #
-    # Note: `EmbedConfig` is not resolved here to avoid issues with trying to build the the embed analyzer.
+    # Note: `EmbedConfig` is not resolved here to avoid issues with trying to build the embed analyzer.
     # The `EmbedConfig` will be resolved in `build_pkg_target.py` rules.
     embed_patterns: tuple[str, ...]
     embed_files: tuple[str, ...]

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -138,7 +138,7 @@ async def setup_pex_cli_process(
     input_digest = await Get(Digest, MergeDigests(digests_to_merge))
 
     global_args = [
-        # Ensure Pex and its subprocesses create temporary files in the the process execution
+        # Ensure Pex and its subprocesses create temporary files in the process execution
         # sandbox. It may make sense to do this generally for Processes, but in the short term we
         # have known use cases where /tmp is too small to hold large wheel downloads Pex is asked to
         # perform. Making the TMPDIR local to the sandbox allows control via

--- a/src/python/pants/backend/scala/bsp/spec.py
+++ b/src/python/pants/backend/scala/bsp/spec.py
@@ -260,7 +260,7 @@ class ScalaTestClassesItem:
     # The build target that contains the test classes.
     target: BuildTargetIdentifier
 
-    # Name of the the framework to which classes belong.
+    # Name of the framework to which classes belong.
     # It's optional in order to maintain compatibility, however it is expected
     # from the newer implementations to not leave that field unspecified.
     framework: str | None

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -78,7 +78,7 @@ def test_init_terraform_without_backends(
     # Not initialising the backend means that ./.terraform/.terraform.tfstate will not be present
     assert not find_file(
         initialised_files, "**/*.tfstate"
-    ), "Terraform state file should not be present if the the request was to not initialise the backend"
+    ), "Terraform state file should not be present if the request was to not initialise the backend"
 
     # The dependencies should still be present
     assert find_file(

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -789,7 +789,7 @@ async def resolve_environment_name(
                 machine's platform: {localhost_platform}. The environment only works with the
                 platforms: {env_tgt.val[CompatiblePlatformsField].value}
 
-                Consider setting the the field `{FallbackEnvironmentField.alias}` for the target
+                Consider setting the field `{FallbackEnvironmentField.alias}` for the target
                 {env_tgt.val.address}, such as to a `docker_environment` or `remote_environment`
                 target. You can also set that field to another `local_environment` target, such as
                 one that is compatible with the current platform {localhost_platform}.

--- a/src/python/pants/option/option_types.py
+++ b/src/python/pants/option/option_types.py
@@ -429,7 +429,7 @@ class EnumOption(_OptionBase[_OptT, _DefaultT]):
     """An Enum option.
 
     - If you provide a static non-None `default` parameter, the `enum_type` parameter will be
-        inferred from the type of the the default.
+        inferred from the type of the default.
     - If you provide a dynamic `default` or `default` is `None`, you must also provide `enum_type`.
 
     E.g.

--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -119,7 +119,7 @@ class Subsystem(metaclass=_SubsystemMeta):
             # If the descriptor is an `OptionsInfo`, we can resolve it against the environment
             # target.
             if isinstance(v, OptionsInfo):
-                # If the the value is not defined in the `EnvironmentTarget`, return the value
+                # If the value is not defined in the `EnvironmentTarget`, return the value
                 # from the options system.
                 override = resolve_environment_sensitive_option(v.flag_names[0], self)
                 return override if override is not None else default

--- a/src/rust/engine/pantsd/src/lib.rs
+++ b/src/rust/engine/pantsd/src/lib.rs
@@ -272,7 +272,7 @@ pub(crate) fn probe(
           &actual_command_line[0]
         }
       };
-      // It appears the the daemon only records a prefix of the process name, so we just check that.
+      // It appears that the daemon only records a prefix of the process name, so we just check that.
       if actual_argv0.starts_with(&expected_process_name_prefix) {
         Ok(port)
       } else {


### PR DESCRIPTION
Saw "the the" in an error message. Grepped the codebase and found 
several instances of this common typo.