### PR TITLE
Use a named_cache for downloading go modules

### DIFF
--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -579,6 +579,7 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
         ),
     )
 
+    # Called for the side effect downloading modules to the local cache
     await Get(
         ProcessResult,
         GoSdkProcess(

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -584,7 +584,6 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
         GoSdkProcess(
             ["mod", "download", "all"],
             input_digest=go_mod_digest,
-            output_directories=("gopath",),
             description="Download Go `protoc` plugin sources.",
             allow_downloads=True,
             cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
@@ -595,9 +594,11 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
         Get(
             ProcessResult,
             GoSdkProcess(
-                ["install", "google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1"],
-                input_digest=download_sources_result.output_digest,
-                output_files=["gopath/bin/protoc-gen-go"],
+                [
+                    "install",
+                    "google.golang.org/protobuf/cmd/protoc-gen-go@v1.27.1",
+                ],
+                output_files=["gobin/protoc-gen-go"],
                 description="Build Go protobuf plugin for `protoc`.",
             ),
         ),
@@ -608,8 +609,7 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
                     "install",
                     "google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2.0",
                 ],
-                input_digest=download_sources_result.output_digest,
-                output_files=["gopath/bin/protoc-gen-go-grpc"],
+                output_files=["gobin/protoc-gen-go-grpc"],
                 description="Build Go gRPC protobuf plugin for `protoc`.",
             ),
         ),
@@ -633,7 +633,8 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
             [go_plugin_build_result.output_digest, go_grpc_plugin_build_result.output_digest]
         ),
     )
-    plugin_digest = await Get(Digest, RemovePrefix(merged_output_digests, "gopath/bin"))
+    plugin_digest = await Get(Digest, RemovePrefix(merged_output_digests, "gobin"))
+
     return _SetupGoProtocPlugin(plugin_digest)
 
 

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -579,7 +579,7 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
         ),
     )
 
