### PR TITLE
stats: add output format option to save Pants stats as JSON

### DIFF
--- a/src/python/pants/goal/stats_aggregator.py
+++ b/src/python/pants/goal/stats_aggregator.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 
 import base64
 import datetime
+import json
 import logging
 from collections import Counter
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 
 from pants.engine.internals.scheduler import Workunit
 from pants.engine.rules import collect_rules, rule
@@ -20,13 +22,55 @@ from pants.engine.streaming_workunit_handler import (
     WorkunitsCallbackFactoryRequest,
 )
 from pants.engine.unions import UnionRule
-from pants.option.option_types import BoolOption, StrOption
+from pants.option.option_types import BoolOption, EnumOption, StrOption
 from pants.option.subsystem import Subsystem
 from pants.util.collections import deep_getsizeof
 from pants.util.dirutil import safe_open
 from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
+
+HISTOGRAM_PERCENTILES = [25, 50, 75, 90, 95, 99]
+
+
+class CounterObject(TypedDict):
+    name: str
+    count: int
+
+
+class MemorySummaryObject(TypedDict):
+    name: str
+    count: int
+    bytes: int
+
+
+class ObservationHistogramObject(TypedDict):
+    name: str
+    min: int
+    max: int
+    mean: float
+    std_dev: float
+    total_observations: int
+    sum: int
+
+
+class StatsObject(TypedDict, total=False):
+    timestamp: str
+    command: str
+    counters: list[CounterObject]
+    memory_summary: list[MemorySummaryObject]
+    observation_histograms: list[ObservationHistogramObject]
+
+
+class StatsOutputFormat(Enum):
+    """Output format for reporting Pants stats.
+
+    text: Report stats in plain text.
+    json: Report stats in JSON.
+    """
+
+    text = "text"
+    json = "json"
 
 
 class StatsAggregatorSubsystem(Subsystem):
@@ -64,10 +108,14 @@ class StatsAggregatorSubsystem(Subsystem):
         metavar="<path>",
         help="Output the stats to this file. If unspecified, outputs to stdout.",
     )
+    format = EnumOption(
+        default=StatsOutputFormat.text,
+        help="Output format for reporting stats.",
+    )
 
 
-def _log_or_write_to_file(output_file: Optional[str], lines: list[str]) -> None:
-    """Send text to the stdout or write to the output file."""
+def _log_or_write_to_file_plain(output_file: Optional[str], lines: list[str]) -> None:
+    """Send text to the stdout or write to the output file (plain text)."""
     if lines:
         text = "\n".join(lines)
         if output_file:
@@ -78,32 +126,54 @@ def _log_or_write_to_file(output_file: Optional[str], lines: list[str]) -> None:
             logger.info(text)
 
 
+def _log_or_write_to_file_json(output_file: Optional[str], stats_object: StatsObject) -> None:
+    """Send JSON object to the stdout or write to the file."""
+    if not stats_object:
+        return
+
+    if not output_file:
+        logger.info(stats_object)
+        return
+
+    existing_stats = None
+    if Path(output_file).exists():
+        try:
+            with open(output_file) as fh:
+                existing_stats = json.load(fh)
+            if isinstance(existing_stats.get("stats"), list):
+                existing_stats["stats"].append(stats_object)
+        except Exception:
+            pass
+
+    with safe_open(output_file, "w") as fh:
+        stats = existing_stats if existing_stats else {"stats": [stats_object]}
+        json.dump(stats, fh, indent=4)
+    logger.info(f"Wrote Pants stats to {output_file}")
+
+
 class StatsAggregatorCallback(WorkunitsCallback):
     def __init__(
-        self, *, log: bool, memory: bool, output_file: Optional[str], has_histogram_module: bool
+        self,
+        *,
+        log: bool,
+        memory: bool,
+        output_file: Optional[str],
+        has_histogram_module: bool,
+        format: StatsOutputFormat,
     ) -> None:
         super().__init__()
         self.log = log
         self.memory = memory
         self.output_file = output_file
         self.has_histogram_module = has_histogram_module
+        self.format = format
 
     @property
     def can_finish_async(self) -> bool:
         # We need to finish synchronously for access to the console.
         return False
 
-    def __call__(
-        self,
-        *,
-        started_workunits: tuple[Workunit, ...],
-        completed_workunits: tuple[Workunit, ...],
-        finished: bool,
-        context: StreamingWorkunitContext,
-    ) -> None:
-        if not finished:
-            return
-
+    def _output_stats_in_plain_text(self, context: StreamingWorkunitContext):
         output_lines = []
         if self.output_file:
             timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -153,7 +223,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
             )
 
         if not (self.log and self.has_histogram_module):
