### PR TITLE
Add TypeScript plugin to Pants loader

### DIFF
--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -73,6 +73,7 @@ target(
         "src/python/pants/backend/experimental/tools/semgrep",
         "src/python/pants/backend/experimental/tools/yamllint",
         "src/python/pants/backend/experimental/tools/workunit_logger",
+        "src/python/pants/backend/experimental/typescript",
         "src/python/pants/backend/experimental/visibility",
         "src/python/pants/backend/google_cloud_function/python",
         "src/python/pants/backend/plugin_development",


### PR DESCRIPTION
The Typescript plugin is missing from Pants' distribution, this may be an overlook so this PR simply adds it to the list of available built-in backends.