### PR TITLE
Misc help text cleanups

### DIFF
--- a/src/python/pants/core/goals/generate_lockfiles.py
+++ b/src/python/pants/core/goals/generate_lockfiles.py
@@ -298,9 +298,11 @@ class UnrecognizedResolveNamesError(Exception):
         super().__init__(
             softwrap(
                 f"""
-            Unrecognized resolve {name_description} from {description_of_origin}:
-            {unrecognized_str}\n\nAll valid resolve names: {sorted(all_valid_names)}
-            """
+                Unrecognized resolve {name_description} from {description_of_origin}:
+                {unrecognized_str}
+
+                All valid resolve names: {sorted(all_valid_names)}
+                """
             )
         )
 
@@ -420,14 +422,15 @@ def filter_tool_lockfile_requests(
             raise ValueError(
                 softwrap(
                     f"""
-                You requested to generate a lockfile for {resolve} because
-                you included it in `--generate-lockfiles-resolve`, but
-                `[{resolve}].lockfile` is set to `{req.lockfile_dest}`
-                so a lockfile will not be generated.\n\n
-                If you would like to generate a lockfile for {resolve}, please
-                set `[{resolve}].lockfile` to the path where it should be
-                generated and run again.
-                """
+                    You requested to generate a lockfile for {resolve} because
+                    you included it in `--generate-lockfiles-resolve`, but
+                    `[{resolve}].lockfile` is set to `{req.lockfile_dest}`
+                    so a lockfile will not be generated.
+
+                    If you would like to generate a lockfile for {resolve}, please
+                    set `[{resolve}].lockfile` to the path where it should be
+                    generated and run again.
+                    """
                 )
             )
 
@@ -637,11 +640,13 @@ class NoCompatibleResolveException(Exception):
         return NoCompatibleResolveException(
             softwrap(
                 f"""
-            The input targets did not have a resolve in common.\n\n
-            {formatted_resolve_lists}\n\n
-            Targets used together must use the same resolve, set by the `resolve` field. For more
-            information on 'resolves' (lockfiles), see {doc_url(doc_url_slug)}.
-            """
+                The input targets did not have a resolve in common.
+
+                {formatted_resolve_lists}
+
+                Targets used together must use the same resolve, set by the `resolve` field. For more
+                information on 'resolves' (lockfiles), see {doc_url(doc_url_slug)}.
+                """
             )
             + (f"\n\n{workaround}" if workaround else "")
         )

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -372,12 +372,13 @@ class TailorSubsystem(GoalSubsystem):
             raise ValueError(
                 softwrap(
                     f"""
-                The option `[{self.options_scope}].build_file_name` is set to
-                `{self.build_file_name}`, which is not compatible with
-                `[GLOBAL].build_patterns`: {sorted(build_file_patterns)}. This means that
-                generated BUILD files would be ignored.\n\n
-                To fix, please update the options so that they are compatible.
-                """
+                    The option `[{self.options_scope}].build_file_name` is set to
+                    `{self.build_file_name}`, which is not compatible with
+                    `[GLOBAL].build_patterns`: {sorted(build_file_patterns)}. This means that
+                    generated BUILD files would be ignored.
+
+                    To fix, please update the options so that they are compatible.
+                    """
                 )
             )
 

--- a/src/python/pants/core/target_types.py
+++ b/src/python/pants/core/target_types.py
@@ -732,12 +732,15 @@ class ArchivePackagesField(SpecialCasedDependencies):
     alias = "packages"
     help = help_text(
         f"""
-        Addresses to any targets that can be built with `{bin_name()} package`, e.g.
-        `["project:app"]`.\n\nPants will build the assets as if you had run `{bin_name()} package`.
-        It will include the results in your archive using the same name they would normally have,
-        but without the `--distdir` prefix (e.g. `dist/`).\n\nYou can include anything that can
-        be built by `{bin_name()} package`, e.g. a `pex_binary`, `python_aws_lambda_function`, or even another
-        `archive`.
+        Addresses to any targets that can be built with `{bin_name()} package`,
+        e.g. `["project:app"]`.
+
+        Pants will build the assets as if you had run `{bin_name()} package`.
+        It will include the results in your archive using the same name they
+        would normally have, but without the `--distdir` prefix (e.g. `dist/`).
+
+        You can include anything that can be built by `{bin_name()} package`,
+        e.g. a `pex_binary`, `python_awslambda`, or even another `archive`.
         """
     )
 

--- a/src/python/pants/core/util_rules/wrap_source.py
+++ b/src/python/pants/core/util_rules/wrap_source.py
@@ -126,13 +126,18 @@ def wrap_source_rule_and_target(
             WrapSourceOutputsField,
         )
         help = help_text(
-            "Allow files and sources produced by the targets specified by `inputs` to be consumed "
-            f"by rules that specifically expect a `{source_field_type.__name__}`.\n\n"
-            f"Note that this target does not modify the files in any way. {outputs_help}\n\n"
-            "This target must be explicitly specified as a dependency of any target that requires "
-            "it. Sources from this target will not be automatically inferred as dependencies.\n\n"
-            "This target is experimental: in future versions of Pants, this functionality may be "
-            "made available with a different interface."
+            f"""
+            Allow files and sources produced by the targets specified by `inputs` to be consumed
+            by rules that specifically expect a `{source_field_type.__name__}`.
+
+            Note that this target does not modify the files in any way. {outputs_help}
+
+            This target must be explicitly specified as a dependency of any target that requires
+            it. Sources from this target will not be automatically inferred as dependencies.
+
+            This target is experimental: in future versions of Pants, this functionality may be
+            made available with a different interface.
+            """
         )
 
     # need to use `_param_type_overrides` to stop `@rule` from inspecting the function's source

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -78,7 +78,7 @@ class SymlinkEntry:
     """A symlink pointing to a target path.
 
     For the symlink target:
-        - uses a a forward slash `/` path separator.
+        - uses a forward slash `/` path separator.
         - can be relative to the parent directory of the symlink or can be an absolute path starting with `/`.
         - Allows `..` components anywhere in the path (as logical canonicalization may lead to
             different behavior in the presence of directory symlinks).


### PR DESCRIPTION
Reformat some help texts into `"""` strings so they are easier to read in the source code. Plus a typo fix.