### PR TITLE
Use Python subsystem's default ICs when generating builtin lockfile

### DIFF
--- a/build-support/bin/generate_builtin_lockfiles.py
+++ b/build-support/bin/generate_builtin_lockfiles.py
@@ -90,7 +90,7 @@ class Tool(Generic[ToolBaseT]):
 
 @dataclass
 class PythonTool(Tool[PythonToolRequirementsBase]):
-    interpreter_constraints: str = default_python_interpreter_constraints
+    ...
 
 
 @dataclass
@@ -124,9 +124,7 @@ all_python_tools = tuple(
             PythonTool(Pylint, "pants.backend.python.lint.pylint"),
             PythonTool(PythonProtobufMypyPlugin, "pants.backend.codegen.protobuf.python"),
             PythonTool(PythonProtobufGrpclibPlugin, "pants.backend.codegen.protobuf.python"),
-            PythonTool(
-                Pytype, "pants.backend.experimental.python.typecheck.pytype", "CPython>=3.7,<3.11"
-            ),
+            PythonTool(Pytype, "pants.backend.experimental.python.typecheck.pytype"),
             PythonTool(PyOxidizer, "pants.backend.experimental.python.packaging.pyoxidizer"),
             PythonTool(Ruff, "pants.backend.experimental.python.lint.ruff"),
             PythonTool(SemgrepSubsystem, "pants.backend.experimental.tools.semgrep"),
@@ -227,7 +225,7 @@ def generate_python_tool_lockfiles(tools: Sequence[PythonTool], dry_run: bool) -
                     )
                 )
         resolves = {tool.resolve: tool.lockfile_name for tool in tools}
-        resolves_to_ics = {tool.resolve: [tool.interpreter_constraints] for tool in tools}
+        resolves_to_ics = {tool.resolve: tool.cls.default_interpreter_constraints for tool in tools}
         for file in resolves.values():
             touch(os.path.join(tmp_buildroot, file))  # Prevent "Unmatched glob" warning.
         python_args = [

--- a/src/python/pants/backend/python/typecheck/pytype/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pytype/subsystem.py
@@ -21,7 +21,7 @@ class Pytype(PythonToolBase):
     )
 
     register_interpreter_constraints = True
-    default_interpreter_constraints = ["CPython>=3.7,<3.10"]
+    default_interpreter_constraints = ["CPython>=3.7,<3.11"]
 
     default_main = ConsoleScript("pytype")
     default_requirements = ["pytype==2023.6.16"]


### PR DESCRIPTION
This eliminates a bit of duplication of ICs between the script for generating lockfiles for builtin tools, and the subsystems for those tools. In particular, subsystems (optionally) have a class property indicating their interpreter constraints, which previously had to be then duplicated into the script for generating lockfiles so that the lockfile used those constraints rather than the system-wide default `>=3.7,<4` ones.

This affected only the `pytype` subsystem, which happened to actually have inconsistent interpreter constraints (3.10.* was excluded in the subsystem, but allowed by the locker). I've made them match what the lockfile was being generated with here, I'm not 100% sure this is correct.

(This is a refactoring I noticed when trying to do #20501, since that requires adjusting the lower-bound of the semgrep ICs and it wasn't working as I expected, due to missing this duplication.)