### PR TITLE
Fix algorithm for gathering prebuilt Go object files

### DIFF
--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -471,9 +471,12 @@ async def _gather_transitive_prebuilt_object_files(
     prebuilt_objects: list[tuple[Digest, list[str]]] = []
 
     queue: deque[BuildGoPackageRequest] = deque([build_request])
+    seen: set[BuildGoPackageRequest] = {build_request}
     while queue:
         pkg = queue.popleft()
-        queue.extend(pkg.direct_dependencies)
+        unseen = [dd for dd in build_request.direct_dependencies if dd not in seen]
+        queue.extend(unseen)
+        seen.update(unseen)
         if pkg.prebuilt_object_files:
             prebuilt_objects.append(
                 (
@@ -695,7 +698,7 @@ async def build_go_package(
         )
         symabis_path = symabis_result.symabis_path
 
-    # Build the arguments for compiling the Go coe in this package.
+    # Build the arguments for compiling the Go code in this package.
     compile_args = [
         "tool",
         "compile",


### PR DESCRIPTION
The previous algorithm did not check if a package had already been traversed,
which can lead to exponential blowup of the queue.

This is an identical fix to the one in #20030, which was for coverage build 
requests. These are the only two places in the go backend (that I can find) 
where a transitive walk like this is done.

Unlike #20030 this one is not known to have caused a problem for any
users in practice.