-    download_sources_result = await Get(
+    await Get(
         ProcessResult,
         GoSdkProcess(
             ["mod", "download", "all"],

--- a/src/python/pants/backend/codegen/protobuf/go/rules.py
+++ b/src/python/pants/backend/codegen/protobuf/go/rules.py
@@ -68,7 +68,7 @@ from pants.engine.fs import (
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult
+from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     GeneratedSources,
@@ -587,6 +587,7 @@ async def setup_go_protoc_plugin() -> _SetupGoProtocPlugin:
             output_directories=("gopath",),
             description="Download Go `protoc` plugin sources.",
             allow_downloads=True,
+            cache_scope=ProcessCacheScope.PER_RESTART_SUCCESSFUL,
         ),
     )
 

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -122,10 +122,7 @@ async def generate_go_assembly_symabisfile(
     #   that we don't need the actual definitions that would appear in go_asm.h.
     #
     # See https://go-review.googlesource.com/c/go/+/146999/8/src/cmd/go/internal/work/gc.go
-    if os.path.isabs(request.dir_path):
-        symabis_path = "symabis"
-    else:
-        symabis_path = os.path.join(request.dir_path, "symabis")
+    symabis_path = str(PurePath("obj_dir", "symabis"))
     go_asm_h_digest, asm_tool_id = await MultiGet(
         Get(Digest, CreateDigest([FileContent("go_asm.h", b"")])),
         Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm")),
@@ -181,10 +178,7 @@ async def assemble_go_assembly_files(
     asm_tool_id = await Get(GoSdkToolIDResult, GoSdkToolIDRequest("asm"))
 
     def obj_output_path(s_file: str) -> str:
-        if os.path.isabs(request.dir_path):
-            return str(PurePath(s_file).with_suffix(".o"))
-        else:
-            return str(request.dir_path / PurePath(s_file).with_suffix(".o"))
+        return str(PurePath("obj_dir", s_file).with_suffix(".o"))
 
     assembly_results = await MultiGet(
         Get(

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -752,10 +752,7 @@ async def build_go_package(
     # about the Go code that can be used by assembly files.
     asm_header_path: str | None = None
     if s_files:
-        if os.path.isabs(request.dir_path):
-            asm_header_path = "go_asm.h"
-        else:
-            asm_header_path = os.path.join(request.dir_path, "go_asm.h")
+        asm_header_path = str(PurePath("go_asm.h"))
         compile_args.extend(["-asmhdr", asm_header_path])
 
     if embedcfg.digest != EMPTY_DIGEST:

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -753,7 +753,7 @@ async def build_go_package(
     asm_header_path: str | None = None
     if s_files:
         # Ideally, this would follow convention that generated files live in _objdir/{file} - but changing go_asm.h
-        # fails standard library builds when used in a subdir.
+        # fails standard library builds when used in a subdir. Tracked by bug #20618
         asm_header_path = str(PurePath("go_asm.h"))
         compile_args.extend(["-asmhdr", asm_header_path])
 

--- a/src/python/pants/backend/go/util_rules/build_pkg.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg.py
@@ -752,6 +752,8 @@ async def build_go_package(
     # about the Go code that can be used by assembly files.
     asm_header_path: str | None = None
     if s_files:
+        # Ideally, this would follow convention that generated files live in _objdir/{file} - but changing go_asm.h
+        # fails standard library builds when used in a subdir.
         asm_header_path = str(PurePath("go_asm.h"))
         compile_args.extend(["-asmhdr", asm_header_path])
 

--- a/src/python/pants/backend/go/util_rules/build_pkg_target.py
+++ b/src/python/pants/backend/go/util_rules/build_pkg_target.py
@@ -291,7 +291,7 @@ async def setup_build_go_package_target_request(
         imports = set(_third_party_pkg_info.imports)
         dir_path = _third_party_pkg_info.dir_path
         pkg_name = _third_party_pkg_info.name
-        digest = _third_party_pkg_info.digest
+        digest = EMPTY_DIGEST
         minimum_go_version = _third_party_pkg_info.minimum_go_version
         go_file_names = _third_party_pkg_info.go_files
         s_files = _third_party_pkg_info.s_files

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -356,7 +356,7 @@ async def _cc(
         src_file,
     ]
     return Process(
-        append_only_caches=gosdk.sdk_cache(),
+        append_only_caches=gosdk.sdk_append_only_caches(),
         argv=args,
         env={"TERM": "dumb", **env},
         input_digest=input_digest,
@@ -409,7 +409,7 @@ async def _gccld(
     result = await Get(
         FallibleProcessResult,
         Process(
-            append_only_caches=gosdk.sdk_cache(),
+            append_only_caches=gosdk.sdk_append_only_caches(),
             argv=args,
             env={"TERM": "dumb", **env},
             input_digest=input_digest,

--- a/src/python/pants/backend/go/util_rules/cgo.py
+++ b/src/python/pants/backend/go/util_rules/cgo.py
@@ -669,9 +669,10 @@ async def cgo_compile_request(
     dir_path = request.dir_path if request.dir_path else "."
 
     obj_dir_path = (
-        # avoid writing under gopath (digests overwrite the symlink)
-        # and avoid writing under stdlib (outside the sandbox)
-        # the root of the sandbox (".") is used for the primary package
+        # This represents three cases, some of which do or do not write under dir_path:
+        # 1. avoid writing under gopath (digests overwrite the symlink)
+        # 2. avoid writing under stdlib (it's outside the sandbox)
+        # 3. otherwise, the root of the sandbox (".") is used, to build the 'main' package.
         f"_objdir/{request.import_path}"
         if dir_path != "."
         else dir_path

--- a/src/python/pants/backend/go/util_rules/third_party_pkg.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg.py
@@ -321,7 +321,6 @@ async def _check_go_sum_has_not_changed(
                 )
             )
             go_sum_diff_rendered = "\n".join(line.rstrip() for line in go_sum_diff)
-
             raise ValueError(
                 f"For `{GoModTarget.alias}` target `{go_mod_address}`, the go.sum file is incomplete "
                 f"because it was updated while processing third-party dependency `{import_path}`. "
@@ -437,7 +436,6 @@ async def analyze_go_third_party_module(
         Process(
             [os.path.join(analyzer_relpath, analyzer.path), *chosen_paths],
             append_only_caches=gosdk.sdk_cache(),
-            input_digest=EMPTY_DIGEST,
             immutable_input_digests={
                 analyzer_relpath: analyzer.digest,
             },
@@ -478,9 +476,10 @@ async def analyze_go_third_party_module(
 async def analyze_go_third_party_package(
     request: AnalyzeThirdPartyPackageRequest,
 ) -> FallibleThirdPartyPkgAnalysis:
-    """Return an analysis for a given package. The analysis object corresponds to the output.
+    """Return an analysis for a given package.
 
-    of `go list` - combining the location, imports and build details for a package.
+    The analysis object corresponds to the -json output of `go list` - combining the location,
+    imports and build details for a package.
     """
     if not request.package_path.startswith(request.module_sources_path):
         raise AssertionError(

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import os.path
 import re
 from textwrap import dedent
-from typing import Generator
+from typing import Iterator
 
 import pytest
 
@@ -31,7 +31,7 @@ from pants.backend.go.util_rules.third_party_pkg import (
     ThirdPartyPkgAnalysisRequest,
 )
 from pants.build_graph.address import Address
-from pants.engine.fs import EMPTY_DIGEST, Digest, Snapshot
+from pants.engine.fs import Digest
 from pants.engine.internals.scheduler import ExecutionError
 from pants.engine.process import ProcessExecutionFailure
 from pants.engine.rules import QueryRule
@@ -40,7 +40,7 @@ from pants.util.contextutil import temporary_dir
 
 
 @pytest.fixture(scope="module")
-def named_caches_dir() -> Generator[str]:
+def named_caches_dir() -> Iterator[str]:
     with temporary_dir(prefix="test_tpp_cache_") as tmpdir:
         yield tmpdir
 
@@ -194,8 +194,7 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner) -> None:
             rule_runner.options_bootstrapper.bootstrap_options.for_global_scope().named_caches_dir
         )
         expected_files = {
-            os.path.join(dir_path, file_name)
-            for file_name in (*go_files, *extra_files)
+            os.path.join(dir_path, file_name) for file_name in (*go_files, *extra_files)
         }
         seen_files = set()
 

--- a/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
+++ b/src/python/pants/backend/go/util_rules/third_party_pkg_test.py
@@ -200,7 +200,7 @@ def test_download_and_analyze_all_packages(rule_runner: RuleRunner, named_caches
         }
         seen_files = set()
 
-        path_in_named_cache = dir_path.replace(sdk.SANDBOX_CACHE, sdk.NAMED_CACHE)
+        path_in_named_cache = dir_path.replace(sdk.SANDBOX_CACHE_RELPATH, sdk.NAMED_CACHE_RELPATH)
         cache_path = os.path.join(named_caches_dir, path_in_named_cache)
         for _root, _dirs, files in os.walk(cache_path):
             for name in files:

--- a/src/python/pants/backend/visibility/rule_types_test.py
+++ b/src/python/pants/backend/visibility/rule_types_test.py
@@ -926,7 +926,7 @@ def test_single_rules_declaration_per_build_file(rule_runner: RuleRunner) -> Non
     )
 
     msg = "BuildFileVisibilityRulesError: There must be at most one each"
-    with engine_error(MappingError, contains=msg):
+    with engine_error(MappingError, contains=msg, normalize_tracebacks=True):
         assert_dependency_rules(
             rule_runner,
             "test",

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -385,6 +385,10 @@ class ReadlinkBinary(BinaryPath):
     pass
 
 
+class FindBinary(BinaryPath):
+    pass
+
+
 class GitBinaryException(Exception):
     pass
 
@@ -743,6 +747,14 @@ async def find_git(system_binaries: SystemBinariesSubsystem.EnvironmentAware) ->
         request, rationale="track changes to files in your build environment"
     )
     return GitBinary(first_path.path, first_path.fingerprint)
+
+
+@rule(desc="Finding the `find` binary", level=LogLevel.DEBUG)
+async def find_find(system_binaries: SystemBinariesSubsystem.EnvironmentAware) -> FindBinary:
+    request = BinaryPathRequest(binary_name="find", search_path=system_binaries.system_binary_paths)
+    paths = await Get(BinaryPaths, BinaryPathRequest, request)
+    first_path = paths.first_path_or_raise(request, rationale="find files")
+    return FindBinary(first_path.path, first_path.fingerprint)
 
 
 def rules():

--- a/src/python/pants/engine/internals/mapper.py
+++ b/src/python/pants/engine/internals/mapper.py
@@ -69,7 +69,7 @@ class AddressMap:
                 dependencies_rules,
             )
         except Exception as e:
-            raise MappingError(f"Failed to parse ./{filepath}:\n{type(e).__name__}: {e}")
+            raise MappingError(f"Failed to parse ./{filepath} in {os.path.abspath('.')}") from e
         return cls.create(filepath, target_adaptors)
 
     @classmethod

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -268,7 +268,11 @@ class RuleRunner:
             root_dir = Path(mkdtemp(prefix="RuleRunner."))
             print(f"Preserving rule runner temporary directories at {root_dir}.", file=sys.stderr)
             bootstrap_args.extend(
-                ["--keep-sandboxes=always", f"--local-execution-root-dir={root_dir}"]
+                [
+                    "--keep-sandboxes=always",
+                    f"--local-execution-root-dir={root_dir}",
+                    f"--named-caches-dir={root_dir}/named_caches",
+                ]
             )
             build_root = (root_dir / "BUILD_ROOT").resolve()
             build_root.mkdir()


### PR DESCRIPTION
After this change, the go build process uses a cached copy of gopath where possible.  My guess was that downloading a large number of go modules, and then passing and unpacking them as digests was responsible for most of the memory overhead of the experimental go build.

## Testing
I'm comparing builds of my sample repo: https://github.com/JettJones/go-include (it includes some temporal libraries which result in a very large set of third party packages).  For scale, after running `pants check ::` named_caches / lmdb_store contain about 3.0G of files.

Command: `time PANTS_SOURCE=~/dev/pantsbuild/pants/ pants --no-pantsd check ::`

| case | build after cache clear | build with cache | memory (with cache) |
| --- | --- | --- | --- | 
| before | 2m 10s | 33s | 10G |
| with patch | 2m 6s | 16s |  0.5G |

Memory graph before:
![image](https://github.com/pantsbuild/pants/assets/1045582/1b0aa13c-6c16-48b9-bd0a-8e54e7e3b9b0)
and after:
![image](https://github.com/pantsbuild/pants/assets/1045582/abcb6dd0-7c52-4347-a773-5c990a2952b9)

## Bugs addressed
* Hook up GOPATH to named_caches? #13390
* High memory use in Golang #20274 