### PR TITLE
Parse dict options in the rust options parser.

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -239,7 +239,7 @@ class PythonSetup(Subsystem):
         ),
         advanced=True,
     )
-    _resolves_to_interpreter_constraints = DictOption["list[str]"](
+    _resolves_to_interpreter_constraints = DictOption[List[str]](
         help=softwrap(
             """
             Override the interpreter constraints to use when generating a resolve's lockfile

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -41,6 +41,25 @@ pub use build_root::BuildRoot;
 pub use id::{OptionId, Scope};
 pub use types::OptionType;
 
+// NB: The legacy Python options parser supported dicts with member_type "Any", which means
+// the values can be arbitrarily-nested lists, tuples and dicts, including heterogeneous
+// ones that are not supported as top-level option values. We have very few dict[Any] options,
+// but there are a handful, and user plugins may also define them. Therefore we must continue
+// to support this in the Rust options parser, hence this clunky enum.
+//
+// We only use this for parsing values in dicts, as in other cases we know that the type must
+// be some scalar or string, or a uniform list of one type of scalar or string, so we can
+// parse as such.
+#[derive(Debug, PartialEq)]
+pub(crate) enum Val {
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    String(String),
+    List(Vec<Val>),
+    Dict(HashMap<String, Val>),
+}
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub(crate) enum ListEditAction {
     Replace,
@@ -52,6 +71,18 @@ pub(crate) enum ListEditAction {
 pub(crate) struct ListEdit<T> {
     pub action: ListEditAction,
     pub items: Vec<T>,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub(crate) enum DictEditAction {
+    Replace,
+    Add,
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) struct DictEdit {
+    pub action: DictEditAction,
+    pub items: HashMap<String, Val>,
 }
 
 ///

--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -1,8 +1,10 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use super::{ListEdit, ListEditAction};
+use super::{DictEdit, DictEditAction, ListEdit, ListEditAction, Val};
 use crate::render_choice;
+
+use std::collections::HashMap;
 
 peg::parser! {
     grammar option_value_parser() for str {
@@ -11,7 +13,7 @@ peg::parser! {
         rule whitespace() -> ()
             = quiet!{ " " / "\n" / "\r" / "\t" }
 
-        rule value<T>(parse_value: rule<T>) -> T
+        rule value_with_ws<T>(parse_value: rule<T>) -> T
             = whitespace()* value:parse_value() whitespace()* { value }
 
         rule false() -> bool
@@ -68,14 +70,14 @@ peg::parser! {
         rule escaped_character() -> char
             = "\\" c:$([_]) { c.chars().next().unwrap() }
 
-        rule add() -> ListEditAction
+        rule list_add() -> ListEditAction
             = "+" { ListEditAction::Add }
 
-        rule remove() -> ListEditAction
+        rule list_remove() -> ListEditAction
             = "-" { ListEditAction::Remove }
 
-        rule action() -> ListEditAction
-            = quiet!{ action:(add() / remove()) { action } }
+        rule list_action() -> ListEditAction
+            = quiet!{ action:(list_add() / list_remove()) { action } }
             / expected!(
                 "an optional list edit action of '+' indicating `add` or '-' indicating `remove`"
             )
@@ -92,7 +94,7 @@ peg::parser! {
 
         rule tuple_items<T>(parse_value: rule<T>) -> Vec<T>
             = tuple_start()
-            items:value(&parse_value) ** ","
+            items:value_with_ws(&parse_value) ** ","
             ","? whitespace()*
             tuple_end() {
                 items
@@ -108,7 +110,7 @@ peg::parser! {
 
         rule list_items<T>(parse_value: rule<T>) -> Vec<T>
             = list_start()
-            items:value(&parse_value) ** ","
+            items:value_with_ws(&parse_value) ** ","
             ","? whitespace()*
             list_end() {
                 items
@@ -120,7 +122,7 @@ peg::parser! {
             whitespace()* { items }
 
         rule list_edit<T>(parse_value: rule<T>) -> ListEdit<T>
-            = whitespace()* action:action() items:items(&parse_value) whitespace()* {
+            = whitespace()* action:list_action() items:items(&parse_value) whitespace()* {
                 ListEdit { action, items }
             }
 
@@ -135,7 +137,9 @@ peg::parser! {
         rule implicit_add<T>(parse_raw_value: rule<T>) -> Vec<ListEdit<T>>
             // If the value is not prefixed with any of the syntax that we recognize as indicating
             // our list edit syntax, then it is implicitly an Add.
-            = !(whitespace() / (action() list_start()) / (action() tuple_start()) / tuple_start() / list_start()) item:parse_raw_value() {
+            = !(whitespace() / (list_action() list_start()) / (list_action() tuple_start()) /
+                tuple_start() / list_start()
+               ) item:parse_raw_value() {
                 vec![ListEdit { action: ListEditAction::Add, items: vec![item] }]
             }
 
@@ -150,6 +154,51 @@ peg::parser! {
 
         pub(crate) rule string_list_edits() -> Vec<ListEdit<String>>
             = implicit_add(<unquoted_string()>) / list_replace(<quoted_string()>) / list_edits(<quoted_string()>)
+
+        // Heterogeneous values embedded in dicts. Note that float_val() must precede int_val() so that
+        // the integer prefix of a float is not interpreted as an int.
+        rule val() -> Val
+            = v:(bool_val() / float_val()/ int_val() / string_val() / list_val() / tuple_val() / dict_val()) {
+            v
+        }
+
+        rule bool_val() -> Val = x:bool() { Val::Bool(x) }
+        rule float_val() -> Val = x:float() { Val::Float(x) }
+        rule int_val() -> Val = x:int() { Val::Int(x) }
+        rule string_val() -> Val = x:quoted_string() { Val::String(x) }
+        rule list_val() -> Val = items:list_items(<val()>) { Val::List(items) }
+        rule tuple_val() -> Val = items:tuple_items(<val()>) { Val::List(items) }
+        rule dict_val() -> Val = whitespace()* d:dict() { Val::Dict(d) }
+
+        rule dict() -> HashMap<String, Val>
+            = dict_start()
+            items:dict_item() ** ","
+            whitespace()* ","? whitespace()*
+            dict_end()
+            whitespace()* {
+                items.into_iter().collect()
+            }
+
+        rule dict_start() -> ()
+            = quiet!{ "{" }
+            / expected!("the start of a dict indicated by '{' or '+{'")
+
+        rule dict_end() -> ()
+            = quiet!{ "}" }
+            / expected!("the end of a dict indicated by '}'")
+
+        rule dict_item() -> (String, Val)
+            = whitespace()* key:quoted_string() whitespace()* ":" whitespace()* value:val() whitespace()* {
+                (key, value)
+            }
+
+        pub(crate) rule dict_edit() -> DictEdit
+            = whitespace()* plus:"+"? d:dict() {
+                DictEdit {
+                    action: if plus.is_some() { DictEditAction::Add } else { DictEditAction::Replace },
+                    items: d,
+                }
+            }
     }
 }
 
@@ -265,4 +314,9 @@ pub(crate) fn parse_float_list(value: &str) -> Result<Vec<ListEdit<f64>>, ParseE
 pub(crate) fn parse_string_list(value: &str) -> Result<Vec<ListEdit<String>>, ParseError> {
     option_value_parser::string_list_edits(value)
         .map_err(|e| format_parse_error("string list", value, e))
+}
+
+#[allow(dead_code)]
+pub(crate) fn parse_dict(value: &str) -> Result<DictEdit, ParseError> {
+    option_value_parser::dict_edit(value).map_err(|e| format_parse_error("dict", value, e))
 }

--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -158,7 +158,7 @@ peg::parser! {
         // Heterogeneous values embedded in dicts. Note that float_val() must precede int_val() so that
         // the integer prefix of a float is not interpreted as an int.
         rule val() -> Val
-            = v:(bool_val() / float_val()/ int_val() / string_val() / list_val() / tuple_val() / dict_val()) {
+            = v:(bool_val() / float_val() / int_val() / string_val() / list_val() / tuple_val() / dict_val()) {
             v
         }
 

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -2,32 +2,68 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use crate::parse::*;
-use crate::{ListEdit, ListEditAction};
+use crate::{DictEdit, DictEditAction, ListEdit, ListEditAction, Val};
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+// Helper macro (and associated functions) to print multiline parse errors.
+// unwrap() and assert_eq! print the debug representation on error, which displays
+// the multiline error message on one line, with escaped newlines.
+// However our ParseError messages include a visual pointer to the error location,
+// and so are much more useful when displayed multiline.
+
+macro_rules! check {
+    ($left:expr, $right:expr $(,)?) => { check($left, $right); };
+    ($left:expr, $right:expr, $($arg:tt)+) => { check_with_arg($left, $right, $($arg)+); };
+}
+
+fn check<T: PartialEq + Debug>(expected: T, res: Result<T, ParseError>) {
+    match res {
+        Ok(actual) => assert_eq!(expected, actual),
+        Err(s) => panic!("{}", s.render("test")),
+    }
+}
+
+fn check_with_arg<T: PartialEq + Debug>(
+    expected: T,
+    res: Result<T, ParseError>,
+    arg: &'static str,
+) {
+    match res {
+        Ok(actual) => assert_eq!(expected, actual, "{}", arg),
+        Err(s) => panic!("{}", s.render("test")),
+    }
+}
 
 #[test]
 fn test_parse_quoted_string() {
-    fn check(expected: &str, input: &str) {
-        assert_eq!(Ok(expected.to_string()), parse_quoted_string(input));
+    fn check_str(expected: &str, input: &str) {
+        check!(expected.to_string(), parse_quoted_string(input));
     }
-    check("", "''");
-    check("", r#""""#);
-    check("foo", "'foo'");
-    check("foo", r#""foo""#);
-    check("hanakapi'ai", r#"'hanakapi\'ai'"#);
-    check("hanakapi'ai", r#""hanakapi'ai""#);
-    check("bs\"d", r#""bs\"d""#);
-    check("1995", r#""1995""#);
+
+    check_str("", "''");
+    check_str("", r#""""#);
+    check_str("foo", "'foo'");
+    check_str("foo", r#""foo""#);
+    check_str("hanakapi'ai", r#"'hanakapi\'ai'"#);
+    check_str("hanakapi'ai", r#""hanakapi'ai""#);
+    check_str("bs\"d", r#""bs\"d""#);
+    check_str("1995", r#""1995""#);
 }
 
 #[test]
 fn test_parse_bool() {
-    assert_eq!(Ok(true), parse_bool("true"));
-    assert_eq!(Ok(true), parse_bool("True"));
-    assert_eq!(Ok(true), parse_bool("TRUE"));
+    fn check_bool(expected: bool, input: &str) {
+        check!(expected, parse_bool(input));
+    }
 
-    assert_eq!(Ok(false), parse_bool("false"));
-    assert_eq!(Ok(false), parse_bool("False"));
-    assert_eq!(Ok(false), parse_bool("FALSE"));
+    check_bool(true, "true");
+    check_bool(true, "True");
+    check_bool(true, "TRUE");
+
+    check_bool(false, "false");
+    check_bool(false, "False");
+    check_bool(false, "FALSE");
 
     assert_eq!(
         "Problem parsing foo bool value:\n1:1\n  ^\nExpected 'true' or 'false' \
@@ -39,16 +75,19 @@ fn test_parse_bool() {
 
 #[test]
 fn test_parse_int() {
-    assert_eq!(Ok(0), parse_int("0"));
-    assert_eq!(Ok(1), parse_int("1"));
-    assert_eq!(Ok(1), parse_int("+1"));
-    assert_eq!(Ok(-1), parse_int("-1"));
-    assert_eq!(Ok(42), parse_int("42"));
-    assert_eq!(Ok(999), parse_int("999"));
-    assert_eq!(Ok(-123456789), parse_int("-123456789"));
-    assert_eq!(Ok(-123456789), parse_int("-123_456_789"));
-    assert_eq!(Ok(9223372036854775807), parse_int("9223372036854775807"));
-    assert_eq!(Ok(-9223372036854775808), parse_int("-9223372036854775808"));
+    fn check_int(expected: i64, input: &str) {
+        check!(expected, parse_int(input));
+    }
+    check_int(0, "0");
+    check_int(1, "1");
+    check_int(1, "+1");
+    check_int(-1, "-1");
+    check_int(42, "42");
+    check_int(999, "999");
+    check_int(-123456789, "-123456789");
+    check_int(-123456789, "-123_456_789");
+    check_int(9223372036854775807, "9223372036854775807");
+    check_int(-9223372036854775808, "-9223372036854775808");
     assert_eq!(
         "Problem parsing foo int value:\n1:badint\n  ^\nExpected \"+\", \"-\" or ['0' ..= '9'] \
                at line 1 column 1"
@@ -65,17 +104,20 @@ fn test_parse_int() {
 
 #[test]
 fn test_parse_float() {
-    assert_eq!(Ok(0.0), parse_float("0.0"));
-    assert_eq!(Ok(0.0), parse_float("-0.0"));
-    assert_eq!(Ok(0.0), parse_float("0."));
-    assert_eq!(Ok(1.0), parse_float("1.0"));
-    assert_eq!(Ok(0.1), parse_float("0.1"));
-    assert_eq!(Ok(0.01), parse_float("+0.01"));
-    assert_eq!(Ok(-98.101), parse_float("-98.101"));
-    assert_eq!(Ok(-245678.1012), parse_float("-245_678.10_12"));
-    assert_eq!(Ok(6.022141793e+23), parse_float("6.022141793e+23"));
-    assert_eq!(Ok(5.67123e+11), parse_float("567.123e+9"));
-    assert_eq!(Ok(9.1093837e-31), parse_float("9.1093837E-31"));
+    fn check_float(expected: f64, input: &str) {
+        check!(expected, parse_float(input));
+    }
+    check_float(0.0, "0.0");
+    check_float(0.0, "-0.0");
+    check_float(0.0, "0.");
+    check_float(1.0, "1.0");
+    check_float(0.1, "0.1");
+    check_float(0.01, "+0.01");
+    check_float(-98.101, "-98.101");
+    check_float(-245678.1012, "-245_678.10_12");
+    check_float(6.022141793e+23, "6.022141793e+23");
+    check_float(5.67123e+11, "567.123e+9");
+    check_float(9.1093837e-31, "9.1093837E-31");
 }
 
 #[test]
@@ -110,332 +152,332 @@ const EMPTY_FLOAT_LIST: [f64; 0] = [];
 
 #[test]
 fn test_parse_string_list_replace() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, EMPTY_STRING_LIST)],
-        parse_string_list("[]").unwrap()
+        parse_string_list("[]")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo"])],
-        parse_string_list("['foo']").unwrap()
+        parse_string_list("['foo']")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo", "bar"])],
-        parse_string_list("['foo','bar']").unwrap()
+        parse_string_list("['foo','bar']")
     );
 }
 
 #[test]
 fn test_parse_bool_list_replace() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, EMPTY_BOOL_LIST)],
-        parse_bool_list("[]").unwrap()
+        parse_bool_list("[]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [true])],
-        parse_bool_list("[True]").unwrap()
+        parse_bool_list("[True]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [true, false])],
-        parse_bool_list("[True,FALSE]").unwrap()
+        parse_bool_list("[True,FALSE]")
     );
 }
 
 #[test]
 fn test_parse_int_list_replace() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, EMPTY_INT_LIST)],
-        parse_int_list("[]").unwrap()
+        parse_int_list("[]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42])],
-        parse_int_list("[42]").unwrap()
+        parse_int_list("[42]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42, -127])],
-        parse_int_list("[42,-127]").unwrap()
+        parse_int_list("[42,-127]")
     );
 }
 
 #[test]
 fn test_parse_float_list_replace() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, EMPTY_FLOAT_LIST)],
-        parse_float_list("[]").unwrap()
+        parse_float_list("[]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [123456.78])],
-        parse_float_list("[123_456.78]").unwrap()
+        parse_float_list("[123_456.78]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42.0, -1.27e+7])],
-        parse_float_list("[42.0,-127.0e+5]").unwrap()
+        parse_float_list("[42.0,-127.0e+5]")
     );
 }
 
 #[test]
 fn test_parse_string_list_add() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, EMPTY_STRING_LIST)],
-        parse_string_list("+[]").unwrap()
+        parse_string_list("+[]")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_add() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Add, EMPTY_INT_LIST)],
-        parse_int_list("+[]").unwrap()
+        parse_int_list("+[]")
     );
 }
 
 #[test]
 fn test_parse_string_list_remove() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Remove, EMPTY_STRING_LIST)],
