### PR TITLE
enable pyupgrade for pants itself as a regular backend

### DIFF
--- a/build-support/bin/terraform_tool_versions.py
+++ b/build-support/bin/terraform_tool_versions.py
@@ -59,7 +59,7 @@ class GPGVerifier:
         Looks the import results for one which has an "ok" status. We can't use the number of keys
         imported because a re-import of a key results in 0 keys imported.
         """
-        has_ok = any(("ok" in r for r in import_results.results))
+        has_ok = any("ok" in r for r in import_results.results)
         return has_ok
 
 

--- a/build-support/bin/terraform_tool_versions_test.py
+++ b/build-support/bin/terraform_tool_versions_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 from terraform_tool_versions import (

--- a/pants.toml
+++ b/pants.toml
@@ -14,6 +14,7 @@ backend_packages.add = [
   "pants.backend.python.lint.flake8",
   "pants.backend.python.lint.isort",
   "pants.backend.python.typecheck.mypy",
+  "pants.backend.python.lint.pyupgrade",
   "pants.backend.python.mixed_interpreter_constraints",
   "pants.backend.shell",
   "pants.backend.shell.lint.shellcheck",
@@ -92,7 +93,6 @@ enabled = true
 repo_id = "7775F8D5-FC58-4DBC-9302-D00AE4A1505F"
 
 [cli.alias]
-run-pyupgrade = "--backend-packages=pants.backend.experimental.python.lint.pyupgrade fmt"
 --all-changed = "--changed-since=HEAD --changed-dependents=transitive"
 
 [source]
@@ -205,6 +205,10 @@ template_by_globs = "@build-support/preambles/config.yaml"
 
 [generate-lockfiles]
 diff = true
+
+[pyupgrade]
+args = ["--keep-runtime-typing"]
+
 
 [jvm]
 default_resolve = "jvm_testprojects"

--- a/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules_integration_test.py
@@ -113,7 +113,7 @@ def assert_files_generated(
 
 
 def test_extracts_go_package() -> None:
-    import_path = parse_go_package_option("""option go_package = "example.com/dir1";""".encode())
+    import_path = parse_go_package_option(b"""option go_package = "example.com/dir1";""")
     assert import_path == "example.com/dir1"
 
 

--- a/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
+++ b/src/python/pants/backend/codegen/protobuf/lint/buf/lint_rules.py
@@ -62,7 +62,7 @@ async def run_buf(
 ) -> LintResult:
     transitive_targets = await Get(
         TransitiveTargets,
-        TransitiveTargetsRequest((field_set.address for field_set in request.elements)),
+        TransitiveTargetsRequest(field_set.address for field_set in request.elements),
     )
 
     all_stripped_sources_request = Get(

--- a/src/python/pants/backend/go/lint/golangci_lint/rules.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules.py
@@ -67,7 +67,7 @@ async def run_golangci_lint(
 ) -> LintResult:
     transitive_targets = await Get(
         TransitiveTargets,
-        TransitiveTargetsRequest((field_set.address for field_set in request.elements)),
+        TransitiveTargetsRequest(field_set.address for field_set in request.elements),
     )
 
     all_source_files_request = Get(

--- a/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
+++ b/src/python/pants/backend/go/lint/golangci_lint/rules_integration_test.py
@@ -138,7 +138,7 @@ def test_failing(rule_runner: RuleRunner) -> None:
             "BUILD": "go_mod(name='mod')\ngo_package(name='pkg')\n",
         }
     )
-    tgt = rule_runner.get_target((Address("", target_name="pkg")))
+    tgt = rule_runner.get_target(Address("", target_name="pkg"))
     lint_results = run_golangci_lint(rule_runner, [tgt])
     assert len(lint_results) == 1
     assert lint_results[0].exit_code == 1

--- a/src/python/pants/backend/go/testutil.py
+++ b/src/python/pants/backend/go/testutil.py
@@ -40,7 +40,7 @@ def gen_module_gomodproxy(
     prefix = f"{import_path}@{version}"
 
     all_files = [(f"{prefix}/go.mod", go_mod_content)]
-    all_files.extend(((f"{prefix}/{path}", contents) for (path, contents) in files))
+    all_files.extend((f"{prefix}/{path}", contents) for (path, contents) in files)
 
     mod_zip_bytes = io.BytesIO()
     with zipfile.ZipFile(mod_zip_bytes, "w") as mod_zip:

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -964,7 +964,7 @@ async def compute_compile_action_id(
     # See https://github.com/golang/go/blob/master/src/cmd/go/internal/cache/hash.go#L32-L46
     h.update(goroot.full_version.encode())
 
-    h.update("compile\n".encode())
+    h.update(b"compile\n")
     if bq.minimum_go_version:
         h.update(f"go {bq.minimum_go_version}\n".encode())
     h.update(f"goos {goroot.goos} goarch {goroot.goarch}\n".encode())

--- a/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
@@ -13,7 +13,7 @@ def main(args: list[str]):
 
     found_image_refs: dict[tuple[int, str], str] = {}
 
-    with open(input_filename, "r") as file:
+    with open(input_filename) as file:
         try:
             parsed_docs = load_full_yaml(stream=file)
         except RuntimeError:

--- a/src/python/pants/backend/helm/subsystems/post_renderer_main.py
+++ b/src/python/pants/backend/helm/subsystems/post_renderer_main.py
@@ -38,7 +38,7 @@ def build_manifest_map(input_file: str) -> dict[str, list[str]]:
 
     result = defaultdict(list)
     template_files = []
-    with open(input_file, "r", encoding="utf-8") as f:
+    with open(input_file, encoding="utf-8") as f:
         template_files = f.read().split("---")
 
     for template in template_files:

--- a/src/python/pants/backend/openapi/lint/spectral/rules.py
+++ b/src/python/pants/backend/openapi/lint/spectral/rules.py
@@ -49,7 +49,7 @@ async def run_spectral(
 ) -> LintResult:
     transitive_targets = await Get(
         TransitiveTargets,
-        TransitiveTargetsRequest((field_set.address for field_set in request.elements)),
+        TransitiveTargetsRequest(field_set.address for field_set in request.elements),
     )
 
     all_sources_request = Get(

--- a/src/python/pants/backend/python/framework/django/detect_apps.py
+++ b/src/python/pants/backend/python/framework/django/detect_apps.py
@@ -42,7 +42,7 @@ class DjangoApps(FrozenDict[str, DjangoApp]):
     def label_to_file(self) -> FrozenDict[str, str]:
         return FrozenDict((label, app.config_file) for label, app in self.items())
 
-    def add_from_json(self, json_bytes: bytes, strip_prefix="") -> "DjangoApps":
+    def add_from_json(self, json_bytes: bytes, strip_prefix="") -> DjangoApps:
         json_dict: dict[str, dict[str, str]] = json.loads(json_bytes.decode())
         apps = {
             label: DjangoApp(

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies_test.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies_test.py
@@ -161,10 +161,8 @@ def test_find_python_distributions_with_entry_points_in_stevedore_namespaces(
         )
     ) == set(
         StevedoreExtensionTargets(
-            (
-                rule_runner.get_target(Address(f"runners/{runner}_runner"))
-                for runner in sorted(st2_runners)
-            )
+            rule_runner.get_target(Address(f"runners/{runner}_runner"))
+            for runner in sorted(st2_runners)
         )
     )
 

--- a/src/python/pants/backend/python/lint/isort/rules_integration_test.py
+++ b/src/python/pants/backend/python/lint/isort/rules_integration_test.py
@@ -158,7 +158,7 @@ def test_invalid_config_file(rule_runner: RuleRunner) -> None:
             "BUILD": "python_sources()",
         }
     )
-    tgt = rule_runner.get_target((Address("", relative_file_path="example.py")))
+    tgt = rule_runner.get_target(Address("", relative_file_path="example.py"))
     with pytest.raises(ExecutionError) as isort_error:
         run_isort(rule_runner, [tgt])
     assert any(

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -554,10 +554,8 @@ def _invalid_lockfile_error(
     consumed_msg_parts = [f"`{str(r)}`" for r in user_requirements[0:2]]
     if len(user_requirements) > 2:
         consumed_msg_parts.append(
-            (
-                f"{len(user_requirements) - 2} other "
-                f"{pluralize(len(user_requirements) - 2, 'requirement', include_count=False)}"
-            )
+            f"{len(user_requirements) - 2} other "
+            f"{pluralize(len(user_requirements) - 2, 'requirement', include_count=False)}"
         )
 
     yield f"\n\nYou are consuming {comma_separated_list(consumed_msg_parts)} from "

--- a/src/python/pants/backend/python/util_rules/scripts/pep660_backend_wrapper.py
+++ b/src/python/pants/backend/python/util_rules/scripts/pep660_backend_wrapper.py
@@ -73,7 +73,7 @@ def standardize_dist_info_path(build_dir, metadata_path):
         # The wrapped backend does not conform to the latest specs.
         pkg = pkg_version
         version = ""
-        with open(os.path.join(build_dir, metadata_path, "METADATA"), "r") as f:
+        with open(os.path.join(build_dir, metadata_path, "METADATA")) as f:
             lines = f.readlines()
         for line in lines:
             if line.startswith("Version: "):
@@ -170,7 +170,7 @@ def main(build_backend, dist_dir, pth_file_path, wheel_config_settings, tags, di
 
 
 if __name__ == "__main__":
-    with open(sys.argv[1], "r") as f:
+    with open(sys.argv[1]) as f:
         settings = json.load(f)
 
     main(**settings)

--- a/src/python/pants/base/exception_sink.py
+++ b/src/python/pants/base/exception_sink.py
@@ -92,7 +92,7 @@ class SignalHandler:
             self.signum = signum
             self.signame = signame
             self.traceback_lines = traceback.format_stack()
-            super(SignalHandler.SignalHandledNonLocalExit, self).__init__()
+            super().__init__()
 
             if "I/O operation on closed file" in self.traceback_lines:
                 logger.debug(

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -170,7 +170,7 @@ async def export(
             resolves_exported.add(result.resolve)
         console.print_stdout(f"Wrote {result.description} to {result_dir}")
 
-    unexported_resolves = sorted((set(export_subsys.resolve) - resolves_exported))
+    unexported_resolves = sorted(set(export_subsys.resolve) - resolves_exported)
     if unexported_resolves:
         all_known_user_resolve_names = await MultiGet(
             Get(KnownUserResolveNames, KnownUserResolveNamesRequest, request())

--- a/src/python/pants/engine/fs.py
+++ b/src/python/pants/engine/fs.py
@@ -284,7 +284,7 @@ class NativeDownloadFile:
 class Workspace(SideEffecting):
     """A handle for operations that mutate the local filesystem."""
 
-    _scheduler: "SchedulerSession"
+    _scheduler: SchedulerSession
     _enforce_effects: bool = True
 
     def write_digest(
@@ -326,7 +326,7 @@ class SnapshotDiff:
     changed_files: tuple[str, ...] = ()
 
     @classmethod
-    def from_snapshots(cls, ours: Snapshot, theirs: Snapshot) -> "SnapshotDiff":
+    def from_snapshots(cls, ours: Snapshot, theirs: Snapshot) -> SnapshotDiff:
         return cls(*ours._diff(theirs))
 
 

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -136,7 +136,7 @@ class Outputting:
 
     @final
     @contextmanager
-    def output(self, console: "Console") -> Iterator[Callable[[str], None]]:
+    def output(self, console: Console) -> Iterator[Callable[[str], None]]:
         """Given a Console, yields a function for writing data to stdout, or a file.
 
         The passed options instance will generally be the `Goal.Options` of an `Outputting` `Goal`.
