### PR TITLE
Improve build file syntax error

### DIFF
--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -75,9 +75,13 @@ class BuildFileSyntaxError(SyntaxError):
 
     def __str__(self) -> str:
         first_line = f"Error parsing BUILD file {self.filename}:{self.lineno}: {self.msg}"
-        second_line = f"  {self.text.rstrip()}"
-        third_line = f"  {' ' * (self.offset - 1)}^"
-        return f"{first_line}\n{second_line}\n{third_line}"
+        # These two fields are optional per the spec, so we can't rely on them being set.
+        if self.text is not None and self.offset is not None:
+            second_line = f"  {self.text.rstrip()}"
+            third_line = f"  {' ' * (self.offset - 1)}^"
+            return f"{first_line}\n{second_line}\n{third_line}"
+
+        return first_line
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/engine/internals/build_files.py
+++ b/src/python/pants/engine/internals/build_files.py
@@ -204,7 +204,11 @@ class BUILDFileEnvVarExtractor(ast.NodeVisitor):
     @classmethod
     def get_env_vars(cls, file_content: FileContent) -> Sequence[str]:
         obj = cls(file_content.path)
-        obj.visit(ast.parse(file_content.content, file_content.path))
+        try:
+            obj.visit(ast.parse(file_content.content, file_content.path))
+        except SyntaxError as e:
+            raise Exception(f"Error parsing BUILD file {file_content.path}:{e.lineno}: {e.msg}")
+
         return tuple(obj.env_vars)
 
     def visit_Call(self, node: ast.Call):

--- a/src/python/pants/engine/internals/build_files_test.py
+++ b/src/python/pants/engine/internals/build_files_test.py
@@ -18,7 +18,9 @@ from pants.engine.env_vars import CompleteEnvironmentVars, EnvironmentVars, Envi
 from pants.engine.fs import DigestContents, FileContent, PathGlobs
 from pants.engine.internals.build_files import (
     AddressFamilyDir,
+    BUILDFileEnvVarExtractor,
     BuildFileOptions,
+    BuildFileSyntaxError,
     OptionalAddressFamily,
     evaluate_preludes,
     parse_address_family,
@@ -944,3 +946,39 @@ def test_build_file_description_of_origin(target_adaptor_rule_runner: RuleRunner
         [TargetAdaptorRequest(Address("src", target_name="foo"), description_of_origin="test")],
     )
     assert "src/BUILD:2" == target_adaptor.description_of_origin
+
+
+@pytest.mark.parametrize(
+    "filename, contents, expect_failure, expected_message",
+    [
+        ("BUILD", "data()", False, None),
+        (
+            "BUILD.qq",
+            "data()qq",
+            True,
+            "Error parsing BUILD file BUILD.qq:1: invalid syntax\n  data()qq\n        ^",
+        ),
+        (
+            "foo/BUILD",
+            "data()\nqwe asd",
+            True,
+            "Error parsing BUILD file foo/BUILD:2: invalid syntax\n  qwe asd\n      ^",
+        ),
+    ],
+)
+def test_build_file_syntax_error(filename, contents, expect_failure, expected_message):
+    class MockFileContent:
+        def __init__(self, path, content):
+            self.path = path
+            self.content = content
+
+    if expect_failure:
+        with pytest.raises(BuildFileSyntaxError) as e:
+            BUILDFileEnvVarExtractor.get_env_vars(MockFileContent(filename, contents))
+
+        formatted = str(e.value)
+
+        assert formatted == expected_message
+
+    else:
+        BUILDFileEnvVarExtractor.get_env_vars(MockFileContent(filename, contents))


### PR DESCRIPTION
Inspired by this thread: https://pantsbuild.slack.com/archives/C046T6T9U/p1706779724173179

What it currently looks like: 
<img width="805" alt="image" src="https://github.com/pantsbuild/pants/assets/8234817/33a8ed1f-e019-48dc-b1c2-c92a5122a3d1">

With this change:
<img width="908" alt="image" src="https://github.com/pantsbuild/pants/assets/8234817/886de937-c1d9-4d41-b168-305f3b1cf5da">

In later Python versions we would also have end_lineno and end_offset, but those properties aren't accessible (or set?) in 3.9.