-        parse_string_list("-[]").unwrap()
+        parse_string_list("-[]")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_remove() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Remove, EMPTY_BOOL_LIST)],
-        parse_bool_list("-[]").unwrap()
+        parse_bool_list("-[]")
     );
 }
 
 #[test]
 fn test_parse_string_list_edits() {
-    assert_eq!(
+    check!(
         vec![
             string_list_edit(ListEditAction::Remove, ["foo", "bar"]),
             string_list_edit(ListEditAction::Add, ["baz"]),
             string_list_edit(ListEditAction::Remove, EMPTY_STRING_LIST),
         ],
-        parse_string_list("-['foo', 'bar'],+['baz'],-[]").unwrap()
+        parse_string_list("-['foo', 'bar'],+['baz'],-[]")
     );
 }
 
 #[test]
 fn test_parse_bool_list_edits() {
-    assert_eq!(
+    check!(
         vec![
             scalar_list_edit(ListEditAction::Remove, [true, false]),
             scalar_list_edit(ListEditAction::Add, [false]),
             scalar_list_edit(ListEditAction::Remove, EMPTY_BOOL_LIST),
         ],
-        parse_bool_list("-[True, FALSE],+[false],-[]").unwrap()
+        parse_bool_list("-[True, FALSE],+[false],-[]")
     );
 }
 
 #[test]
 fn test_parse_int_list_edits() {
-    assert_eq!(
+    check!(
         vec![
             scalar_list_edit(ListEditAction::Remove, [-3, 4]),
             scalar_list_edit(ListEditAction::Add, [42]),
             scalar_list_edit(ListEditAction::Remove, EMPTY_INT_LIST),
         ],
-        parse_int_list("-[-3, 4],+[42],-[]").unwrap()
+        parse_int_list("-[-3, 4],+[42],-[]")
     );
 }
 
 #[test]
 fn test_parse_float_list_edits() {
-    assert_eq!(
+    check!(
         vec![
             scalar_list_edit(ListEditAction::Remove, [-3.0, 4.1]),
             scalar_list_edit(ListEditAction::Add, [42.7]),
             scalar_list_edit(ListEditAction::Remove, EMPTY_FLOAT_LIST),
         ],
-        parse_float_list("-[-3.0, 4.1],+[42.7],-[]").unwrap()
+        parse_float_list("-[-3.0, 4.1],+[42.7],-[]")
     );
 }
 
 #[test]
 fn test_parse_string_list_edits_whitespace() {
-    assert_eq!(
+    check!(
         vec![
             string_list_edit(ListEditAction::Remove, ["foo"]),
             string_list_edit(ListEditAction::Add, ["bar"]),
         ],
-        parse_string_list(" - [ 'foo' , ] , + [ 'bar' ] ").unwrap()
+        parse_string_list(" - [ 'foo' , ] ,\n + [ 'bar' ] ")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_edits_whitespace() {
-    assert_eq!(
+    check!(
         vec![
             scalar_list_edit(ListEditAction::Remove, [42.0]),
             scalar_list_edit(ListEditAction::Add, [-127.1, 0.0]),
         ],
-        parse_float_list(" - [ 42.0 , ] , + [ -127.1  ,0. ] ").unwrap()
+        parse_float_list(" - [ 42.0 , ] , + [ -127.1  ,0. ] ")
     );
 }
 
 #[test]
 fn test_parse_string_list_implicit_add() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec!["foo"])],
-        parse_string_list("foo").unwrap()
+        parse_string_list("foo")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec!["foo bar"])],
-        parse_string_list("foo bar").unwrap()
+        parse_string_list("foo bar")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, ["--bar"])],
-        parse_string_list("--bar").unwrap()
+        parse_string_list("--bar")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_implicit_add() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Add, vec![true])],
-        parse_bool_list("True").unwrap()
+        parse_bool_list("True")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Add, vec![-127])],
-        parse_int_list("-127").unwrap()
+        parse_int_list("-127")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Add, vec![0.7])],
-        parse_float_list("0.7").unwrap()
+        parse_float_list("0.7")
     );
 }
 
 #[test]
 fn test_parse_string_list_quoted_chars() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec!["[]"])],
