### PR TITLE
Anonymize sandbox paths instead of stripping completely

### DIFF
--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -138,7 +138,19 @@ def strip_v2_chroot_path(v: bytes | str) -> str:
     """
     if isinstance(v, bytes):
         v = v.decode()
-    return re.sub(r"/.*/pants-sandbox-[a-zA-Z0-9]+/", "", v)
+
+    found_sandbox_paths = re.findall(r"(/.*/pants-sandbox-[a-zA-Z0-9]+)/", v)
+    sandbox_path_to_replacement = {}
+    for sandbox_path in found_sandbox_paths:
+        if sandbox_path not in sandbox_path_to_replacement:
+            sandbox_path_to_replacement[
+                sandbox_path
+            ] = f"/<sandbox-{len(sandbox_path_to_replacement)+1}>"
+
+    for sandbox, replacement in sandbox_path_to_replacement.items():
+        v = v.replace(sandbox, replacement)
+
+    return v
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -128,7 +128,7 @@ def strip_prefix(string: str, prefix: str) -> str:
 
 
 # NB: We allow bytes because `ProcessResult.std{err,out}` uses bytes.
-def strip_v2_chroot_path(v: bytes | str) -> str:
+def anonymize_v2_chroot_path(v: bytes | str) -> str:
     """Remove all instances of the chroot tmpdir path from the str so that it only uses relative
     paths.
 
