### PR TITLE
Change the slug of the Shell backend doc.

### DIFF
--- a/docs/markdown/Introduction/welcome-to-pants.md
+++ b/docs/markdown/Introduction/welcome-to-pants.md
@@ -42,7 +42,7 @@ Pants is designed for fast, consistent, ergonomic builds. Some noteworthy featur
 Which languages and frameworks does Pants support?
 ==================================================
 
-- Pants [ships](page:language-support) with support for [Python](doc:python), [Go](doc:go), [Java](doc:jvm-overview), [Scala](doc:jvm-overview) and [Shell](doc:shell).
+- Pants [ships](page:language-support) with support for [Python](doc:python), [Go](doc:go), [Java](doc:jvm-overview), [Scala](doc:jvm-overview) and [Shell](doc:shell-overview).
 - Pants supports a wide range of code generators (such as Thrift, Protobuf, Scrooge and Avro), linters and formatters, and it is easy to add support for new or custom ones
 - Pants can create standalone binaries, [Docker images](doc:docker), AWS Lambdas and GCP Cloud Functions
 

--- a/docs/markdown/Shell/shell.md
+++ b/docs/markdown/Shell/shell.md
@@ -1,6 +1,6 @@
 ---
 title: "Shell overview"
-slug: "shell"
+slug: "shell-overview"
 excerpt: "Pants's support for Shellcheck, shfmt, and shUnit2."
 hidden: false
 createdAt: "2021-04-14T04:21:15.028Z"

--- a/docs/markdown/Using Pants/concepts/enabling-backends.md
+++ b/docs/markdown/Using Pants/concepts/enabling-backends.md
@@ -47,12 +47,12 @@ This list is also available via `pants backends --help`, which includes any addi
 | `pants.backend.python.lint.pyupgrade`                | Enables Pyupgrade, which upgrades to new Python syntax: <https://pypi.org/project/pyupgrade/>      | [Linters and formatters](doc:python-linters-and-formatters)       |
 | `pants.backend.python.lint.yapf`                     | Enables Yapf, the Python formatter: <https://pypi.org/project/yapf/>                               | [Linters and formatters](doc:python-linters-and-formatters)       |
 | `pants.backend.python.typecheck.mypy`                | Enables MyPy, the Python type checker: <https://mypy.readthedocs.io/en/stable/>.                   | [typecheck](doc:python-check-goal)                                |
-| `pants.backend.shell`                                | Core Shell support, including shUnit2 test runner.                                                 | [Shell overview](doc:shell)                                       |
-| `pants.backend.shell.lint.shfmt`                     | Enables shfmt, a Shell autoformatter: <https://github.com/mvdan/sh>.                               | [Shell overview](doc:shell)                                       |
-| `pants.backend.shell.lint.shellcheck`                | Enables Shellcheck, a Shell linter: <https://www.shellcheck.net/>.                                 | [Shell overview](doc:shell)                                       |
+| `pants.backend.shell`                                | Core Shell support, including shUnit2 test runner.                                                 | [Shell overview](doc:shell-overview)                              |
+| `pants.backend.shell.lint.shfmt`                     | Enables shfmt, a Shell autoformatter: <https://github.com/mvdan/sh>.                               | [Shell overview](doc:shell-overview)                              |
+| `pants.backend.shell.lint.shellcheck`                | Enables Shellcheck, a Shell linter: <https://www.shellcheck.net/>.                                 | [Shell overview](doc:shell-overview)                              |
 | `pants.backend.tools.preamble`                       | Enables "preamble", a Pants fixer for copyright headers and shebang lines                          | [`preamble`](doc:reference-preamble)                              |
 | `pants.backend.tools.taplo`                          | Enables Taplo, a TOML autoformatter: <https://taplo.tamasfe.dev>                                   |                                                                   |
-| `pants.backend.url_handlers.s3`                      | Enables accessing s3 via credentials in `file(source=http_source(...))`                            |                                                              |
+| `pants.backend.url_handlers.s3`                      | Enables accessing s3 via credentials in `file(source=http_source(...))`                            |                                                                   |
 
 Available experimental backends
 -------------------------------


### PR DESCRIPTION
It used to be "shell", now it's "shell-overview" because we were getting 401s from readme.com for that page, and their support claims we discovered a bug whereby "shell" is not a valid slug.

This will all be moot once we switch off readme, but this is a bandaid for now.