### PR TITLE
Terraform lockfiles (take 2)

### DIFF
--- a/docs/docs/terraform/index.mdx
+++ b/docs/docs/terraform/index.mdx
@@ -26,6 +26,14 @@ backend_packages = [
 
 The Terraform backend also needs Python to run Pants's analysers. The setting `[python].interpreter_constraints` will need to be set.
 
+Terraform needs git to download modules. Many providers and provisioners need additional binaries to be available on the PATH. Currently, you can forward your PATH by adding `"PATH"` to `[download-terraform].extra_env_vars` in `pants.toml`, like:
+```toml pants.toml
+[download-terraform]
+extra_env_vars = [
+  "PATH"
+]
+```
+
 ### Adding Terraform targets
 
 The Terraform backend has 2 target types:
@@ -35,7 +43,7 @@ The Terraform backend has 2 target types:
 
 #### Modules
 
-The `tailor` goal will automatically generate `terraform_module` targets. Run [`pants tailor ::`](../getting-started/initial-configuration.mdx#5-generate-build-files). For example:
+The `tailor` goal will automatically generate `terraform_module`, `terraform_backend`, and `terraform_var_files` targets. Run [`pants tailor ::`](../getting-started/initial-configuration.mdx#5-generate-build-files). For example:
 
 ```
 ❯ pants tailor ::
@@ -146,7 +154,7 @@ terraform_module(skip_terraform_validate=True)
 
 :::caution Terraform deployment support is in alpha stage
 Many options and features aren't supported yet.
-Local state backends aren't supported.
+For the local state backend, use an absolute path.
 :::
 
 Run `terraform apply` as part of the `experimental-deploy` goal. The process is run interactively, so you will be prompted for variables and confirmation as usual.

--- a/docs/docs/terraform/index.mdx
+++ b/docs/docs/terraform/index.mdx
@@ -43,24 +43,72 @@ Created src/terraform/root/BUILD:
   - Add terraform_module target root
 ```
 
+> 🚧 `terraform_module`s must be defined in a BUILD file in the same directory as the module sources
+>
+> Terraform only uses files in a single directory. The Pants Terraform plugin uses the directory of the BUILD file for this.
+
 #### Deployments
 
-`terraform_deployments` must be manually created. The deployment points to a `terraform_module` target as its `root_module` field. This module will be the "root" module that Terraform operations will be run on. You can reference vars files with the `var_files` field. You can have multiple deployments reference the same module:
+`terraform_deployment`s must be manually created. The deployment points to a `terraform_module` target as its `root_module` field. This module will be the "root" module that Terraform operations will be run on. Identify backend configs with a `terraform_backend` target, and var files with a `terraform_var_files` target. Pants will automatically use `terraform_backend`s and `terraform_var_files` in the same directory as a `terraform_deployment`.
 
 ```
 terraform_module(name="root")
-terraform_deployment(name="prod", root_module=":root", var_files=["prod.tfvars"])
-terraform_deployment(name="test", root_module=":root", var_files=["test.tfvars"])
+terraform_deployment(name="prod", root_module=":root")
+terraform_backend(name="tfbackend")
+terraform_var_files(name="tfvars")
+```
+
+You can override this behaviour by explicitly specifying these in the `dependencies` field.
+
+```
+terraform_module(name="root")
+terraform_backend(name="prod_backend", source="prod.tfbackend")
+terraform_deployment(name="prod", root_module=":root", dependencies=["prod_backend"])
+terraform_backend(name="test_backend", source="test.tfbackend")
+terraform_deployment(name="test", root_module=":root", dependencies=["test_backend"])
 ```
 
 #### Lockfiles
 
-Automatic lockfile management is currently in progress. You can include lockfiles manually as a dependency:
+Lockfiles will be loaded from the directory of the root module of a deployment, just like with the `terraform` command.
 
+``` prod/BUILD
+terraform_deployment(name="prod", root_module="//tf:infrastructure")
 ```
-terraform_deployment(name="prod", root_module=":root", dependencies=[":lockfile"])
-file(name="lockfile", source=".terraform.lock.hcl")
+
+``` tf/BUILD
+terraform_module(name="infrastructure")
 ```
+
+``` tf/main.tf
+resource "null_resource" "dep" {}
+```
+
+``` tf/.terraform.lock.hcl
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.2"
+  hashes = [
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+  ]
+}
+```
+
+Pants can generate and update lockfiles with the `generate-lockfiles` command. Use the target of the `terraform_module`'s address as the resolve name. For example, `pants generate-lockfiles --resolve=tf:infrastructure`.
 
 ### Basic Operations
 

--- a/docs/docs/terraform/index.mdx
+++ b/docs/docs/terraform/index.mdx
@@ -54,7 +54,7 @@ Created src/terraform/root/BUILD:
 ```
 terraform_module(name="root")
 terraform_deployment(name="prod", root_module=":root")
-terraform_backend(name="tfbackend")
+terraform_backend(name="tfbackend", source="main.tfbackend")
 terraform_var_files(name="tfvars")
 ```
 

--- a/docs/docs/writing-plugins/common-plugin-tasks/add-a-repl.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/add-a-repl.mdx
@@ -1,6 +1,6 @@
 ---
     title: Add a REPL
-    sidebar_position: 6
+    sidebar_position: 5
 ---
 
 How to add a new implementation to the `repl` goal.

--- a/docs/docs/writing-plugins/common-plugin-tasks/custom-python-artifact-kwargs.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/custom-python-artifact-kwargs.mdx
@@ -1,6 +1,6 @@
 ---
     title: Custom `python_artifact()` kwargs
-    sidebar_position: 8
+    sidebar_position: 9
 ---
 
 How to add your own logic to `python_artifact()`.

--- a/docs/docs/writing-plugins/common-plugin-tasks/index.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/index.mdx
@@ -7,7 +7,11 @@
 
 - [Add a linter](./add-a-linter.mdx)
 - [Add a formatter](./add-a-formatter.mdx)
+- [Add a typechecker](./add-a-typechecker.mdx)
 - [Add codegen](./add-codegen.mdx)
 - [Add a REPL](./add-a-repl.mdx)
+- [Add Tests](./run-tests.mdx)
+- [Add lockfile support](./plugin-lockfiles.mdx)
 - [Custom `setup-py` kwargs](./custom-python-artifact-kwargs.mdx)
 - [Plugin upgrade guide](./plugin-upgrade-guide.mdx)
+- [Plugin helpers](./plugin-helpers.mdx)

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
@@ -157,5 +157,3 @@ async def init_fortran(request: FortranInitRequest) -> FortranInitResponse:
     ...
     Get(Snapshot, PathGlobs([(Path(request.root_module.address.spec_path) / ".fortran.lock").as_posix()])),
 ```
-
-TODO: You can also reference this in the dependency inference. This dependency link will result in the lockfile being imported through the standard dependency request, and it will also cause all dependent source files to be marked as transitively changed

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
@@ -1,6 +1,6 @@
 ---
     title: "Add lockfiles"
-    sidebar_position: 10
+    sidebar_position: 7
 ---
 
 How to add lockfiles and the `generate-lockfiles` goal.

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
@@ -8,11 +8,9 @@ How to add lockfiles and the `generate-lockfiles` goal.
 ---
 Lockfiles are a way to pin to exact versions of dependencies, often including hashes to guarantee integrity between the version pinned and the version downloaded.
 
-This guide will walk you through implementing lockfiles, hooking them into the `generate-lockfiles` goal, and implementing the `export` goal which will allow you to export dependencies for use outside of Pants. It assumes that your language has a tool that supports generating and using lockfiles or that you have written code which does these. 
+This guide will walk you through implementing lockfiles and hooking them into the `generate-lockfiles` goal. It assumes that your language has a tool that supports generating and using lockfiles or that you have written code which does these.
 
-1. Expose your lockfiles to Pants
-
----
+## 1. Expose your lockfiles to Pants
 
 Create subclasses of `KnownUserResolveNamesRequest` to inform Pants about which resolves exist, and a subclass of `RequestedUserResolveNames` for Pants to request those resolves later. Implement the resolve-finding logic in a Rule from your subclass of `KnownUserResolveNamesRequest` to `KnownUserResolveNames`. Set `KnownResolveNames.requested_resolve_names_cls` to your subclass of `RequestedUserResolveNames`. 
 
@@ -42,9 +40,7 @@ async def identify_user_resolves_from_fortran_files(
     )
 ```
 
-2. Connect resolve names to requests to generate lockfiles
-
----
+## 2. Connect resolve names to requests to generate lockfiles
 
 Create a subclass of `GenerateLockfile`. Pants will use this to represent a lockfile to generate. Then create a rule from your subclass of `RequestedUserResolveNames` to `UserGenerateLockfiles`. Pants will use this rule to convert from a user's request to export a resolve by name into the information needed to export the resolve.
 
@@ -75,9 +71,7 @@ async def setup_user_lockfile_requests(
     )
 ```
 
-3. Generate lockfiles
-
----
+## 3. Generate lockfiles
 
 Create a rule from your subclass of `GenerateLockfile` to `GenerateLockfileResult`. This rule generates the lockfile. In the common case that you're running a process to generate this lockfile, you can use the `Process.output_files` to gather those files from the execution sandbox.
 
@@ -104,9 +98,7 @@ async def generate_lockfile_from_sources(
 
 ```
 
-4. Register rules
-
----
+## 4. Register rules
 
 At the bottom of the file, let Pants know what your rules and types do. Update your plugin's `register.py` to tell Pants about them/
 
@@ -137,9 +129,7 @@ def rules():
     ]
 ```
 
-5. Use lockfiles for fetching dependencies
-
----
+## 5. Use lockfiles for fetching dependencies
 
 If you have a tool that supports lockfiles, the easiest way to get the lockfile to it is to simply use a glob to pull the file into a digest.
 

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
@@ -1,0 +1,161 @@
+---
+    title: "Add lockfiles"
+    sidebar_position: 10
+---
+
+How to add lockfiles and the `generate-lockfiles` goal.
+
+---
+Lockfiles are a way to pin to exact versions of dependencies, often including hashes to guarantee integrity between the version pinned and the version downloaded.
+
+This guide will walk you through implementing lockfiles, hooking them into the `generate-lockfiles` goal, and implementing the `export` goal which will allow you to export dependencies for use outside of Pants. It assumes that your language has a tool that supports generating and using lockfiles or that you have written code which does these. 
+
+1. Expose your lockfiles to Pants
+
+---
+
+Create subclasses of `KnownUserResolveNamesRequest` to inform Pants about which resolves exist, and a subclass of `RequestedUserResolveNames` for Pants to request those resolves later. Implement the resolve-finding logic in a Rule from your subclass of `KnownUserResolveNamesRequest` to `KnownUserResolveNames`. Set `KnownResolveNames.requested_resolve_names_cls` to your subclass of `RequestedUserResolveNames`. 
+
+```python
+from pants.core.goals.generate_lockfiles import KnownUserResolveNamesRequest, RequestedUserResolveNames, KnownUserResolveNames
+from pants.engine.rules import rule
+from pants.engine.target import AllTargets
+
+
+class KnownFortranResolveNamesRequest(KnownUserResolveNamesRequest):
+    pass
+
+
+class RequestedFortranResolveNames(RequestedUserResolveNames):
+    pass
+
+
+@rule
+async def identify_user_resolves_from_fortran_files(
+        _: KnownFortranResolveNamesRequest,
+        all_targets: AllTargets,
+) -> KnownUserResolveNames:
+    ...
+    return KnownUserResolveNames(
+        ...,
+        requested_resolve_names_cls=RequestedFortranResolveNames
+    )
+```
+
+2. Connect resolve names to requests to generate lockfiles
+
+---
+
+Create a subclass of `GenerateLockfile`. Pants will use this to represent a lockfile to generate. Then create a rule from your subclass of `RequestedUserResolveNames` to `UserGenerateLockfiles`. Pants will use this rule to convert from a user's request to export a resolve by name into the information needed to export the resolve.
+
+```python
+from dataclasses import dataclass
+
+from pants.backend.fortran.target_types import FortranDeploymentTarget
+from pants.core.goals.generate_lockfiles import GenerateLockfile, UserGenerateLockfiles
+from pants.engine.rules import rule
+
+
+@dataclass(frozen=True)
+class GenerateFortranLockfile(GenerateLockfile):
+    target: FortranDeploymentTarget
+
+
+@rule
+async def setup_user_lockfile_requests(
+        requested: RequestedFortranResolveNames,
+) -> UserGenerateLockfiles:
+    ...
+    return UserGenerateLockfiles(
+        [
+            GenerateFortranLockfile(
+                ...
+            )
+        ]
+    )
+```
+
+3. Generate lockfiles
+
+---
+
+Create a rule from your subclass of `GenerateLockfile` to `GenerateLockfileResult`. This rule generates the lockfile. In the common case that you're running a process to generate this lockfile, you can use the `Process.output_files` to gather those files from the execution sandbox.
+
+```python
+from pants.backend.fortran.tool import FortranProcess
+from pants.core.goals.generate_lockfiles import GenerateLockfileResult
+from pants.engine.internals.selectors import Get
+from pants.engine.process import ProcessResult
+from pants.engine.rules import rule
+
+
+@rule
+async def generate_lockfile_from_sources(
+        request: GenerateFortranLockfile,
+) -> GenerateLockfileResult:
+    ...
+
+    result = await Get(
+        ProcessResult,
+        FortranProcess(...),
+    )
+
+    return GenerateLockfileResult(result.output_digest, request.resolve_name, request.lockfile_dest)
+
+```
+
+4. Register rules
+
+---
+
+At the bottom of the file, let Pants know what your rules and types do. Update your plugin's `register.py` to tell Pants about them/
+
+```python pants-plugins/fortran/lockfiles.py
+
+
+from pants.core.goals.generate_lockfiles import GenerateLockfile, KnownUserResolveNamesRequest, RequestedUserResolveNames
+from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateLockfile, GenerateFortranLockfile),
+        UnionRule(KnownUserResolveNamesRequest, KnownFortranResolveNamesRequest),
+        UnionRule(RequestedUserResolveNames, RequestedFortranResolveNames),
+    )
+```
+
+```python pants-plugins/fortran/register.py
+from fortran import lockfiles
+
+def rules():
+    return [
+        ...,
+        *lockfiles.rules()
+    ]
+```
+
+5. Use lockfiles for fetching dependencies
+
+---
+
+If you have a tool that supports lockfiles, the easiest way to get the lockfile to it is to simply use a glob to pull the file into a digest.
+
+```python
+from pathlib import Path
+
+from pants.engine.fs import PathGlobs
+from pants.engine.internals.native_engine import Snapshot
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import rule
+
+
+@rule
+async def init_fortran(request: FortranInitRequest) -> FortranInitResponse:
+    ...
+    Get(Snapshot, PathGlobs([(Path(request.root_module.address.spec_path) / ".fortran.lock").as_posix()])),
+```
+
+TODO: You can also reference this in the dependency inference. This dependency link will result in the lockfile being imported through the standard dependency request, and it will also cause all dependent source files to be marked as transitively changed

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-lockfiles.mdx
@@ -14,7 +14,7 @@ This guide will walk you through implementing lockfiles and hooking them into th
 
 Create subclasses of `KnownUserResolveNamesRequest` to inform Pants about which resolves exist, and a subclass of `RequestedUserResolveNames` for Pants to request those resolves later. Implement the resolve-finding logic in a Rule from your subclass of `KnownUserResolveNamesRequest` to `KnownUserResolveNames`. Set `KnownResolveNames.requested_resolve_names_cls` to your subclass of `RequestedUserResolveNames`. 
 
-```python
+```python tab={"label": "pants-plugins/fortran/lockfiles.py"}
 from pants.core.goals.generate_lockfiles import KnownUserResolveNamesRequest, RequestedUserResolveNames, KnownUserResolveNames
 from pants.engine.rules import rule
 from pants.engine.target import AllTargets
@@ -44,7 +44,7 @@ async def identify_user_resolves_from_fortran_files(
 
 Create a subclass of `GenerateLockfile`. Pants will use this to represent a lockfile to generate. Then create a rule from your subclass of `RequestedUserResolveNames` to `UserGenerateLockfiles`. Pants will use this rule to convert from a user's request to export a resolve by name into the information needed to export the resolve.
 
-```python
+```python tab={"label": "pants-plugins/fortran/lockfiles.py"}
 from dataclasses import dataclass
 
 from pants.backend.fortran.target_types import FortranDeploymentTarget
@@ -75,7 +75,7 @@ async def setup_user_lockfile_requests(
 
 Create a rule from your subclass of `GenerateLockfile` to `GenerateLockfileResult`. This rule generates the lockfile. In the common case that you're running a process to generate this lockfile, you can use the `Process.output_files` to gather those files from the execution sandbox.
 
-```python
+```python tab={"label": "pants-plugins/fortran/lockfiles.py"}
 from pants.backend.fortran.tool import FortranProcess
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult
 from pants.engine.internals.selectors import Get
@@ -102,7 +102,7 @@ async def generate_lockfile_from_sources(
 
 At the bottom of the file, let Pants know what your rules and types do. Update your plugin's `register.py` to tell Pants about them/
 
-```python pants-plugins/fortran/lockfiles.py
+```python tab={"label": "pants-plugins/fortran/lockfiles.py"}
 
 
 from pants.core.goals.generate_lockfiles import GenerateLockfile, KnownUserResolveNamesRequest, RequestedUserResolveNames
@@ -119,7 +119,7 @@ def rules():
     )
 ```
 
