### PR TITLE
Parametrize the peg grammar for parsing list-valued options.

### DIFF
--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -40,6 +40,8 @@ peg::parser! {
             = quoted_character("'")
             / escaped_character()
 
+        // NB: ##method(X) is an undocumented peg feature expression that calls input.method(pos, X)
+        // (see https://github.com/kevinmehall/rust-peg/issues/283).
         rule quoted_character(quote_char: &'static str) -> char
             = !(##parse_string_literal(quote_char) / "\\") c:$([_]) { c.chars().next().unwrap() }
 


### PR DESCRIPTION
Previously it only parsed lists of strings, as only those were needed
to parse bootstrap options.

Now it can parse lists of other values, which is demonstrated by adding
support for parsing lists of ints.

This is a necessary step towards supporting all option types in the Rust
parser.