### PR TITLE
Support coursier `--force-version` argument

### DIFF
--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -153,6 +153,7 @@ class ArtifactRequirement:
     url: str | None = None
     jar: JvmArtifactJarSourceField | None = None
     excludes: frozenset[str] | None = None
+    force_version: bool = False
 
     @classmethod
     def from_jvm_artifact_target(cls, target: Target) -> ArtifactRequirement:
@@ -168,7 +169,6 @@ class ArtifactRequirement:
                 group=target[JvmArtifactGroupField].value,
                 artifact=target[JvmArtifactArtifactField].value,
                 version=target[JvmArtifactVersionField].value,
-                strict=target[JvmArtifactForceVersionField].value,
             ),
             url=target[JvmArtifactUrlField].value,
             jar=(
@@ -177,6 +177,7 @@ class ArtifactRequirement:
                 else None
             ),
             excludes=frozenset([*(exclusion.to_coord_str() for exclusion in exclusions)]) or None,
+            force_version=target[JvmArtifactForceVersionField].value,
         )
 
     def with_extra_excludes(self, *excludes: str) -> ArtifactRequirement:

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -153,7 +153,6 @@ class ArtifactRequirement:
     url: str | None = None
     jar: JvmArtifactJarSourceField | None = None
     excludes: frozenset[str] | None = None
-    force_version: bool = False
 
     @classmethod
     def from_jvm_artifact_target(cls, target: Target) -> ArtifactRequirement:
@@ -169,6 +168,7 @@ class ArtifactRequirement:
                 group=target[JvmArtifactGroupField].value,
                 artifact=target[JvmArtifactArtifactField].value,
                 version=target[JvmArtifactVersionField].value,
+                strict=target[JvmArtifactForceVersionField].value,
             ),
             url=target[JvmArtifactUrlField].value,
             jar=(
@@ -177,7 +177,6 @@ class ArtifactRequirement:
                 else None
             ),
             excludes=frozenset([*(exclusion.to_coord_str() for exclusion in exclusions)]) or None,
-            force_version=target[JvmArtifactForceVersionField].value,
         )
 
     def with_extra_excludes(self, *excludes: str) -> ArtifactRequirement:

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -15,6 +15,7 @@ from pants.jvm.target_types import (
     JvmArtifactArtifactField,
     JvmArtifactExclusionsField,
     JvmArtifactFieldSet,
+    JvmArtifactForceVersionField,
     JvmArtifactGroupField,
     JvmArtifactJarSourceField,
     JvmArtifactUrlField,
@@ -152,6 +153,7 @@ class ArtifactRequirement:
     url: str | None = None
     jar: JvmArtifactJarSourceField | None = None
     excludes: frozenset[str] | None = None
+    force_version: bool = False
 
     @classmethod
     def from_jvm_artifact_target(cls, target: Target) -> ArtifactRequirement:
@@ -175,6 +177,7 @@ class ArtifactRequirement:
                 else None
             ),
             excludes=frozenset([*(exclusion.to_coord_str() for exclusion in exclusions)]) or None,
