### PR TITLE
Fix spurious warnings about Helm interpolations due to incorrect comparison

### DIFF
--- a/src/python/pants/backend/helm/target_types.py
+++ b/src/python/pants/backend/helm/target_types.py
@@ -524,12 +524,15 @@ class HelmDeploymentValuesField(DictStringToStringField, AsyncFieldMixin):
         result = {}
         default_curr_value: dict[str, str] = {}
         current_value: Mapping[str, str] = self.value or default_curr_value
+        any_change = False
         for key, value in current_value.items():
             formatted_value = format_value(value)
             if formatted_value is not None:
                 result[key] = formatted_value
 
-        if result != current_value:
+            any_change |= formatted_value != value
+
+        if any_change:
             warn_or_error(
                 "2.19.0.dev0",
                 "Using the {env.VAR_NAME} interpolation syntax",


### PR DESCRIPTION
This fixes the second half of #20210 by more accurately detecting when the helm `values` value had deprecated `{env.X}`-style interpolations applied. Previously, it compared a `FrozenDict` (`current_value`) to a `dict`, which always returns non-equal (#20219, a very subtle issue), i.e. implying that there was changes, even when there was not.

This rewrites the code to avoid comparing `FrozenDict`s because that's currently so "dangerous".

(#20217 fixed the first half.)