### PR TITLE
Fix `protobuf_sources` with parametrized `python_resolve`

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
+++ b/src/python/pants/backend/codegen/protobuf/python/additional_fields.py
@@ -33,10 +33,15 @@ def rules():
     return [
         ProtobufSourceTarget.register_plugin_field(ProtobufPythonInterpreterConstraintsField),
         ProtobufSourcesGeneratorTarget.register_plugin_field(
-            ProtobufPythonInterpreterConstraintsField
+            ProtobufPythonInterpreterConstraintsField,
+            as_moved_field=True,
         ),
         ProtobufSourceTarget.register_plugin_field(ProtobufPythonResolveField),
-        ProtobufSourcesGeneratorTarget.register_plugin_field(ProtobufPythonResolveField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(
+            ProtobufPythonResolveField, as_moved_field=True
+        ),
         ProtobufSourceTarget.register_plugin_field(PythonSourceRootField),
-        ProtobufSourcesGeneratorTarget.register_plugin_field(PythonSourceRootField),
+        ProtobufSourcesGeneratorTarget.register_plugin_field(
+            PythonSourceRootField, as_moved_field=True
+        ),
     ]


### PR DESCRIPTION
Fixes #19186 

Depends on https://github.com/pantsbuild/pants/pull/20059

## Installation in Python/Protobuf plugin

We have made the `python_resolve` and `python_interpreter_constraints` plugin fields on Protobuf Source Generators parametrizable, solving the original reported issue.

# E2E testing

Tested this against a [modified example-codegen ](https://github.com/gauthamnair/example-codegen/tree/gpndev/multi-resolve-19186) with the following structure:

## setup
```
.
├── 3rdparty
│   └── python
│       ├── BUILD
│       ├── default.lock
│       ├── nx28.lock
│       ├── other-requirements.txt
│       └── requirements.txt
├── LICENSE
├── README.md
├── pants.ci.toml
├── pants.toml
└── src
    ├── protobuf
    │   └── simple_example
    │       └── v1
    │           ├── BUILD
    │           └── person.proto
    └── python
        ├── BUILD
        ├── __init_.py
        └── protobuf_examples
            ├── BUILD
            ├── __init__.py
            ├── nx_lib.py
            ├── proto_nx_script.py
            └── simple_example_test.py
```
with build file contents:
```python
# ./3rdparty/python/BUILD 
python_requirements(
    name="reqs",
    source="requirements.txt",
    resolve="python-default"
)

python_requirements(
    name="nx28reqs",
    source="other-requirements.txt",
    resolve="nx28"
)

# ./src/python/protobuf_examples/BUILD 
python_tests(name="tests", resolve=parametrize("python-default", "nx28"))

python_sources(resolve=parametrize("python-default", "nx28"))

# ./src/python/BUILD 
python_sources()

# ./src/protobuf/simple_example/v1/BUILD 
protobuf_sources(
    # This will generate files under `src/python`, rather than `src/protobuf`, which is convenient
    # so that we do not need to add `__init__.py` files to `src/protobuf`. See
    # https://www.pantsbuild.org/docs/protobuf-python#protobuf-and-source-roots
    python_source_root="src/python",
    python_resolve=parametrize("python-default", "nx28")
)
```

And python files:
```python
# src/python/protobuf_examples/nx_lib.py 
import networkx


def version_string():
    return f'Nx version: {networkx.__version__}'

# src/python/protobuf_examples/proto_nx_script.py 
from simple_example.v1.person_pb2 import Person
from .nx_lib import version_string


if __name__ == '__main__':
    p = Person()
    p.name = "Me"
    p.id = 3
    p.email = "me@example.com"
    print(p)
    print(version_string())

# src/python/protobuf_examples/simple_example_test.py 
from simple_example.v1.person_pb2 import Person

def test_person() -> None:
  p = Person()
  p.name = "Me"
  p.id = 3
  p.email = "me@example.com"
  assert p.name == "Me"
  assert p.id == 3
  assert p.email == "me@example.com"
```
and requirements:
```
# ./3rdparty/python/requirements.txt 
protobuf==4.24.4
networkx==3.2

# ./3rdparty/python/other-requirements.txt 
protobuf==4.24.4
networkx==2.8.8
```

## running

```
$ pants test ::
✓ src/python/protobuf_examples/simple_example_test.py:tests@resolve=nx28 succeeded in 0.56s (cached locally).
✓ src/python/protobuf_examples/simple_example_test.py:tests@resolve=python-default succeeded in 0.56s (cached locally).
```

And to demonstrate both resolves in action at runtime:
```
$ pants run src/python/protobuf_examples/pro
to_nx_script.py@resolve=nx28
06:43:45.42 [INFO] Completed: Building 2 requirements for protobuf_examples.pex from the 3rdparty/python/nx28.lock resolve: networkx==2.8.8, protobuf==4.24.4
name: "Me"
id: 3
email: "me@example.com"

Nx version: 2.8.8
```

```
06:44:30.61 [INFO] Completed: Building 2 requirements for protobuf_examples.pex from the 3rdparty/python/default.lock resolve: networkx==3.2, protobuf==4.24.4
name: "Me"
id: 3
email: "me@example.com"

Nx version: 3.2
```

Lastly, checked that things like `help` on the generator target still works:
```
$ pants help protobuf_sources
...
python_interpreter_constraints
    type: Iterable[str] | None
    default: None

    The Python interpreters this code is compatible with...

python_resolve
    type: str | None
    default: None

    The resolve from `[python].resolves` to use...
```