-        parse_string_list(r"\[]").unwrap(),
+        parse_string_list(r"\[]"),
         "Expected an implicit add of the literal string `[]` via an escaped opening `[`."
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec![" "])],
-        parse_string_list(r"\ ").unwrap(),
+        parse_string_list(r"\ "),
         "Expected an implicit add of the literal string ` `."
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec!["+"])],
-        parse_string_list(r"\+").unwrap(),
+        parse_string_list(r"\+"),
         "Expected an implicit add of the literal string `+`."
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Add, vec!["-"])],
-        parse_string_list(r"\-").unwrap(),
+        parse_string_list(r"\-"),
         "Expected an implicit add of the literal string `-`."
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(
             ListEditAction::Replace,
             vec!["'foo", r"\"]
         )],
-        parse_string_list(r"['\'foo', '\\']").unwrap()
+        parse_string_list(r"['\'foo', '\\']")
     );
 }
 
 #[test]
 fn test_parse_string_list_quote_forms() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo"])],
-        parse_string_list(r#"["foo"]"#).unwrap(),
+        parse_string_list(r#"["foo"]"#),
         "Expected double quotes to work."
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo", "bar"])],
-        parse_string_list(r#"["foo", 'bar']"#).unwrap(),
+        parse_string_list(r#"["foo", 'bar']"#),
         "Expected mixed quote forms to work."
     );
 }
 
 #[test]
 fn test_parse_string_list_trailing_comma() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo"])],
-        parse_string_list("['foo',]").unwrap()
+        parse_string_list("['foo',]")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo", "bar"])],
-        parse_string_list("['foo','bar',]").unwrap()
+        parse_string_list("['foo','bar',]")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_trailing_comma() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [false, true])],
-        parse_bool_list("[false,true,]").unwrap()
+        parse_bool_list("[false,true,]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42])],
-        parse_int_list("[42,]").unwrap()
+        parse_int_list("[42,]")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42.0, -127.1])],
-        parse_float_list("[42.0,-127.1,]").unwrap()
+        parse_float_list("[42.0,-127.1,]")
     );
 }
 
 #[test]
 fn test_parse_string_list_whitespace() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo"])],
