### PR TITLE
add reformat commit to ignore revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ d0998872d8116edd5ebc8231dbdd28779591dc2b
 
 # README in german was reverted within a day by 208e941ce6281ee9ce7ba16815f643e116bfdbc9
 dc8227b9841a1057b6ca8629c430f072dd9a190f
+
+# This commit formatted all Rust code
+3632a66bc7918ace25c0aa6f05b4b6a4253d908e


### PR DESCRIPTION
This completely slipped my mind since the reformat took a while to land, but remembered it today when seeing my name in a blame.