-```python pants-plugins/fortran/register.py
+```python tab={"label": "pants-plugins/fortran/register.py"}
 from fortran import lockfiles
 
 def rules():

--- a/docs/docs/writing-plugins/common-plugin-tasks/run-tests.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/run-tests.mdx
@@ -1,6 +1,6 @@
 ---
     title: Run tests
-    sidebar_position: 7
+    sidebar_position: 6
 ---
 
 How to add a new test runner to the `test` goal.

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -3,7 +3,9 @@
 
 from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.terraform import dependencies, dependency_inference, tool
-from pants.backend.terraform.goals import check, deploy, tailor
+from pants.backend.terraform.goals import check, deploy
+from pants.backend.terraform.goals import lockfiles as terraform_lockfile
+from pants.backend.terraform.goals import tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
 from pants.backend.terraform.target_types import (
     TerraformBackendTarget,
@@ -35,5 +37,6 @@ def rules():
         *tool.rules(),
         *tffmt_rules(),
         *deploy.rules(),
+        *terraform_lockfile.rules(),
         *python_lockfile.rules(),
     ]

--- a/src/python/pants/backend/experimental/terraform/register.py
+++ b/src/python/pants/backend/experimental/terraform/register.py
@@ -5,13 +5,23 @@ from pants.backend.python.goals import lockfile as python_lockfile
 from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.goals import check, deploy, tailor
 from pants.backend.terraform.lint.tffmt.tffmt import rules as tffmt_rules
