### PR TITLE
Fix update build files formatter selection

### DIFF
--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -234,7 +234,7 @@ async def update_build_files(
         raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")
 
     for request in union_membership[RewrittenBuildFileRequest]:
-        if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
+        if update_build_files_subsystem.fmt and request == chosen_formatter_request_class:
             rewrite_request_classes.append(request)
 
         if update_build_files_subsystem.fix_safe_deprecations and issubclass(
@@ -242,8 +242,8 @@ async def update_build_files(
         ):
             rewrite_request_classes.append(request)
 
-        # If there are other types of formatters that aren't the standard backends
-        # or deprecation fixers, add them here.
+        # If there are other types of requests that aren't the standard formatter
+        # backends or deprecation fixers, add them here.
         if request not in formatter_to_request_class.values() and not issubclass(
             request, DeprecationFixerRequest
         ):

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -233,9 +233,7 @@ async def update_build_files(
     if not chosen_formatter_request_class:
         raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")
 
-    logger.info("Chosen formatter request class: %s", chosen_formatter_request_class.__name__)
     for request in union_membership[RewrittenBuildFileRequest]:
-        # 18:12:24.29 [INFO] Using BLACK formatter to format BUILD files for subsystem update-build-files and request class <class 'abc.ABCMeta'>.
         if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
             rewrite_request_classes.append(request)
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -235,12 +235,14 @@ async def update_build_files(
 
     logger.info("Chosen formatter request class: %s", chosen_formatter_request_class.__name__)
     for request in union_membership[RewrittenBuildFileRequest]:
+        # 18:12:24.29 [INFO] Using BLACK formatter to format BUILD files for subsystem update-build-files and request class <class 'abc.ABCMeta'>.
         if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
             logger.info(
-                "Using %s formatter to format BUILD files for subsystem %s and request class %s.",
+                "Using %s formatter to format BUILD files for subsystem %s and request class %s for chosen class %s.",
                 update_build_files_subsystem.formatter.name,
                 update_build_files_subsystem.name,
-                type(request),
+                type(request).__name__,
+                chosen_formatter_request_class.__name__,
             )
             rewrite_request_classes.append(request)
 

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -242,6 +242,13 @@ async def update_build_files(
         ):
             rewrite_request_classes.append(request)
 
+        # If there are other types of formatters that aren't the standard backends
+        # or deprecation fixers, add them here.
+        if request not in formatter_to_request_class.values() and not issubclass(
+            request, DeprecationFixerRequest
+        ):
+            rewrite_request_classes.append(request)
+
     build_file_to_lines = {
         build_file.path: tuple(build_file.content.decode("utf-8").splitlines())
         for build_file in specified_build_files

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -237,16 +237,9 @@ async def update_build_files(
     for request in union_membership[RewrittenBuildFileRequest]:
         # 18:12:24.29 [INFO] Using BLACK formatter to format BUILD files for subsystem update-build-files and request class <class 'abc.ABCMeta'>.
         if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
-            logger.info(
-                "Using %s formatter to format BUILD files for subsystem %s and request class %s for chosen class %s.",
-                update_build_files_subsystem.formatter.name,
-                update_build_files_subsystem.name,
-                type(request).__name__,
-                chosen_formatter_request_class.__name__,
-            )
             rewrite_request_classes.append(request)
 
-        if update_build_files_subsystem.fix_safe_deprecations or not issubclass(
+        if update_build_files_subsystem.fix_safe_deprecations and issubclass(
             request, DeprecationFixerRequest
         ):
             rewrite_request_classes.append(request)

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -233,8 +233,15 @@ async def update_build_files(
     if not chosen_formatter_request_class:
         raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")
 
+    logger.info("Chosen formatter request class: %s", chosen_formatter_request_class.__name__)
     for request in union_membership[RewrittenBuildFileRequest]:
         if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
+            logger.info(
+                "Using %s formatter to format BUILD files for subsystem %s and request class %s.",
+                update_build_files_subsystem.formatter.name,
+                update_build_files_subsystem.name,
+                type(request),
+            )
             rewrite_request_classes.append(request)
 
         if update_build_files_subsystem.fix_safe_deprecations or not issubclass(

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -74,12 +74,16 @@ def reverse_lines(request: MockRewriteReverseLines) -> RewrittenBuildFile:
 def generic_goal_rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=(
-            update_build_files,
             add_line,
             reverse_lines,
+            format_build_file_with_ruff,
+            format_build_file_with_yapf,
+            update_build_files,
             # Ruff and Yapf are included, but Black is not because
             # that's the formatter we enable in pants.toml.
             # These tests check that Ruff and Yapf are NOT invoked.
+            *config_files.rules(),
+            *pex.rules(),
             *Ruff.rules(),
             *Yapf.rules(),
             *UpdateBuildFilesSubsystem.rules(),

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -77,7 +77,6 @@ def generic_goal_rule_runner() -> RuleRunner:
             update_build_files,
             add_line,
             reverse_lines,
-            *UpdateBuildFilesSubsystem.rules(),
             # Ruff and Yapf are included, but Black is not because
             # that's the formatter we enable in pants.toml.
             # These tests check that Ruff and Yapf are NOT invoked.

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -216,12 +216,20 @@ def black_rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=(
             format_build_file_with_black,
+            format_build_file_with_ruff,
+            format_build_file_with_yapf,
             update_build_files,
             *config_files.rules(),
             *pex.rules(),
             *Black.rules(),
+            # Even though Ruff and Yapf are included here,
+            # only Black should be used for formatting.
+            *Ruff.rules(),
+            *Yapf.rules(),
             *UpdateBuildFilesSubsystem.rules(),
             UnionRule(RewrittenBuildFileRequest, FormatWithBlackRequest),
+            UnionRule(RewrittenBuildFileRequest, FormatWithRuffRequest),
+            UnionRule(RewrittenBuildFileRequest, FormatWithYapfRequest),
         ),
         target_types=[GenericTarget],
     )

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -78,8 +78,16 @@ def generic_goal_rule_runner() -> RuleRunner:
             add_line,
             reverse_lines,
             *UpdateBuildFilesSubsystem.rules(),
+            # Ruff and Yapf are included, but Black is not because
+            # that's the formatter we enable in pants.toml.
+            # These tests check that Ruff and Yapf are NOT invoked.
+            *Ruff.rules(),
+            *Yapf.rules(),
+            *UpdateBuildFilesSubsystem.rules(),
             UnionRule(RewrittenBuildFileRequest, MockRewriteAddLine),
             UnionRule(RewrittenBuildFileRequest, MockRewriteReverseLines),
+            UnionRule(RewrittenBuildFileRequest, FormatWithRuffRequest),
+            UnionRule(RewrittenBuildFileRequest, FormatWithYapfRequest),
         )
     )
 
@@ -108,7 +116,7 @@ def test_goal_rewrite_mode(generic_goal_rule_runner: RuleRunner) -> None:
     )
 
 
-def test_multi_formatter_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
+def test_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
     """Checks that we correctly set the exit code and pipe fixers to each other."""
     generic_goal_rule_runner.write_files({"BUILD": "# line\n", "dir/BUILD": "# line 1\n# line 2\n"})
     result = generic_goal_rule_runner.run_goal_rule(
@@ -365,82 +373,3 @@ def test_yapf_fixer_noops() -> None:
     assert result.exit_code == 0
     assert not result.stdout
     assert build == 'target(name="t")\n'
-
-
-# ------------------------------------------------------------------------------------------
-# Test with multiple formatters enabled
-# ------------------------------------------------------------------------------------------
-
-
-@pytest.fixture
-def multi_formatter_rule_runner() -> RuleRunner:
-    return RuleRunner(
-        rules=(
-            update_build_files,
-            add_line,
-            reverse_lines,
-            *config_files.rules(),
-            *pex.rules(),
-            # Ruff and Yapf are included, but Black is not because
-            # that's the formatter we enable in pants.toml.
-            # The tests should ensure that Ruff and Yapf do NOT run on these files.
-            *Ruff.rules(),
-            *Yapf.rules(),
-            *UpdateBuildFilesSubsystem.rules(),
-            UnionRule(RewrittenBuildFileRequest, MockRewriteAddLine),
-            UnionRule(RewrittenBuildFileRequest, MockRewriteReverseLines),
-            UnionRule(RewrittenBuildFileRequest, FormatWithRuffRequest),
-            UnionRule(RewrittenBuildFileRequest, FormatWithYapfRequest),
-        )
-    )
-
-
-def test_multi_formatter_goal_rewrite_mode(generic_goal_rule_runner: RuleRunner) -> None:
-    """Checks that we correctly write the changes and pipe fixers to each other."""
-    generic_goal_rule_runner.write_files({"BUILD": "# line\n", "dir/BUILD": "# line 1\n# line 2\n"})
-    result = generic_goal_rule_runner.run_goal_rule(UpdateBuildFilesGoal, args=["::"])
-    assert result.exit_code == 0
-    assert result.stdout == dedent(
-        """\
-        Updated BUILD:
-          - Add a new line
-          - Reverse lines
-        Updated dir/BUILD:
-          - Add a new line
-          - Reverse lines
-        """
-    )
-    assert (
-        Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "# added line\n# line\n"
-    )
-    assert (
-        Path(generic_goal_rule_runner.build_root, "dir/BUILD").read_text()
-        == "# added line\n# line 2\n# line 1\n"
-    )
-
-
-def test_multi_formatter_goal_check_mode(generic_goal_rule_runner: RuleRunner) -> None:
-    """Checks that we correctly set the exit code and pipe fixers to each other."""
-    generic_goal_rule_runner.write_files({"BUILD": "# line\n", "dir/BUILD": "# line 1\n# line 2\n"})
-    result = generic_goal_rule_runner.run_goal_rule(
-        UpdateBuildFilesGoal,
-        global_args=["--pants-bin-name=./custom_pants"],
-        args=["--check", "::"],
-    )
-    assert result.exit_code == 1
-    assert result.stdout == dedent(
-        """\
-        Would update BUILD:
-          - Add a new line
-          - Reverse lines
-        Would update dir/BUILD:
-          - Add a new line
-          - Reverse lines
-
-        To fix `update-build-files` failures, run `./custom_pants update-build-files`.
-        """
-    )
-    assert Path(generic_goal_rule_runner.build_root, "BUILD").read_text() == "# line\n"
-    assert (
-        Path(generic_goal_rule_runner.build_root, "dir/BUILD").read_text() == "# line 1\n# line 2\n"
-    )

--- a/src/python/pants/core/goals/update_build_files_test.py
+++ b/src/python/pants/core/goals/update_build_files_test.py
@@ -79,11 +79,12 @@ def generic_goal_rule_runner() -> RuleRunner:
             format_build_file_with_ruff,
             format_build_file_with_yapf,
             update_build_files,
-            # Ruff and Yapf are included, but Black is not because
-            # that's the formatter we enable in pants.toml.
-            # These tests check that Ruff and Yapf are NOT invoked.
             *config_files.rules(),
             *pex.rules(),
+            # Ruff and Yapf are included, but Black isn't because
+            # that's the formatter we enable in pants.toml.
+            # These tests check that Ruff and Yapf are NOT invoked,
+            # but the other rewrite targets are invoked.
             *Ruff.rules(),
             *Yapf.rules(),
             *UpdateBuildFilesSubsystem.rules(),


### PR DESCRIPTION
Closes #20576.

Although this is a relatively small change, I think it's good to understand the change in context so I've included the new and old logic below for comparison.

New logic:

```py
formatter_to_request_class: dict[Formatter, type[RewrittenBuildFileRequest]] = {
    Formatter.BLACK: FormatWithBlackRequest,
    Formatter.YAPF: FormatWithYapfRequest,
    Formatter.RUFF: FormatWithRuffRequest,
}
chosen_formatter_request_class = formatter_to_request_class.get(
    update_build_files_subsystem.formatter
)
if not chosen_formatter_request_class:
    raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")

for request in union_membership[RewrittenBuildFileRequest]:
    if update_build_files_subsystem.fmt and request == chosen_formatter_request_class:
        rewrite_request_classes.append(request)

    if update_build_files_subsystem.fix_safe_deprecations and issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)

    # If there are other types of requests that aren't the standard formatter
    # backends or deprecation fixers, add them here.
    if request not in formatter_to_request_class.values() and not issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)
```

Old logic:

```py
for request in union_membership[RewrittenBuildFileRequest]:
    if issubclass(request, (FormatWithBlackRequest, FormatWithYapfRequest)):
        is_chosen_formatter = issubclass(request, FormatWithBlackRequest) ^ (
            update_build_files_subsystem.formatter == Formatter.YAPF
        )

        if update_build_files_subsystem.fmt and is_chosen_formatter:
            rewrite_request_classes.append(request)
        else:
            continue
        
    if update_build_files_subsystem.fix_safe_deprecations or not issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)
```

The `else: continue` in the old logic was load-bearing, because it would skip over the second top-level `if` statement and move to the next loop iteration in cases where the request class was one of the regular formatters (`FormatWithBlackRequest` or `FormatWithYapfRequest`). 

The `or not issubclass(request, DeprecationFixerRequest)` was intended to catch formatters that live outside of the list of formatter backends and deprecation fixers - the last `if` statement in the new logic is intended to cover this case as well.