### PR TITLE
Add `exclude_files` field to `deploy_jar` target

### DIFF
--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -35,8 +35,8 @@ from pants.jvm.strip_jar.strip_jar import StripJarRequest
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import (
     DeployJarDuplicatePolicyField,
-    DeployJarShadingRulesField,
     DeployJarExcludeFilesField,
+    DeployJarShadingRulesField,
     JvmDependenciesField,
     JvmJdkField,
     JvmMainClassNameField,

--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -36,6 +36,7 @@ from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import (
     DeployJarDuplicatePolicyField,
     DeployJarShadingRulesField,
+    DeployJarExcludeFilesField,
     JvmDependenciesField,
     JvmJdkField,
     JvmMainClassNameField,
@@ -60,6 +61,7 @@ class DeployJarFieldSet(PackageFieldSet, RunFieldSet):
     jdk_version: JvmJdkField
     duplicate_policy: DeployJarDuplicatePolicyField
     shading_rules: DeployJarShadingRulesField
+    exclude_files: DeployJarExcludeFilesField
 
 
 class DeployJarClasspathEntryRequest(ClasspathEntryRequest):
@@ -136,6 +138,7 @@ async def package_deploy_jar(
                 (rule.pattern, rule.action)
                 for rule in field_set.duplicate_policy.value_or_default()
             ],
+            skip=field_set.exclude_files.value,
             compress=True,
         ),
     )

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -732,6 +732,15 @@ class DeployJarShadingRulesField(JvmShadingRulesField):
     help = _shading_rules_field_help("Shading rules to be applied to the final JAR artifact.")
 
 
+class DeployJarExcludeFilesField(StringSequenceField):
+    alias = "exclude_files"
+    help = help_text(
+        """
+        A list of patterns to exclude from the final jar.
+        """
+    )
+
+
 class DeployJarTarget(Target):
     alias = "deploy_jar"
     core_fields = (
@@ -744,6 +753,7 @@ class DeployJarTarget(Target):
         JvmResolveField,
         DeployJarDuplicatePolicyField,
         DeployJarShadingRulesField,
+        DeployJarExcludeFilesField,
     )
     help = help_text(
         """


### PR DESCRIPTION
I tried running `pants package :my_deploy_jar` and got this:
```
Exception in thread "main" java.lang.SecurityException: Invalid signature file digest for Manifest main attributes
```
To fix this issue I've added `exclude_files` field to `deploy_jar` target, which allowed me to exclude jar signature:
```python
deploy_jar(
    name="my_deploy_jar",
    ...,
    exclude_files=["META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA"],
)
```