### PR TITLE
docs: provide options to refer to a group of targets

### DIFF
--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -194,6 +194,7 @@ If you have an operation that you perform often on a certain group of targets, y
 [cli](../../reference/subsystems/cli) subsystem options to create shortcuts. For instance, this alias
 
 ```toml title="pants.toml"
+[cli.alias]
 publish-libraries = "--filter-target-type=python_distribution --filter-address-regex=\"['^src/libA/,^src/libB/']\" publish src::"
 ```
 

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -198,7 +198,7 @@ If you have an operation that you perform often on a certain group of targets, y
 publish-libraries = "--filter-target-type=python_distribution --filter-address-regex=\"['^src/libA/,^src/libB/']\" publish src::"
 ```
 
-would you let run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
+would let you run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
 directories. You can use any argument or goal, and the alias doesn't need to be a "full" invocation of Pants.
 For instance, you could combine filtering arguments along with `--changed-since` flag and a tag to refer to long-running
 integration tests that have been recently modified:

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -186,57 +186,24 @@ For other goals, you can leverage shell piping to partition the input targets in
 pants list :: | awk 'NR % 5 == 0' | xargs pants package
 ```
 
-## Referring to a group of targets
+## Using CLI aliases
 
 If setting tags on individual targets is not feasible, there are a few other options available to refer to multiple targets.
 
 If you have an operation that you perform often on a certain group of targets, you can use the
