### PR TITLE
Add docker image output field to support publish to repository when using BuildKit (Cherry-pick of #20154)

### DIFF
--- a/docs/markdown/Docker/docker.md
+++ b/docs/markdown/Docker/docker.md
@@ -184,12 +184,6 @@ very-secret-value
 
 BuildKit supports exporting build cache to an external location, making it possible to import in future builds. Cache backends can be configured using the [`cache_to`](doc:reference-docker_image#codecache_tocode) and [`cache_from`](doc:reference-docker_image#codecache_fromcode) fields.
 
-Enable BuildKit if necessary (it is the default in later versions of Docker):
-
-```
-❯ export DOCKER_BUILDKIT=1
-```
-
 Create a builder using a [build driver](https://docs.docker.com/build/drivers/) that is compatible with the cache backend:
 
 ```
@@ -205,17 +199,17 @@ Use the builder:
 Optionally, validate a build with the Docker CLI directly:
 
 ```
-❯ docker build -t pants-cache-test:latest \
+❯ docker buildx build -t pants-cache-test:latest \
   --cache-to type=local,dest=/tmp/docker/pants-test-cache \
   --cache-from type=local,src=/tmp/docker/pants-test-cache .
 ```
 
-Configure Pants:
+Configure Pants to use buildx and pass the BUILDX_BUILDER environment variable:
 
 ```toml pants.toml
 [docker]
+use_buildx = true
 env_vars = [
-  "DOCKER_BUILDKIT",
   "BUILDX_BUILDER"
 ]
 ```

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -19,12 +19,12 @@ from pants.backend.docker.package_types import BuiltDockerImage as BuiltDockerIm
 from pants.backend.docker.registries import DockerRegistries, DockerRegistryOptions
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.target_types import (
+    DockerBuildKitOptionField,
     DockerBuildOptionFieldMixin,
+    DockerBuildOptionFieldMultiValueDictMixin,
     DockerBuildOptionFieldMultiValueMixin,
     DockerBuildOptionFieldValueMixin,
     DockerBuildOptionFlagFieldMixin,
-    DockerImageBuildImageCacheFromField,
-    DockerImageBuildImageCacheToField,
     DockerImageContextRootField,
     DockerImageRegistriesField,
     DockerImageRepositoryField,
@@ -316,28 +316,31 @@ def get_build_options(
     global_target_stage_option: str | None,
     global_build_hosts_options: dict | None,
     global_build_no_cache_option: bool | None,
+    use_buildx_option: bool,
     target: Target,
 ) -> Iterator[str]:
     # Build options from target fields inheriting from DockerBuildOptionFieldMixin
     for field_type in target.field_types:
-        if issubclass(field_type, DockerBuildOptionFieldMixin):
-            source = InterpolationContext.TextSource(
-                address=target.address, target_alias=target.alias, field_alias=field_type.alias
-            )
-            format = partial(
-                context.interpolation_context.format,
-                source=source,
-                error_cls=DockerImageOptionValueError,
-            )
-            yield from target[field_type].options(format, global_build_hosts_options)
-        elif issubclass(field_type, DockerBuildOptionFieldValueMixin):
-            yield from target[field_type].options()
-        elif issubclass(field_type, DockerBuildOptionFieldMultiValueMixin):
-            yield from target[field_type].options()
-        elif issubclass(field_type, DockerBuildOptionFlagFieldMixin):
-            yield from target[field_type].options()
-        elif issubclass(field_type, DockerImageBuildImageCacheToField) or issubclass(
-            field_type, DockerImageBuildImageCacheFromField
+        if issubclass(field_type, DockerBuildKitOptionField):
+            if use_buildx_option is not True:
+                if target[field_type].value != target[field_type].default:
+                    raise DockerImageOptionValueError(
+                        f"The {target[field_type].alias} field on the = `{target.alias}` target in `{target.address}` was set to `{target[field_type].value}`"
+                        f" and buildx is not enabled. Buildx must be enabled via the Docker subsystem options in order to use this field."
+                    )
+                else:
+                    # Case where BuildKit option has a default value - still should not be generated
+                    continue
+
+        if issubclass(
+            field_type,
+            (
+                DockerBuildOptionFieldMixin,
+                DockerBuildOptionFieldMultiValueDictMixin,
+                DockerBuildOptionFieldValueMixin,
+                DockerBuildOptionFieldMultiValueMixin,
+                DockerBuildOptionFlagFieldMixin,
+            ),
         ):
             source = InterpolationContext.TextSource(
                 address=target.address, target_alias=target.alias, field_alias=field_type.alias
@@ -347,7 +350,7 @@ def get_build_options(
                 source=source,
                 error_cls=DockerImageOptionValueError,
             )
-            yield from target[field_type].options(format)
+            yield from target[field_type].options(format, global_build_hosts_options=global_build_hosts_options)  # type: ignore[attr-defined]
 
     # Target stage
     target_stage = None
@@ -440,6 +443,7 @@ async def build_docker_image(
         context_root=context_root,
         env=env,
         tags=tags,
+        use_buildx=options.use_buildx,
         extra_args=tuple(
             get_build_options(
                 context=context,
@@ -447,6 +451,7 @@ async def build_docker_image(
                 global_target_stage_option=options.build_target_stage,
                 global_build_hosts_options=options.build_hosts,
                 global_build_no_cache_option=options.build_no_cache,
+                use_buildx_option=options.use_buildx,
                 target=wrapped_target.target,
             )
         ),

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -14,6 +14,7 @@ import pytest
 
 from pants.backend.docker.goals.package_image import (
     DockerBuildTargetStageError,
+    DockerImageOptionValueError,
     DockerImageTagValueError,
     DockerInfoV1,
     DockerPackageFieldSet,
@@ -171,6 +172,7 @@ def assert_build(
         opts.setdefault("build_hosts", None)
         opts.setdefault("build_verbose", False)
         opts.setdefault("build_no_cache", False)
+        opts.setdefault("use_buildx", False)
         opts.setdefault("env_vars", [])
 
         docker_options = create_subsystem(
@@ -1113,8 +1115,10 @@ def test_docker_cache_to_option(rule_runner: RuleRunner) -> None:
     def check_docker_proc(process: Process):
         assert process.argv == (
             "/dummy/docker",
+            "buildx",
             "build",
             "--cache-to=type=local,dest=/tmp/docker/pants-test-cache",
+            "--output=type=docker",
             "--pull=False",
             "--tag",
             "img1:latest",
@@ -1127,6 +1131,7 @@ def test_docker_cache_to_option(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("docker/test", target_name="img1"),
         process_assertions=check_docker_proc,
+        options=dict(use_buildx=True),
     )
 
 
@@ -1147,8 +1152,10 @@ def test_docker_cache_from_option(rule_runner: RuleRunner) -> None:
     def check_docker_proc(process: Process):
         assert process.argv == (
             "/dummy/docker",
+            "buildx",
             "build",
             "--cache-from=type=local,dest=/tmp/docker/pants-test-cache",
+            "--output=type=docker",
             "--pull=False",
             "--tag",
             "img1:latest",
@@ -1161,7 +1168,72 @@ def test_docker_cache_from_option(rule_runner: RuleRunner) -> None:
         rule_runner,
         Address("docker/test", target_name="img1"),
         process_assertions=check_docker_proc,
+        options=dict(use_buildx=True),
     )
+
+
+def test_docker_output_option(rule_runner: RuleRunner) -> None:
+    """Testing non-default output type 'image'.
+
+    Default output type 'docker' tested implicitly in other scenarios
+    """
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  output={"type": "image"}
+                )
+                """
+            ),
+        }
+    )
+
+    def check_docker_proc(process: Process):
+        assert process.argv == (
+            "/dummy/docker",
+            "buildx",
+            "build",
+            "--output=type=image",
+            "--pull=False",
+            "--tag",
+            "img1:latest",
+            "--file",
+            "docker/test/Dockerfile",
+            ".",
+        )
+
+    assert_build(
+        rule_runner,
+        Address("docker/test", target_name="img1"),
+        process_assertions=check_docker_proc,
+        options=dict(use_buildx=True),
+    )
+
+
+def test_docker_output_option_raises_when_no_buildkit(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "docker/test/BUILD": dedent(
+                """\
+                docker_image(
+                  name="img1",
+                  output={"type": "image"}
+                )
+                """
+            ),
+        }
+    )
+
+    with pytest.raises(
+        DockerImageOptionValueError,
+        match=r"Buildx must be enabled via the Docker subsystem options in order to use this field.",
+    ):
+        assert_build(
+            rule_runner,
+            Address("docker/test", target_name="img1"),
+        )
 
 
 def test_docker_build_network_option(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -143,6 +143,14 @@ class DockerOptions(Subsystem):
             """
         ),
     )
+    use_buildx = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            Use [buildx](https://github.com/docker/buildx#buildx) (and BuildKit) for builds.
+            """
+        ),
+    )
     _build_args = ShellStrListOption(
         help=softwrap(
             f"""

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -62,9 +62,15 @@ class DockerBinary(BinaryPath):
         build_args: DockerBuildArgs,
         context_root: str,
         env: Mapping[str, str],
+        use_buildx: bool,
         extra_args: tuple[str, ...] = (),
     ) -> Process:
-        args = [self.path, "build", *extra_args]
+        if use_buildx:
+            build_commands = ["buildx", "build"]
+        else:
+            build_commands = ["build"]
+
+        args = [self.path, *build_commands, *extra_args]
 
         for tag in tags:
             args.extend(["--tag", tag])

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -36,6 +36,7 @@ def test_docker_binary_build_image(docker_path: str, docker: DockerBinary) -> No
         build_args=DockerBuildArgs.from_strings("arg1=2"),
         context_root="build/context",
         env=env,
+        use_buildx=False,
         extra_args=("--pull", "--squash"),
     )
 


### PR DESCRIPTION
Currently, the `publish` goal doesn't work with docker images when buildkit is enabled, as by [default buildkit doesn't save the build output locally](https://github.com/docker/buildx/issues/166), and `publish` expects that the images were saved. 

This PR adds support for setting the output type, and defaults it to`docker`, which is the legacy docker build behavior, i.e. saves to the local image store.

However, we only want to set that when buildkit is enabled. I thought it better to add an explicit option for that at the subsystem level; this allows for validation of buildkit-only options. 

This eliminates the need to set `DOCKER_BUILDKIT=1` in env vars - I need to update the docs on that actually. 

I have validated that with this change, docker images can be published to a registry. 
