### PR TITLE
Fix formatting of the "pex.platforms is deprecated" message

### DIFF
--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -413,7 +413,7 @@ class PexPlatformsField(StringSequenceField):
     alias = "platforms"
     removal_version = "2.22.0.dev0"
     removal_hint = softwrap(
-        """\
+        f"""\
     The platforms field is a hack. The abbreviated information it provides is sometimes insufficient,
     leading to hard-to-debug build issues. Use complete_platforms instead.
     See {doc_url('pex')} for details.


### PR DESCRIPTION
Fixes a missing f-string formatter for the `pex_binary`'s `platforms` field

Before:
> 16:02:15.59 [WARN] DEPRECATED: the platforms field is scheduled to be removed in version 2.22.0.dev0.
Using the `platforms` field in the target src/python/something_something:pex-executable. The platforms field is a hack. The abbreviated information it provides is sometimes insufficient, leading to hard-to-debug build issues. Use complete_platforms instead. See {doc_url('pex')} for details.

After:
> 16:03:43.09 [WARN] DEPRECATED: the platforms field is scheduled to be removed in version 2.22.0.dev0.
Using the `platforms` field in the target src/python/something_something:pex-executable. The platforms field is a hack. The abbreviated information it provides is sometimes insufficient, leading to hard-to-debug build issues. Use complete_platforms instead. See https://www.pantsbuild.org/v2.20/docs/pex for details.