### PR TITLE
Methods to return dict and scalar lists in OptionParser.

### DIFF
--- a/src/rust/engine/client/src/client_tests.rs
+++ b/src/rust/engine/client/src/client_tests.rs
@@ -33,11 +33,12 @@ async fn test_client_fingerprint_mismatch() {
     // Then connect with a different set of options (but with a matching `pants_subprocessdir`, so
     // that we find the relevant `.pants.d/pids` directory).
     let options_parser = OptionParser::new(
-        Env::new(HashMap::new()),
         Args::new(vec![format!(
             "--pants-subprocessdir={}",
             tmpdir.path().display()
         )]),
+        Env::new(HashMap::new()),
+        None,
         true,
     )
     .unwrap();

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -32,7 +32,7 @@ async fn execute(start: SystemTime) -> Result<i32, String> {
     let (env, dropped) = Env::capture_lossy();
     let env_items = (&env).into();
     let argv = env::args().collect::<Vec<_>>();
-    let options_parser = OptionParser::new(env, Args::argv(), true)?;
+    let options_parser = OptionParser::new(Args::argv(), env, None, true)?;
 
     let use_pantsd = options_parser.parse_bool(&option_id!("pantsd"), true)?;
     if !use_pantsd.value {

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -429,10 +429,12 @@ impl OptionParser {
     ) -> Result<HashMap<String, Val>, String> {
         let mut dict = default;
         for (_, source) in self.sources.iter().rev() {
-            if let Some(dict_edit) = source.get_dict(id)? {
-                match dict_edit.action {
-                    DictEditAction::Replace => dict = dict_edit.items,
-                    DictEditAction::Add => dict.extend(dict_edit.items),
+            if let Some(dict_edits) = source.get_dict(id)? {
+                for dict_edit in dict_edits {
+                    match dict_edit.action {
+                        DictEditAction::Replace => dict = dict_edit.items,
+                        DictEditAction::Add => dict.extend(dict_edit.items),
+                    }
                 }
             }
         }

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -1,0 +1,169 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use crate::{option_id, Args, Env, OptionParser};
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Write;
+use tempfile::TempDir;
+
+fn with_setup(
+    args: Vec<&'static str>,
+    env: Vec<(&'static str, &'static str)>,
+    config: &'static str,
+    extra_config: &'static str,
+    do_check: impl Fn(OptionParser),
+) {
+    let buildroot = TempDir::new().unwrap();
+    let config_path = buildroot.path().join("pants.toml");
+    File::create(&config_path)
+        .unwrap()
+        .write_all(config.as_bytes())
+        .unwrap();
+    let extra_config_path = buildroot.path().join("pants_extra.toml");
+    File::create(&extra_config_path)
+        .unwrap()
+        .write_all(extra_config.as_bytes())
+        .unwrap();
+    let config_file_arg = vec![format!(
+        "--pants-config-files={}",
+        extra_config_path.to_str().unwrap()
+    )];
+
+    let option_parser = OptionParser::new(
+        Args {
+            args: config_file_arg
+                .into_iter()
+                .chain(args.into_iter().map(str::to_string))
+                .collect(),
+        },
+        Env {
+            env: env
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect::<HashMap<_, _>>(),
+        },
+        Some(vec![
+            config_path.to_str().unwrap(),
+            extra_config_path.to_str().unwrap(),
+        ]),
+        false,
+    )
+    .unwrap();
+    do_check(option_parser);
+}
+
+#[test]
+fn test_parse_single_valued_options() {
+    fn check(
+        expected: i64,
+        args: Vec<&'static str>,
+        env: Vec<(&'static str, &'static str)>,
+        config: &'static str,
+    ) {
+        with_setup(args, env, config, "", |option_parser| {
+            let id = option_id!(["scope"], "foo");
+            assert_eq!(expected, option_parser.parse_int(&id, 0).unwrap().value);
+        });
+    }
+
+    check(
+        3,
+        vec!["--scope-foo=3"],
+        vec![("PANTS_SCOPE_FOO", "2")],
+        "[scope]\nfoo = 1",
+    );
+    check(3, vec!["--scope-foo=3"], vec![("PANTS_SCOPE_FOO", "2")], "");
+    check(3, vec!["--scope-foo=3"], vec![], "[scope]\nfoo = 1");
+    check(
+        2,
+        vec![],
+        vec![("PANTS_SCOPE_FOO", "2")],
+        "[scope]\nfoo = 1",
+    );
+    check(2, vec![], vec![("PANTS_SCOPE_FOO", "2")], "");
+    check(1, vec![], vec![], "[scope]\nfoo = 1");
+    check(0, vec![], vec![], "");
+}
+
+#[test]
+fn test_parse_list_options() {
+    fn check(
+        expected: Vec<i64>,
+        args: Vec<&'static str>,
+        env: Vec<(&'static str, &'static str)>,
+        config: &'static str,
+        extra_config: &'static str,
+    ) {
+        with_setup(args, env, config, extra_config, |option_parser| {
+            let id = option_id!(["scope"], "foo");
+            assert_eq!(expected, option_parser.parse_int_list(&id, &[0]).unwrap());
+        });
+    }
+
+    check(
+        vec![0, 1, 2, 3, 4, 5, 6, 7],
+        vec!["--scope-foo=+[5, 6, 7]"],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "[scope]\nfoo.add = [1, 2]",
+        "",
+    );
+
+    check(
+        vec![1, 2, 3, 4, 5, 6, 7],
+        vec!["--scope-foo=+[5, 6, 7]"],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "[scope]\nfoo = [1, 2]",
+        "",
+    );
+
+    check(
+        vec![3, 4, 5, 6, 7],
+        vec!["--scope-foo=+[5, 6, 7]"],
+        vec![("PANTS_SCOPE_FOO", "[3, 4]")],
+        "[scope]\nfoo.add = [1, 2]",
+        "",
+    );
+
+    check(
+        vec![5, 6, 7],
+        vec!["--scope-foo=[5, 6, 7]"],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "[scope]\nfoo.add = [1, 2]",
+        "",
+    );
+
+    check(
+        vec![0, 1, 2, 11, 22, 3, 4],
+        vec![],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "[scope]\nfoo = \"+[1, 2]\"",
+        "[scope]\nfoo = \"+[11, 22]\"",
+    );
+
+    check(
+        vec![1, 2, 3, 4],
+        vec![],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "[scope]\nfoo = [1, 2]",
+        "",
+    );
+
+    check(
+        vec![0, 3, 4],
+        vec![],
+        vec![("PANTS_SCOPE_FOO", "+[3, 4]")],
+        "",
+        "",
+    );
+
+    check(
+        vec![0, 1, 3, 4, 5, 6, 7],
+        vec!["--scope-foo=+[5, 6, 7]"],
+        vec![("PANTS_SCOPE_FOO", "-[2],+[3, 4]")],
+        "[scope]\nfoo.add = [1, 2]",
+        "",
+    );
+
+    check(vec![0, 5, 6, 7], vec!["--scope-foo=+[5, 6, 7]"], vec![], "", "");
+}

--- a/src/rust/engine/pantsd/src/pantsd_testing.rs
+++ b/src/rust/engine/pantsd/src/pantsd_testing.rs
@@ -25,8 +25,13 @@ pub fn launch_pantsd() -> (BuildRoot, OptionParser, TempDir) {
         ),
         "-V".to_owned(),
     ];
-    let options_parser =
-        OptionParser::new(Args::new(args.clone()), Env::new(HashMap::new()), None, true).unwrap();
+    let options_parser = OptionParser::new(
+        Args::new(args.clone()),
+        Env::new(HashMap::new()),
+        None,
+        true,
+    )
+    .unwrap();
 
     let mut cmd = Command::new(build_root.join("pants"));
     cmd.current_dir(build_root.as_path())

--- a/src/rust/engine/pantsd/src/pantsd_testing.rs
+++ b/src/rust/engine/pantsd/src/pantsd_testing.rs
@@ -26,7 +26,7 @@ pub fn launch_pantsd() -> (BuildRoot, OptionParser, TempDir) {
         "-V".to_owned(),
     ];
     let options_parser =
-        OptionParser::new(Env::new(HashMap::new()), Args::new(args.clone()), true).unwrap();
+        OptionParser::new(Args::new(args.clone()), Env::new(HashMap::new()), None, true).unwrap();
 
     let mut cmd = Command::new(build_root.join("pants"));
     cmd.current_dir(build_root.as_path())

--- a/src/rust/engine/src/externs/pantsd.rs
+++ b/src/rust/engine/src/externs/pantsd.rs
@@ -21,7 +21,7 @@ pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
 #[pyfunction]
 fn pantsd_fingerprint_compute(expected_option_names: HashSet<String>) -> PyResult<String> {
     let build_root = BuildRoot::find().map_err(PyException::new_err)?;
-    let options_parser = OptionParser::new(Env::capture_lossy().0, Args::argv(), true)
+    let options_parser = OptionParser::new(Args::argv(), Env::capture_lossy().0, None, true)
         .map_err(PyException::new_err)?;
 
     let options = pantsd::fingerprinted_options(&build_root).map_err(PyException::new_err)?;


### PR DESCRIPTION
Previous changes implemented parsing of these types, and 
their extraction from each option source (args, env, config). 
This change now exposes these types in the Rust-side 
OptionParser API.

This means that Rust code can now consume any
option type, rather than just the limited types
available before (which were all that was needed
for parsing bootstrap options).

A future change will wire this up to Python, so
we can finally remove the Python option parsing code.