### PR TITLE
DRAFT: support modifying a lockfile with `pex lock update`

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -298,11 +298,7 @@ async def generate_updated_lockfile(
                 *(["--pin"] if pex_lock_subsystem.pin else []),
                 "lock.json"
             ),
-            #additional_input_digest=pip_args_setup.digest,
-            #FIXME
-            additional_input_digest=old_lockfile_digest,
-
-
+            additional_input_digest = await Get(Digest, MergeDigests((pip_args_setup.digest, old_lockfile_digest))),
             output_files=("lock.json",),
             description=f"Generate lockfile for {req.resolve_name}",
             # Instead of caching lockfile generation with LMDB, we instead use the invalidation

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -75,7 +75,7 @@ class PexLockSubsystem(Subsystem):
             """
         ),
     )
-    
+
     project = StrListOption(
         advanced=False,
         help=softwrap(
@@ -93,9 +93,9 @@ class PexLockSubsystem(Subsystem):
         default=False,
         advanced=False,
         help=softwrap(
-            """When performing the update, pin all projects in the lock to their current 
-            versions. This is useful to pick up newly published wheels for those projects or 
-            else switch repositories from the original ones when used in conjunction with any 
+            """When performing the update, pin all projects in the lock to their current
+            versions. This is useful to pick up newly published wheels for those projects or
+            else switch repositories from the original ones when used in conjunction with any
             of --index, --no-pypi and --find-links.
             """
         ))
@@ -114,6 +114,17 @@ class GeneratePythonLockfile(GenerateLockfile):
     def requirements_hex_digest(self) -> str:
         """Produces a hex digest of the requirements input for this lockfile."""
         return calculate_invalidation_digest(self.requirements)
+
+
+@dataclass(frozen=True)
+class NewPythonLockfileRequest():
+    new_req: GeneratePythonLockfile
+
+
+@dataclass(frozen=True)
+class UpdatePythonLockfileRequest():
+    gen_req: GeneratePythonLockfile
+
 
 
 @rule
@@ -154,24 +165,25 @@ async def _setup_pip_args_and_constraints_file(resolve_name: str) -> _PipArgsAnd
     return _PipArgsAndConstraintsSetup(resolve_config, tuple(args), input_digest)
 
 
-    
 
 
 
+
+@rule
 async def generate_new_lockfile(
-    req: GeneratePythonLockfile,
+    new_req: NewPythonLockfileRequest,
     generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
     python_setup: PythonSetup,
-) -> GenerateLockfileResult:
-    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
+) -> ProcessResult:
+    req = new_req.gen_req
+    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)    
 
