### PR TITLE
Remove `--title` from release creation automation

### DIFF
--- a/build-support/bin/_release_helper.py
+++ b/build-support/bin/_release_helper.py
@@ -859,8 +859,6 @@ def do_github_release() -> None:
                 f"release_{version}",
                 "--notes-file",
                 notes_file,
-                "--title",
-                version,
                 "--draft",
                 *(["--prerelease"] if is_prerelease else []),
             ],


### PR DESCRIPTION
This change removes the `--title` call from the release creation, so that the default is used (which is our convention so far)