### PR TITLE
fix pants.log location in docs

### DIFF
--- a/docs/docs/using-pants/using-pants-in-ci.mdx
+++ b/docs/docs/using-pants/using-pants-in-ci.mdx
@@ -237,7 +237,7 @@ attempts_default = 3
 
 ## Tip: store Pants logs as artifacts
 
-We recommend that you configure your CI system to store the pants log (`.pantsd.d/pants.log`) as a build artifact, so that it is available in case you need to troubleshoot CI issues.
+We recommend that you configure your CI system to store the pants log (`.pants.d/workdir/pants.log`) as a build artifact, so that it is available in case you need to troubleshoot CI issues.
 
 Different CI providers and systems have different ways to configure build artifacts:
 

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -178,9 +178,9 @@ class WorkunitsCallback(ABC):
         completed?
 
         The main reason to `return False` is if your callback logs in its final call, when
-        `finished=True`, as it may end up logging to `.pantsd.d/pants.log` instead of the console,
-        which is harder for users to find. Otherwise, most callbacks should return `True` to avoid
-        slowing down Pants from finishing the run.
+        `finished=True`, as it may end up logging to `.pants.d/workdir/pants.log` instead of the
+        console, which is harder for users to find. Otherwise, most callbacks should return `True`
+        to avoid slowing down Pants from finishing the run.
         """
 
 


### PR DESCRIPTION
Update the `pants.log` file location after the changes in https://github.com/pantsbuild/pants/pull/19911