### PR TITLE
Remove asm -compiling-runtime flag for go 1.22+ compatible versions

### DIFF
--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -92,8 +92,11 @@ def _asm_args(
     # - https://cs.opensource.google/go/go/+/72946ae8674a295e7485982fe57c65c7142b2c14
     maybe_assembling_stdlib_runtime_args = (
         ["-compiling-runtime"]
-        if not goroot.is_compatible_version("1.22") and (import_path in ("runtime", "reflect", "syscall", "internal/bytealg")
-        or import_path.startswith("runtime/internal"))
+        if not goroot.is_compatible_version("1.22")
+        and (
+            import_path in ("runtime", "reflect", "syscall", "internal/bytealg")
+            or import_path.startswith("runtime/internal")
+        )
         else []
     )
 

--- a/src/python/pants/backend/go/util_rules/assembly.py
+++ b/src/python/pants/backend/go/util_rules/assembly.py
@@ -86,10 +86,14 @@ def _asm_args(
     # See:
     # - https://github.com/golang/go/blob/245e95dfabd77f337373bf2d6bb47cd353ad8d74/src/cmd/go/internal/work/gc.go#L370-L372
     # - https://github.com/golang/go/blob/245e95dfabd77f337373bf2d6bb47cd353ad8d74/src/cmd/internal/objabi/path.go#L43-L67
+    # From Go 1.22+ this flag has been removed, since we're already passing the package path, asm can make that determination,
+    # and there's no need to pass the flag anymore.
+    # See:
+    # - https://cs.opensource.google/go/go/+/72946ae8674a295e7485982fe57c65c7142b2c14
     maybe_assembling_stdlib_runtime_args = (
         ["-compiling-runtime"]
-        if import_path in ("runtime", "reflect", "syscall", "internal/bytealg")
-        or import_path.startswith("runtime/internal")
+        if not goroot.is_compatible_version("1.22") and (import_path in ("runtime", "reflect", "syscall", "internal/bytealg")
+        or import_path.startswith("runtime/internal"))
         else []
     )
 


### PR DESCRIPTION
When using go 1.22, trying to compile a go package using pants fails with:

```
13:07:42.25 [INFO] Initialization options changed: reinitializing scheduler...
13:07:46.62 [INFO] Scheduler initialized.
13:07:51.89 [ERROR] Completed: Compile with Go - runtime/internal/syscall - runtime/internal/syscall failed (exit code 1).
flag provided but not defined: -compiling-runtime
usage: asm [options] file.s ...
Flags:
  -D value
        predefined symbol with optional simple value -D=identifier=value; can be set multiple times
  -I value
        include directory; can be set multiple times
  -S    print assembly and machine code
  -V    print version and exit
  -d value
        enable debugging settings; try -d help
  -debug
        dump instructions as they are parsed
  -dynlink
        support references to Go symbols defined in other shared libraries
  -e    no limit on number of errors reported
  -gensymabis
        write symbol ABI information to output file, don't assemble
  -linkshared
        generate code that will be linked against Go shared libraries
  -o string
        output file; default foo.o for /a/b/c/foo.s as first argument
  -p string
        set expected package import to path (default "<unlinkable>")
  -shared
        generate code that can be linked into a shared library
  -spectre list
        enable spectre mitigations in list (all, ret)
  -trimpath string
        remove prefix from recorded source file paths
  -v    print debug output
```

This flag has been removed from version 1.22 - asm can now make the determination itself regarding whether or not we're compiling a `runtime` package, so there's no need to pass that flag anymore.

See: https://cs.opensource.google/go/go/+/72946ae8674a295e7485982fe57c65c7142b2c14