### PR TITLE
Allow docker image pulling without creds (Cherry-pick of #20307)

### DIFF
--- a/src/rust/engine/process_execution/docker/src/docker.rs
+++ b/src/rust/engine/process_execution/docker/src/docker.rs
@@ -218,9 +218,17 @@ async fn credentials_for_image(
                 // TODO: https://github.com/keirlawson/docker_credential/issues/7 means that this will only
                 // work for credential helpers and credentials encoded directly in the docker config,
                 // rather than for general credStore implementations.
-                let credential = docker_credential::get_credential(&server).map_err(|e| {
-                    format!("Failed to retrieve credentials for server `{server}`: {e}")
-                })?;
+                let credential = match docker_credential::get_credential(&server) {
+                    Ok(credential) => credential,
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to retrieve Docker credentials for server `{}`: {}",
+                            server,
+                            e
+                        );
+                        return Ok(None);
+                    }
+                };
 
                 let bollard_credentials = match credential {
                     docker_credential::DockerCredential::IdentityToken(token) => {


### PR DESCRIPTION
Fixes #20306 by letting a failure to get credentials pass through
