### PR TITLE
Update to Pex 2.1.155

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ fasteners==0.16.3
 freezegun==1.2.1
 ijson==3.1.4
 packaging==21.3
-pex==2.1.152
+pex==2.1.155
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.1.152",
+//     "pex==2.1.155",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -909,13 +909,13 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "130998cb57ff3510dba628265ab7b52c0b3f88aaf93a5ca45c06fc7eee05d331",
-              "url": "https://files.pythonhosted.org/packages/1a/85/c8064384619a498f6d9a35b09e04bd29da3429c1020b9cae60684289645c/pex-2.1.152-py2.py3-none-any.whl"
+              "hash": "c0edd74bf00c4cc73f4b0117498113d9eb6ea05c0d219936fe1686306d029d05",
+              "url": "https://files.pythonhosted.org/packages/07/90/1cb58e83604eb82436bc72a431a3a693d4db4cc81eed8fb56accc02ac1d2/pex-2.1.155-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "b43161dc44f2631961b6ccd57cea381a986b64415e48446de9aee63657c56716",
-              "url": "https://files.pythonhosted.org/packages/19/8f/2539976fd05dac4cccaf4da6f4dc2907d9ce6d9627148495063c75ba6dd7/pex-2.1.152.tar.gz"
+              "hash": "ec5b4d84a227e167d9f10234f7226d2fb09d561fe0b9a92e69ca8ce9c8d9813f",
+              "url": "https://files.pythonhosted.org/packages/59/ab/7563b395f5a7701ca0952fecd2f5bf755fdf5565340e63e0a957bdc42e27/pex-2.1.155.tar.gz"
             }
           ],
           "project_name": "pex",
@@ -923,7 +923,7 @@
             "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.13,>=2.7",
-          "version": "2.1.152"
+          "version": "2.1.155"
         },
         {
           "artifacts": [
@@ -2216,8 +2216,8 @@
     }
   ],
   "path_mappings": {},
-  "pex_version": "2.1.152",
-  "pip_version": "23.3.1",
+  "pex_version": "2.1.155",
+  "pip_version": "23.3.2",
   "prefer_older_binary": false,
   "requirements": [
     "PyGithub==2.0.0rc1",
@@ -2233,7 +2233,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.1.152",
+    "pex==2.1.155",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -35,7 +35,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.152"
+    default_version = "v2.1.155"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.135,<3.0"
 
@@ -46,8 +46,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "64640336f60ec06c52ffa174f1b59b39ae1e3894d475ea0ae0abc62c0dda9fac",
-                    "4205187",
+                    "421dc73e900648fbc26cb4e1f4be57bf91e4481ede224aedf174b47b9ab9f73a",
+                    "3665792",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
All changes:

- https://github.com/pantsbuild/pex/releases/tag/v2.1.153
- https://github.com/pantsbuild/pex/releases/tag/v2.1.154
- https://github.com/pantsbuild/pex/releases/tag/v2.1.155

Highlights:

- `--no-pre-install-wheels` (and `--max-install-jobs`) that likely helps with:
  - #15062 
  - (the root cause of) #20227
  - _maybe_ arguably #18293, #18965, #19681 
- improved shebang selection, helping with https://github.com/pantsbuild/pants/issues/19514, but probably not the full solution (#19925)
- performance improvements