### PR TITLE
Move jvm `Coordinate` class to a separate module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ GTAGS
 /.pants.rc
 /.venv
 .tool-versions
+.ropeproject/

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,3 @@ GTAGS
 /.pants.rc
 /.venv
 .tool-versions
-.ropeproject/

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,7 @@ GTAGS
 /.pants.rc
 /.venv
 .tool-versions
+# for rope refactoring
 .ropeproject/
+# for nvim pyright lsp server
+pyrightconfig.json

--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,4 @@ GTAGS
 /.pants.rc
 /.venv
 .tool-versions
-# for rope refactoring
 .ropeproject/
-# for nvim pyright lsp server
-pyrightconfig.json

--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
@@ -9,10 +9,12 @@ from typing import Iterable
 
 from _pytest.fixtures import FixtureRequest
 
-from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import LockfileContext
 from pants.util.docutil import bin_name
+from pants.jvm.resolve.common import ArtifactRequirement
+from pants.jvm.resolve.common import ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
+++ b/pants-plugins/internal_plugins/test_lockfile_fixtures/lockfile_fixture.py
@@ -9,12 +9,11 @@ from typing import Iterable
 
 from _pytest.fixtures import FixtureRequest
 
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
 from pants.jvm.resolve.lockfile_metadata import LockfileContext
 from pants.util.docutil import bin_name
-from pants.jvm.resolve.common import ArtifactRequirement
-from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -16,9 +16,9 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
-from pants.jvm.resolve.coordinate import Coordinate
 
 _SCALAPB_RUNTIME_GROUP = "com.thesamet.scalapb"
 _SCALAPB_RUNTIME_ARTIFACT = "scalapb-runtime"

--- a/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
+++ b/src/python/pants/backend/codegen/protobuf/scala/dependency_inference.py
@@ -16,9 +16,9 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
+from pants.jvm.resolve.coordinate import Coordinate
 
 _SCALAPB_RUNTIME_GROUP = "com.thesamet.scalapb"
 _SCALAPB_RUNTIME_ARTIFACT = "scalapb-runtime"

--- a/src/python/pants/backend/codegen/soap/java/dependency_inference.py
+++ b/src/python/pants/backend/codegen/soap/java/dependency_inference.py
@@ -15,7 +15,7 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.resolve.common import Coordinate
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 

--- a/src/python/pants/backend/kotlin/compile/kotlinc.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc.py
@@ -37,9 +37,10 @@ from pants.jvm.compile import (
 )
 from pants.jvm.compile import rules as jvm_compile_rules
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
+from pants.jvm.resolve.coordinate import Coordinate
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/kotlin/compile/kotlinc.py
+++ b/src/python/pants/backend/kotlin/compile/kotlinc.py
@@ -38,9 +38,9 @@ from pants.jvm.compile import (
 from pants.jvm.compile import rules as jvm_compile_rules
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.util.logging import LogLevel
-from pants.jvm.resolve.coordinate import Coordinate
 
 logger = logging.getLogger(__name__)
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -18,6 +18,7 @@ from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.common import ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.option.global_options import KeepSandboxes
@@ -25,7 +26,6 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.resources import read_resource
-from pants.jvm.resolve.coordinate import Coordinate
 
 _PARSER_KOTLIN_VERSION = "1.6.20"
 

--- a/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/kotlin_parser.py
@@ -17,7 +17,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.jdk_rules import InternalJdk, JdkEnvironment, JdkRequest, JvmProcess
-from pants.jvm.resolve.common import ArtifactRequirements, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirements
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
 from pants.option.global_options import KeepSandboxes
@@ -25,6 +25,7 @@ from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.ordered_set import FrozenOrderedSet
 from pants.util.resources import read_resource
+from pants.jvm.resolve.coordinate import Coordinate
 
 _PARSER_KOTLIN_VERSION = "1.6.20"
 

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -28,10 +28,10 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.ordered_set import OrderedSet
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/kotlin/dependency_inference/rules.py
+++ b/src/python/pants/backend/kotlin/dependency_inference/rules.py
@@ -28,10 +28,10 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     find_jvm_artifacts_or_raise,
 )
 from pants.jvm.dependency_inference.symbol_mapper import SymbolMapping
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.ordered_set import OrderedSet
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/kotlin/test/junit.py
+++ b/src/python/pants/backend/kotlin/test/junit.py
@@ -15,9 +15,9 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/kotlin/test/junit.py
+++ b/src/python/pants/backend/kotlin/test/junit.py
@@ -15,9 +15,9 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/openapi/codegen/java/rules.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules.py
@@ -58,11 +58,11 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 class GenerateJavaFromOpenAPIRequest(GenerateSourcesRequest):

--- a/src/python/pants/backend/openapi/codegen/java/rules.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules.py
@@ -58,11 +58,11 @@ from pants.jvm.dependency_inference.artifact_mapper import (
     AllJvmArtifactTargets,
     find_jvm_artifacts_or_raise,
 )
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.source.source_root import SourceRoot, SourceRootRequest
 from pants.util.logging import LogLevel
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 class GenerateJavaFromOpenAPIRequest(GenerateSourcesRequest):

