### PR TITLE
python: improve error message when parsing Python interpreter constraints

### DIFF
--- a/src/python/pants/backend/python/util_rules/interpreter_constraints.py
+++ b/src/python/pants/backend/python/util_rules/interpreter_constraints.py
@@ -8,6 +8,7 @@ import re
 from collections import defaultdict
 from typing import Iterable, Iterator, Protocol, Sequence, Tuple, TypeVar
 
+from packaging.requirements import InvalidRequirement
 from pkg_resources import Requirement
 
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -65,8 +66,14 @@ def parse_constraint(constraint: str) -> Requirement:
     """
     try:
         parsed_requirement = Requirement.parse(constraint)
-    except ValueError:
-        parsed_requirement = Requirement.parse(f"CPython{constraint}")
+    except ValueError as err:
+        try:
+            parsed_requirement = Requirement.parse(f"CPython{constraint}")
+        except ValueError:
+            raise InvalidRequirement(
+                f"Failed to parse Python interpreter constraint `{constraint}`: {err.args[0]}"
+            )
+
     return parsed_requirement
 
 


### PR DESCRIPTION
When passing invalid Python interpreter constraint, a very general error message is shown:

```
pkg_resources.extern.packaging.requirements.InvalidRequirement: Parse error at "'.*'": Expected string_end
```

By catching an exception and augmenting it with the constraint, we let users grep this string in the codebase to see where it's been defined.

With 
```diff
diff --git a/pants.toml b/pants.toml
-interpreter_constraints = ["==3.9.*"]
+interpreter_constraints = ["3.9.*"]
```


```
packaging.requirements.InvalidRequirement: Failed to parse Python interpreter constraint `3.9.*`: Parse error at "'.*'": Expected string_end
```

I am open to changing the wording and/or raising a different type of exception (e.g. keeping generic `ValueError`).

Closes https://github.com/pantsbuild/pants/issues/20251.