### PR TITLE
javascript,typescript: refactor common code from tailor goal into shared library

### DIFF
--- a/src/python/pants/backend/javascript/goals/tailor.py
+++ b/src/python/pants/backend/javascript/goals/tailor.py
@@ -6,8 +6,7 @@ from __future__ import annotations
 import dataclasses
 import os
 from dataclasses import dataclass
-from pathlib import PurePath
-from typing import Collection, Iterable
+from typing import Iterable
 
 from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.target_types import (
@@ -22,10 +21,9 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
+from pants.core.util_rules.ownership import get_unowned_files_for_globs
+from pants.core.util_rules.source_files import classify_files_for_sources_and_tests
 from pants.engine.rules import Rule, collect_rules, rule
-from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
@@ -41,34 +39,6 @@ class PutativePackageJsonTargetsRequest(PutativeTargetsRequest):
     pass
 
 
-@dataclass(frozen=True)
-class _ClassifiedSources:
-    target_type: type[Target]
-    files: Collection[str]
-    name: str | None = None
-
-
-def classify_source_files(paths: Iterable[str]) -> Iterable[_ClassifiedSources]:
-    sources_files = set(paths)
-    test_file_glob = JSTestsGeneratorSourcesField.default
-    test_files = {
-        path for path in paths if any(PurePath(path).match(glob) for glob in test_file_glob)
-    }
-    if sources_files:
-        yield _ClassifiedSources(JSSourcesGeneratorTarget, files=sources_files - test_files)
-    if test_files:
-        yield _ClassifiedSources(JSTestsGeneratorTarget, test_files, "tests")
-
-
-async def _get_unowned_files_for_globs(
-    request: PutativeTargetsRequest,
-    all_owned_sources: AllOwnedSources,
-    filename_globs: Iterable[str],
-) -> set[str]:
-    matching_paths = await Get(Paths, PathGlobs, request.path_globs(*filename_globs))
-    return set(matching_paths.files) - set(all_owned_sources)
-
-
 _LOG_DESCRIPTION_TEMPLATE = "Determine candidate {} to create"
 
 
@@ -76,10 +46,15 @@ _LOG_DESCRIPTION_TEMPLATE = "Determine candidate {} to create"
 async def find_putative_js_targets(
     req: PutativeJSTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    unowned_js_files = await _get_unowned_files_for_globs(
+    unowned_js_files = await get_unowned_files_for_globs(
         req, all_owned_sources, (f"*{ext}" for ext in JS_FILE_EXTENSIONS)
     )
-    classified_unowned_js_files = classify_source_files(unowned_js_files)
+    classified_unowned_js_files = classify_files_for_sources_and_tests(
+        paths=unowned_js_files,
+        test_file_glob=JSTestsGeneratorSourcesField.default,
+        sources_generator=JSSourcesGeneratorTarget,
+        tests_generator=JSTestsGeneratorTarget,
+    )
 
     return PutativeTargets(
         PutativeTarget.for_target_type(
@@ -94,7 +69,7 @@ async def find_putative_js_targets(
 async def find_putative_package_json_targets(
     req: PutativePackageJsonTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    unowned_package_json_files = await _get_unowned_files_for_globs(
+    unowned_package_json_files = await get_unowned_files_for_globs(
         req, all_owned_sources, (f"**{os.path.sep}package.json",)
     )
 

--- a/src/python/pants/backend/javascript/goals/tailor_test.py
+++ b/src/python/pants/backend/javascript/goals/tailor_test.py
@@ -8,11 +8,11 @@ from pants.backend.javascript.goals import tailor
 from pants.backend.javascript.goals.tailor import (
     PutativeJSTargetsRequest,
     PutativePackageJsonTargetsRequest,
-    _ClassifiedSources,
 )
 from pants.backend.javascript.package_json import PackageJsonTarget
 from pants.backend.javascript.target_types import JSSourcesGeneratorTarget, JSTestsGeneratorTarget
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.core.util_rules.source_files import ClassifiedSources
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -41,7 +41,7 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile3.cjs": "",
             },
             [
-                _ClassifiedSources(
+                ClassifiedSources(
                     JSSourcesGeneratorTarget,
                     ["UnownedFile1.js", "UnownedFile2.mjs", "UnownedFile3.cjs"],
                 )
@@ -57,7 +57,7 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile3.test.cjs": "",
             },
             [
-                _ClassifiedSources(
+                ClassifiedSources(
                     JSTestsGeneratorTarget,
                     ["UnownedFile1.test.js", "UnownedFile2.test.mjs", "UnownedFile3.test.cjs"],
                     "tests",
@@ -73,15 +73,15 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile1.test.js": "",
             },
             [
-                _ClassifiedSources(JSTestsGeneratorTarget, ["UnownedFile1.test.js"], "tests"),
-                _ClassifiedSources(JSSourcesGeneratorTarget, ["UnownedFile1.js"]),
+                ClassifiedSources(JSTestsGeneratorTarget, ["UnownedFile1.test.js"], "tests"),
+                ClassifiedSources(JSSourcesGeneratorTarget, ["UnownedFile1.js"]),
             ],
             id="both_tests_and_source",
         ),
     ],
 )
 def test_find_putative_js_targets(
-    rule_runner: RuleRunner, files: dict, putative_map: list[_ClassifiedSources]
+    rule_runner: RuleRunner, files: dict, putative_map: list[ClassifiedSources]
 ) -> None:
     rule_runner.write_files(files)
     putative_targets = rule_runner.request(

--- a/src/python/pants/backend/javascript/target_types.py
+++ b/src/python/pants/backend/javascript/target_types.py
@@ -22,6 +22,7 @@ from pants.engine.target import (
 from pants.util.strutil import help_text
 
 JS_FILE_EXTENSIONS = (".js", ".cjs", ".mjs")
+JS_TEST_FILE_EXTENSIONS = tuple(f"*.test{ext}" for ext in JS_FILE_EXTENSIONS)
 
 
 class JSDependenciesField(Dependencies):
@@ -60,7 +61,9 @@ class JSSourcesOverridesField(OverridesField):
 
 
 class JSSourcesGeneratorSourcesField(JSGeneratorSourcesField):
-    default = tuple(f"*{ext}" for ext in JS_FILE_EXTENSIONS)
+    default = tuple(f"*{ext}" for ext in JS_FILE_EXTENSIONS) + tuple(
+        f"!{pat}" for pat in JS_TEST_FILE_EXTENSIONS
+    )
     help = generate_multiple_sources_field_help_message(
         "Example: `sources=['utils.js', 'subdir/*.js', '!ignore_me.js']`"
     )

--- a/src/python/pants/backend/typescript/goals/tailor_test.py
+++ b/src/python/pants/backend/typescript/goals/tailor_test.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 import pytest
 
 from pants.backend.typescript.goals import tailor
-from pants.backend.typescript.goals.tailor import (
-    PutativeTypeScriptTargetsRequest,
-    _ClassifiedSources,
-)
+from pants.backend.typescript.goals.tailor import PutativeTypeScriptTargetsRequest
 from pants.backend.typescript.target_types import (
     TypeScriptSourcesGeneratorTarget,
     TypeScriptTestsGeneratorTarget,
 )
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
+from pants.core.util_rules.source_files import ClassifiedSources
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
@@ -41,7 +39,7 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile3.ts": "",
             },
             [
-                _ClassifiedSources(
+                ClassifiedSources(
                     TypeScriptSourcesGeneratorTarget,
                     ["UnownedFile1.ts", "UnownedFile2.ts", "UnownedFile3.ts"],
                 )
@@ -57,7 +55,7 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile3.test.ts": "",
             },
             [
-                _ClassifiedSources(
+                ClassifiedSources(
                     TypeScriptTestsGeneratorTarget,
                     ["UnownedFile1.test.ts", "UnownedFile2.test.ts", "UnownedFile3.test.ts"],
                     "tests",
@@ -73,17 +71,17 @@ def rule_runner() -> RuleRunner:
                 "src/unowned/UnownedFile1.test.ts": "",
             },
             [
-                _ClassifiedSources(
+                ClassifiedSources(
                     TypeScriptTestsGeneratorTarget, ["UnownedFile1.test.ts"], "tests"
                 ),
-                _ClassifiedSources(TypeScriptSourcesGeneratorTarget, ["UnownedFile1.ts"]),
+                ClassifiedSources(TypeScriptSourcesGeneratorTarget, ["UnownedFile1.ts"]),
             ],
             id="both_tests_and_source",
         ),
     ],
 )
 def test_find_putative_ts_targets(
-    rule_runner: RuleRunner, files: dict, putative_map: list[_ClassifiedSources]
+    rule_runner: RuleRunner, files: dict, putative_map: list[ClassifiedSources]
 ) -> None:
     rule_runner.write_files(files)
     putative_targets = rule_runner.request(
@@ -117,16 +115,14 @@ def test_find_putative_ts_targets(
                 "src/partially_unowned/UnownedFile.test.ts": "",
             },
             [
-                _ClassifiedSources(
-                    TypeScriptTestsGeneratorTarget, ["UnownedFile.test.ts"], "tests"
-                ),
+                ClassifiedSources(TypeScriptTestsGeneratorTarget, ["UnownedFile.test.ts"], "tests"),
             ],
             id="source_tailored_but_tests_are_not",
         ),
     ],
 )
 def test_find_putative_ts_targets_partially_owned(
-    rule_runner: RuleRunner, files: dict, putative_map: list[_ClassifiedSources]
+    rule_runner: RuleRunner, files: dict, putative_map: list[ClassifiedSources]
 ) -> None:
     """Check that if `typescript_sources` target exist owning all `*.ts` files, the `.test.ts` files
     can still be tailored."""

--- a/src/python/pants/core/util_rules/ownership.py
+++ b/src/python/pants/core/util_rules/ownership.py
@@ -1,0 +1,16 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from typing import Iterable
+
+from pants.core.goals.tailor import AllOwnedSources, PutativeTargetsRequest
+from pants.engine.fs import PathGlobs, Paths
+from pants.engine.internals.selectors import Get
+
+
+async def get_unowned_files_for_globs(
+    request: PutativeTargetsRequest,
+    all_owned_sources: AllOwnedSources,
+    filename_globs: Iterable[str],
+) -> set[str]:
+    matching_paths = await Get(Paths, PathGlobs, request.path_globs(*filename_globs))
+    return set(matching_paths.files) - set(all_owned_sources)


### PR DESCRIPTION
Follow-up of https://github.com/pantsbuild/pants/pull/20252. Both JavaScript and TypeScript tailor goals have the same code to classify sources and tests which can live in a common location to avoid code duplication.

Addressing https://github.com/pantsbuild/pants/pull/20252#discussion_r1415867488