@@ -165,7 +165,7 @@ class Simplifier:
 
     def simplify(self, v: bytes | str) -> str:
         chroot = (
-            strip_v2_chroot_path(v)
+            anonymize_v2_chroot_path(v)
             if self.strip_chroot_path
             else v.decode()
             if isinstance(v, bytes)

--- a/src/python/pants/util/strutil.py
+++ b/src/python/pants/util/strutil.py
@@ -139,7 +139,7 @@ def anonymize_v2_chroot_path(v: bytes | str) -> str:
     if isinstance(v, bytes):
         v = v.decode()
 
-    found_sandbox_paths = re.findall(r"(/.*/pants-sandbox-[a-zA-Z0-9]+)/", v)
+    found_sandbox_paths = re.findall(r"(/.*?/pants-sandbox-[a-zA-Z0-9]+)/", v)
     sandbox_path_to_replacement = {}
     for sandbox_path in found_sandbox_paths:
         if sandbox_path not in sandbox_path_to_replacement:

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -115,6 +115,25 @@ def test_strip_chroot_path() -> None:
     assert anonymize_v2_chroot_path("hello world") == "hello world"
 
 
+def test_path_issue_strip_chroot_path() -> None:
+    # This was a specific bug observed where the PATH variable got anonymized incorrectly. In particular, the
+    # replacement crossed over into *another* PATH item, i.e, including `:`.
+    assert (
+        anonymize_v2_chroot_path(
+            dedent(
+                """\
+            /var/pants-sandbox-123/red:/var/pants-sandbox-123/blue
+            """
+            )
+        )
+        == dedent(
+            """\
+        /<sandbox-1>/red:/<sandbox-1>/blue
+        """
+        )
+    )
+
+
 @pytest.mark.parametrize(
     ("strip_chroot_path", "strip_formatting", "expected"),
     [

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -123,12 +123,14 @@ def test_path_issue_strip_chroot_path() -> None:
             dedent(
                 """\
             /var/pants-sandbox-123/red:/var/pants-sandbox-123/blue
+            /var/pants-sandbox-345/red:/var/pants-sandbox-456/blue
             """
             )
         )
         == dedent(
             """\
         /<sandbox-1>/red:/<sandbox-1>/blue
+        /<sandbox-2>/red:/<sandbox-3>/blue
         """
         )
     )

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -10,6 +10,7 @@ import pytest
 from pants.util.frozendict import FrozenDict
 from pants.util.strutil import (
     Simplifier,
+    anonymize_v2_chroot_path,
     bullet_list,
     comma_separated_list,
     docstring,
@@ -23,7 +24,6 @@ from pants.util.strutil import (
     softwrap,
     stable_hash,
     strip_prefix,
-    strip_v2_chroot_path,
 )
 
 
@@ -71,7 +71,7 @@ def test_strip_prefix() -> None:
 
 def test_strip_chroot_path() -> None:
     assert (
-        strip_v2_chroot_path(
+        anonymize_v2_chroot_path(
             dedent(
                 """\
             Would reformat /private/var/folders/sx/pdpbqz4x5cscn9hhfpbsbqvm0000gn/T/pants-sandbox-3zt5Ph/src/python/example.py
@@ -95,24 +95,24 @@ def test_strip_chroot_path() -> None:
 
     # A subdir must be prefixed with `pants-sandbox-`, then some characters after it.
     assert (
-        strip_v2_chroot_path("/var/pants_sandbox_OCnquv/test.py")
+        anonymize_v2_chroot_path("/var/pants_sandbox_OCnquv/test.py")
         == "/var/pants_sandbox_OCnquv/test.py"
     )
     assert (
-        strip_v2_chroot_path("/var/pants_sandboxOCnquv/test.py")
+        anonymize_v2_chroot_path("/var/pants_sandboxOCnquv/test.py")
         == "/var/pants_sandboxOCnquv/test.py"
     )
-    assert strip_v2_chroot_path("/var/pants-sandbox/test.py") == "/var/pants-sandbox/test.py"
+    assert anonymize_v2_chroot_path("/var/pants-sandbox/test.py") == "/var/pants-sandbox/test.py"
 
     # Our heuristic requires absolute paths.
     assert (
-        strip_v2_chroot_path("var/pants-sandbox-OCnquv/test.py")
+        anonymize_v2_chroot_path("var/pants-sandbox-OCnquv/test.py")
         == "var/pants-sandbox-OCnquv/test.py"
     )
 
     # Confirm we can handle values with no chroot path.
-    assert strip_v2_chroot_path("") == ""
-    assert strip_v2_chroot_path("hello world") == "hello world"
+    assert anonymize_v2_chroot_path("") == ""
+    assert anonymize_v2_chroot_path("hello world") == "hello world"
 
 
 @pytest.mark.parametrize(

--- a/src/python/pants/util/strutil_test.py
+++ b/src/python/pants/util/strutil_test.py
@@ -84,9 +84,9 @@ def test_strip_chroot_path() -> None:
         )
         == dedent(
             """\
-        Would reformat src/python/example.py
-        Would reformat test.py
-        Would reformat custom_tmpdir.py
+        Would reformat /<sandbox-1>/src/python/example.py
+        Would reformat /<sandbox-2>/test.py
+        Would reformat /<sandbox-3>/custom_tmpdir.py
 
         Some other output.
         """
@@ -120,8 +120,8 @@ def test_strip_chroot_path() -> None:
     [
         (False, False, "\033[0;31m/var/pants-sandbox-123/red/path.py\033[0m \033[1mbold\033[0m"),
         (False, True, "/var/pants-sandbox-123/red/path.py bold"),
-        (True, False, "\033[0;31mred/path.py\033[0m \033[1mbold\033[0m"),
-        (True, True, "red/path.py bold"),
+        (True, False, "\033[0;31m/<sandbox-1>/red/path.py\033[0m \033[1mbold\033[0m"),
+        (True, True, "/<sandbox-1>/red/path.py bold"),
     ],
 )
 def test_simplifier(strip_chroot_path: bool, strip_formatting: bool, expected: str) -> None:


### PR DESCRIPTION
This is a partial reversal of #19923 which ended up stripping all mentions the sandbox in such a way that debugging *some* issues becomes very hard. For example [this thread on Slack](https://pantsbuild.slack.com/archives/C046T6TA4/p1706558243804239), which was spawned by [this thread](https://pantsbuild.slack.com/archives/C0D7TNJHL/p1706564121559079). In both cases, the stripping of paths led to undebuggable issues because I couldn't trust the output and I couldn't see if paths were correct.

This PR attempts to strike a middle ground where we anonymize the sandbox paths. In practice, this should have as high cache hit rate as before but should leave some breadcrumbs when multiple sandboxes might be involved, and show that absolute paths *are* absolute, and so on.

Also converts the regex to a non-greedy variant, as it'd otherwise strip too much in a string like `/tmp/pants-sandbox-.../:/tmp/pants-sandbox/...`, removing full first item. Now it will take *as few* characters as possible, which should behave better.