### PR TITLE
python: respect closed option when exporting dependency graph as JSON

### DIFF
--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -80,10 +80,11 @@ async def list_dependencies_as_json(
         )
 
         iterated_targets = []
-        for transitive_targets in transitive_targets_group:
-            iterated_targets.append(
-                sorted([str(tgt.address) for tgt in transitive_targets.dependencies])
-            )
+        for idx, transitive_targets in enumerate(transitive_targets_group):
+            targets_collection = {str(tgt.address) for tgt in transitive_targets.dependencies}
+            if dependencies_subsystem.closed:
+                targets_collection.add(addresses[idx].spec)
+            iterated_targets.append(sorted(targets_collection))
 
     else:
         dependencies_per_target_root = await MultiGet(
@@ -98,8 +99,11 @@ async def list_dependencies_as_json(
         )
 
         iterated_targets = []
-        for targets in dependencies_per_target_root:
-            iterated_targets.append(sorted([str(tgt.address) for tgt in targets]))
+        for idx, targets in enumerate(dependencies_per_target_root):
+            targets_collection = {str(tgt.address) for tgt in targets}
+            if dependencies_subsystem.closed:
+                targets_collection.add(str(target_roots[idx].address))
+            iterated_targets.append(sorted(targets_collection))
 
     # The assumption is that when iterating the targets and sending dependency requests
     # for them, the lists of dependencies are returned in the very same order.

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -282,6 +282,32 @@ def test_python_dependencies_output_format_json_direct_deps(rule_runner: PythonR
             ],
         },
     )
