### PR TITLE
Discover ASDF interpreters by default

### DIFF
--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -89,7 +89,7 @@ class PythonBootstrapSubsystem(Subsystem):
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
         search_path = StrListOption(
-            default=["<PYENV>", "<PATH>"],
+            default=["<PYENV>", f"{AsdfPathString.STANDARD}", "<PATH>"],
             help=softwrap(
                 f"""
                 A list of paths to search for Python interpreters.

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -91,7 +91,7 @@ class PythonBootstrapSubsystem(Subsystem):
         search_path = StrListOption(
             # f"{AsdfPathString.STANDARD}" cannot be replaced with AsdfPathString.STANDARD here
             # str(AsdfPathString.STANDARD) != f"{AsdfPathString.STANDARD}"
-            default=["<PYENV>", f"{AsdfPathString.STANDARD}", "<PATH>"],
+            default=["<PYENV>", AsdfPathString.STANDARD.value, "<PATH>"],
             help=softwrap(
                 f"""
                 A list of paths to search for Python interpreters.

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -89,7 +89,9 @@ class PythonBootstrapSubsystem(Subsystem):
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
         search_path = StrListOption(
-            default=["<PYENV>", AsdfPathString.STANDARD, "<PATH>"],
+            # f"{AsdfPathString.STANDARD}" cannot be replaced with AsdfPathString.STANDARD here
+            # str(AsdfPathString.STANDARD) != f"{AsdfPathString.STANDARD}"
+            default=["<PYENV>", f"{AsdfPathString.STANDARD}", "<PATH>"],
             help=softwrap(
                 f"""
                 A list of paths to search for Python interpreters.

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -89,8 +89,6 @@ class PythonBootstrapSubsystem(Subsystem):
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
         search_path = StrListOption(
-            # f"{AsdfPathString.STANDARD}" cannot be replaced with AsdfPathString.STANDARD here
-            # str(AsdfPathString.STANDARD) != f"{AsdfPathString.STANDARD}"
             default=["<PYENV>", AsdfPathString.STANDARD.value, "<PATH>"],
             help=softwrap(
                 f"""

--- a/src/python/pants/core/subsystems/python_bootstrap.py
+++ b/src/python/pants/core/subsystems/python_bootstrap.py
@@ -89,7 +89,7 @@ class PythonBootstrapSubsystem(Subsystem):
 
     class EnvironmentAware(Subsystem.EnvironmentAware):
         search_path = StrListOption(
-            default=["<PYENV>", f"{AsdfPathString.STANDARD}", "<PATH>"],
+            default=["<PYENV>", AsdfPathString.STANDARD, "<PATH>"],
             help=softwrap(
                 f"""
                 A list of paths to search for Python interpreters.


### PR DESCRIPTION
I struggled for a while to debug the error messages I was getting from pants (via pex), but it was ultimately because I had not added `<ASDF>` to the search-path.

`["<PYENV>", "<PATH>"]` only puts the asdf shims on the path, and they are powerless without the `.tool-versions`. It took me a long while to understand what was happening because even in the sandbox it _looked_ like the asdf pythons should be findable.

In the spirit of making pants "just work" more often, and given the fair popularity of asdf, should we support asdf by default?