### PR TITLE
options: do not ignore .github directory with pants_ignore

### DIFF
--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1047,7 +1047,7 @@ class BootstrapOptions:
     )
     pants_ignore = StrListOption(
         advanced=True,
-        default=[".*/", _default_rel_distdir, "__pycache__", "!.semgrep/"],
+        default=[".*/", _default_rel_distdir, "__pycache__", "!.semgrep/", "!.github/"],
         help=softwrap(
             """
             Paths to ignore for all filesystem operations performed by pants


### PR DESCRIPTION
Use case: https://pantsbuild.slack.com/archives/C046T6T9U/p1706623117526929

Using `.github` directory is very common with YAML files (and other resources) to be linted or included as part of a Pants build in a more general sense.
