### PR TITLE
Fix algorithm for gathering Go build requests with coverage.

### DIFF
--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -210,13 +210,17 @@ def _lift_build_requests_with_coverage(
     result: list[BuildGoPackageRequest] = []
 
     queue: deque[BuildGoPackageRequest] = deque()
+    seen: set[BuildGoPackageRequest] = set()
     queue.extend(roots)
+    seen.update(roots)
 
     while queue:
         build_request = queue.popleft()
         if build_request.with_coverage:
             result.append(build_request)
-        queue.extend(build_request.direct_dependencies)
+        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+        queue.extend(unseen)
+        seen.update(unseen)
 
     return result
 


### PR DESCRIPTION
The previous algorithm did not check if a package had already been
traversed, which leads to exponential blowup of the queue.

Go doesn't support dependency cycles, so the previous algorithm
would converge eventually, but before it did so the queue could get
to sizes that were infinite in practice. This happened in a real-world
case.