### PR TITLE
docs: Remove pants 2.15 example configuration.

### DIFF
--- a/docs/markdown/Python/python/python-backend.md
+++ b/docs/markdown/Python/python/python-backend.md
@@ -19,10 +19,6 @@ Enable the Python [backend](doc:enabling-backends) like this:
 backend_packages = [
   "pants.backend.python"
 ]
-
-[python]
-# This will become the default in Pants 2.15.
-tailor_pex_binary_targets = false
 ```
 
 Pants use [`python_source`](doc:reference-python_source) and [`python_test`](doc:reference-python_test) targets to know which Python files to run on and to set any metadata.


### PR DESCRIPTION
Hi,

This PR removes mention of pants 2.15 configuration.

I saw this showing up in 2.17 docs:

![image](https://github.com/pantsbuild/pants/assets/47760695/fe5c41ff-6785-461e-8e27-12c318f32cdb)

WDYT
