### PR TITLE
Enable use of kernel copies of files in more cases

### DIFF
--- a/src/rust/engine/fs/store/src/lib.rs
+++ b/src/rust/engine/fs/store/src/lib.rs
@@ -268,7 +268,7 @@ impl RemoteStore {
           );
           local_store
             .get_file_fsdb()
-            .write_using(digest.hash, |file| {
+            .write_using(digest.hash, |file, _path| {
               Self::remote_writer(&remote_store, digest, file)
             })
             .await?;

--- a/src/rust/engine/hashing/src/lib.rs
+++ b/src/rust/engine/hashing/src/lib.rs
@@ -426,7 +426,6 @@ where
 ///
 pub async fn async_verified_copy<R, W>(
   expected_digest: Digest,
-  data_is_immutable: bool,
   reader: &mut R,
   writer: &mut W,
 ) -> tokio::io::Result<bool>
@@ -434,13 +433,7 @@ where
   R: AsyncRead + Unpin + ?Sized,
   W: AsyncWrite + Unpin + ?Sized,
 {
-  if data_is_immutable {
-    // Trust that the data hasn't changed, and only validate its length.
-    let copied = tokio::io::copy(reader, writer).await?;
-    Ok(copied as usize == expected_digest.size_bytes)
-  } else {
-    Ok(expected_digest == async_copy_and_hash(reader, writer).await?)
-  }
+  Ok(expected_digest == async_copy_and_hash(reader, writer).await?)
 }
 
 #[cfg(test)]

--- a/src/rust/engine/remote_provider/remote_provider_opendal/src/lib.rs
+++ b/src/rust/engine/remote_provider/remote_provider_opendal/src/lib.rs
@@ -186,7 +186,7 @@ impl Provider {
 
     match mode {
       LoadMode::Validate => {
-        let correct_digest = async_verified_copy(digest, false, &mut reader, destination)
+        let correct_digest = async_verified_copy(digest, &mut reader, destination)
           .await
           .map_err(|e| format!("failed to read {}: {}", path, e))?;
 


### PR DESCRIPTION
[`std::io::copy`](https://doc.rust-lang.org/std/io/fn.copy.html) will use syscalls to execute copies in-kernel on a best-effort basis, but the syscalls which provide copies for file ranges are limited, and the wrapping `Write` implementation must be identified as one backed by file handles without intermediate layers.

[`std::fs::copy`](https://doc.rust-lang.org/std/fs/fn.copy.html), on the other hand, can more reliably use syscalls to copy in kernel, including using `fclonefileat`/`fcopyfile` on macOS to effectively create a decoupled hardlink.

This change moves to using `tokio::fs::copy` for capturing of files into the filesystem-based store.