+            force_version=target[JvmArtifactForceVersionField].value,
         )
 
     def with_extra_excludes(self, *excludes: str) -> ArtifactRequirement:

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -400,7 +400,7 @@ async def prepare_coursier_resolve_info(
     for req in to_resolve:
         coord_arg_str = req.to_coord_arg_str()
         coord_arg_strings.add(coord_arg_str)
-        if req.force_version:
+        if req.coordinate.strict:
             force_version_coord_arg_strings.add(coord_arg_str)
 
     return CoursierResolveInfo(

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -400,7 +400,7 @@ async def prepare_coursier_resolve_info(
     for req in to_resolve:
         coord_arg_str = req.to_coord_arg_str()
         coord_arg_strings.add(coord_arg_str)
-        if req.coordinate.strict:
+        if req.force_version:
             force_version_coord_arg_strings.add(coord_arg_str)
 
     return CoursierResolveInfo(

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -728,7 +728,7 @@ def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> Non
 
 @maybe_skip_jdk_test
 def test_force_version(rule_runner):
-    # first check that strict=False leads to a different version
+    # first check that force_version=False leads to a different version
     reqs = ArtifactRequirements(
         [
             Coordinate(
@@ -750,7 +750,7 @@ def test_force_version(rule_runner):
         version="1.7.22",
     ) in [e.coord for e in entries]
 
-    # then check strict=True pins the version
+    # then check force_version=True pins the version
     reqs = ArtifactRequirements(
         [
             Coordinate(

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -723,3 +723,52 @@ def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> Non
         match=r"Exception: No jar found for org.apache.curator:apache-curator:5.5.0. .*",
     ):
         rule_runner.request(CoursierResolvedLockfile, [reqs])
+
+
+@maybe_skip_jdk_test
+def test_force_version(rule_runner):
+    # first check that strict=False leads to a different version
+    reqs = ArtifactRequirements(
+        [
+            Coordinate(
+                group="org.apache.parquet",
+                artifact="parquet-common",
+                version="1.13.1",
+            ).as_requirement(),
+            Coordinate(
+                group="org.slf4j",
+                artifact="slf4j-api",
+                version="1.7.19",
+                strict=False,
+            ).as_requirement(),
+        ]
+    )
+    entries = rule_runner.request(CoursierResolvedLockfile, [reqs]).entries
+    assert Coordinate(
+        group="org.slf4j",
+        artifact="slf4j-api",
+        version="1.7.22",
+    ) in [e.coord for e in entries]
+
+    # then check strict=True pins the version
+    reqs = ArtifactRequirements(
+        [
+            Coordinate(
+                group="org.apache.parquet",
+                artifact="parquet-common",
+                version="1.13.1",
+            ).as_requirement(),
+            Coordinate(
+                group="org.slf4j",
+                artifact="slf4j-api",
+                version="1.7.19",
+                strict=True,
+            ).as_requirement(),
+        ]
+    )
+    entries = rule_runner.request(CoursierResolvedLockfile, [reqs]).entries
+    assert Coordinate(
+        group="org.slf4j",
+        artifact="slf4j-api",
+        version="1.7.19",
+    ) in [e.coord for e in entries]

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import textwrap
 
 import pytest
@@ -739,7 +740,6 @@ def test_force_version(rule_runner):
                 group="org.slf4j",
                 artifact="slf4j-api",
                 version="1.7.19",
-                strict=False,
             ).as_requirement(),
         ]
     )
@@ -758,12 +758,14 @@ def test_force_version(rule_runner):
                 artifact="parquet-common",
                 version="1.13.1",
             ).as_requirement(),
-            Coordinate(
-                group="org.slf4j",
-                artifact="slf4j-api",
-                version="1.7.19",
-                strict=True,
-            ).as_requirement(),
+            dataclasses.replace(
+                Coordinate(
+                    group="org.slf4j",
+                    artifact="slf4j-api",
+                    version="1.7.19",
+                ).as_requirement(),
+                force_version=True,
+            ),
         ]
     )
     entries = rule_runner.request(CoursierResolvedLockfile, [reqs]).entries
@@ -771,4 +773,5 @@ def test_force_version(rule_runner):
         group="org.slf4j",
         artifact="slf4j-api",
         version="1.7.19",
+        strict=True,
     ) in [e.coord for e in entries]

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -255,8 +255,10 @@ class JvmArtifactForceVersionField(BoolField):
     alias = "force_version"
     default = False
     help = help_text(
-        f"""
+        """
         Force artifact version during resolution.
+
+        If set, pants will pass `--force-version` argument to `coursier fetch` for this artifact.
         """
     )
 

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -19,6 +19,7 @@ from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,
+    BoolField,
     Dependencies,
     FieldDefaultFactoryRequest,
     FieldDefaultFactoryResult,
@@ -250,6 +251,16 @@ class JvmArtifactPackagesField(StringSequenceField):
     )
 
 
+class JvmArtifactForceVersionField(BoolField):
+    alias = "force_version"
+    default = False
+    help = help_text(
+        f"""
+        Force artifact version during resolution.
+        """
+    )
+
+
 class JvmProvidesTypesField(StringSequenceField):
     alias = "experimental_provides_types"
     help = help_text(
@@ -370,12 +381,14 @@ class JvmArtifactFieldSet(JvmRunnableSourceFieldSet):
     version: JvmArtifactVersionField
     packages: JvmArtifactPackagesField
     url: JvmArtifactUrlField
+    force_version: JvmArtifactForceVersionField
 
     required_fields = (
         JvmArtifactGroupField,
         JvmArtifactArtifactField,
         JvmArtifactVersionField,
         JvmArtifactPackagesField,
+        JvmArtifactForceVersionField,
     )
 
 


### PR DESCRIPTION
Adds `force_version` field to `jvm_artifact` target:
```python
jvm_artifact(
    group="org.apache.logging.log4j",
    artifact="log4j-core",
    version="2.19.0",
    name="log4j-core",
    force_version=True,
)
```
If set to `True`, pants will pass `--force-version` argument to `coursier fetch` when you run `pants generate-lockfiles`