-        parse_string_list(" [ 'foo' ] ").unwrap()
+        parse_string_list(" [ 'foo' ] ")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo", "bar"])],
-        parse_string_list(" [ 'foo' , 'bar' , ] ").unwrap()
+        parse_string_list(" [ 'foo' , 'bar' , ] ")
     );
 }
 
 #[test]
 fn test_parse_scalar_list_whitespace() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [true, false])],
-        parse_bool_list("  [  True,  False  ] ").unwrap()
+        parse_bool_list("  [  True,  False  ] ")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42])],
-        parse_int_list(" [ 42 ] ").unwrap()
+        parse_int_list(" [ 42 ] ")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42.0, -127.1])],
-        parse_float_list(" [ 42.0 , -127.1 , ] ").unwrap()
+        parse_float_list(" [ 42.0 , -127.1 , ] ")
     );
 }
 
 #[test]
 fn test_parse_string_list_tuple() {
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, EMPTY_STRING_LIST)],
-        parse_string_list("()").unwrap()
+        parse_string_list("()")
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo"])],
-        parse_string_list(r#"("foo")"#).unwrap()
+        parse_string_list(r#"("foo")"#)
     );
-    assert_eq!(
+    check!(
         vec![string_list_edit(ListEditAction::Replace, ["foo", "bar"])],
-        parse_string_list(r#" ('foo', "bar",)"#).unwrap()
+        parse_string_list(r#" ('foo', "bar",)"#)
     );
 }
 
 #[test]
 fn test_parse_scalar_list_tuple() {
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, EMPTY_INT_LIST)],
-        parse_int_list("()").unwrap()
+        parse_int_list("()")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [true])],
-        parse_bool_list("(True)").unwrap()
+        parse_bool_list("(True)")
     );
