### PR TITLE
Support inferring JS deps from `export ... from ...` statements

### DIFF
--- a/src/rust/engine/dep_inference/src/javascript/mod.rs
+++ b/src/rust/engine/dep_inference/src/javascript/mod.rs
@@ -146,6 +146,15 @@ impl Visitor for ImportCollector<'_> {
         }
         ChildBehavior::Ignore
     }
+
+    fn visit_export_statement(&mut self, node: Node) -> ChildBehavior {
+        if !self.is_pragma_ignored(node) {
+            self.insert_import(node.child_by_field_name("source"));
+        }
+
+        ChildBehavior::Ignore
+    }
+
     fn visit_expression_statement(&mut self, node: Node) -> ChildBehavior {
         if node.children(&mut node.walk()).any(|child| {
             let id = child.kind_id();

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -176,6 +176,39 @@ fn simple_exports() {
 }
 
 #[test]
+fn export_without_from() {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
+    assert_imports(
+        "
+// Exporting declarations
+export let name1, name2/*, … */; // also var
+export const name1 = 1, name2 = 2/*, … */; // also var, let
+export function functionName() { /* … */ }
+export class ClassName { /* … */ }
+export function* generatorFunctionName() { /* … */ }
+export const { name1, name2: bar } = o;
+export const [ name1, name2 ] = array;
+
+// Export list
+export { name1, /* …, */ nameN };
+export { variable1 as name1, variable2 as name2, /* …, */ nameN };
+export { variable1 as \"string name\" };
+export { name1 as default /*, … */ };
+
+// Default exports
+export default expression;
+export default function functionName() { /* … */ }
+export default class ClassName { /* … */ }
+export default function* generatorFunctionName() { /* … */ }
+export default function () { /* … */ }
+export default class { /* … */ }
+export default function* () { /* … */ }
+",
+        &[],
+    );
+}
+
+#[test]
 fn ignore_exports() {
     assert_imports("export * from 'a'; // pants: no-infer-dep", &[]);
     assert_imports("export * as x from './b' // pants: no-infer-dep", &[]);

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -155,24 +155,6 @@ fn simple_exports() {
     );
     // just confirm a relative path is preserved
     assert_imports("export * from './b/c'", &["./b/c"]);
-
-    // multi-line
-    assert_imports(
-        "export {
-            a
-        } from 'ignored'; // pants: no-infer-dep",
-        &[],
-    );
-    // NB. the inference is driven off the 'from'.
-    assert_imports(
-        "export { // pants: no-infer-dep
-            a
-        } from 'b';
-        export {
-            c // pants: no-infer-dep
-        } from 'd';",
-        &["b", "d"],
-    );
 }
 
 #[test]
@@ -213,6 +195,24 @@ fn ignore_exports() {
     assert_imports("export * from 'a'; // pants: no-infer-dep", &[]);
     assert_imports("export * as x from './b' // pants: no-infer-dep", &[]);
     assert_imports("export { y } from \"../c\"  // pants: no-infer-dep", &[]);
+
+    // multi-line
+    assert_imports(
+        "export {
+            a
+        } from 'ignored'; // pants: no-infer-dep",
+        &[],
+    );
+    // NB. the inference is driven off the 'from'.
+    assert_imports(
+        "export { // pants: no-infer-dep
+            a
+        } from 'b';
+        export {
+            c // pants: no-infer-dep
+        } from 'd';",
+        &["b", "d"],
+    );
 }
 
 #[test]

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -77,6 +77,59 @@ fn ignore_imports() {
     assert_imports("require('f') // pants: no-infer-dep", &[]);
     assert_imports("import('e'); // pants: no-infer-dep", &[]);
     assert_imports("require('f'); // pants: no-infer-dep", &[]);
+
+    // multi-line
+    assert_imports(
+        "import {
+            a
+        } from 'ignored'; // pants: no-infer-dep",
+        &[],
+    );
+    // NB. the inference (and thus ignoring) is driven off the 'from'.
+    assert_imports(
+        "
+        import { // pants: no-infer-dep
+            a
+        } from 'b';
+        import {
+            c  // pants: no-infer-dep
+        } from 'd';",
+        &["b", "d"],
+    );
+
+    assert_imports(
+        "require(
+            'ignored'
+        ) // pants: no-infer-dep",
+        &[],
+    );
+    // as above, driven off the end of the require()
+    assert_imports(
+        "require( // pants: no-infer-dep
+            'a'
+        );
+        require(
+            'b' // pants: no-infer-dep
+        )",
+        &["a", "b"],
+    );
+
+    assert_imports(
+        "import(
+            'ignored'
+        ) // pants: no-infer-dep",
+        &[],
+    );
+    // as above, driven off the end of the import()
+    assert_imports(
+        "import( // pants: no-infer-dep
+            'a'
+        );
+        import(
+            'b' // pants: no-infer-dep
+        )",
+        &["a", "b"],
+    );
 }
 
 #[test]
@@ -102,6 +155,24 @@ fn simple_exports() {
     );
     // just confirm a relative path is preserved
     assert_imports("export * from './b/c'", &["./b/c"]);
+
+    // multi-line
+    assert_imports(
+        "export {
+            a
+        } from 'ignored'; // pants: no-infer-dep",
+        &[],
+    );
+    // NB. the inference is driven off the 'from'.
+    assert_imports(
+        "export { // pants: no-infer-dep
+            a
+        } from 'b';
+        export {
+            c // pants: no-infer-dep
+        } from 'd';",
+        &["b", "d"],
+    );
 }
 
 #[test]

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -80,8 +80,41 @@ fn ignore_imports() {
 }
 
 #[test]
+fn simple_exports() {
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export
+    assert_imports(r#"export * from "module-name";"#, &["module-name"]);
+    assert_imports(r#"export * as name1 from "module-name";"#, &["module-name"]);
+    assert_imports(
+        r#"export { name1, /* …, */ nameN } from "module-name";"#,
+        &["module-name"],
+    );
+    assert_imports(
+        r#"export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name";"#,
+        &["module-name"],
+    );
+    assert_imports(
+        r#"export { default, /* …, */ } from "module-name";"#,
+        &["module-name"],
+    );
+    assert_imports(
+        r#"export { default as name1 } from "module-name";"#,
+        &["module-name"],
+    );
+    // just confirm a relative path is preserved
+    assert_imports("export * from './b/c'", &["./b/c"]);
+}
+
+#[test]
+fn ignore_exports() {
+    assert_imports("export * from 'a'; // pants: no-infer-dep", &[]);
+    assert_imports("export * as x from './b' // pants: no-infer-dep", &[]);
+    assert_imports("export { y } from \"../c\"  // pants: no-infer-dep", &[]);
+}
+
+#[test]
 fn still_parses_from_syntax_error() {
     assert_imports("import a from '.'; x=", &["."]);
+    assert_imports("export {some nonsense} from '.'", &["."]);
 }
 
 #[test]


### PR DESCRIPTION
This extends the dependency inference for JS to also consider `export` statements. This uses all the cases from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export as test cases.

This also adds some tests for how `// pants: no-infer-dep` is interpreted for multi-line statements for `export`, and also for the existing support for `import ...`, `require(...)` and `import(...)`. This may not be the behaviour we exactly want, but we at least now don't change it accidentally. #20207 covers nailing it down.

Fixes #19819 