### PR TITLE
Extend dependencies goal with output format to support JSON

### DIFF
--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -1,13 +1,15 @@
 # Copyright 2019 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-
+import dataclasses
 import itertools
+import json
+from enum import Enum
 
 from pants.engine.addresses import Addresses
 from pants.engine.console import Console
 from pants.engine.goal import Goal, GoalSubsystem, LineOriented
 from pants.engine.rules import Get, MultiGet, collect_rules, goal_rule
-from pants.engine.target import AlwaysTraverseDeps
+from pants.engine.target import AlwaysTraverseDeps, Target
 from pants.engine.target import Dependencies as DependenciesField
 from pants.engine.target import (
     DependenciesRequest,
@@ -16,7 +18,18 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
     UnexpandedTargets,
 )
-from pants.option.option_types import BoolOption
+from pants.option.option_types import BoolOption, EnumOption
+
+
+class DependenciesOutputFormat(Enum):
+    """Output format for listing dependencies.
+
+    merged: List all dependencies as a single list of targets.
+    json: List all dependencies as a mapping `{target: [dependencies]}`.
+    """
+
+    merged = "merged"
+    json = "json"
 
 
 class DependenciesSubsystem(LineOriented, GoalSubsystem):
@@ -31,50 +44,80 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
         default=False,
         help="Include the input targets in the output, along with the dependencies.",
     )
+    format = EnumOption(
+        default=DependenciesOutputFormat.merged,
+        help="Output format for listing dependencies.",
+    )
 
 
 class Dependencies(Goal):
     subsystem_cls = DependenciesSubsystem
     environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
+@dataclasses.dataclass
+class TargetToDependencies:
+    target: Target
+    dependencies: Targets
+
 
 @goal_rule
 async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
