### PR TITLE
Add note in docker_environment image field help on tool requirements

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -197,9 +197,7 @@ class DockerImageField(StringField):
         - `bash`
         - `tar`
 
-        While most images will have these preinstalled, users of base images such as Distroless
-        or scratch will need to bake these tools into the image themselves. All of these
-        except `bash` are available via busybox.
+        While most images will have these preinstalled, users of base images such as Distroless or scratch will need to bake these tools into the image themselves. All of these except `bash` are available via busybox.
         """
     )
 

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -190,6 +190,16 @@ class DockerImageField(StringField):
         The choice of image ID can affect the reproducibility of builds. Consider using an
         immutable digest if reproducibility is needed, but regularly ensure that the image
         is free of relevant bugs or security vulnerabilities.
+
+        Note that in order to use an image as a `docker_environment` it must have a few tools:
+        - `/bin/sh`
+        - `/usr/bin/env`
+        - `bash`
+        - `tar`
+
+        While most images will have these preinstalled, users of base images such as Distroless
+        or scratch will need to bake these tools into the image themselves. All of these
+        except `bash` are available via busybox.
         """
     )
 


### PR DESCRIPTION
There are a few assumptions about available tools baked into the docker_environment process. These were previously undocumented, so if you were using a slim container like Distroless or similar, you might struggle to work through them all one at a time.