### PR TITLE
Skip flaky pex_test.py::test_interpreter_constraints test

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -417,7 +417,7 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
     assert pex_info["entry_point"] == entry_point
 
 
-@pytest.mark.skip(reason="#20103 this is intermittently flaky in CI")
+@pytest.mark.xfail(reason="#20103 this is intermittently flaky in CI", strict=False)
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
     constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
     pex_info = create_pex_and_get_pex_info(

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -417,6 +417,7 @@ def test_entry_point(rule_runner: RuleRunner) -> None:
     assert pex_info["entry_point"] == entry_point
 
 
+@pytest.mark.skip(reason="#20103 this is intermittently flaky in CI")
 def test_interpreter_constraints(rule_runner: RuleRunner) -> None:
     constraints = InterpreterConstraints(["CPython>=2.7,<3", "CPython>=3.6"])
     pex_info = create_pex_and_get_pex_info(


### PR DESCRIPTION
This works around #20103 blocking changes from landing by disabling the `test_interpreter_constraints` test in `src/python/pants/backend/python/util_rules/pex_test.py`.

It seems like this test is of something fairly fundamental, so it'd be good to re-enable, but I don't personally have time to devote to digging into this just yet.