-    if dependencies_subsystem.transitive:
-        transitive_targets = await Get(
-            TransitiveTargets,
-            TransitiveTargetsRequest(
-                addresses, should_traverse_deps_predicate=AlwaysTraverseDeps()
-            ),
-        )
-        targets = Targets(transitive_targets.dependencies)
-    else:
-        # NB: We must preserve target generators for the roots, i.e. not replace with their
-        # generated targets.
-        target_roots = await Get(UnexpandedTargets, Addresses, addresses)
-        # NB: When determining dependencies, though, we replace target generators with their
-        # generated targets.
-        dependencies_per_target_root = await MultiGet(
-            Get(
+    # NB: We must preserve target generators for the roots, i.e. not replace with their
+    # generated targets.
+    target_roots = await Get(UnexpandedTargets, Addresses, addresses)
+    # NB: When determining dependencies, though, we replace target generators with their
+    # generated targets.
+
+    if dependencies_subsystem.format == DependenciesOutputFormat.json:
+        mapping = {}
+        for tgt in target_roots:
+            targets = await Get(
                 Targets,
                 DependenciesRequest(
                     tgt.get(DependenciesField),
                     should_traverse_deps_predicate=AlwaysTraverseDeps(),
                 ),
             )
-            for tgt in target_roots
-        )
-        targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
+            mapping[str(tgt.address)] = [str(t.address) for t in targets]
+        output = json.dumps(mapping, indent=4)
+        console.print_stdout(output)
 
-    address_strings = {addr.spec for addr in addresses} if dependencies_subsystem.closed else set()
-    for tgt in targets:
-        address_strings.add(tgt.address.spec)
+    if dependencies_subsystem.format == DependenciesOutputFormat.merged:
+        if dependencies_subsystem.transitive:
+            transitive_targets = await Get(
+                TransitiveTargets,
+                TransitiveTargetsRequest(
+                    addresses, should_traverse_deps_predicate=AlwaysTraverseDeps()
+                ),
+            )
+            targets = Targets(transitive_targets.dependencies)
+        else:
+            # NB: We must preserve target generators for the roots, i.e. not replace with their
+            # generated targets.
+            target_roots = await Get(UnexpandedTargets, Addresses, addresses)
+            # NB: When determining dependencies, though, we replace target generators with their
+            # generated targets.
+            dependencies_per_target_root = await MultiGet(
+                Get(
+                    Targets,
+                    DependenciesRequest(
+                        tgt.get(DependenciesField),
+                        should_traverse_deps_predicate=AlwaysTraverseDeps(),
+                    ),
+                )
+                for tgt in target_roots
+            )
+            targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
 
-    with dependencies_subsystem.line_oriented(console) as print_stdout:
-        for address in sorted(address_strings):
-            print_stdout(address)
+        address_strings = {addr.spec for addr in addresses} if dependencies_subsystem.closed else set()
+        for tgt in targets:
+            address_strings.add(tgt.address.spec)
+
+        with dependencies_subsystem.line_oriented(console) as print_stdout:
+            for address in sorted(address_strings):
+                print_stdout(address)
 
     return Dependencies(exit_code=0)
 

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 import itertools
 import json
-from dataclasses import dataclass
 from enum import Enum
 
 from pants.engine.addresses import Addresses
@@ -13,7 +12,6 @@ from pants.engine.target import AlwaysTraverseDeps
 from pants.engine.target import Dependencies as DependenciesField
 from pants.engine.target import (
     DependenciesRequest,
-    Target,
     Targets,
     TransitiveTargets,
     TransitiveTargetsRequest,
@@ -56,104 +54,115 @@ class Dependencies(Goal):
     environment_behavior = Goal.EnvironmentBehavior.LOCAL_ONLY
 
 
-@dataclass
-class TargetToDependencies:
-    target: Target
-    dependencies: Targets
+async def list_dependencies_as_json(
+    addresses: Addresses, dependencies_subsystem: DependenciesSubsystem, console: Console
+) -> None:
+    """Get dependencies for given addresses and list them in the console in JSON.
+
+    Note that `--closed` option is ignored as it doesn't make sense to duplicate source address in
+    the list of its dependencies.
+    """
+    # NB: We must preserve target generators for the roots, i.e. not replace with their
+    # generated targets.
+    target_roots = await Get(UnexpandedTargets, Addresses, addresses)
+    # NB: When determining dependencies, though, we replace target generators with their
+    # generated targets.
+    if dependencies_subsystem.transitive:
+        transitive_targets_group = await MultiGet(
+            Get(
+                TransitiveTargets,
+                TransitiveTargetsRequest(
+                    (address,), should_traverse_deps_predicate=AlwaysTraverseDeps()
+                ),
+            )
+            for address in addresses
+        )
+
+        iterated_targets = []
+        for transitive_targets in transitive_targets_group:
+            iterated_targets.append(
+                sorted([str(tgt.address) for tgt in transitive_targets.dependencies])
+            )
+
+    else:
+        dependencies_per_target_root = await MultiGet(
+            Get(
+                Targets,
+                DependenciesRequest(
+                    tgt.get(DependenciesField),
+                    should_traverse_deps_predicate=AlwaysTraverseDeps(),
+                ),
+            )
+            for tgt in target_roots
+        )
+
+        iterated_targets = []
+        for targets in dependencies_per_target_root:
+            iterated_targets.append(sorted([str(tgt.address) for tgt in targets]))
+
+    # the assumption is that when iterating the targets and sending dependency requests
+    # for them, the lists of dependencies are returned in the very same order
+    mapping = dict(zip([str(tgt.address) for tgt in target_roots], iterated_targets))
+    output = json.dumps(mapping, indent=4)
+    console.print_stdout(output)
 
 
-@dataclass
-class TargetsToDirectDependencies:
-    mapping: Addresses
-    dependencies: list[str]
+async def list_dependencies_as_merged(
+    addresses: Addresses, dependencies_subsystem: DependenciesSubsystem, console: Console
+) -> None:
+    """Get dependencies for given addresses and list them in the console as a single list."""
+    if dependencies_subsystem.transitive:
+        transitive_targets = await Get(
+            TransitiveTargets,
+            TransitiveTargetsRequest(
+                addresses, should_traverse_deps_predicate=AlwaysTraverseDeps()
+            ),
+        )
+        targets = Targets(transitive_targets.dependencies)
+    else:
+        # NB: We must preserve target generators for the roots, i.e. not replace with their
+        # generated targets.
+        target_roots = await Get(UnexpandedTargets, Addresses, addresses)
+        # NB: When determining dependencies, though, we replace target generators with their
+        # generated targets.
+        dependencies_per_target_root = await MultiGet(
+            Get(
+                Targets,
+                DependenciesRequest(
+                    tgt.get(DependenciesField),
+                    should_traverse_deps_predicate=AlwaysTraverseDeps(),
+                ),
+            )
+            for tgt in target_roots
+        )
+        targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
+
+    address_strings = {addr.spec for addr in addresses} if dependencies_subsystem.closed else set()
+    for tgt in targets:
+        address_strings.add(tgt.address.spec)
+
+    with dependencies_subsystem.line_oriented(console) as print_stdout:
+        for address in sorted(address_strings):
+            print_stdout(address)
 
 
 @goal_rule
 async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
-    # NB: We must preserve target generators for the roots, i.e. not replace with their
-    # generated targets.
-    target_roots = await Get(UnexpandedTargets, Addresses, addresses)
-    # NB: When determining dependencies, though, we replace target generators with their
-    # generated targets.
-
-    if dependencies_subsystem.format == DependenciesOutputFormat.json:
-        if dependencies_subsystem.transitive:
-            transitive_targets_group = await MultiGet(
-                Get(
-                    TransitiveTargets,
-                    TransitiveTargetsRequest(
-                        (address,), should_traverse_deps_predicate=AlwaysTraverseDeps()
-                    ),
-                )
-                for address in addresses
-            )
-
-            iterated_targets = []
-            for transitive_targets in transitive_targets_group:
-                iterated_targets.append(
-                    sorted([str(tgt.address) for tgt in transitive_targets.dependencies])
-                )
-
-        else:  # dependencies_subsystem.direct
-            dependencies_per_target_root = await MultiGet(
-                Get(
-                    Targets,
-                    DependenciesRequest(
-                        tgt.get(DependenciesField),
-                        should_traverse_deps_predicate=AlwaysTraverseDeps(),
-                    ),
-                )
-                for tgt in target_roots
-            )
-
-            iterated_targets = []
-            for targets in dependencies_per_target_root:
-                iterated_targets.append(sorted([str(tgt.address) for tgt in targets]))
-
-        # the assumption is that when iterating the targets and sending dependency requests
-        # for them, the lists of dependencies are returned in the very same order
-        mapping = dict(zip([str(tgt.address) for tgt in target_roots], iterated_targets))
-        output = json.dumps(mapping, indent=4)
-        console.print_stdout(output)
-
     if dependencies_subsystem.format == DependenciesOutputFormat.merged:
-        if dependencies_subsystem.transitive:
-            transitive_targets = await Get(
-                TransitiveTargets,
-                TransitiveTargetsRequest(
-                    addresses, should_traverse_deps_predicate=AlwaysTraverseDeps()
-                ),
-            )
-            targets = Targets(transitive_targets.dependencies)
-        else:
-            # NB: We must preserve target generators for the roots, i.e. not replace with their
-            # generated targets.
-            target_roots = await Get(UnexpandedTargets, Addresses, addresses)
-            # NB: When determining dependencies, though, we replace target generators with their
-            # generated targets.
-            dependencies_per_target_root = await MultiGet(
-                Get(
-                    Targets,
-                    DependenciesRequest(
-                        tgt.get(DependenciesField),
-                        should_traverse_deps_predicate=AlwaysTraverseDeps(),
-                    ),
-                )
-                for tgt in target_roots
-            )
-            targets = Targets(itertools.chain.from_iterable(dependencies_per_target_root))
-
-        address_strings = (
-            {addr.spec for addr in addresses} if dependencies_subsystem.closed else set()
+        await list_dependencies_as_merged(
+            addresses=addresses,
+            dependencies_subsystem=dependencies_subsystem,
+            console=console,
         )
-        for tgt in targets:
-            address_strings.add(tgt.address.spec)
 
-        with dependencies_subsystem.line_oriented(console) as print_stdout:
-            for address in sorted(address_strings):
-                print_stdout(address)
+    elif dependencies_subsystem.format == DependenciesOutputFormat.json:
+        await list_dependencies_as_json(
+            addresses=addresses,
+            dependencies_subsystem=dependencies_subsystem,
+            console=console,
+        )
 
     return Dependencies(exit_code=0)
 

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -42,7 +42,7 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
     closed = BoolOption(
         default=False,
         help="Include the input targets in the output, along with the dependencies. This option "
-        "is ignored when listing dependencies in any format other than plain text.",
+        "only applies when using the `text` format.",
     )
     format = EnumOption(
         default=DependenciesOutputFormat.text,
@@ -101,8 +101,8 @@ async def list_dependencies_as_json(
         for targets in dependencies_per_target_root:
             iterated_targets.append(sorted([str(tgt.address) for tgt in targets]))
 
-    # the assumption is that when iterating the targets and sending dependency requests
-    # for them, the lists of dependencies are returned in the very same order
+    # The assumption is that when iterating the targets and sending dependency requests
+    # for them, the lists of dependencies are returned in the very same order.
     mapping = dict(zip([str(tgt.address) for tgt in target_roots], iterated_targets))
     output = json.dumps(mapping, indent=4)
     console.print_stdout(output)

--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -23,11 +23,11 @@ from pants.option.option_types import BoolOption, EnumOption
 class DependenciesOutputFormat(Enum):
     """Output format for listing dependencies.
 
-    merged: List all dependencies as a single list of targets.
+    text: List all dependencies as a single list of targets in plain text.
     json: List all dependencies as a mapping `{target: [dependencies]}`.
     """
 
-    merged = "merged"
+    text = "text"
     json = "json"
 
 
@@ -41,10 +41,11 @@ class DependenciesSubsystem(LineOriented, GoalSubsystem):
     )
     closed = BoolOption(
         default=False,
-        help="Include the input targets in the output, along with the dependencies.",
+        help="Include the input targets in the output, along with the dependencies. This option "
+        "is ignored when listing dependencies in any format other than plain text.",
     )
     format = EnumOption(
-        default=DependenciesOutputFormat.merged,
+        default=DependenciesOutputFormat.text,
         help="Output format for listing dependencies.",
     )
 
@@ -107,7 +108,7 @@ async def list_dependencies_as_json(
     console.print_stdout(output)
 
 
-async def list_dependencies_as_merged(
+async def list_dependencies_as_plain_text(
     addresses: Addresses, dependencies_subsystem: DependenciesSubsystem, console: Console
 ) -> None:
     """Get dependencies for given addresses and list them in the console as a single list."""
@@ -150,14 +151,14 @@ async def list_dependencies_as_merged(
 async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
-    if dependencies_subsystem.format == DependenciesOutputFormat.merged:
-        await list_dependencies_as_merged(
+    if DependenciesOutputFormat.text == dependencies_subsystem.format:
+        await list_dependencies_as_plain_text(
             addresses=addresses,
             dependencies_subsystem=dependencies_subsystem,
             console=console,
         )
 
-    elif dependencies_subsystem.format == DependenciesOutputFormat.json:
+    elif DependenciesOutputFormat.json == dependencies_subsystem.format:
         await list_dependencies_as_json(
             addresses=addresses,
             dependencies_subsystem=dependencies_subsystem,

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -72,7 +72,7 @@ def assert_dependencies(
     expected: List[str],
     transitive: bool = False,
     closed: bool = False,
-    output_format: DependenciesOutputFormat = DependenciesOutputFormat.merged,
+    output_format: DependenciesOutputFormat = DependenciesOutputFormat.text,
 ) -> None:
     args = []
     if transitive:
@@ -84,7 +84,7 @@ def assert_dependencies(
     result = rule_runner.run_goal_rule(
         Dependencies, args=[*args, *specs], env_inherit={"PATH", "PYENV_ROOT", "HOME"}
     )
-    if output_format == DependenciesOutputFormat.merged:
+    if output_format == DependenciesOutputFormat.text:
         assert result.stdout.splitlines() == expected
     elif output_format == DependenciesOutputFormat.json:
         assert json.loads(result.stdout) == expected


### PR DESCRIPTION
Add `--format` option to the `dependencies` goal to be able to emit dependencies in JSON format (think adjacency list). See [Exporting project's dependency graph](https://github.com/pantsbuild/pants/discussions/20242) to learn about the use cases.

Usage:

```
$ pants dependencies --format=json src/python/pants/backend/project_info/dependencies_test.py src/python/pants/backend/project_info/list_roots_test.py
{
    "src/python/pants/backend/project_info/dependencies_test.py:tests": [
        "//conftest.py:test_utils",
        "3rdparty/python#pytest",
        "src/python/pants/__init__.py",
        "src/python/pants/backend/project_info/dependencies.py",
        "src/python/pants/backend/python/target_types.py",
        "src/python/pants/backend/python/target_types_rules.py",
        "src/python/pants/conftest.py:test_utils",
        "src/python/pants/engine/target.py",
        "src/python/pants/testutil/python_rule_runner.py"
    ],
    "src/python/pants/backend/project_info/list_roots_test.py:tests": [
        "//conftest.py:test_utils",
        "3rdparty/python#pytest",
        "src/python/pants/__init__.py",
        "src/python/pants/backend/project_info/list_roots.py",
        "src/python/pants/conftest.py:test_utils",
        "src/python/pants/testutil/rule_runner.py"
    ]
}
```

Adding correspondent functionality for the `dependents` goal is going to be done in a separate PR.