-from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformDeploymentTarget,
+    TerraformModuleTarget,
+    TerraformVarFileTarget,
+)
 from pants.backend.terraform.target_types import rules as target_types_rules
 from pants.engine.rules import collect_rules
 
 
 def target_types():
-    return [TerraformModuleTarget, TerraformDeploymentTarget]
+    return [
+        TerraformModuleTarget,
+        TerraformDeploymentTarget,
+        TerraformBackendTarget,
+        TerraformVarFileTarget,
+    ]
 
 
 def rules():

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -76,7 +76,6 @@ async def get_terraform_providers(
 
     args.append(terraform_arg("-backend", str(req.initialise_backend)))
 
-    # TODO: Does this need to be a MultiGet? I think we will now always get one directory
     fetched_deps = await Get(
         FallibleProcessResult,
         TerraformProcess(
@@ -117,9 +116,13 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
 
     address_input = request.root_module.to_address_input()
     module_address = await Get(Address, AddressInput, address_input)
-    chdir = module_address.spec_path  # TODO: spec_path is wrong, that's to the build file
 
-    # TODO: is this still necessary, or do we pull it in with (transitive) depenendencies?
+    chdir = module_address.spec_path  # TODO: spec_path is wrong, that's to the build file
+    # if the Terraform module is in the root, chdir will be "". Terraform needs a valid dir to change to
+    if not chdir:
+        chdir = "."
+
+    # TODO: is this still necessary, or do we pull it in with (transitive) dependencies?
     module = await Get(
         WrappedTarget,
         WrappedTargetRequest(

--- a/src/python/pants/backend/terraform/dependencies.py
+++ b/src/python/pants/backend/terraform/dependencies.py
@@ -185,7 +185,14 @@ async def init_terraform(request: TerraformInitRequest) -> TerraformInitResponse
     )
 
     all_terraform_files = await Get(
-        Digest, MergeDigests([third_party_deps.digest, source_for_validate])
+        Digest,
+        MergeDigests(
+            [
+                source_files.snapshot.digest,
+                dependencies_files.snapshot.digest,
+                third_party_deps.digest,
+            ]
+        ),
     )
 
     return TerraformInitResponse(

--- a/src/python/pants/backend/terraform/dependencies_test.py
+++ b/src/python/pants/backend/terraform/dependencies_test.py
@@ -31,7 +31,6 @@ def _do_init_terraform(
         [
             TerraformInitRequest(
                 field_set.root_module,
-                field_set.backend_config,
                 field_set.dependencies,
                 initialise_backend=initialise_backend,
             )

--- a/src/python/pants/backend/terraform/dependency_inference_test.py
+++ b/src/python/pants/backend/terraform/dependency_inference_test.py
@@ -13,7 +13,12 @@ from pants.backend.terraform.dependency_inference import (
     TerraformHcl2Parser,
     TerraformModuleDependenciesInferenceFieldSet,
 )
-from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformDeploymentTarget,
+    TerraformModuleTarget,
+    TerraformVarFileTarget,
+)
 from pants.build_graph.address import Address
 from pants.core.util_rules import external_tool, source_files
 from pants.engine.process import ProcessResult
@@ -33,7 +38,12 @@ from pants.util.ordered_set import FrozenOrderedSet
 @pytest.fixture
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        target_types=[
+            TerraformModuleTarget,
+            TerraformDeploymentTarget,
+            TerraformBackendTarget,
+            TerraformVarFileTarget,
+        ],
         rules=[
             *external_tool.rules(),
             *source_files.rules(),
@@ -122,6 +132,65 @@ def test_dependency_inference_deployment(rule_runner: RuleRunner) -> None:
     assert inferred_deps == InferredDependencies(
         FrozenOrderedSet([Address("src/tf", target_name="mod")])
     )
+
+
+def test_dependency_inference_autoinfered_files(rule_runner: RuleRunner) -> None:
+    """Check that autoinference on tfvars and tfbackends works."""
+    rule_runner.write_files(
+        {
+            "src/tf/BUILD": 'terraform_module(name="mod")\nterraform_deployment(name="deployment",root_module=":mod",)\nterraform_backend(name="tfbackend", source="main.tfbackend")\nterraform_var_files(name="tfvars")',
+            "src/tf/main.tf": "",
+            "src/tf/main.tfvars": "",
+            "src/tf/main.tfbackend": "",
+        }
+    )
+    target = rule_runner.get_target(Address("src/tf", target_name="deployment"))
+    inferred_deps = rule_runner.request(
+        InferredDependencies,
+        [
+            InferTerraformDeploymentDependenciesRequest(
+                TerraformDeploymentDependenciesInferenceFieldSet.create(target)
+            )
+        ],
+    )
+    assert set(inferred_deps.include) == {
+        Address("src/tf", target_name=tgt) for tgt in ("mod", "tfbackend", "tfvars")
+    }
+
+
+def test_dependency_inference_autoinfered_override(rule_runner: RuleRunner) -> None:
+    """Check that autoinference on tfvars and tfbackends can be overridden."""
+    rule_runner.write_files(
+        {
+            "src/tf/BUILD": textwrap.dedent(
+                """\
+                terraform_module(name="mod")
+                terraform_deployment(name="deployment",root_module=":mod",dependencies=[":0.tfbackend",":0.tfvars"])
+                terraform_backend(name="0.tfbackend", source="0.tfbackend")
+                terraform_backend(name="1.tfbackend", source="1.tfbackend")
+                terraform_var_files(name="0.tfvars", sources=["0.tfvars"])
+                terraform_var_files(name="1.tfvars", sources=["1.tfvars"])
+                """
+            ),
+            "src/tf/main.tf": "",
+            "src/tf/0.tfvars": "",
+            "src/tf/1.tfvars": "",
+            "src/tf/0.tfbackend": "",
+            "src/tf/1.tfbackend": "",
+        }
+    )
+    target = rule_runner.get_target(Address("src/tf", target_name="deployment"))
+    inferred_deps = rule_runner.request(
+        InferredDependencies,
+        [
+            InferTerraformDeploymentDependenciesRequest(
+                TerraformDeploymentDependenciesInferenceFieldSet.create(target)
+            )
+        ],
+    )
+    assert set(inferred_deps.include) == {
+        Address("src/tf", target_name=tgt) for tgt in ("mod", "0.tfvars", "0.tfbackend")
+    }
 
 
 @pytest.mark.platform_specific_behavior

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -85,8 +85,8 @@ async def terraform_check(
             TerraformProcess(
                 args=("validate",),
                 input_digest=deployment.sources_and_deps,
-                output_files=tuple(deployment.terraform_files),
-                description=f"Run `terraform fmt` on {pluralize(len(deployment.terraform_files), 'file')}.",
+                output_files=tuple(deployment.terraform_files.files),
+                description=f"Run `terraform validate` on module {deployment.chdir} with {pluralize(len(deployment.terraform_files.files), 'file')}.",
                 chdir=deployment.chdir,
             ),
         )

--- a/src/python/pants/backend/terraform/goals/check.py
+++ b/src/python/pants/backend/terraform/goals/check.py
@@ -5,7 +5,6 @@ from typing import Union
 
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.target_types import (
-    TerraformBackendConfigField,
     TerraformDeploymentFieldSet,
     TerraformDeploymentTarget,
     TerraformFieldSet,
@@ -55,14 +54,11 @@ def terraform_fieldset_to_init_request(
 ) -> TerraformInitRequest:
     if isinstance(terraform_fieldset, TerraformDeploymentFieldSet):
         deployment = terraform_fieldset
-        return TerraformInitRequest(
-            deployment.root_module, deployment.backend_config, deployment.dependencies
-        )
+        return TerraformInitRequest(deployment.root_module, deployment.dependencies)
     if isinstance(terraform_fieldset, TerraformFieldSet):
         module = terraform_fieldset
         return TerraformInitRequest(
             TerraformRootModuleField(module.address.spec, module.address),
-            TerraformBackendConfigField(None, module.address),
             module.dependencies,
         )
 

--- a/src/python/pants/backend/terraform/goals/lockfiles.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles.py
@@ -1,0 +1,124 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+from pathlib import Path
+
+from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
+from pants.backend.terraform.target_types import (
+    TerraformDependenciesField,
+    TerraformDeploymentTarget,
+    TerraformRootModuleField,
+)
+from pants.backend.terraform.tool import TerraformProcess
+from pants.base.specs import DirGlobSpec, RawSpecs
+from pants.core.goals.generate_lockfiles import (
+    GenerateLockfile,
+    GenerateLockfileResult,
+    KnownUserResolveNames,
+    KnownUserResolveNamesRequest,
+    RequestedUserResolveNames,
+    UserGenerateLockfiles,
+)
+from pants.engine.internals.selectors import Get
+from pants.engine.process import ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import AllTargets, Targets
+from pants.engine.unions import UnionRule
+
+
+class KnownTerraformResolveNamesRequest(KnownUserResolveNamesRequest):
+    pass
+
+
+class RequestedTerraformResolveNames(RequestedUserResolveNames):
+    pass
+
+
+@rule
+async def identify_user_resolves_from_terraform_files(
+    _: KnownTerraformResolveNamesRequest,
+    all_targets: AllTargets,
+) -> KnownUserResolveNames:
+    known_terraform_module_dirs = []
+    for tgt in all_targets:
+        if tgt.has_field(TerraformRootModuleField):
+            known_terraform_module_dirs.append(tgt.residence_dir)
+
+    return KnownUserResolveNames(
+        names=tuple(known_terraform_module_dirs),
+        option_name="[terraform].resolves",
+        requested_resolve_names_cls=RequestedTerraformResolveNames,
+    )
+
+
+@dataclass(frozen=True)
+class GenerateTerraformLockfile(GenerateLockfile):
+    target: TerraformDeploymentTarget
+
+
+@rule
+async def setup_user_lockfile_requests(
+    requested: RequestedTerraformResolveNames,
+) -> UserGenerateLockfiles:
+    targets_in_dirs = await Get(
+        Targets,
+        RawSpecs(
+            description_of_origin="setup Terraform lockfiles",
+            dir_globs=tuple(DirGlobSpec(d) for d in requested),
+        ),
+    )
+    deployment_targets = [t for t in targets_in_dirs if isinstance(t, TerraformDeploymentTarget)]
+
+    return UserGenerateLockfiles(
+        [
+            GenerateTerraformLockfile(
+                target=tgt,
+                resolve_name=tgt.residence_dir,
+                lockfile_dest=(Path(tgt.residence_dir) / ".terraform.lock.hcl").as_posix(),
+                diff=False,
+            )
+            for tgt in deployment_targets
+        ]
+    )
+
+
+@rule
+async def generate_lockfile_from_sources(
+    lockfile_request: GenerateTerraformLockfile,
+) -> GenerateLockfileResult:
+    """Generate a Terraform lockfile by running `terraform providers lock` on the sources."""
+    initialised_terraform = await Get(
+        TerraformInitResponse,
+        TerraformInitRequest(
+            lockfile_request.target[TerraformRootModuleField],
+            lockfile_request.target[TerraformDependenciesField],
+            initialise_backend=False,
+            upgrade=True,
+        ),
+    )
+    result = await Get(
+        ProcessResult,
+        TerraformProcess(
+            args=(
+                "providers",
+                "lock",
+            ),
+            input_digest=initialised_terraform.sources_and_deps,
+            output_files=(".terraform.lock.hcl",),
+            description=f"Update terraform lockfile for {lockfile_request.resolve_name}",
+            chdir=initialised_terraform.chdir,
+        ),
+    )
+
+    return GenerateLockfileResult(
+        result.output_digest, lockfile_request.resolve_name, lockfile_request.lockfile_dest
+    )
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(GenerateLockfile, GenerateTerraformLockfile),
+        UnionRule(KnownUserResolveNamesRequest, KnownTerraformResolveNamesRequest),
+        UnionRule(RequestedUserResolveNames, RequestedTerraformResolveNames),
+    )

--- a/src/python/pants/backend/terraform/goals/lockfiles_test.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles_test.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import pytest
+
+from pants.backend.terraform.testutil import (
+    StandardDeployment,
+    rule_runner_with_auto_approve,
+    standard_deployment,
+    terraform_lockfile,
+    terraform_lockfile_regenerated,
+)
+from pants.core.goals.generate_lockfiles import GenerateLockfilesGoal
+from pants.testutil.rule_runner import RuleRunner
+
+rule_runner = rule_runner_with_auto_approve
+standard_deployment = standard_deployment
+
+
+@pytest.mark.parametrize("existing_lockfile", [False, True])
+def test_integration_generate_lockfile(
+    rule_runner: RuleRunner, standard_deployment: StandardDeployment, existing_lockfile: bool
+) -> None:
+    rule_runner.write_files(standard_deployment.files)
+    if existing_lockfile:
+        rule_runner.write_files({"src/tf/.terraform.lock.hcl": terraform_lockfile})
+
+    result = rule_runner.run_goal_rule(
+        GenerateLockfilesGoal,
+        global_args=[*rule_runner.options_bootstrapper.args],
+        args=["--generate-lockfiles-resolve=src/tf"],
+    )
+
+    # assert Pants things we succeeded
+    assert result.exit_code == 0
+
+    # assert Terraform wrote the lockfile
+    lockfile_contents = rule_runner.read_file("src/tf/.terraform.lock.hcl")
+    assert lockfile_contents == terraform_lockfile_regenerated

--- a/src/python/pants/backend/terraform/goals/lockfiles_test.py
+++ b/src/python/pants/backend/terraform/goals/lockfiles_test.py
@@ -29,7 +29,7 @@ def test_integration_generate_lockfile(
     result = rule_runner.run_goal_rule(
         GenerateLockfilesGoal,
         global_args=[*rule_runner.options_bootstrapper.args],
-        args=["--generate-lockfiles-resolve=src/tf"],
+        args=["--generate-lockfiles-resolve=src/tf:mod"],
     )
 
     # assert Pants things we succeeded

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -63,20 +63,24 @@ async def find_putative_terrform_module_targets(
             PutativeTarget.for_target_type(
                 TerraformBackendTarget,
                 path=dirname,
-                name=None,
+                name=filename,
+                kwargs={"source": filename},
                 triggering_sources=(filename,),
             )
         )
 
+    # We generate separate targets for each var file,
+    # to not make assumptions that they're all together.
     all_var_files = await Get(Paths, PathGlobs, request.path_globs("*.tfvars"))
     unowned_var_files = set(all_var_files.files) - set(all_owned_sources)
-    for backend_file in unowned_var_files:
-        dirname, filename = os.path.split(backend_file)
+    for var_file in unowned_var_files:
+        dirname, filename = os.path.split(var_file)
         putative_targets.append(
             PutativeTarget.for_target_type(
                 TerraformVarFileTarget,
                 path=dirname,
-                name=None,
+                name=filename,
+                kwargs={"sources": (filename,)},
                 triggering_sources=(filename,),
             )
         )

--- a/src/python/pants/backend/terraform/goals/tailor.py
+++ b/src/python/pants/backend/terraform/goals/tailor.py
@@ -3,9 +3,15 @@
 
 from __future__ import annotations
 
+import os.path
 from dataclasses import dataclass
+from typing import List
 
-from pants.backend.terraform.target_types import TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformModuleTarget,
+    TerraformVarFileTarget,
+)
 from pants.backend.terraform.tool import TerraformTool
 from pants.core.goals.tailor import (
     AllOwnedSources,
@@ -34,11 +40,12 @@ async def find_putative_terrform_module_targets(
 ) -> PutativeTargets:
     if not terraform.tailor:
         return PutativeTargets()
+    putative_targets: List[PutativeTarget] = []
 
     all_terraform_files = await Get(Paths, PathGlobs, request.path_globs("*.tf"))
     unowned_terraform_files = set(all_terraform_files.files) - set(all_owned_sources)
 
-    putative_targets = [
+    putative_targets.extend(
         PutativeTarget.for_target_type(
             TerraformModuleTarget,
             path=dirname,
@@ -46,7 +53,33 @@ async def find_putative_terrform_module_targets(
             triggering_sources=sorted(filenames),
         )
         for dirname, filenames in group_by_dir(unowned_terraform_files).items()
-    ]
+    )
+
+    all_backend_files = await Get(Paths, PathGlobs, request.path_globs("*.tfbackend"))
+    unowned_backend_files = set(all_backend_files.files) - set(all_owned_sources)
+    for backend_file in unowned_backend_files:
+        dirname, filename = os.path.split(backend_file)
+        putative_targets.append(
+            PutativeTarget.for_target_type(
+                TerraformBackendTarget,
+                path=dirname,
+                name=None,
+                triggering_sources=(filename,),
+            )
+        )
+
+    all_var_files = await Get(Paths, PathGlobs, request.path_globs("*.tfvars"))
+    unowned_var_files = set(all_var_files.files) - set(all_owned_sources)
+    for backend_file in unowned_var_files:
+        dirname, filename = os.path.split(backend_file)
+        putative_targets.append(
+            PutativeTarget.for_target_type(
+                TerraformVarFileTarget,
+                path=dirname,
+                name=None,
+                triggering_sources=(filename,),
+            )
+        )
 
     return PutativeTargets(putative_targets)
 

--- a/src/python/pants/backend/terraform/goals/tailor_test.py
+++ b/src/python/pants/backend/terraform/goals/tailor_test.py
@@ -58,26 +58,30 @@ def test_find_putative_targets() -> None:
                 PutativeTarget.for_target_type(
                     TerraformBackendTarget,
                     "prod/terraform/unowned-module",
-                    "unowned-module",
+                    "prod0.tfbackend",
                     ("prod0.tfbackend",),
+                    kwargs={"source": "prod0.tfbackend"},
                 ),
                 PutativeTarget.for_target_type(
                     TerraformBackendTarget,
                     "prod/terraform/unowned-module",
-                    "unowned-module",
+                    "prod1.tfbackend",
                     ("prod1.tfbackend",),
+                    kwargs={"source": "prod1.tfbackend"},
                 ),
                 PutativeTarget.for_target_type(
                     TerraformVarFileTarget,
                     "prod/terraform/unowned-module",
-                    "unowned-module",
+                    "prod0.tfvars",
                     ("prod0.tfvars",),
+                    kwargs={"sources": ("prod0.tfvars",)},
                 ),
                 PutativeTarget.for_target_type(
                     TerraformVarFileTarget,
                     "prod/terraform/unowned-module",
-                    "unowned-module",
+                    "prod1.tfvars",
                     ("prod1.tfvars",),
+                    kwargs={"sources": ("prod1.tfvars",)},
                 ),
             ]
         )

--- a/src/python/pants/backend/terraform/goals/tailor_test.py
+++ b/src/python/pants/backend/terraform/goals/tailor_test.py
@@ -3,7 +3,11 @@
 
 from pants.backend.terraform.goals.tailor import PutativeTerraformTargetsRequest
 from pants.backend.terraform.goals.tailor import rules as terraform_tailor_rules
-from pants.backend.terraform.target_types import TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformModuleTarget,
+    TerraformVarFileTarget,
+)
 from pants.core.goals.tailor import AllOwnedSources, PutativeTarget, PutativeTargets
 from pants.core.goals.tailor import rules as core_tailor_rules
 from pants.engine.rules import QueryRule
@@ -27,6 +31,10 @@ def test_find_putative_targets() -> None:
             "prod/terraform/owned-module/BUILD": "terraform_module()",
             "prod/terraform/owned-module/versions.tf": "",
             "prod/terraform/unowned-module/versions.tf": "",
+            "prod/terraform/unowned-module/prod0.tfbackend": "",
+            "prod/terraform/unowned-module/prod1.tfbackend": "",
+            "prod/terraform/unowned-module/prod0.tfvars": "",
+            "prod/terraform/unowned-module/prod1.tfvars": "",
         }
     )
     pts = rule_runner.request(
@@ -46,6 +54,30 @@ def test_find_putative_targets() -> None:
                     "prod/terraform/unowned-module",
                     "unowned-module",
                     ("versions.tf",),
+                ),
+                PutativeTarget.for_target_type(
+                    TerraformBackendTarget,
+                    "prod/terraform/unowned-module",
+                    "unowned-module",
+                    ("prod0.tfbackend",),
+                ),
+                PutativeTarget.for_target_type(
+                    TerraformBackendTarget,
+                    "prod/terraform/unowned-module",
+                    "unowned-module",
+                    ("prod1.tfbackend",),
+                ),
+                PutativeTarget.for_target_type(
+                    TerraformVarFileTarget,
+                    "prod/terraform/unowned-module",
+                    "unowned-module",
+                    ("prod0.tfvars",),
+                ),
+                PutativeTarget.for_target_type(
+                    TerraformVarFileTarget,
+                    "prod/terraform/unowned-module",
+                    "unowned-module",
+                    ("prod1.tfvars",),
                 ),
             ]
         )

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -89,7 +89,8 @@ class TerraformRootModuleField(StringField, AsyncFieldMixin):
 
 
 class TerraformBackendConfigField(SingleSourceField):
-    help = "Configuration to be merged with what is in the configuration file's 'backend' block"
+    default = "*.tfbackend"
+    help = "Configuration to be merged with what is in the root module's 'backend' block"
 
 
 class TerraformBackendTarget(Target):
@@ -98,6 +99,7 @@ class TerraformBackendTarget(Target):
 
 
 class TerraformVarFileSourceField(MultipleSourcesField):
+    default = ("*.tfvars",)
     expected_file_extensions = (".tfvars",)
     help = generate_multiple_sources_field_help_message(
         "Example: `var_files=['common.tfvars', 'prod.tfvars']`"

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -15,7 +15,7 @@ from pants.engine.target import (
     DescriptionField,
     FieldSet,
     MultipleSourcesField,
-    OptionalSingleSourceField,
+    SingleSourceField,
     StringField,
     Target,
     Targets,
@@ -88,17 +88,25 @@ class TerraformRootModuleField(StringField, AsyncFieldMixin):
         )
 
 
-class TerraformBackendConfigField(OptionalSingleSourceField):
-    alias = "backend_config"
+class TerraformBackendConfigField(SingleSourceField):
     help = "Configuration to be merged with what is in the configuration file's 'backend' block"
 
 
-class TerraformVarFileSourcesField(MultipleSourcesField):
-    alias = "var_files"
+class TerraformBackendTarget(Target):
+    alias = "terraform_backend"
+    core_fields = (*COMMON_TARGET_FIELDS, TerraformBackendConfigField)
+
+
+class TerraformVarFileSourceField(MultipleSourcesField):
     expected_file_extensions = (".tfvars",)
     help = generate_multiple_sources_field_help_message(
         "Example: `var_files=['common.tfvars', 'prod.tfvars']`"
     )
+
+
+class TerraformVarFileTarget(Target):
+    alias = "terraform_var_files"
+    core_fields = (*COMMON_TARGET_FIELDS, TerraformVarFileSourceField)
 
 
 class TerraformDeploymentTarget(Target):
@@ -107,8 +115,6 @@ class TerraformDeploymentTarget(Target):
         *COMMON_TARGET_FIELDS,
         TerraformDependenciesField,
         TerraformRootModuleField,
-        TerraformBackendConfigField,
-        TerraformVarFileSourcesField,
     )
     help = "A deployment of Terraform"
 
@@ -122,9 +128,6 @@ class TerraformDeploymentFieldSet(FieldSet):
     description: DescriptionField
     root_module: TerraformRootModuleField
     dependencies: TerraformDependenciesField
-
-    backend_config: TerraformBackendConfigField
-    var_files: TerraformVarFileSourcesField
 
 
 class AllTerraformDeploymentTargets(Targets):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -96,19 +96,21 @@ class TerraformBackendConfigField(SingleSourceField):
 class TerraformBackendTarget(Target):
     alias = "terraform_backend"
     core_fields = (*COMMON_TARGET_FIELDS, TerraformBackendConfigField)
+    help = "Configuration to be merged with what is in the root module's 'backend' block"
 
 
 class TerraformVarFileSourceField(MultipleSourcesField):
     default = ("*.tfvars",)
     expected_file_extensions = (".tfvars",)
     help = generate_multiple_sources_field_help_message(
-        "Example: `var_files=['common.tfvars', 'prod.tfvars']`"
+        "Example: `sources=['common.tfvars', 'prod.tfvars']`"
     )
 
 
 class TerraformVarFileTarget(Target):
     alias = "terraform_var_files"
     core_fields = (*COMMON_TARGET_FIELDS, TerraformVarFileSourceField)
+    help = "Terraform vars files"
 
 
 class TerraformDeploymentTarget(Target):

--- a/src/python/pants/backend/terraform/target_types.py
+++ b/src/python/pants/backend/terraform/target_types.py
@@ -89,7 +89,7 @@ class TerraformRootModuleField(StringField, AsyncFieldMixin):
 
 
 class TerraformBackendConfigField(SingleSourceField):
-    default = "*.tfbackend"
+    default = ".tfbackend"
     help = "Configuration to be merged with what is in the root module's 'backend' block"
 
 

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -51,6 +51,7 @@ def rule_runner_with_auto_approve() -> RuleRunner:
         ],
         preserve_tmpdirs=True,
     )
