### PR TITLE
Skip jvm dependencies without entries

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -235,9 +235,10 @@ class CoursierResolvedLockfile:
             tuple(
                 dependency_entry
                 for d in entry.dependencies
-                # If the dependency is missing from the entries, we want to skip the dependency.
-                # More details in the issue:
-                # https://github.com/pantsbuild/pants/issues/20162
+                # The dependency might not be present in the entries due to coursier bug:
+                # https://github.com/coursier/coursier/issues/2884
+                # As a workaround, if this happens, we want to skip the dependency.
+                # TODO Drop the check once the bug is fixed.
                 if (dependency_entry := entries.get((d.group, d.artifact))) is not None
             ),
         )

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -230,7 +230,18 @@ class CoursierResolvedLockfile:
         if entry is None:
             raise self._coordinate_not_found(key, coord)
 
-        return (entry, tuple(entries[(i.group, i.artifact)] for i in entry.dependencies))
+        dependency_entries = []
+        for d in entry.dependencies:
+            dependency = (d.group, d.artifact)
+            if dependency not in entries:
+                if d.packaging == "pom":
+                    # https://github.com/pantsbuild/pants/issues/20162#issuecomment-1813374036
+                    continue
+                else:
+                    raise RuntimeError(f"missing entry: {dependency}")
+            dependency_entries.append(entries[dependency])
+
+        return (entry, tuple(dependency_entries))
 
     @classmethod
     def from_toml(cls, lockfile: str | bytes) -> CoursierResolvedLockfile:

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -238,7 +238,7 @@ class CoursierResolvedLockfile:
                 # If the dependency is missing from the entries, we want to skip the dependency.
                 # More details in the issue:
                 # https://github.com/pantsbuild/pants/issues/20162
-                if (dependency := (d.group, d.artifact)) not in entries
+                if (dependency := (d.group, d.artifact)) in entries
             ),
         )
 

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -233,12 +233,12 @@ class CoursierResolvedLockfile:
         return (
             entry,
             tuple(
-                entries[dependency]
+                dependency_entry
                 for d in entry.dependencies
                 # If the dependency is missing from the entries, we want to skip the dependency.
                 # More details in the issue:
                 # https://github.com/pantsbuild/pants/issues/20162
-                if (dependency := (d.group, d.artifact)) in entries
+                if (dependency_entry := entries.get((d.group, d.artifact))) is not None
             ),
         )
 

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -670,7 +670,9 @@ def test_transitive_excludes(rule_runner: RuleRunner) -> None:
     assert not any(i for i in entries if i.coord.artifact == "jackson-core")
 
 
-@pytest.mark.xfail(reason="bug in coursier: https://github.com/coursier/coursier/issues/2884")
+@pytest.mark.xfail(
+    reason="coursier bug: https://github.com/coursier/coursier/issues/2884", strict=True
+)
 @maybe_skip_jdk_test
 def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> None:
     resolve = rule_runner.request(
@@ -706,3 +708,20 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
     # for ("junit", "junit") and ("org.apache.curator", "apache-curator").
     # TODO Remove the workaround once the bug is fixed.
     assert missing == []
+
+
+@pytest.mark.xfail(reason="coursier bug?", strict=True)
+@maybe_skip_jdk_test
+def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> None:
+    reqs = ArtifactRequirements(
+        [
+            Coordinate(
+                group="org.apache.curator",
+                artifact="apache-curator",
+                version="5.5.0",
+            ).as_requirement()
+        ]
+    )
+
+    # Exception: No jar found for org.apache.curator:apache-curator:5.5.0.
+    rule_runner.request(CoursierResolvedLockfile, [reqs])

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -670,9 +670,6 @@ def test_transitive_excludes(rule_runner: RuleRunner) -> None:
     assert not any(i for i in entries if i.coord.artifact == "jackson-core")
 
 
-@pytest.mark.xfail(
-    reason="coursier bug: https://github.com/coursier/coursier/issues/2884", strict=True
-)
 @maybe_skip_jdk_test
 def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> None:
     resolve = rule_runner.request(
@@ -696,21 +693,18 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
         ],
     )
 
-    lookup = {(entry.coord.group, entry.coord.artifact): entry for entry in resolve.entries}
-    missing = []
-    for entry in resolve.entries:
-        for d in entry.dependencies:
-            coord = (d.group, d.artifact)
-            if coord not in lookup:
-                missing.append(coord)
+    coords_of_entries = {(entry.coord.group, entry.coord.artifact) for entry in resolve.entries}
+    coords_of_dependencies = {
+        (d.group, d.artifact) for entry in resolve.entries for d in entry.dependencies
+    }
+    missing = coords_of_dependencies - coords_of_entries
 
     # We expect all the dependencies to have an entry, but right now it's not true
     # for ("junit", "junit") and ("org.apache.curator", "apache-curator").
     # TODO Remove the workaround once the bug is fixed.
-    assert missing == []
+    assert missing == {("junit", "junit"), ("org.apache.curator", "apache-curator")}
 
 
-@pytest.mark.xfail(reason="coursier bug?", strict=True)
 @maybe_skip_jdk_test
 def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> None:
     reqs = ArtifactRequirements(
@@ -723,5 +717,9 @@ def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> Non
         ]
     )
 
-    # Exception: No jar found for org.apache.curator:apache-curator:5.5.0.
-    rule_runner.request(CoursierResolvedLockfile, [reqs])
+    # TODO Remove the workaround once the bug is fixed.
+    with pytest.raises(
+        Exception,
+        match=r"Exception: No jar found for org.apache.curator:apache-curator:5.5.0. .*",
+    ):
+        rule_runner.request(CoursierResolvedLockfile, [reqs])


### PR DESCRIPTION
A dependency might not be present in the top-level entries due to potential coursier bug:  https://github.com/coursier/coursier/issues/2884

As a workaround, if this happens, we want to skip the dependency.

Fixes https://github.com/pantsbuild/pants/issues/20162