### PR TITLE
plumb through Pex's --check zipapp validation

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -8,6 +8,7 @@ from typing import Tuple
 from pants.backend.python.target_types import (
     PexArgsField,
     PexBinaryDefaults,
+    PexCheckField,
     PexCompletePlatformsField,
     PexEmitWarningsField,
     PexEntryPointField,
@@ -79,6 +80,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     venv_site_packages_copies: PexVenvSitePackagesCopies
     venv_hermetic_scripts: PexVenvHermeticScripts
     environment: EnvironmentField
+    check: PexCheckField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:
@@ -96,6 +98,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append(f"--inherit-path={self.inherit_path.value}")
         if self.sh_boot.value is True:
             args.append("--sh-boot")
+        if self.check.value is not None:
+            args.append(f"--check={self.check.value}")
         if self.shebang.value is not None:
             args.append(f"--python-shebang={self.shebang.value}")
         if self.strip_env.value is False:

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -385,7 +385,7 @@ class PexCheckField(StringField):
     alias = "check"
     valid_choices = ("none", "warn", "error")
     expected_type = str
-    default = "error"
+    default = "warn"
     help = help_text(
         """
         Check that the built PEX is valid. Currently this only

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -381,6 +381,24 @@ class PexArgsField(StringSequenceField):
     )
 
 
+class PexCheckField(StringField):
+    alias = "check"
+    valid_choices = ("none", "warn", "error")
+    expected_type = str
+    default = "error"
+    help = help_text(
+        """
+        Check that the built PEX is valid. Currently this only
+        applies to `--layout zipapp` where the PEX zip is
+        tested for importability of its `__main__` module by
+        the Python zipimport module. This check will fail for
+        PEX zips that use ZIP64 extensions since the Python
+        zipimport zipimporter only works with 32 bit zips. The
+        check no-ops for all other layouts.
+        """
+    )
+
+
 class PexEnvField(DictStringToStringField):
     alias = "env"
     help = help_text(
@@ -697,6 +715,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     InterpreterConstraintsField,
     PythonResolveField,
     PexBinaryDependenciesField,
+    PexCheckField,
     PexPlatformsField,
     PexCompletePlatformsField,
     PexResolveLocalPlatformsField,

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -37,7 +37,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = "v2.1.159"
     default_url_template = "https://github.com/pantsbuild/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.135,<3.0"
+    version_constraints = ">=2.1.148,<3.0"
 
     @classproperty
     def default_known_versions(cls):


### PR DESCRIPTION
Pex exposes the `--check` flag to "check" if the resulting zipapp can be opened by CPython.  Plumb that through so that Pants stops making PEXs that won't work at runtime.

NOTE: The default of `error` differs from Pex.  I'm struggling to think of a case where one would want a zipapp CPython can't open and Pants has a history of swalling warnings from Pex (`warn` is Pex's default).

ref #19957