### PR TITLE
DRY when handling Scala version values

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -55,8 +55,7 @@ async def resolve_scalapb_runtime_for_resolve(
     scalapb: ScalaPBSubsystem,
 ) -> ScalaPBRuntimeForResolve:
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    # TODO: Does not handle Scala 3 suffix which is just `_3` nor X.Y.Z versions.
-    scala_binary_version, _, _ = scala_version.rpartition(".")
+    scala_binary_version = scala_version.binary
     version = scalapb.version
 
     addresses = find_jvm_artifacts_or_raise(

--- a/src/python/pants/backend/codegen/protobuf/scala/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/rules.py
@@ -14,6 +14,11 @@ from pants.backend.codegen.protobuf.target_types import (
     ProtobufSourceTarget,
 )
 from pants.backend.scala.target_types import ScalaSourceField
+from pants.backend.scala.util_rules.versions import (
+    ScalaArtifactsForVersionRequest,
+    ScalaArtifactsForVersionResult,
+    ScalaVersion,
+)
 from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
 from pants.core.util_rules import distdir
 from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
@@ -46,7 +51,7 @@ from pants.jvm.compile import ClasspathEntry
 from pants.jvm.dependency_inference import artifact_mapper
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import InternalJdk, JvmProcess
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate, GatherJvmCoordinatesRequest
+from pants.jvm.resolve.common import ArtifactRequirements, GatherJvmCoordinatesRequest
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.jvm.target_types import PrefixedJvmJdkField, PrefixedJvmResolveField
@@ -234,7 +239,7 @@ async def materialize_jvm_plugins(
     return MaterializedJvmPlugins(merged_plugins_digest, materialized_plugins)
 
 
-SHIM_SCALA_VERSION = "2.13.7"
+SHIM_SCALA_VERSION = ScalaVersion.parse("2.13.7")
 
 
 # TODO(13879): Consolidate compilation of wrapper binaries to common rules.
@@ -253,30 +258,17 @@ async def setup_scalapb_shim_classfiles(
 
     scalapb_shim_source = FileContent("ScalaPBShim.scala", scalapb_shim_content)
 
-    lockfile_request = await Get(GenerateJvmLockfileFromTool, ScalapbcToolLockfileSentinel())
+    lockfile_request, scala_artifacts = await MultiGet(
+        Get(GenerateJvmLockfileFromTool, ScalapbcToolLockfileSentinel()),
+        Get(ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(SHIM_SCALA_VERSION)),
+    )
     tool_classpath, shim_classpath, source_digest = await MultiGet(
         Get(
             ToolClasspath,
             ToolClasspathRequest(
                 prefix="__toolcp",
                 artifact_requirements=ArtifactRequirements.from_coordinates(
-                    [
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-compiler",
-                            version=SHIM_SCALA_VERSION,
-                        ),
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-library",
-                            version=SHIM_SCALA_VERSION,
-                        ),
-                        Coordinate(
-                            group="org.scala-lang",
-                            artifact="scala-reflect",
-                            version=SHIM_SCALA_VERSION,
-                        ),
-                    ]
+                    scala_artifacts.all_coordinates
                 ),
             ),
         ),

--- a/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/java/rules.py
@@ -103,7 +103,7 @@ async def resolve_scrooge_thrift_java_runtime_for_resolve(
     scala_subsystem: ScalaSubsystem,
 ) -> ScroogeThriftJavaRuntimeForResolve:
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    scala_binary_version, _, _ = scala_version.rpartition(".")
+    scala_binary_version = scala_version.binary
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
             UnversionedCoordinate(

--- a/src/python/pants/backend/codegen/thrift/scrooge/scala/rules.py
+++ b/src/python/pants/backend/codegen/thrift/scrooge/scala/rules.py
@@ -103,7 +103,7 @@ async def resolve_scrooge_thrift_scala_runtime_for_resolve(
     scala_subsystem: ScalaSubsystem,
 ) -> ScroogeThriftScalaRuntimeForResolve:
     scala_version = scala_subsystem.version_for_resolve(request.resolve_name)
-    scala_binary_version, _, _ = scala_version.rpartition(".")
+    scala_binary_version = scala_version.binary
     addresses = find_jvm_artifacts_or_raise(
         required_coordinates=[
             UnversionedCoordinate(

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -24,6 +24,7 @@ from pants.backend.scala.target_types import ScalaFieldSet, ScalaSourceField
 from pants.backend.scala.util_rules.versions import (
     ScalaArtifactsForVersionRequest,
     ScalaArtifactsForVersionResult,
+    ScalaVersion,
 )
 from pants.base.build_root import BuildRoot
 from pants.bsp.protocol import BSPHandlerMapping
@@ -151,7 +152,7 @@ async def collect_thirdparty_modules(
     )
 
 
-async def _materialize_scala_runtime_jars(scala_version: str) -> Snapshot:
+async def _materialize_scala_runtime_jars(scala_version: ScalaVersion) -> Snapshot:
     scala_artifacts = await Get(
         ScalaArtifactsForVersionResult, ScalaArtifactsForVersionRequest(scala_version)
     )
@@ -276,17 +277,11 @@ async def bsp_resolve_scala_metadata(
         java_version=f"1.{jdk.jre_major_version}",
     )
 
-    scala_version_parts = scala_version.split(".")
-    scala_binary_version = (
-        ".".join(scala_version_parts[0:2])
-        if int(scala_version_parts[0]) < 3
-        else scala_version_parts[0]
-    )
     return BSPBuildTargetsMetadataResult(
         metadata=ScalaBuildTarget(
             scala_organization="org.scala-lang",
-            scala_version=scala_version,
-            scala_binary_version=scala_binary_version,
+            scala_version=str(scala_version),
+            scala_binary_version=scala_version.binary,
             platform=ScalaPlatform.JVM,
             jars=scala_jar_uris,
             jvm_build_target=jvm_build_target,

--- a/src/python/pants/backend/scala/compile/scalac.py
+++ b/src/python/pants/backend/scala/compile/scalac.py
@@ -23,6 +23,7 @@ from pants.backend.scala.util_rules import versions
 from pants.backend.scala.util_rules.versions import (
     ScalaArtifactsForVersionRequest,
     ScalaArtifactsForVersionResult,
+    ScalaVersion,
 )
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.fs import EMPTY_DIGEST, Digest, MergeDigests
@@ -58,7 +59,7 @@ class CompileScalaSourceRequest(ClasspathEntryRequest):
 
 @dataclass(frozen=True)
 class ScalaLibraryRequest:
-    version: str
+    version: ScalaVersion
 
 
 # TODO: This code is duplicated in the scalac and BSP rules.

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -13,6 +13,7 @@ from pants.backend.scala.dependency_inference.scala_parser import (
     ScalaSourceDependencyAnalysis,
 )
 from pants.backend.scala.target_types import ScalaSourceField, ScalaSourceTarget
+from pants.backend.scala.util_rules import versions
 from pants.build_graph.address import Address
 from pants.core.util_rules import source_files
 from pants.core.util_rules.source_files import SourceFilesRequest
@@ -37,6 +38,7 @@ def rule_runner() -> RuleRunner:
             *target_types.rules(),
             *jvm_util_rules.rules(),
             *process.rules(),
+            *versions.rules(),
             QueryRule(AnalyzeScalaSourceRequest, (SourceFilesRequest,)),
             QueryRule(ScalaSourceDependencyAnalysis, (AnalyzeScalaSourceRequest,)),
         ],

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -88,9 +88,9 @@ async def validate_scala_runtime_is_present_in_resolve(
             artifact.coordinate.group == SCALA_LIBRARY_GROUP
             and artifact.coordinate.artifact == scala_artifacts.library_coordinate.artifact
         ):
-            if artifact.coordinate.version != scala_version:
+            if artifact.coordinate.version != str(scala_version):
                 raise ConflictingScalaLibraryVersionInResolveError(
-                    request.resolve_name, scala_version, artifact.coordinate
+                    request.resolve_name, str(scala_version), artifact.coordinate
                 )
 
             # This does not `break` so the loop can validate the entire set of requirements to ensure no conflicting

--- a/src/python/pants/backend/scala/subsystems/scala.py
+++ b/src/python/pants/backend/scala/subsystems/scala.py
@@ -3,15 +3,12 @@
 
 from __future__ import annotations
 
-import logging
-
+from pants.backend.scala.util_rules.versions import ScalaVersion
 from pants.option.option_types import BoolOption, DictOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
-DEFAULT_SCALA_VERSION = "2.13.6"
-
-_logger = logging.getLogger(__name__)
+DEFAULT_SCALA_VERSION = ScalaVersion.parse("2.13.6")
 
 
 class ScalaSubsystem(Subsystem):
@@ -42,8 +39,8 @@ class ScalaSubsystem(Subsystem):
         advanced=True,
     )
 
-    def version_for_resolve(self, resolve: str) -> str:
+    def version_for_resolve(self, resolve: str) -> ScalaVersion:
         version = self._version_for_resolve.get(resolve)
         if version:
-            return version
+            return ScalaVersion.parse(version)
         return DEFAULT_SCALA_VERSION

--- a/src/python/pants/backend/scala/util_rules/BUILD
+++ b/src/python/pants/backend/scala/util_rules/BUILD
@@ -2,3 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 python_sources()
+
+python_tests(
+    name="tests",
+)

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 
-from pants.base.deprecated import warn_or_error
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.resolve.common import Coordinate
 from pants.util.strutil import softwrap
@@ -26,17 +25,6 @@ class ScalaCrossVersionMode(Enum):
     PARTIAL = "partial"
     BINARY = "binary"
     FULL = "full"
-
-    @classmethod
-    def from_str(cls, value: str) -> ScalaCrossVersionMode:
-        if value == ScalaCrossVersionMode.PARTIAL.value:
-            warn_or_error(
-                "2.21.0",
-                f"Scala cross version: {value}",
-                "Use value `binary` instead",
-                start_version="2.20.0",
-            )
-        return cls(value)
 
 
 _SCALA_VERSION_PATTERN = re.compile(r"^([0-9]+)\.([0-9]+)\.([0-9]+)(\-(.+))?$")

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -3,14 +3,74 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 
+from pants.base.deprecated import warn_or_error
 from pants.engine.rules import collect_rules, rule
 from pants.jvm.resolve.common import Coordinate
+from pants.util.strutil import softwrap
+
+
+class InvalidScalaVersion(ValueError):
+    def __init__(self, scala_version: str) -> None:
+        super().__init__(
+            softwrap(
+                f"""Value '{scala_version}' is not a valid Scala version.
+            It should be formed of [major].[minor].[patch]"""
+            )
+        )
+
+
+class ScalaCrossVersionMode(Enum):
+    PARTIAL = "partial"
+    BINARY = "binary"
+    FULL = "full"
+
+    @classmethod
+    def from_str(cls, value: str) -> ScalaCrossVersionMode:
+        if value == ScalaCrossVersionMode.PARTIAL.value:
+            warn_or_error(
+                "2.21.0",
+                f"Scala cross version: {value}",
+                "Use value `binary` instead",
+                start_version="2.20.0",
+            )
+        return cls(value)
+
+
+@dataclass(frozen=True)
+class ScalaVersion:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, scala_version: str) -> ScalaVersion:
+        version_parts = scala_version.split(".")
+        if len(version_parts) != 3:
+            raise InvalidScalaVersion(scala_version)
+        return cls(
+            major=int(version_parts[0]), minor=int(version_parts[1]), patch=int(version_parts[2])
+        )
+
+    def crossversion(self, mode: ScalaCrossVersionMode) -> str:
+        if mode == ScalaCrossVersionMode.FULL:
+            return str(self)
+        if self.major >= 3:
+            return str(self.major)
+        return f"{self.major}.{self.minor}"
+
+    @property
+    def binary(self) -> str:
+        return self.crossversion(ScalaCrossVersionMode.BINARY)
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
 
 
 @dataclass(frozen=True)
 class ScalaArtifactsForVersionRequest:
-    scala_version: str
+    scala_version: ScalaVersion
 
 
 @dataclass(frozen=True)
@@ -33,18 +93,17 @@ class ScalaArtifactsForVersionResult:
 async def resolve_scala_artifacts_for_version(
     request: ScalaArtifactsForVersionRequest,
 ) -> ScalaArtifactsForVersionResult:
-    version_parts = request.scala_version.split(".")
-    if version_parts[0] == "3":
+    if request.scala_version.major == 3:
         return ScalaArtifactsForVersionResult(
             compiler_coordinate=Coordinate(
                 group="org.scala-lang",
                 artifact="scala3-compiler_3",
-                version=request.scala_version,
+                version=str(request.scala_version),
             ),
             library_coordinate=Coordinate(
                 group="org.scala-lang",
                 artifact="scala3-library_3",
-                version=request.scala_version,
+                version=str(request.scala_version),
             ),
             reflect_coordinate=None,
             compiler_main="dotty.tools.dotc.Main",
@@ -55,17 +114,17 @@ async def resolve_scala_artifacts_for_version(
         compiler_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-compiler",
-            version=request.scala_version,
+            version=str(request.scala_version),
         ),
         library_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-library",
-            version=request.scala_version,
+            version=str(request.scala_version),
         ),
         reflect_coordinate=Coordinate(
             group="org.scala-lang",
             artifact="scala-reflect",
-            version=request.scala_version,
+            version=str(request.scala_version),
         ),
         compiler_main="scala.tools.nsc.Main",
         repl_main="scala.tools.nsc.MainGenericRunner",

--- a/src/python/pants/backend/scala/util_rules/versions_test.py
+++ b/src/python/pants/backend/scala/util_rules/versions_test.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import pytest
+
+from pants.backend.scala.util_rules.versions import ScalaCrossVersionMode, ScalaVersion
+
+
+@pytest.mark.parametrize(
+    "version_str, expected_obj, expected_binary",
+    [
+        ("2.12.0", ScalaVersion(2, 12, 0), "2.12"),
+        ("3.3.1", ScalaVersion(3, 3, 1), "3"),
+        ("3.0.1-RC2", ScalaVersion(3, 0, 1, "RC2"), "3"),
+        ("2.13.8-jfhd8fyd834-SNAPSHOT", ScalaVersion(2, 13, 8, "jfhd8fyd834-SNAPSHOT"), "2.13"),
+    ],
+)
+def test_scala_version_parser(
+    version_str: str, expected_obj: ScalaVersion, expected_binary: str
+) -> None:
+    parsed = ScalaVersion.parse(version_str)
+    assert parsed == expected_obj
+    assert str(parsed) == version_str
+    assert parsed.binary == expected_binary
+    assert parsed.crossversion(ScalaCrossVersionMode.FULL) == version_str
+    assert parsed.crossversion(ScalaCrossVersionMode.PARTIAL) == parsed.crossversion(
+        ScalaCrossVersionMode.BINARY
+    )

--- a/src/python/pants/jvm/target_types.py
+++ b/src/python/pants/jvm/target_types.py
@@ -279,7 +279,7 @@ class JvmArtifactExclusion:
     group: str
     artifact: str | None = None
 
-    def validate(self) -> set[str]:
+    def validate(self, _: Address) -> set[str]:
         return set()
 
     def to_coord_str(self) -> str:
@@ -310,10 +310,12 @@ def _jvm_artifact_exclusions_field_help(
 class JvmArtifactExclusionsField(SequenceField[JvmArtifactExclusion]):
     alias = "exclusions"
     help = _jvm_artifact_exclusions_field_help(
-        lambda: JvmArtifactExclusionsField.supported_rule_types
+        lambda: JvmArtifactExclusionsField.supported_exclusion_types
     )
 
-    supported_rule_types: ClassVar[tuple[type[JvmArtifactExclusion], ...]] = (JvmArtifactExclusion,)
+    supported_exclusion_types: ClassVar[tuple[type[JvmArtifactExclusion], ...]] = (
+        JvmArtifactExclusion,
+    )
     expected_element_type = JvmArtifactExclusion
     expected_type_description = "an iterable of JvmArtifactExclusionRule"
 
@@ -326,7 +328,7 @@ class JvmArtifactExclusionsField(SequenceField[JvmArtifactExclusion]):
         if computed_value:
             errors: list[str] = []
             for exclusion_rule in computed_value:
-                err = exclusion_rule.validate()
+                err = exclusion_rule.validate(address)
                 if err:
                     errors.extend(err)
 
@@ -334,8 +336,8 @@ class JvmArtifactExclusionsField(SequenceField[JvmArtifactExclusion]):
                 raise InvalidFieldException(
                     softwrap(
                         f"""
-                        Invalid value for `{JvmArtifactExclusionsField.alias}` field.
-                        Found following errors:
+                        Invalid value for `{JvmArtifactExclusionsField.alias}` field at target
+                        {address}. Found following errors:
 
                         {bullet_list(errors)}
                         """
@@ -713,8 +715,8 @@ class DeployJarDuplicatePolicyField(SequenceField[DeployJarDuplicateRule]):
                 raise InvalidFieldException(
                     softwrap(
                         f"""
-                        Invalid value for `{DeployJarDuplicatePolicyField.alias}` field.
-                        Found following errors:
+                        Invalid value for `{DeployJarDuplicatePolicyField.alias}` field at target:
+                        {address}. Found following errors:
 
                         {bullet_list(errors)}
                         """


### PR DESCRIPTION
Noticing a lot of repetition when dealing with Scala version numbers and its particularities, like the binary compatibility version (required to figure out the actual JARs filenames), decided to make this small refactoring using a new `ScalaVersion` data class.