### PR TITLE
Produce bool parsing error message idiomatically

### DIFF
--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -68,7 +68,7 @@ fn test_bool() {
 
     assert!(args.get_bool(&option_id!("dne")).unwrap().is_none());
     assert_eq!(
-        "Got 'swallow' for -c. Expected 'true' or 'false', at line 1 column 1.".to_owned(),
+        "Problem parsing -c bool value:\n1:swallow\n  ^\nExpected 'true' or 'false' at line 1 column 1".to_owned(),
         args.get_bool(&option_id!(-'c', "unladen", "capacity"))
             .unwrap_err()
     );

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -111,7 +111,9 @@ fn test_bool() {
 
     assert!(env.get_bool(&option_id!("dne")).unwrap().is_none());
     assert_eq!(
-        "Got 'swallow' for PANTS_EGGS. Expected 'true' or 'false', at line 1 column 1.".to_owned(),
+        "Problem parsing PANTS_EGGS bool value:\n1:swallow\n  ^\nExpected 'true' or 'false' \
+        at line 1 column 1"
+            .to_owned(),
         env.get_bool(&option_id!("pants", "eggs")).unwrap_err()
     );
 }

--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -15,13 +15,13 @@ peg::parser! {
             = whitespace()* value:parse_value() whitespace()* { value }
 
         rule false() -> bool
-            = ("F"/"f") ("A"/"a") ("L"/"l") ("S"/"s") ("E"/"e") { false }
+            = quiet!{ ("F"/"f") ("A"/"a") ("L"/"l") ("S"/"s") ("E"/"e") } { false }
 
         rule true() -> bool
-            = ("T"/"t") ("R"/"r") ("U"/"u") ("E"/"e") { true }
+            = quiet!{ ("T"/"t") ("R"/"r") ("U"/"u") ("E"/"e") } { true }
 
         pub(crate) rule bool() -> bool
-            = b:(true() / false()) { b }
+            = b:(true() / false() / expected!("'true' or 'false'")) { b }
 
         // Python numeric literals can include digit-separator underscores. It's unlikely
         // that anyone relies on those in option values, but since the old Python options
@@ -227,11 +227,7 @@ fn format_parse_error(
 
 #[allow(dead_code)]
 pub(crate) fn parse_bool(value: &str) -> Result<bool, ParseError> {
-    // This is a more readable error message than the one format_parse_error emits, which
-    // would say something like `Expected \"F\", \"T\", \"f\" or \"t\" at...`.
-    option_value_parser::bool(value).map_err(|e| ParseError::new(
-        format!("Got '{value}' for {{name}}. Expected 'true' or 'false', at line {line} column {column}.",
-                line = e.location.line, column = e.location.column,)))
+    option_value_parser::bool(value).map_err(|e| format_parse_error("bool", value, e))
 }
 
 #[allow(dead_code)]

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -30,7 +30,9 @@ fn test_parse_bool() {
     assert_eq!(Ok(false), parse_bool("FALSE"));
 
     assert_eq!(
-        "Got '1' for foo. Expected 'true' or 'false', at line 1 column 1.".to_owned(),
+        "Problem parsing foo bool value:\n1:1\n  ^\nExpected 'true' or 'false' \
+        at line 1 column 1"
+            .to_owned(),
         parse_bool("1").unwrap_err().render("foo")
     )
 }


### PR DESCRIPTION
The PEG parser has built-in directives to provide better error messages,
which we now use instead of our previous, bespoke attempt.