### PR TITLE
docs: fix slack channel references

### DIFF
--- a/docs/docs/contributions/development/developing-rust.mdx
+++ b/docs/docs/contributions/development/developing-rust.mdx
@@ -10,11 +10,11 @@ Hacking on the Pants engine in Rust.
 We welcome contributions to Rust! We use Rust to implement the Pants engine in a performant, safe, and ergonomic way.
 
 :::note Still learning Rust? Ask to get added to reviews
-We'd be happy to ping you on Rust changes we make for you to see how Rust is used in the wild. Please message us on the #engine channel in [Slack](/community/members) to let us know your interest.
+We'd be happy to ping you on Rust changes we make for you to see how Rust is used in the wild. Please message us on the #development channel in [Slack](/community/members) to let us know your interest.
 :::
 
 :::caution Recommendation: share your plan first
-Because changes to Rust deeply impact how Pants runs, it is especially helpful to share any plans to work on Rust before making changes. Please message us on [Slack](/community/members) in the #engine channel or open a [GitHub issue](https://github.com/pantsbuild/pants/issues).
+Because changes to Rust deeply impact how Pants runs, it is especially helpful to share any plans to work on Rust before making changes. Please message us on [Slack](/community/members) in the #development channel or open a [GitHub issue](https://github.com/pantsbuild/pants/issues).
 :::
 
 ## Code organization


### PR DESCRIPTION
Minor update to replace `#engine` channel in the docs with `#development`.