### PR TITLE
DRY gather config files by directories

### DIFF
--- a/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
+++ b/src/python/pants/backend/scala/lint/scalafmt/subsystem.py
@@ -1,8 +1,12 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+from pants.core.util_rules.config_files import OrphanFilepathConfigBehavior
 from pants.jvm.resolve.jvm_tool import JvmToolBase
-from pants.option.option_types import SkipOption
+from pants.option.option_types import EnumOption, SkipOption, StrOption
+from pants.util.strutil import softwrap
+
+DEFAULT_SCALAFMT_CONF_FILENAME = ".scalafmt.conf"
 
 
 class ScalafmtSubsystem(JvmToolBase):
@@ -15,6 +19,29 @@ class ScalafmtSubsystem(JvmToolBase):
     default_lockfile_resource = (
         "pants.backend.scala.lint.scalafmt",
         "scalafmt.default.lockfile.txt",
+    )
+
+    config_file_name = StrOption(
+        "--config-file-name",
+        default=DEFAULT_SCALAFMT_CONF_FILENAME,
+        advanced=True,
+        help=softwrap(
+            """
+            Name of a config file understood by scalafmt (https://scalameta.org/scalafmt/docs/configuration.html).
+            The plugin will search the ancestors of each directory in which Scala files are found for a config file of this name.
+            """
+        ),
+    )
+
+    orphan_files_behavior = EnumOption(
+        default=OrphanFilepathConfigBehavior.ERROR,
+        advanced=True,
+        help=softwrap(
+            f"""
+            Whether to ignore, error or show a warning when files are found that are not
+            covered by the config file provided in `[{options_scope}].config_file_name` setting.
+            """
+        ),
     )
 
     skip = SkipOption("fmt", "lint")

--- a/src/python/pants/backend/tools/yamllint/rules.py
+++ b/src/python/pants/backend/tools/yamllint/rules.py
@@ -10,13 +10,16 @@ from typing import Any
 from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
 from pants.backend.tools.yamllint.subsystem import Yamllint
 from pants.core.goals.lint import LintFilesRequest, LintResult
+from pants.core.util_rules.config_files import (
+    GatherConfigFilesByDirectoriesRequest,
+    GatheredConfigFilesByDirectories,
+)
 from pants.core.util_rules.partitions import Partition, Partitions
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs
 from pants.engine.internals.native_engine import FilespecMatcher, Snapshot
 from pants.engine.process import FallibleProcessResult
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
-from pants.util.dirutil import find_nearest_ancestor_file, group_by_dir
-from pants.util.frozendict import FrozenDict
+from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -37,49 +40,6 @@ class PartitionInfo:
             return "<default>"
 
 
-@dataclass(frozen=True)
-class YamllintConfigFilesRequest:
-    filepaths: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class YamllintConfigFiles:
-    snapshot: Snapshot
-    source_dir_to_config_files: FrozenDict[str, str]
-
-
-# @TODO: This logic is very similar, but not identical to the one for scalafmt. It should be generalized and shared.
-@rule
-async def gather_config_files(
-    request: YamllintConfigFilesRequest, yamllint: Yamllint
-) -> YamllintConfigFiles:
-    """Gather yamllint configuration files."""
-    source_dirs = frozenset(os.path.dirname(path) for path in request.filepaths)
-    source_dirs_with_ancestors = {"", *source_dirs}
-    for source_dir in source_dirs:
-        source_dir_parts = source_dir.split(os.path.sep)
-        source_dir_parts.pop()
-        while source_dir_parts:
-            source_dirs_with_ancestors.add(os.path.sep.join(source_dir_parts))
-            source_dir_parts.pop()
-
-    config_file_globs = [
-        os.path.join(dir, yamllint.config_file_name) for dir in source_dirs_with_ancestors
-    ]
-    config_files_snapshot = await Get(Snapshot, PathGlobs(config_file_globs))
-    config_files_set = set(config_files_snapshot.files)
-
-    source_dir_to_config_file: dict[str, str] = {}
-    for source_dir in source_dirs:
-        config_file = find_nearest_ancestor_file(
-            config_files_set, source_dir, yamllint.config_file_name
-        )
-        if config_file:
-            source_dir_to_config_file[source_dir] = config_file
-
-    return YamllintConfigFiles(config_files_snapshot, FrozenDict(source_dir_to_config_file))
-
-
 @rule
 async def partition_inputs(
     request: YamllintRequest.PartitionRequest, yamllint: Yamllint
@@ -92,15 +52,21 @@ async def partition_inputs(
     ).matches(request.files)
 
     config_files = await Get(
-        YamllintConfigFiles, YamllintConfigFilesRequest(filepaths=tuple(sorted(matching_filepaths)))
+        GatheredConfigFilesByDirectories,
+        GatherConfigFilesByDirectoriesRequest(
+            tool_name=yamllint.name,
+            config_filename=yamllint.config_file_name,
+            filepaths=tuple(sorted(matching_filepaths)),
+            orphan_filepath_behavior=yamllint.orphan_files_behavior,
+        ),
     )
 
     default_source_files: set[str] = set()
     source_files_by_config_file: dict[str, set[str]] = defaultdict(set)
     for source_dir, files_in_source_dir in group_by_dir(matching_filepaths).items():
         files = (os.path.join(source_dir, name) for name in files_in_source_dir)
-        if source_dir in config_files.source_dir_to_config_files:
-            config_file = config_files.source_dir_to_config_files[source_dir]
+        if source_dir in config_files.source_dir_to_config_file:
+            config_file = config_files.source_dir_to_config_file[source_dir]
             source_files_by_config_file[config_file].update(files)
         else:
             default_source_files.update(files)

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -7,9 +7,16 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.util_rules.config_files import OrphanFilepathConfigBehavior
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.unions import UnionRule
-from pants.option.option_types import ArgsListOption, SkipOption, StrListOption, StrOption
+from pants.option.option_types import (
+    ArgsListOption,
+    EnumOption,
+    SkipOption,
+    StrListOption,
+    StrOption,
+)
 from pants.util.strutil import softwrap
 
 
@@ -33,6 +40,17 @@ class Yamllint(PythonToolBase):
             """
             Name of a config file understood by yamllint (https://yamllint.readthedocs.io/en/stable/configuration.html).
             The plugin will search the ancestors of each directory in which YAML files are found for a config file of this name.
+            """
+        ),
+    )
+
+    orphan_files_behavior = EnumOption(
+        default=OrphanFilepathConfigBehavior.IGNORE,
+        advanced=True,
+        help=softwrap(
+            f"""
+            Whether to ignore, error or show a warning when files are found that are not
+            covered by the config file provided in `[{options_scope}].config_file_name` setting.
             """
         ),
     )


### PR DESCRIPTION
Sliced from #20328.

Refactors the gathering and indexing of config files by the given file paths. Paves the way to use the same logic for other similar tools (i.e. scalafix).

