### PR TITLE
Allow passing arbitrary args to PEX invocation when building FaaS artifacts

### DIFF
--- a/docs/markdown/Python/python-integrations/awslambda-python.md
+++ b/docs/markdown/Python/python-integrations/awslambda-python.md
@@ -80,6 +80,14 @@ Wrote dist/project/lambda.zip
 >
 > If this happens, you must either change your dependencies to only use dependencies with pre-built [wheels](https://pythonwheels.com) or find a Linux environment to run `pants package`.
 
+> 🚧 "Encountering collisions" errors and failing to build?
+>
+> If a build fails with an error like `Encountered collisions populating ... from PEX at faas_repository.pex:`, listing one or more files with different `sha1` hashes, this likely means your dependencies package files in unexpected locations, outside their "scoped" directory (for instance, a package `example-pkg` typically only includes files within `example_pkg/` and `example_pkg-*.dist-info/` directories). When multiple dependencies do this, those files can have exactly matching file paths but different contents, and so it is impossible to create a Lambda artifact: which of the files should be installed and which should be ignored? Resolving this requires human intervention to understand whether any of those files are important, and hence PEX emits an error rather than making an (arbitrary) choice that may result in confusing and/or broken behaviour at runtime.
+>
+> Most commonly this seems to happen with metadata like a README or LICENSE file, or test files (in a `tests/` subdirectory), which are likely not important at runtime. In these cases, the collision can be worked around by adding [a `pex3_venv_create_extra_args=["--collisions-ok"]` field](doc:reference-python_aws_lambda_function#codepex3_venv_create_extra_argscode) to the `python_aws_lambda_...` targets.
+>
+> A better solution is to work with the dependencies to stop them from packaging files outside their scoped directories.
+
 Step 4: Upload to AWS
 ---------------------
 

--- a/docs/markdown/Python/python-integrations/google-cloud-function-python.md
+++ b/docs/markdown/Python/python-integrations/google-cloud-function-python.md
@@ -82,6 +82,15 @@ Wrote dist/project/cloud_function.zip
 >
 > If this happens, you must either change your dependencies to only use dependencies with pre-built [wheels](https://pythonwheels.com) or find a Linux environment to run `pants package`.
 
+> 🚧 "Encountering collisions" errors and failing to build?
+>
+> If a build fails with an error like `Encountered collisions populating ... from PEX at faas_repository.pex:`, listing one or more files with different `sha1` hashes, this likely means your dependencies package files in unexpected locations, outside their "scoped" directory (for instance, a package `example-pkg` typically only includes files within `example_pkg/` and `example_pkg-*.dist-info/` directories). When multiple dependencies do this, those files can have exactly matching file paths but different contents, and so it is impossible to create a GCF artifact: which of the files should be installed and which should be ignored? Resolving this requires human intervention to understand whether any of those files are important, and hence PEX emits an error rather than making an (arbitrary) choice that may result in confusing and/or broken behaviour at runtime.
+>
+> Most commonly this seems to happen with metadata like a README or LICENSE file, or test files (in a `tests/` subdirectory), which are likely not important at runtime. In these cases, the collision can be worked around by adding [a `pex3_venv_create_extra_args=["--collisions-ok"]` field](doc:reference-python_google_cloud_function#codepex3_venv_create_extra_argscode) to the `python_google_cloud_function` target.
+>
+> A better solution is to work with the dependencies to stop them from packaging files outside their scoped directories.
+
+
 Step 4: Upload to Google Cloud
 ------------------------------
 

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -17,8 +17,8 @@ from pants.backend.awslambda.python.target_types import (
 )
 from pants.backend.python.util_rules.faas import (
     BuildPythonFaaSRequest,
-    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
+    PythonFaaSPex3VenvCreateExtraArgsField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
@@ -35,7 +35,7 @@ class _BaseFieldSet(PackageFieldSet):
     include_requirements: PythonAwsLambdaIncludeRequirements
     runtime: PythonAwsLambdaRuntime
     complete_platforms: PythonFaaSCompletePlatforms
-    collisions_ok: PythonFaaSCollisionsOkField
+    pex3_venv_create_extra_args: PythonFaaSPex3VenvCreateExtraArgsField
     output_path: OutputPathField
     environment: EnvironmentField
 
@@ -70,7 +70,7 @@ async def package_python_aws_lambda_function(
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
             include_sources=True,
-            collisions_ok=field_set.collisions_ok,
+            pex3_venv_create_extra_args=field_set.pex3_venv_create_extra_args,
             reexported_handler_module=PythonAwsLambdaHandlerField.reexported_handler_module,
         ),
     )
@@ -90,7 +90,7 @@ async def package_python_aws_lambda_layer(
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
             include_sources=field_set.include_sources.value,
-            collisions_ok=field_set.collisions_ok,
+            pex3_venv_create_extra_args=field_set.pex3_venv_create_extra_args,
             # See
             # https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
             #

--- a/src/python/pants/backend/awslambda/python/rules.py
+++ b/src/python/pants/backend/awslambda/python/rules.py
@@ -15,7 +15,11 @@ from pants.backend.awslambda.python.target_types import (
     PythonAwsLambdaLayerDependenciesField,
     PythonAwsLambdaRuntime,
 )
-from pants.backend.python.util_rules.faas import BuildPythonFaaSRequest, PythonFaaSCompletePlatforms
+from pants.backend.python.util_rules.faas import (
+    BuildPythonFaaSRequest,
+    PythonFaaSCollisionsOkField,
+    PythonFaaSCompletePlatforms,
+)
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.core.util_rules.environments import EnvironmentField
@@ -31,6 +35,7 @@ class _BaseFieldSet(PackageFieldSet):
     include_requirements: PythonAwsLambdaIncludeRequirements
     runtime: PythonAwsLambdaRuntime
     complete_platforms: PythonFaaSCompletePlatforms
+    collisions_ok: PythonFaaSCollisionsOkField
     output_path: OutputPathField
     environment: EnvironmentField
 
@@ -65,6 +70,7 @@ async def package_python_aws_lambda_function(
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
             include_sources=True,
+            collisions_ok=field_set.collisions_ok,
             reexported_handler_module=PythonAwsLambdaHandlerField.reexported_handler_module,
         ),
     )
@@ -84,6 +90,7 @@ async def package_python_aws_lambda_layer(
             output_path=field_set.output_path,
             include_requirements=field_set.include_requirements.value,
             include_sources=field_set.include_sources.value,
+            collisions_ok=field_set.collisions_ok,
             # See
             # https://docs.aws.amazon.com/lambda/latest/dg/configuration-layers.html#configuration-layers-path
             #

--- a/src/python/pants/backend/awslambda/python/rules_test.py
+++ b/src/python/pants/backend/awslambda/python/rules_test.py
@@ -7,6 +7,8 @@ import os
 import subprocess
 from io import BytesIO
 from textwrap import dedent
+from typing import Any
+from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
@@ -14,6 +16,9 @@ import pytest
 from pants.backend.awslambda.python.rules import (
     PythonAwsLambdaFieldSet,
     PythonAwsLambdaLayerFieldSet,
+    _BaseFieldSet,
+    package_python_aws_lambda_function,
+    package_python_aws_lambda_layer,
 )
 from pants.backend.awslambda.python.rules import rules as awslambda_python_rules
 from pants.backend.awslambda.python.target_types import PythonAWSLambda, PythonAWSLambdaLayer
@@ -26,6 +31,10 @@ from pants.backend.python.target_types import (
     PythonSourcesGeneratorTarget,
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.faas import (
+    BuildPythonFaaSRequest,
+    PythonFaaSPex3VenvCreateExtraArgsField,
+)
 from pants.core.goals import package
 from pants.core.goals.package import BuiltPackage
 from pants.core.target_types import (
@@ -40,7 +49,7 @@ from pants.engine.fs import DigestContents
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import FieldSet
 from pants.testutil.python_rule_runner import PythonRuleRunner
-from pants.testutil.rule_runner import QueryRule
+from pants.testutil.rule_runner import MockGet, QueryRule, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -344,73 +353,58 @@ def test_layer_must_have_dependencies(rule_runner: PythonRuleRunner) -> None:
         )
 
 
-def test_collisions_ok(rule_runner: PythonRuleRunner) -> None:
-    rule_runner.write_files(
-        {
-            "src/python/foo/bar/hello_world.py": dedent(
-                """
-                def handler(event, context):
-                    print('Hello, World!')
-                """
-            ),
-            "src/python/foo/bar/BUILD": dedent(
-                """
-                # Per https://github.com/pantsbuild/pants/issues/20224, these both package their `tests/`
-                # folder at the top level with non-equal __init__.py and test_defaults.py within it.
-                python_requirement(name="django-hosts", requirements=["django-hosts==5.1"])
-                python_requirement(name="draftjs-exporter", requirements=["draftjs-exporter==2.1.7"])
-                python_sources()
-
-                python_aws_lambda_function(
-                    name='lambda-ok',
-                    handler='foo.bar.hello_world:handler',
-                    dependencies=[":django-hosts", ":draftjs-exporter"],
-                    runtime='python3.9',
-                    collisions_ok=True,
-                )
-                python_aws_lambda_layer(
-                    name='layer-ok',
-                    dependencies=[":django-hosts", ":draftjs-exporter"],
-                    runtime="python3.9",
-                    collisions_ok=True,
-                )
-
-                python_aws_lambda_function(
-                    name='lambda-error',
-                    handler='foo.bar.hello_world:handler',
-                    dependencies=[":django-hosts", ":draftjs-exporter"],
-                    runtime='python3.9',
-                )
-                python_aws_lambda_layer(
-                    name='layer-error',
-                    dependencies=[":django-hosts", ":draftjs-exporter"],
-                    runtime="python3.9",
-                )
-                """
-            ),
-        }
-    )
-
-    # Verify - without the flag, we get an error
-    target = rule_runner.get_target(Address("src/python/foo/bar", target_name="lambda-error"))
-    with pytest.raises(ExecutionError, match="Encountered collisions"):
-        rule_runner.request(BuiltPackage, [PythonAwsLambdaFieldSet.create(target)])
-    target = rule_runner.get_target(Address("src/python/foo/bar", target_name="layer-error"))
-    with pytest.raises(ExecutionError, match="Encountered collisions"):
-        rule_runner.request(BuiltPackage, [PythonAwsLambdaLayerFieldSet.create(target)])
-
-    # Exercise/Verify - passing collisions_ok resolves the issue
-    create_python_awslambda(
-        rule_runner,
-        Address("src/python/foo/bar", target_name="lambda-ok"),
-        expected_extra_log_lines=(
-            "    Runtime: python3.9",
-            "    Handler: lambda_function.handler",
+@pytest.mark.parametrize(
+    ("rule", "field_set_ty", "extra_field_set_args"),
+    [
+        pytest.param(
+            package_python_aws_lambda_function, PythonAwsLambdaFieldSet, ["handler"], id="function"
         ),
+        pytest.param(
+            package_python_aws_lambda_layer,
+            PythonAwsLambdaLayerFieldSet,
+            ["dependencies", "include_sources"],
+            id="layer",
+        ),
+    ],
+)
+def test_pex3_venv_create_extra_args_are_passed_through(
+    rule: Any, field_set_ty: type[_BaseFieldSet], extra_field_set_args: list[str]
+) -> None:
+    # Setup
+    addr = Address("addr")
+    extra_args = (
+        "--extra-args-for-test",
+        "distinctive-value-E40B861A-266B-4F37-8394-767840BE9E44",
     )
-    create_python_awslambda(
-        rule_runner,
-        Address("src/python/foo/bar", target_name="layer-ok"),
-        expected_extra_log_lines=("    Runtime: python3.9",),
-        layer=True,
+    extra_args_field = PythonFaaSPex3VenvCreateExtraArgsField(extra_args, addr)
+    field_set = field_set_ty(
+        address=addr,
+        include_requirements=Mock(),
+        runtime=Mock(),
+        complete_platforms=Mock(),
+        output_path=Mock(),
+        environment=Mock(),
+        **{arg: Mock() for arg in extra_field_set_args},
+        pex3_venv_create_extra_args=extra_args_field,
     )
+
+    observed_calls = []
+
+    def mocked_build(request: BuildPythonFaaSRequest) -> BuiltPackage:
+        observed_calls.append(request.pex3_venv_create_extra_args)
+        return Mock()
+
+    # Exercise
+    run_rule_with_mocks(
+        rule,
+        rule_args=[field_set],
+        mock_gets=[
+            MockGet(
+                output_type=BuiltPackage, input_types=(BuildPythonFaaSRequest,), mock=mocked_build
+            )
+        ],
+    )
+
+    # Verify
+    assert len(observed_calls) == 1
+    assert observed_calls[0] is extra_args_field

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -9,11 +9,11 @@ from typing import ClassVar, Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
-    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
     PythonFaaSKnownRuntime,
+    PythonFaaSPex3VenvCreateExtraArgsField,
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
@@ -151,7 +151,7 @@ class _AWSLambdaBaseTarget(Target):
         PythonAwsLambdaIncludeRequirements,
         PythonAwsLambdaRuntime,
         PythonFaaSCompletePlatforms,
-        PythonFaaSCollisionsOkField,
+        PythonFaaSPex3VenvCreateExtraArgsField,
         PythonResolveField,
         EnvironmentField,
     )

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -9,6 +9,7 @@ from typing import ClassVar, Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
+    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
@@ -150,6 +151,7 @@ class _AWSLambdaBaseTarget(Target):
         PythonAwsLambdaIncludeRequirements,
         PythonAwsLambdaRuntime,
         PythonFaaSCompletePlatforms,
+        PythonFaaSCollisionsOkField,
         PythonResolveField,
         EnvironmentField,
     )

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -12,7 +12,11 @@ from pants.backend.google_cloud_function.python.target_types import (
     PythonGoogleCloudFunctionRuntime,
     PythonGoogleCloudFunctionType,
 )
-from pants.backend.python.util_rules.faas import BuildPythonFaaSRequest, PythonFaaSCompletePlatforms
+from pants.backend.python.util_rules.faas import (
+    BuildPythonFaaSRequest,
+    PythonFaaSCollisionsOkField,
+    PythonFaaSCompletePlatforms,
+)
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
 from pants.core.util_rules.environments import EnvironmentField
@@ -30,6 +34,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
     handler: PythonGoogleCloudFunctionHandlerField
     runtime: PythonGoogleCloudFunctionRuntime
     complete_platforms: PythonFaaSCompletePlatforms
+    collisions_ok: PythonFaaSCollisionsOkField
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
     environment: EnvironmentField
@@ -47,6 +52,7 @@ async def package_python_google_cloud_function(
             complete_platforms=field_set.complete_platforms,
             runtime=field_set.runtime,
             handler=field_set.handler,
+            collisions_ok=field_set.collisions_ok,
             output_path=field_set.output_path,
             include_requirements=True,
             include_sources=True,

--- a/src/python/pants/backend/google_cloud_function/python/rules.py
+++ b/src/python/pants/backend/google_cloud_function/python/rules.py
@@ -14,8 +14,8 @@ from pants.backend.google_cloud_function.python.target_types import (
 )
 from pants.backend.python.util_rules.faas import (
     BuildPythonFaaSRequest,
-    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
+    PythonFaaSPex3VenvCreateExtraArgsField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
 from pants.core.goals.package import BuiltPackage, OutputPathField, PackageFieldSet
@@ -34,7 +34,7 @@ class PythonGoogleCloudFunctionFieldSet(PackageFieldSet):
     handler: PythonGoogleCloudFunctionHandlerField
     runtime: PythonGoogleCloudFunctionRuntime
     complete_platforms: PythonFaaSCompletePlatforms
-    collisions_ok: PythonFaaSCollisionsOkField
+    pex3_venv_create_extra_args: PythonFaaSPex3VenvCreateExtraArgsField
     type: PythonGoogleCloudFunctionType
     output_path: OutputPathField
     environment: EnvironmentField
@@ -52,7 +52,7 @@ async def package_python_google_cloud_function(
             complete_platforms=field_set.complete_platforms,
             runtime=field_set.runtime,
             handler=field_set.handler,
-            collisions_ok=field_set.collisions_ok,
+            pex3_venv_create_extra_args=field_set.pex3_venv_create_extra_args,
             output_path=field_set.output_path,
             include_requirements=True,
             include_sources=True,

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -7,10 +7,10 @@ from typing import Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
-    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
+    PythonFaaSPex3VenvCreateExtraArgsField,
     PythonFaaSRuntimeField,
 )
 from pants.backend.python.util_rules.faas import rules as faas_rules
@@ -117,7 +117,7 @@ class PythonGoogleCloudFunction(Target):
         PythonGoogleCloudFunctionRuntime,
         PythonFaaSCompletePlatforms,
         PythonGoogleCloudFunctionType,
-        PythonFaaSCollisionsOkField,
+        PythonFaaSPex3VenvCreateExtraArgsField,
         PythonResolveField,
         EnvironmentField,
     )

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -7,6 +7,7 @@ from typing import Match, Optional, Tuple, cast
 
 from pants.backend.python.target_types import PexCompletePlatformsField, PythonResolveField
 from pants.backend.python.util_rules.faas import (
+    PythonFaaSCollisionsOkField,
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
@@ -116,6 +117,7 @@ class PythonGoogleCloudFunction(Target):
         PythonGoogleCloudFunctionRuntime,
         PythonFaaSCompletePlatforms,
         PythonGoogleCloudFunctionType,
+        PythonFaaSCollisionsOkField,
         PythonResolveField,
         EnvironmentField,
     )

--- a/src/python/pants/backend/python/util_rules/faas_test.py
+++ b/src/python/pants/backend/python/util_rules/faas_test.py
@@ -2,8 +2,10 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from __future__ import annotations
 
+from pathlib import Path
 from textwrap import dedent
 from typing import Optional
+from unittest.mock import Mock
 
 import pytest
 
@@ -15,24 +17,37 @@ from pants.backend.python.target_types import (
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
 from pants.backend.python.util_rules.faas import (
+    BuildPythonFaaSRequest,
     InferPythonFaaSHandlerDependency,
     PythonFaaSCompletePlatforms,
     PythonFaaSDependencies,
     PythonFaaSHandlerField,
     PythonFaaSHandlerInferenceFieldSet,
     PythonFaaSKnownRuntime,
+    PythonFaaSPex3VenvCreateExtraArgsField,
     PythonFaaSRuntimeField,
     ResolvedPythonFaaSHandler,
     ResolvePythonFaaSHandlerRequest,
     RuntimePlatforms,
     RuntimePlatformsRequest,
+    build_python_faas,
 )
-from pants.backend.python.util_rules.pex import CompletePlatforms, PexPlatforms
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
+from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvRequest
 from pants.build_graph.address import Address
+from pants.core.goals.package import OutputPathField
 from pants.core.target_types import FileTarget
+from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import InferredDependencies, InvalidFieldException, Target
-from pants.testutil.rule_runner import QueryRule, RuleRunner, engine_error
+from pants.testutil.rule_runner import (
+    MockGet,
+    QueryRule,
+    RuleRunner,
+    engine_error,
+    run_rule_with_mocks,
+)
 from pants.util.strutil import softwrap
 
 
@@ -381,3 +396,61 @@ def test_infer_runtime_platforms_errors_when_wide_ics(
         in str(exc.value)
     )
     assert ics in str(exc.value)
+
+
+def test_venv_create_extra_args_are_passed_through() -> None:
+    # Setup
+    addr = Address("addr")
+    extra_args = (
+        "--extra-args-for-test",
+        "distinctive-value-FA943D37-51DA-445A-8F00-7E9C7DA8FAAA",
+    )
+    extra_args_field = PythonFaaSPex3VenvCreateExtraArgsField(extra_args, addr)
+    request = BuildPythonFaaSRequest(
+        address=addr,
+        target_name="x",
+        complete_platforms=Mock(),
+        handler=None,
+        output_path=OutputPathField(None, addr),
+        runtime=Mock(),
+        pex3_venv_create_extra_args=extra_args_field,
+        include_requirements=False,
+        include_sources=False,
+        reexported_handler_module=None,
+    )
+
+    observed_extra_args = []
+
+    def mock_get_pex_venv(request: PexVenvRequest) -> PexVenv:
+        observed_extra_args.append(request.extra_args)
+
+        return PexVenv(digest=EMPTY_DIGEST, path=Path())
+
+    # Exercise
+    run_rule_with_mocks(
+        build_python_faas,
+        rule_args=[request],
+        mock_gets=[
+            MockGet(
+                output_type=RuntimePlatforms,
+                input_types=(RuntimePlatformsRequest,),
+                mock=lambda _: RuntimePlatforms(interpreter_version=None),
+            ),
+            MockGet(
+                output_type=ResolvedPythonFaaSHandler,
+                input_types=(ResolvePythonFaaSHandlerRequest,),
+                mock=lambda _: Mock(),
+            ),
+            MockGet(output_type=Digest, input_types=(CreateDigest,), mock=lambda _: EMPTY_DIGEST),
+            MockGet(
+                output_type=Pex,
+                input_types=(PexFromTargetsRequest,),
+                mock=lambda _: Pex(digest=EMPTY_DIGEST, name="pex", python=None),
+            ),
+            MockGet(output_type=PexVenv, input_types=(PexVenvRequest,), mock=mock_get_pex_venv),
+        ],
+    )
+
+    # Verify
+    assert len(observed_extra_args) == 1
+    assert observed_extra_args[0] == extra_args

--- a/src/python/pants/backend/python/util_rules/pex_venv.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv.py
@@ -31,6 +31,7 @@ class PexVenvRequest:
     platforms: PexPlatforms = PexPlatforms()
     complete_platforms: CompletePlatforms = CompletePlatforms()
     prefix: None | str = None
+    collisions_ok: bool = False
 
 
 @dataclass(frozen=True)
@@ -77,6 +78,7 @@ async def pex_venv(request: PexVenvRequest) -> PexVenv:
                 f"--pex-repository={request.pex.name}",
                 f"--layout={request.layout.value}",
                 *((f"--prefix={request.prefix}",) if request.prefix is not None else ()),
+                *(("--collisions-ok",) if request.collisions_ok else ()),
                 # NB. Specifying more than one of these args doesn't make sense for `venv
                 # create`. Incorrect usage will be surfaced as a subprocess failure.
                 *request.platforms.generate_pex_arg_list(),

--- a/src/python/pants/backend/python/util_rules/pex_venv.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv.py
@@ -31,7 +31,7 @@ class PexVenvRequest:
     platforms: PexPlatforms = PexPlatforms()
     complete_platforms: CompletePlatforms = CompletePlatforms()
     prefix: None | str = None
-    collisions_ok: bool = False
+    extra_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -78,11 +78,11 @@ async def pex_venv(request: PexVenvRequest) -> PexVenv:
                 f"--pex-repository={request.pex.name}",
                 f"--layout={request.layout.value}",
                 *((f"--prefix={request.prefix}",) if request.prefix is not None else ()),
-                *(("--collisions-ok",) if request.collisions_ok else ()),
                 # NB. Specifying more than one of these args doesn't make sense for `venv
                 # create`. Incorrect usage will be surfaced as a subprocess failure.
                 *request.platforms.generate_pex_arg_list(),
                 *request.complete_platforms.generate_pex_arg_list(),
+                *request.extra_args,
             ),
             additional_input_digest=input_digest,
             output_files=output_files,

--- a/src/python/pants/backend/python/util_rules/pex_venv_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_venv_test.py
@@ -3,25 +3,32 @@
 
 from __future__ import annotations
 
-import dataclasses
 import fnmatch
 import io
 import zipfile
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
 from pants.backend.python.util_rules import pex_test_utils
 from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
 from pants.backend.python.util_rules.pex import rules as pex_rules
+from pants.backend.python.util_rules.pex_cli import PexCliProcess
 from pants.backend.python.util_rules.pex_requirements import PexRequirements
 from pants.backend.python.util_rules.pex_test_utils import create_pex_and_get_all_data
-from pants.backend.python.util_rules.pex_venv import PexVenv, PexVenvLayout, PexVenvRequest
+from pants.backend.python.util_rules.pex_venv import (
+    PexVenv,
+    PexVenvLayout,
+    PexVenvRequest,
+    pex_venv,
+)
 from pants.backend.python.util_rules.pex_venv import rules as pex_venv_rules
 from pants.engine.fs import CreateDigest, DigestContents, FileContent
-from pants.engine.internals.native_engine import Digest, Snapshot
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest, MergeDigests, Snapshot
 from pants.engine.internals.scheduler import ExecutionError
-from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.engine.process import ProcessResult
+from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -219,45 +226,47 @@ def test_prefix_should_add_path(
     )
 
 
-def test_collisions_ok_should_allow_distributions_that_have_colliding_files(
+def test_extra_args_should_be_passed_through(
     rule_runner: RuleRunner,
 ) -> None:
-    # Setup - we need a PEX that has distributions that collide
-    result = create_pex_and_get_all_data(
-        rule_runner,
-        # Per https://github.com/pantsbuild/pants/issues/20224, these both package their `tests/`
-        # folder at the top level with non-equal __init__.py and test_defaults.py within it.
-        requirements=PexRequirements(["django-hosts==5.1", "draftjs-exporter==2.1.7"]),
-        internal_only=False,
+    # Setup
+    pex = Pex(digest=EMPTY_DIGEST, name="pex", python=None)
+    extra_args = (
+        "--extra-args-for-test",
+        "distinctive-value-C3B8DC34-6A27-4A35-AE25-59538ABE8082",
     )
-    assert isinstance(result.pex, Pex)
-    pex = result.pex
 
     request = PexVenvRequest(
         pex=pex,
         layout=PexVenvLayout.FLAT,
         output_path=Path("out"),
         description="testing",
-        collisions_ok=False,
+        extra_args=extra_args,
     )
 
-    # Verify - these distributions have the collisions we expect
-    with pytest.raises(ExecutionError) as exc:
-        rule_runner.request(PexVenv, [request])
+    observed_calls = []
 
-    assert "Encountered collisions" in str(exc.value)
-    assert "out/tests/__init__.py was provided by" in str(exc.value)
-    assert "out/tests/test_defaults.py was provided by" in str(exc.value)
+    def mocked_run_pex_cli_process(process: PexCliProcess) -> ProcessResult:
+        assert process.subcommand == ("venv", "create")
+        observed_calls.append(process.extra_args)
 
-    # Exercise/Verify - if we allow collisions, we get something useful
-    run_and_validate(
-        rule_runner,
-        dataclasses.replace(request, collisions_ok=True),
-        check_globs_exist=(
-            "out/django_hosts/__init__.py",
-            "out/draftjs_exporter/__init__.py",
-            # the colliding files themselves; one of them will be chosen arbitrarily;
-            "out/tests/__init__.py",
-            "out/tests/test_defaults.py",
-        ),
+        return Mock()
+
+    # Exercise
+    run_rule_with_mocks(
+        pex_venv,
+        rule_args=[request],
+        mock_gets=[
+            MockGet(output_type=Digest, input_types=(MergeDigests,), mock=lambda _: EMPTY_DIGEST),
+            MockGet(
+                output_type=ProcessResult,
+                input_types=(PexCliProcess,),
+                mock=mocked_run_pex_cli_process,
+            ),
+        ],
     )
+
+    # Verify
+    assert len(observed_calls) == 1
+    # the extra args are always at the end
+    assert observed_calls[0][-2:] == extra_args


### PR DESCRIPTION
This adds an `pex3_venv_create_extra_args` field to all FaaS targets (`python_aws_lambda_function`, `python_aws_lambda_layer`, `python_google_cloud_function`). This allows adding arbitrary extra arguments that are passed to the `pex3 venv create --layout=flat-zipped ...` invocation that is used to create the final zip file.

Most acutely, this is driven by making it possible to pass the `--collisions-ok` flag. This allows work around dependencies that are packaged with files outside a namespaced directories, e.g. commonly a LICENCE or README file, or `tests/` directory, since they'll have different content. A command like `pip install ...` will happily install them and have one of the files "win" arbitrarily, while PEX is more correct and flags that it doesn't know what to do in that circumstance.

Fixes #20224

This is marked for cherry picking back to 2.18 because it can block adoption of the new layout, and the old (lambdex) layout is deprecated and using it is noisy in 2.18.
