### PR TITLE
helm: add option to pass `--quiet` when linting charts

### DIFF
--- a/src/python/pants/backend/helm/goals/lint.py
+++ b/src/python/pants/backend/helm/goals/lint.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pants.backend.helm.subsystems.helm import HelmSubsystem
 from pants.backend.helm.target_types import (
     HelmChartFieldSet,
+    HelmChartLintQuietField,
     HelmChartLintStrictField,
     HelmSkipLintField,
 )
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class HelmLintFieldSet(HelmChartFieldSet):
     lint_strict: HelmChartLintStrictField
+    lint_quiet: HelmChartLintQuietField
     skip_lint: HelmSkipLintField
 
 
@@ -64,6 +66,9 @@ async def run_helm_lint(
     strict = field_set.lint_strict.value or helm_subsystem.lint_strict
     if strict:
         argv.append("--strict")
+    quiet = field_set.lint_quiet.value or helm_subsystem.lint_quiet
+    if quiet:
+        argv.append("--quiet")
 
     process_result = await Get(
         FallibleProcessResult,

--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -130,6 +130,7 @@ class HelmSubsystem(TemplatedExternalTool):
 
     _registries = DictOption[Any](help=registries_help, fromfile=True)
     lint_strict = BoolOption(default=False, help="Enables strict linting of Helm charts")
+    lint_quiet = BoolOption(default=False, help="Only print warnings and errors for Helm charts")
     default_registry_repository = StrOption(
         default=None,
         help=softwrap(

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -168,6 +168,11 @@ class HelmChartLintStrictField(TriBoolField):
     help = "If set to true, enables strict linting of this Helm chart."
 
 
+class HelmChartLintQuietField(TriBoolField):
+    alias = "lint_quiet"
+    help = "If set to true, only print only warnings and errors."
+
+
 class HelmChartRepositoryField(StringField):
     alias = "repository"
     help = help_text(
@@ -201,6 +206,7 @@ class HelmChartTarget(Target):
         HelmChartDependenciesField,
         HelmChartOutputPathField,
         HelmChartLintStrictField,
+        HelmChartLintQuietField,
         HelmChartRepositoryField,
         HelmChartVersionField,
         HelmRegistriesField,

--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -170,7 +170,7 @@ class HelmChartLintStrictField(TriBoolField):
 
 class HelmChartLintQuietField(TriBoolField):
     alias = "lint_quiet"
-    help = "If set to true, only print only warnings and errors."
+    help = "If set to true, print only warnings and errors."
 
 
 class HelmChartRepositoryField(StringField):


### PR DESCRIPTION
helm lint [1] includes a `--quiet` option that will "print only warnings and errors".  This is useful because in addition to those warnings and errors, helm lint also has a variety of verbose INFO statements such as suggesting every chart have an icon.

[1] https://helm.sh/docs/helm/helm_lint/