### PR TITLE
upgrade PEX to 2.1.159

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -10,7 +10,7 @@ fasteners==0.16.3
 freezegun==1.2.1
 ijson==3.1.4
 packaging==21.3
-pex==2.1.156
+pex==2.1.159
 psutil==5.9.0
 # This should be compatible with pytest.py, although it can be looser so that we don't
 # over-constrain pantsbuild.pants.testutil

--- a/3rdparty/python/user_reqs.lock
+++ b/3rdparty/python/user_reqs.lock
@@ -22,7 +22,7 @@
 //     "mypy-typing-asserts==0.1.1",
 //     "node-semver==0.9.0",
 //     "packaging==21.3",
-//     "pex==2.1.156",
+//     "pex==2.1.159",
 //     "psutil==5.9.0",
 //     "pydevd-pycharm==203.5419.8",
 //     "pytest<7.1.0,>=6.2.4",
@@ -141,30 +141,31 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
-              "url": "https://files.pythonhosted.org/packages/f0/eb/fcb708c7bf5056045e9e98f62b93bd7467eb718b0202e7698eb11d66416c/attrs-23.1.0-py3-none-any.whl"
+              "hash": "99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1",
+              "url": "https://files.pythonhosted.org/packages/e0/44/827b2a91a5816512fcaf3cc4ebc465ccd5d598c45cefa6703fcf4a79018f/attrs-23.2.0-py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015",
-              "url": "https://files.pythonhosted.org/packages/97/90/81f95d5f705be17872843536b1868f351805acf6971251ff07c1b8334dbb/attrs-23.1.0.tar.gz"
+              "hash": "935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
+              "url": "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz"
             }
           ],
           "project_name": "attrs",
           "requires_dists": [
-            "attrs[docs,tests]; extra == \"dev\"",
+            "attrs[tests-mypy]; extra == \"tests-no-zope\"",
             "attrs[tests-no-zope]; extra == \"tests\"",
             "attrs[tests]; extra == \"cov\"",
+            "attrs[tests]; extra == \"dev\"",
             "cloudpickle; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
             "coverage[toml]>=5.3; extra == \"cov\"",
             "furo; extra == \"docs\"",
             "hypothesis; extra == \"tests-no-zope\"",
             "importlib-metadata; python_version < \"3.8\"",
-            "mypy>=1.1.1; platform_python_implementation == \"CPython\" and extra == \"tests-no-zope\"",
+            "mypy>=1.6; (platform_python_implementation == \"CPython\" and python_version >= \"3.8\") and extra == \"tests-mypy\"",
             "myst-parser; extra == \"docs\"",
             "pre-commit; extra == \"dev\"",
             "pympler; extra == \"tests-no-zope\"",
-            "pytest-mypy-plugins; platform_python_implementation == \"CPython\" and python_version < \"3.11\" and extra == \"tests-no-zope\"",
+            "pytest-mypy-plugins; (platform_python_implementation == \"CPython\" and python_version >= \"3.8\") and extra == \"tests-mypy\"",
             "pytest-xdist[psutil]; extra == \"tests-no-zope\"",
             "pytest>=4.3.0; extra == \"tests-no-zope\"",
             "sphinx-notfound-page; extra == \"docs\"",
@@ -175,7 +176,7 @@
             "zope-interface; extra == \"tests\""
           ],
           "requires_python": ">=3.7",
-          "version": "23.1.0"
+          "version": "23.2.0"
         },
         {
           "artifacts": [
@@ -909,21 +910,21 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "e7c00fe6f12f6b2ed57ab8e55c4d422647b30e25a4a275cfbc3d3b0bc26e774a",
-              "url": "https://files.pythonhosted.org/packages/f6/88/bbee170b731c326ec90fc79ad13d10f834be56b0b449affa2b1855ee026d/pex-2.1.156-py2.py3-none-any.whl"
+              "hash": "7cc37a64706bf111ee9d0485044026beffe51f500c4fe044fb69c4adcbcd608f",
+              "url": "https://files.pythonhosted.org/packages/5d/3d/f8d2919aa4afa8beaac731078b76ece5d5fbb8db41477f50db7c2c1afb36/pex-2.1.159-py2.py3-none-any.whl"
             },
             {
               "algorithm": "sha256",
-              "hash": "542ecb457c21f5ae8fa749894098e1c54e8639628efee70ece7f89da602aa4c2",
-              "url": "https://files.pythonhosted.org/packages/92/2c/75759b0c4f8a909014f7a78be7e1ea237354b2b8b94c7475408e5038299a/pex-2.1.156.tar.gz"
+              "hash": "8419707f24353db0fa0320acadadb2670b74c7cfa21ad0e2b14f5ca134894592",
+              "url": "https://files.pythonhosted.org/packages/76/3c/84ecba3102885f739dfdcb858324bc9e76be40a5e4fb65e0279297661482/pex-2.1.159.tar.gz"
             }
           ],
           "project_name": "pex",
           "requires_dists": [
-            "subprocess32>=3.2.7; extra == \"subprocess\" and python_version < \"3\""
+            "subprocess32>=3.2.7; python_version < \"3\" and extra == \"subprocess\""
           ],
           "requires_python": "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,<3.13,>=2.7",
-          "version": "2.1.156"
+          "version": "2.1.159"
         },
         {
           "artifacts": [
@@ -2229,7 +2230,7 @@
     "mypy-typing-asserts==0.1.1",
     "node-semver==0.9.0",
     "packaging==21.3",
-    "pex==2.1.156",
+    "pex==2.1.159",
     "psutil==5.9.0",
     "pydevd-pycharm==203.5419.8",
     "pytest<7.1.0,>=6.2.4",

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -35,7 +35,7 @@ class PexCli(TemplatedExternalTool):
     name = "pex"
     help = "The PEX (Python EXecutable) tool (https://github.com/pantsbuild/pex)."
 
-    default_version = "v2.1.156"
+    default_version = "v2.1.159"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
     version_constraints = ">=2.1.135,<3.0"
 
@@ -46,8 +46,8 @@ class PexCli(TemplatedExternalTool):
                 (
                     cls.default_version,
                     plat,
-                    "b606aefcc5da71b16fd483ecf2114703332fb85e279825afdae45c05c975974b",
-                    "3666831",
+                    "83c3090938b4d276703864c34ba50bcb3616db0663c54b56dd0521a668d9555f",
+                    "3671772",
                 )
             )
             for plat in ["macos_arm64", "macos_x86_64", "linux_x86_64", "linux_arm64"]


### PR DESCRIPTION
Changelogs:
 * https://github.com/pantsbuild/pex/releases/tag/v2.1.157
 * https://github.com/pantsbuild/pex/releases/tag/v2.1.158
 * https://github.com/pantsbuild/pex/releases/tag/v2.1.159

```
Lockfile diff: 3rdparty/python/user_reqs.lock [python-default]

==                    Upgraded dependencies                     ==

  attrs                          23.1.0       -->   23.2.0
  pex                            2.1.156      -->   2.1.159
```

Enables repl tab completion for #20389
Fixes a bug with `pex3 lock update` of relevance for #15704