### PR TITLE
pants CI test retry

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -810,7 +810,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 0/10
-      run: './pants test --shard=0/10 ::
+      run: './pants test --shard=0/10 :: || ( echo "Retrying..." && ./pants test --shard=0/10 :: )
 
         '
     - continue-on-error: true
@@ -901,7 +901,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 1/10
-      run: './pants test --shard=1/10 ::
+      run: './pants test --shard=1/10 :: || ( echo "Retrying..." && ./pants test --shard=1/10 :: )
 
         '
     - continue-on-error: true
@@ -992,7 +992,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 2/10
-      run: './pants test --shard=2/10 ::
+      run: './pants test --shard=2/10 :: || ( echo "Retrying..." && ./pants test --shard=2/10 :: )
 
         '
     - continue-on-error: true
@@ -1083,7 +1083,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 3/10
-      run: './pants test --shard=3/10 ::
+      run: './pants test --shard=3/10 :: || ( echo "Retrying..." && ./pants test --shard=3/10 :: )
 
         '
     - continue-on-error: true
@@ -1174,7 +1174,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 4/10
-      run: './pants test --shard=4/10 ::
+      run: './pants test --shard=4/10 :: || ( echo "Retrying..." && ./pants test --shard=4/10 :: )
 
         '
     - continue-on-error: true
@@ -1265,7 +1265,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 5/10
-      run: './pants test --shard=5/10 ::
+      run: './pants test --shard=5/10 :: || ( echo "Retrying..." && ./pants test --shard=5/10 :: )
 
         '
     - continue-on-error: true
@@ -1356,7 +1356,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 6/10
-      run: './pants test --shard=6/10 ::
+      run: './pants test --shard=6/10 :: || ( echo "Retrying..." && ./pants test --shard=6/10 :: )
 
         '
     - continue-on-error: true
@@ -1447,7 +1447,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 7/10
-      run: './pants test --shard=7/10 ::
+      run: './pants test --shard=7/10 :: || ( echo "Retrying..." && ./pants test --shard=7/10 :: )
 
         '
     - continue-on-error: true
@@ -1538,7 +1538,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 8/10
-      run: './pants test --shard=8/10 ::
+      run: './pants test --shard=8/10 :: || ( echo "Retrying..." && ./pants test --shard=8/10 :: )
 
         '
     - continue-on-error: true
@@ -1629,7 +1629,7 @@ jobs:
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
     - name: Run Python test shard 9/10
-      run: './pants test --shard=9/10 ::
+      run: './pants test --shard=9/10 :: || ( echo "Retrying..." && ./pants test --shard=9/10 :: )
 
         '
     - continue-on-error: true

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -679,7 +679,11 @@ def bootstrap_jobs(
 
 
 def test_jobs(
-    helper: Helper, shard: str | None, platform_specific: bool, with_remote_caching: bool
+    helper: Helper,
+    shard: str | None,
+    platform_specific: bool,
+    with_remote_caching: bool,
+    retry: bool = False,
 ) -> Jobs:
     human_readable_job_name = f"Test Python ({helper.platform_name()})"
     human_readable_step_name = "Run Python tests"
@@ -698,6 +702,8 @@ def test_jobs(
             + ["--", "-m", "platform_specific_behavior"]
         )
     pants_args = ["./pants"] + pants_args
+    if retry:
+        pants_args = pants_args + ["||", "(", "echo", '"Retrying..."', "&&"] + pants_args + [")"]
     pants_args_str = " ".join(pants_args) + "\n"
 
     return {
@@ -735,7 +741,9 @@ def linux_x86_64_test_jobs() -> Jobs:
     helper = Helper(Platform.LINUX_X86_64)
 
     def test_python_linux(shard: str) -> dict[str, Any]:
-        return test_jobs(helper, shard, platform_specific=False, with_remote_caching=True)
+        return test_jobs(
+            helper, shard, platform_specific=False, with_remote_caching=True, retry=True
+        )
 
     shard_name_prefix = helper.job_name("test_python")
     jobs = {


### PR DESCRIPTION
This is an attempt to reduce the flakiness of our tests in CI. Relates to [this slack thread](https://pantsbuild.slack.com/archives/C0D7TNJHL/p1697637112946469?thread_ts=1697563460.898739&cid=C0D7TNJHL) and suggested by @jriddy 

Given:
- pants CI tests are subject to spurious failures, usually via timeout
- a second invocation of pants test should only rerun failed tests since the passing test results are cached (memoized)
Expect:
- Retrying `pants test` after a first failure will be cheap and will save some spurious CI failures.

## Results

So far this PR as is has had only fully succeeding tests so have not seen a case of a retry saving the build.

## Testing

Initially tested with [a toy setup](https://github.com/pantsbuild/pants/compare/main...gauthamnair:pants:dev-ci-test-retry?expand=1) that ran only two tests, one of which was artificially made to fail by dropping its timeout to 2s instead of 60s. The results in CI were:
```
✓ src/python/pants/backend/javascript/goals/tailor_test.py:tests succeeded in 3.19s.
✕ src/python/pants/backend/javascript/goals/lockfile_test.py:tests failed in 2.07s.
...
Retrying...
...
✓ src/python/pants/backend/javascript/goals/tailor_test.py:tests succeeded in 3.19s (memoized).
✕ src/python/pants/backend/javascript/goals/lockfile_test.py:tests failed in 2.07s.
```
Showing that the retry happened and the passing test's result was not recomputed.