### PR TITLE
add `always` mode for `RemoteCacheWarningsBehavior`

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -334,6 +334,7 @@ class RemoteCacheWarningsBehavior(Enum):
     ignore = "ignore"
     first_only = "first_only"
     backoff = "backoff"
+    always = "always"
 
 
 @enum.unique

--- a/tests/python/pants_test/integration/remote_cache_integration_test.py
+++ b/tests/python/pants_test/integration/remote_cache_integration_test.py
@@ -103,6 +103,17 @@ def test_warns_on_remote_cache_errors() -> None:
     for err in [third_read_err, third_write_err]:
         assert err not in backoff_result
 
+    always_result = run(RemoteCacheWarningsBehavior.always)
+    for err in [
+        first_read_err,
+        first_write_err,
+        third_read_err,
+        third_write_err,
+        fourth_read_err,
+        fourth_write_err,
+    ]:
+        assert err in always_result, f"Not found in:\n{always_result}"
+
 
 class ProcessOutputEntries(DigestEntries):
     pass


### PR DESCRIPTION
Looked at the configuration docs here for a Slack thread, and felt like this would've been the most sensible option to use -- but it did not exist. 🤷 