### PR TITLE
Use fork of indicatif to work around output truncation

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1760,8 +1760,7 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+source = "git+https://github.com/tgolsson/indicatif.git?rev=31890f0ac55f9727d152ad314a78757ccc0142b6#31890f0ac55f9727d152ad314a78757ccc0142b6"
 dependencies = [
  "console",
  "instant",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -334,7 +334,10 @@ tree-sitter-javascript = "0.20.1"
 tree-sitter-python = "0.20.4"
 
 [patch.crates-io]
+# https://github.com/console-rs/console/pull/186
 console = { version = "0.15.7", git = "https://github.com/tgolsson/console.git", rev = "5483880905f384679d322e83c37180f122951995" }
+# https://github.com/console-rs/indicatif/pull/608
+indicatif = { version = "0.17.7", git = "https://github.com/tgolsson/indicatif.git", rev = "31890f0ac55f9727d152ad314a78757ccc0142b6" }
 
 
 # Default lints adopted by most crates in this workspace.


### PR DESCRIPTION
Fixes #20171.

Upstream seems very slow on merging the fix so adding my fork. @lilatomic can you validate this also solves the problem on your end?