### PR TITLE
add back copyright header lint for rust files

### DIFF
--- a/build-support/preambles/config.yaml
+++ b/build-support/preambles/config.yaml
@@ -1,6 +1,9 @@
 "**/*.py:!**/__init__.py:**/BUILD:**/BUILD.*": |+
   # Copyright $year Pants project contributors (see CONTRIBUTORS.md).
   # Licensed under the Apache License, Version 2.0 (see LICENSE).
+"**/lib.rs:**/build.rs::**/main.rs": |+
+  // Copyright $year Pants project contributors (see CONTRIBUTORS.md).
+  // Licensed under the Apache License, Version 2.0 (see LICENSE).
 "**/*.rs:**/*.cjs:**/*.mjs:**/*.js": |+
   // Copyright $year Pants project contributors (see CONTRIBUTORS.md).
   // Licensed under the Apache License, Version 2.0 (see LICENSE).


### PR DESCRIPTION
As part of #20201, I inadvertently deleted the entire header lint for Rust files including the copyright header part, even though I should have just deleted the lint setup.

Add back the copyright header lint for Rust files.