### PR TITLE
Fix update build files formatter selection (Cherry-pick of #20580)

### DIFF
--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -234,10 +234,17 @@ async def update_build_files(
         raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")
 
     for request in union_membership[RewrittenBuildFileRequest]:
-        if update_build_files_subsystem.fmt and issubclass(request, chosen_formatter_request_class):
+        if update_build_files_subsystem.fmt and request == chosen_formatter_request_class:
             rewrite_request_classes.append(request)
 
-        if update_build_files_subsystem.fix_safe_deprecations or not issubclass(
+        if update_build_files_subsystem.fix_safe_deprecations and issubclass(
+            request, DeprecationFixerRequest
+        ):
+            rewrite_request_classes.append(request)
+
+        # If there are other types of requests that aren't the standard formatter
+        # backends or deprecation fixers, add them here.
+        if request not in formatter_to_request_class.values() and not issubclass(
             request, DeprecationFixerRequest
         ):
             rewrite_request_classes.append(request)


### PR DESCRIPTION
Closes #20576.

Although this is a relatively small change, I think it's good to understand the change in context so I've included the new and old logic below for comparison.

New logic:

```py
formatter_to_request_class: dict[Formatter, type[RewrittenBuildFileRequest]] = {
    Formatter.BLACK: FormatWithBlackRequest,
    Formatter.YAPF: FormatWithYapfRequest,
    Formatter.RUFF: FormatWithRuffRequest,
}
chosen_formatter_request_class = formatter_to_request_class.get(
    update_build_files_subsystem.formatter
)
if not chosen_formatter_request_class:
    raise ValueError(f"Unrecognized formatter: {update_build_files_subsystem.formatter}")

for request in union_membership[RewrittenBuildFileRequest]:
    if update_build_files_subsystem.fmt and request == chosen_formatter_request_class:
        rewrite_request_classes.append(request)

    if update_build_files_subsystem.fix_safe_deprecations and issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)

    # If there are other types of requests that aren't the standard formatter
    # backends or deprecation fixers, add them here.
    if request not in formatter_to_request_class.values() and not issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)
```

Old logic:

```py
for request in union_membership[RewrittenBuildFileRequest]:
    if issubclass(request, (FormatWithBlackRequest, FormatWithYapfRequest)):
        is_chosen_formatter = issubclass(request, FormatWithBlackRequest) ^ (
            update_build_files_subsystem.formatter == Formatter.YAPF
        )

        if update_build_files_subsystem.fmt and is_chosen_formatter:
            rewrite_request_classes.append(request)
        else:
            continue
        
    if update_build_files_subsystem.fix_safe_deprecations or not issubclass(
        request, DeprecationFixerRequest
    ):
        rewrite_request_classes.append(request)
```

The `else: continue` in the old logic was load-bearing, because it would skip over the second top-level `if` statement and move to the next loop iteration in cases where the request class was one of the regular formatters (`FormatWithBlackRequest` or `FormatWithYapfRequest`). 

The `or not issubclass(request, DeprecationFixerRequest)` was intended to catch formatters that live outside of the list of formatter backends and deprecation fixers - the last `if` statement in the new logic is intended to cover this case as well.
