### PR TITLE
Update broken link to default versioning scheme

### DIFF
--- a/docs/docs/using-pants/generating-version-tags-from-git.mdx
+++ b/docs/docs/using-pants/generating-version-tags-from-git.mdx
@@ -71,7 +71,7 @@ require an explicit dependency.
 ## The generated version string
 
 Pants delegates the version string computation to [setuptools_scm](https://github.com/pypa/setuptools_scm).
-See [here](https://github.com/pypa/setuptools_scm#default-versioning-scheme) for how it computes the version string from the Git state.
+See [here](https://setuptools-scm.readthedocs.io/en/latest/usage/#default-versioning-scheme) for how it computes the version string from the Git state.
 
 We don't yet support any of the configuration options that control how the string is computed. Please
 [let us know](/community/getting-help) if you need such advanced functionality.


### PR DESCRIPTION
The README.md being pointed to by the existing link does not mention default versioning scheme anymore.