### PR TITLE
docs: provide example of having a --option in [cli.alias]

### DIFF
--- a/src/python/pants/option/alias.py
+++ b/src/python/pants/option/alias.py
@@ -51,7 +51,6 @@ class CliOptions(Subsystem):
 
             This would allow you to run `{bin_name()} green --all-changed`, which is shorthand for
             `{bin_name()} fmt lint check --changed-since=HEAD --changed-dependents=transitive`.
-            You can also now run `{bin_name()} test --troubleshoot ::` to debug tests.
 
             Notice: this option must be placed in a config file (e.g. `pants.toml` or `pantsrc`)
             to have any effect.

--- a/src/python/pants/option/alias.py
+++ b/src/python/pants/option/alias.py
@@ -49,7 +49,7 @@ class CliOptions(Subsystem):
                 --all-changed = "--changed-since=HEAD --changed-dependents=transitive"
 
 
-            This would allow you to run `{bin_name()} green all-changed`, which is shorthand for
+            This would allow you to run `{bin_name()} green --all-changed`, which is shorthand for
             `{bin_name()} fmt lint check --changed-since=HEAD --changed-dependents=transitive`.
             You can also now run `{bin_name()} test --troubleshoot ::` to debug tests.
 

--- a/src/python/pants/option/alias.py
+++ b/src/python/pants/option/alias.py
@@ -47,10 +47,12 @@ class CliOptions(Subsystem):
                 [cli.alias]
                 green = "fmt lint check"
                 all-changed = "--changed-since=HEAD --changed-dependents=transitive"
+                --troubleshoot = "--test-debug --test-force --test-timeout-maximum=300"
 
 
             This would allow you to run `{bin_name()} green all-changed`, which is shorthand for
             `{bin_name()} fmt lint check --changed-since=HEAD --changed-dependents=transitive`.
+            You can also now run `{bin_name()} test --troubleshoot ::` to debug tests.
 
             Notice: this option must be placed in a config file (e.g. `pants.toml` or `pantsrc`)
             to have any effect.

--- a/src/python/pants/option/alias.py
+++ b/src/python/pants/option/alias.py
@@ -46,8 +46,7 @@ class CliOptions(Subsystem):
 
                 [cli.alias]
                 green = "fmt lint check"
-                all-changed = "--changed-since=HEAD --changed-dependents=transitive"
-                --troubleshoot = "--test-debug --test-force --test-timeout-maximum=300"
+                --all-changed = "--changed-since=HEAD --changed-dependents=transitive"
 
 
             This would allow you to run `{bin_name()} green all-changed`, which is shorthand for


### PR DESCRIPTION
I have learnt only recently that you can provide a flag like `--flag` in `[cli.alias]` and I think it would be useful to have it in the docs among the examples.