### PR TITLE
Add docker image output field to support publish to repository when using BuildKit

### DIFF
--- a/docs/markdown/Docker/docker.md
+++ b/docs/markdown/Docker/docker.md
@@ -184,12 +184,6 @@ very-secret-value
 
 BuildKit supports exporting build cache to an external location, making it possible to import in future builds. Cache backends can be configured using the [`cache_to`](doc:reference-docker_image#codecache_tocode) and [`cache_from`](doc:reference-docker_image#codecache_fromcode) fields.
 
-Enable BuildKit if necessary (it is the default in later versions of Docker):
-
-```
-❯ export DOCKER_BUILDKIT=1
-```
-
 Create a builder using a [build driver](https://docs.docker.com/build/drivers/) that is compatible with the cache backend:
 
 ```
@@ -205,17 +199,17 @@ Use the builder:
 Optionally, validate a build with the Docker CLI directly:
 
 ```
-❯ docker build -t pants-cache-test:latest \
+❯ docker buildx build -t pants-cache-test:latest \
   --cache-to type=local,dest=/tmp/docker/pants-test-cache \
   --cache-from type=local,src=/tmp/docker/pants-test-cache .
 ```
 
-Configure Pants:
+Configure Pants to use buildx and pass the BUILDX_BUILDER environment variable:
 
 ```toml pants.toml
 [docker]
+use_buildx = true
 env_vars = [
-  "DOCKER_BUILDKIT",
   "BUILDX_BUILDER"
 ]
 ```

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -19,13 +19,11 @@ from pants.backend.docker.package_types import BuiltDockerImage as BuiltDockerIm
 from pants.backend.docker.registries import DockerRegistries, DockerRegistryOptions
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import (
+    DockerBuildKitOptionField,
     DockerBuildOptionFieldMixin,
     DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
-    DockerImageBuildImageCacheFromField,
-    DockerImageBuildImageCacheToField,
-    DockerImageBuildImageOutputField,
     DockerImageContextRootField,
     DockerImageRegistriesField,
     DockerImageRepositoryField,
@@ -338,11 +336,7 @@ def get_build_options(
             yield from target[field_type].options()
         elif issubclass(field_type, DockerBuildOptionFlagFieldMixin):
             yield from target[field_type].options()
-        elif (
-            issubclass(field_type, DockerImageBuildImageCacheToField)
-            or issubclass(field_type, DockerImageBuildImageCacheFromField)
-            or issubclass(field_type, DockerImageBuildImageOutputField)
-        ):
+        elif issubclass(field_type, DockerBuildKitOptionField):
             if use_buildx_option is True:
                 source = InterpolationContext.TextSource(
                     address=target.address, target_alias=target.alias, field_alias=field_type.alias

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -355,7 +355,6 @@ def get_build_options(
                 yield from target[field_type].options(format)
             elif target[field_type].value != target[field_type].default:
                 raise DockerImageOptionValueError(
-                    # TODO: improve
                     f"The {target[field_type].alias} field on the = `{target.alias}` target in `{target.address}` was set to `{target[field_type].value}`"
                     f" and buildx is not enabled. Buildx must be enabled via the Docker subsystem options in order to use this field."
                 )

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1116,6 +1116,7 @@ def test_docker_cache_to_option(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "buildx",
+            "build",
             "--cache-to=type=local,dest=/tmp/docker/pants-test-cache",
             "--output=type=docker",
             "--pull=False",
@@ -1152,6 +1153,7 @@ def test_docker_cache_from_option(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "buildx",
+            "build",
             "--cache-from=type=local,dest=/tmp/docker/pants-test-cache",
             "--output=type=docker",
             "--pull=False",
@@ -1192,6 +1194,7 @@ def test_docker_output_option(rule_runner: RuleRunner) -> None:
         assert process.argv == (
             "/dummy/docker",
             "buildx",
+            "build",
             "--output=type=image",
             "--pull=False",
             "--tag",

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -146,7 +146,7 @@ class DockerOptions(Subsystem):
     use_buildx = BoolOption(
         default=False,
         help=softwrap(
-            f"""
+            """
             Use [buildx](https://github.com/docker/buildx#buildx) (and BuildKit) for builds.
             """
         ),

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -143,6 +143,14 @@ class DockerOptions(Subsystem):
             """
         ),
     )
+    use_buildx = BoolOption(
+        default=False,
+        help=softwrap(
+            f"""
+            Use [buildx](https://github.com/docker/buildx#buildx) (and BuildKit) for builds.
+            """
+        ),
+    )
     _build_args = ShellStrListOption(
         help=softwrap(
             f"""

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -377,11 +377,11 @@ class DockerImageBuildImageOutputField(
         f"""
         Sets the export action for the build result.
 
-        When using `pants publish` to publish Docker images to a registry, the output type 
-        must be 'docker', as `publish` expects that the built images exist in the local 
+        When using `pants publish` to publish Docker images to a registry, the output type
+        must be 'docker', as `publish` expects that the built images exist in the local
         image store.
 
-        Currently, multi-platform images cannot be exported with the 'docker' export type, 
+        Currently, multi-platform images cannot be exported with the 'docker' export type,
         although experimental support is available with the [containerd image store](https://docs.docker.com/desktop/containerd/)
 
         {_interpolation_help.format(kind="Values")}

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -312,13 +312,25 @@ class DockerBuildOptionFieldMultiValueDictMixin(DictStringToStringField):
             )
 
 
+class DockerBuildKitOptionField:
+    """Mixin to indicate a BuildKit-specific option."""
+
+    @abstractmethod
+    def options(self, value_formatter: OptionValueFormatter) -> Iterator[str]:
+        ...
+
+    required_help = "This option requires BuildKit to be enabled via the Docker subsystem options."
+
+
 class DockerImageBuildImageCacheToField(
-    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField, DockerBuildKitOptionField
 ):
     alias = "cache_to"
     help = help_text(
         f"""
         Export image build cache to an external cache destination.
+
+        {DockerBuildKitOptionField.required_help}
 
         Example:
 
@@ -341,12 +353,14 @@ class DockerImageBuildImageCacheToField(
 
 
 class DockerImageBuildImageCacheFromField(
-    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField, DockerBuildKitOptionField
 ):
     alias = "cache_from"
     help = help_text(
         f"""
         Use an external cache source when building the image.
+
+        {DockerBuildKitOptionField.required_help}
 
         Example:
 
@@ -369,13 +383,15 @@ class DockerImageBuildImageCacheFromField(
 
 
 class DockerImageBuildImageOutputField(
-    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField, DockerBuildKitOptionField
 ):
     alias = "output"
     default = FrozenDict({"type": "docker"})
     help = help_text(
         f"""
         Sets the export action for the build result.
+
+        {DockerBuildKitOptionField.required_help}
 
         When using `pants publish` to publish Docker images to a registry, the output type
         must be 'docker', as `publish` expects that the built images exist in the local

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -305,7 +305,7 @@ class DockerBuildOptionFieldMultiValueDictMixin(DictStringToStringField):
     docker_build_option: ClassVar[str]
 
     @final
-    def options(self, value_formatter: OptionValueFormatter) -> Iterator[str]:
+    def options(self, value_formatter: OptionValueFormatter, **kwargs) -> Iterator[str]:
         if self.value:
             yield f"{self.docker_build_option}=" + ",".join(
                 f"{key}={value_formatter(value)}" for key, value in self.value.items()
@@ -480,7 +480,7 @@ class DockerBuildOptionFieldValueMixin(Field):
     docker_build_option: ClassVar[str]
 
     @final
-    def options(self) -> Iterator[str]:
+    def options(self, *args, **kwargs) -> Iterator[str]:
         if self.value is not None:
             yield f"{self.docker_build_option}={self.value}"
 
@@ -492,7 +492,7 @@ class DockerBuildOptionFieldMultiValueMixin(StringSequenceField):
     docker_build_option: ClassVar[str]
 
     @final
-    def options(self) -> Iterator[str]:
+    def options(self, *args, **kwargs) -> Iterator[str]:
         if self.value:
             yield f"{self.docker_build_option}={','.join(list(self.value))}"
 
@@ -518,7 +518,7 @@ class DockerBuildOptionFlagFieldMixin(BoolField, ABC):
     docker_build_option: ClassVar[str]
 
     @final
-    def options(self) -> Iterator[str]:
+    def options(self, *args, **kwargs) -> Iterator[str]:
         if self.value:
             yield f"{self.docker_build_option}"
 

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -37,6 +37,7 @@ from pants.engine.target import (
 )
 from pants.engine.unions import union
 from pants.util.docutil import bin_name, doc_url
+from pants.util.frozendict import FrozenDict
 from pants.util.strutil import help_text, softwrap
 
 # Common help text to be applied to each field that supports value interpolation.
@@ -367,6 +368,28 @@ class DockerImageBuildImageCacheFromField(
     docker_build_option = "--cache-from"
 
 
+class DockerImageBuildImageOutputField(
+    DockerBuildOptionFieldMultiValueDictMixin, DictStringToStringField
+):
+    alias = "output"
+    default = FrozenDict({"type": "docker"})
+    help = help_text(
+        f"""
+        Sets the export action for the build result.
+
+        When using `pants publish` to publish Docker images to a registry, the output type 
+        must be 'docker', as `publish` expects that the built images exist in the local 
+        image store.
+
+        Currently, multi-platform images cannot be exported with the 'docker' export type, 
+        although experimental support is available with the [containerd image store](https://docs.docker.com/desktop/containerd/)
+
+        {_interpolation_help.format(kind="Values")}
+        """
+    )
+    docker_build_option = "--output"
+
+
 class DockerImageBuildSecretsOptionField(
     AsyncFieldMixin, DockerBuildOptionFieldMixin, DictStringToStringField
 ):
@@ -547,6 +570,7 @@ class DockerImageTarget(Target):
         DockerImageBuildPlatformOptionField,
         DockerImageBuildImageCacheToField,
         DockerImageBuildImageCacheFromField,
+        DockerImageBuildImageOutputField,
         OutputPathField,
         RestartableField,
     )

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -62,9 +62,15 @@ class DockerBinary(BinaryPath):
         build_args: DockerBuildArgs,
         context_root: str,
         env: Mapping[str, str],
+        use_buildx: bool,
         extra_args: tuple[str, ...] = (),
     ) -> Process:
-        args = [self.path, "build", *extra_args]
+        if use_buildx:
+            build_command = "buildx"
+        else:
+            build_command = "build"
+
+        args = [self.path, build_command, *extra_args]
 
         for tag in tags:
             args.extend(["--tag", tag])

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -66,11 +66,11 @@ class DockerBinary(BinaryPath):
         extra_args: tuple[str, ...] = (),
     ) -> Process:
         if use_buildx:
-            build_command = "buildx"
+            build_commands = ["buildx", "build"]
         else:
-            build_command = "build"
+            build_commands = ["build"]
 
-        args = [self.path, build_command, *extra_args]
+        args = [self.path, *build_commands, *extra_args]
 
         for tag in tags:
             args.extend(["--tag", tag])

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -36,6 +36,7 @@ def test_docker_binary_build_image(docker_path: str, docker: DockerBinary) -> No
         build_args=DockerBuildArgs.from_strings("arg1=2"),
         context_root="build/context",
         env=env,
+        use_buildx=False,
         extra_args=("--pull", "--squash"),
     )
 


### PR DESCRIPTION
Currently, the `publish` goal doesn't work with docker images when buildkit is enabled, as by [default buildkit doesn't save the build output locally](https://github.com/docker/buildx/issues/166), and `publish` expects that the images were saved. 

This PR adds support for setting the output type, and defaults it to`docker`, which is the legacy docker build behavior, i.e. saves to the local image store.

However, we only want to set that when buildkit is enabled. I thought it better to add an explicit option for that at the subsystem level; this allows for validation of buildkit-only options. 

This eliminates the need to set `DOCKER_BUILDKIT=1` in env vars - I need to update the docs on that actually. 

I have validated that with this change, docker images can be published to a registry. 