--- a/src/python/pants/backend/openapi/util_rules/pom_parser.py
+++ b/src/python/pants/backend/openapi/util_rules/pom_parser.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 from pants.engine.fs import Digest, DigestContents
 from pants.engine.rules import Get, collect_rules, rule
-from pants.jvm.resolve.common import Coordinate
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/backend/openapi/util_rules/pom_parser_test.py
+++ b/src/python/pants/backend/openapi/util_rules/pom_parser_test.py
@@ -10,8 +10,8 @@ import pytest
 from pants.backend.openapi.util_rules import pom_parser
 from pants.backend.openapi.util_rules.pom_parser import AnalysePomRequest, PomReport
 from pants.engine.fs import Digest, PathGlobs
-from pants.jvm.resolve.common import Coordinate
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @pytest.fixture

--- a/src/python/pants/backend/openapi/util_rules/pom_parser_test.py
+++ b/src/python/pants/backend/openapi/util_rules/pom_parser_test.py
@@ -10,8 +10,8 @@ import pytest
 from pants.backend.openapi.util_rules import pom_parser
 from pants.backend.openapi.util_rules.pom_parser import AnalysePomRequest, PomReport
 from pants.engine.fs import Digest, PathGlobs
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.jvm.resolve.coordinate import Coordinate
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 
 @pytest.fixture

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -64,7 +64,6 @@ from pants.jvm.bsp.resources import rules as jvm_resources_rules
 from pants.jvm.bsp.spec import JvmBuildTarget, MavenDependencyModule, MavenDependencyModuleArtifact
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
 from pants.jvm.jdk_rules import DefaultJdk, JdkEnvironment, JdkRequest