-    header_delimiter = "//"
-    result = await Get(
+    return await Get(
         ProcessResult,
         PexCliProcess(
             subcommand=("lock", "create"),
             extra_args=(
-                "--output=lock.json",                
+                "--output=lock.json",
                 "--no-emit-warnings",
                 # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
                 # generate universal locks because they have the best compatibility. We may
@@ -217,6 +229,113 @@ async def generate_new_lockfile(
         ),
     )
 
+
+
+
+@rule
+async def generate_updated_lockfile(
+    update_req: UpdatePythonLockfileRequest,
+    generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
+    pex_lock_subsystem: PexLockSubsystem,
+    python_setup: PythonSetup,
+) -> ProcessResult:
+    req = update_req.gen_req
+    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
+
+
+    original_loaded_lockfile = await Get(
+        LoadedLockfile,
+        LoadedLockfileRequest(
+            Lockfile(
+                url=req.lockfile_dest,
+                url_description_of_origin=f"existing lockfile from {req.resolve_name}",
+                resolve_name=req.resolve_name,
+            )
+       )
+    )
+
+    original_loaded_lockfile_entries = await Get(DigestEntries, Digest, original_loaded_lockfile.lockfile_digest)
+    assert len(original_loaded_lockfile_entries) == 1
+    old_lockfile_digest = await Get(Digest,
+                                    CreateDigest([FileEntry("lock.json",
+                                                            original_loaded_lockfile_entries[0].file_digest)]))
+
+
+    return await Get(
+        ProcessResult,
+        PexCliProcess(
+            subcommand=("lock", "update"),
+            extra_args=(
+                #"--output=lock.json",
+                "--no-emit-warnings",
+                # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
+                # generate universal locks because they have the best compatibility. We may
+                # want to let users change this, as `style=strict` is safer.
+                #"--style=universal",
+                #"--pip-version",
+                #python_setup.pip_version,
+                #"--resolver-version",
+                #"pip-2020-resolver",
+                # PEX files currently only run on Linux and Mac machines; so we hard code this
+                # limit on lock universaility to avoid issues locking due to irrelevant
+                # Windows-only dependency issues. See this Pex issue that originated from a
+                # Pants user issue presented in Slack:
+                #   https://github.com/pantsbuild/pex/issues/1821
+                #
+                # At some point it will probably make sense to expose `--target-system` for
+                # configuration.
+                # "--target-system",
+                #"linux",
+                #"--target-system",
+                #"mac",
+                # This makes diffs more readable when lockfiles change.
+                "--indent=2",
+                *(f"--find-links={link}" for link in req.find_links),
+                *pip_args_setup.args,
+                *req.interpreter_constraints.generate_pex_arg_list(),
+                #*req.requirements,
+                *(f"--project={project}" for project in pex_lock_subsystem.project),
+                *(["--pin"] if pex_lock_subsystem.pin else []),
+                "lock.json"
+            ),
+            #additional_input_digest=pip_args_setup.digest,
+            #FIXME
+            additional_input_digest=old_lockfile_digest,
+
+
+            output_files=("lock.json",),
+            description=f"Generate lockfile for {req.resolve_name}",
+            # Instead of caching lockfile generation with LMDB, we instead use the invalidation
+            # scheme from `lockfile_metadata.py` to check for stale/invalid lockfiles. This is
+            # necessary so that our invalidation is resilient to deleting LMDB or running on a
+            # new machine.
+            #
+            # We disable caching with LMDB so that when you generate a lockfile, you always get
+            # the most up-to-date snapshot of the world. This is generally desirable and also
+            # necessary to avoid an awkward edge case where different developers generate
+            # different lockfiles even when generating at the same time. See
+            # https://github.com/pantsbuild/pants/issues/12591.
+            cache_scope=ProcessCacheScope.PER_SESSION,
+        ),
+    )
+
+
+
+@rule(desc="Generate Python lockfile", level=LogLevel.DEBUG)
+async def generate_lockfile(
+    req: GeneratePythonLockfile,
+    generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
+    pex_lock_subsystem: PexLockSubsystem,
+    python_setup: PythonSetup,
+) -> GenerateLockfileResult:
+    header_delimiter = "//"    
+    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
+    
+    if pex_lock_subsystem.update:
+        result = await Get(ProcessResult, UpdatePythonLockfileRequest(req))
+    else:
+        result = await Get(ProcessResult, NewPythonLockfileRequest(req))
+
     initial_lockfile_digest_contents = await Get(DigestContents, Digest, result.output_digest)
     metadata = PythonLockfileMetadata.new(
         valid_for_interpreter_constraints=req.interpreter_constraints,
@@ -257,145 +376,6 @@ async def generate_new_lockfile(
 
     return GenerateLockfileResult(final_lockfile_digest, req.resolve_name, req.lockfile_dest, diff)
 
-
-
-async def generate_updated_lockfile(
-    req: GeneratePythonLockfile,
-    generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
-    pex_lock_subsystem: PexLockSubsystem,        
-    python_setup: PythonSetup,
-) -> GenerateLockfileResult:
-   pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
-
-
-   original_loaded_lockfile = await Get(
-       LoadedLockfile,
-       LoadedLockfileRequest(
-           Lockfile(
-               url=req.lockfile_dest,
-               url_description_of_origin=f"existing lockfile from {req.resolve_name}",
-               resolve_name=req.resolve_name,
-        )
-       )
-   )
-
-   original_loaded_lockfile_entries = await Get(DigestEntries, Digest, original_loaded_lockfile.lockfile_digest)
-   assert len(original_loaded_lockfile_entries) == 1
-   old_lockfile_digest = await Get(Digest,
-                                   CreateDigest([FileEntry("lock.json",
-                                                           original_loaded_lockfile_entries[0].file_digest)]))
-
-   header_delimiter = "//"
-   result = await Get(
-       ProcessResult,
-       PexCliProcess(
-           subcommand=("lock", "update"),
-           extra_args=(
-               #"--output=lock.json",
-               "--no-emit-warnings",
-               # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
-               # generate universal locks because they have the best compatibility. We may
-               # want to let users change this, as `style=strict` is safer.
-               #"--style=universal",
-               #"--pip-version",
-               #python_setup.pip_version,
-               #"--resolver-version",
-               #"pip-2020-resolver",
-               # PEX files currently only run on Linux and Mac machines; so we hard code this
-               # limit on lock universaility to avoid issues locking due to irrelevant
-               # Windows-only dependency issues. See this Pex issue that originated from a
-               # Pants user issue presented in Slack:
-               #   https://github.com/pantsbuild/pex/issues/1821
-               #
-               # At some point it will probably make sense to expose `--target-system` for
-               # configuration.
-               # "--target-system",
-               #"linux",
-               #"--target-system",
-               #"mac",
-               # This makes diffs more readable when lockfiles change.
-                "--indent=2",
-               *(f"--find-links={link}" for link in req.find_links),
-               *pip_args_setup.args,
-               *req.interpreter_constraints.generate_pex_arg_list(),
-               #*req.requirements,
-               *(f"--project={project}" for project in pex_lock_subsystem.project),
-               *(["--pin"] if pex_lock_subsystem.pin else []),
-               "lock.json"
-           ),
-           #additional_input_digest=pip_args_setup.digest,
-           additional_input_digest=old_lockfile_digest,
-
-
-           output_files=("lock.json",),
-           description=f"Generate lockfile for {req.resolve_name}",
-           # Instead of caching lockfile generation with LMDB, we instead use the invalidation
-           # scheme from `lockfile_metadata.py` to check for stale/invalid lockfiles. This is
-           # necessary so that our invalidation is resilient to deleting LMDB or running on a
-           # new machine.
-           #
-           # We disable caching with LMDB so that when you generate a lockfile, you always get
-           # the most up-to-date snapshot of the world. This is generally desirable and also
-           # necessary to avoid an awkward edge case where different developers generate
-           # different lockfiles even when generating at the same time. See
-           # https://github.com/pantsbuild/pants/issues/12591.
-            cache_scope=ProcessCacheScope.PER_SESSION,
-       ),
-   )
-
-   initial_lockfile_digest_contents = await Get(DigestContents, Digest, result.output_digest)
-   metadata = PythonLockfileMetadata.new(
-       valid_for_interpreter_constraints=req.interpreter_constraints,
-       requirements={
-           PipRequirement.parse(
-               i,
-               description_of_origin=f"the lockfile {req.lockfile_dest} for the resolve {req.resolve_name}",
-           )
-           for i in req.requirements
-       },
-       manylinux=pip_args_setup.resolve_config.manylinux,
-       requirement_constraints=(
-           set(pip_args_setup.resolve_config.constraints_file.constraints)
-           if pip_args_setup.resolve_config.constraints_file
-           else set()
-       ),
-       only_binary=set(pip_args_setup.resolve_config.only_binary),
-       no_binary=set(pip_args_setup.resolve_config.no_binary),
-   )
-   lockfile_with_header = metadata.add_header_to_lockfile(
-       initial_lockfile_digest_contents[0].content,
-       regenerate_command=(
-           generate_lockfiles_subsystem.custom_command
-           or f"{bin_name()} generate-lockfiles --resolve={req.resolve_name}"
-       ),
-       delimeter=header_delimiter,
-   )
-   final_lockfile_digest = await Get(
-       Digest, CreateDigest([FileContent(req.lockfile_dest, lockfile_with_header)])
-   )
-   
-   if req.diff:
-       diff = await _generate_python_lockfile_diff(
-           final_lockfile_digest, req.resolve_name, req.lockfile_dest
-       )
-   else:
-       diff = None
-       
-   return GenerateLockfileResult(final_lockfile_digest, req.resolve_name, req.lockfile_dest, diff)
-
-
-
-@rule(desc="Generate Python lockfile", level=LogLevel.DEBUG)
-async def generate_lockfile(
-    req: GeneratePythonLockfile,
-    generate_lockfiles_subsystem: GenerateLockfilesSubsystem,
-    pex_lock_subsystem: PexLockSubsystem,
-    python_setup: PythonSetup,
-) -> GenerateLockfileResult:
-    if pex_lock_subsystem.update:
-        return await generate_updated_lockfile(req, generate_lockfiles_subsystem, pex_lock_subsystem, python_setup)        
-    else:
-        return await generate_new_lockfile(req, generate_lockfiles_subsystem, python_setup)
 
 
 class RequestedPythonUserResolveNames(RequestedUserResolveNames):

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -76,16 +76,18 @@ class PexLockSubsystem(Subsystem):
         ),
     )
     
+    project = StrListOption(
+        advanced=False,
+        help=softwrap(
+            f""" Just attempt to update the given projects in the lock,
+            leaving all others unchanged.  If the projects aren't already in
+            the lock, attempt to add them as top-level requirements leaving
+            all others unchanged.
 
-    # project = StrListOption(
-    #     advanced=False,
-    #     help=softwrap(
-    #         f""" Just attempt to update the given projects in the lock,
-    #         leaving all others unchanged.  If the projects aren't already in
-    #         the lock, attempt to add them as top-level requirements leaving
-    #         all others unchanged.  """
-    #     ),
-    # )
+            Must be combined with `update`
+            """
+        ),
+    )
 
 
 
@@ -157,7 +159,7 @@ async def generate_new_lockfile(
         PexCliProcess(
             subcommand=("lock", "create"),
             extra_args=(
-                "--output=lock.json",
+                "--output=lock.json",                
                 "--no-emit-warnings",
                 # See https://github.com/pantsbuild/pants/issues/12458. For now, we always
                 # generate universal locks because they have the best compatibility. We may
@@ -305,6 +307,7 @@ async def generate_updated_lockfile(
                *pip_args_setup.args,
                *req.interpreter_constraints.generate_pex_arg_list(),
                #*req.requirements,
+               *(f"--project={project}" for project in pex_lock_subsystem.project),
                "lock.json"
            ),
            #additional_input_digest=pip_args_setup.digest,

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -70,7 +70,7 @@ class PexLockSubsystem(Subsystem):
         default=False,
         advanced=False,
         help=softwrap(
-            f"""
+            """
             update instead of creating a new lockfile
             """
         ),
@@ -88,6 +88,18 @@ class PexLockSubsystem(Subsystem):
             """
         ),
     )
+
+    pin = BoolOption(
+        default=False,
+        advanced=False,
+        help=softwrap(
+            """When performing the update, pin all projects in the lock to their current 
+            versions. This is useful to pick up newly published wheels for those projects or 
+            else switch repositories from the original ones when used in conjunction with any 
+            of --index, --no-pypi and --find-links.
+            """
+        ))
+
 
 
 
@@ -308,6 +320,7 @@ async def generate_updated_lockfile(
                *req.interpreter_constraints.generate_pex_arg_list(),
                #*req.requirements,
                *(f"--project={project}" for project in pex_lock_subsystem.project),
+               *(f"--pin" if pex_lock_subsystem.pin else []),
                "lock.json"
            ),
            #additional_input_digest=pip_args_setup.digest,

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -320,7 +320,7 @@ async def generate_updated_lockfile(
                *req.interpreter_constraints.generate_pex_arg_list(),
                #*req.requirements,
                *(f"--project={project}" for project in pex_lock_subsystem.project),
-               *(f"--pin" if pex_lock_subsystem.pin else []),
+               *(["--pin"] if pex_lock_subsystem.pin else []),
                "lock.json"
            ),
            #additional_input_digest=pip_args_setup.digest,

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -245,9 +245,8 @@ async def generate_updated_lockfile(
 
     existing_dependency_names = {Requirement(dep).name for dep in req.requirements}
     for project in pex_lock_subsystem.project:
-        req = Requirement(project)
-        print(req, project)
-        if req.name != project:
+        requirement = Requirement(project)
+        if requirement.name != project:
             raise ValueError(f"project {project} is not a bare name; specifier, markers must be specified in BUILD files")
 
     original_loaded_lockfile = await Get(

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -260,6 +260,9 @@ async def generate_updated_lockfile(
        )
     )
 
+    if req.interpreter_constraints != original_loaded_lockfile.metadata.valid_for_interpreter_constraints:
+        raise ValueError(f"Request interpreter constraints {req.interpreter_constraints} do not match {original_loaded_lockfile.metadata.valid_for_interpreter_constraints} in current lockfile, can not update in place")
+
     original_loaded_lockfile_entries = await Get(DigestEntries, Digest, original_loaded_lockfile.lockfile_digest)
     assert len(original_loaded_lockfile_entries) == 1
     old_lockfile_digest = await Get(Digest,


### PR DESCRIPTION
To support updating part of the dependency graph instead of regenerating from scratch, `pex` has a `lock update` sub command which tries to make the minimal changes needed.  This allows updating only a single package, or adding new packages without updating all preexisting  ones.  `pex` naturally needs the previous lockfile for this, which requires some plumbing adjustments.

ref #15704