### PR TITLE
stop swallowing warnings from Pex by default

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -88,6 +88,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
         args = []
         if self.emit_warnings.value_or_global_default(pex_binary_defaults) is False:
             args.append("--no-emit-warnings")
+        elif self.emit_warnings.value_or_global_default(pex_binary_defaults) is True:
+            args.append("--emit-warnings")
         if self.resolve_local_platforms.value_or_global_default(pex_binary_defaults) is True:
             args.append("--resolve-local-platforms")
         if self.ignore_errors.value is True:

--- a/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary_integration_test.py
@@ -135,6 +135,7 @@ def test_include_sources_avoids_files_targets_warning(
                 """\
                 python_sources(
                     name='sources',
+                    interpreter_constraints=["CPython==3.10.*"]
                 )
 
                 python_distribution(
@@ -147,12 +148,14 @@ def test_include_sources_avoids_files_targets_warning(
                         name='my-dist',
                         version='1.2.3',
                     ),
+                    interpreter_constraints=["CPython==3.10.*"]
                 )
 
                 pex_binary(
                     dependencies=[':wheel'],
                     entry_point="none",
                     include_sources=False,
+                    interpreter_constraints=["CPython==3.10.*"]
                 )
                 """
             ),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -26,7 +26,6 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.base.deprecated import warn_or_error
 from pants.core.goals.generate_lockfiles import UnrecognizedResolveNamesError
 from pants.core.goals.package import OutputPathField
 from pants.core.goals.run import RestartableField
@@ -546,18 +545,6 @@ class PexEmitWarningsField(TriBoolField):
     def value_or_global_default(self, pex_binary_defaults: PexBinaryDefaults) -> bool:
         if self.value is None:
             return pex_binary_defaults.emit_warnings
-        warn_or_error(
-            "2.21.0.dev0",
-            softwrap(
-                """
-                          `emit_warnings` no longer set per target.
-                          Use `emit_warnings` on the [pex] subsytem to control warnings for
-                          all pex invocations
-                          """
-            ),
-            "use [pex] subsystem instead",
-            start_version="2.20.0.dev0",
-        )
 
         return self.value
 
@@ -851,8 +838,6 @@ class PexBinaryDefaults(Subsystem):
             `pex_binary` targets
             """
         ),
-        removal_version="2.21.0.dev0",
-        removal_hint="Use the [pex] subsystem to control warnings for all Pex invocations",
         advanced=True,
     )
     resolve_local_platforms = BoolOption(

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -382,24 +382,6 @@ class PexArgsField(StringSequenceField):
     )
 
 
-class PexCheckField(StringField):
-    alias = "check"
-    valid_choices = ("none", "warn", "error")
-    expected_type = str
-    default = "error"
-    help = help_text(
-        """
-        Check that the built PEX is valid. Currently this only
-        applies to `--layout zipapp` where the PEX zip is
-        tested for importability of its `__main__` module by
-        the Python zipimport module. This check will fail for
-        PEX zips that use ZIP64 extensions since the Python
-        zipimport zipimporter only works with 32 bit zips. The
-        check no-ops for all other layouts.
-        """
-    )
-
-
 class PexEnvField(DictStringToStringField):
     alias = "env"
     help = help_text(
@@ -729,7 +711,6 @@ _PEX_BINARY_COMMON_FIELDS = (
     InterpreterConstraintsField,
     PythonResolveField,
     PexBinaryDependenciesField,
-    PexCheckField,
     PexPlatformsField,
     PexCompletePlatformsField,
     PexResolveLocalPlatformsField,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -211,10 +211,10 @@ async def setup_pex_cli_process(
 def maybe_log_pex_stderr(stderr: bytes, pex_verbosity: int) -> None:
     """Forward Pex's stderr to a Pants logger if conditions are met."""
     log_output = stderr.decode()
-    if log_output and pex_verbosity > 0:
-        logger.info("%s", log_output)
-    elif log_output and "PEXWarning:" in log_output:
+    if log_output and "PEXWarning:" in log_output:
         logger.warning("%s", log_output)
+    elif log_output and pex_verbosity > 0:
+        logger.info("%s", log_output)
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import logging
 import os.path
 from dataclasses import dataclass
 from typing import Iterable, List, Mapping, Optional, Tuple
@@ -28,6 +29,8 @@ from pants.option.global_options import GlobalOptions, ca_certs_path_to_file_con
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
+
+logger = logging.getLogger(__name__)
 
 
 class PexCli(TemplatedExternalTool):
@@ -156,6 +159,8 @@ async def setup_pex_cli_process(
 
     verbosity_args = [f"-{'v' * pex_subsystem.verbosity}"] if pex_subsystem.verbosity > 0 else []
 
+    warnings_args = [] if pex_subsystem.emit_warnings else ["--no-emit-warnings"]
+
     # NB: We should always pass `--python-path`, as that tells Pex where to look for interpreters
     # when `--python` isn't an absolute path.
     resolve_args = [
@@ -171,6 +176,7 @@ async def setup_pex_cli_process(
         *request.subcommand,
         *global_args,
         *verbosity_args,
+        *warnings_args,
         *pip_version_args,
         *resolve_args,
         # NB: This comes at the end because it may use `--` passthrough args, # which must come at
@@ -200,6 +206,15 @@ async def setup_pex_cli_process(
         concurrency_available=request.concurrency_available,
         cache_scope=request.cache_scope,
     )
+
+
+def maybe_log_pex_stderr(stderr: bytes, pex_verbosity: int) -> None:
+    """Forward Pex's stderr to a Pants logger if conditions are met."""
+    log_output = stderr.decode()
+    if log_output and pex_verbosity > 0:
+        logger.info("%s", log_output)
+    elif log_output and "PEXWarning:" in log_output:
+        logger.warning("%s", log_output)
 
 
 def rules():

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -81,6 +81,14 @@ class PexSubsystem(Subsystem):
         ),
         advanced=True,
     )
+    emit_warnings = BoolOption(
+        default=True,
+        help=softwrap(
+            """
+            If warnings from Pex should be logged by Pants to the console.
+            """
+        ),
+    )
 
     @property
     def verbosity(self) -> int:


### PR DESCRIPTION
Pants has traditionally run Pex with --no-emit-warnings which as the name implies... doesn't emit warnings.  This hides pertinent information like "the pex file you created won't actually work" from the user and sends them off on a debugging hunt.

 * Create an `emit_warnings` option, defaulting to True like the underlying tool..
 * A little logic for pipeing Pex's stderr to Pants' logging.
 * Fix the logic for old per target `emit_warnings` that didn't quite work.

ref #19957