### PR TITLE
Raise OptionsError when passing --closed option with non-text output format for dependencies and dependents goals

### DIFF
--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     TransitiveTargetsRequest,
     UnexpandedTargets,
 )
+from pants.option.errors import OptionsError
 from pants.option.option_types import BoolOption, EnumOption
 
 
@@ -151,6 +152,12 @@ async def list_dependencies_as_plain_text(
 async def dependencies(
     console: Console, addresses: Addresses, dependencies_subsystem: DependenciesSubsystem
 ) -> Dependencies:
+    if (
+        dependencies_subsystem.closed
+        and dependencies_subsystem.format != DependenciesOutputFormat.text
+    ):
+        raise OptionsError("`--closed` option can only be used with the `text` format output.")
+
     if DependenciesOutputFormat.text == dependencies_subsystem.format:
         await list_dependencies_as_plain_text(
             addresses=addresses,

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -10,6 +10,7 @@ import pytest
 from pants.backend.project_info.dependencies import Dependencies, DependenciesOutputFormat, rules
 from pants.backend.python import target_types_rules
 from pants.backend.python.target_types import PythonRequirementTarget, PythonSourcesGeneratorTarget
+from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import SpecialCasedDependencies, Target
 from pants.testutil.python_rule_runner import PythonRuleRunner
 
@@ -232,6 +233,15 @@ def test_python_dependencies_output_format_json_direct_deps(rule_runner: PythonR
         rule_runner,
         output_format=DependenciesOutputFormat.json,
     )
+
+    # using `--closed` option on non-text format output
+    with pytest.raises(ExecutionError) as err:
+        assert_deps(
+            specs=["base"],
+            closed=True,
+            expected={},
+        )
+    assert "OptionsError" in str(err.value)
 
     # input: single module
     assert_deps(

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -17,6 +17,7 @@ from pants.engine.target import (
     Dependencies,
     DependenciesRequest,
 )
+from pants.option.errors import OptionsError
 from pants.option.option_types import BoolOption, EnumOption
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -179,6 +180,9 @@ async def list_dependents_as_json(
 async def dependents_goal(
     specified_addresses: Addresses, dependents_subsystem: DependentsSubsystem, console: Console
 ) -> DependentsGoal:
+    if dependents_subsystem.closed and dependents_subsystem.format != DependentsOutputFormat.text:
+        raise OptionsError("`--closed` option can only be used with the `text` format output.")
+
     if DependentsOutputFormat.text == dependents_subsystem.format:
         await list_dependents_as_plain_text(
             addresses=specified_addresses,

--- a/src/python/pants/backend/project_info/dependents_test.py
+++ b/src/python/pants/backend/project_info/dependents_test.py
@@ -8,6 +8,7 @@ import pytest
 
 from pants.backend.project_info.dependents import DependentsGoal, DependentsOutputFormat
 from pants.backend.project_info.dependents import rules as dependent_rules
+from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.target import Dependencies, SpecialCasedDependencies, Target
 from pants.testutil.rule_runner import RuleRunner
 
@@ -117,6 +118,16 @@ def test_dependents_as_json_direct_deps(rule_runner: RuleRunner) -> None:
         rule_runner,
         output_format=DependentsOutputFormat.json,
     )
+
+    # using `--closed` option on non-text format output
+    with pytest.raises(ExecutionError) as err:
+        assert_deps(
+            targets=["base"],
+            closed=True,
+            expected={},
+        )
+    assert "OptionsError" in str(err.value)
+
     # input: single target
     assert_deps(
         targets=["base"],


### PR DESCRIPTION
As per https://github.com/pantsbuild/pants/pull/20443#discussion_r1464133342.

The `--closed` option is ignored as it doesn't make sense to duplicate source address in the list of its dependencies/dependents.

This is because a graph is going to be constructed and one wouldn't normally want to have a node in the list of its dependency as this would be creating a cycle, i.e. `{N: [D1, D2, N}`.

To avoid any confusion when someone (however unlikely!) will be interested in having the target included in the list of its dependencies/dependents, we shall raise an error when non-text output format is used.