### PR TITLE
Add support for using `MultiGet` with call-by-name `@rule`s and rule helpers

### DIFF
--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -735,9 +735,6 @@ def hash_prefix_zero_bits(item: str) -> int: ...
 # Selectors
 # ------------------------------------------------------------------------------
 
-class PyGeneratorResponseBreak:
-    def __init__(self, val: Any) -> None: ...
-
 _Output = TypeVar("_Output")
 _Input = TypeVar("_Input")
 

--- a/src/python/pants/engine/internals/native_engine.pyi
+++ b/src/python/pants/engine/internals/native_engine.pyi
@@ -795,9 +795,6 @@ class PyGeneratorResponseGet(Generic[_Output]):
         input_arg1: _Input | None = None,
     ) -> None: ...
 
-class PyGeneratorResponseGetMulti:
-    def __init__(self, gets: tuple[PyGeneratorResponseGet, ...]) -> None: ...
-
 # ------------------------------------------------------------------------------
 # (uncategorized)
 # ------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -11,7 +11,7 @@ import pytest
 
 from pants.base.exceptions import IncorrectProductError
 from pants.engine.internals.scheduler import ExecutionError
-from pants.engine.rules import Get, implicitly, rule
+from pants.engine.rules import Get, MultiGet, implicitly, rule
 from pants.engine.unions import UnionRule, union
 from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
 
@@ -142,6 +142,11 @@ def c() -> C:
 async def a() -> A:
     _ = await b(**implicitly(int(1)))
     _ = await c()
+    b1, c1, b2 = await MultiGet(
+        b(**implicitly(int(1))),
+        c(),
+        Get(B, int(1)),
+    )
     return A()
 
 
@@ -481,8 +486,6 @@ def test_trace_includes_nested_exception_traceback() -> None:
         The above exception was the direct cause of the following exception:
 
         Traceback (most recent call last):
-          File LOCATION-INFO, in native_engine_generator_send
-            res = rule.send(arg) if err is None else rule.throw(throw or err)
           File LOCATION-INFO, in catch_and_reraise
             raise Exception("nested exception!") from e
         Exception: nested exception!

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -375,6 +375,111 @@ async def MultiGet(  # noqa: F811
 
     if (
         isinstance(__arg0, (Get, Coroutine))
+        and __arg1 is None
+        and __arg2 is None
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0,))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and __arg2 is None
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and __arg3 is None
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and __arg4 is None
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and __arg5 is None
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and __arg6 is None
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and isinstance(__arg6, (Get, Coroutine))
+        and __arg7 is None
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
+    ):
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6))
+
+    if (
+        isinstance(__arg0, (Get, Coroutine))
         and isinstance(__arg1, (Get, Coroutine))
         and isinstance(__arg2, (Get, Coroutine))
         and isinstance(__arg3, (Get, Coroutine))
@@ -382,25 +487,11 @@ async def MultiGet(  # noqa: F811
         and isinstance(__arg5, (Get, Coroutine))
         and isinstance(__arg6, (Get, Coroutine))
         and isinstance(__arg7, (Get, Coroutine))
-        and isinstance(__arg8, (Get, Coroutine))
-        and isinstance(__arg9, (Get, Coroutine))
-        and all(isinstance(arg, Get) for arg in __args)
+        and __arg8 is None
+        and __arg9 is None
+        and not __args
     ):
-        return await _MultiGet(
-            (
-                __arg0,
-                __arg1,
-                __arg2,
-                __arg3,
-                __arg4,
-                __arg5,
-                __arg6,
-                __arg7,
-                __arg8,
-                __arg9,
-                *__args,
-            )
-        )
+        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7))
 
     if (
         isinstance(__arg0, (Get, Coroutine))
@@ -428,116 +519,25 @@ async def MultiGet(  # noqa: F811
         and isinstance(__arg5, (Get, Coroutine))
         and isinstance(__arg6, (Get, Coroutine))
         and isinstance(__arg7, (Get, Coroutine))
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
+        and isinstance(__arg8, (Get, Coroutine))
+        and isinstance(__arg9, (Get, Coroutine))
+        and all(isinstance(arg, Get) for arg in __args)
     ):
-        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and isinstance(__arg2, (Get, Coroutine))
-        and isinstance(__arg3, (Get, Coroutine))
-        and isinstance(__arg4, (Get, Coroutine))
-        and isinstance(__arg5, (Get, Coroutine))
-        and isinstance(__arg6, (Get, Coroutine))
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and isinstance(__arg2, (Get, Coroutine))
-        and isinstance(__arg3, (Get, Coroutine))
-        and isinstance(__arg4, (Get, Coroutine))
-        and isinstance(__arg5, (Get, Coroutine))
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and isinstance(__arg2, (Get, Coroutine))
-        and isinstance(__arg3, (Get, Coroutine))
-        and isinstance(__arg4, (Get, Coroutine))
-        and __arg5 is None
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and isinstance(__arg2, (Get, Coroutine))
-        and isinstance(__arg3, (Get, Coroutine))
-        and __arg4 is None
-        and __arg5 is None
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1, __arg2, __arg3))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and isinstance(__arg2, (Get, Coroutine))
-        and __arg3 is None
-        and __arg4 is None
-        and __arg5 is None
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1, __arg2))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and isinstance(__arg1, (Get, Coroutine))
-        and __arg2 is None
-        and __arg3 is None
-        and __arg4 is None
-        and __arg5 is None
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0, __arg1))
-
-    if (
-        isinstance(__arg0, (Get, Coroutine))
-        and __arg1 is None
-        and __arg2 is None
-        and __arg3 is None
-        and __arg4 is None
-        and __arg5 is None
-        and __arg6 is None
-        and __arg7 is None
-        and __arg8 is None
-        and __arg9 is None
-        and not __args
-    ):
-        return await _MultiGet((__arg0,))
+        return await _MultiGet(
+            (
+                __arg0,
+                __arg1,
+                __arg2,
+                __arg3,
+                __arg4,
+                __arg5,
+                __arg6,
+                __arg7,
+                __arg8,
+                __arg9,
+                *__args,
+            )
+        )
 
     args = __arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7, __arg8, __arg9, *__args
 

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
     Any,
