### PR TITLE
Improve the cache nuking recommendation.

### DIFF
--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -44,7 +44,8 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >    size_mb=$(du -m -d0 "${path}" | cut -f 1)
 >    if (( size_mb > limit_mb )); then
 >      echo "${path} is too large (${size_mb}mb), nuking it."
->      rm -rf "${path}"
+>      mv "${path}" "${path}.nuke"
+>      rm -rf "${path}.nuke"
 >    fi
 >  }
 >

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -44,10 +44,10 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >    size_mb=$(du -m -d0 "${path}" | cut -f 1)
 >    if (( size_mb > limit_mb )); then
 >      echo "${path} is too large (${size_mb}mb), nuking it."
->      parent_dir=$(dirname "${path}")
->      nuke_path=$(mktemp -d "${parent_dir}/nuke.XXXXXX")
+>      nuke_prefix="$(dirname "${path}")/$(basename "${path}").nuke"
+>      nuke_path=$(mktemp -d "${nuke_prefix}.XXXXXX")
 >      mv "${path}" "${nuke_path}/"
->      rm -rf "${parent_dir}/nuke.*"
+>      rm -rf "${nuke_prefix}.*"
 >    fi
 >  }
 >

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -35,7 +35,7 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 > 
 > In CI, the cache must be uploaded and downloaded every run. This takes time, so there is a tradeoff where too large a cache will slow down your CI.
 > 
-> You can use this script to nuke the cache when it gets too big (you must ensure that uuidgen is installed on the system):
+> You can use this script to nuke the cache when it gets too big:
 > 
 > ```bash
 >  function nuke_if_too_big() {
@@ -44,9 +44,10 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >    size_mb=$(du -m -d0 "${path}" | cut -f 1)
 >    if (( size_mb > limit_mb )); then
 >      echo "${path} is too large (${size_mb}mb), nuking it."
->      nuke_path="${path}.$(uuidgen)"
->      mv "${path}" "${nuke_path}"
->      rm -rf "${nuke_path}"
+>      parent_dir=$(dirname "${path}")
+>      nuke_path=$(mktemp -d "${parent_dir}/nuke.XXXXXX")
+>      mv "${path}" "${nuke_path}/"
+>      rm -rf "${parent_dir}/nuke.*"
 >    fi
 >  }
 >

--- a/docs/markdown/Using Pants/using-pants-in-ci.md
+++ b/docs/markdown/Using Pants/using-pants-in-ci.md
@@ -35,7 +35,7 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 > 
 > In CI, the cache must be uploaded and downloaded every run. This takes time, so there is a tradeoff where too large a cache will slow down your CI.
 > 
-> You can use this script to nuke the cache when it gets too big:
+> You can use this script to nuke the cache when it gets too big (you must ensure that uuidgen is installed on the system):
 > 
 > ```bash
 >  function nuke_if_too_big() {
@@ -44,8 +44,9 @@ See [Troubleshooting](doc:troubleshooting#how-to-change-your-cache-directory) fo
 >    size_mb=$(du -m -d0 "${path}" | cut -f 1)
 >    if (( size_mb > limit_mb )); then
 >      echo "${path} is too large (${size_mb}mb), nuking it."
->      mv "${path}" "${path}.nuke"
->      rm -rf "${path}.nuke"
+>      nuke_path="${path}.$(uuidgen)"
+>      mv "${path}" "${nuke_path}"
+>      rm -rf "${nuke_path}"
 >    fi
 >  }
 >


### PR DESCRIPTION
Pants fails in hard-to-debug ways if a cache is partially deleted. 
This recommendation ensures that the cache nuking is atomic
from Pants's perspective.

See https://github.com/pantsbuild/pants/issues/17221#issuecomment-1883816347 for context.