-from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements, Coordinate
 from pants.jvm.resolve.coursier_fetch import (
     CoursierLockfileEntry,
     CoursierResolvedLockfile,
@@ -75,6 +74,9 @@ from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactFieldSet, JvmJdkField, JvmResolveField
 from pants.util.logging import LogLevel
+from pants.jvm.resolve.common import ArtifactRequirement
+from pants.jvm.resolve.common import ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 
 LANGUAGE_ID = "scala"
 

--- a/src/python/pants/backend/scala/bsp/rules.py
+++ b/src/python/pants/backend/scala/bsp/rules.py
@@ -64,6 +64,8 @@ from pants.jvm.bsp.resources import rules as jvm_resources_rules
 from pants.jvm.bsp.spec import JvmBuildTarget, MavenDependencyModule, MavenDependencyModuleArtifact
 from pants.jvm.compile import ClasspathEntry, ClasspathEntryRequest, ClasspathEntryRequestFactory
 from pants.jvm.jdk_rules import DefaultJdk, JdkEnvironment, JdkRequest
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import (
     CoursierLockfileEntry,
     CoursierResolvedLockfile,
@@ -74,9 +76,6 @@ from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmArtifactFieldSet, JvmJdkField, JvmResolveField
 from pants.util.logging import LogLevel
-from pants.jvm.resolve.common import ArtifactRequirement
-from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinate
 
 LANGUAGE_ID = "scala"
 

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -13,10 +13,10 @@ from pants.jvm.goals.lockfile import (
     ValidateJvmArtifactsForResolveRequest,
     ValidateJvmArtifactsForResolveResult,
 )
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.docutil import bin_name
+from pants.jvm.resolve.coordinate import Coordinate
 
 SCALA_LIBRARY_GROUP = "org.scala-lang"
 SCALA_LIBRARY_ARTIFACT = "scala-library"

--- a/src/python/pants/backend/scala/resolve/lockfile.py
+++ b/src/python/pants/backend/scala/resolve/lockfile.py
@@ -13,10 +13,10 @@ from pants.jvm.goals.lockfile import (
     ValidateJvmArtifactsForResolveRequest,
     ValidateJvmArtifactsForResolveResult,
 )
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import JvmResolveField
 from pants.util.docutil import bin_name
-from pants.jvm.resolve.coordinate import Coordinate
 
 SCALA_LIBRARY_GROUP = "org.scala-lang"
 SCALA_LIBRARY_ARTIFACT = "scala-library"

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from enum import Enum
 
 from pants.engine.rules import collect_rules, rule
-from pants.util.strutil import softwrap
 from pants.jvm.resolve.coordinate import Coordinate
+from pants.util.strutil import softwrap
 
 
 class InvalidScalaVersion(ValueError):

--- a/src/python/pants/backend/scala/util_rules/versions.py
+++ b/src/python/pants/backend/scala/util_rules/versions.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from enum import Enum
 
 from pants.engine.rules import collect_rules, rule
-from pants.jvm.resolve.common import Coordinate
 from pants.util.strutil import softwrap
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 class InvalidScalaVersion(ValueError):

--- a/src/python/pants/jvm/dependency_inference/artifact_mapper.py
+++ b/src/python/pants/jvm/dependency_inference/artifact_mapper.py
@@ -11,7 +11,8 @@ from pants.build_graph.address import Address
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, Targets
 from pants.jvm.dependency_inference.jvm_artifact_mappings import JVM_ARTIFACT_MAPPINGS
-from pants.jvm.resolve.common import ArtifactRequirement, Coordinate
+from pants.jvm.resolve.common import ArtifactRequirement
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import (
     JvmArtifactArtifactField,

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -15,12 +15,6 @@ from pants.engine.fs import DigestContents, FileDigest
 from pants.engine.internals.parametrize import Parametrize
 from pants.jvm.goals import lockfile
 from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMUserResolveNames
-from pants.jvm.resolve.common import (
-    ArtifactRequirement,
-    ArtifactRequirements,
-    Coordinate,
-    Coordinates,
-)
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
@@ -29,6 +23,10 @@ from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
+from pants.jvm.resolve.common import ArtifactRequirement
+from pants.jvm.resolve.common import ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate
+from pants.jvm.resolve.coordinate import Coordinates
 
 
 @pytest.fixture

--- a/src/python/pants/jvm/goals/lockfile_test.py
+++ b/src/python/pants/jvm/goals/lockfile_test.py
@@ -15,6 +15,8 @@ from pants.engine.fs import DigestContents, FileDigest
 from pants.engine.internals.parametrize import Parametrize
 from pants.jvm.goals import lockfile
 from pants.jvm.goals.lockfile import GenerateJvmLockfile, RequestedJVMUserResolveNames
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
@@ -23,10 +25,6 @@ from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
-from pants.jvm.resolve.common import ArtifactRequirement
-from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinate
-from pants.jvm.resolve.coordinate import Coordinates
 
 
 @pytest.fixture

--- a/src/python/pants/jvm/jdk_rules.py
+++ b/src/python/pants/jvm/jdk_rules.py
@@ -21,7 +21,7 @@ from pants.engine.process import FallibleProcessResult, Process, ProcessCacheSco
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import CoarsenedTarget
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.resolve.common import Coordinate, Coordinates
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry
 from pants.jvm.resolve.coursier_setup import Coursier
 from pants.jvm.subsystems import JvmSubsystem

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -93,7 +93,7 @@ class ArtifactRequirements(DeduplicatedCollection[ArtifactRequirement]):
 
     @classmethod
     def from_coordinates(cls, coordinates: Iterable[Coordinate]) -> ArtifactRequirements:
-        return ArtifactRequirements(coord.as_requirement() for coord in coordinates)
+        return ArtifactRequirements(ArtifactRequirement(coord) for coord in coordinates)
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/common.py
+++ b/src/python/pants/jvm/resolve/common.py
@@ -4,13 +4,13 @@
 from __future__ import annotations
 
 import dataclasses
-import re
 from dataclasses import dataclass
 from typing import Iterable
 from urllib.parse import quote_plus as url_quote_plus
 
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.target import Target
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.target_types import (
     JvmArtifactArtifactField,
     JvmArtifactExclusionsField,
@@ -22,125 +22,6 @@ from pants.jvm.target_types import (
     JvmArtifactVersionField,
 )
 from pants.util.ordered_set import FrozenOrderedSet
-
-
-class InvalidCoordinateString(Exception):
-    """The coordinate string being passed is invalid or malformed."""
-
-    def __init__(self, coords: str) -> None:
-        super().__init__(f"Received invalid artifact coordinates: {coords}")
-
-
-@dataclass(frozen=True, order=True)
-class Coordinate:
-    """A single Maven-style coordinate for a JVM dependency.
-
-    Coursier uses at least two string serializations of coordinates:
-    1. A format that is accepted by the Coursier CLI which uses trailing attributes to specify
-       optional fields like `packaging`/`type`, `classifier`, `url`, etc. See `to_coord_arg_str`.
-    2. A format in the JSON report, which uses token counts to specify optional fields. We
-       additionally use this format in our own lockfile. See `to_coord_str` and `from_coord_str`.
-    """
-
-    REGEX = re.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)")
-
-    group: str
-    artifact: str
-    version: str
-    packaging: str = "jar"
-    classifier: str | None = None
-
-    # True to enforce that the exact declared version of a coordinate is fetched, rather than
-    # allowing dependency resolution to adjust the version when conflicts occur.
-    strict: bool = True
-
-    @staticmethod
-    def from_json_dict(data: dict) -> Coordinate:
-        return Coordinate(
-            group=data["group"],
-            artifact=data["artifact"],
-            version=data["version"],
-            packaging=data.get("packaging", "jar"),
-            classifier=data.get("classifier", None),
-        )
-
-    def to_json_dict(self) -> dict:
-        ret = {
-            "group": self.group,
-            "artifact": self.artifact,
-            "version": self.version,
-            "packaging": self.packaging,
-            "classifier": self.classifier,
-        }
-        return ret
-
-    @classmethod
-    def from_coord_str(cls, s: str) -> Coordinate:
-        """Parses from a coordinate string with optional `packaging` and `classifier` coordinates.
-
-        See the classdoc for more information on the format.
-
-        Using Aether's implementation as reference
-        http://www.javased.com/index.php?source_dir=aether-core/aether-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
-
-        ${organisation}:${artifact}[:${packaging}[:${classifier}]]:${version}
-
-        See also: `to_coord_str`.
-        """
-
-        parts = Coordinate.REGEX.match(s)
-        if parts is not None:
-            packaging_part = parts.group(4)
-            return cls(
-                group=parts.group(1),
-                artifact=parts.group(2),
-                packaging=packaging_part if packaging_part is not None else "jar",
-                classifier=parts.group(6),
-                version=parts.group(7),
-            )
-        else:
-            raise InvalidCoordinateString(s)
-
-    def as_requirement(self) -> ArtifactRequirement:
-        """Creates a `RequirementCoordinate` from a `Coordinate`."""
-        return ArtifactRequirement(coordinate=self)
-
-    def to_coord_str(self, versioned: bool = True) -> str:
-        """Renders the coordinate in Coursier's JSON-report format, which does not use attributes.
-
-        See also: `from_coord_str`.
-        """
-        unversioned = f"{self.group}:{self.artifact}"
-        if self.classifier is not None:
-            unversioned += f":{self.packaging}:{self.classifier}"
-        elif self.packaging != "jar":
-            unversioned += f":{self.packaging}"
-
-        version_suffix = ""
-        if versioned:
-            version_suffix = f":{self.version}"
-        return f"{unversioned}{version_suffix}"
-
-    def to_coord_arg_str(self, extra_attrs: dict[str, str] | None = None) -> str:
-        """Renders the coordinate in Coursier's CLI input format.
-
-        The CLI input format uses trailing key-val attributes to specify `packaging`, `url`, etc.
-
-        See https://github.com/coursier/coursier/blob/b5d5429a909426f4465a9599d25c678189a54549/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala#L7
-        """
-        attrs = dict(extra_attrs or {})
-        if self.packaging != "jar":
-            # NB: Coursier refers to `packaging` as `type` internally.
-            attrs["type"] = self.packaging
-        if self.classifier:
-            attrs["classifier"] = self.classifier
-        attrs_sep_str = "," if attrs else ""
-        attrs_str = ",".join((f"{k}={v}" for k, v in attrs.items()))
-        return f"{self.group}:{self.artifact}:{self.version}{attrs_sep_str}{attrs_str}"
-
-
-class Coordinates(DeduplicatedCollection[Coordinate]):
-    """An ordered list of `Coordinate`s."""
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/jvm/resolve/coordinate.py
+++ b/src/python/pants/jvm/resolve/coordinate.py
@@ -1,0 +1,123 @@
+# Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from pants.engine.collection import DeduplicatedCollection
+
+
+class InvalidCoordinateString(Exception):
+    """The coordinate string being passed is invalid or malformed."""
+
+    def __init__(self, coords: str) -> None:
+        super().__init__(f"Received invalid artifact coordinates: {coords}")
+
+
+@dataclass(frozen=True, order=True)
+class Coordinate:
+    """A single Maven-style coordinate for a JVM dependency.
+
+    Coursier uses at least two string serializations of coordinates:
+    1. A format that is accepted by the Coursier CLI which uses trailing attributes to specify
+       optional fields like `packaging`/`type`, `classifier`, `url`, etc. See `to_coord_arg_str`.
+    2. A format in the JSON report, which uses token counts to specify optional fields. We
+       additionally use this format in our own lockfile. See `to_coord_str` and `from_coord_str`.
+    """
+
+    REGEX = re.compile("([^: ]+):([^: ]+)(:([^: ]*)(:([^: ]+))?)?:([^: ]+)")
+
+    group: str
+    artifact: str
+    version: str
+    packaging: str = "jar"
+    classifier: str | None = None
+
+    # True to enforce that the exact declared version of a coordinate is fetched, rather than
+    # allowing dependency resolution to adjust the version when conflicts occur.
+    strict: bool = True
+
+    @staticmethod
+    def from_json_dict(data: dict) -> Coordinate:
+        return Coordinate(
+            group=data["group"],
+            artifact=data["artifact"],
+            version=data["version"],
+            packaging=data.get("packaging", "jar"),
+            classifier=data.get("classifier", None),
+        )
+
+    def to_json_dict(self) -> dict:
+        ret = {
+            "group": self.group,
+            "artifact": self.artifact,
+            "version": self.version,
+            "packaging": self.packaging,
+            "classifier": self.classifier,
+        }
+        return ret
+
+    @classmethod
+    def from_coord_str(cls, s: str) -> Coordinate:
+        """Parses from a coordinate string with optional `packaging` and `classifier` coordinates.
+
+        See the classdoc for more information on the format.
+
+        Using Aether's implementation as reference
+        http://www.javased.com/index.php?source_dir=aether-core/aether-api/src/main/java/org/eclipse/aether/artifact/DefaultArtifact.java
+
+        ${organisation}:${artifact}[:${packaging}[:${classifier}]]:${version}
+
+        See also: `to_coord_str`.
+        """
+
+        parts = Coordinate.REGEX.match(s)
+        if parts is not None:
+            packaging_part = parts.group(4)
+            return cls(
+                group=parts.group(1),
+                artifact=parts.group(2),
+                packaging=packaging_part if packaging_part is not None else "jar",
+                classifier=parts.group(6),
+                version=parts.group(7),
+            )
+        else:
+            raise InvalidCoordinateString(s)
+
+    def to_coord_str(self, versioned: bool = True) -> str:
+        """Renders the coordinate in Coursier's JSON-report format, which does not use attributes.
+
+        See also: `from_coord_str`.
+        """
+        unversioned = f"{self.group}:{self.artifact}"
+        if self.classifier is not None:
+            unversioned += f":{self.packaging}:{self.classifier}"
+        elif self.packaging != "jar":
+            unversioned += f":{self.packaging}"
+
+        version_suffix = ""
+        if versioned:
+            version_suffix = f":{self.version}"
+        return f"{unversioned}{version_suffix}"
+
+    def to_coord_arg_str(self, extra_attrs: dict[str, str] | None = None) -> str:
+        """Renders the coordinate in Coursier's CLI input format.
+
+        The CLI input format uses trailing key-val attributes to specify `packaging`, `url`, etc.
+
+        See https://github.com/coursier/coursier/blob/b5d5429a909426f4465a9599d25c678189a54549/modules/coursier/shared/src/test/scala/coursier/parse/DependencyParserTests.scala#L7
+        """
+        attrs = dict(extra_attrs or {})
+        if self.packaging != "jar":
+            # NB: Coursier refers to `packaging` as `type` internally.
+            attrs["type"] = self.packaging
+        if self.classifier:
+            attrs["classifier"] = self.classifier
+        attrs_sep_str = "," if attrs else ""
+        attrs_str = ",".join((f"{k}={v}" for k, v in attrs.items()))
+        return f"{self.group}:{self.artifact}:{self.version}{attrs_sep_str}{attrs_str}"
+
+
+class Coordinates(DeduplicatedCollection[Coordinate]):
+    """An ordered list of `Coordinate`s."""

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -49,10 +49,9 @@ from pants.jvm.resolve import coursier_setup
 from pants.jvm.resolve.common import (
     ArtifactRequirement,
     ArtifactRequirements,
-    Coordinate,
-    Coordinates,
     GatherJvmCoordinatesRequest,
 )
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_setup import Coursier, CoursierFetchProcess
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.resolve.lockfile_metadata import JVMLockfileMetadata, LockfileContext

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -9,10 +9,9 @@ from unittest import mock
 import pytest
 
 from pants.engine.fs import EMPTY_DIGEST
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.key import CoursierResolveKey
-from pants.jvm.resolve.coordinate import Coordinate
-from pants.jvm.resolve.coordinate import Coordinates
 
 coord1 = Coordinate("test", "art1", "1.0.0")
 coord2 = Coordinate("test", "art2", "1.0.0")

--- a/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_filter_test.py
@@ -9,9 +9,10 @@ from unittest import mock
 import pytest
 
 from pants.engine.fs import EMPTY_DIGEST
-from pants.jvm.resolve.common import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.key import CoursierResolveKey
+from pants.jvm.resolve.coordinate import Coordinate
+from pants.jvm.resolve.coordinate import Coordinates
 
 coord1 = Coordinate("test", "art1", "1.0.0")
 coord2 = Coordinate("test", "art2", "1.0.0")

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -15,9 +15,8 @@ from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.target import Targets
 from pants.jvm.compile import ClasspathEntry
-from pants.jvm.resolve import coordinate
 from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinates
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
 from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.target_types import JvmArtifactJarSourceField, JvmArtifactTarget
@@ -25,12 +24,6 @@ from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
-
-
-class Coordinate(coordinate.Coordinate):
-    def as_requirement(self) -> ArtifactRequirement:
-        return ArtifactRequirement(coordinate=self)
-
 
 HAMCREST_COORD = Coordinate(
     group="org.hamcrest",
@@ -655,15 +648,13 @@ def test_transitive_excludes(rule_runner: RuleRunner) -> None:
     resolve = rule_runner.request(
         CoursierResolvedLockfile,
         [
-            ArtifactRequirements(
+            ArtifactRequirements.from_coordinates(
                 [
                     Coordinate(
                         group="com.fasterxml.jackson.core",
                         artifact="jackson-databind",
                         version="2.12.1",
-                    )
-                    .as_requirement()
-                    .with_extra_excludes("com.fasterxml.jackson.core:jackson-core")
+                    ).with_extra_excludes("com.fasterxml.jackson.core:jackson-core")
                 ]
             ),
         ],
@@ -679,15 +670,13 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
     resolve = rule_runner.request(
         CoursierResolvedLockfile,
         [
-            ArtifactRequirements(
+            ArtifactRequirements.from_coordinates(
                 [
                     Coordinate(
                         group="org.apache.hive",
                         artifact="hive-exec",
                         version="1.1.0",
-                    )
-                    .as_requirement()
-                    .with_extra_excludes(
+                    ).with_extra_excludes(
                         "org.apache.calcite:calcite-avatica",
                         "org.apache.calcite:calcite-core",
                         "jdk.tools:jdk.tools",
@@ -711,13 +700,13 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
 
 @maybe_skip_jdk_test
 def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> None:
-    reqs = ArtifactRequirements(
+    reqs = ArtifactRequirements.from_coordinates(
         [
             Coordinate(
                 group="org.apache.curator",
                 artifact="apache-curator",
                 version="5.5.0",
-            ).as_requirement()
+            )
         ]
     )
 
@@ -732,18 +721,18 @@ def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> Non
 @maybe_skip_jdk_test
 def test_force_version(rule_runner):
     # first check that force_version=False leads to a different version
-    reqs = ArtifactRequirements(
+    reqs = ArtifactRequirements.from_coordinates(
         [
             Coordinate(
                 group="org.apache.parquet",
                 artifact="parquet-common",
                 version="1.13.1",
-            ).as_requirement(),
+            ),
             Coordinate(
                 group="org.slf4j",
                 artifact="slf4j-api",
                 version="1.7.19",
-            ).as_requirement(),
+            ),
         ]
     )
     entries = rule_runner.request(CoursierResolvedLockfile, [reqs]).entries
@@ -754,19 +743,19 @@ def test_force_version(rule_runner):
     ) in [e.coord for e in entries]
 
     # then check force_version=True pins the version
-    reqs = ArtifactRequirements(
+    reqs = ArtifactRequirements.from_coordinates(
         [
             Coordinate(
                 group="org.apache.parquet",
                 artifact="parquet-common",
                 version="1.13.1",
-            ).as_requirement(),
+            ),
             dataclasses.replace(
                 Coordinate(
                     group="org.slf4j",
                     artifact="slf4j-api",
                     version="1.7.19",
-                ).as_requirement(),
+                ),
                 force_version=True,
             ),
         ]

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -741,15 +741,17 @@ def test_force_version(rule_runner):
     ) in [e.coord for e in entries]
 
     # then check force_version=True pins the version
-    reqs = ArtifactRequirements.from_coordinates(
+    reqs = ArtifactRequirements(
         [
-            Coordinate(
-                group="org.apache.parquet",
-                artifact="parquet-common",
-                version="1.13.1",
-            ),
-            dataclasses.replace(
+            ArtifactRequirement(
                 Coordinate(
+                    group="org.apache.parquet",
+                    artifact="parquet-common",
+                    version="1.13.1",
+                ),
+            ),
+            ArtifactRequirement(
+                coordinate=Coordinate(
                     group="org.slf4j",
                     artifact="slf4j-api",
                     version="1.7.19",

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import dataclasses
 import textwrap
 
 import pytest

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -8,31 +8,22 @@ import textwrap
 
 import pytest
 
+from pants.base.specs import RawSpecs, RecursiveGlobSpec
+from pants.core.util_rules import config_files, source_files
 from pants.engine.fs import FileDigest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.target import Targets
 from pants.jvm.compile import ClasspathEntry
+from pants.jvm.resolve.common import ArtifactRequirement, ArtifactRequirements
+from pants.jvm.resolve.coordinate import Coordinate, Coordinates
+from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry, CoursierResolvedLockfile
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
+from pants.jvm.target_types import JvmArtifactJarSourceField, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import ExtractFileDigest
 from pants.jvm.util_rules import rules as util_rules
-from pants.jvm.resolve.common import ArtifactRequirement
-from pants.jvm.resolve.common import ArtifactRequirements
-from pants.jvm.resolve.coordinate import Coordinate
-from pants.jvm.resolve.coordinate import Coordinates
-from pants.base.specs import RawSpecs
-from pants.base.specs import RecursiveGlobSpec
-from pants.core.util_rules import config_files
-from pants.core.util_rules import source_files
-from pants.jvm.resolve.coursier_fetch import CoursierLockfileEntry
-from pants.jvm.resolve.coursier_fetch import CoursierResolvedLockfile
-from pants.jvm.target_types import JvmArtifactJarSourceField
-from pants.jvm.target_types import JvmArtifactTarget
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV
-from pants.testutil.rule_runner import QueryRule
-from pants.testutil.rule_runner import RuleRunner
-from pants.testutil.rule_runner import engine_error
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
 
 HAMCREST_COORD = Coordinate(
     group="org.hamcrest",
@@ -659,8 +650,13 @@ def test_transitive_excludes(rule_runner: RuleRunner) -> None:
         [
             ArtifactRequirements(
                 [
-                    ArtifactRequirement(coordinate=Coordinate(                         group="com.fasterxml.jackson.core",                         artifact="jackson-databind",                         version="2.12.1",                     ))
-                    .with_extra_excludes("com.fasterxml.jackson.core:jackson-core")
+                    ArtifactRequirement(
+                        coordinate=Coordinate(
+                            group="com.fasterxml.jackson.core",
+                            artifact="jackson-databind",
+                            version="2.12.1",
+                        )
+                    ).with_extra_excludes("com.fasterxml.jackson.core:jackson-core")
                 ]
             ),
         ],
@@ -678,8 +674,13 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
         [
             ArtifactRequirements(
                 [
-                    ArtifactRequirement(coordinate=Coordinate(                         group="org.apache.hive",                         artifact="hive-exec",                         version="1.1.0",                     ))
-                    .with_extra_excludes(
+                    ArtifactRequirement(
+                        coordinate=Coordinate(
+                            group="org.apache.hive",
+                            artifact="hive-exec",
+                            version="1.1.0",
+                        )
+                    ).with_extra_excludes(
                         "org.apache.calcite:calcite-avatica",
                         "org.apache.calcite:calcite-core",
                         "jdk.tools:jdk.tools",
@@ -705,7 +706,13 @@ def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> Non
 def test_failed_to_fetch_jar_given_packaging_pom(rule_runner: RuleRunner) -> None:
     reqs = ArtifactRequirements(
         [
-            ArtifactRequirement(coordinate=Coordinate(                 group="org.apache.curator",                 artifact="apache-curator",                 version="5.5.0",             ))
+            ArtifactRequirement(
+                coordinate=Coordinate(
+                    group="org.apache.curator",
+                    artifact="apache-curator",
+                    version="5.5.0",
+                )
+            )
         ]
     )
 
@@ -722,7 +729,13 @@ def test_force_version(rule_runner):
     # first check that force_version=False leads to a different version
     reqs = ArtifactRequirements(
         [
-            ArtifactRequirement(coordinate=Coordinate(                 group="org.apache.parquet",                 artifact="parquet-common",                 version="1.13.1",             )),
+            ArtifactRequirement(
+                coordinate=Coordinate(
+                    group="org.apache.parquet",
+                    artifact="parquet-common",
+                    version="1.13.1",
+                )
+            ),
             Coordinate(
                 group="org.slf4j",
                 artifact="slf4j-api",
@@ -737,7 +750,13 @@ def test_force_version(rule_runner):
                 artifact="parquet-common",
                 version="1.13.1",
             ).as_requirement(),
-            ArtifactRequirement(coordinate=Coordinate(                 group="org.slf4j",                 artifact="slf4j-api",                 version="1.7.19",             )),
+            ArtifactRequirement(
+                coordinate=Coordinate(
+                    group="org.slf4j",
+                    artifact="slf4j-api",
+                    version="1.7.19",
+                )
+            ),
         ]
     )
     entries = rule_runner.request(CoursierResolvedLockfile, [reqs]).entries
@@ -750,7 +769,13 @@ def test_force_version(rule_runner):
     # then check force_version=True pins the version
     reqs = ArtifactRequirements(
         [
-            ArtifactRequirement(coordinate=Coordinate(                 group="org.apache.parquet",                 artifact="parquet-common",                 version="1.13.1",             )),
+            ArtifactRequirement(
+                coordinate=Coordinate(
+                    group="org.apache.parquet",
+                    artifact="parquet-common",
+                    version="1.13.1",
+                )
+            ),
             dataclasses.replace(
                 Coordinate(
                     group="org.slf4j",
@@ -769,7 +794,13 @@ def test_force_version(rule_runner):
                 version="1.13.1",
             ).as_requirement(),
             dataclasses.replace(
-                ArtifactRequirement(coordinate=Coordinate(                     group="org.slf4j",                     artifact="slf4j-api",                     version="1.7.19",                 )),
+                ArtifactRequirement(
+                    coordinate=Coordinate(
+                        group="org.slf4j",
+                        artifact="slf4j-api",
+                        version="1.7.19",
+                    )
+                ),
                 force_version=True,
             ),
         ]

--- a/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_integration_test.py
@@ -645,19 +645,17 @@ def test_user_repo_order_is_respected(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_transitive_excludes(rule_runner: RuleRunner) -> None:
+    requirement = ArtifactRequirement(
+        coordinate=Coordinate(
+            group="com.fasterxml.jackson.core",
+            artifact="jackson-databind",
+            version="2.12.1",
+        ),
+        excludes=frozenset(["com.fasterxml.jackson.core:jackson-core"]),
+    )
     resolve = rule_runner.request(
         CoursierResolvedLockfile,
-        [
-            ArtifactRequirements.from_coordinates(
-                [
-                    Coordinate(
-                        group="com.fasterxml.jackson.core",
-                        artifact="jackson-databind",
-                        version="2.12.1",
-                    ).with_extra_excludes("com.fasterxml.jackson.core:jackson-core")
-                ]
-            ),
-        ],
+        [ArtifactRequirements([requirement])],
     )
 
     entries = resolve.entries
@@ -667,23 +665,23 @@ def test_transitive_excludes(rule_runner: RuleRunner) -> None:
 
 @maybe_skip_jdk_test
 def test_missing_entry_for_transitive_dependency(rule_runner: RuleRunner) -> None:
+    requirement = ArtifactRequirement(
+        coordinate=Coordinate(
+            group="org.apache.hive",
+            artifact="hive-exec",
+            version="1.1.0",
+        ),
+        excludes=frozenset(
+            [
+                "org.apache.calcite:calcite-avatica",
+                "org.apache.calcite:calcite-core",
+                "jdk.tools:jdk.tools",
+            ]
+        ),
+    )
     resolve = rule_runner.request(
         CoursierResolvedLockfile,
-        [
-            ArtifactRequirements.from_coordinates(
-                [
-                    Coordinate(
-                        group="org.apache.hive",
-                        artifact="hive-exec",
-                        version="1.1.0",
-                    ).with_extra_excludes(
-                        "org.apache.calcite:calcite-avatica",
-                        "org.apache.calcite:calcite-core",
-                        "jdk.tools:jdk.tools",
-                    )
-                ]
-            )
-        ],
+        [ArtifactRequirements([requirement])],
     )
 
     coords_of_entries = {(entry.coord.group, entry.coord.artifact) for entry in resolve.entries}

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -11,6 +11,7 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address, Addresses
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.key import CoursierResolveKey
@@ -18,7 +19,6 @@ from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
-from pants.jvm.resolve.coordinate import Coordinate
 
 NAMED_RESOLVE_OPTIONS = (
     '--jvm-resolves={"one": "coursier_resolve.lockfile", "two": "coursier_resolve.lockfile"}'

--- a/src/python/pants/jvm/resolve/coursier_fetch_test.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch_test.py
@@ -11,7 +11,6 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget
 from pants.backend.java.target_types import rules as target_types_rules
 from pants.core.util_rules import config_files, source_files
 from pants.engine.addresses import Address, Addresses
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.resolve.coursier_fetch import NoCompatibleResolve
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.key import CoursierResolveKey
@@ -19,6 +18,7 @@ from pants.jvm.target_types import DeployJarTarget, JvmArtifactTarget
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, engine_error
+from pants.jvm.resolve.coordinate import Coordinate
 
 NAMED_RESOLVE_OPTIONS = (
     '--jvm-resolves={"one": "coursier_resolve.lockfile", "two": "coursier_resolve.lockfile"}'

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -17,9 +17,9 @@ from pants.jvm.goals.lockfile import GenerateJvmLockfile
 from pants.jvm.resolve.common import (
     ArtifactRequirement,
     ArtifactRequirements,
-    Coordinate,
     GatherJvmCoordinatesRequest,
 )
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.target_types import JvmArtifactFieldSet
 from pants.option.option_types import StrListOption, StrOption
 from pants.option.subsystem import Subsystem

--- a/src/python/pants/jvm/resolve/jvm_tool.py
+++ b/src/python/pants/jvm/resolve/jvm_tool.py
@@ -122,7 +122,7 @@ async def gather_coordinates_for_jvm_lockfile(
         # group name is a file on disk.
         if 2 <= artifact_input.count(":"):
             try:
-                maybe_coord = Coordinate.from_coord_str(artifact_input).as_requirement()
+                maybe_coord = ArtifactRequirement(Coordinate.from_coord_str(artifact_input))
                 requirements.add(maybe_coord)
                 continue
             except Exception:

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -13,6 +13,7 @@ from pants.engine.rules import rule
 from pants.jvm.goals.lockfile import GenerateJvmLockfile
 from pants.jvm.goals.lockfile import rules as lockfile_rules
 from pants.jvm.resolve import jvm_tool
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
@@ -20,7 +21,6 @@ from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 class MockJvmTool(JvmToolBase):

--- a/src/python/pants/jvm/resolve/jvm_tool_test.py
+++ b/src/python/pants/jvm/resolve/jvm_tool_test.py
@@ -13,7 +13,6 @@ from pants.engine.rules import rule
 from pants.jvm.goals.lockfile import GenerateJvmLockfile
 from pants.jvm.goals.lockfile import rules as lockfile_rules
 from pants.jvm.resolve import jvm_tool
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.resolve.coursier_fetch import rules as coursier_fetch_rules
 from pants.jvm.resolve.coursier_setup import rules as coursier_setup_rules
 from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, JvmToolBase
@@ -21,6 +20,7 @@ from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 from pants.util.ordered_set import FrozenOrderedSet
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 class MockJvmTool(JvmToolBase):

--- a/src/python/pants/jvm/shading/rules_integration_test.py
+++ b/src/python/pants/jvm/shading/rules_integration_test.py
@@ -22,7 +22,6 @@ from pants.jvm import compile as jvm_compile
 from pants.jvm import jdk_rules, non_jvm_dependencies
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
-from pants.jvm.resolve.common import Coordinate
 from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.shading.rules import ShadedJar, ShadeJarRequest
@@ -37,6 +36,7 @@ from pants.jvm.target_types import (
 from pants.jvm.testutil import _get_jar_contents_snapshot, maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as jvm_util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
+from pants.jvm.resolve.coordinate import Coordinate
 
 
 @pytest.fixture

--- a/src/python/pants/jvm/shading/rules_integration_test.py
+++ b/src/python/pants/jvm/shading/rules_integration_test.py
@@ -22,6 +22,7 @@ from pants.jvm import compile as jvm_compile
 from pants.jvm import jdk_rules, non_jvm_dependencies
 from pants.jvm.compile import ClasspathEntry
 from pants.jvm.resolve import coursier_fetch, coursier_setup, jvm_tool
+from pants.jvm.resolve.coordinate import Coordinate
 from pants.jvm.resolve.coursier_fetch import CoursierFetchRequest
 from pants.jvm.resolve.key import CoursierResolveKey
 from pants.jvm.shading.rules import ShadedJar, ShadeJarRequest
@@ -36,7 +37,6 @@ from pants.jvm.target_types import (
 from pants.jvm.testutil import _get_jar_contents_snapshot, maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as jvm_util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
-from pants.jvm.resolve.coordinate import Coordinate
 
 
 @pytest.fixture


### PR DESCRIPTION
## The problem
Right now `Coordinate` class has a an `as_requirement` method which returns `ArtifactRequirement` which in turn depends on target types from `pants.jvm.target_types` module. This means that we can't use a `Coordinate` class inside the `pants.jvm.target_types` module, but I need it for [this patch](https://github.com/pantsbuild/pants/pull/20336/files#diff-f818e035e4c8de838719ce80a0c71eee4a933a14385bea07d843e51974d61571R550).
## The solution
1. Remove `as_requirement` method from `Coordinate` class. It's ok because it's only used in tests
2. Move `Coordinate` class to a separate module. This allows us to import it without importing `pants.jvm.target_types`