### PR TITLE
remove cyclic dependency betweeen `fs` and `testutil` crates

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1201,7 +1201,6 @@ dependencies = [
  "serde",
  "task_executor",
  "tempfile",
- "testutil",
  "tokio",
  "workunit_store",
 ]

--- a/src/rust/engine/fs/Cargo.toml
+++ b/src/rust/engine/fs/Cargo.toml
@@ -30,5 +30,4 @@ workunit_store = { path = "../workunit_store" }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-testutil = { path = "../testutil" }
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/src/rust/engine/fs/src/gitignore.rs
+++ b/src/rust/engine/fs/src/gitignore.rs
@@ -124,8 +124,8 @@ mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
 
+    use crate::testutil::make_file;
     use crate::{GitignoreStyleExcludes, PosixFS, Stat};
-    use testutil::make_file;
 
     async fn read_mock_files(input: Vec<PathBuf>, posix_fs: &Arc<PosixFS>) -> Vec<Stat> {
         input

--- a/src/rust/engine/fs/src/lib.rs
+++ b/src/rust/engine/fs/src/lib.rs
@@ -34,6 +34,8 @@ mod glob_matching;
 mod glob_matching_tests;
 #[cfg(test)]
 mod posixfs_tests;
+#[cfg(test)]
+mod testutil;
 
 pub use crate::directory::{
     DigestTrie, DirectoryDigest, Entry, SymlinkBehavior, TypedPath, EMPTY_DIGEST_TREE,

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use hashing::EMPTY_DIGEST;
-use testutil::make_file;
 
+use crate::testutil::make_file;
 use crate::{
     DigestTrie, Dir, DirectoryListing, File, GitignoreStyleExcludes, GlobExpansionConjunction,
     GlobMatching, Link, PathGlobs, PathStat, PosixFS, Stat, StrictGlobMatching, SymlinkBehavior,

--- a/src/rust/engine/fs/src/testutil.rs
+++ b/src/rust/engine/fs/src/testutil.rs
@@ -1,0 +1,24 @@
+// Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+// NOTE: This method is not in the `src/rust/engine/testutil` crate because that will cause a cyclic
+// dependency between `fs` and `testutil` due to `testutil` using types from this `fs` crate in its
+// public interface.
+
+pub(crate) fn make_file(path: &Path, contents: &[u8], mode: u32) {
+    let mut file = File::create(path).unwrap();
+    file.write_all(contents).unwrap();
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(mode);
+        file.set_permissions(permissions).unwrap();
+    }
+}


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/20086, there is currently a cyclic dependency between the `fs` and `testutil` crates due to `fs` using a method from `testutil` in its tests and `testutil` using types from `fs` in its public interface.

While `cargo` tolerates this cyclic dependency because it was a "dev" dependency, rust-analyzer (used by VSCode) does not tolerate it and fails to load the Pants crates.

Since the dependency in one direction is only a single method, break the dependency by vendoring the `testutil::make_file` method into the `fs` crate. With that done, rust-analyzer is able to continue.