-    assert_eq!(
+    check!(
         vec![scalar_list_edit(ListEditAction::Replace, [42.0, -127.1])],
-        parse_float_list(r#" (42.0, -127.1,)"#).unwrap()
+        parse_float_list(r#" (42.0, -127.1,)"#)
     );
 }
 
@@ -481,4 +523,128 @@ or '-' indicating `remove` at line 2 column 10"
         expected_error_msg,
         parse_int_list(bad_input).unwrap_err().render("foo")
     )
+}
+
+fn mk_hashmap(items: &Vec<(&str, &str)>) -> HashMap<String, Val> {
+    HashMap::<_, _>::from_iter(
+        items
+            .iter()
+            .map(|(k, v)| (k.to_string(), Val::String(v.to_string()))),
+    )
+}
+
+fn mk_dict_edit(action: DictEditAction, items: &Vec<(&str, &str)>) -> DictEdit {
+    DictEdit {
+        action,
+        items: mk_hashmap(items),
+    }
+}
+
+#[test]
+fn test_parse_dict_empty() {
+    check!(
+        mk_dict_edit(DictEditAction::Replace, &vec![]),
+        parse_dict("{}")
+    );
+}
+
+#[test]
+fn test_parse_dict_simple() {
+    check!(
+        mk_dict_edit(
+            DictEditAction::Replace,
+            &vec![("foo", "bar"), ("baz", "qux")]
+        ),
+        parse_dict(r#"{'foo': "bar", "baz": 'qux'}"#)
+    );
+}
+
+#[test]
+fn test_parse_dict_add() {
+    check!(
+        mk_dict_edit(DictEditAction::Add, &vec![("foo", "bar"), ("baz", "qux")]),
+        parse_dict(r#"+{'foo': "bar", "baz": 'qux'}"#)
+    );
+}
+
+#[test]
+fn test_parse_dict_whitespace() {
+    check!(
+        mk_dict_edit(
+            DictEditAction::Replace,
+            &vec![("foo", "bar"), ("baz", "qux")]
+        ),
+        parse_dict(
+            r#" {  'foo' :'bar'  ,
+        'baz'  :    'qux'  }  "#
+        )
+    );
+}
+
+#[test]
+fn test_parse_dict_of_list_of_string() {
+    let mut expected = HashMap::<String, Val>::new();
+    expected.insert(
+        "foo".to_string(),
+        Val::List(vec![
+            Val::String("foo1".to_string()),
+            Val::String("foo2".to_string()),
+        ]),
+    );
+    expected.insert(
+        "bar".to_string(),
+        Val::List(vec![Val::String("bar1".to_string())]),
+    );
+    expected.insert("baz".to_string(), Val::List(vec![]));
+
+    check!(
+        DictEdit {
+            action: DictEditAction::Add,
+            items: expected
+        },
+        parse_dict(r#" +{'foo': ["foo1", 'foo2'], "bar" : ('bar1' ,), "baz": []} "#)
+    );
+}
+
+#[test]
+fn test_parse_heterogeneous_dict() {
+    let mut nested = HashMap::<String, Val>::new();
+    nested.insert("x".to_string(), Val::Float(3.14));
+    nested.insert(
+        "y".to_string(),
+        Val::List(vec![Val::String("y1".to_string())]),
+    );
+    let mut expected = HashMap::<String, Val>::new();
+    expected.insert(
+        "foo".to_string(),
+        Val::List(vec![Val::Int(42), Val::String("foo1".to_string())]),
+    );
+    expected.insert(
+        "bar".to_string(),
+        Val::List(vec![
+            Val::String("bar1".to_string()),
+            Val::Bool(true),
+            Val::List(vec![]),
+        ]),
+    );
+    expected.insert("baz".to_string(), Val::Dict(nested));
+
+    check!(
+        DictEdit {
+            action: DictEditAction::Replace,
+            items: expected
+        },
+        parse_dict(
+            r#"
+        {
+          "foo": [42, 'foo1'],
+          "bar" : ('bar1' , true, []),
+          'baz': {
+            'x': 3.14,
+            'y': ["y1",],
+          },
+        }
+        "#
+        )
+    );
 }


### PR DESCRIPTION
Dicts are more awkward than other option types, since
the Python options parser supports options whose type
is "dict of string to Any" (in practice, "Any" means bool,
float, int, string, nested list or nested dict). 

The values in those nested lists and dicts can even be
heterogeneous (although we only support string keys in
nested dicts). 

Adds a custom check! macro in the test, so that multiline
parse errors are displayed properly.