### PR TITLE
Specify pants as running with cp3.9 only in plugin docs (Cherry-pick of #20003)

### DIFF
--- a/docs/markdown/Writing Plugins/plugins-overview.md
+++ b/docs/markdown/Writing Plugins/plugins-overview.md
@@ -155,21 +155,21 @@ If you do not want your plugin requirements to mix with your normal requirements
 [python]
 enable_resolves = true
 # The repository's own constraints.
-interpreter_constraints = ["==3.9.*"]
+interpreter_constraints = ["==3.12.*"]
 
 [python.resolves]
 pants-plugins = "pants-plugins/lock.txt"
 python-default = "3rdparty/python/default_lock.txt"
 
 [python.resolves_to_interpreter_constraints]
-# Pants can run with 3.7-3.9, so this lets us 
-# use different interpreter constraints when 
-# generating the lockfile than the rest of our project. 
+# Pants runs with Python 3.9, so this lets us
+# use different interpreter constraints when
+# generating the lockfile than the rest of our project.
 #
-# Warning: it's still necessary to set the `interpreter_constraints` 
-# field on each `python_sources` and `python_tests` target in 
+# Warning: it's still necessary to set the `interpreter_constraints`
+# field on each `python_sources` and `python_tests` target in
 # our plugin! This only impacts how the lockfile is generated.
-pants-plugins = [">=3.7,<3.10"]
+pants-plugins = ["==3.9.*"]
 ```
 
 Then, update your `pants_requirements` target generator with `resolve="pants-plugins"`, and run `pants generate-lockfiles`. You will also need to update the relevant `python_source` / `python_sources` and `python_test` / `python_tests` targets to set `resolve="pants-plugins"` (along with possibly the `interpreter_constraints` field).


### PR DESCRIPTION
As of 2.18, Pants only works on Python 3.9: those are the only wheels we publish, and that's the only interpreter that scie-pants provides. Thus, the documentation about setting up resolves for a plugin needs some tweaks.
