### PR TITLE
upgrade to Rust v1.76.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -276,7 +276,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -367,7 +367,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -232,7 +232,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -441,7 +441,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 
@@ -508,7 +508,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.75.0-*
+        path: '~/.rustup/toolchains/1.76.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -95,7 +95,7 @@ fn test_float() {
 
     assert_eq!(
         "Problem parsing --bad float value:\n1:swallow\n  ^\n\
-        Expected \"+\", \"-\" or ['0' ..= '9'] at line 1 column 1"
+        Expected \"+\", \"-\" or ['0'..='9'] at line 1 column 1"
             .to_owned(),
         args.get_float(&option_id!("bad")).unwrap_err()
     );

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -138,7 +138,7 @@ fn test_float() {
 
     assert_eq!(
         "Problem parsing PANTS_BAD float value:\n1:swallow\n  ^\n\
-        Expected \"+\", \"-\" or ['0' ..= '9'] at line 1 column 1"
+        Expected \"+\", \"-\" or ['0'..='9'] at line 1 column 1"
             .to_owned(),
         env.get_float(&option_id!("pants", "bad")).unwrap_err()
     );

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -89,13 +89,13 @@ fn test_parse_int() {
     check_int(9223372036854775807, "9223372036854775807");
     check_int(-9223372036854775808, "-9223372036854775808");
     assert_eq!(
-        "Problem parsing foo int value:\n1:badint\n  ^\nExpected \"+\", \"-\" or ['0' ..= '9'] \
+        "Problem parsing foo int value:\n1:badint\n  ^\nExpected \"+\", \"-\" or ['0'..='9'] \
                at line 1 column 1"
             .to_owned(),
         parse_int("badint").unwrap_err().render("foo")
     );
     assert_eq!(
-        "Problem parsing foo int value:\n1:12badint\n  --^\nExpected \"_\", EOF or ['0' ..= '9'] \
+        "Problem parsing foo int value:\n1:12badint\n  --^\nExpected \"_\", EOF or ['0'..='9'] \
                at line 1 column 3"
             .to_owned(),
         parse_int("12badint").unwrap_err().render("foo")

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.76.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade to Rust v1.76.0. [Blog post](https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html)