@@ -146,7 +146,7 @@ class Outputting:
 
     @final
     @contextmanager
-    def output_sink(self, console: "Console") -> Iterator:
+    def output_sink(self, console: Console) -> Iterator:
         stdout_file = None
         if self.output_file:
             stdout_file = open(self.output_file, "w")
@@ -170,7 +170,7 @@ class LineOriented(Outputting):
 
     @final
     @contextmanager
-    def line_oriented(self, console: "Console") -> Iterator[Callable[[str], None]]:
+    def line_oriented(self, console: Console) -> Iterator[Callable[[str], None]]:
         """Given a Console, yields a function for printing lines to stdout or a file.
 
         The passed options instance will generally be the `Goal.Options` of an `Outputting` `Goal`.

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -267,7 +267,7 @@ class Example(Goal):
 
 @goal_rule
 async def a_goal_rule_generator(console: Console) -> Example:
-    a = await Get(A, str("a str!"))
+    a = await Get(A, "a str!")
     console.print_stdout(str(a))
     return Example(exit_code=0)
 

--- a/src/python/pants/engine/rules_test.py
+++ b/src/python/pants/engine/rules_test.py
@@ -267,7 +267,7 @@ class Example(Goal):
 
 @goal_rule
 async def a_goal_rule_generator(console: Console) -> Example:
-    a = await Get(A, "a str!")
+    a = await Get(A, str, "a str!")
     console.print_stdout(str(a))
     return Example(exit_code=0)
 

--- a/src/python/pants/util/collections_test.py
+++ b/src/python/pants/util/collections_test.py
@@ -97,7 +97,7 @@ def test_partition_sequentially(size_target: int) -> None:
         return {tuple(p) for p in partition_sequentially(items, key=str, size_target=size_target)}
 
     # We start with base items containing every other element from a sorted sequence.
-    all_items = sorted((f"item{i}" for i in range(0, 1024)))
+    all_items = sorted(f"item{i}" for i in range(0, 1024))
     base_items = [item for i, item in enumerate(all_items) if i % 2 == 0]
     base_partitions = partitioned_buckets(base_items)
 

--- a/src/python/pants_release/reversion.py
+++ b/src/python/pants_release/reversion.py
@@ -121,7 +121,7 @@ def reversion(
         # Get version from the input whl's metadata.
         input_version = None
         metadata_file = os.path.join(workspace, dist_info_dir, "METADATA")
-        with open(metadata_file, "r") as info:
+        with open(metadata_file) as info:
             for line in info:
                 mo = _version_re.match(line)
                 if mo:

--- a/tests/python/pants_test/pantsd/test_lock.py
+++ b/tests/python/pants_test/pantsd/test_lock.py
@@ -50,7 +50,7 @@ class TestOwnerPrintingInterProcessFileLock(unittest.TestCase):
         self.lock_process.start()
         self.lock_held.wait()
         self.assertTrue(os.path.exists(self.lock.message_path))
-        with open(self.lock.message_path, "r") as f:
+        with open(self.lock.message_path) as f:
             message_content = f.read()
         self.assertIn(str(self.lock_process.pid), message_content)
 


### PR DESCRIPTION
In #13317 an alias for pyupgrade was added before the `fix` goal existed. Now that `fix` exists pyupgrade can be used as a regular backend and run consistently.  For now --keep-runtime-typing to avoid this balooning into a single gigantic diff.