### PR TITLE
upgrade to Rust v1.75.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -276,7 +276,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -367,7 +367,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -232,7 +232,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -441,7 +441,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 
@@ -508,7 +508,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.74.1-*
+        path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/client/src/client.rs
+++ b/src/rust/engine/client/src/client.rs
@@ -54,8 +54,7 @@ pub async fn execute_command(
         }
     }
 
-    let command = argv
-        .get(0)
+    let command = argv.first()
         .ok_or_else(|| "Failed to determine current process argv0".to_owned())?
         .clone();
 

--- a/src/rust/engine/client/src/client.rs
+++ b/src/rust/engine/client/src/client.rs
@@ -54,7 +54,8 @@ pub async fn execute_command(
         }
     }
 
-    let command = argv.first()
+    let command = argv
+        .first()
         .ok_or_else(|| "Failed to determine current process argv0".to_owned())?
         .clone();
 

--- a/src/rust/engine/dep_inference/src/javascript/tests.rs
+++ b/src/rust/engine/dep_inference/src/javascript/tests.rs
@@ -255,7 +255,7 @@ fn dynamic_scope() {
 #[test]
 fn adds_dir_to_file_imports() -> Result<(), Box<dyn std::error::Error>> {
     let result = get_dependencies(
-        &"import a from './file.js'",
+        "import a from './file.js'",
         Path::new("dir/index.js").to_path_buf(),
         Default::default(),
     )?;
@@ -270,7 +270,7 @@ fn adds_dir_to_file_imports() -> Result<(), Box<dyn std::error::Error>> {
 fn root_level_files_have_no_dir() {
     assert_dependency_imports(
         "index.mjs",
-        &r#"import a from "./file.js""#,
+        r#"import a from "./file.js""#,
         ["file.js"],
         [],
         given_metadata(Default::default(), Default::default()),
@@ -281,7 +281,7 @@ fn root_level_files_have_no_dir() {
 fn only_walks_one_dir_level_for_curdir() {
     assert_dependency_imports(
         "src/js/index.mjs",
-        &r#"
+        r#"
     import fs from "fs";
     import { x } from "./xes.mjs";
   "#,
@@ -295,7 +295,7 @@ fn only_walks_one_dir_level_for_curdir() {
 fn walks_two_dir_levels_for_pardir() {
     assert_dependency_imports(
         "src/js/a/index.mjs",
-        &r#"
+        r#"
     import fs from "fs";
     import { x } from "../xes.mjs";
   "#,
@@ -309,7 +309,7 @@ fn walks_two_dir_levels_for_pardir() {
 fn silly_walking() {
     assert_dependency_imports(
         "src/js/a/index.mjs",
-        &r#"
+        r#"
     import { x } from "././///../../xes.mjs";
   "#,
         ["src/xes.mjs"],
@@ -322,7 +322,7 @@ fn silly_walking() {
 fn imports_outside_of_provided_source_root_are_unchanged() {
     assert_dependency_imports(
         "src/index.mjs",
-        &r#"
+        r#"
     import { x } from "../../xes.mjs";
   "#,
         ["../../xes.mjs"],
@@ -332,7 +332,7 @@ fn imports_outside_of_provided_source_root_are_unchanged() {
 
     assert_dependency_imports(
         "js/src/lib/index.mjs",
-        &r#"
+        r#"
     import { x } from "./../../../../lib2/xes.mjs";
   "#,
         ["./../../../../lib2/xes.mjs"],
@@ -345,7 +345,7 @@ fn imports_outside_of_provided_source_root_are_unchanged() {
 fn subpath_package_import() {
     assert_dependency_imports(
         "js/src/lib/index.mjs",
-        &r#"
+        r#"
     import chalk from '#myChalk';
     "#,
         [],
@@ -361,7 +361,7 @@ fn subpath_package_import() {
 fn subpath_file_import() {
     assert_dependency_imports(
         "js/src/lib/index.mjs",
-        &r#"
+        r#"
     import stuff from '#nested/stuff.mjs';
     "#,
         ["js/src/lib/nested/stuff.mjs"],
@@ -380,7 +380,7 @@ fn subpath_file_import() {
 fn polyfills() {
     assert_dependency_imports(
         "js/src/index.mjs",
-        &r#"
+        r#"
     import { ws } from '#websockets';
     "#,
         ["js/websockets-polyfill.js"],

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -16,11 +16,7 @@ fn assert_collected(
         collector.import_map
     );
     assert_eq!(
-        HashMap::from_iter(
-            string_candidates
-                .iter()
-                .map(|(k, v)| (k.to_string(), *v))
-        ),
+        HashMap::from_iter(string_candidates.iter().map(|(k, v)| (k.to_string(), *v))),
         collector.string_candidates
     );
 }

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -12,14 +12,14 @@ fn assert_collected(
     let mut collector = ImportCollector::new(code);
     collector.collect();
     assert_eq!(
-        HashMap::from_iter(import_map.iter().map(|(k, v)| (k.to_string(), v.clone()))),
+        HashMap::from_iter(import_map.iter().map(|(k, v)| (k.to_string(), *v))),
         collector.import_map
     );
     assert_eq!(
         HashMap::from_iter(
             string_candidates
                 .iter()
-                .map(|(k, v)| (k.to_string(), v.clone()))
+                .map(|(k, v)| (k.to_string(), *v))
         ),
         collector.string_candidates
     );

--- a/src/rust/engine/fs/src/directory_tests.rs
+++ b/src/rust/engine/fs/src/directory_tests.rs
@@ -344,7 +344,6 @@ fn walk_too_many_links_rootdir() {
     assert_walk(
         &tree,
         (0..MAX_LINK_DEPTH)
-            .into_iter()
             .map(|n| ("self/".repeat(n.into()) + "file.txt"))
             .collect::<Vec<_>>(),
         vec!["".to_string()],
@@ -366,7 +365,6 @@ fn walk_too_many_links_subdir() {
     assert_walk(
         &tree,
         (0..MAX_LINK_DEPTH)
-            .into_iter()
             .map(|n| ("a/".to_string() + &"self/".repeat(n.into()) + "file.txt"))
             .collect::<Vec<_>>(),
         vec!["".to_string(), "a".to_string()],

--- a/src/rust/engine/fs/src/posixfs_tests.rs
+++ b/src/rust/engine/fs/src/posixfs_tests.rs
@@ -363,7 +363,7 @@ async fn assert_only_file_is_executable(path: &Path, want_is_executable: bool) {
     let fs = new_posixfs(path);
     let stats = fs.scandir(Dir(PathBuf::from("."))).await.unwrap();
     assert_eq!(stats.0.len(), 1);
-    match stats.0.get(0).unwrap() {
+    match stats.0.first().unwrap() {
         &super::Stat::File(File {
             is_executable: got, ..
         }) => assert_eq!(want_is_executable, got),

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -33,8 +33,8 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
 
     let mut cgroup = c.benchmark_group("materialize_directory");
 
-    for perms in vec![Permissions::ReadOnly, Permissions::Writable] {
-        for (count, size) in vec![(100, 100), (20, 10_000_000), (1, 200_000_000), (10000, 100)] {
+    for perms in [Permissions::ReadOnly, Permissions::Writable] {
+        for (count, size) in [(100, 100), (20, 10_000_000), (1, 200_000_000), (10000, 100)] {
             let (store, _tempdir, digest) = snapshot(&executor, count, size);
             let parent_dest = TempDir::new().unwrap();
             let parent_dest_path = parent_dest.path();
@@ -50,7 +50,7 @@ pub fn criterion_benchmark_materialize(c: &mut Criterion) {
                             let new_temp = TempDir::new_in(parent_dest_path).unwrap();
                             let dest = new_temp.path().to_path_buf();
                             std::mem::forget(new_temp);
-                            let _ = executor
+                            executor
                                 .block_on(store.materialize_directory(
                                     dest,
                                     parent_dest_path,
@@ -79,11 +79,9 @@ pub fn criterion_benchmark_snapshot_capture(c: &mut Criterion) {
     // The number of files, file size, whether the inputs should be assumed to be immutable, and the
     // number of times to capture (only the first capture actually stores anything: the rest should
     // ignore the duplicated data.)
-    for params in vec![
-        (100, 100, false, 100),
+    for params in [(100, 100, false, 100),
         (20, 10_000_000, true, 10),
-        (1, 200_000_000, true, 10),
-    ] {
+        (1, 200_000_000, true, 10)] {
         let (count, size, immutable, captures) = params;
         let storedir = TempDir::new().unwrap();
         let store = Store::local_only(executor.clone(), storedir.path()).unwrap();
@@ -176,7 +174,7 @@ pub fn criterion_benchmark_merge(c: &mut Criterion) {
         files: all_file_nodes
             .iter()
             .cloned()
-            .chain(file_nodes_to_modify.into_iter())
+            .chain(file_nodes_to_modify)
             .collect(),
         directories: directory.directories.clone(),
         ..remexec::Directory::default()

--- a/src/rust/engine/fs/store/benches/store.rs
+++ b/src/rust/engine/fs/store/benches/store.rs
@@ -79,9 +79,11 @@ pub fn criterion_benchmark_snapshot_capture(c: &mut Criterion) {
     // The number of files, file size, whether the inputs should be assumed to be immutable, and the
     // number of times to capture (only the first capture actually stores anything: the rest should
     // ignore the duplicated data.)
-    for params in [(100, 100, false, 100),
+    for params in [
+        (100, 100, false, 100),
         (20, 10_000_000, true, 10),
-        (1, 200_000_000, true, 10)] {
+        (1, 200_000_000, true, 10),
+    ] {
         let (count, size, immutable, captures) = params;
         let storedir = TempDir::new().unwrap();
         let store = Store::local_only(executor.clone(), storedir.path()).unwrap();

--- a/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
+++ b/src/rust/engine/fs/store/src/snapshot_ops_tests.rs
@@ -101,7 +101,7 @@ async fn subset_symlink() {
     // Make the second snapshot with a symlink pointing to the file in the first snapshot.
     let (_store2, tempdir2, posix_fs2, digester2) = setup();
     create_dir_all(tempdir2.path().join("subdir")).unwrap();
-    symlink("./roland1", &tempdir2.path().join("subdir/roland2")).unwrap();
+    symlink("./roland1", tempdir2.path().join("subdir/roland2")).unwrap();
     let snapshot_with_symlink =
         Snapshot::from_path_stats(digester2, expand_all_sorted(posix_fs2).await)
             .await

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1529,9 +1529,11 @@ async fn returns_upload_summary_on_empty_cas() {
         .expect("Error uploading file");
 
     // We store all 3 files, and so we must sum their digests
-    let test_data = [testdir.digest().size_bytes,
+    let test_data = [
+        testdir.digest().size_bytes,
         testroland.digest().size_bytes,
-        testcatnip.digest().size_bytes];
+        testcatnip.digest().size_bytes,
+    ];
     let test_bytes = test_data.iter().sum();
     summary.upload_wall_time = Duration::default();
     assert_eq!(

--- a/src/rust/engine/fs/store/src/tests.rs
+++ b/src/rust/engine/fs/store/src/tests.rs
@@ -1529,11 +1529,9 @@ async fn returns_upload_summary_on_empty_cas() {
         .expect("Error uploading file");
 
     // We store all 3 files, and so we must sum their digests
-    let test_data = vec![
-        testdir.digest().size_bytes,
+    let test_data = [testdir.digest().size_bytes,
         testroland.digest().size_bytes,
-        testcatnip.digest().size_bytes,
-    ];
+        testcatnip.digest().size_bytes];
     let test_bytes = test_data.iter().sum();
     summary.upload_wall_time = Duration::default();
     assert_eq!(

--- a/src/rust/engine/grpc_util/src/channel.rs
+++ b/src/rust/engine/grpc_util/src/channel.rs
@@ -129,7 +129,7 @@ mod tests {
                 .unwrap();
         });
 
-        let uri = Uri::try_from(format!("http://{}", addr.to_string())).unwrap();
+        let uri = Uri::try_from(format!("http://{}", addr)).unwrap();
 
         let mut channel = Channel::new(None, uri).await.unwrap();
 
@@ -168,7 +168,7 @@ mod tests {
             server.serve(router().into_make_service()).await.unwrap();
         });
 
-        let uri = Uri::try_from(format!("https://{}", addr.to_string())).unwrap();
+        let uri = Uri::try_from(format!("https://{}", addr)).unwrap();
 
         let tls_config = ClientConfig::builder()
             .with_safe_defaults()
@@ -269,7 +269,7 @@ mod tests {
             server.serve(router().into_make_service()).await.unwrap();
         });
 
-        let uri = Uri::try_from(format!("https://{}", addr.to_string())).unwrap();
+        let uri = Uri::try_from(format!("https://{}", addr)).unwrap();
 
         let mut tls_config =
             crate::tls::Config::new(Some(&cert_pem), Some((&cert_pem, &key_pem))).unwrap();

--- a/src/rust/engine/process_execution/docker/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/docker/src/docker_tests.rs
@@ -384,7 +384,6 @@ async fn output_files_partial_output() {
         ])
         .output_files(
             relative_paths(&["roland.ext", "susannah"])
-                .into_iter()
                 .collect(),
         )
         .docker(IMAGE.to_owned()),

--- a/src/rust/engine/process_execution/docker/src/docker_tests.rs
+++ b/src/rust/engine/process_execution/docker/src/docker_tests.rs
@@ -382,10 +382,7 @@ async fn output_files_partial_output() {
             "-c".to_owned(),
             format!("echo -n {} > roland.ext", TestData::roland().string()),
         ])
-        .output_files(
-            relative_paths(&["roland.ext", "susannah"])
-                .collect(),
-        )
+        .output_files(relative_paths(&["roland.ext", "susannah"]).collect())
         .docker(IMAGE.to_owned()),
     )
     .await

--- a/src/rust/engine/process_execution/pe_nailgun/src/tests.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/tests.rs
@@ -17,7 +17,7 @@ fn pool(size: usize) -> (NailgunPool, NamedCaches, ImmutableInputs, TempDir) {
     let named_caches_dir = base_dir.path().join("named");
     let store_dir = base_dir.path().join("store");
     let executor = Executor::new();
-    let store = Store::local_only(executor.clone(), &store_dir).unwrap();
+    let store = Store::local_only(executor.clone(), store_dir).unwrap();
 
     let pool = NailgunPool::new(base_dir.path().to_owned(), size, store.clone(), executor);
     (

--- a/src/rust/engine/process_execution/remote/src/remote_tests.rs
+++ b/src/rust/engine/process_execution/remote/src/remote_tests.rs
@@ -2683,7 +2683,7 @@ async fn make_store(
 ) -> Store {
     Store::local_only(executor, store_dir)
         .unwrap()
-        .into_with_remote(remote_options_for_cas(&cas))
+        .into_with_remote(remote_options_for_cas(cas))
         .await
         .unwrap()
 }

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -257,7 +257,6 @@ async fn output_files_partial_output() {
         ])
         .output_files(
             relative_paths(&["roland.ext", "susannah"])
-                .into_iter()
                 .collect(),
         ),
     )

--- a/src/rust/engine/process_execution/src/local_tests.rs
+++ b/src/rust/engine/process_execution/src/local_tests.rs
@@ -255,10 +255,7 @@ async fn output_files_partial_output() {
             "-c".to_owned(),
             format!("echo -n {} > roland.ext", TestData::roland().string()),
         ])
-        .output_files(
-            relative_paths(&["roland.ext", "susannah"])
-                .collect(),
-        ),
+        .output_files(relative_paths(&["roland.ext", "susannah"]).collect()),
     )
     .await
     .unwrap();

--- a/src/rust/engine/process_execution/src/switched.rs
+++ b/src/rust/engine/process_execution/src/switched.rs
@@ -99,7 +99,7 @@ mod tests {
         let right = MockCommandRunner(Err(ProcessError::Unclassified("right".to_string())));
 
         let runner =
-            SwitchedCommandRunner::new(left, right, |req| req.argv.get(0).unwrap() == "left");
+            SwitchedCommandRunner::new(left, right, |req| req.argv.first().unwrap() == "left");
 
         let req = Process::new(vec!["left".to_string()]);
         let err = runner

--- a/src/rust/engine/remote_provider/remote_provider_opendal/src/byte_store_tests.rs
+++ b/src/rust/engine/remote_provider/remote_provider_opendal/src/byte_store_tests.rs
@@ -45,7 +45,7 @@ fn new_provider() -> Provider {
 async fn write_test_data(provider: &Provider, data: &TestData) {
     provider
         .operator
-        .write(&test_path(&data), data.bytes())
+        .write(&test_path(data), data.bytes())
         .await
         .unwrap();
 }

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.75.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -45,7 +45,7 @@ async fn shard_counts() {
 #[tokio::test]
 async fn store_immutable() {
     let (s, _tempdir) = new_store(1);
-    let _ = s
+    s
         .store(true, true, Digest::of_bytes(&bytes(0)), || {
             Ok(bytes(0).reader())
         })
@@ -56,7 +56,7 @@ async fn store_immutable() {
 #[tokio::test]
 async fn store_stable() {
     let (s, _tempdir) = new_store(1);
-    let _ = s
+    s
         .store(true, false, Digest::of_bytes(&bytes(0)), || {
             Ok(bytes(0).reader())
         })
@@ -72,7 +72,7 @@ async fn store_changing() {
     // fourth.
     let contents = Mutex::new(vec![bytes(0), bytes(1), bytes(2), bytes(2)].into_iter());
 
-    let _ = s
+    s
         .store(true, false, Digest::of_bytes(&bytes(2)), move || {
             Ok(contents.lock().next().unwrap().reader())
         })

--- a/src/rust/engine/sharded_lmdb/src/tests.rs
+++ b/src/rust/engine/sharded_lmdb/src/tests.rs
@@ -45,23 +45,21 @@ async fn shard_counts() {
 #[tokio::test]
 async fn store_immutable() {
     let (s, _tempdir) = new_store(1);
-    s
-        .store(true, true, Digest::of_bytes(&bytes(0)), || {
-            Ok(bytes(0).reader())
-        })
-        .await
-        .unwrap();
+    s.store(true, true, Digest::of_bytes(&bytes(0)), || {
+        Ok(bytes(0).reader())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn store_stable() {
     let (s, _tempdir) = new_store(1);
-    s
-        .store(true, false, Digest::of_bytes(&bytes(0)), || {
-            Ok(bytes(0).reader())
-        })
-        .await
-        .unwrap();
+    s.store(true, false, Digest::of_bytes(&bytes(0)), || {
+        Ok(bytes(0).reader())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
@@ -72,12 +70,11 @@ async fn store_changing() {
     // fourth.
     let contents = Mutex::new(vec![bytes(0), bytes(1), bytes(2), bytes(2)].into_iter());
 
-    s
-        .store(true, false, Digest::of_bytes(&bytes(2)), move || {
-            Ok(contents.lock().next().unwrap().reader())
-        })
-        .await
-        .unwrap();
+    s.store(true, false, Digest::of_bytes(&bytes(2)), move || {
+        Ok(contents.lock().next().unwrap().reader())
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]

--- a/src/rust/engine/workunit_store/src/tests.rs
+++ b/src/rust/engine/workunit_store/src/tests.rs
@@ -167,8 +167,8 @@ fn create_store(
     // Collect and sort by SpanId.
     let mut all = started
         .into_iter()
-        .chain(blocked.into_iter())
-        .chain(completed.into_iter())
+        .chain(blocked)
+        .chain(completed)
         .collect::<Vec<_>>();
     all.sort_by(|a, b| a.1.cmp(&b.1));
 


### PR DESCRIPTION
Upgrade to Rust v1.75.0.

[Blog post](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html):

- [async fn and return-position impl Trait in traits](https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html#where-the-gaps-lie)