### PR TITLE
Infers Django migrations and management commands as dependencies of `apps.py`

### DIFF
--- a/src/python/pants/backend/python/framework/django/detect_apps.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps.py
@@ -33,7 +33,6 @@ class DjangoApp:
     config_file: str
 
 
-# @dataclass(frozen=True)
 class DjangoApps(FrozenDict[str, DjangoApp]):
     @property
     def label_to_name(self) -> FrozenDict[str, str]:

--- a/src/python/pants/backend/python/framework/django/detect_apps.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps.py
@@ -43,14 +43,15 @@ class DjangoApps(FrozenDict[str, DjangoApp]):
         return FrozenDict((label, app.config_file) for label, app in self.items())
 
     def add_from_json(self, json_bytes: bytes, strip_prefix="") -> "DjangoApps":
-        json_dict = dict(self, **json.loads(json_bytes.decode()))
+        json_dict: dict[str, dict[str, str]] = json.loads(json_bytes.decode())
         apps = {
             label: DjangoApp(
                 val["app_name"], val["config_file"].partition(f"{strip_prefix}{os.sep}")[2]
             )
             for label, val in json_dict.items()
         }
-        return DjangoApps(sorted(apps.items()))
+        combined = dict(self, **apps)
+        return DjangoApps(sorted(combined.items()))
 
 
 _script_resource = "scripts/app_detector.py"

--- a/src/python/pants/backend/python/framework/django/detect_apps_test.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps_test.py
@@ -7,7 +7,7 @@ import pytest
 
 from pants.backend.python.dependency_inference import parse_python_dependencies
 from pants.backend.python.framework.django import detect_apps
-from pants.backend.python.framework.django.detect_apps import DjangoApps
+from pants.backend.python.framework.django.detect_apps import DjangoApp, DjangoApps
 from pants.backend.python.target_types import PythonSourceTarget
 from pants.backend.python.util_rules import pex
 from pants.core.util_rules import stripped_source_files
@@ -114,7 +114,13 @@ def assert_apps_detected(
         [],
     )
     assert result == DjangoApps(
-        FrozenDict({"app1": "path.to.app1", "app2_label": "another.path.app2", "app3": "some.app3"})
+        FrozenDict(
+            {
+                "app1": DjangoApp("path.to.app1", "path/to/app1/apps.py"),
+                "app2_label": DjangoApp("another.path.app2", "another/path/app2/apps.py"),
+                "app3": DjangoApp("some.app3", "some/app3/apps.py"),
+            }
+        )
     )
 
 

--- a/src/python/pants/backend/python/framework/django/scripts/app_detector.py
+++ b/src/python/pants/backend/python/framework/django/scripts/app_detector.py
@@ -77,7 +77,7 @@ def handle_file(apps, path):
     visitor.visit(tree)
 
     if visitor.app_name:
-        apps[visitor.app_label] = visitor.app_name
+        apps[visitor.app_label] = {"app_name": visitor.app_name, "config_file": path}
 
 
 def main(paths):


### PR DESCRIPTION
This adds Django migrations and management commands as dependencies of `apps.py` files.

With the current implementation, it can detect all `.py` files in a `migrations` or `management.commands` subpackage of a Django app, assuming those subpackages themselves have `__init__.py` files present. 

Resolves #20246.