### PR TITLE
Use a Zulu JDK 8 to run the Kotlin analyzer. (Cherry-pick of #20184)

### DIFF
--- a/src/python/pants/backend/kotlin/dependency_inference/BUILD
+++ b/src/python/pants/backend/kotlin/dependency_inference/BUILD
@@ -4,4 +4,13 @@
 python_sources(dependencies=[":kotlin_resources"])
 resources(name="kotlin_resources", sources=["*.kt", "*.lock"])
 
-python_tests(name="tests", timeout=240)
+python_tests(
+    name="tests",
+    timeout=240,
+    overrides={
+        "kotlin_parser_test.py": {
+            # Dep inference installs its own JDK, we must make sure that works on all platforms.
+            "tags": ["platform_specific_behavior"],
+        },
+    },
+)

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -144,7 +144,7 @@ async def analyze_kotlin_source_dependencies(
     source_files: SourceFiles,
 ) -> FallibleKotlinSourceDependencyAnalysisResult:
     # Use JDK 8 due to https://youtrack.jetbrains.com/issue/KTIJ-17192 and https://youtrack.jetbrains.com/issue/KT-37446.
-    request = JdkRequest("adopt:8")
+    request = JdkRequest("zulu:8.0.392")
     env = await Get(JdkEnvironment, JdkRequest, request)
     jdk = InternalJdk.from_jdk_environment(env)
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser_test.py
@@ -69,6 +69,7 @@ def _analyze(rule_runner: RuleRunner, source: str) -> KotlinSourceDependencyAnal
 
 
 @logging
+@pytest.mark.platform_specific_behavior
 def test_parser_simple(rule_runner: RuleRunner) -> None:
     analysis = _analyze(
         rule_runner,


### PR DESCRIPTION
There is no native adopt:8 for M1s.
