### PR TITLE
Use `GLOBAL` when required in toml in docs (Cherry-pick of #20345)

### DIFF
--- a/build-support/bin/generate_docs.py
+++ b/build-support/bin/generate_docs.py
@@ -35,6 +35,7 @@ from readme_api import DocRef, ReadmeAPI
 
 from pants.base.build_environment import get_buildroot, get_pants_cachedir
 from pants.help.help_info_extracter import to_help_str
+from pants.option.scope import GLOBAL_SCOPE, GLOBAL_SCOPE_CONFIG_SECTION
 from pants.util.strutil import softwrap
 from pants.version import MAJOR_MINOR
 
@@ -332,6 +333,10 @@ class ReferenceGenerator:
         if not option_data.get("config_key", None):
             # This option is not configurable.
             return ""
+
+        if scope == GLOBAL_SCOPE:
+            # make sure we're rendering with the section name as appears in pants.toml
+            scope = GLOBAL_SCOPE_CONFIG_SECTION
 
         toml_lines = []
         example_cli = option_data["display_args"][0]


### PR DESCRIPTION
This fixes #20344 by resolving the subtle differences in how the GLOBAL "scope" is tracked: in Pants' code, it's represented by an empty scope (`""`); in `pants.toml` for users, it's the `[GLOBAL]` section. This difference lead to the new toml snippet in docs being rendered like:

```toml
[]
level = <LogLevel>
```

After this change, it now looks like:

```toml
[GLOBAL]
level = <LogLevel>
```

