### PR TITLE
Resolve appropriate Scala artifacts for BSP

### DIFF
--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -276,11 +276,17 @@ async def bsp_resolve_scala_metadata(
         java_version=f"1.{jdk.jre_major_version}",
     )
 
+    scala_version_parts = scala_version.split(".")
+    scala_binary_version = (
+        ".".join(scala_version_parts[0:2])
+        if int(scala_version_parts[0]) < 3
+        else scala_version_parts[0]
+    )
     return BSPBuildTargetsMetadataResult(
         metadata=ScalaBuildTarget(
             scala_organization="org.scala-lang",
             scala_version=scala_version,
-            scala_binary_version=".".join(scala_version.split(".")[0:2]),
+            scala_binary_version=scala_binary_version,
             platform=ScalaPlatform.JVM,
             jars=scala_jar_uris,
             jvm_build_target=jvm_build_target,

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -21,6 +21,10 @@ from pants.backend.scala.bsp.spec import (
 )
 from pants.backend.scala.subsystems.scala import ScalaSubsystem
 from pants.backend.scala.target_types import ScalaFieldSet, ScalaSourceField
+from pants.backend.scala.util_rules.versions import (
+    ScalaArtifactsForVersionRequest,
+    ScalaArtifactsForVersionResult,
+)
 from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
 from pants.bsp.spec.base import BuildTargetIdentifier
@@ -148,22 +152,15 @@ async def collect_thirdparty_modules(
 
 
 async def _materialize_scala_runtime_jars(scala_version: str) -> Snapshot:
+    scala_artifacts = await Get(
+        ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(scala_version)
+    )
+
     tool_classpath = await Get(
         ToolClasspath,
         ToolClasspathRequest(
             artifact_requirements=ArtifactRequirements.from_coordinates(
-                [
-                    Coordinate(
-                        group="org.scala-lang",
-                        artifact="scala-compiler",
-                        version=scala_version,
-                    ),
-                    Coordinate(
-                        group="org.scala-lang",
-                        artifact="scala-library",
-                        version=scala_version,
-                    ),
-                ]
+                scala_artifacts.all_coordinates
             ),
         ),
     )


### PR DESCRIPTION
Uses a rule to resolve the right artifacts for the given Scala version instead of relying on hardcoded artifact names. It also amends the binary version in the metadata as in Scala 3 it's only made up of the major version number.

Fixes #20156 