### PR TITLE
Restore x86-on-Arm Mac downloads for older coursier versions (Cherry-pick of #20121)

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -117,16 +117,23 @@ class CoursierSubsystem(TemplatedExternalTool):
         "v2.1.6|macos_x86_64|36a5d42a0724be2ac39d0ebd8869b985e3d58ceb121bc60389ee2d6d7408dd56|20037412",
         "v2.1.0-M5-18-gfebf9838c|linux_arm64 |d4ad15ba711228041ad8a46d848c83c8fbc421d7b01c415d8022074dd609760f|19264005",
         "v2.1.0-M5-18-gfebf9838c|linux_x86_64|3e1a1ad1010d5582e9e43c5a26b273b0147baee5ebd27d3ac1ab61964041c90b|19551533",
+        "v2.1.0-M5-18-gfebf9838c|macos_arm64 |d13812c5a5ef4c9b3e25cc046d18addd09bacd149f95b20a14e4d2a73e358ecf|18826510",
         "v2.1.0-M5-18-gfebf9838c|macos_x86_64|d13812c5a5ef4c9b3e25cc046d18addd09bacd149f95b20a14e4d2a73e358ecf|18826510",
         "v2.0.16-169-g194ebc55c|linux_arm64 |da38c97d55967505b8454c20a90370c518044829398b9bce8b637d194d79abb3|18114472",
         "v2.0.16-169-g194ebc55c|linux_x86_64|4c61a634c4bd2773b4543fe0fc32210afd343692891121cddb447204b48672e8|18486946",
+        "v2.0.16-169-g194ebc55c|macos_arm64 |15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
         "v2.0.16-169-g194ebc55c|macos_x86_64|15bce235d223ef1d022da30b67b4c64e9228d236b876c834b64e029bbe824c6f|17957182",
     ]
     default_url_template = (
         "https://github.com/coursier/coursier/releases/download/{version}/cs-{platform}.gz"
     )
     default_url_platform_mapping = {
-        "macos_arm64": "aarch64-apple-darwin",
+        # By default we pull x86 binaries for Mac, since arm binaries
+        # are unavailable for older supported versions of coursier. They work fine with rosetta.
+        # For recent versions, arm binaries for mac and linux are available
+        # at https://github.com/VirtusLab/coursier-m1/
+        # Set the fifth field in known_versions to pull from this alternative source.
+        "macos_arm64": "x86_64-apple-darwin",
         "macos_x86_64": "x86_64-apple-darwin",
         "linux_arm64": "aarch64-pc-linux",
         "linux_x86_64": "x86_64-pc-linux",
@@ -149,7 +156,9 @@ class CoursierSubsystem(TemplatedExternalTool):
     )
 
     def generate_exe(self, plat: Platform) -> str:
-        archive_filename = os.path.basename(self.generate_url(plat))
+        tool_version = self.known_version(plat)
+        url = (tool_version and tool_version.url_override) or self.generate_url(plat)
+        archive_filename = os.path.basename(url)
         filename = os.path.splitext(archive_filename)[0]
         return f"./{filename}"
 


### PR DESCRIPTION

This is a fix-forward of the regression for some M1 coursier users introduced in #19940. We can do the revert first and then rebase this on that.

We continue to support previous coursier versions on M1 via rosetta, and add the Virtuslabs versions for recent versions.

There is some refactoring to ensure that in all cases we pull out the correct executable from the archive.
