### PR TITLE
Avoid quotes in suggested .env file for IDEs (Cherry-pick of #20144)

### DIFF
--- a/docs/markdown/Using Pants/setting-up-an-ide.md
+++ b/docs/markdown/Using Pants/setting-up-an-ide.md
@@ -25,7 +25,7 @@ For Python, to generate the `.env` file containing all the source roots, you can
 
 ```shell
 $ ROOTS=$(pants roots)
-$ python3 -c "print('PYTHONPATH=\"./' + ':./'.join('''${ROOTS}'''.split('\n')) + ':\$PYTHONPATH\"')" > .env
+$ python3 -c "print('PYTHONPATH=./' + ':./'.join('''${ROOTS}'''.replace(' ', '\\ ').split('\n')) + ':\$PYTHONPATH')" > .env
 ```
 
 See [Use of the PYTHONPATH variable](https://code.visualstudio.com/docs/python/environments#_use-of-the-pythonpath-variable) to learn more about using the `PYTHONPATH` variable in VSCode.


### PR DESCRIPTION
This fixes #20127 by avoiding double quotes in the `.env` file generated by the code snippet in the IDE set-up docs.

Double quotes aren't supported by the `scie-pants` `.env` loader, and a line containing them was previously silently ignored (plus all lines after), but with scie-pants 0.11.0, will be an error. See https://github.com/pantsbuild/scie-pants/issues/307 and https://github.com/pantsbuild/scie-pants/pull/319.

The new suggestion has _no_ quotes at all, because there's no other way to have a line that includes a substitution. To handle source roots with spaces in their paths, this has to also manually escape them. Supporting double quotes is effectively a new feature of `scie-pants` launcher (via scie jump https://github.com/a-scie/jump/issues/166 via `dotenvy` https://github.com/allan2/dotenvy/issues/11), but for now we can at least stop suggesting incorrect things.

For instance, with source roots `a b/c` and `def`, this generates:

```
PYTHONPATH=./a\ b/c:./def:$PYTHONPATH
```