-            _log_or_write_to_file(self.output_file, output_lines)
+            _log_or_write_to_file_plain(self.output_file, output_lines)
             return
 
         from hdrh.histogram import HdrHistogram  # pants: no-infer-dep
@@ -161,7 +231,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
         histograms = context.get_observation_histograms()["histograms"]
         if not histograms:
             output_lines.append("No observation histogram were recorded.")
-            _log_or_write_to_file(self.output_file, output_lines)
+            _log_or_write_to_file_plain(self.output_file, output_lines)
             return
 
         output_lines.append("Observation histogram summaries:")
@@ -173,7 +243,7 @@ class StatsAggregatorCallback(WorkunitsCallback):
             percentile_to_vals = "\n".join(
                 f"  p{percentile}: {value}"
                 for percentile, value in histogram.get_percentile_to_value_dict(
-                    [25, 50, 75, 90, 95, 99]
+                    HISTOGRAM_PERCENTILES
                 ).items()
             )
             output_lines.append(
@@ -186,7 +256,107 @@ class StatsAggregatorCallback(WorkunitsCallback):
                 f"  sum: {int(histogram.get_mean_value() * histogram.total_count)}\n"
                 f"{percentile_to_vals}"
             )
-        _log_or_write_to_file(self.output_file, output_lines)
+        _log_or_write_to_file_plain(self.output_file, output_lines)
+
+    def _output_stats_in_json(self, context: StreamingWorkunitContext):
+        stats_object: StatsObject = {}
+
+        if self.output_file:
+            stats_object["timestamp"] = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            stats_object["command"] = context.run_tracker.run_information().get("cmd_line", "")
+
+        if self.log:
+            # Capture global counters.
+            counters = Counter(context.get_metrics())
+
+            # Add any counters with a count of 0.
+            for counter in context.run_tracker.counter_names:
+                if counter not in counters:
+                    counters[counter] = 0
+
+            # Log aggregated counters.
+            stats_object["counters"] = [
+                {"name": name, "count": count} for name, count in sorted(counters.items())
+            ]
+
+        if self.memory:
+            ids: set[int] = set()
+            count_by_type: Counter[type] = Counter()
+            sizes_by_type: Counter[type] = Counter()
+
+            items, rust_sizes = context._scheduler.live_items()
+            for item in items:
+                count_by_type[type(item)] += 1
+                sizes_by_type[type(item)] += deep_getsizeof(item, ids)
+
+            entries = [
+                (size, count_by_type[typ], f"{typ.__module__}.{typ.__qualname__}")
+                for typ, size in sizes_by_type.items()
+            ]
+            entries.extend(
+                (size, count, f"(native) {name}") for name, (count, size) in rust_sizes.items()
+            )
+            memory_lines: list[MemorySummaryObject] = [
+                {"bytes": size, "count": count, "name": name}
+                for size, count, name in sorted(entries)
+            ]
+            stats_object["memory_summary"] = memory_lines
+
+        if not (self.log and self.has_histogram_module):
+            _log_or_write_to_file_json(self.output_file, stats_object)
+            return
+
+        from hdrh.histogram import HdrHistogram  # pants: no-infer-dep
+
+        histograms = context.get_observation_histograms()["histograms"]
+        if not histograms:
+            stats_object["observation_histograms"] = []
+            _log_or_write_to_file_json(self.output_file, stats_object)
+            return
+
+        observation_histograms: list[ObservationHistogramObject] = []
+        for name, encoded_histogram in histograms.items():
+            # Note: The Python library for HDR Histogram will only decode compressed histograms
+            # that are further encoded with base64. See
+            # https://github.com/HdrHistogram/HdrHistogram_py/issues/29.
+            histogram = HdrHistogram.decode(base64.b64encode(encoded_histogram))
+            percentile_to_vals = {
+                f"p{percentile}": value
+                for percentile, value in histogram.get_percentile_to_value_dict(
+                    HISTOGRAM_PERCENTILES
+                ).items()
+            }
+
+            observation_histogram: ObservationHistogramObject = {
+                "name": name,
+                "min": histogram.get_min_value(),
+                "max": histogram.get_max_value(),
+                "mean": round(histogram.get_mean_value(), 3),
+                "std_dev": round(histogram.get_stddev(), 3),
+                "total_observations": histogram.total_count,
+                "sum": int(histogram.get_mean_value() * histogram.total_count),
+                **percentile_to_vals,  # type: ignore
+            }
+            observation_histograms.append(observation_histogram)
+        stats_object["observation_histograms"] = observation_histograms
+
+        _log_or_write_to_file_json(self.output_file, stats_object)
+
+    def __call__(
+        self,
+        *,
+        started_workunits: tuple[Workunit, ...],
+        completed_workunits: tuple[Workunit, ...],
+        finished: bool,
+        context: StreamingWorkunitContext,
+    ) -> None:
+        if not finished:
+            return
+
+        if StatsOutputFormat.text == self.format:
+            self._output_stats_in_plain_text(context)
+        elif StatsOutputFormat.json == self.format:
+            self._output_stats_in_json(context)
 
 
 @dataclass(frozen=True)
