### PR TITLE
Upgrade pyright from 1.1.316 to 1.1.343

### DIFF
--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -100,19 +100,27 @@ PYRIGHT_LOCKFILE = json.dumps(
         "packages": {
             "": {"name": "@the-company/project", "devDependencies": {"pyright": "1.1.316"}},
             "node_modules/pyright": {
-                "version": "1.1.316",
-                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.316.tgz",
-                "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
+                "version": "1.1.343",
+                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.343.tgz",
+                "integrity": "sha512-lOsiufTR94E0Z3O7n19q5Zr9maSI0uDEtyke4ACFuA8gwVdcj3ewOUdzCdPchzJuXTAJq2B+qvyGiNOFF6d0vw==",
                 "dev": True,
-                "bin": {"pyright": "index.js", "pyright-langserver": "langserver.index.js"},
-                "engines": {"node": ">=12.0.0"},
+                "bin": {
+                    "pyright": "index.js",
+                    "pyright-langserver": "langserver.index.js"
+                },
+                "engines": {
+                    "node": ">=12.0.0"
+                },
+                "optionalDependencies": {
+                    "fsevents": "~2.3.2"
+                }
             },
         },
         "dependencies": {
             "pyright": {
-                "version": "1.1.316",
-                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.316.tgz",
-                "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
+                "version": "1.1.343",
+                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.343.tgz",
+                "integrity": "sha512-lOsiufTR94E0Z3O7n19q5Zr9maSI0uDEtyke4ACFuA8gwVdcj3ewOUdzCdPchzJuXTAJq2B+qvyGiNOFF6d0vw==",
                 "dev": True,
             }
         },

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -23,6 +23,7 @@ from pants.backend.python.typecheck.pyright.rules import (
     PyrightRequest,
 )
 from pants.backend.python.typecheck.pyright.rules import rules as pyright_rules
+from pants.backend.python.typecheck.pyright.subsystem import PYRIGHT_VERSION_STRING
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.check import CheckResult, CheckResults
 from pants.engine.addresses import Address
@@ -98,7 +99,7 @@ PYRIGHT_LOCKFILE = json.dumps(
         "lockfileVersion": 2,
         "requires": True,
         "packages": {
-            "": {"name": "@the-company/project", "devDependencies": {"pyright": "1.1.316"}},
+            "": {"name": "@the-company/project", "devDependencies": {"pyright": PYRIGHT_VERSION_STRING}},
             "node_modules/pyright": {
                 "version": "1.1.343",
                 "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.343.tgz",
@@ -229,7 +230,7 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "src/js/lib3/BUILD": "package_json()",
                 "src/js/lib3/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
                 ),
                 "src/js/lib3/package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -247,7 +248,7 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "BUILD": "package_json(name='root_package')",
                 "package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
                 ),
                 "package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -369,7 +370,7 @@ def test_passing_cache_clear(rule_runner: PythonRuleRunner) -> None:
                 f"{PACKAGE}/BUILD": "python_sources()",
                 "src/js/BUILD": "package_json()",
                 "src/js/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
                 ),
                 "src/js/package-lock.json": PYRIGHT_LOCKFILE,
             },

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -99,22 +99,18 @@ PYRIGHT_LOCKFILE = json.dumps(
         "lockfileVersion": 2,
         "requires": True,
         "packages": {
-            "": {"name": "@the-company/project", "devDependencies": {"pyright": PYRIGHT_VERSION_STRING}},
+            "": {
+                "name": "@the-company/project",
+                "devDependencies": {"pyright": PYRIGHT_VERSION_STRING},
+            },
             "node_modules/pyright": {
                 "version": "1.1.343",
                 "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.343.tgz",
                 "integrity": "sha512-lOsiufTR94E0Z3O7n19q5Zr9maSI0uDEtyke4ACFuA8gwVdcj3ewOUdzCdPchzJuXTAJq2B+qvyGiNOFF6d0vw==",
                 "dev": True,
-                "bin": {
-                    "pyright": "index.js",
-                    "pyright-langserver": "langserver.index.js"
-                },
-                "engines": {
-                    "node": ">=12.0.0"
-                },
-                "optionalDependencies": {
-                    "fsevents": "~2.3.2"
-                }
+                "bin": {"pyright": "index.js", "pyright-langserver": "langserver.index.js"},
+                "engines": {"node": ">=12.0.0"},
+                "optionalDependencies": {"fsevents": "~2.3.2"},
             },
         },
         "dependencies": {
@@ -230,7 +226,10 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "src/js/lib3/BUILD": "package_json()",
                 "src/js/lib3/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
+                    {
+                        "name": "@the-company/project",
+                        "dependencies": {"pyright": PYRIGHT_VERSION_STRING},
+                    }
                 ),
                 "src/js/lib3/package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -248,7 +247,10 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "BUILD": "package_json(name='root_package')",
                 "package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
+                    {
+                        "name": "@the-company/project",
+                        "dependencies": {"pyright": PYRIGHT_VERSION_STRING},
+                    }
                 ),
                 "package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -370,7 +372,10 @@ def test_passing_cache_clear(rule_runner: PythonRuleRunner) -> None:
                 f"{PACKAGE}/BUILD": "python_sources()",
                 "src/js/BUILD": "package_json()",
                 "src/js/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION_STRING}}
+                    {
+                        "name": "@the-company/project",
+                        "dependencies": {"pyright": PYRIGHT_VERSION_STRING},
+                    }
                 ),
                 "src/js/package-lock.json": PYRIGHT_LOCKFILE,
             },

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -9,7 +9,6 @@ from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
 from pants.util.strutil import help_text
 
-
 PYRIGHT_VERSION_STRING = "1.1.343"
 
 

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -10,6 +10,9 @@ from pants.option.option_types import ArgsListOption, SkipOption, StrListOption
 from pants.util.strutil import help_text
 
 
+PYRIGHT_VERSION_STRING = "1.1.343"
+
+
 class Pyright(NodeJSToolBase):
     options_scope = "pyright"
     name = "Pyright"
@@ -20,7 +23,7 @@ class Pyright(NodeJSToolBase):
         """
     )
 
-    default_version = "pyright@1.1.343"
+    default_version = f"pyright@{PYRIGHT_VERSION_STRING}"
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -20,7 +20,7 @@ class Pyright(NodeJSToolBase):
         """
     )
 
-    default_version = "pyright@1.1.316"
+    default_version = "pyright@1.1.343"
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")


### PR DESCRIPTION
Closes #19816.

Looking at the difference between these two releases, there may be some changes in behavior for Pyright but all seem to be bugfixes that should be pulled in.

The changes: https://github.com/microsoft/pyright/compare/1.1.316...1.1.343