### PR TITLE
Ensure `experimental_test_shell_command` runs in relevant environment (Cherry-pick of #20319)

### DIFF
--- a/src/python/pants/backend/shell/goals/test.py
+++ b/src/python/pants/backend/shell/goals/test.py
@@ -15,6 +15,7 @@ from pants.backend.shell.target_types import (
 from pants.backend.shell.util_rules import shell_command
 from pants.backend.shell.util_rules.shell_command import ShellCommandProcessFromTargetRequest
 from pants.core.goals.test import TestExtraEnv, TestFieldSet, TestRequest, TestResult, TestSubsystem
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.internals.selectors import Get
 from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
 from pants.engine.rules import collect_rules, rule
@@ -23,11 +24,14 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 
 
+@dataclasses.dataclass(frozen=True)
 class TestShellCommandFieldSet(TestFieldSet):
     required_fields = (
         ShellCommandCommandField,
         ShellCommandTestDependenciesField,
     )
+
+    environment: EnvironmentField
 
     @classmethod
     def opt_out(cls, tgt: Target) -> bool:


### PR DESCRIPTION
Fixes #20318 by adding an `EnvironmentField` attribute to `TestShellCommandFieldSet`.

Not sure if we ought to add a dedicated test for this. I didn't see one in `src/python/pants/backend/python/goals/pytest_runner_test.py` or `src/python/pants/backend/python/goals/pytest_runner_test.py`.

Verified that the test case in the linked issue "passes":

```
josh@cephandrius:~/work/pants$ pants test //:test-bind-mount
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"



✕ //:test-bind-mount failed in 0.07s (ran in docker environment `docker`).
```
