### PR TITLE
Remove print() statement (Cherry-pick of #20196)

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -150,7 +150,6 @@ async def infer_dependencies(
             ),
         )
 
-        print(addresses_for_grpc, locality)
         result.append(
             find_python_runtime_library_or_raise_error(
                 addresses_for_grpc,


### PR DESCRIPTION
Our CI/CD pipeline got awfully chatty after moving from 2.19.0.dev3 to 2.19.0a0. Turns out #19939 accidentally snuck in a little `print()` :)
