### PR TITLE
Mention the Scala repl and its current gotchas in the docs

### DIFF
--- a/docs/docs/java-and-scala/index.mdx
+++ b/docs/docs/java-and-scala/index.mdx
@@ -259,7 +259,7 @@ junit_tests(
 ## Repl
 
 Pants supports the [Scala repl](https://docs.scala-lang.org/overviews/scala-book/scala-repl.html), but
-doesn't autodetect it based on the active backend, it always defaults to using "python"
+doesn't yet autodetect it based on the active backend, it always defaults to using "python"
 (see [#14133](https://github.com/pantsbuild/pants/issues/14133)), so you'll have to
 explicitly add `--repl-shell=scala` to the command line:
 

--- a/docs/docs/java-and-scala/index.mdx
+++ b/docs/docs/java-and-scala/index.mdx
@@ -256,6 +256,31 @@ junit_tests(
 )
 ```
 
+## Repl
+
+Pants supports the [Scala repl](https://docs.scala-lang.org/overviews/scala-book/scala-repl.html), but
+doesn't autodetect it based on the active backend, it always defaults to using "python"
+(see [#14133](https://github.com/pantsbuild/pants/issues/14133)), so you'll have to
+explicitly add `--repl-shell=scala` to the command line:
+
+```
+❯ pants repl --repl-shell=scala src/jvm/org/pantsbuild/example/app/ExampleApp.scala
+Welcome to Scala 2.13.8 (OpenJDK 64-Bit Server VM, Java 11.0.21).
+Type in expressions for evaluation. Or try :help.
+
+scala> import org.pantsbuild.example.app.ExampleApp
+scala> ExampleApp.main(Array())
+Hello World!
+scala>
+```
+
+Alternatively, you can set "scala" to be the default repl in `pants.toml`:
+
+```toml tab={"label":"pants.toml"}
+[repl]
+shell = "scala"
+```
+
 ## Protobuf
 
 There's support for [ScalaPB](https://scalapb.github.io/) and [protoc Java generated code](https://developers.google.com/protocol-buffers/docs/reference/java-generated), currently in beta stage. To enable them, activate the relevant backends in `pants.toml`:

--- a/docs/docs/java-and-scala/index.mdx
+++ b/docs/docs/java-and-scala/index.mdx
@@ -260,7 +260,7 @@ junit_tests(
 
 Pants supports the [Scala repl](https://docs.scala-lang.org/overviews/scala-book/scala-repl.html), but
 doesn't yet autodetect it based on the active backend, it always defaults to using "python"
-(see [#14133](https://github.com/pantsbuild/pants/issues/14133)), so you'll have to
+(see [#14133](https://github.com/pantsbuild/pants/issues/14133)), so for now you'll have to
 explicitly add `--repl-shell=scala` to the command line:
 
 ```


### PR DESCRIPTION
The Scala repl isn't currently mentioned at all in the docs, and needs some extra command line option to be used.

https://pantsbuild.slack.com/archives/C046T6T9U/p1705672565883029