### PR TITLE
stats: add output_file option to output the stats to a file

### DIFF
--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -110,7 +110,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
             # have an empty line between stats of different Pants invocations
             space = "\n\n" if Path(self.output_file).exists() else ""
             output_lines.append(
-                f"{space}{timestamp} Executing goals: {','.join(context._run_tracker.goals)}"
+                f"{space}{timestamp} Command: {context.run_tracker.run_information().get('cmd_line')}"
             )
 
         if self.log:

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -67,7 +67,7 @@ def _log_or_write_to_file(output_file: Optional[str], text: str) -> None:
     """Send text to the stdout or write to the output file."""
     if text:
         if output_file:
-            with open(output_file, "w") as fh:
+            with safe_open(output_file, "w") as fh:
                 fh.write(text)
             logger.info(f"Wrote Pants stats to {output_file}")
         else:

--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -21,6 +21,7 @@ from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.collections import deep_getsizeof
+from pants.util.dirutil import safe_open
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -51,15 +51,15 @@ def test_warn_if_no_histograms() -> None:
 
 def test_writing_to_output_file() -> None:
     with setup_tmpdir({"src/py/app.py": "print(0)\n", "src/py/BUILD": "python_sources()"}):
-        argv = [
+        argv1 = [
             "--backend-packages=['pants.backend.python']",
             "--stats-log",
             "--stats-memory-summary",
             "--stats-output-file=stats.txt",
             "roots",
         ]
-        run_pants(argv).assert_success()
-        argv = [
+        run_pants(argv1).assert_success()
+        argv2 = [
             "--backend-packages=['pants.backend.python']",
             "--stats-log",
             "--stats-memory-summary",
@@ -67,10 +67,13 @@ def test_writing_to_output_file() -> None:
             "list",
             "::",
         ]
-        run_pants(argv).assert_success()
+        run_pants(argv2).assert_success()
         output_file_contents = Path("stats.txt").read_text()
         for item in ("Counters:", "Memory summary"):
             assert output_file_contents.count(item) == 2
 
         for item in ("roots", "list"):
             assert item in output_file_contents
+
+        for cmd in (argv1, argv2):
+            assert " ".join(cmd) in output_file_contents

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -59,6 +59,18 @@ def test_writing_to_output_file() -> None:
             "roots",
         ]
         run_pants(argv).assert_success()
+        argv = [
+            "--backend-packages=['pants.backend.python']",
+            "--stats-log",
+            "--stats-memory-summary",
+            "--stats-output-file=stats.txt",
+            "list",
+            "::",
+        ]
+        run_pants(argv).assert_success()
         output_file_contents = Path("stats.txt").read_text()
         for item in ("Counters:", "Memory summary"):
+            assert output_file_contents.count(item) == 2
+
+        for item in ("roots", "list"):
             assert item in output_file_contents

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 from pants.testutil.pants_integration_test import run_pants, setup_tmpdir
 
@@ -46,3 +47,18 @@ def test_warn_if_no_histograms() -> None:
     assert "Counters:" in result.stderr
     assert "Please run with `--plugins=hdrhistogram`" in result.stderr
     assert "Observation histogram summaries:" not in result.stderr
+
+
+def test_writing_to_output_file() -> None:
+    with setup_tmpdir({"src/py/app.py": "print(0)\n", "src/py/BUILD": "python_sources()"}):
+        argv = [
+            "--backend-packages=['pants.backend.python']",
+            "--stats-log",
+            "--stats-memory-summary",
+            "--stats-output-file=stats.txt",
+            "roots",
+        ]
+        run_pants(argv).assert_success()
+        output_file_contents = Path("stats.txt").read_text()
+        for item in ("Counters:", "Memory summary"):
+            assert item in output_file_contents


### PR DESCRIPTION
Currently when running a Pants goal with the `--stats-log` enabled, the stats are showing at the end of the goal's output. This makes distinguishing between the goal output and stats difficult. One cannot redirect only the stats data to a file as it's just part of the goal output.

This PR adds a new option to request saving the stats into a file to be able to parse it later or archive.

As a next step, I'd like to see a structured data produced. JSON seems sensible so that one can mung it to obtain data in any desired format such as [Prometheus](https://prometheus.io/docs/practices/naming/). The logged stats data is not really suitable for parsing.

---

Usage:

```
$ rm -rf stats.txt; pants --stats-log --stats-output-file="stats.txt" roots; head stats.txt
.
3rdparty/jvm
3rdparty/python
3rdparty/tools
build-support/bin
build-support/flake8
build-support/migration-support
pants-plugins
src/assets
src/python
src/rust
src/rust/engine/dep_inference/src/javascript
src/rust/engine/dep_inference/src/python
src/rust/engine/src/externs
src/rust/engine/ui/src/instance
testprojects/pants-plugins/src/python
testprojects/src/go
testprojects/src/js
testprojects/src/js/coverage_workspaces/jest_coverage/src/test
testprojects/src/js/coverage_workspaces/mocha_coverage/src/test
testprojects/src/js/jest_coverage/src/test
testprojects/src/js/mocha_coverage/src/test
testprojects/src/jvm
testprojects/src/python
testprojects/src/ts
tests/python
Counters:
  backtrack_attempts: 0
  docker_execution_errors: 0
  docker_execution_requests: 0
  docker_execution_successes: 0
  local_cache_read_errors: 0
  local_cache_requests: 0
  local_cache_requests_cached: 0
  local_cache_requests_uncached: 0
  local_cache_total_time_saved_ms: 0
```