### PR TITLE
Do not choke on values from macros on environment targets during bootstrap.

### DIFF
--- a/docs/markdown/Using Pants/environments.md
+++ b/docs/markdown/Using Pants/environments.md
@@ -47,6 +47,11 @@ docker_environment(
 )
 ```
 
+> 🚧 Environment targets and macros
+> 
+> Environment targets are loaded before regular targets in a bootstrap phase, during which macros are unavailable. As such any required field values must be fully defined in the BUILD file without referencing any macros. For optional fields, the use of macros are still discouraged as it may or may not work and Pants makes no guarantees that it will not break in a future version if it were to currently work.
+
+
 ### Environment-aware options
 
 Environment targets have fields ([target](doc:targets) arguments) which correspond to [options](doc:options) which are marked "environment-aware". When an option is environment-aware, the value of the option that will be used in an environment can be overridden by setting the corresponding field value on the associated environment target. If an environment target does not set a value, it defaults to the value which is set globally via options values.

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -270,6 +270,12 @@ class Registrar:
         return self._type_alias
 
     def __call__(self, **kwargs: Any) -> TargetAdaptor:
+        if self._parse_state.is_bootstrap and any(
+            isinstance(v, _UnrecognizedSymbol) for v in kwargs.values()
+        ):
+            # Remove any field values that are not recognized during the bootstrap phase.
+            kwargs = {k: v for k, v in kwargs.items() if not isinstance(v, _UnrecognizedSymbol)}
+
         # Target names default to the name of the directory their BUILD file is in
         # (as long as it's not the root directory).
         if "name" not in kwargs:


### PR DESCRIPTION
Clear all unrecognized field values during bootstrap. (Such as from calls to macros, which are not loaded during that phase.)

Add note to docs discouraging use of macros for environment targets.

Fixes #20178 
