### PR TITLE
Fix a copypasta error in target field's removal_version.

### DIFF
--- a/src/rust/engine/src/externs/target.rs
+++ b/src/rust/engine/src/externs/target.rs
@@ -203,7 +203,7 @@ impl Field {
   }
 
   fn cls_removal_version(cls: &PyAny) -> PyResult<Option<&str>> {
-    cls.getattr("removal_hint")?.extract()
+    cls.getattr("removal_version")?.extract()
   }
 
   fn cls_removal_hint(cls: &PyAny) -> PyResult<Option<&str>> {


### PR DESCRIPTION
Now field deprecation logic works again.