+    # We have to forward "--auto-approve" to TF because `mock_console` is noninteractive
     rule_runner.set_options(["--download-terraform-args='-auto-approve'"])
     return rule_runner
 
@@ -64,7 +65,6 @@ class StandardDeployment:
 
 @pytest.fixture
 def standard_deployment(tmpdir) -> StandardDeployment:
-    # We have to forward "--auto-approve" to TF because `mock_console` is noninteractive
     state_file = Path(str(tmpdir.mkdir(".terraform").join("state.json")))
     return StandardDeployment(
         {
@@ -89,7 +89,7 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                     required_providers {
                         null = {
                           source = "hashicorp/null"
-                          version = "~>3.2.0" # there are later versions, so we can lock it to this version to check lockfile use
+                          version = "~> 3.2.0, <= 3.2.2"
                         }
                     }
                 }
@@ -107,7 +107,7 @@ def standard_deployment(tmpdir) -> StandardDeployment:
 terraform_lockfile = """\
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.0"
-  constraints = "~> 3.2.0"
+  constraints = "~> 3.2.0, <= 3.2.2"
   hashes = [
     "h1:pfjuwssoCoBDRbutlVLAP8wiDrkQ3G4d3rs+f7uSh2A=",
     "zh:1d88ea3af09dcf91ad0aaa0d3978ca8dcb49dc866c8615202b738d73395af6b5",
@@ -125,28 +125,27 @@ provider "registry.terraform.io/hashicorp/null" {
   ]
 }"""
 
-# TODO: pin upper bound so this doesn't break with a new release of the provider
 terraform_lockfile_regenerated = """\
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.1"
-  constraints = "~> 3.2.0"
+  version     = "3.2.2"
+  constraints = "~> 3.2.0, <= 3.2.2"
   hashes = [
-    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
-    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
-    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
-    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
-    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
+    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
+    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
+    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
+    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
+    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
+    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
+    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
-    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
-    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
-    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
-    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
-    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
-    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
+    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
+    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
+    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
   ]
 }
 """

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -10,7 +10,12 @@ from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
-from pants.backend.terraform.target_types import TerraformDeploymentTarget, TerraformModuleTarget
+from pants.backend.terraform.target_types import (
+    TerraformBackendTarget,
+    TerraformDeploymentTarget,
+    TerraformModuleTarget,
+    TerraformVarFileTarget,
+)
 from pants.core.goals import deploy
 from pants.core.goals.deploy import DeployProcess
 from pants.core.register import rules as core_rules
@@ -24,7 +29,12 @@ from pants.testutil.rule_runner import RuleRunner
 @pytest.fixture
 def rule_runner_with_auto_approve() -> RuleRunner:
     rule_runner = RuleRunner(
-        target_types=[TerraformModuleTarget, TerraformDeploymentTarget],
+        target_types=[
+            TerraformModuleTarget,
+            TerraformDeploymentTarget,
+            TerraformBackendTarget,
+            TerraformVarFileTarget,
+        ],
         rules=[
             *dependency_inference.rules(),
             *dependencies.rules(),
@@ -60,10 +70,11 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                 """
                 terraform_deployment(
                     name="stg",
-                    var_files=["stg.tfvars"],
-                    backend_config="stg.tfbackend",
                     root_module=":mod",
+                    dependencies=[":stg.tfvars", ":stg.tfbackend"],
                 )
+                terraform_backend(name="stg.tfbackend", source="stg.tfbackend")
+                terraform_var_files(name="stg.tfvars")
                 terraform_module(name="mod")
             """
             ),

--- a/src/python/pants/backend/terraform/testutil.py
+++ b/src/python/pants/backend/terraform/testutil.py
@@ -10,6 +10,7 @@ from pants.backend.terraform import dependencies, dependency_inference, tool
 from pants.backend.terraform.dependencies import TerraformInitRequest, TerraformInitResponse
 from pants.backend.terraform.goals.deploy import DeployTerraformFieldSet
 from pants.backend.terraform.goals.deploy import rules as terraform_deploy_rules
+from pants.backend.terraform.goals.lockfiles import rules as terraform_lockfile_rules
 from pants.backend.terraform.target_types import (
     TerraformBackendTarget,
     TerraformDeploymentTarget,
@@ -40,6 +41,7 @@ def rule_runner_with_auto_approve() -> RuleRunner:
             *dependencies.rules(),
             *tool.rules(),
             *terraform_deploy_rules(),
+            *terraform_lockfile_rules(),
             *source_files.rules(),
             *deploy.rules(),
             *core_rules(),
@@ -84,6 +86,12 @@ def standard_deployment(tmpdir) -> StandardDeployment:
                     backend "local" {
                         path = "/tmp/will/not/exist"
                     }
+                    required_providers {
+                        null = {
+                          source = "hashicorp/null"
+                          version = "~>3.2.0" # there are later versions, so we can lock it to this version to check lockfile use
+                        }
+                    }
                 }
                 variable "var0" {}
                 resource "null_resource" "dep" {}
@@ -94,3 +102,51 @@ def standard_deployment(tmpdir) -> StandardDeployment:
         },
         state_file,
     )