+    Coroutine,
     Generator,
     Generic,
     Iterable,
@@ -165,9 +166,9 @@ class Get(Generic[_Output], Awaitable[_Output]):
 
 @dataclass(frozen=True)
 class _MultiGet:
-    gets: tuple[Get, ...]
+    gets: tuple[Get | Coroutine, ...]
 
-    def __await__(self) -> Generator[tuple[Get, ...], None, tuple]:
+    def __await__(self) -> Generator[tuple[Get | Coroutine, ...], None, tuple]:
         result = yield self.gets
         return cast(Tuple, result)
 
@@ -188,143 +189,152 @@ _Out9 = TypeVar("_Out9")
 
 
 @overload
-async def MultiGet(__gets: Iterable[Get[_Output]]) -> tuple[_Output, ...]:  # noqa: F811
+async def MultiGet(
+    __gets: Iterable[Get[_Output] | Coroutine[Any, Any, _Output]]
+) -> tuple[_Output, ...]:  # noqa: F811
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Output],
-    __get1: Get[_Output],
-    __get2: Get[_Output],
-    __get3: Get[_Output],
-    __get4: Get[_Output],
-    __get5: Get[_Output],
-    __get6: Get[_Output],
-    __get7: Get[_Output],
-    __get8: Get[_Output],
-    __get9: Get[_Output],
-    __get10: Get[_Output],
-    *__gets: Get[_Output],
+    __get0: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get1: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get2: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get3: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get4: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get5: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get6: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get7: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get8: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get9: Get[_Output] | Coroutine[Any, Any, _Output],
+    __get10: Get[_Output] | Coroutine[Any, Any, _Output],
+    *__gets: Get[_Output] | Coroutine[Any, Any, _Output],
 ) -> tuple[_Output, ...]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
