### PR TITLE
Silence warnings about internal call of deprecated Helm function on 2.18

### DIFF
--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -499,6 +499,11 @@ class HelmDeploymentValuesField(DictStringToStringField, AsyncFieldMixin):
     def format_with(
         self, interpolation_context: InterpolationContext, *, ignore_missing: bool = False
     ) -> dict[str, str]:
+        return self._format_with(interpolation_context, ignore_missing=ignore_missing)
+
+    def _format_with(
+        self, interpolation_context: InterpolationContext, *, ignore_missing: bool = False
+    ) -> dict[str, str]:
         source = InterpolationContext.TextSource(
             self.address,
             target_alias=HelmDeploymentTarget.alias,
@@ -625,7 +630,7 @@ class HelmDeploymentFieldSet(FieldSet):
     def format_values(
         self, interpolation_context: InterpolationContext, *, ignore_missing: bool = False
     ) -> dict[str, str]:
-        return self.values.format_with(interpolation_context, ignore_missing=ignore_missing)
+        return self.values._format_with(interpolation_context, ignore_missing=ignore_missing)
 
 
 class AllHelmDeploymentTargets(Targets):

--- a/src/python/pants/backend/helm/util_rules/renderer.py
+++ b/src/python/pants/backend/helm/util_rules/renderer.py
@@ -326,7 +326,7 @@ async def setup_render_helm_deployment_process(
         request.field_set.release_name.value
         or request.field_set.address.target_name.replace("_", "-")
     )
-    inline_values = request.field_set.values.format_with(
+    inline_values = request.field_set.values._format_with(
         interpolation_context, ignore_missing=is_render_cmd
     )
 


### PR DESCRIPTION
This fixes #20210 by ensuring that Pants itself isn't calling the deprecated `HelmDeploymentValuesField.format_with` method. The deprecation is just for external plugins, and a non-plugin user getting the warning can't (and shouldn't) do anything about it.

I can't reproduce the issue about spurious warnings about `{env.X}` despite not using it, so this probably doesn't resolve that.

