### PR TITLE
Allow plugins to add transitive excludes

### DIFF
--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -687,6 +687,7 @@ class _DependencyMapping:
 @dataclass(frozen=True)
 class _DependenciesInfo:
     addresses: Addresses
+    # These are the transitive excludes gathered from dependency inference plugins
     transitive_excludes: FrozenOrderedSet[Address]
 
 

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -2680,16 +2680,21 @@ class InferDependenciesRequest(Generic[FS], EngineAwareParameter):
 class InferredDependencies:
     include: FrozenOrderedSet[Address]
     exclude: FrozenOrderedSet[Address]
+    transitive_excludes: FrozenOrderedSet[Address]
 
     def __init__(
         self,
         include: Iterable[Address],
         *,
         exclude: Iterable[Address] = (),
+        transitive_excludes: Iterable[Address] = (),
     ) -> None:
         """The result of inferring dependencies."""
         object.__setattr__(self, "include", FrozenOrderedSet(sorted(include)))
         object.__setattr__(self, "exclude", FrozenOrderedSet(sorted(exclude)))
+        object.__setattr__(
+            self, "transitive_excludes", FrozenOrderedSet(sorted(transitive_excludes))
+        )
 
 
 @union(in_scope_types=[EnvironmentName])


### PR DESCRIPTION
This change makes it so `InferredDependencies` contains `transitive_excludes` which acts just like transitive excludes on the `Dependencies` field.