### PR TITLE
Move the pydevd-pycharm requirement into requirements.txt.

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -28,11 +28,6 @@ python_requirements(
     resolve="pytest",
 )
 
-# Useful when using IntelliJ/PyCharm remote debugging. Importing `pydevd_pycharm` at
-# the breakpoint will cause dep inference to add this dep on the remote debugger client.
-python_requirement(name="pydevd-pycharm", requirements=["pydevd-pycharm==203.5419.8"])
-
-
 __dependents_rules__(
     (  # Only the explorer server may depend on these libraries
         (

--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -35,8 +35,10 @@ mypy-typing-asserts==0.1.1
 node-semver==0.9.0
 
 
-# This dependency is only for debugging Pants itself, and should never be imported
+# These dependencies are only for debugging Pants itself (in VSCode/PyCharm respectively),
+# and should never be imported.
 debugpy==1.6.0
+pydevd-pycharm==203.5419.8
 
 # These dependencies must only be used from the explorer backend, and no code outside that backend
 # may import anything from it, so these libraries are not ending up as requirements of Pants itself.


### PR DESCRIPTION
Previously it was in a special-cased python_requirement target
for no apparent reason.

This allows it to be used for debugging pants itself's non-test
code (previously it was only useful for debugging pants tests).