### PR TITLE
Bump PyO3 to 0.20 to fix backtraces (Cherry-pick of #20517)

### DIFF
--- a/src/python/pants/engine/internals/scheduler_test.py
+++ b/src/python/pants/engine/internals/scheduler_test.py
@@ -481,6 +481,8 @@ def test_trace_includes_nested_exception_traceback() -> None:
             return await Get(SomeOutput, SomeInput(outer_input.s))
           File LOCATION-INFO, in __await__
             result = yield self
+          File LOCATION-INFO, in raise_an_exception
+            raise Exception(some_input.s)
         Exception: asdf
 
         The above exception was the direct cause of the following exception:

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1761,12 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.4"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7906a9fababaeacb774f72410e497a1d18de916322e33797bb2cd29baa23c9e"
-dependencies = [
- "unindent",
-]
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "inotify"
@@ -2772,16 +2769,16 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef52f74ec3b1a1baf295d9b8fcc3070327aefc39a6d00656b13c1d0b8885c"
+checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
 dependencies = [
  "cfg-if 1.0.0",
  "indoc",
  "libc",
  "memoffset 0.9.0",
  "parking_lot 0.12.1",
- "pyo3-build-config 0.19.0",
+ "pyo3-build-config 0.20.2",
  "pyo3-ffi",
  "pyo3-macros",
  "unindent",
@@ -2799,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713eccf888fb05f1a96eb78c0dbc51907fee42b3377272dc902eb38985f418d5"
+checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2809,35 +2806,36 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ecbdcfb01cbbf56e179ce969a048fd7305a66d4cdf3303e0da09d69afe4c3"
+checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
 dependencies = [
  "libc",
- "pyo3-build-config 0.19.0",
+ "pyo3-build-config 0.20.2",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b78fdc0899f2ea781c463679b20cb08af9247febc8d052de941951024cd8aea0"
+checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60da7b84f1227c3e2fe7593505de274dcf4c8928b4e0a1c23d551a14e4e80a0f"
+checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
 dependencies = [
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4214,9 +4212,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "unindent"
-version = "0.1.8"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "untrusted"

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -277,7 +277,7 @@ prodash = { git = "https://github.com/stuhood/prodash", rev = "stuhood/raw-messa
 prost = "0.11"
 prost-build = "0.11"
 prost-types = "0.11"
-pyo3 = "0.19"
+pyo3 = "0.20"
 rand = "0.8"
 regex = "1"
 rlimit = "0.8"

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -257,8 +257,8 @@ pub struct PyMergeDigests(pub Vec<DirectoryDigest>);
 #[pymethods]
 impl PyMergeDigests {
     #[new]
-    fn __new__(digests: &PyAny, py: Python) -> PyResult<Self> {
-        let digests: PyResult<Vec<DirectoryDigest>> = PyIterator::from_object(py, digests)?
+    fn __new__(digests: &PyAny, _py: Python) -> PyResult<Self> {
+        let digests: PyResult<Vec<DirectoryDigest>> = PyIterator::from_object(digests)?
             .map(|v| {
                 let py_digest = v?.extract::<PyDigest>()?;
                 Ok(py_digest.0)

--- a/src/rust/engine/src/interning.rs
+++ b/src/rust/engine/src/interning.rs
@@ -54,7 +54,7 @@ impl Interns {
         let (id, type_id): (u64, TypeId) = {
             let v = v.as_ref(py);
             let keys = self.keys.as_ref(py);
-            let id: u64 = if let Some(key) = keys.get_item(v) {
+            let id: u64 = if let Some(key) = keys.get_item(v)? {
                 key.extract()?
             } else {
                 let id = self.id_generator.fetch_add(1, atomic::Ordering::Relaxed);


### PR DESCRIPTION
Fixes #20460. Caused by https://github.com/PyO3/pyo3/issues/3327.

Nothing in the [changelog](https://pyo3.rs/v0.20.0/changelog.html) stands out to me as a super-immediate need so doing the minimal upgrade. 

@ndellosa95 if you check this out branch run it as `MODE=debug ../path/to/repo/pants`, does it fix your cases too? I only tested a single rule in my case.

Edit: It looks like this broke a single test, but the original nested chain seems odd to me -- where it previously showed just a "raise from" pointing at a yield (?) it now shows the full proper callstack. So now we have an extraneous "original error" at the top that ends at the rule edge. I think this is still an improvement over #20460, but if we can figure out where that original chained exception is added it'd be great.

EEdit: The reason it looks like this is that we throw when we handle the error on the Rust side. Unfortunately, at the point where we throw we can't tell whether we're in the middle of handling a raised error from Python or a new one. So the below reads:

* Rust received an error from a rule invocation, 
* And re-raised a new error with the full stack trace,
* And that was then re-raised

Since this chaining doesn't seem to show up in most actual usage I'm opting to leave this as is/future work.

![image](https://github.com/pantsbuild/pants/assets/8234817/cfcc1477-998b-4f17-95a8-5692cf36b59e)
 