@@ -219,6 +389,7 @@ def construct_callback(
                 memory=subsystem.memory_summary,
                 output_file=subsystem.output_file,
                 has_histogram_module=has_histogram_module,
+                format=subsystem.format,
             )
             if subsystem.log or subsystem.memory_summary
             else None

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -87,8 +87,8 @@ def test_writing_to_output_file_json() -> None:
             "--plugins=hdrhistogram",
             "--stats-log",
             "--stats-memory-summary",
-            "--stats-format=json",
-            "--stats-output-file=stats.json",
+            "--stats-format=jsonlines",
+            "--stats-output-file=stats.jsonl",
             "roots",
         ]
         run_pants(argv1).assert_success()
@@ -97,14 +97,16 @@ def test_writing_to_output_file_json() -> None:
             "--plugins=hdrhistogram",
             "--stats-log",
             "--stats-memory-summary",
-            "--stats-format=json",
-            "--stats-output-file=stats.json",
+            "--stats-format=jsonlines",
+            "--stats-output-file=stats.jsonl",
             "list",
             "::",
         ]
         run_pants(argv2).assert_success()
-        with open("stats.json") as fh:
-            stats = json.load(fh)["stats"]
+        stats = []
+        with open("stats.jsonl") as fh:
+            for line in fh.readlines():
+                stats.append(json.loads(line))
 
         assert len(stats) == 2
 

--- a/src/python/pants/goal/stats_aggregator_integration_test.py
+++ b/src/python/pants/goal/stats_aggregator_integration_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from pathlib import Path
 
@@ -49,7 +50,7 @@ def test_warn_if_no_histograms() -> None:
     assert "Observation histogram summaries:" not in result.stderr
 
 
-def test_writing_to_output_file() -> None:
+def test_writing_to_output_file_plain_text() -> None:
     with setup_tmpdir({"src/py/app.py": "print(0)\n", "src/py/BUILD": "python_sources()"}):
         argv1 = [
             "--backend-packages=['pants.backend.python']",
@@ -77,3 +78,48 @@ def test_writing_to_output_file() -> None:
 
         for cmd in (argv1, argv2):
             assert " ".join(cmd) in output_file_contents
+
+
+def test_writing_to_output_file_json() -> None:
+    with setup_tmpdir({"src/py/app.py": "print(0)\n", "src/py/BUILD": "python_sources()"}):
+        argv1 = [
+            "--backend-packages=['pants.backend.python']",
+            "--plugins=hdrhistogram",
+            "--stats-log",
+            "--stats-memory-summary",
+            "--stats-format=json",
+            "--stats-output-file=stats.json",
+            "roots",
+        ]
+        run_pants(argv1).assert_success()
+        argv2 = [
+            "--backend-packages=['pants.backend.python']",
+            "--plugins=hdrhistogram",
+            "--stats-log",
+            "--stats-memory-summary",
+            "--stats-format=json",
+            "--stats-output-file=stats.json",
+            "list",
+            "::",
+        ]
+        run_pants(argv2).assert_success()
+        with open("stats.json") as fh:
+            stats = json.load(fh)["stats"]
+
+        assert len(stats) == 2
+
+        for obj in stats:
+            for key in (
+                "timestamp",
+                "command",
+                "counters",
+                "memory_summary",
+                "observation_histograms",
+            ):
+                assert obj.get(key) is not None
+
+            for field in ("name", "count"):
+                assert obj["counters"][0].get(field) is not None
+
+            for field in ("bytes", "count", "name"):
+                assert obj["memory_summary"][0].get(field) is not None


### PR DESCRIPTION
With the current implementation, when stats output is shown, it's always in plain text which makes parsing the stats really hard. For instance, it may be useful to track the cache hit rate for every Pants invocation to make sure it's being used effectively.

To make parsing the stats easy, it's now possible to export stats as JSON Lines objects. The amount and type of information is identical to what's being produced for plain text output, only the output format differs.

A few implementation details worth sharing:
* when saving the output into a file (that may already have previous executions saved), the write happens in append mode to keep the stats of a previous execution. This makes it possible to have a single place with all the Pants invocations stats (e.g. after a CI build where multiple separate Pants invocations might have happened is complete).

As a follow-up, I'll refactor the code responsible for production of the stats so that the logic is defined in a single place (e.g. getting all the data in JSON format and then dumping it into plain text, if user asks to do so).