### PR TITLE
Enable opt-in to previously excluded filters

### DIFF
--- a/src/python/pants/util/filtering_test.py
+++ b/src/python/pants/util/filtering_test.py
@@ -67,3 +67,40 @@ def test_negated_filter() -> None:
     assert coprime_to_2_and_3(4) is False
     assert coprime_to_2_and_3(5) is True
     assert coprime_to_2_and_3(6) is False
+
+
+def test_merged_filter() -> None:
+    # This tests that multiple filters are merged into a single consistent filter
+    divisible_by_3_and_not_2 = and_filters(
+        create_filters(
+            ["-3", "-2", "+3"],
+            is_divisible_by,
+        )
+    )
+    assert divisible_by_3_and_not_2(2) is False
+    assert divisible_by_3_and_not_2(3) is True
+    assert divisible_by_3_and_not_2(4) is False
+    assert divisible_by_3_and_not_2(5) is False
+    assert divisible_by_3_and_not_2(6) is False
+    assert divisible_by_3_and_not_2(7) is False
+    assert divisible_by_3_and_not_2(8) is False
+    assert divisible_by_3_and_not_2(9) is True
+
+
+def test_merged_filter_coprime() -> None:
+    # This tests that multiple filters are merged into a single consistent filter
+    coprime_to_2_and_3_and_divisible_by_7 = and_filters(
+        create_filters(
+            ["-2,3", "+7"],
+            is_divisible_by,
+        )
+    )
+
+    assert coprime_to_2_and_3_and_divisible_by_7(1) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(2) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(3) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(4) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(5) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(7) is True
+    assert coprime_to_2_and_3_and_divisible_by_7(34) is False
+    assert coprime_to_2_and_3_and_divisible_by_7(35) is True


### PR DESCRIPTION
This PR attempts to solve #15012 in such a way that you can disable a tag in `pants.toml` and then later re-add it on the command line. I'm not super optimistic on the composition semantics of this feature, and maybe a bigger rewrite would make sense -- but I'd like input on that before I go deeper.

The issue I'm seeing is something like this:
```toml
# pants.toml
[GLOBAL]
tag = ['-foo,bar']
```
and 
```shell
$ pants --tag='foo' ...
```
Is the same as 
```
not (has_tag('foo') or has_tag('bar')) and has_tag('foo')
```
whereas removing the `,bar` leads to 
```
has_tag('foo')
```
Inversely, if the pants.toml was defined as follows `tag = ['-foo', '-bar']` we skip targets that have either (desired?) (`not has_tag(foo) and not has_tag(bar)`), but `tag = ['foo', 'bar'] ` requires targets to have both (`has_tag(bar) and has_tag(foo)`). 

So if my actual pants.toml f.ex. is `tag = ['-no-ci', '-integration-test']` I can't select all untagged *plus* all no-ci targets, nor can I run all no-ci *and* all integration-tests unless those targets overlap completely. For example, `--tag='no-ci'` would effectively evaluate to `not has_tag(integration-test) and has_tag(no-ci)`. That is *better* than the current formulation where it evaluates to `not has_tag(integration-test) and not has_tag(no-ci) and has_tag(no-ci)` which is a fallacy.

One way of solving this is to track the meaning of the requirement in three levels -- `-` for excluded, `+` for required, otherwise allowed. But that would be a breaking change, I think... And doesn't solve the way disjoint requirements work. But in that case my above example of `--tag='no-ci'` would expand to `not has_tag(integration_test)`, whereas `--tag='+no-ci'` would expand to the current meaning.