### PR TITLE
fix: in-repo plugin requirements.txt not loading (Cherry-pick of #20355)

### DIFF
--- a/src/python/pants/init/options_initializer.py
+++ b/src/python/pants/init/options_initializer.py
@@ -48,14 +48,15 @@ def _initialize_build_configuration(
     """
 
     bootstrap_options = options_bootstrapper.get_bootstrap_options().for_global_scope()
-    backends_requirements = _collect_backends_requirements(bootstrap_options.backend_packages)
-    working_set = plugin_resolver.resolve(options_bootstrapper, env, backends_requirements)
 
     # Add any extra paths to python path (e.g., for loading extra source backends).
     for path in bootstrap_options.pythonpath:
         if path not in sys.path:
             sys.path.append(path)
             pkg_resources.fixup_namespace_packages(path)
+
+    backends_requirements = _collect_backends_requirements(bootstrap_options.backend_packages)
+    working_set = plugin_resolver.resolve(options_bootstrapper, env, backends_requirements)
 
     # Load plugins and backends.
     return load_backends_and_plugins(

--- a/tests/python/pants_test/integration/plugin_requirements_integration_test.py
+++ b/tests/python/pants_test/integration/plugin_requirements_integration_test.py
@@ -1,16 +1,9 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import os
-import sys
-
-from pants.base.build_environment import get_buildroot
 from pants.testutil.pants_integration_test import run_pants
 
 
 def test_plugin_with_dependencies() -> None:
-    testproject_backend_src_dir = os.path.join(
-        get_buildroot(), "testprojects/pants-plugins/src/python"
-    )
     testproject_backend_pkg_name = "test_pants_plugin"
 
     pants_run = run_pants(
@@ -19,9 +12,9 @@ def test_plugin_with_dependencies() -> None:
             f"--backend-packages=['{testproject_backend_pkg_name}']",
             "help",
         ],
+        config={"GLOBAL": {"pythonpath": ["%(buildroot)s/testprojects/pants-plugins/src/python"]}},
         extra_env={
             "_IMPORT_REQUIREMENT": "True",
-            "PYTHONPATH": os.pathsep.join(sys.path + [testproject_backend_src_dir]),
         },
     )
     pants_run.assert_success()


### PR DESCRIPTION
This fixes the change that was introduced on #19406: Due to the fact sys.path was not yet altered, `_collect_backends_requirements` fails to load in-repo plugins, thus ignoring the requirements.txt file.
