### PR TITLE
Add (optional) support for podman.

### DIFF
--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -515,8 +515,7 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
                 # Podman output
                 r"^(?P<podman_long_id>\S{64})$",
             ),
-        ),
-        re.MULTILINE,
+        )
     )
     for output in outputs:
         image_id_match = next(

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -474,7 +474,7 @@ async def build_docker_image(
             keep_sandboxes=keep_sandboxes,
         )
 
-    image_id = parse_image_id_from_docker_build_output(result.stdout, result.stderr)
+    image_id = parse_image_id_from_docker_build_output(docker, result.stdout, result.stderr)
     docker_build_output_msg = "\n".join(
         (
             f"Docker build output for {tags[0]}:",
@@ -500,42 +500,48 @@ async def build_docker_image(
     )
 
 
-def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
+def parse_image_id_from_docker_build_output(docker: DockerBinary, *outputs: bytes) -> str:
     """Outputs are typically the stdout/stderr pair from the `docker build` process."""
     # NB: We use the extracted image id for invalidation. The short_id may theoretically
     #  not be unique enough, although in a non adversarial situation, this is highly unlikely
     #  to be an issue in practice.
-    image_id_regexp = re.compile(
-        "|".join(
-            (
-                # BuildKit output.
-                r"(writing image (?P<digest>sha256:\S+) done)",
-                # Docker output.
-                r"(Successfully built (?P<short_id>\S+))",
-                # Podman output
-                r"^(?P<podman_long_id>\S{64})$",
-            ),
-        )
-    )
-    for output in outputs:
-        image_id_match = next(
-            (
-                match
-                for match in (
-                    re.search(image_id_regexp, line)
-                    for line in reversed(output.decode().split("\n"))
-                )
-                if match
-            ),
-            None,
-        )
-        if image_id_match:
-            image_id = (
-                image_id_match.group("digest")
-                or image_id_match.group("short_id")
-                or image_id_match.group("podman_long_id")
+    if docker.is_podman:
+        for output in outputs:
+            try:
+                _, image_id, success, *__ = reversed(output.decode().split("\n"))
+            except ValueError:
+                continue
+
+            if success.startswith("Successfully tagged"):
+                return image_id
+
+    else:
+        image_id_regexp = re.compile(
+            "|".join(
+                (
+                    # BuildKit output.
+                    r"(writing image (?P<digest>sha256:\S+) done)",
+                    # Docker output.
+                    r"(Successfully built (?P<short_id>\S+))",
+                    # Podman output
+                ),
             )
-            return image_id
+        )
+        for output in outputs:
+            image_id_match = next(
+                (
+                    match
+                    for match in (
+                        re.search(image_id_regexp, line)
+                        for line in reversed(output.decode().split("\n"))
+                    )
+                    if match
+                ),
+                None,
+            )
+            if image_id_match:
+                image_id = image_id_match.group("digest") or image_id_match.group("short_id")
+                return image_id
 
     return "<unknown>"
 

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -512,8 +512,8 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
                 r"(writing image (?P<digest>sha256:\S+) done)",
                 # Docker output.
                 r"(Successfully built (?P<short_id>\S+))",
-                # Podman output (Use the last short-hash to verify the long-hash on the final line)
-                r"(--> (\S+)\nSuccessfully tagged .*\n(?P<podman_id>\2\S+))",
+                # Podman output
+                r"^(?P<podman_long_id>\S{64})$",
             ),
         )
         , re.MULTILINE
@@ -531,7 +531,7 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
             None,
         )
         if image_id_match:
-            image_id = image_id_match.group("digest") or image_id_match.group("short_id") or image_id_match.group("podman_id")
+            image_id = image_id_match.group("digest") or image_id_match.group("short_id") or image_id_match.group("podman_long_id")
             return image_id
 
     return "<unknown>"

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -515,8 +515,8 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
                 # Podman output
                 r"^(?P<podman_long_id>\S{64})$",
             ),
-        )
-        , re.MULTILINE
+        ),
+        re.MULTILINE,
     )
     for output in outputs:
         image_id_match = next(
@@ -531,7 +531,11 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
             None,
         )
         if image_id_match:
