### PR TITLE
Extend deprecation period for `python_awslambda` alias (Cherry-pick of #20101)

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -181,7 +181,7 @@ class PythonAWSLambda(_AWSLambdaBaseTarget):
     alias = "python_aws_lambda_function"
 
     deprecated_alias = "python_awslambda"
-    deprecated_alias_removal_version = "2.19.0.dev0"
+    deprecated_alias_removal_version = "2.21.0.dev0"
 
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,


### PR DESCRIPTION
This PR extends the deprecation of the old `python_awslambda` alias for the `python_aws_lambda_function` target, to make it easier/smoother for people to upgrade to 2.18 and particularly 2.19.

We renamed the `python_awslambda` target to `python_aws_lambda_function` in #19216 (in 2.18), and deprecated the old name. This was originally scheduled to be removed in 2.19, and happened in #19759, but I've reconsidered that slightly: 2.17 - 2.19 is a time of much upheaval for Pants' FaaS support, so it seems sensible to try to smooth that over if we can, especially for something like this, that's just two lines of configuration (not even "real" code).