-[cli](https://www.pantsbuild.org/2.19/reference/subsystems/cli) subsystem options to create shortcuts. For instance,
-this alias
+[cli](../../reference/subsystems/cli) subsystem options to create shortcuts. For instance, this alias
 
 ```toml title="pants.toml"
 publish-libraries = "--filter-target-type=python_distribution --filter-address-regex=\"['^src/libA/,^src/libB/']\" publish src::"
 ```
 
 would you let run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
-directories.
+directories. You can use any argument or goal, and the alias doesn't need to be a "full" invocation of Pants.
+For instance, you could combine filtering arguments along with `--changed-since` flag and a tag to refer to long-running
+integration tests that have been recently modified:
 
-If you want to be able to run an arbitrary Pants goal on a group of targets, you can create a generic target with no
-specific type named [`target`](https://www.pantsbuild.org/2.19/reference/targets/target):
-
-```python title="BUILD"
-target(name="python-libs", dependencies=["src/python/libraries/libA", "src/python/libraries/libB"])
+```toml title="pants.toml"
+integration-long = "--changed-since --filter-target-type=python_test --tag=long"
 ```
 
-If declared in the root of your workspace, you can now address the Python libraries by `//:python-libs`:
-
-```bash
-$ pants publish //:python-libs
-````
-
-:::note Tip: create aliases for targets.
-If you have some targets declared in BUILD files that are stored deep within the directory structure of your workspace,
-you can make it easier to refer to that target such as when listing that target among dependencies of other targets.
-
-For example, you can simplify accessing a target by creating another target that will serve as an alias definition in
-a BUILD file stored in a more convenient location in the workspace, for instance, in the build root directory:
-
-```python title="BUILD"
-target(
-    name="deployment-bins",
-    dependencies=["src/golang/production/cloud/deployment/binaries:tools"]
-)
-```
-
-You can now refer to that target more concisely in BUILD files:
-
-```python title="BUILD"
-python_sources(dependencies=["//:deployment-bins"])
-```
-
-and when running Pants goals:
-
-```bash
-$ pants dependents --transitive //:deployment-bins
-```
-:::
+and invoke `pants integration-long test tests::` to run the relevant tests.

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -192,14 +192,15 @@ If setting tags on individual targets is not feasible, there are a few other opt
 
 If you have an operation that you perform often on a certain group of targets, you can use the
 [cli](../../reference/subsystems/cli) subsystem options to create shortcuts. For instance, this alias
+would let you run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
+directories.
 
 ```toml title="pants.toml"
 [cli.alias]
 publish-libraries = "--filter-target-type=python_distribution --filter-address-regex=\"['^src/libA/,^src/libB/']\" publish src::"
 ```
 
-would let you run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
-directories. You can use any argument or goal, and the alias doesn't need to be a "full" invocation of Pants.
+You can use any argument or goal, and the alias doesn't need to be a "full" invocation of Pants.
 For instance, you could combine filtering arguments along with `--changed-since` flag and a tag to refer to long-running
 integration tests that have been recently modified:
 
@@ -208,4 +209,4 @@ integration tests that have been recently modified:
 --integration-long = "--changed-since --filter-target-type=python_test --tag=long"
 ```
 
-and invoke `pants --integration-long test tests::` to run the relevant tests.
+You can now invoke `pants --integration-long test tests::` to run the relevant tests.

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -204,7 +204,8 @@ For instance, you could combine filtering arguments along with `--changed-since`
 integration tests that have been recently modified:
 
 ```toml title="pants.toml"
-integration-long = "--changed-since --filter-target-type=python_test --tag=long"
+[cli.alias]
+--integration-long = "--changed-since --filter-target-type=python_test --tag=long"
 ```
 
 and invoke `pants integration-long test tests::` to run the relevant tests.

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -185,3 +185,58 @@ For other goals, you can leverage shell piping to partition the input targets in
 ```bash
 pants list :: | awk 'NR % 5 == 0' | xargs pants package
 ```
+
+## Referring to a group of targets
+
+If setting tags on individual targets is not feasible, there are a few other options available to refer to multiple targets.
+
+If you have an operation that you perform often on a certain group of targets, you can use the
+[cli](https://www.pantsbuild.org/2.19/reference/subsystems/cli) subsystem options to create shortcuts. For instance,
+this alias
+
+```toml title="pants.toml"
+publish-libraries = "--filter-target-type=python_distribution --filter-address-regex=\"['^src/libA/,^src/libB/']\" publish src::"
+```
+
+would you let run `pants publish-libraries` to publish all Python distributions declared in the `src/libA` and `src/libB`
+directories.
+
+If you want to be able to run an arbitrary Pants goal on a group of targets, you can create a generic target with no
+specific type named [`target`](https://www.pantsbuild.org/2.19/reference/targets/target):
+
+```python title="BUILD"
+target(name="python-libs", dependencies=["src/python/libraries/libA", "src/python/libraries/libB"])
+```
+
+If declared in the root of your workspace, you can now address the Python libraries by `//:python-libs`:
+
+```bash
+$ pants publish //:python-libs
+````
+
+:::note Tip: create aliases for targets.
+If you have some targets declared in BUILD files that are stored deep within the directory structure of your workspace,
+you can make it easier to refer to that target such as when listing that target among dependencies of other targets.
+
+For example, you can simplify accessing a target by creating another target that will serve as an alias definition in
+a BUILD file stored in a more convenient location in the workspace, for instance, in the build root directory:
+
+```python title="BUILD"
+target(
+    name="deployment-bins",
+    dependencies=["src/golang/production/cloud/deployment/binaries:tools"]
+)
+```
+
+You can now refer to that target more concisely in BUILD files:
+
+```python title="BUILD"
+python_sources(dependencies=["//:deployment-bins"])
+```
+
+and when running Pants goals:
+
+```bash
+$ pants dependents --transitive //:deployment-bins
+```
+:::

--- a/docs/docs/using-pants/advanced-target-selection.mdx
+++ b/docs/docs/using-pants/advanced-target-selection.mdx
@@ -208,4 +208,4 @@ integration tests that have been recently modified:
 --integration-long = "--changed-since --filter-target-type=python_test --tag=long"
 ```
 
-and invoke `pants integration-long test tests::` to run the relevant tests.
+and invoke `pants --integration-long test tests::` to run the relevant tests.

--- a/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -166,9 +166,15 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not depended upon by other targets, such as `pex_binary`, `python_distribution`, and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
-## Referring to a group of targets
+## Using the generic `target`
 
-If you want to group multiple targets to refer to them as a unit (a single dependency) to reduce repetition, you can use the generic [`target`](../../reference/targets/target):
+[`target`](../../..reference/targets/target) is a generic target with no specific type.
+It can be used as a generic collection of targets to group related, but distinct targets into one single target.
+
+### Referring to a group of targets
+
+You could use the generic `target` when you need to group multiple targets to refer to them as a unit
+(a single dependency) to reduce repetition:
 
 ```python title="BUILD"
 target(
@@ -183,7 +189,7 @@ If declared in the root of your workspace, you can now address the Python librar
 $ pants dependencies //:python-libs
 ````
 
-## Creating aliases for targets
+### Creating aliases for targets
 
 If you have some targets declared in BUILD files that are stored deep within the directory structure of your workspace,
 you can make it easier to refer to that target when listing that target among dependencies of other targets.

--- a/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -168,8 +168,7 @@ Transitive excludes can only be used in target types that conventionally are not
 
 ## Referring to a group of targets
 
-If you want to group multiple targets to refer to them as dependencies, you can create a generic target with no
-specific type named [`target`](../../reference/targets/target):
+If you want to group multiple targets to refer to them as a unit (a single dependency) to reduce repetition, you can use the generic [`target`](../../reference/targets/target):
 
 ```python title="BUILD"
 target(

--- a/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -166,6 +166,45 @@ You can use the prefix `!!` to transitively exclude a dependency, meaning that e
 Transitive excludes can only be used in target types that conventionally are not depended upon by other targets, such as `pex_binary`, `python_distribution`, and `python_test` / `python_tests`. This is meant to limit confusion, as using `!!` in something like a `python_source` / `python_sources` target could result in surprising behavior for everything that depends on it. (Pants will print a helpful error when using `!!` when it's not legal.)
 :::
 
+## Referring to a group of targets
+
+If you want to group multiple targets to refer to them as dependencies, you can create a generic target with no
+specific type named [`target`](../../reference/targets/target):
+
+```python title="BUILD"
+target(
+    name="python-libs",
+    dependencies=["src/python/libraries/libA", "src/python/libraries/libB"],
+)
+```
+
+If declared in the root of your workspace, you can now address the Python libraries by `//:python-libs`:
+
+```bash
+$ pants dependencies //:python-libs
+````
+
+## Creating aliases for targets
+
+If you have some targets declared in BUILD files that are stored deep within the directory structure of your workspace,
+you can make it easier to refer to that target when listing that target among dependencies of other targets.
+
+For example, you can simplify accessing a target by creating another target that will serve as an alias definition in
+a BUILD file stored in a more convenient location in the workspace, for instance, in the build root directory:
+
+```python title="BUILD"
+target(
+    name="deployment-bins",
+    dependencies=["src/golang/production/cloud/deployment/binaries:tools"]
+)
+```
+
+You can now refer to that target more concisely in BUILD files:
+
+```python title="BUILD"
+python_sources(dependencies=["//:deployment-bins"])
+```
+
 ## Field default values
 
 As mentioned above in [BUILD files](./targets-and-build-files.mdx#build-files), most target fields have sensible defaults. And it's easy to override those values on a specific target. But applying the same non-default value on many targets can get unwieldy, error-prone and hard to maintain. Enter `__defaults__`.


### PR DESCRIPTION
I believe the docs would benefit from having `cli` subsystem mentioned when explaining how to address targets. Also, the generic `target` is not referred anywhere, but is a powerful technique to provide a proxy to address multiple targets.

Rendered

![image](https://github.com/pantsbuild/pants/assets/50622389/2f437314-232d-4989-b89c-fd0922705342)

---

![image](https://github.com/pantsbuild/pants/assets/50622389/7d6ca180-b99b-4970-914b-22b793ef8e50)
