### PR TITLE
Add support for the pex `--executable` argument

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -12,6 +12,7 @@ from pants.backend.python.target_types import (
     PexEmitWarningsField,
     PexEntryPointField,
     PexEnvField,
+    PexExecutableField,
     PexExecutionMode,
     PexExecutionModeField,
     PexIgnoreErrorsField,
@@ -58,6 +59,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
 
     entry_point: PexEntryPointField
     script: PexScriptField
+    executable: PexExecutableField
     args: PexArgsField
     env: PexEnvField
 
@@ -141,7 +143,7 @@ async def package_pex_binary(
     request = PexFromTargetsRequest(
         addresses=[field_set.address],
         internal_only=False,
-        main=resolved_entry_point.val or field_set.script.value,
+        main=resolved_entry_point.val or field_set.script.value or field_set.executable.value,
         inject_args=field_set.args.value or [],
         inject_env=field_set.env.value or FrozenDict[str, str](),
         platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),

--- a/src/python/pants/backend/python/goals/run_helper.py
+++ b/src/python/pants/backend/python/goals/run_helper.py
@@ -10,6 +10,7 @@ from typing import Iterable, Optional
 from pants.backend.python.subsystems.debugpy import DebugPy
 from pants.backend.python.target_types import (
     ConsoleScript,
+    Executable,
     PexEntryPointField,
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
@@ -43,6 +44,7 @@ async def _create_python_source_run_request(
     run_in_sandbox: bool,
     pex_path: Iterable[Pex] = (),
     console_script: Optional[ConsoleScript] = None,
+    executable: Optional[Executable] = None,
 ) -> RunRequest:
     addresses = [address]
     entry_point, transitive_targets = await MultiGet(
@@ -67,7 +69,7 @@ async def _create_python_source_run_request(
                 include_source_files=False,
                 include_local_dists=True,
                 # `PEX_EXTRA_SYS_PATH` should contain this entry_point's module.
-                main=console_script or entry_point.val,
+                main=executable or console_script or entry_point.val,
                 additional_args=(
                     # N.B.: Since we cobble together the runtime environment via PEX_EXTRA_SYS_PATH
                     # below, it's important for any app that re-executes itself that these environment

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -213,6 +213,51 @@ def test_local_dist() -> None:
         assert result.stdout == "LOCAL DIST\n"
 
 
+def test_local_dist_with_executable_main() -> None:
+    sources = {
+        "foo/bar.py": "BAR = 'LOCAL DIST'",
+        "foo/setup.py": dedent(
+            """\
+            from setuptools import setup
+
+            # Double-brace the package_dir to avoid setup_tmpdir treating it as a format.
+            setup(name="foo", version="9.8.7", packages=["foo"], package_dir={{"foo": "."}},)
+            """
+        ),
+        "foo/foo-bar-main": "from foo.bar import BAR; print(BAR)",
+        "foo/BUILD": dedent(
+            """\
+            python_sources(name="lib", sources=["bar.py", "setup.py"])
+
+            python_sources(name="main_exe", sources=["foo-bar-main"])
+
+            python_distribution(
+                name="dist",
+                dependencies=[":lib"],
+                provides=python_artifact(name="foo", version="9.8.7"),
+                sdist=False,
+                generate_setup=False,
+            )
+
+            pex_binary(
+                name="bin",
+                executable="foo-bar-main",
+                # Force-exclude any dep on bar.py, so the only way to consume it is via the dist.
+                dependencies=[":main_exe", ":dist", "!!:lib"])
+            """
+        ),
+    }
+    with setup_tmpdir(sources) as tmpdir:
+        args = [
+            "--backend-packages=pants.backend.python",
+            f"--source-root-patterns=['/{tmpdir}']",
+            "run",
+            f"{tmpdir}/foo:bin",
+        ]
+        result = run_pants(args)
+        assert result.stdout == "LOCAL DIST\n"
+
+
 def test_run_script_from_3rdparty_dist_issue_13747() -> None:
     sources = {
         "src/BUILD": dedent(

--- a/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
+++ b/src/python/pants/backend/python/goals/run_pex_binary_integration_test.py
@@ -218,7 +218,7 @@ def test_local_dist_with_executable_main() -> None:
         "foo/bar.py": "BAR = 'LOCAL DIST'",
         "foo/setup.py": dedent(
             """\
-            from setuptools import setup
+            from setuptools import setup  # pants: no-infer-dep
 
             # Double-brace the package_dir to avoid setup_tmpdir treating it as a format.
             setup(name="foo", version="9.8.7", packages=["foo"], package_dir={{"foo": "."}},)
@@ -255,6 +255,7 @@ def test_local_dist_with_executable_main() -> None:
             f"{tmpdir}/foo:bin",
         ]
         result = run_pants(args)
+        result.assert_success()
         assert result.stdout == "LOCAL DIST\n"
 
 

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -54,7 +54,7 @@ class PythonSourceFieldSet(RunFieldSet):
     def _executable_main(self) -> Optional[Executable]:
         source = PurePath(self.source.value)
         source_name = source.stem if source.suffix == ".py" else source.name
-        if not source_name.isidentifier():
+        if not all(part.isidentifier() for part in source_name.split(".")):
             # If the python source is not importable (python modules can't be named with '-'),
             # then it must be an executable script.
             executable = Executable(self.source.value)

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -214,11 +214,13 @@ class PythonToolBase(PythonToolRequirementsBase):
 
     # Subclasses must set.
     default_main: ClassVar[MainSpecification]
-    # TODO: default_main can be an Executable, which is very uncommon.
-    #       This does not add an --executable option because that complicates
-    #       the UX for most tools, even though Executable should be very uncommon.
-    #       If we need to allow users to set --executable, then add a mixin class:
-    #       PythonToolExecutableMixin
+
+    # Though possible, we do not recommend setting `default_main` to an Executable
+    # instead of a ConsoleScript or an EntryPoint. Executable is a niche pex feature
+    # designed to support poorly named executable python scripts that cannot be imported
+    # (eg when a file has a character like "-" that is not valid in python identifiers).
+    # As this should be rare or even non-existant, we do NOT add an `executable` option
+    # to mirror the other MainSpecification options.
 
     console_script = StrOption(
         advanced=True,

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -219,7 +219,7 @@ class PythonToolBase(PythonToolRequirementsBase):
     # instead of a ConsoleScript or an EntryPoint. Executable is a niche pex feature
     # designed to support poorly named executable python scripts that cannot be imported
     # (eg when a file has a character like "-" that is not valid in python identifiers).
-    # As this should be rare or even non-existant, we do NOT add an `executable` option
+    # As this should be rare or even non-existent, we do NOT add an `executable` option
     # to mirror the other MainSpecification options.
 
     console_script = StrOption(

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -214,6 +214,11 @@ class PythonToolBase(PythonToolRequirementsBase):
 
     # Subclasses must set.
     default_main: ClassVar[MainSpecification]
+    # TODO: default_main can be an Executable, which is very uncommon.
+    #       This does not add an --executable option because that complicates
+    #       the UX for most tools, even though Executable should be very uncommon.
+    #       If we need to allow users to set --executable, then add a mixin class:
+    #       PythonToolExecutableMixin
 
     console_script = StrOption(
         advanced=True,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -410,7 +410,7 @@ class PexExecutableField(Field):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
         # spec_path is relative to the workspace. The rule is responsible for
         # stripping the source root as needed.
-        return Executable(f"{address.spec_path}/{value}".lstrip("/"))
+        return Executable(os.path.join(address.spec_path, value).lstrip(os.path.sep))
 
 
 class PexArgsField(StringSequenceField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -323,8 +323,8 @@ class EntryPointField(AsyncFieldMixin, Field):
           1) `'app.py'`, Pants will convert into the module `path.to.app`;
           2) `'app.py:func'`, Pants will convert into `path.to.app:func`.
 
-        You may either set this field or the `script` field, but not both. Leave off both fields
-        to have no entry point.
+        You may only set one of: this field, or the `script` field, or the `executable` field.
+        Leave off all three fields to have no entry point.
         """
     )
     value: EntryPoint | None
@@ -369,8 +369,8 @@ class PexScriptField(Field):
         Set the entry point, i.e. what gets run when executing `./my_app.pex`, to a script or
         console_script as defined by any of the distributions in the PEX.
 
-        You may either set this field or the `entry_point` field, but not both. Leave off both
-        fields to have no entry point.
+        You may only set one of: this field, or the `entry_point` field, or the `executable` field.
+        Leave off all three fields to have no entry point.
         """
     )
     value: ConsoleScript | None
@@ -390,9 +390,9 @@ class PexExecutableField(Field):
     default = None
     help = help_text(
         """
-        Set the entry point, i.e. what gets run when executing `./my_app.pex`, to a execuatble
+        Set the entry point, i.e. what gets run when executing `./my_app.pex`, to an execuatble
         local python script. This executable python script is typically something that cannot
-        be imported so it cannot be used via script or entry_point.
+        be imported so it cannot be used via `script` or `entry_point`.
 
         You may only set one of: this field, or the `entry_point` field, or the `script` field.
         Leave off all three fields to have no entry point.
@@ -784,13 +784,12 @@ class PexBinary(Target):
 
         if (got_entry_point + got_script + got_executable) > 1:
             raise InvalidTargetException(
-                # TODO: this is ugly. How to improve?
                 softwrap(
                     f"""
                     The `{self.alias}` target {self.address} cannot set more than one of the
                     `{self[PexEntryPointField].alias}`, `{self[PexScriptField].alias}`, and
-                    `{self[PexExecutableField].alias}` fields at
-                    the same time. To fix, please remove one.
+                    `{self[PexExecutableField].alias}` fields at the same time.
+                    To fix, please remove all but one.
                     """
                 )
             )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -410,7 +410,7 @@ class PexExecutableField(Field):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
         # spec_path is relative to the workspace. The rule is responsible for
         # stripping the source root as needed.
-        return Executable(f"{address.spec_path}/{value}")
+        return Executable(f"{address.spec_path}/{value}".lstrip("/"))
 
 
 class PexArgsField(StringSequenceField):

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -37,7 +37,6 @@ from pants.core.goals.test import (
 )
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address, Addresses
-from pants.engine.rules import Get
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
     AsyncFieldMixin,

--- a/src/python/pants/backend/python/target_types_test.py
+++ b/src/python/pants/backend/python/target_types_test.py
@@ -15,9 +15,11 @@ from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.target_types import (
     ConsoleScript,
     EntryPoint,
+    Executable,
     PexBinariesGeneratorTarget,
     PexBinary,
     PexEntryPointField,
+    PexExecutableField,
     PexScriptField,
     PythonDistribution,
     PythonRequirementsField,
@@ -54,15 +56,28 @@ from pants.util.strutil import softwrap
 
 
 def test_pex_binary_validation() -> None:
-    def create_tgt(*, script: str | None = None, entry_point: str | None = None) -> PexBinary:
+    def create_tgt(
+        *, script: str | None = None, executable: str | None = None, entry_point: str | None = None
+    ) -> PexBinary:
         return PexBinary(
-            {PexScriptField.alias: script, PexEntryPointField.alias: entry_point},
+            {
+                PexScriptField.alias: script,
+                PexExecutableField.alias: executable,
+                PexEntryPointField.alias: entry_point,
+            },
             Address("", target_name="t"),
         )
 
     with pytest.raises(InvalidTargetException):
+        create_tgt(script="foo", executable="foo", entry_point="foo")
+    with pytest.raises(InvalidTargetException):
+        create_tgt(script="foo", executable="foo")
+    with pytest.raises(InvalidTargetException):
         create_tgt(script="foo", entry_point="foo")
+    with pytest.raises(InvalidTargetException):
+        create_tgt(executable="foo", entry_point="foo")
     assert create_tgt(script="foo")[PexScriptField].value == ConsoleScript("foo")
+    assert create_tgt(executable="foo")[PexExecutableField].value == Executable("foo")
     assert create_tgt(entry_point="foo")[PexEntryPointField].value == EntryPoint("foo")
 
 

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -694,9 +694,7 @@ async def build_pex(
             # request.main.spec is a python source file including it's spec_path.
             # To make it relative to the sandbox, we strip the source root
             # and add the source_dir_name (sources get prefixed with that below).
-            stripped = await Get(
-                StrippedFileName, StrippedFileNameRequest(request.main.spec)
-            )
+            stripped = await Get(StrippedFileName, StrippedFileNameRequest(request.main.spec))
             argv.append(f"{source_dir_name}/{stripped.value}")
 
     argv.extend(

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -57,6 +57,7 @@ from pants.build_graph.address import Address
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.environments import EnvironmentTarget
 from pants.core.util_rules.stripped_source_files import StrippedFileName, StrippedFileNameRequest
+from pants.core.util_rules.stripped_source_files import rules as stripped_source_rules
 from pants.core.util_rules.system_binaries import BashBinary
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.collection import Collection, DeduplicatedCollection
@@ -1371,4 +1372,4 @@ async def determine_pex_resolve_info(pex_pex: PexPEX, pex: Pex) -> PexResolveInf
 
 
 def rules():
-    return [*collect_rules(), *pex_cli.rules(), *pex_requirements.rules()]
+    return [*collect_rules(), *pex_cli.rules(), *pex_requirements.rules(), *stripped_source_rules()]

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -696,7 +696,7 @@ async def build_pex(
             # To make it relative to the sandbox, we strip the source root
             # and add the source_dir_name (sources get prefixed with that below).
             stripped = await Get(StrippedFileName, StrippedFileNameRequest(request.main.spec))
-            argv.append(f"{source_dir_name}/{stripped.value}")
+            argv.append(os.path.join(source_dir_name, stripped.value))
 
     argv.extend(
         f"--inject-args={shlex.quote(injected_arg)}" for injected_arg in request.inject_args

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -692,7 +692,7 @@ async def build_pex(
         if isinstance(request.main, Executable):
             # Unlike other MainSpecifiecation types (that can pass spec as-is to pex),
             # Executable must be an actual path relative to the sandbox.
-            # request.main.spec is a python source file including it's spec_path.
+            # request.main.spec is a python source file including its spec_path.
             # To make it relative to the sandbox, we strip the source root
             # and add the source_dir_name (sources get prefixed with that below).
             stripped = await Get(StrippedFileName, StrippedFileNameRequest(request.main.spec))


### PR DESCRIPTION
This PR adds support for `pex --executable <path to script>` added in pex [2.1.93](https://github.com/pantsbuild/pex/releases/tag/v2.1.93):
https://github.com/pantsbuild/pex/pull/1807

With this change, users should be able to do `pants run bin/my-python-script.py`.

Closes #18290