### PR TITLE
Make docker_environment's Pants-provided-PBS an absolute path

### DIFF
--- a/src/python/pants/core/util_rules/adhoc_binaries.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries.py
@@ -104,10 +104,11 @@ async def download_python_binary(
             cp -r python "{installation_root}"
             touch "{installation_root}/DONE"
         fi
+        echo $(realpath "{installation_root}")/bin/python3
     """
     )
 
-    await Get(
+    result = await Get(
         ProcessResult,
         Process(
             [bash_binary.path, "-c", installation_script],
@@ -123,7 +124,7 @@ async def download_python_binary(
         ),
     )
 
-    return _PythonBuildStandaloneBinary(f"{installation_root}/bin/python3")
+    return _PythonBuildStandaloneBinary(result.stdout.decode().splitlines()[-1].strip())
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/util_rules/adhoc_binaries.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries.py
@@ -104,7 +104,7 @@ async def download_python_binary(
             cp -r python "{installation_root}"
             touch "{installation_root}/DONE"
         fi
-        echo $(realpath "{installation_root}")/bin/python3
+        echo "$(realpath "{installation_root}")/bin/python3"
     """
     )
 

--- a/src/python/pants/core/util_rules/adhoc_binaries_test.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries_test.py
@@ -76,21 +76,3 @@ def test_docker_uses_helper(rule_runner: RuleRunner) -> None:
     )
     assert pbs.path.startswith("/pants-named-caches")
     assert pbs.path.endswith("/bin/python3")
-
-
-def test_local_environment(rule_runner: RuleRunner):
-    rule_runner.write_files(
-        {
-            "BUILD": "local_environment(name='local')",
-        }
-    )
-    rule_runner.set_options(
-        ["--environments-preview-names={'local': '//:local'}"], env_inherit={"PATH"}
-    )
-    pbs = rule_runner.request(
-        _PythonBuildStandaloneBinary,
-        [_DownloadPythonBuildStandaloneBinaryRequest()],
-    )
-    assert pbs.path.startswith("/")
-    assert pbs.path.endswith("/bin/python3")
-    assert "named_caches/python_build_standalone" in pbs.path

--- a/src/python/pants/core/util_rules/adhoc_binaries_test.py
+++ b/src/python/pants/core/util_rules/adhoc_binaries_test.py
@@ -75,4 +75,4 @@ def test_docker_helper(rule_runner: RuleRunner):
         _PythonBuildStandaloneBinary,
         [_DownloadPythonBuildStandaloneBinaryRequest()],
     )
-    assert not pbs.path.startswith("/")
+    assert pbs.path.startswith("/")


### PR DESCRIPTION
Fixes #20313 by ensuring that the `PEX_PYTHON` used for Pex CLI invocations inside a docker environment is an absolute path.

I also did some drive-by improvements of the test code.