-    __get5: Get[_Out5],
-    __get6: Get[_Out6],
-    __get7: Get[_Out7],
-    __get8: Get[_Out8],
-    __get9: Get[_Out9],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
+    __get5: Get[_Out5] | Coroutine[Any, Any, _Out5],
+    __get6: Get[_Out6] | Coroutine[Any, Any, _Out6],
+    __get7: Get[_Out7] | Coroutine[Any, Any, _Out7],
+    __get8: Get[_Out8] | Coroutine[Any, Any, _Out8],
+    __get9: Get[_Out9] | Coroutine[Any, Any, _Out9],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8, _Out9]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
-    __get5: Get[_Out5],
-    __get6: Get[_Out6],
-    __get7: Get[_Out7],
-    __get8: Get[_Out8],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
+    __get5: Get[_Out5] | Coroutine[Any, Any, _Out5],
+    __get6: Get[_Out6] | Coroutine[Any, Any, _Out6],
+    __get7: Get[_Out7] | Coroutine[Any, Any, _Out7],
+    __get8: Get[_Out8] | Coroutine[Any, Any, _Out8],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
-    __get5: Get[_Out5],
-    __get6: Get[_Out6],
-    __get7: Get[_Out7],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
+    __get5: Get[_Out5] | Coroutine[Any, Any, _Out5],
+    __get6: Get[_Out6] | Coroutine[Any, Any, _Out6],
+    __get7: Get[_Out7] | Coroutine[Any, Any, _Out7],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
-    __get5: Get[_Out5],
-    __get6: Get[_Out6],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
+    __get5: Get[_Out5] | Coroutine[Any, Any, _Out5],
+    __get6: Get[_Out6] | Coroutine[Any, Any, _Out6],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
-    __get5: Get[_Out5],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
+    __get5: Get[_Out5] | Coroutine[Any, Any, _Out5],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
-    __get4: Get[_Out4],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
+    __get4: Get[_Out4] | Coroutine[Any, Any, _Out4],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3, _Out4]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0],
-    __get1: Get[_Out1],
-    __get2: Get[_Out2],
-    __get3: Get[_Out3],
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
+    __get3: Get[_Out3] | Coroutine[Any, Any, _Out3],
 ) -> tuple[_Out0, _Out1, _Out2, _Out3]:
     ...
 
 
 @overload
 async def MultiGet(  # noqa: F811
-    __get0: Get[_Out0], __get1: Get[_Out1], __get2: Get[_Out2]
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+    __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
 ) -> tuple[_Out0, _Out1, _Out2]:
     ...
 
 
 @overload
