### PR TITLE
What's new in 2.19 (Cherry-pick of #20310)

### DIFF
--- a/src/python/pants/notes/2.19.x.md
+++ b/src/python/pants/notes/2.19.x.md
@@ -1,7 +1,168 @@
 # 2.19.x Release Series
 
+Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
+
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
 ## What's New
 
+### Highlights
+
+- Test retries for flaky Python tests.
+- Using the `parametrize` to set multiple fields at once when generating new groups of targets.
+- `buildx` support in the Docker backend.
+- New backends for running semgrep and openapi-format.
+
+Keep reading to see the details and what's also included.
+
+### Overall
+
+The `.pids/` internal directory is now under `.pants.d/` by default, rather that adjacent to it (this can be controlled via [the `[GLOBAL].pants_subprocessdir` option](https://www.pantsbuild.org/2.19/reference/global-options#pants_subprocessdir)).
+
+[The new `[system-binaries]` subsystem](https://www.pantsbuild.org/2.19/reference/subsystems/system-binaries) allows controlling where Pants searches for binaries like `bash`, `zip`, `tar` that is uses as part of normal operation. Set [the `system_binaries_paths`](https://www.pantsbuild.org/2.19/reference/subsystems/system-binaries#system_binary_paths) as appropriate, potentially using the `<PATH>` special value. This can also be set on specific [environments](https://www.pantsbuild.org/2.19/docs/using-pants/environments) using the `system_binaries_system_binary_paths` field.
+
+Additional features and fixes:
+
+- New versions of [the `get-pants.sh` script](https://www.pantsbuild.org/2.19/docs/getting-started/installing-pants) install to `~/.local/bin`, not `~/bin`.
+- Environment variables that aren't valid UTF-8 no longer cause Pants to crash (note, `PANTS_...` environment variables that Pants needs to read but aren't UTF-8 will be ignored).
+- Reference documentation for subsystem options includes how to set them in `pants.toml`, in addition to the environment variable and CLI arguments.
+- [Environments](https://www.pantsbuild.org/2.19/docs/using-pants/environments) are now more resilient to being (partially) defined via macros, although this is not recommended.
+- [Docker environments](https://www.pantsbuild.org/2.19/reference/targets/docker_environment) can now pull public images without credentials, and can now handle docker images without Python.
+- The `fix` goal now partitions files across multiple processes in a way that's more similar to the partitioning of the `lint` goal, which can work around some spurious linting failures.
+
+### BUILD files
+
+[The `parametrize` helper](https://www.pantsbuild.org/2.19/docs/using-pants/key-concepts/targets-and-build-files#field-default-values#parametrizing-targets) now supports parametrizing multiple fields together, in lock step. For instance:
+
+``` python
+# Creates two targets:
+#
+#    example:tests@parametrize=py2
+#    example:tests@parametrize=py3
+
+python_test(
+    name="tests",
+    source="tests.py",
+    **parametrize("py2", interpreter_constraints=["==2.7.*"], resolve="lock-a"),
+    **parametrize("py3", interpreter_constraints=[">=3.6,<3.7"], resolve="lock-b"),
+)
+```
+
+In addition, `parametrize` can now be used with a single value (`field=parametrize("for-consistency")`), and now works on target generations in more cases (particularly those with "plugin" fields).
+
+### Performance
+
+Some processes are run with more consistent "color" configuration which may result in more cache hits: Pytest, Helm unittest and shunit2 processes now always run with colored output enabled. If [`[GLOBAL].colors`](https://www.pantsbuild.org/2.19/reference/global-options#colors) is not enabled, Pants removes the coloring before displaying.
+
+### Remote caching/execution
+
+Large files that need to be stored to a remote cache are now streamed to it directly from disk, in a way that should reduce overhead and increase concurrency ([#19711](https://github.com/pantsbuild/pants/pull/19711)).
+
+The deprecation has expired for the `[GLOBAL].remote_store_chunk_upload_timeout_seconds` and `[GLOBAL].remote_cache_read_timeout_millis` options. Use [`[GLOBAL].remote_store_rpc_timeout_millis`](https://www.pantsbuild.org/2.19/reference/global-options#remote_store_rpc_timeout_millis) and [`[GLOBAL].remote_cache_rpc_timeout_millis`](https://www.pantsbuild.org/2.19/reference/global-options#remote_cache_rpc_timeout_millis) instead.
+
+### Backends
+
+#### Docker
+
+The [docker backend](https://www.pantsbuild.org/2.19/docs/docker) now has explicit support for using [`buildx` (and thus BuildKit)](https://github.com/docker/buildx#buildx), via [the new `use_buildx` option](https://www.pantsbuild.org/2.19/reference/subsystems/docker#use_buildx). This also allows adding few additional fields for [`docker_image` targets](https://www.pantsbuild.org/2.19/reference/targets/docker_image), for `buildx`-specific functionality:
+
+- [`cache_from` and `cache_to`](https://www.pantsbuild.org/2.19/docs/docker#external-cache-storage-backends) for using external cache storage backends
+- [`output`](https://www.pantsbuild.org/2.19/reference/targets/docker_image#output) to control how/where `buildx` outputs an image when running `pants package ::`
+
+#### JVM
+
+JVM lock-files are more reliable, handling [some cases](https://github.com/pantsbuild/pants/issues/20162) of Coursier not including dependencies when expected.
+
+Using [`shading_rules`](https://www.pantsbuild.org/2.19/reference/targets/deploy_jar#shading_rules) is now supported on `deploy_jar` targets defined in directories of the build root.
+
+##### Kotlin
+
+The Kotlin analyzer now runs using the Zulu JDK, to be able to run natively on Apple Silicon (arm64 macOS).
+
+##### Java
+
+Dependency inference for Java now supports code using recently added syntax like `sealed class` & `permits`, `switch` expressions and `yield`.
+
+##### Scala
+
+Scala 3 is now supported when using [the BSP in an IDE](https://www.pantsbuild.org/2.19/docs/java-and-scala#working-in-an-ide).
+
+#### OpenAPI
+
+[The new `pants.backend.experimental.openapi.lint.openapi_format` backend](https://www.pantsbuild.org/2.19/reference/subsystems/openapi-format) supports running [openapi-format](https://github.com/thim81/openapi-format) to format `openapi_...` targets.
+
+#### Protobuf
+
+[The `pants.backend.codegen.protobuf.python` backend](https://www.pantsbuild.org/2.19/docs/python/integrations/protobuf-and-grpc) now supports:
+
+- `protobuf_sources` targets that are part of multiple Python resolves, like `python_resolve=parametrize("first-resolve", "second-resolve")`.
+- `[python-infer].ambiguity_resolution = "by_source_root"` to infer dependencies without warnings or errors in more cases.
+
+Version 24.4 of [the `protoc` compiler](https://www.pantsbuild.org/2.19/reference/subsystems/protoc) is included as a known version (but is not the default). It can be selected by setting `[protoc].version = "24.4"`. This version has native support for Apple Silicon (arm64 macOS).
+
+[Buf (`pants.backend.codegen.protobuf.lint.buf`)](https://www.pantsbuild.org/2.19/reference/subsystems/buf) now correctly ignores `buf.work.yaml`, `buf.lock`, `buf.gen.lock` when running as a linter.
+
+#### Python
+
+**Deprecation**: Using the `platforms` field on `pex_binary` is now deprecated. It is not a recommended way to build for platforms other than the local one, as it is a lossy abbreviation of the target platform and often leads to binaries that don't work. To replace this, either [use `complete_platforms` to continue cross-compiling](https://www.pantsbuild.org/2.19/docs/python/overview/pex#setting-the-target-platforms-for-a-pex) or use [an environment matching the target platform](https://www.pantsbuild.org/2.19/docs/using-pants/environments).
+
+Python tests can now be [attempted multiple times](https://www.pantsbuild.org/2.19/docs/using-pants/using-pants-in-ci#tip-automatically-retry-failed-tests), if they fail. This can help with limiting the impact of flaky tests. For instance, to require tests to fail three times before the overall `pants test` goal fails, set [`[test].attempts_default = 3`](https://www.pantsbuild.org/2.19/reference/goals/test#attempts_default). In this case, a very flaky test might fail on the first and second runs but finally pass on the third run, and thus the overall Pants invocation would pass.
+
+Pants now uses version 2.1.148 of the PEX CLI by default, which includes support for Python 3.12. To use Python 3.12, you will need to set [`[python].pip_version`](https://www.pantsbuild.org/2.19/reference/subsystems/python#pip_version) to `23.2` or newer (or `latest`), and ensure all of your tools use resolves generated with this new version (Pants' built-in ones are not, yet).
+
+Python interpreters provided by ASDF are now searched by default, in addition those provided by pyenv and on the system `PATH`, by being included in the [`[python-bootstrap].search_path`](https://www.pantsbuild.org/2.19/reference/subsystems/python-bootstrap#search_path) option.
+
+Many more "groups" of PyPI dependencies have default module mappings that guide how an `import` statement in code matches particular `python_requirement`s. All packages from the `azure-...`, `django-...`, `google-cloud-...`, `opentelemetry-instrumentation-...`, `oslo-...` ecosystems are now matched to modules matching their usual conventions. In addition, packages starting with `python-...` now have that `python-` prefix removed by default: for instance, a package like `python-example-name` will be implicitly assumed to be imported like `import example_name`. [The value of any `module_mapping` field](https://www.pantsbuild.org/2.19/reference/targets/python_requirements#module_mapping) can thus be tweaked (hopefully simplified!).
+
+[The `[generate-lockfiles].diff` option](https://www.pantsbuild.org/2.19/reference/goals/generate-lockfiles#diff) is now `True` by default, so running `pants generate-lockfiles` now pretty-prints any differences in the dependencies and their versions.
+
+Additional features and fixes:
+
+- [Additional arguments](https://www.pantsbuild.org/2.19/reference/goals/repl#args) can be passed to the IPython REPL, like `pants repl --shell=ipython :: -- -i helloworld/main.py`.
+- Additional arguments can be passed to the underlying PEX invocations when building FaaS artifacts ([AWS Lambda](https://www.pantsbuild.org/2.19/docs/python/integrations/aws-lambda), [Google Cloud Functions](https://www.pantsbuild.org/2.19/docs/python/integrations/google-cloud-functions)) via the new [`pex3_venv_create_extra_args`](https://www.pantsbuild.org/2.19/reference/targets/python_aws_lambda_function#pex3_venv_create_extra_args) field. For instance, if  dependencies have packaged files in unexpected locations, passing  `pex3_venv_create_extra_args=["--collisions-ok"]` can side-step collision errors.
+- The [`pip_version`](https://www.pantsbuild.org/2.19/reference/subsystems/python#pip_version) field no longer restricts the values, and so allows more flexibility when upgrading the PEX CLI if it supports newer Pip versions.
+- Running tests or `pants run` a source file now make binaries provided by `python_requirement` available for execution as normal processes (for instance, using `subprocess.run(["name-of-binary", ...])`).
+- The `PATH` environment variable can now be set using [`[subprocess-environment].env_vars`](https://www.pantsbuild.org/2.19/reference/subsystems/subprocess-environment#env_vars)
+- Import statements within a `with contextlib.suppress(ImportError)` context are now weak, and so no longer warn if not provided by a dependency.
+- Computing an aggregate coverage sandbox report is now more reliable in the presence of name collisions in files created via code-generation (including `relocated_files`).
+- Pyright (`pants.backend.experimental.python.typecheck.pyright`) now runs with an appropriately initialised environment and so runs more reliably (especially in transient CI environments, where "named caches" might not be preserved).
+- [Ruff (`pants.backend.experimental.python.lint.ruff`)](https://www.pantsbuild.org/2.19/reference/subsystems/ruff) now properly respects any `exclude` configuration from `ruff.toml` or `pyproject.toml`.
+
+The following code has been removed, because deprecations have expired:
+
+- Support for building FaaS artifacts ([AWS Lambda](https://www.pantsbuild.org/2.19/docs/python/integrations/aws-lambda), [Google Cloud Functions](https://www.pantsbuild.org/2.19/docs/python/integrations/google-cloud-functions)) via Lambdex has been fully replaced with the new `zip` layout: remove the `[lambdex]` section and its `layout` setting from `pants.toml`.
+- Passing both `runtime` and `complete_platforms` to a FaaS target (`python_aws_lambda_function`, `python_google_cloud_function`) is now longer supported, as `complete_platforms` fully overrides `runtime`.
+- Dependency inference now only supports running with the new Rust-based parser. That is, the `[python-infer].use_rust_parser` option cannot be disabled and is now unnecessary.
+
+#### NEW: Semgrep
+
+[The new `pants.backend.experimental.tools.semgrep` backend](https://www.pantsbuild.org/2.19/reference/subsystems/semgrep) supports running [Semgrep](https://semgrep.dev) as a local linter on all files that Pants knows about (any target with a `source` or `sources` field). Configuration files are automatically discovered.
+
+#### Shell
+
+[The `experimental_test_shell_command` target](https://www.pantsbuild.org/2.19/reference/targets/experimental_test_shell_command) now obeys its `environment` field, and thus runs the command within the specified environment instead of the host.
+
+#### Terraform
+
+The `check` goal runs `terraform validate` on [`terraform_module`s targets](https://www.pantsbuild.org/2.19/reference/targets/terraform_module) by default, again. For modules for which this doesn't work and/or isn't desirable, use [the new `skip_terraform_validate` field](https://www.pantsbuild.org/2.19/reference/targets/terraform_module#skip_terraform_validate). (This restores the behaviour from Pants 2.17 and earlier, with the addition of the `skip` field, based on feedback about Pants 2.18.0 which switched to only validating `terraform_deployment`s.)
+
+[`terraform_deployment`'s `var_files` field](https://www.pantsbuild.org/2.19/reference/targets/terraform_deployment#var_files) now supports files in a different directory to the `root_module`.
+
+Transitive dependencies are now automatically included, in addition to direct dependencies.
+
+### Plugin API changes
+
+Processes, especially tests, can now be run with retries on failure using `ProcessWithRetries` ([#20378](https://github.com/pantsbuild/pants/issues/20378)). In addition, to support tests that have been retried multiple times, `TestResult.from_fallible_process_result` now accepts a tuple of multiple `FallibleProcessResult`s, instead of just one. ([#19760](https://github.com/pantsbuild/pants/pull/19760)).
+
+Some `@rule`s may now need to pass `canonical_name_suffix` in preparation for ["call by name"](https://github.com/pantsbuild/pants/issues/19730). ([#19755](https://github.com/pantsbuild/pants/pull/19755))
+
+The new `TransitivelyExcludeDependenciesRequest` can be used to emulate transitive excludes (`!!<address>`). ([#20080](https://github.com/pantsbuild/pants/pull/20080))
+
+The `TestResult.stdout` and `TestResult.stderr` fields are now removed, in favour of `stdout_bytes` and `stderr_bytes`. ([#19768](https://github.com/pantsbuild/pants/pull/19768))
 
 ## Full Changelog
 


### PR DESCRIPTION
This is the start of release notes/what's new in 2.19.

This involved:

1. taking the GitHub release descriptions up to 2.19.0rc4 and pasting them in
2. removing the PRs that were cherry picked back to 2.18.0 (but leaving ones cherry picked to 2.18.1 or newer)
3. turning the remainder into summaries grouped by backend/etc, as appropriate.

