### PR TITLE
Include guidance on skipping files under Black & isort

### DIFF
--- a/docs/markdown/Python/python/python-linters-and-formatters.md
+++ b/docs/markdown/Python/python/python-linters-and-formatters.md
@@ -287,7 +287,7 @@ You may also want to try downgrading to iSort 4.x by setting `version = "isort>=
 
 Although it is possible to skip linters for individual targets using `skip_` parameters, sometimes an entire category of files needs to be excluded, e.g. generated files with a prefix or suffix. This can be done by configuring those tools directly within `pyproject.toml`.
 
-In order to exclude files from being formatted by Black and isort, it may be necessary to tell those tools to respect skip configuration options. Since Pants runs these tools on individual files rather than directories, they often run on every Python file in spite of the intuitive skip arguments. See e.g. [this post](https://stackoverflow.com/a/73296261 from the Black maintainers).
+In order to exclude files from being formatted by Black and isort, it may be necessary to tell those tools to respect skip configuration options. Since Pants runs these tools on individual files rather than directories, they often run on every Python file in spite of the intuitive skip arguments. See e.g. [this post](https://stackoverflow.com/a/73296261) from the Black maintainers.
 
 Pants users report that this config works for them:
 

--- a/docs/markdown/Python/python/python-linters-and-formatters.md
+++ b/docs/markdown/Python/python/python-linters-and-formatters.md
@@ -285,7 +285,9 @@ You may also want to try downgrading to iSort 4.x by setting `version = "isort>=
 
 ### Black and isort: excluding files
 
-In order to exclude files from being formatted by Black and isort, it may be necessary to tell those tools to respect skip configuration options. Otherwise, they may unconditionally format all files passed to them by the Pants runner.
+Although it is possible to skip linters for individual targets using `skip_` parameters, sometimes an entire category of files needs to be excluded, e.g. generated files with a prefix or suffix. This can be done by configuring those tools directly within `pyproject.toml`.
+
+In order to exclude files from being formatted by Black and isort, it may be necessary to tell those tools to respect skip configuration options. Since Pants runs these tools on individual files rather than directories, they often run on every Python file in spite of the intuitive skip arguments. See e.g. [this post](https://stackoverflow.com/a/73296261 from the Black maintainers).
 
 Pants users report that this config works for them:
 

--- a/docs/markdown/Python/python/python-linters-and-formatters.md
+++ b/docs/markdown/Python/python/python-linters-and-formatters.md
@@ -285,9 +285,9 @@ You may also want to try downgrading to iSort 4.x by setting `version = "isort>=
 
 ### Black and isort: excluding files
 
-In order to exclude files from being formatted by Black and isort, it may be necessary to explicitly tell those tools to respect skip configuration options. Otherwise, the tools may unconditionally format all files passed to them by the Pants runner.
+In order to exclude files from being formatted by Black and isort, it may be necessary to tell those tools to respect skip configuration options. Otherwise, they may unconditionally format all files passed to them by the Pants runner.
 
-They report that this config works for them:
+Pants users report that this config works for them:
 
 ```toml
 # pyproject.toml

--- a/docs/markdown/Python/python/python-linters-and-formatters.md
+++ b/docs/markdown/Python/python/python-linters-and-formatters.md
@@ -282,3 +282,29 @@ default_section = "THIRDPARTY"
 ```
 
 You may also want to try downgrading to iSort 4.x by setting `version = "isort>=4.6,<5"` in the `[isort]` options scope.
+
+### Black and isort: excluding files
+
+In order to exclude files from being formatted by Black and isort, it may be necessary to explicitly tell those tools to respect skip configuration options. Otherwise, the tools may unconditionally format all files passed to them by the Pants runner.
+
+They report that this config works for them:
+
+```toml
+# pyproject.toml
+[tool.isort]
+# tell isort to respect skip_glob
+filter_files = true  
+# in particular, extend_skip_glob doesn't seem to work under Pants isort
+skip_glob = [
+    "**/*_skip_me.py",
+    "**/*_skip_me.pyi",
+]
+
+[tool.black]
+# in particular, extend-exclude and exclude will not work
+force-exclude='''
+^(
+    .*_skip_me\.py(i)?
+)$
+'''
+```


### PR DESCRIPTION
Add documentation for skipping files under Black & isort, as this doesn't seem to be natively supported by the
corresponding Pants plugins, and the most intuitive options under isort and Black docs will not work because
they only take effect when these tools "autodiscover" files.