### PR TITLE
Fix mypy cache dir not being created

### DIFF
--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -294,8 +294,8 @@ async def mypy_typecheck_partition(
                             SANDBOX_CACHE_DIR="{run_cache_dir}/{py_version}"
                             SANDBOX_CACHE_DB="$SANDBOX_CACHE_DIR/cache.db"
 
-                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" > /dev/null 2>&1
                             {mkdir.path} -p "$NAMED_CACHE_DIR" > /dev/null 2>&1
+                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" > /dev/null 2>&1
                             {cp.path} "$NAMED_CACHE_DB" "$SANDBOX_CACHE_DB" > /dev/null 2>&1
 
                             {' '.join((shell_quote(arg) for arg in argv))}

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -294,7 +294,7 @@ async def mypy_typecheck_partition(
                             SANDBOX_CACHE_DIR="{run_cache_dir}/{py_version}"
                             SANDBOX_CACHE_DB="$SANDBOX_CACHE_DIR/cache.db"
 
-                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" > /dev/null 2>&1
+                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" "$NAMED_CACHE_DIR" > /dev/null 2>&1
                             {cp.path} "$NAMED_CACHE_DB" "$SANDBOX_CACHE_DB" > /dev/null 2>&1
 
                             {' '.join((shell_quote(arg) for arg in argv))}

--- a/src/python/pants/backend/python/typecheck/mypy/rules.py
+++ b/src/python/pants/backend/python/typecheck/mypy/rules.py
@@ -294,7 +294,8 @@ async def mypy_typecheck_partition(
                             SANDBOX_CACHE_DIR="{run_cache_dir}/{py_version}"
                             SANDBOX_CACHE_DB="$SANDBOX_CACHE_DIR/cache.db"
 
-                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" "$NAMED_CACHE_DIR" > /dev/null 2>&1
+                            {mkdir.path} -p "$SANDBOX_CACHE_DIR" > /dev/null 2>&1
+                            {mkdir.path} -p "$NAMED_CACHE_DIR" > /dev/null 2>&1
                             {cp.path} "$NAMED_CACHE_DB" "$SANDBOX_CACHE_DB" > /dev/null 2>&1
 
                             {' '.join((shell_quote(arg) for arg in argv))}


### PR DESCRIPTION
This PR fixes an issue/bug mentioned in #19888. 

**Problem**
Internal mypy cache directory/folder used by Pants is not being created. Therefore, the mypy cache cannot moved copied from temporary cache location [here](https://github.com/pantsbuild/pants/blob/d5ffed441396d89a2a7bc52fc994c52a00808f8a/src/python/pants/backend/python/typecheck/mypy/rules.py#L306)

**Solution**
Make sure the mypy cache directory/folder is created. 