### PR TITLE
Support allow_pantsrc to turn off pantsrc processing in rust

### DIFF
--- a/src/rust/engine/client/src/client_tests.rs
+++ b/src/rust/engine/client/src/client_tests.rs
@@ -38,6 +38,7 @@ async fn test_client_fingerprint_mismatch() {
             "--pants-subprocessdir={}",
             tmpdir.path().display()
         )]),
+        true,
     )
     .unwrap();
     let error = pantsd::find_pantsd(&build_root, &options_parser)

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -32,7 +32,7 @@ async fn execute(start: SystemTime) -> Result<i32, String> {
     let (env, dropped) = Env::capture_lossy();
     let env_items = (&env).into();
     let argv = env::args().collect::<Vec<_>>();
-    let options_parser = OptionParser::new(env, Args::argv())?;
+    let options_parser = OptionParser::new(env, Args::argv(), true)?;
 
     let use_pantsd = options_parser.parse_bool(&option_id!("pantsd"), true)?;
     if !use_pantsd.value {

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -158,7 +158,7 @@ pub struct OptionParser {
 }
 
 impl OptionParser {
-    pub fn new(env: Env, args: Args) -> Result<OptionParser, String> {
+    pub fn new(env: Env, args: Args, allow_pantsrc: bool) -> Result<OptionParser, String> {
         let buildroot = BuildRoot::find()?;
         let buildroot_string = String::from_utf8(buildroot.as_os_str().as_bytes().to_vec())
             .map_err(|e| {
@@ -216,10 +216,14 @@ impl OptionParser {
             sources: sources.clone(),
         };
 
-        if *parser.parse_bool(&option_id!("pantsrc"), true)? {
+        if allow_pantsrc && *parser.parse_bool(&option_id!("pantsrc"), true)? {
             for rcfile in parser.parse_string_list(
                 &option_id!("pantsrc", "files"),
-                &["/etc/pantsrc", shellexpand::tilde("~/.pants.rc").as_ref()],
+                &[
+                    "/etc/pantsrc",
+                    shellexpand::tilde("~/.pants.rc").as_ref(),
+                    ".pants.rc",
+                ],
             )? {
                 let rcfile_path = Path::new(&rcfile);
                 if rcfile_path.exists() {

--- a/src/rust/engine/pantsd/src/pantsd_testing.rs
+++ b/src/rust/engine/pantsd/src/pantsd_testing.rs
@@ -26,7 +26,7 @@ pub fn launch_pantsd() -> (BuildRoot, OptionParser, TempDir) {
         "-V".to_owned(),
     ];
     let options_parser =
-        OptionParser::new(Env::new(HashMap::new()), Args::new(args.clone())).unwrap();
+        OptionParser::new(Env::new(HashMap::new()), Args::new(args.clone()), true).unwrap();
 
     let mut cmd = Command::new(build_root.join("pants"));
     cmd.current_dir(build_root.as_path())

--- a/src/rust/engine/src/externs/pantsd.rs
+++ b/src/rust/engine/src/externs/pantsd.rs
@@ -21,8 +21,8 @@ pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
 #[pyfunction]
 fn pantsd_fingerprint_compute(expected_option_names: HashSet<String>) -> PyResult<String> {
     let build_root = BuildRoot::find().map_err(PyException::new_err)?;
-    let options_parser =
-        OptionParser::new(Env::capture_lossy().0, Args::argv()).map_err(PyException::new_err)?;
+    let options_parser = OptionParser::new(Env::capture_lossy().0, Args::argv(), true)
+        .map_err(PyException::new_err)?;
 
     let options = pantsd::fingerprinted_options(&build_root).map_err(PyException::new_err)?;
     let actual_option_names = options


### PR DESCRIPTION
This is part of the Python config implementation, this change brings 
the Rust implementation up to par.

This is needed in tests, so that they don't consume a real pantsrc
by mistake.

Also adds `.pants.rc` as a default pantsrc file, which exists in the
`pantsrc` option's registration on the Python side, but was not
used on the Rust side (which has to repeat the registration defaults
since it cannot access them from the Python side).