### PR TITLE
fix: terraform_relpath works on files not in direct subpath (Cherry-pick of #20276)

### DIFF
--- a/src/python/pants/backend/terraform/utils.py
+++ b/src/python/pants/backend/terraform/utils.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import os.path
 import shlex
-from pathlib import PurePath
 
 
 def terraform_arg(name: str, value: str) -> str:
@@ -11,4 +11,4 @@ def terraform_arg(name: str, value: str) -> str:
 
 def terraform_relpath(chdir: str, target: str) -> str:
     """Compute the relative path of a target file to the Terraform deployment root."""
-    return PurePath(target).relative_to(chdir).as_posix()
+    return os.path.relpath(target, start=chdir)

--- a/src/python/pants/backend/terraform/utils_test.py
+++ b/src/python/pants/backend/terraform/utils_test.py
@@ -1,0 +1,39 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import pytest
+
+from pants.backend.terraform.utils import terraform_relpath
+
+
+@pytest.mark.parametrize(
+    "chdir, target, expected_result",
+    [
+        pytest.param(
+            "path/to/deployment",
+            "path/to/deployment/file.txt",
+            "file.txt",
+            id="file_in_same_directory",
+        ),
+        pytest.param(
+            "path/to/deployment",
+            "path/to/other/file.txt",
+            "../other/file.txt",
+            id="file_in_different_directory",
+        ),
+        pytest.param(
+            "path/to/deployment",
+            "path/to/deployment/subdir/file.txt",
+            "subdir/file.txt",
+            id="file_in_subdirectory",
+        ),
+        pytest.param(
+            "path/to/deployment/subdir",
+            "path/to/deployment/file.txt",
+            "../file.txt",
+            id="file_in_parent_directory",
+        ),
+    ],
+)
+def test_terraform_relpath(chdir: str, target: str, expected_result: str):
+    result = terraform_relpath(chdir, target)
+    assert result == expected_result


### PR DESCRIPTION
fixes #20275 