+
+
+terraform_lockfile = """\
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.0"
+  constraints = "~> 3.2.0"
+  hashes = [
+    "h1:pfjuwssoCoBDRbutlVLAP8wiDrkQ3G4d3rs+f7uSh2A=",
+    "zh:1d88ea3af09dcf91ad0aaa0d3978ca8dcb49dc866c8615202b738d73395af6b5",
+    "zh:3844db77bfac2aca43aaa46f3f698c8e5320a47e838ee1318408663449547e7e",
+    "zh:538fadbd87c576a332b7524f352e6004f94c27afdd3b5d105820d328dc49c5e3",
+    "zh:56def6f00fc2bc9c3c265b841ce71e80b77e319de7b0f662425b8e5e7eb26846",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fce56e5f1d13041d8047a1d0c93f930509704813a28f8d39c2b2082d7eebf9f",
+    "zh:989e909a5eca96b8bdd4a0e8609f1bd525949fd226ae870acedf2da0c55b0451",
+    "zh:99ddc34ad13e04e9c3477f5422fbec20fc13395ff940720c287bfa5c546d2fbc",
+    "zh:b546666da4b4b60c0eec23faab7f94dc900e48f66b5436fc1ac0b87c6709ef04",
+    "zh:d56643cb08cba6e074d70c4af37d5de2bd7c505f81d866d6d47c9e1d28ec65d1",
+    "zh:f39ac5ff9e9d00e6a670bce6825529eded4b0b4966abba36a387db5f0712d7ba",
+    "zh:fe102389facd09776502327352be99becc1ac09e80bc287db84a268172be641f",
+  ]
+}"""
+
+# TODO: pin upper bound so this doesn't break with a new release of the provider
+terraform_lockfile_regenerated = """\
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.1"
+  constraints = "~> 3.2.0"
+  hashes = [
+    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+"""


