### PR TITLE
Use fork of indicatif to work around output truncation (Cherry-pick of #20269)

### DIFF
--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1750,8 +1750,7 @@ dependencies = [
 [[package]]
 name = "indicatif"
 version = "0.17.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25"
+source = "git+https://github.com/tgolsson/indicatif.git?rev=31890f0ac55f9727d152ad314a78757ccc0142b6#31890f0ac55f9727d152ad314a78757ccc0142b6"
 dependencies = [
  "console",
  "instant",

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -322,4 +322,8 @@ tree-sitter-javascript = "0.20.1"
 tree-sitter-python = "0.20.4"
 
 [patch.crates-io]
+# https://github.com/console-rs/console/pull/186
 console = { version = "0.15.7", git = "https://github.com/tgolsson/console.git", rev = "5483880905f384679d322e83c37180f122951995" }
+
+# https://github.com/console-rs/indicatif/pull/608
+indicatif = { version = "0.17.7", git = "https://github.com/tgolsson/indicatif.git", rev = "31890f0ac55f9727d152ad314a78757ccc0142b6" }


### PR DESCRIPTION
Fixes #20171.