### PR TITLE
Don't eagerly merge configs.

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -143,9 +143,11 @@ impl OptionsSource for Args {
         self.get_list(id, parse_string_list)
     }
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
+    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
         match self.find_flag(Self::arg_names(id, Negate::False))? {
-            Some((name, ref value, _)) => parse_dict(value).map(Some).map_err(|e| e.render(name)),
+            Some((name, ref value, _)) => parse_dict(value)
+                .map(|e| Some(vec![e]))
+                .map_err(|e| e.render(name)),
             None => Ok(None),
         }
     }

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -135,10 +135,10 @@ impl OptionsSource for Env {
         self.get_list(id, parse_string_list)
     }
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
+    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
         if let Some(value) = self.get_string(id)? {
             parse_dict(&value)
-                .map(Some)
+                .map(|e| Some(vec![e]))
                 .map_err(|e| e.render(self.display(id)))
         } else {
             Ok(None)

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -178,7 +178,11 @@ pub(crate) trait OptionsSource {
     ///
     fn get_string_list(&self, id: &OptionId) -> Result<Option<Vec<ListEdit<String>>>, String>;
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String>;
+    ///
+    /// Get the dict option identified by `id` from this source.
+    /// Errors when this source has an option value for `id` but that value is not a dict.
+    ///
+    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String>;
 }
 
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq)]
@@ -260,7 +264,7 @@ impl OptionParser {
             ("pants_distdir".to_string(), subdir("distdir", "dist")?),
         ]);
 
-        let mut config = Config::merged(&repo_config_files, &seed_values)?;
+        let mut config = Config::parse(&repo_config_files, &seed_values)?;
         sources.insert(Source::Config, Rc::new(config.clone()));
         parser = OptionParser {
             sources: sources.clone(),
@@ -277,7 +281,7 @@ impl OptionParser {
             )? {
                 let rcfile_path = Path::new(&rcfile);
                 if rcfile_path.exists() {
-                    let rc_config = Config::parse(rcfile_path, &seed_values)?;
+                    let rc_config = Config::parse(&[rcfile_path], &seed_values)?;
                     config = config.merge(rc_config);
                 }
             }


### PR DESCRIPTION
Merging the config values is incorrect for list- and
dict-valued options, where we want to concatenate
edits, not stomp them.

For example, if for some list-valued option the default
value is [0,1], config1 has -[0] and config2 has +[2,3]
then the resulting value should be [1,2,3], but before
this change it would have been [0,1,2,3].

Instead, we preserve each config file as a separate
source, and do the appropriate stomping/merging
at option value get time.