+    # input: directory, recursively, closed
+    assert_deps(
+        specs=["some::"],
+        transitive=False,
+        closed=True,
+        expected={
+            "some/target:target": [
+                "some/target/a.py",
+                "some/target:target",
+            ],
+            "some/target/a.py": [
+                "3rdparty/python:req1",
+                "dep/target/a.py",
+                "some/target/a.py",
+            ],
+            "some/other/target:target": [
+                "some/other/target/a.py",
+                "some/other/target:target",
+            ],
+            "some/other/target/a.py": [
+                "3rdparty/python:req2",
+                "some/other/target/a.py",
+                "some/target/a.py",
+            ],
+        },
+    )
     assert_deps(
         specs=["some/other/target:target"],
         transitive=True,
@@ -291,6 +317,21 @@ def test_python_dependencies_output_format_json_direct_deps(rule_runner: PythonR
                 "3rdparty/python:req2",
                 "dep/target/a.py",
                 "some/other/target/a.py",
+                "some/target/a.py",
+            ]
+        },
+    )
+    assert_deps(
+        specs=["some/other/target:target"],
+        transitive=True,
+        closed=True,
+        expected={
+            "some/other/target:target": [
+                "3rdparty/python:req1",
+                "3rdparty/python:req2",
+                "dep/target/a.py",
+                "some/other/target/a.py",
+                "some/other/target:target",
                 "some/target/a.py",
             ]
         },
@@ -362,6 +403,41 @@ def test_python_dependencies_output_format_json_transitive_deps(
                 "3rdparty/python:req1",
                 "3rdparty/python:req2",
                 "dep/target/a.py",
+                "some/target/a.py",
+            ],
+        },
+    )
+
+    # input: directory, recursively, closed
+    assert_deps(
+        specs=["some::"],
+        transitive=True,
+        closed=True,
+        expected={
+            "some/target:target": [
+                "3rdparty/python:req1",
+                "dep/target/a.py",
+                "some/target/a.py",
+                "some/target:target",
+            ],
+            "some/target/a.py": [
+                "3rdparty/python:req1",
+                "dep/target/a.py",
+                "some/target/a.py",
+            ],
+            "some/other/target:target": [
+                "3rdparty/python:req1",
+                "3rdparty/python:req2",
+                "dep/target/a.py",
+                "some/other/target/a.py",
+                "some/other/target:target",
+                "some/target/a.py",
+            ],
+            "some/other/target/a.py": [
+                "3rdparty/python:req1",
+                "3rdparty/python:req2",
+                "dep/target/a.py",
+                "some/other/target/a.py",
                 "some/target/a.py",
             ],
         },

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -162,7 +162,7 @@ async def list_dependents_as_json(
             DependentsRequest(
                 (address,),
                 transitive=dependents_subsystem.transitive,
-                include_roots=False,
+                include_roots=dependents_subsystem.closed,
             ),
         )
         for address in addresses

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -117,8 +117,7 @@ class DependentsSubsystem(LineOriented, GoalSubsystem):
     )
     closed = BoolOption(
         default=False,
-        help="Include the input targets in the output, along with the dependents. This option "
-        "only applies when using the `text` format.",
+        help="Include the input targets in the output, along with the dependents.",
     )
     format = EnumOption(
         default=DependentsOutputFormat.text,
@@ -151,11 +150,7 @@ async def list_dependents_as_plain_text(
 async def list_dependents_as_json(
     addresses: Addresses, dependents_subsystem: DependentsSubsystem, console: Console
 ) -> None:
-    """Get dependents for given addresses and list them in the console in JSON.
-
-    Note that `--closed` option is ignored as it doesn't make sense to duplicate source address in
-    the list of its dependents.
-    """
+    """Get dependents for given addresses and list them in the console in JSON."""
     dependents_group = await MultiGet(
         Get(
             Dependents,

--- a/src/python/pants/backend/project_info/dependents_test.py
+++ b/src/python/pants/backend/project_info/dependents_test.py
@@ -148,6 +148,23 @@ def test_dependents_as_json_direct_deps(rule_runner: RuleRunner) -> None:
         },
     )
 
+    # input: all targets, closed
+    assert_deps(
+        targets=["::"],
+        transitive=False,
+        closed=True,
+        expected={
+            "base:base": ["base:base", "intermediate:intermediate"],
+            "intermediate:intermediate": [
+                "intermediate:intermediate",
+                "leaf:leaf",
+                "special:special",
+            ],
+            "leaf:leaf": ["leaf:leaf"],
+            "special:special": ["special:special"],
+        },
+    )
+
 
 def test_dependents_as_json_transitive_deps(rule_runner: RuleRunner) -> None:
     rule_runner.write_files({"special/BUILD": "tgt(special_deps=['intermediate'])"})
@@ -179,11 +196,28 @@ def test_dependents_as_json_transitive_deps(rule_runner: RuleRunner) -> None:
     # input: all targets
     assert_deps(
         targets=["::"],
-        transitive=False,
+        transitive=True,
         expected={
-            "base:base": ["intermediate:intermediate"],
+            "base:base": ["intermediate:intermediate", "leaf:leaf", "special:special"],
             "intermediate:intermediate": ["leaf:leaf", "special:special"],
             "leaf:leaf": [],
             "special:special": [],
+        },
+    )
+
+    # input: all targets, closed
+    assert_deps(
+        targets=["::"],
+        transitive=True,
+        closed=True,
+        expected={
+            "base:base": ["base:base", "intermediate:intermediate", "leaf:leaf", "special:special"],
+            "intermediate:intermediate": [
+                "intermediate:intermediate",
+                "leaf:leaf",
+                "special:special",
+            ],
+            "leaf:leaf": ["leaf:leaf"],
+            "special:special": ["special:special"],
         },
     )


### PR DESCRIPTION
The `--closed` flag is to be respected when exporting dep graph into JSON. It's by default off, so a proper adjacency list is going to be exported (without any self-dependencies), but should user need to create a closure, this is now possible.

```
$ pants dependencies --format=json \
  src/python/pants/backend/project_info/dependencies_test.py \
  src/python/pants/backend/project_info/list_roots_test.py > deps.json

$ pants dependencies --format=json --closed \
  src/python/pants/backend/project_info/dependencies_test.py \
  src/python/pants/backend/project_info/list_roots_test.py > deps-closed.json

$ diff deps.json deps-closed.json

6a7
>         "src/python/pants/backend/project_info/dependencies_test.py:tests",
17a19
>         "src/python/pants/backend/project_info/list_roots_test.py:tests",

```