-            image_id = image_id_match.group("digest") or image_id_match.group("short_id") or image_id_match.group("podman_long_id")
+            image_id = (
+                image_id_match.group("digest")
+                or image_id_match.group("short_id")
+                or image_id_match.group("podman_long_id")
+            )
             return image_id
 
     return "<unknown>"

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -523,7 +523,6 @@ def parse_image_id_from_docker_build_output(docker: DockerBinary, *outputs: byte
                     r"(writing image (?P<digest>sha256:\S+) done)",
                     # Docker output.
                     r"(Successfully built (?P<short_id>\S+))",
-                    # Podman output
                 ),
             )
         )

--- a/src/python/pants/backend/docker/goals/package_image.py
+++ b/src/python/pants/backend/docker/goals/package_image.py
@@ -512,8 +512,11 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
                 r"(writing image (?P<digest>sha256:\S+) done)",
                 # Docker output.
                 r"(Successfully built (?P<short_id>\S+))",
+                # Podman output (Use the last short-hash to verify the long-hash on the final line)
+                r"(--> (\S+)\nSuccessfully tagged .*\n(?P<podman_id>\2\S+))",
             ),
         )
+        , re.MULTILINE
     )
     for output in outputs:
         image_id_match = next(
@@ -528,7 +531,7 @@ def parse_image_id_from_docker_build_output(*outputs: bytes) -> str:
             None,
         )
         if image_id_match:
