### PR TITLE
Remove the unneeded util function create_path_env_var.

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os.path
 from dataclasses import dataclass
 from typing import Iterable, List, Mapping, Optional, Tuple
 
@@ -27,7 +28,6 @@ from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_con
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
-from pants.util.strutil import create_path_env_var
 
 
 class PexCli(TemplatedExternalTool):
@@ -161,7 +161,7 @@ async def setup_pex_cli_process(
     resolve_args = [
         *cert_args,
         "--python-path",
-        create_path_env_var(pex_env.interpreter_search_paths),
+        os.pathsep.join(pex_env.interpreter_search_paths),
     ]
     # All old-style pex runs take the --pip-version flag, but only certain subcommands of the
     # `pex3` console script do. So if invoked with a subcommand, the caller must selectively

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -22,7 +22,7 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.memo import memoized_property
 from pants.util.ordered_set import OrderedSet
-from pants.util.strutil import create_path_env_var, softwrap
+from pants.util.strutil import softwrap
 
 
 class PexSubsystem(Subsystem):
@@ -216,7 +216,7 @@ class CompletePexEnvironment:
         to avoid PEX from trying to find a new interpreter.
         """
         d = dict(
-            PATH=create_path_env_var(self._pex_environment.path),
+            PATH=os.pathsep.join(self._pex_environment.path),
             PEX_IGNORE_RCFILES="true",
             PEX_ROOT=(
                 os.path.relpath(self.pex_root, self._working_directory)
@@ -228,7 +228,7 @@ class CompletePexEnvironment:
         if python:
             d["PEX_PYTHON"] = python.path
         else:
-            d["PEX_PYTHON_PATH"] = create_path_env_var(self.interpreter_search_paths)
+            d["PEX_PYTHON_PATH"] = os.pathsep.join(self.interpreter_search_paths)
         return d
 
 

--- a/src/python/pants/backend/shell/shunit2_test_runner.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner.py
@@ -1,6 +1,7 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+import os
 import re
 from dataclasses import dataclass
 from typing import Any
@@ -50,7 +51,6 @@ from pants.engine.target import SourcesField, Target, TransitiveTargets, Transit
 from pants.option.global_options import GlobalOptions
 from pants.util.docutil import bin_name
 from pants.util.logging import LogLevel
-from pants.util.strutil import create_path_env_var
 
 
 @dataclass(frozen=True)
@@ -214,7 +214,7 @@ async def setup_shunit2_for_target(
     )
 
     env_dict = {
-        "PATH": create_path_env_var(shell_setup.executable_search_path),
+        "PATH": os.pathsep.join(shell_setup.executable_search_path),
         # Always include colors and strip them out for display below (if required), for better cache
         # hit rates
         "SHUNIT_COLOR": "always",

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -71,33 +71,6 @@ def safe_shlex_join(arg_list: Iterable[str]) -> str:
     return " ".join(shell_quote(arg) for arg in arg_list)
 
 
-def create_path_env_var(
-    new_entries: Iterable[str],
-    env: dict[str, str] | None = None,
-    env_var: str = "PATH",
-    delimiter: str = ":",
-    prepend: bool = False,
-):
-    """Join path entries, combining with an environment variable if specified."""
-    if env is None:
-        env = {}
-
-    prev_path = env.get(env_var, None)
-    if prev_path is None:
-        path_dirs: list[str] = []
-    else:
-        path_dirs = list(prev_path.split(delimiter))
-
-    new_entries_list = list(new_entries)
-
-    if prepend:
-        path_dirs = new_entries_list + path_dirs
-    else:
-        path_dirs += new_entries_list
-
-    return delimiter.join(path_dirs)
-
-
 def pluralize(count: int, item_type: str, include_count: bool = True) -> str:
     """Pluralizes the item_type if the count does not equal one.
 


### PR DESCRIPTION
It was unnecessarily convoluted, and In practice we never passed it any non-trivial args,
so all it did was join the input paths (and non-portably at that).