### PR TITLE
python: add _typeshed module to the list of unowned dependencies

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_unowned_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/default_unowned_dependencies.py
@@ -86,6 +86,7 @@ _STDLIB_MODULES = [
     "_threading_local",
     "_tkinter",
     "_tracemalloc",
+    "_typeshed",
     "_uuid",
     "_warnings",
     "_weakref",


### PR DESCRIPTION
Reported in https://pantsbuild.slack.com/archives/C046T6T9U/p1706315300139529

With this code:

```
from typing import TYPE_CHECKING, TypeVar
if TYPE_CHECKING:
    from _typeshed import SupportsRichComparison
    K = TypeVar("K", bound=SupportsRichComparison)
else:
    K = TypeVar("K")
```

Pants won't be able to find the `_typeshed` module:

```
UnownedDependencyError: Pants cannot infer owners for the following imports in the target projects/simulator/engine/utils/range_map_helper.py:

  * _typeshed.SupportsRichComparison (line: 5)
```

As per https://github.com/python/typeshed?tab=readme-ov-file#the-_typeshed-package:

> typeshed includes a package _typeshed as part of the standard library. This package and its submodules contains utility types, but is not available at runtime. For more information about how to use this package, [see the stdlib/_typeshed directory](https://github.com/python/typeshed/tree/main/stdlib/_typeshed).

It feels sensible to add `_typeshed` as a unownable module to avoid forcing users to add the `no-dep-infer` pragmas.

---

With this change, running `pants python-dump-source-analysis --analysis-flavor=raw_dependency_inference typeinfo.py | jq`, abridged for brevity:

```
    "resolved": {
      "resolve_results": {
        "typing.TypeVar": {
          "status": "ImportOwnerStatus.unownable",
          "address": []
        },
        "_typeshed.SupportsRichComparison": {
          "status": "ImportOwnerStatus.unownable",
          "address": []
        },
        "typing.TYPE_CHECKING": {
          "status": "ImportOwnerStatus.unownable",
          "address": []
        }
      },
      "assets": {},
      "explicit": {
        "address": "src/python/pants/util/typeinfo.py",
        "includes": [],
        "ignores": []
      }
    },
```