-            image_id = image_id_match.group("digest") or image_id_match.group("short_id")
+            image_id = image_id_match.group("digest") or image_id_match.group("short_id") or image_id_match.group("podman_id")
             return image_id
 
     return "<unknown>"

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1589,15 +1589,17 @@ def test_get_context_root(
 
 
 @pytest.mark.parametrize(
-    "expected, stdout, stderr",
+    "docker, expected, stdout, stderr",
     [
         (
+            DockerBinary("/bin/docker", "1234", is_podman=False),
             "<unknown>",
             "",
             "",
         ),
         # Docker
         (
+            DockerBinary("/bin/docker", "1234", is_podman=False),
             "0e09b442b572",
             "",
             dedent(
@@ -1613,6 +1615,7 @@ def test_get_context_root(
         ),
         # Buildkit
         (
+            DockerBinary("/bin/docker", "1234", is_podman=False),
             "sha256:7805a7da5f45a70bb9e47e8de09b1f5acd8f479dda06fb144c5590b9d2b86dd7",
             dedent(
                 """\
@@ -1635,6 +1638,7 @@ def test_get_context_root(
         ),
         # Podman
         (
+            DockerBinary("/bin/podman", "abcd", is_podman=True),
             "a85499e9039a4add9712f7ea96a4aa9f0edd57d1008c6565822561ceed927eee",
             dedent(
                 """\
@@ -1649,8 +1653,12 @@ def test_get_context_root(
         ),
     ],
 )
-def test_parse_image_id_from_docker_build_output(expected: str, stdout: str, stderr: str) -> None:
-    assert expected == parse_image_id_from_docker_build_output(stdout.encode(), stderr.encode())
+def test_parse_image_id_from_docker_build_output(
+    docker: DockerBinary, expected: str, stdout: str, stderr: str
+) -> None:
+    assert expected == parse_image_id_from_docker_build_output(
+        docker, stdout.encode(), stderr.encode()
+    )
 
 
 ImageRefTest = namedtuple(

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1596,6 +1596,7 @@ def test_get_context_root(
             "",
             "",
         ),
+        # Docker
         (
             "0e09b442b572",
             "",
@@ -1610,6 +1611,7 @@ def test_get_context_root(
                 """
             ),
         ),
+        # Buildkit
         (
             "sha256:7805a7da5f45a70bb9e47e8de09b1f5acd8f479dda06fb144c5590b9d2b86dd7",
             dedent(
@@ -1631,6 +1633,20 @@ def test_get_context_root(
             ),
             "",
         ),
+        # Podman
+        (
+            "a85499e9039a4add9712f7ea96a4aa9f0edd57d1008c6565822561ceed927eee",
+            dedent(
+                """\
+                STEP 5/5: COPY ./ .
+                COMMIT example
+                --> a85499e9039a
+                Successfully tagged localhost/example:latest
+                a85499e9039a4add9712f7ea96a4aa9f0edd57d1008c6565822561ceed927eee
+                """
+            ),
+            ""
+        )
     ],
 )
 def test_parse_image_id_from_docker_build_output(expected: str, stdout: str, stderr: str) -> None:

--- a/src/python/pants/backend/docker/goals/package_image_test.py
+++ b/src/python/pants/backend/docker/goals/package_image_test.py
@@ -1645,8 +1645,8 @@ def test_get_context_root(
                 a85499e9039a4add9712f7ea96a4aa9f0edd57d1008c6565822561ceed927eee
                 """
             ),
-            ""
-        )
+            "",
+        ),
     ],
 )
 def test_parse_image_id_from_docker_build_output(expected: str, stdout: str, stderr: str) -> None:

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -152,15 +152,6 @@ class DockerOptions(Subsystem):
         ),
     )
 
-    enable_podman = BoolOption(
-        default=False,
-        help=softwrap(
-            """
-            EXPERIMENTAL. Allow support for podman where available instead of docker.
-            """
-        ),
-    )
-
     _build_args = ShellStrListOption(
         help=softwrap(
             f"""

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -158,7 +158,7 @@ class DockerOptions(Subsystem):
             """
             EXPERIMENTAL. Allow support for podman where available instead of docker.
             """
-        )
+        ),
     )
 
     _build_args = ShellStrListOption(

--- a/src/python/pants/backend/docker/subsystems/docker_options.py
+++ b/src/python/pants/backend/docker/subsystems/docker_options.py
@@ -151,6 +151,16 @@ class DockerOptions(Subsystem):
             """
         ),
     )
+
+    enable_podman = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            EXPERIMENTAL. Allow support for podman where available instead of docker.
+            """
+        )
+    )
+
     _build_args = ShellStrListOption(
         help=softwrap(
             f"""

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -134,7 +134,8 @@ async def get_docker(
 
     first_path: BinaryPath | None = None
 
-    if docker_options.enable_podman:
+    if getattr(docker_options, "experimental_enable_podman", False):
+        # Enable podman support with `pants.backend.experimental.docker.podman`
         request = BinaryPathRequest(
             binary_name="podman",
             search_path=search_path,

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -2,8 +2,8 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import annotations
-import logging
 
+import logging
 import os
 from dataclasses import dataclass
 from typing import Mapping

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -134,7 +134,7 @@ async def get_docker(
 
     first_path: BinaryPath | None = None
 
-    if getattr(docker_options, "experimental_enable_podman", False):
+    if getattr(docker_options.options, "experimental_enable_podman", False):
         # Enable podman support with `pants.backend.experimental.docker.podman`
         request = BinaryPathRequest(
             binary_name="podman",

--- a/src/python/pants/backend/docker/util_rules/docker_binary.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from __future__ import annotations
+import logging
 
 import os
 from dataclasses import dataclass
@@ -22,6 +23,8 @@ from pants.engine.process import Process, ProcessCacheScope
 from pants.engine.rules import Get, collect_rules, rule
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -139,6 +142,8 @@ async def get_docker(
         )
         paths = await Get(BinaryPaths, BinaryPathRequest, request)
         first_path = paths.first_path
+        if first_path:
+            logger.warning("podman found. Podman support is experimental.")
 
     if not first_path:
         request = BinaryPathRequest(

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -6,13 +6,13 @@ from unittest import mock
 
 import pytest
 
-from pants.backend.docker.util_rules.docker_binary import DockerBinary, rules, get_docker
-from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.backend.docker.subsystems.docker_options import DockerOptions
+from pants.backend.docker.util_rules.docker_binary import DockerBinary, get_docker, rules
+from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
-from pants.testutil.rule_runner import MockGet, QueryRule, RuleRunner, run_rule_with_mocks
 from pants.testutil.option_util import create_subsystem
+from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
 
 
 @pytest.fixture
@@ -97,13 +97,15 @@ def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None
     )
     assert run_request.description == f"Running docker image {image_ref}"
 
+
 from pants.core.util_rules.system_binaries import (
     BinaryPath,
-    BinaryPaths,
     BinaryPathRequest,
+    BinaryPaths,
     BinaryShims,
     BinaryShimsRequest,
 )
+
 
 @pytest.mark.parametrize("podman_enabled", [True, False])
 @pytest.mark.parametrize("podman_found", [True, False])
@@ -126,14 +128,17 @@ def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> No
 
     result = run_rule_with_mocks(
         get_docker,
-        rule_args=[
-            docker_options,
-            docker_options_env_aware
-        ],
+        rule_args=[docker_options, docker_options_env_aware],
         mock_gets=[
-            MockGet(output_type=BinaryPaths, input_types=(BinaryPathRequest,), mock=mock_get_binary_path),
-            MockGet(output_type=BinaryShims, input_types=(BinaryShimsRequest,), mock=mock_get_binary_shims)
-        ]
+            MockGet(
+                output_type=BinaryPaths, input_types=(BinaryPathRequest,), mock=mock_get_binary_path
+            ),
+            MockGet(
+                output_type=BinaryShims,
+                input_types=(BinaryShimsRequest,),
+                mock=mock_get_binary_shims,
+            ),
+        ],
     )
 
     if podman_enabled and podman_found:

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -16,7 +16,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.fs import Digest
+from pants.engine.fs import Digest, EMPTY_DIGEST
 from pants.engine.process import Process, ProcessCacheScope
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
@@ -122,7 +122,9 @@ def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> No
             return BinaryPaths(request.binary_name, ())
 
     def mock_get_binary_shims(request: BinaryShimsRequest) -> BinaryShims:
-        return BinaryShims()
+        return BinaryShims(
+            EMPTY_DIGEST, "cache_name"
+        )
 
     result = run_rule_with_mocks(
         get_docker,

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -108,7 +108,7 @@ def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None
 @pytest.mark.parametrize("podman_enabled", [True, False])
 @pytest.mark.parametrize("podman_found", [True, False])
 def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> None:
-    docker_options = create_subsystem(DockerOptions, enable_podman=podman_enabled, tools=[])
+    docker_options = create_subsystem(DockerOptions, experimental_enable_podman=podman_enabled, tools=[])
     docker_options_env_aware = mock.MagicMock(spec=DockerOptions.EnvironmentAware)
 
     def mock_get_binary_path(request: BinaryPathRequest) -> BinaryPaths:

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -9,6 +9,7 @@ import pytest
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary, get_docker, rules
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
+from pants.backend.experimental.docker.podman.register import rules as podman_rules
 from pants.core.util_rules.system_binaries import (
     BinaryPath,
     BinaryPathRequest,
@@ -16,7 +17,7 @@ from pants.core.util_rules.system_binaries import (
     BinaryShims,
     BinaryShimsRequest,
 )
-from pants.engine.fs import Digest, EMPTY_DIGEST
+from pants.engine.fs import EMPTY_DIGEST, Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, run_rule_with_mocks
@@ -34,7 +35,12 @@ def docker(docker_path: str) -> DockerBinary:
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
-    return RuleRunner(rules=rules())
+    return RuleRunner(
+        rules=[
+            *rules(),
+            *podman_rules(),
+        ]
+    )
 
 
 def test_docker_binary_build_image(docker_path: str, docker: DockerBinary) -> None:
@@ -108,7 +114,9 @@ def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None
 @pytest.mark.parametrize("podman_enabled", [True, False])
 @pytest.mark.parametrize("podman_found", [True, False])
 def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> None:
-    docker_options = create_subsystem(DockerOptions, experimental_enable_podman=podman_enabled, tools=[])
+    docker_options = create_subsystem(
+        DockerOptions, experimental_enable_podman=podman_enabled, tools=[]
+    )
     docker_options_env_aware = mock.MagicMock(spec=DockerOptions.EnvironmentAware)
 
     def mock_get_binary_path(request: BinaryPathRequest) -> BinaryPaths:
@@ -122,9 +130,7 @@ def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> No
             return BinaryPaths(request.binary_name, ())
 
     def mock_get_binary_shims(request: BinaryShimsRequest) -> BinaryShims:
-        return BinaryShims(
-            EMPTY_DIGEST, "cache_name"
-        )
+        return BinaryShims(EMPTY_DIGEST, "cache_name")
 
     result = run_rule_with_mocks(
         get_docker,
@@ -143,5 +149,7 @@ def test_get_docker(rule_runner: RuleRunner, podman_enabled, podman_found) -> No
 
     if podman_enabled and podman_found:
         assert result.path == "/bin/podman"
+        assert result.is_podman
     else:
         assert result.path == "/bin/docker"
+        assert not result.is_podman

--- a/src/python/pants/backend/docker/util_rules/docker_binary_test.py
+++ b/src/python/pants/backend/docker/util_rules/docker_binary_test.py
@@ -9,6 +9,13 @@ import pytest
 from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.backend.docker.util_rules.docker_binary import DockerBinary, get_docker, rules
 from pants.backend.docker.util_rules.docker_build_args import DockerBuildArgs
+from pants.core.util_rules.system_binaries import (
+    BinaryPath,
+    BinaryPathRequest,
+    BinaryPaths,
+    BinaryShims,
+    BinaryShimsRequest,
+)
 from pants.engine.fs import Digest
 from pants.engine.process import Process, ProcessCacheScope
 from pants.testutil.option_util import create_subsystem
@@ -96,15 +103,6 @@ def test_docker_binary_run_image(docker_path: str, docker: DockerBinary) -> None
         description="",  # The description field is marked `compare=False`
     )
     assert run_request.description == f"Running docker image {image_ref}"
-
-
-from pants.core.util_rules.system_binaries import (
-    BinaryPath,
-    BinaryPathRequest,
-    BinaryPaths,
-    BinaryShims,
-    BinaryShimsRequest,
-)
 
 
 @pytest.mark.parametrize("podman_enabled", [True, False])

--- a/src/python/pants/backend/experimental/docker/podman/BUILD
+++ b/src/python/pants/backend/experimental/docker/podman/BUILD
@@ -1,0 +1,1 @@
+python_sources()

--- a/src/python/pants/backend/experimental/docker/podman/BUILD
+++ b/src/python/pants/backend/experimental/docker/podman/BUILD
@@ -1,1 +1,3 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
 python_sources()

--- a/src/python/pants/backend/experimental/docker/podman/register.py
+++ b/src/python/pants/backend/experimental/docker/podman/register.py
@@ -1,7 +1,9 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pants.backend.docker.subsystems.docker_options import DockerOptions
 from pants.option.option_types import BoolOption
 from pants.util.strutil import softwrap
 
-from pants.backend.docker.subsystems.docker_options import DockerOptions
 
 class ExperimentalPodmanOptions:
     experimental_enable_podman = BoolOption(

--- a/src/python/pants/backend/experimental/docker/podman/register.py
+++ b/src/python/pants/backend/experimental/docker/podman/register.py
@@ -1,0 +1,20 @@
+from pants.option.option_types import BoolOption
+from pants.util.strutil import softwrap
+
+from pants.backend.docker.subsystems.docker_options import DockerOptions
+
+class ExperimentalPodmanOptions:
+    experimental_enable_podman = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            Allow support for podman when available.
+            """
+        ),
+    )
+
+
+def rules():
+    return [
+        DockerOptions.register_plugin_options(ExperimentalPodmanOptions),
+    ]

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -34,6 +34,7 @@ target(
         "src/python/pants/backend/experimental/codegen/thrift/scrooge/scala",
         "src/python/pants/backend/experimental/cue",
         "src/python/pants/backend/experimental/debian",
+        "src/python/pants/backend/experimental/docker/podman",
         "src/python/pants/backend/experimental/go",
         "src/python/pants/backend/experimental/go/debug_goals",
         "src/python/pants/backend/experimental/go/lint/golangci_lint",


### PR DESCRIPTION
Podman claims to be binary compatible with Docker, and it _largely_ works as a drop-in replacement.

Largely, symlinking `podman` to `docker` does work with pants. Except where images are built and pants cannot find the resulting checksum of the built image (see: [conversation](https://pantsbuild.slack.com/archives/C046T6T9U/p1701475952213319).

This PR adds:
- A flag to enable (experimental) podman support.
- When enabled, `DockerBinary` will also search for `podman`.
- The successful image-build will also look for the resulting checksum.