-async def MultiGet(__get0: Get[_Out0], __get1: Get[_Out1]) -> tuple[_Out0, _Out1]:  # noqa: F811
+async def MultiGet(
+    __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
+    __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
+) -> tuple[_Out0, _Out1]:  # noqa: F811
     ...
 
 
 async def MultiGet(  # noqa: F811
-    __arg0: Iterable[Get[_Output]] | Get[_Out0],
-    __arg1: Get[_Out1] | None = None,
-    __arg2: Get[_Out2] | None = None,
-    __arg3: Get[_Out3] | None = None,
-    __arg4: Get[_Out4] | None = None,
-    __arg5: Get[_Out5] | None = None,
-    __arg6: Get[_Out6] | None = None,
-    __arg7: Get[_Out7] | None = None,
-    __arg8: Get[_Out8] | None = None,
-    __arg9: Get[_Out9] | None = None,
-    *__args: Get[_Output],
+    __arg0: Iterable[Get[_Output] | Coroutine[Any, Any, _Output]]
+    | Get[_Out0]
+    | Coroutine[Any, Any, _Out0],
+    __arg1: Get[_Out1] | Coroutine[Any, Any, _Out1] | None = None,
+    __arg2: Get[_Out2] | Coroutine[Any, Any, _Out2] | None = None,
+    __arg3: Get[_Out3] | Coroutine[Any, Any, _Out3] | None = None,
+    __arg4: Get[_Out4] | Coroutine[Any, Any, _Out4] | None = None,
+    __arg5: Get[_Out5] | Coroutine[Any, Any, _Out5] | None = None,
+    __arg6: Get[_Out6] | Coroutine[Any, Any, _Out6] | None = None,
+    __arg7: Get[_Out7] | Coroutine[Any, Any, _Out7] | None = None,
+    __arg8: Get[_Out8] | Coroutine[Any, Any, _Out8] | None = None,
+    __arg9: Get[_Out9] | Coroutine[Any, Any, _Out9] | None = None,
+    *__args: Get[_Output] | Coroutine[Any, Any, _Output],
 ) -> (
     tuple[_Output, ...]
     | tuple[_Out0, _Out1, _Out2, _Out3, _Out4, _Out5, _Out6, _Out7, _Out8, _Out9]
@@ -364,16 +374,16 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet(tuple(__arg0))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
-        and isinstance(__arg5, Get)
-        and isinstance(__arg6, Get)
-        and isinstance(__arg7, Get)
-        and isinstance(__arg8, Get)
-        and isinstance(__arg9, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and isinstance(__arg6, (Get, Coroutine))
+        and isinstance(__arg7, (Get, Coroutine))
+        and isinstance(__arg8, (Get, Coroutine))
+        and isinstance(__arg9, (Get, Coroutine))
         and all(isinstance(arg, Get) for arg in __args)
     ):
         return await _MultiGet(
@@ -393,15 +403,15 @@ async def MultiGet(  # noqa: F811
         )
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
-        and isinstance(__arg5, Get)
-        and isinstance(__arg6, Get)
-        and isinstance(__arg7, Get)
-        and isinstance(__arg8, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and isinstance(__arg6, (Get, Coroutine))
+        and isinstance(__arg7, (Get, Coroutine))
+        and isinstance(__arg8, (Get, Coroutine))
         and __arg9 is None
         and not __args
     ):
@@ -410,14 +420,14 @@ async def MultiGet(  # noqa: F811
         )
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
-        and isinstance(__arg5, Get)
-        and isinstance(__arg6, Get)
-        and isinstance(__arg7, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and isinstance(__arg6, (Get, Coroutine))
+        and isinstance(__arg7, (Get, Coroutine))
         and __arg8 is None
         and __arg9 is None
         and not __args
@@ -425,13 +435,13 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6, __arg7))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
-        and isinstance(__arg5, Get)
-        and isinstance(__arg6, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
+        and isinstance(__arg6, (Get, Coroutine))
         and __arg7 is None
         and __arg8 is None
         and __arg9 is None
@@ -440,12 +450,12 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5, __arg6))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
-        and isinstance(__arg5, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
+        and isinstance(__arg5, (Get, Coroutine))
         and __arg6 is None
         and __arg7 is None
         and __arg8 is None
@@ -455,11 +465,11 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4, __arg5))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
-        and isinstance(__arg4, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
+        and isinstance(__arg4, (Get, Coroutine))
         and __arg5 is None
         and __arg6 is None
         and __arg7 is None
@@ -470,10 +480,10 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2, __arg3, __arg4))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
-        and isinstance(__arg3, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
+        and isinstance(__arg3, (Get, Coroutine))
         and __arg4 is None
         and __arg5 is None
         and __arg6 is None
@@ -485,9 +495,9 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2, __arg3))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
-        and isinstance(__arg2, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
+        and isinstance(__arg2, (Get, Coroutine))
         and __arg3 is None
         and __arg4 is None
         and __arg5 is None
@@ -500,8 +510,8 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1, __arg2))
 
     if (
-        isinstance(__arg0, Get)
-        and isinstance(__arg1, Get)
+        isinstance(__arg0, (Get, Coroutine))
+        and isinstance(__arg1, (Get, Coroutine))
         and __arg2 is None
         and __arg3 is None
         and __arg4 is None
@@ -515,7 +525,7 @@ async def MultiGet(  # noqa: F811
         return await _MultiGet((__arg0, __arg1))
 
     if (
-        isinstance(__arg0, Get)
+        isinstance(__arg0, (Get, Coroutine))
         and __arg1 is None
         and __arg2 is None
         and __arg3 is None

--- a/src/python/pants/engine/internals/selectors.py
+++ b/src/python/pants/engine/internals/selectors.py
@@ -191,12 +191,12 @@ _Out9 = TypeVar("_Out9")
 @overload
 async def MultiGet(
     __gets: Iterable[Get[_Output] | Coroutine[Any, Any, _Output]]
-) -> tuple[_Output, ...]:  # noqa: F811
+) -> tuple[_Output, ...]:
     ...
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Output] | Coroutine[Any, Any, _Output],
     __get1: Get[_Output] | Coroutine[Any, Any, _Output],
     __get2: Get[_Output] | Coroutine[Any, Any, _Output],
@@ -214,7 +214,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -230,7 +230,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -245,7 +245,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -259,7 +259,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -272,7 +272,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -284,7 +284,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -295,7 +295,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -305,7 +305,7 @@ async def MultiGet(  # noqa: F811
 
 
 @overload
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
     __get2: Get[_Out2] | Coroutine[Any, Any, _Out2],
@@ -317,11 +317,11 @@ async def MultiGet(  # noqa: F811
 async def MultiGet(
     __get0: Get[_Out0] | Coroutine[Any, Any, _Out0],
     __get1: Get[_Out1] | Coroutine[Any, Any, _Out1],
-) -> tuple[_Out0, _Out1]:  # noqa: F811
+) -> tuple[_Out0, _Out1]:
     ...
 
 
-async def MultiGet(  # noqa: F811
+async def MultiGet(
     __arg0: Iterable[Get[_Output] | Coroutine[Any, Any, _Output]]
     | Get[_Out0]
     | Coroutine[Any, Any, _Out0],


### PR DESCRIPTION
This change makes further progress on #19730 by adding support for using `MultiGet` with call-by-name `@rule` invokes, and with rule helpers (which fixes #18364).

The signature changes to allow `MultiGet` to continue to typecheck are straightforward (albeit slightly verbose): `Get[Output]` becomes `Get[Output] | Coroutine[Any, Any, Output]`.

To simplify the code, this change additionally ports `native_engine_generator_send` to Rust and removes some extraneous wrappers from the implementation of `@rule`s. Performance of `pants dependencies ::` improves by about 2%.