### PR TITLE
Docker: Update hadolint version to fix segmentation fault issue

### DIFF
--- a/src/python/pants/backend/docker/lint/hadolint/subsystem.py
+++ b/src/python/pants/backend/docker/lint/hadolint/subsystem.py
@@ -14,12 +14,12 @@ class Hadolint(TemplatedExternalTool):
     name = "Hadolint"
     help = "A linter for Dockerfiles."
 
-    default_version = "v2.10.0"
+    default_version = "v2.12.1-beta"
     default_known_versions = [
-        "v2.10.0|macos_x86_64|59f0523069a857ae918b8ac0774230013f7bcc00c1ea28119c2311353120867a|2514960",
-        "v2.10.0|macos_arm64 |59f0523069a857ae918b8ac0774230013f7bcc00c1ea28119c2311353120867a|2514960",  # same as mac x86
-        "v2.10.0|linux_x86_64|8ee6ff537341681f9e91bae2d5da451b15c575691e33980893732d866d3cefc4|2301804",
-        "v2.10.0|linux_arm64 |b53d5ab10707a585c9e72375d51b7357522300b5329cfa3f91e482687176e128|27954520",
+        "v2.12.1-beta|macos_x86_64 |911008b09e88b9ce62dbd12345af8f4c933370ebcfb01211d934f1e0a4d9aecc|19743768",
+        "v2.12.1-beta|macos_arm64 |911008b09e88b9ce62dbd12345af8f4c933370ebcfb01211d934f1e0a4d9aecc|19743768",  # same as mac x86
+        "v2.12.1-beta|linux_x86_64|d0779284293475905cfa4b3a7b5c433eca6d731e45b5df0e157f46b4e6311888|2426420",
+        "v2.12.1-beta|linux_arm64 |5997119de9b8332a003be938baff3ebd2ff17dfb62e2bceccd59bd9c112599ce|24002600",
     ]
     default_url_template = (
         "https://github.com/hadolint/hadolint/releases/download/{version}/hadolint-{platform}"


### PR DESCRIPTION
While this is a beta, the only change since 2.12 is to [remove UPX compression](https://github.com/hadolint/hadolint/commit/fcbd01791c9251d83f2486e61ecaf41ee700a766) on the binary releases. 

The UPX compression is believed to cause segmentation fault issues - see https://github.com/hadolint/hadolint/issues/919, https://github.com/hadolint/hadolint/issues/823, also noted in [Pants Slack](https://pantsbuild.slack.com/archives/C046T6T9U/p1670940311837809?thread_ts=1670932332.715499&cid=C046T6T9U). 

There's no darwin_arm64 binary available, although I can confirm the x86 binary works on my m3 machine. 
Although, I'm unable to reproduce the issue on my machine with the original version since doing the testing for this change.