### PR TITLE
Remove deprecated `@rule_helper`

### DIFF
--- a/build-support/flake8/await_in_loop.py
+++ b/build-support/flake8/await_in_loop.py
@@ -109,8 +109,8 @@ def check_for_await_in_loop(tree: ast.AST, filename: str) -> Iterator[tuple[int,
             value = node.value
 
             # This checks for `await Get()` and `await MultiGet()` literally, because there's not
-            # currently MultiGet support for rule_helpers (i.e. `[await some_rule_helper(x) for x in
-            # ...]` cannot become `await MultiGet([rule_helper(x) for x in ...])` ). Once that's
+            # currently MultiGet support for normal async functions (i.e. `[await some_helper(x) for x in
+            # ...]` cannot become `await MultiGet([some_helper(x) for x in ...])` ). Once that's
             # supported, this could flip to default to True, except for `await Effect`.
 
             return (

--- a/src/python/pants/engine/internals/rule_visitor_test.py
+++ b/src/python/pants/engine/internals/rule_visitor_test.py
@@ -11,7 +11,7 @@ import pytest
 from pants.base.exceptions import RuleTypeError
 from pants.engine.internals.rule_visitor import collect_awaitables
 from pants.engine.internals.selectors import Get, GetParseError, MultiGet
-from pants.engine.rules import implicitly, rule, rule_helper
+from pants.engine.rules import implicitly, rule
 from pants.util.strutil import softwrap
 
 # The visitor inspects the module for definitions.
@@ -20,24 +20,20 @@ INT = int
 BOOL = bool
 
 
-@rule_helper
 async def _top_helper(arg1):
     a = await Get(STR, INT, arg1)
     return await _helper_helper(a)
 
 
-@rule_helper
 async def _helper_helper(arg1):
     return await Get(INT, STR, arg1)
 
 
 class HelperContainer:
-    @rule_helper
     async def _method_helper(self):
         return await Get(STR, INT, 42)
 
     @staticmethod
-    @rule_helper
     async def _static_helper():
         a = await Get(STR, INT, 42)
         return await _helper_helper(a)

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -25,7 +25,6 @@ from pants.engine.rules import (
     UnrecognizedRuleArgument,
     goal_rule,
     rule,
-    rule_helper,
 )
 from pants.engine.unions import UnionMembership
 from pants.option.global_options import DEFAULT_EXECUTION_OPTIONS, DEFAULT_LOCAL_STORE_OPTIONS
@@ -1071,40 +1070,4 @@ def test_param_type_overrides() -> None:
 
         @rule(_param_type_overrides={"param1": "A string"})
         async def protect_existence(param1) -> A:
-            return A()
-
-
-def test_invalid_rule_helper_name() -> None:
-    with pytest.raises(ValueError, match="must be private"):
-
-        @rule_helper
-        async def foo() -> A:
-            return A()
-
-    @rule_helper(_public=True)
-    async def bar() -> A:
-        return A()
-
-
-def test_cant_be_both_rule_and_rule_helper() -> None:
-    with pytest.raises(ValueError, match="Cannot use both @rule and @rule_helper"):
-
-        @rule_helper
-        @rule
-        async def _func1() -> A:
-            return A()
-
-    with pytest.raises(ValueError, match="Cannot use both @rule and @rule_helper"):
-
-        @rule
-        @rule_helper
-        async def _func2() -> A:
-            return A()
-
-
-def test_synchronous_rule_helper() -> None:
-    with pytest.raises(ValueError, match="must be async"):
-
-        @rule_helper
-        def _foo() -> A:
             return A()

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -697,7 +697,7 @@ def run_rule_with_mocks(
     func: Callable[..., Coroutine[Any, Any, _O]] | Callable[..., _O]
 
     # Perform additional validation on `@rule` that the correct args are provided. We don't have
-    # an easy way to do this for `@rule_helper` yet.
+    # an easy way to do this for async helper calls yet.
     if task_rule:
         if len(rule_args) != len(task_rule.input_selectors):
             raise ValueError(


### PR DESCRIPTION
The deprecated `@rule_helper` decorator can be removed, since we've branched for 2.19, and are so now about to release 2.20.0.dev0.

The deprecation happened in #18330 and was released in 2.16.0.