### PR TITLE
Support using `__defaults__` in same BUILD file as environment targets. (Cherry-pick of #19446)

### DIFF
--- a/docs/markdown/Using Pants/concepts/targets.md
+++ b/docs/markdown/Using Pants/concepts/targets.md
@@ -187,6 +187,10 @@ Default fields and values are validated against their target types, except when 
 
 This means, that it is legal to provide a default value for `all` targets, even if it is only a subset of targets that actually supports that particular field.
 
+> 📘 `__defaults__` does not apply to environment targets.
+>
+> The environment targets (such as `local_environment` and `docker_environment` etc) are special and used during a bootstrap phase before any targets are defined and as such can not be targeted by the `__defaults__` construct.
+
 Examples:
 
 ```python src/example/BUILD

--- a/src/python/pants/engine/internals/defaults.py
+++ b/src/python/pants/engine/internals/defaults.py
@@ -114,7 +114,7 @@ class BuildFileDefaultsParserState:
         all: SetDefaultsValueT | None = None,
         extend: bool = False,
         ignore_unknown_fields: bool = False,
-        **kwargs,
+        ignore_unknown_targets: bool = False,
     ) -> None:
         defaults: dict[str, dict[str, Any]] = (
             {} if not extend else {k: dict(v) for k, v in self.defaults.items()}
@@ -125,10 +125,16 @@ class BuildFileDefaultsParserState:
                 defaults,
                 {tuple(self.registered_target_types.aliases): all},
                 ignore_unknown_fields=True,
+                ignore_unknown_targets=ignore_unknown_targets,
             )
 
         for arg in args:
-            self._process_defaults(defaults, arg, ignore_unknown_fields=ignore_unknown_fields)
+            self._process_defaults(
+                defaults,
+                arg,
+                ignore_unknown_fields=ignore_unknown_fields,
+                ignore_unknown_targets=ignore_unknown_targets,
+            )
 
         # Update with new defaults, dropping targets without any default values.
         for tgt, default in defaults.items():
@@ -148,6 +154,7 @@ class BuildFileDefaultsParserState:
         defaults: dict[str, dict[str, Any]],
         targets_defaults: SetDefaultsT,
         ignore_unknown_fields: bool = False,
+        ignore_unknown_targets: bool = False,
     ):
         if not isinstance(targets_defaults, dict):
             raise ValueError(
@@ -168,6 +175,8 @@ class BuildFileDefaultsParserState:
             for target_alias in map(str, targets):
                 if target_alias in types:
                     target_type = types[target_alias]
+                elif ignore_unknown_targets:
+                    continue
                 else:
                     raise ValueError(f"Unrecognized target type {target_alias} in {self.address}.")
 

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -198,10 +198,17 @@ class ParseState(threading.local):
         """
     )
     def set_defaults(
-        self, *args: SetDefaultsT, ignore_unknown_fields: bool = False, **kwargs
+        self,
+        *args: SetDefaultsT,
+        ignore_unknown_fields: bool = False,
+        ignore_unknown_targets: bool = False,
+        **kwargs,
     ) -> None:
         self.defaults.set_defaults(
-            *args, ignore_unknown_fields=self.is_bootstrap or ignore_unknown_fields, **kwargs
+            *args,
+            ignore_unknown_fields=self.is_bootstrap or ignore_unknown_fields,
+            ignore_unknown_targets=self.is_bootstrap or ignore_unknown_targets,
+            **kwargs,
         )
 
     def set_dependents_rules(self, *args, **kwargs) -> None:

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -122,6 +122,28 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
     perform_test(test_targs, dym_many)
 
 
+def test_unknown_target_for_defaults_during_bootstrap_issue_19445(
+    defaults_parser_state: BuildFileDefaultsParserState,
+) -> None:
+    parser = Parser(
+        build_root="",
+        registered_target_types=RegisteredTargetTypes({}),
+        union_membership=UnionMembership({}),
+        object_aliases=BuildFileAliases(),
+        ignore_unrecognized_symbols=True,
+    )
+    parser.parse(
+        "BUILD",
+        "__defaults__({'type_1': dict(), type_2: dict()})",
+        BuildFilePreludeSymbols.create({}, ()),
+        EnvironmentVars({}),
+        True,
+        defaults_parser_state,
+        dependents_rules=None,
+        dependencies_rules=None,
+    )
+
+
 @pytest.mark.parametrize("symbol", ["a", "bad", "BAD", "a___b_c", "a231", "áç"])
 def test_extract_symbol_from_name_error(symbol: str) -> None:
     assert _extract_symbol_from_name_error(NameError(f"name '{symbol}' is not defined")) == symbol


### PR DESCRIPTION
Fixes #19445
Fixes #19158

