### PR TITLE
Inline multiple config files into options sources.

### DIFF
--- a/src/rust/engine/client/src/client_tests.rs
+++ b/src/rust/engine/client/src/client_tests.rs
@@ -41,6 +41,7 @@ async fn test_client_fingerprint_mismatch() {
         None,
         true,
         false,
+        None,
     )
     .unwrap();
     let error = pantsd::find_pantsd(&build_root, &options_parser)

--- a/src/rust/engine/client/src/main.rs
+++ b/src/rust/engine/client/src/main.rs
@@ -32,7 +32,7 @@ async fn execute(start: SystemTime) -> Result<i32, String> {
     let (env, dropped) = Env::capture_lossy();
     let env_items = (&env).into();
     let argv = env::args().collect::<Vec<_>>();
-    let options_parser = OptionParser::new(Args::argv(), env, None, true, false)?;
+    let options_parser = OptionParser::new(Args::argv(), env, None, true, false, None)?;
 
     let use_pantsd = options_parser.parse_bool(&option_id!("pantsd"), true)?;
     if !use_pantsd.value {

--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -143,10 +143,10 @@ impl OptionsSource for Args {
         self.get_list(id, parse_string_list)
     }
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
+    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
         match self.find_flag(Self::arg_names(id, Negate::False))? {
             Some((name, ref value, _)) => parse_dict(value)
-                .map(|e| Some(vec![e]))
+                .map(|e| Some(e))
                 .map_err(|e| e.render(name)),
             None => Ok(None),
         }

--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -145,9 +145,7 @@ impl OptionsSource for Args {
 
     fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
         match self.find_flag(Self::arg_names(id, Negate::False))? {
-            Some((name, ref value, _)) => parse_dict(value)
-                .map(Some)
-                .map_err(|e| e.render(name)),
+            Some((name, ref value, _)) => parse_dict(value).map(Some).map_err(|e| e.render(name)),
             None => Ok(None),
         }
     }

--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -146,7 +146,7 @@ impl OptionsSource for Args {
     fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
         match self.find_flag(Self::arg_names(id, Negate::False))? {
             Some((name, ref value, _)) => parse_dict(value)
-                .map(|e| Some(e))
+                .map(Some)
                 .map_err(|e| e.render(name)),
             None => Ok(None),
         }

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use std::collections::{HashMap, HashSet};
-use std::ffi::OsString;
 use std::fs;
 use std::path::Path;
 
@@ -217,132 +216,15 @@ fn toml_table_to_dict(table: &Value) -> HashMap<String, Val> {
 }
 
 #[derive(Clone)]
-struct ConfigSource {
-    #[allow(dead_code)]
-    path: Option<OsString>,
-    config: Value,
-}
-
-impl ConfigSource {
-    fn option_name(id: &OptionId) -> String {
-        id.name("_", NameTransform::None)
-    }
-
-    fn get_value(&self, id: &OptionId) -> Option<&Value> {
-        self.config
-            .get(id.scope())
-            .and_then(|table| table.get(Self::option_name(id)))
-    }
-
-    fn get_list<T: FromValue>(
-        &self,
-        id: &OptionId,
-        parse_list: fn(&str) -> Result<Vec<ListEdit<T>>, ParseError>,
-    ) -> Result<Vec<ListEdit<T>>, String> {
-        let mut list_edits = vec![];
-        if let Some(table) = self.config.get(id.scope()) {
-            let option_name = Self::option_name(id);
-            if let Some(value) = table.get(&option_name) {
-                match value {
-                    Value::Table(sub_table) => {
-                        if sub_table.is_empty()
-                            || !sub_table.keys().collect::<HashSet<_>>().is_subset(
-                                &["add".to_owned(), "remove".to_owned()]
-                                    .iter()
-                                    .collect::<HashSet<_>>(),
-                            )
-                        {
-                            return Err(format!(
-                                "Expected {option_name} to contain an 'add' element, a 'remove' element or both but found: {sub_table:?}"
-                            ));
-                        }
-                        if let Some(add) = sub_table.get("add") {
-                            list_edits.push(ListEdit {
-                                action: ListEditAction::Add,
-                                items: T::extract_list(&format!("{option_name}.add"), add)?,
-                            })
-                        }
-                        if let Some(remove) = sub_table.get("remove") {
-                            list_edits.push(ListEdit {
-                                action: ListEditAction::Remove,
-                                items: T::extract_list(&format!("{option_name}.remove"), remove)?,
-                            })
-                        }
-                    }
-                    Value::String(v) => {
-                        list_edits.extend(parse_list(v).map_err(|e| e.render(option_name))?);
-                    }
-                    value => list_edits.push(ListEdit {
-                        action: ListEditAction::Replace,
-                        items: T::extract_list(&option_name, value)?,
-                    }),
-                }
-            }
-        }
-        Ok(list_edits)
-    }
-
-    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
-        if let Some(table) = self.config.get(id.scope()) {
-            let option_name = Self::option_name(id);
-            if let Some(value) = table.get(&option_name) {
-                match value {
-                    Value::Table(sub_table) => {
-                        if let Some(add) = sub_table.get("add") {
-                            if sub_table.len() == 1 && add.is_table() {
-                                return Ok(Some(DictEdit {
-                                    action: DictEditAction::Add,
-                                    items: toml_table_to_dict(add),
-                                }));
-                            }
-                        }
-                        return Ok(Some(DictEdit {
-                            action: DictEditAction::Replace,
-                            items: toml_table_to_dict(value),
-                        }));
-                    }
-                    Value::String(v) => {
-                        return Ok(Some(parse_dict(v).map_err(|e| e.render(option_name))?));
-                    }
-                    _ => {
-                        return Err(format!(
-                            "Expected {option_name} to be a toml table or Python dict, but given {value}."
-                        ));
-                    }
-                }
-            }
-        }
-        Ok(None)
-    }
-}
-
-#[derive(Clone)]
 pub(crate) struct Config {
-    sources: Vec<ConfigSource>,
+    value: Value,
 }
 
 impl Config {
     pub(crate) fn parse<P: AsRef<Path>>(
-        files: &[P],
-        seed_values: &InterpolationMap,
-    ) -> Result<Config, String> {
-        let mut sources = vec![];
-        for file in files {
-            sources.push(Self::parse_source(file, seed_values)?);
-        }
-        Ok(Config { sources })
-    }
-
-    pub(crate) fn merge(self, other: Config) -> Config {
-        Config {
-            sources: self.sources.into_iter().chain(other.sources).collect(),
-        }
-    }
-
-    fn parse_source<P: AsRef<Path>>(
         file: P,
         seed_values: &InterpolationMap,
-    ) -> Result<ConfigSource, String> {
+    ) -> Result<Config, String> {
         let config_contents = fs::read_to_string(&file).map_err(|e| {
             format!(
                 "Failed to read config file {}: {}",
@@ -419,17 +301,19 @@ impl Config {
         };
 
         let new_table = Table::from_iter(new_sections?);
-        Ok(ConfigSource {
-            path: Some(file.as_ref().as_os_str().into()),
-            config: Value::Table(new_table),
+        Ok(Self {
+            value: Value::Table(new_table),
         })
     }
 
+    fn option_name(id: &OptionId) -> String {
+        id.name("_", NameTransform::None)
+    }
+
     fn get_value(&self, id: &OptionId) -> Option<&Value> {
-        self.sources
-            .iter()
-            .rev()
-            .find_map(|source| source.get_value(id))
+        self.value
+            .get(id.scope())
+            .and_then(|table| table.get(Self::option_name(id)))
     }
 
     fn get_list<T: FromValue>(
@@ -437,11 +321,80 @@ impl Config {
         id: &OptionId,
         parse_list: fn(&str) -> Result<Vec<ListEdit<T>>, ParseError>,
     ) -> Result<Option<Vec<ListEdit<T>>>, String> {
-        let mut edits: Vec<ListEdit<T>> = vec![];
-        for source in self.sources.iter() {
-            edits.append(&mut source.get_list(id, parse_list)?);
+        let mut list_edits = vec![];
+        if let Some(table) = self.value.get(id.scope()) {
+            let option_name = Self::option_name(id);
+            if let Some(value) = table.get(&option_name) {
+                match value {
+                    Value::Table(sub_table) => {
+                        if sub_table.is_empty()
+                            || !sub_table.keys().collect::<HashSet<_>>().is_subset(
+                                &["add".to_owned(), "remove".to_owned()]
+                                    .iter()
+                                    .collect::<HashSet<_>>(),
+                            )
+                        {
+                            return Err(format!(
+                                "Expected {option_name} to contain an 'add' element, a 'remove' element or both but found: {sub_table:?}"
+                            ));
+                        }
+                        if let Some(add) = sub_table.get("add") {
+                            list_edits.push(ListEdit {
+                                action: ListEditAction::Add,
+                                items: T::extract_list(&format!("{option_name}.add"), add)?,
+                            })
+                        }
+                        if let Some(remove) = sub_table.get("remove") {
+                            list_edits.push(ListEdit {
+                                action: ListEditAction::Remove,
+                                items: T::extract_list(&format!("{option_name}.remove"), remove)?,
+                            })
+                        }
+                    }
+                    Value::String(v) => {
+                        list_edits.extend(parse_list(v).map_err(|e| e.render(option_name))?);
+                    }
+                    value => list_edits.push(ListEdit {
+                        action: ListEditAction::Replace,
+                        items: T::extract_list(&option_name, value)?,
+                    }),
+                }
+            }
         }
-        Ok(Some(edits))
+        Ok(Some(list_edits))
+    }
+
+    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
+        if let Some(table) = self.value.get(id.scope()) {
+            let option_name = Self::option_name(id);
+            if let Some(value) = table.get(&option_name) {
+                match value {
+                    Value::Table(sub_table) => {
+                        if let Some(add) = sub_table.get("add") {
+                            if sub_table.len() == 1 && add.is_table() {
+                                return Ok(Some(DictEdit {
+                                    action: DictEditAction::Add,
+                                    items: toml_table_to_dict(add),
+                                }));
+                            }
+                        }
+                        return Ok(Some(DictEdit {
+                            action: DictEditAction::Replace,
+                            items: toml_table_to_dict(value),
+                        }));
+                    }
+                    Value::String(v) => {
+                        return Ok(Some(parse_dict(v).map_err(|e| e.render(option_name))?));
+                    }
+                    _ => {
+                        return Err(format!(
+                            "Expected {option_name} to be a toml table or Python dict, but given {value}."
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(None)
     }
 }
 
@@ -482,13 +435,7 @@ impl OptionsSource for Config {
         self.get_list(id, parse_string_list)
     }
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
-        let mut edits = vec![];
-        for source in self.sources.iter() {
-            if let Some(edit) = source.get_dict(id)? {
-                edits.push(edit);
-            }
-        }
-        Ok(if edits.is_empty() { None } else { Some(edits) })
+    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
+        self.get_dict(id)
     }
 }

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -138,7 +138,7 @@ impl OptionsSource for Env {
     fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
         if let Some(value) = self.get_string(id)? {
             parse_dict(&value)
-                .map(|de| Some(de))
+                .map(Some)
                 .map_err(|e| e.render(self.display(id)))
         } else {
             Ok(None)

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -135,10 +135,10 @@ impl OptionsSource for Env {
         self.get_list(id, parse_string_list)
     }
 
-    fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
+    fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
         if let Some(value) = self.get_string(id)? {
             parse_dict(&value)
-                .map(|e| Some(vec![e]))
+                .map(|de| Some(de))
                 .map_err(|e| e.render(self.display(id)))
         } else {
             Ok(None)

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -34,7 +34,6 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::os::unix::ffi::OsStrExt;
-use std::path;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -259,22 +258,20 @@ impl OptionParser {
         };
 
         fn path_join(prefix: &str, suffix: &str) -> String {
-            if prefix.ends_with(path::MAIN_SEPARATOR) {
-                format!("{}{}", prefix, suffix)
-            } else {
-                format!("{}{}{}", prefix, path::MAIN_SEPARATOR, suffix)
-            }
+            // TODO: The calling code should traffic in Path, or OsString, not String.
+            //  For now we assume the paths are valid UTF8 strings, via unwrap().
+            Path::new(prefix).join(suffix).to_str().unwrap().to_string()
         }
 
         fn path_strip(prefix: &str, path: &str) -> String {
-            match path.strip_prefix(prefix) {
-                Some(suffix) => match suffix.strip_prefix(path::MAIN_SEPARATOR) {
-                    Some(suffix_suffix) => suffix_suffix,
-                    _ => suffix,
-                },
-                _ => path,
-            }
-            .to_string()
+            // TODO: The calling code should traffic in Path, or OsString, not String.
+            //  For now we assume the paths are valid UTF8 strings, via unwrap().
+            Path::new(path)
+                .strip_prefix(prefix)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string()
         }
 
         let repo_config_files = match config_paths {
@@ -316,7 +313,7 @@ impl OptionParser {
                     ordinal,
                     path: path_strip(&buildroot_string, path),
                 },
-                Rc::new(config.clone()),
+                Rc::new(config),
             );
             ordinal += 1;
         }

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -266,9 +266,9 @@ impl OptionParser {
         fn path_strip(prefix: &str, path: &str) -> String {
             // TODO: The calling code should traffic in Path, or OsString, not String.
             //  For now we assume the paths are valid UTF8 strings, via unwrap().
-            Path::new(path)
-                .strip_prefix(prefix)
-                .unwrap()
+            let path = Path::new(path);
+            path.strip_prefix(prefix)
+                .unwrap_or(path)
                 .to_str()
                 .unwrap()
                 .to_string()

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -74,6 +74,33 @@ fn with_setup(
 }
 
 #[test]
+fn test_source_ordering() {
+    assert!(
+        Source::Default
+            < Source::Config {
+                ordinal: 0,
+                path: "pants.toml".to_string()
+            }
+    );
+    assert!(
+        Source::Config {
+            ordinal: 0,
+            path: "pants.toml".to_string()
+        } < Source::Config {
+            ordinal: 1,
+            path: "extra_pants.toml".to_string()
+        }
+    );
+    assert!(
+        Source::Config {
+            ordinal: 1,
+            path: "extra_pants.toml".to_string()
+        } < Source::Env
+    );
+    assert!(Source::Env < Source::Flag);
+}
+
+#[test]
 fn test_parse_single_valued_options() {
     fn check(
         expected: i64,

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -2,14 +2,28 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 use crate::{
-    option_id, Args, DictEdit, DictEditAction, Env, ListEdit, ListEditAction, OptionParser, Source,
-    Val,
+    option_id, Args, BuildRoot, DictEdit, DictEditAction, Env, ListEdit, ListEditAction,
+    OptionParser, Source, Val,
 };
 use maplit::hashmap;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use tempfile::TempDir;
+
+fn config_source() -> Source {
+    Source::Config {
+        ordinal: 0,
+        path: "pants.toml".to_string(),
+    }
+}
+
+fn extra_config_source() -> Source {
+    Source::Config {
+        ordinal: 1,
+        path: "pants_extra.toml".to_string(),
+    }
+}
 
 fn with_setup(
     args: Vec<&'static str>,
@@ -53,6 +67,7 @@ fn with_setup(
         ]),
         false,
         true,
+        Some(BuildRoot::find_from(buildroot.path()).unwrap()),
     )
     .unwrap();
     do_check(option_parser);
@@ -79,7 +94,7 @@ fn test_parse_single_valued_options() {
         3,
         vec![
             (Source::Default, 0),
-            (Source::Config, 1),
+            (config_source(), 1),
             (Source::Env, 2),
             (Source::Flag, 3),
         ],
@@ -96,14 +111,18 @@ fn test_parse_single_valued_options() {
     );
     check(
         3,
-        vec![(Source::Default, 0), (Source::Config, 1), (Source::Flag, 3)],
+        vec![
+            (Source::Default, 0),
+            (config_source(), 1),
+            (Source::Flag, 3),
+        ],
         vec!["--scope-foo=3"],
         vec![],
         "[scope]\nfoo = 1",
     );
     check(
         2,
-        vec![(Source::Default, 0), (Source::Config, 1), (Source::Env, 2)],
+        vec![(Source::Default, 0), (config_source(), 1), (Source::Env, 2)],
         vec![],
         vec![("PANTS_SCOPE_FOO", "2")],
         "[scope]\nfoo = 1",
@@ -117,7 +136,7 @@ fn test_parse_single_valued_options() {
     );
     check(
         1,
-        vec![(Source::Default, 0), (Source::Config, 1)],
+        vec![(Source::Default, 0), (config_source(), 1)],
         vec![],
         vec![],
         "[scope]\nfoo = 1",
@@ -168,7 +187,7 @@ fn test_parse_list_options() {
         vec![0, 1, 2, 3, 4, 5, 6, 7],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![add(vec![1, 2])]),
+            (config_source(), vec![add(vec![1, 2])]),
             (Source::Env, vec![add(vec![3, 4])]),
             (Source::Flag, vec![add(vec![5, 6, 7])]),
         ],
@@ -182,7 +201,7 @@ fn test_parse_list_options() {
         vec![1, 2, 3, 4, 5, 6, 7],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![replace(vec![1, 2])]),
+            (config_source(), vec![replace(vec![1, 2])]),
             (Source::Env, vec![add(vec![3, 4])]),
             (Source::Flag, vec![add(vec![5, 6, 7])]),
         ],
@@ -196,7 +215,7 @@ fn test_parse_list_options() {
         vec![3, 4, 5, 6, 7],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![add(vec![1, 2])]),
+            (config_source(), vec![add(vec![1, 2])]),
             (Source::Env, vec![replace(vec![3, 4])]),
             (Source::Flag, vec![add(vec![5, 6, 7])]),
         ],
@@ -210,7 +229,7 @@ fn test_parse_list_options() {
         vec![5, 6, 7],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![add(vec![1, 2])]),
+            (config_source(), vec![add(vec![1, 2])]),
             (Source::Env, vec![add(vec![3, 4])]),
             (Source::Flag, vec![replace(vec![5, 6, 7])]),
         ],
@@ -224,7 +243,8 @@ fn test_parse_list_options() {
         vec![0, 1, 2, 11, 22, 3, 4],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![add(vec![1, 2]), add(vec![11, 22])]),
+            (config_source(), vec![add(vec![1, 2])]),
+            (extra_config_source(), vec![add(vec![11, 22])]),
             (Source::Env, vec![add(vec![3, 4])]),
         ],
         vec![],
@@ -237,10 +257,8 @@ fn test_parse_list_options() {
         vec![1, 3, 4],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (
-                Source::Config,
-                vec![replace(vec![1, 2]), remove(vec![2, 4])],
-            ),
+            (config_source(), vec![replace(vec![1, 2])]),
+            (extra_config_source(), vec![remove(vec![2, 4])]),
             (Source::Env, vec![add(vec![3, 4])]),
         ],
         vec![],
@@ -265,7 +283,7 @@ fn test_parse_list_options() {
         vec![0, 1, 3, 4, 5, 6, 7],
         vec![
             (Source::Default, vec![replace(vec![0])]),
-            (Source::Config, vec![add(vec![1, 2])]),
+            (config_source(), vec![add(vec![1, 2])]),
             (Source::Env, vec![remove(vec![2]), add(vec![3, 4])]),
             (Source::Flag, vec![add(vec![5, 6, 7])]),
         ],
@@ -296,7 +314,7 @@ fn test_parse_dict_options() {
 
     fn check(
         expected: HashMap<&str, Val>,
-        expected_derivation: Vec<(Source, Vec<DictEdit>)>,
+        expected_derivation: Vec<(Source, DictEdit)>,
         args: Vec<&'static str>,
         env: Vec<(&'static str, &'static str)>,
         config: &'static str,
@@ -331,9 +349,7 @@ fn test_parse_dict_options() {
 
     let default_derivation = (
         Source::Default,
-        vec![replace(
-            hashmap! {"key1" => Val::Int(1), "key2" => Val::String("val2".to_string())},
-        )],
+        replace(hashmap! {"key1" => Val::Int(1), "key2" => Val::String("val2".to_string())}),
     );
 
     check(
@@ -347,15 +363,10 @@ fn test_parse_dict_options() {
         },
         vec![
             default_derivation.clone(),
-            (
-                Source::Config,
-                vec![
-                    add(hashmap! {"key5" => Val::Bool(true)}),
-                    add(hashmap! {"key6" => Val::Int(6)}),
-                ],
-            ),
-            (Source::Env, vec![add(hashmap! {"key4" => Val::Float(4.0)})]),
-            (Source::Flag, vec![add(hashmap! {"key3" => Val::Int(3)})]),
+            (config_source(), add(hashmap! {"key5" => Val::Bool(true)})),
+            (extra_config_source(), add(hashmap! {"key6" => Val::Int(6)})),
+            (Source::Env, add(hashmap! {"key4" => Val::Float(4.0)})),
+            (Source::Flag, add(hashmap! {"key3" => Val::Int(3)})),
         ],
         vec!["--scope-foo=+{'key3': 3}"],
         vec![("PANTS_SCOPE_FOO", "+{'key4': 4.0}")],
@@ -371,15 +382,13 @@ fn test_parse_dict_options() {
         },
         vec![
             default_derivation.clone(),
+            (config_source(), add(hashmap! {"key5" => Val::Bool(true)})),
             (
-                Source::Config,
-                vec![
-                    add(hashmap! {"key5" => Val::Bool(true)}),
-                    replace(hashmap! {"key6" => Val::Int(6)}),
-                ],
+                extra_config_source(),
+                replace(hashmap! {"key6" => Val::Int(6)}),
             ),
-            (Source::Env, vec![add(hashmap! {"key4" => Val::Float(4.0)})]),
-            (Source::Flag, vec![add(hashmap! {"key3" => Val::Int(3)})]),
+            (Source::Env, add(hashmap! {"key4" => Val::Float(4.0)})),
+            (Source::Flag, add(hashmap! {"key3" => Val::Int(3)})),
         ],
         vec!["--scope-foo=+{'key3': 3}"],
         vec![("PANTS_SCOPE_FOO", "+{'key4': 4.0}")],
@@ -394,18 +403,13 @@ fn test_parse_dict_options() {
         },
         vec![
             default_derivation.clone(),
+            (config_source(), add(hashmap! {"key5" => Val::Bool(true)})),
             (
-                Source::Config,
-                vec![
-                    add(hashmap! {"key5" => Val::Bool(true)}),
-                    replace(hashmap! {"key6" => Val::Int(6)}),
-                ],
+                extra_config_source(),
+                replace(hashmap! {"key6" => Val::Int(6)}),
             ),
-            (
-                Source::Env,
-                vec![replace(hashmap! {"key4" => Val::Float(4.0)})],
-            ),
-            (Source::Flag, vec![add(hashmap! {"key3" => Val::Int(3)})]),
+            (Source::Env, replace(hashmap! {"key4" => Val::Float(4.0)})),
+            (Source::Flag, add(hashmap! {"key3" => Val::Int(3)})),
         ],
         vec!["--scope-foo=+{'key3': 3}"],
         vec![("PANTS_SCOPE_FOO", "{'key4': 4.0}")],
@@ -419,21 +423,13 @@ fn test_parse_dict_options() {
         },
         vec![
             default_derivation.clone(),
+            (config_source(), add(hashmap! {"key5" => Val::Bool(true)})),
             (
-                Source::Config,
-                vec![
-                    add(hashmap! {"key5" => Val::Bool(true)}),
-                    replace(hashmap! {"key6" => Val::Int(6)}),
-                ],
+                extra_config_source(),
+                replace(hashmap! {"key6" => Val::Int(6)}),
             ),
-            (
-                Source::Env,
-                vec![replace(hashmap! {"key4" => Val::Float(4.0)})],
-            ),
-            (
-                Source::Flag,
-                vec![replace(hashmap! {"key3" => Val::Int(3)})],
-            ),
+            (Source::Env, replace(hashmap! {"key4" => Val::Float(4.0)})),
+            (Source::Flag, replace(hashmap! {"key3" => Val::Int(3)})),
         ],
         vec!["--scope-foo={'key3': 3}"],
         vec![("PANTS_SCOPE_FOO", "{'key4': 4.0}")],

--- a/src/rust/engine/pantsd/src/pantsd_testing.rs
+++ b/src/rust/engine/pantsd/src/pantsd_testing.rs
@@ -31,6 +31,7 @@ pub fn launch_pantsd() -> (BuildRoot, OptionParser, TempDir) {
         None,
         true,
         false,
+        None,
     )
     .unwrap();
 

--- a/src/rust/engine/src/externs/pantsd.rs
+++ b/src/rust/engine/src/externs/pantsd.rs
@@ -21,8 +21,15 @@ pub fn register(_py: Python, m: &PyModule) -> PyResult<()> {
 #[pyfunction]
 fn pantsd_fingerprint_compute(expected_option_names: HashSet<String>) -> PyResult<String> {
     let build_root = BuildRoot::find().map_err(PyException::new_err)?;
-    let options_parser = OptionParser::new(Args::argv(), Env::capture_lossy().0, None, true, false)
-        .map_err(PyException::new_err)?;
+    let options_parser = OptionParser::new(
+        Args::argv(),
+        Env::capture_lossy().0,
+        None,
+        true,
+        false,
+        None,
+    )
+    .map_err(PyException::new_err)?;
 
     let options = pantsd::fingerprinted_options(&build_root).map_err(PyException::new_err)?;
     let actual_option_names = options


### PR DESCRIPTION
Previously the options sources list could have only one source
per type (flag/env/config/default). Since we support multiple
config files, we had the concept of a "merged config" that
encompassed multiple "config sources". This led to
duplication of the logic that traverses and merges sources.

This change gets rid of the concept of merged config. 
Instead, the list of options sources we consult can now
include multiple config files. This is achieved by enhancing
the Source::Config enum to include an ordinal (to ensure 
that configs are applied in the right order) and the path to
the config file (purely informational). 

The natural `#[derive(Ord)]` will order these augmented
configs appropriately within all the sources. To make this
easier to achieve we change the order of the enum to be
from lowest to highest priority, so that we can add config
files naturally in the order in which we encounter them.

 This also allows us to simplify some types. In particular, 
we no longer need to traffic in `Vec<DictEdit>` - a single
source can only return a single `DictEdit`.

More importantly, this supports derivation history that
includes the specific config file each value comes from.