### PR TITLE
add module mapping for honeycomb-opentelemetry

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -96,6 +96,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple] = {
     "gitpython": ("git",),
     "graphql-core": ("graphql",),
     "grpcio": ("grpc",),
+    "honeycomb-opentelemetry": ("honeycomb.opentelemetry",),
     "ipython": ("IPython",),
     "jack-client": ("jack",),
     "kafka-python": ("kafka",),


### PR DESCRIPTION
This PR adds a [module mapping](https://www.pantsbuild.org/docs/python-third-party-dependencies#use-modules-and-module_mapping-when-the-module-name-is-not-standard) for the [`honeycomb-opentelemetry`](https://pypi.org/project/honeycomb-opentelemetry/) package - used in code, it is named [`honeycomb.opentelemetry`](https://github.com/honeycombio/honeycomb-opentelemetry-python/blob/ae5e8d35a121dcdf4647b16f9767cfa2a62db074/examples/hello-world/app.py#L4).

This package is the python opentelemetry distribution for the [Honeycomb observability product](https://www.honeycomb.io/). The need for this mapping is along the same lines as for other opentelemetry packages:

https://github.com/pantsbuild/pants/blob/3536b34df8867f488bb6f037a128c96e29601934/src/python/pants/backend/python/dependency_inference/default_module_mapping.py#L112-L114

Without the mapping, was seeing this warning:

> 11:44:30.07 [WARN] Pants cannot infer owners for the following imports in the target redacted.py:lib:
> 
>   * honeycomb.opentelemetry.HoneycombOptions (line: 6)
>   * honeycomb.opentelemetry.configure_opentelemetry (line: 6)