### PR DESCRIPTION
Generate and consume Terraform lockfiles! Each `terraform_module` can have a lockfile generated for it. The lockfiles use the target address of the module as the resolve name.

Using `terraform_module`s here instead of `terraform_deployment`s doesn't uphold the idea that `terraform_module`s are child modules  and `terraform_deployment`s are root modules. This distinction was shown to be unintuitive both by feedback with real users and by how difficult it was to explain how lockfiles interacted with multiple deployments and why lockfiles were targeted by deployments but appeared under modules.

This MR also reworks how Terraform pulls in backend configs and var files. These used to be specified simply as files, which was kludgy. (Multiple different sources fields meant requests for SourceFiles didn't work, since they would only pull in one of those fields.) Talking it over, we determined that the best design would be to have separate targets for `terraform_var_files` and `terraform_backend`, each with their own sources field, and pull these in with dep inference. We could ease some of the boilerplate by automatically inferring a dep on these targets in the same directory as the `terraform_deployment`. This can be overridden by manually specifying these in the `dependencies` field. This feature was bundled in this MR because it is linked to the roles that deployments and modules have in Pants's understanding of Terraform, which is an issue precipitated by lockfiles. That is, design decisions we need to make to implement lockfiles will also require changes in these targets.

Supported features:
- Create Terraform lockfiles for each module
- Use Terraform lockfiles for deployments, check, &c.
- Automatic dependency inference on backend config and var files in the deployment's directory

Limitations:
- Multiple deployments sharing the same root module share the same lockfile (this is how it works in Terraform)

This is the second pass at this. The [first](https://github.com/pantsbuild/pants/pull/19762) was getting cluttered by design changes.