### PR TITLE
Fix `release.py test-release` smoke test for new release style

### DIFF
--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -839,6 +839,7 @@ def smoke_test_install_and_version(version: str) -> None:
 
             [python]
             interpreter_constraints = ["==3.9.*"]
+            enable_resolves = true
             """
         )
 
@@ -859,6 +860,11 @@ def smoke_test_install_and_version(version: str) -> None:
         # be imported at all.
         (dir / "example.py").write_text(
             "from pants import version, testutil; print(version.VERSION)"
+        )
+        result = subprocess.run(
+            ["pants", "generate-lockfiles"],
+            cwd=dir,
+            check=True,
         )
         result = subprocess.run(
             ["pants", "run", "example.py"],


### PR DESCRIPTION
This adjusts the `test-release` subcommand of the `release.py` script to do a smoke test that works with the new release style. This is step 4 of the release procedure, and is, in my mind, designed to catch major infra failures. For instance, if things haven't been published at all.
