### PR TITLE
Discover Ruff config in pyproject.toml in subdirectories

### DIFF
--- a/src/python/pants/backend/python/lint/ruff/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/ruff/rules_integration_test.py
@@ -164,6 +164,7 @@ def test_multiple_targets(rule_runner: RuleRunner) -> None:
         [Path("f.py"), Path("pyproject.toml"), [], False],
         [Path("f.py"), Path("ruff.toml"), [], False],
         [Path("custom/f.py"), Path("custom/ruff.toml"), [], False],
+        [Path("custom/f.py"), Path("custom/pyproject.toml"), [], False],
         [Path("f.py"), Path("custom/ruff.toml"), ["--ruff-config=custom/ruff.toml"], False],
         [Path("f.py"), Path("custom/ruff.toml"), [], True],
     ),

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -92,12 +92,13 @@ class Ruff(PythonToolBase):
     def config_request(self, dirs: Iterable[str]) -> ConfigFilesRequest:
         # See https://github.com/astral-sh/ruff#configuration for how ruff discovers
         # config files.
+        all_dirs = ("", *dirs)
         return ConfigFilesRequest(
             specified=self.config,
             specified_option_name=f"[{self.options_scope}].config",
             discovery=self.config_discovery,
-            check_existence=["ruff.toml", *(os.path.join(d, "ruff.toml") for d in ("", *dirs))],
-            check_content={"pyproject.toml": b"[tool.ruff"},
+            check_existence=[os.path.join(d, "ruff.toml") for d in all_dirs],
+            check_content={os.path.join(d, "pyproject.toml"): b"[tool.ruff" for d in all_dirs},
         )
 
 


### PR DESCRIPTION
This ensures that a `pyproject.toml` file in a subdirectory is discovered by the Ruff backend (if it contains configuration for Ruff), same as a `ruff.toml` file.