### PR TITLE
Support bool, float and lists of them in the rust options parser.

### DIFF
--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -68,7 +68,7 @@ fn test_bool() {
 
     assert!(args.get_bool(&option_id!("dne")).unwrap().is_none());
     assert_eq!(
-        "Got 'swallow' for -c. Expected 'true' or 'false'.".to_owned(),
+        "Got 'swallow' for -c. Expected 'true' or 'false', at line 1 column 1.".to_owned(),
         args.get_bool(&option_id!(-'c', "unladen", "capacity"))
             .unwrap_err()
     );

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -111,7 +111,7 @@ fn test_bool() {
 
     assert!(env.get_bool(&option_id!("dne")).unwrap().is_none());
     assert_eq!(
-        "Got 'swallow' for PANTS_EGGS. Expected 'true' or 'false'.".to_owned(),
+        "Got 'swallow' for PANTS_EGGS. Expected 'true' or 'false', at line 1 column 1.".to_owned(),
         env.get_bool(&option_id!("pants", "eggs")).unwrap_err()
     );
 }

--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -270,13 +270,3 @@ pub(crate) fn parse_string_list(value: &str) -> Result<Vec<ListEdit<String>>, Pa
     option_value_parser::string_list_edits(value)
         .map_err(|e| format_parse_error("string list", value, e))
 }
-
-// pub(crate) fn parse_bool(value: &str) -> Result<bool, ParseError> {
-//     match value.to_lowercase().as_str() {
-//         "true" => Ok(true),
-//         "false" => Ok(false),
-//         _ => Err(ParseError::new(format!(
-//             "Got '{value}' for {{name}}. Expected 'true' or 'false'."
-//         ))),
-//     }
-// }


### PR DESCRIPTION
We don't document on the docsite that we support float (and list of float)
but it is supported in the code, and we do actually have one float option
in the codebase. So it's possible more exist in plugins, and therefore
we have to  support it.

"List of bool" seems like a silly option type, and we have no such options, 
but alas we do support it and document that fact, so again, we must 
support it. As a byproduct of supporting list of bool we now parse bool
in the PEG parser and so can remove the previous bespoke bool parsing
function.

This adds a lot of tests for parsing scalars and lists of them, and also
tests individual quoted string parsing. But it does not slavishly perform
every test on every scalar type. In some important cases it tests
bool/int/float lists separately, but in others it uses one or the other as
a stand-in for all scalars.

A future change will support dicts with values of the above.