### PR TITLE
allow passing --timeout along to helm commands

### DIFF
--- a/src/python/pants/backend/helm/subsystems/helm.py
+++ b/src/python/pants/backend/helm/subsystems/helm.py
@@ -39,6 +39,7 @@ _VALID_PASSTHROUGH_OPTS = [
     "--kube-as-user",
     "--kube-ca-file",
     "--kube-token",
+    "--timeout",
 ]
 
 


### PR DESCRIPTION
`--timeout` controls how long helm waits for an install/update to take.  If the deploy is going to take more than 5 minutes, this needs to be increased.  The arg is safe to pass along because it doens't change the generated yaml.

https://helm.sh/docs/helm/helm_upgrade/