### PR TITLE
Add 'cattrs' to 'cattrs' default module mapping

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -82,7 +82,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple] = {
     "attrs": ("attr", "attrs"),
     "beautifulsoup4": ("bs4",),
     "bitvector": ("BitVector",),
-    "cattrs": ("cattr",),
+    "cattrs": ("cattr", "cattrs"),
     "django-filter": ("django_filters",),
     "django-postgres-extra": ("psqlextra",),
     "django-cors-headers": ("corsheaders",),


### PR DESCRIPTION
Since version [1.10.0](https://catt.rs/en/v22.2.0/history.html#id25), `cattrs` supports imports from both `cattr` or `cattrs` (following similar changes in `attrs`, which are already reflected in the default module mapping). We have had to add `cattrs` to our local `module_mapping` because it is not included in the default. This change adds it.

