### PR TITLE
Update `doc_url` calls for new website

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -191,7 +191,7 @@ class PythonAWSLambda(_AWSLambdaBaseTarget):
         f"""
         A self-contained Python function suitable for uploading to AWS Lambda.
 
-        See {doc_url('awslambda-python')}.
+        See {doc_url('docs/python/integrations/aws-lambda')}.
         """
     )
 
@@ -207,7 +207,7 @@ class PythonAWSLambdaLayer(_AWSLambdaBaseTarget):
         f"""
         A Python layer suitable for uploading to AWS Lambda.
 
-        See {doc_url('awslambda-python')}.
+        See {doc_url('docs/python/integrations/aws-lambda')}.
         """
     )
 

--- a/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
+++ b/src/python/pants/backend/codegen/protobuf/python/python_protobuf_subsystem.py
@@ -35,7 +35,7 @@ class PythonProtobufSubsystem(Subsystem):
         f"""
         Options related to the Protobuf Python backend.
 
-        See {doc_url('protobuf-python')}.
+        See {doc_url('docs/python/integrations/protobuf-and-grpc')}.
         """
     )
 

--- a/src/python/pants/backend/codegen/protobuf/target_types.py
+++ b/src/python/pants/backend/codegen/protobuf/target_types.py
@@ -66,8 +66,8 @@ class ProtobufSourceTarget(Target):
         A single Protobuf file used to generate various languages.
 
         See language-specific docs:
-            Python: {doc_url('protobuf-python')}
-            Go: {doc_url('protobuf-go')}
+            Python: {doc_url('docs/python/integrations/protobuf-and-grpc')}
+            Go: {doc_url('docs/go/integrations/protobuf')}
         """
     )
 

--- a/src/python/pants/backend/codegen/thrift/target_types.py
+++ b/src/python/pants/backend/codegen/thrift/target_types.py
@@ -72,7 +72,7 @@ class ThriftSourceTarget(Target):
         A single Thrift file used to generate various languages.
 
         See language-specific docs:
-            Python: {doc_url('thrift-python')}
+            Python: {doc_url('docs/python/integrations/thrift')}
         """
     )
 

--- a/src/python/pants/backend/codegen/utils.py
+++ b/src/python/pants/backend/codegen/utils.py
@@ -54,7 +54,7 @@ def find_python_runtime_library_or_raise_error(
                 No `python_requirement` target was found with the module `{runtime_library_module}`
                 in your project{for_resolve_str}, so the Python code generated from the target
                 {codegen_address} will not work properly. See
-                {doc_url('python-third-party-dependencies')} for how to add a requirement, such as
+                {doc_url('docs/python/overview/third-party-dependencies')} for how to add a requirement, such as
                 adding to requirements.txt. Usually you will want to use the
                 `{recommended_requirement_name}` project at {recommended_requirement_url}.
 

--- a/src/python/pants/backend/docker/target_types.py
+++ b/src/python/pants/backend/docker/target_types.py
@@ -149,7 +149,7 @@ class DockerImageTagsField(StringSequenceField):
 
         {_interpolation_help.format(kind="tag")}
 
-        See {doc_url('tagging-docker-images')}.
+        See {doc_url('docs/docker/tagging-docker-images')}.
         """
     )
 

--- a/src/python/pants/backend/google_cloud_function/python/target_types.py
+++ b/src/python/pants/backend/google_cloud_function/python/target_types.py
@@ -125,7 +125,7 @@ class PythonGoogleCloudFunction(Target):
         f"""
         A self-contained Python function suitable for uploading to Google Cloud Function.
 
-        See {doc_url('google-cloud-function-python')}.
+        See {doc_url('docs/python/integrations/google-cloud-functions')}.
         """
     )
 

--- a/src/python/pants/backend/python/dependency_inference/rules.py
+++ b/src/python/pants/backend/python/dependency_inference/rules.py
@@ -346,7 +346,7 @@ async def _handle_unowned_imports(
 
         If you do not expect an import to be inferrable, add `# pants: no-infer-dep` to the
         import line. Otherwise, see
-        {doc_url('troubleshooting#import-errors-and-missing-dependencies')} for common problems.
+        {doc_url('docs/using-pants/troubleshooting-common-issues#import-errors-and-missing-dependencies')} for common problems.
         """
     )
     if unowned_dependency_behavior is UnownedDependencyUsage.LogWarning:

--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -243,7 +243,7 @@ async def validate_pytest_cov_included(_pytest: PyTest):
                 `{_pytest.install_from_resolve}` used to install pytest is missing
                 `pytest-cov`, which is needed to collect coverage data.
 
-                See {doc_url("python-test-goal#pytest-version-and-plugins")} for details
+                See {doc_url("docs/python/goals/test#pytest-version-and-plugins")} for details
                 on how to set up a custom resolve for use by pytest.
                 """
             )

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -54,7 +54,7 @@ def validate_compatible_resolve(root_targets: Iterable[Target], python_setup: Py
         raise NoCompatibleResolveException.bad_input_roots(
             root_targets,
             maybe_get_resolve=maybe_get_resolve,
-            doc_url_slug="python-third-party-dependencies#multiple-lockfiles",
+            doc_url_slug="docs/python/overview/lockfiles#multiple-lockfiles",
             workaround=softwrap(
                 f"""
                 To work around this, choose which resolve you want to use from above. Then, run

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -108,7 +108,7 @@ class Flake8(PythonToolBase):
             example, if your plugin is at `build-support/flake8/custom_plugin.py`, add
             `'build-support/flake8'` to `[source].root_patterns` in `pants.toml`. This is
             necessary for Pants to know how to tell Flake8 to discover your plugin. See
-            {doc_url('source-roots')}
+            {doc_url('docs/using-pants/key-concepts/source-roots')}
 
             You must also set `[flake8:local-plugins]` in your Flake8 config file.
 
@@ -123,7 +123,7 @@ class Flake8(PythonToolBase):
             directory or a subdirectory.
 
             To instead load third-party plugins, add them to a custom resolve alongside
-            flake8 itself, as described in {doc_url("python-lockfiles#lockfiles-for-tools")}.
+            flake8 itself, as described in {doc_url("docs/python/overview/lockfiles#lockfiles-for-tools")}.
             """
         ),
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -106,7 +106,7 @@ class Pylint(PythonToolBase):
             example, if your plugin is at `build-support/pylint/custom_plugin.py`, add
             `'build-support/pylint'` to `[source].root_patterns` in `pants.toml`. This is
             necessary for Pants to know how to tell Pylint to discover your plugin. See
-            {doc_url('source-roots')}
+            {doc_url('docs/using-pants/key-concepts/source-roots')}
 
             You must also set `load-plugins=$module_name` in your Pylint config file.
 
@@ -115,7 +115,7 @@ class Pylint(PythonToolBase):
             directory or a subdirectory.
 
             To instead load third-party plugins, add them to a custom resolve alongside
-            pylint itself, as described in {doc_url("python-lockfiles#lockfiles-for-tools")}.
+            pylint itself, as described in {doc_url("docs/python/overview/lockfiles#lockfiles-for-tools")}.
             """
         ),
     )

--- a/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/rules.py
@@ -133,7 +133,7 @@ async def package_pyoxidizer_binary(
                 The `{PyOxidizerTarget.alias}` target {field_set.address} must include
                 in its `dependencies` field at least one `python_distribution` target that produces a
                 `.whl` file. For example, if using `{GenerateSetupField.alias}=True`, then make sure
-                `{WheelField.alias}=True`. See {doc_url('python-distributions')}.
+                `{WheelField.alias}=True`. See {doc_url('docs/python/overview/building-distributions')}.
                 """
             )
         )

--- a/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/target_types.py
@@ -78,14 +78,14 @@ class PyOxidizerDependenciesField(Dependencies):
 
         The distribution(s) must generate at least one wheel file. For example, if using
         `{GenerateSetupField.alias}=True`, then make sure `{WheelField.alias}=True`. See
-        {doc_url('python-distributions')}.
+        {doc_url('docs/python/overview/building-distributions')}.
 
         Usually, you only need to specify a single `python_distribution`. However, if
         that distribution depends on another first-party distribution in your repository, you
         must specify that dependency too, otherwise PyOxidizer would try installing the
         distribution from PyPI. Note that a `python_distribution` target might depend on
         another `python_distribution` target even if it is not included in its own `dependencies`
-        field, as explained at {doc_url('python-distributions')}; if code from one distribution
+        field, as explained at {doc_url('docs/python/overview/building-distributions')}; if code from one distribution
         imports code from another distribution, then there is a dependency and you must
         include both `python_distribution` targets in the `dependencies` field of this
         `pyoxidizer_binary` target.
@@ -146,7 +146,7 @@ class PyOxidizerTarget(Target):
         A single-file Python executable with a Python interpreter embedded, built via PyOxidizer.
 
         To use this target, first create a `python_distribution` target with the code you want
-        included in your binary, per {doc_url('python-distributions')}. Then add this
+        included in your binary, per {doc_url('docs/python/overview/building-distributions')}. Then add this
         `python_distribution` target to the `dependencies` field. See the `help` for
         `dependencies` for more information.
 

--- a/src/python/pants/backend/python/subsystems/python_tool_base.py
+++ b/src/python/pants/backend/python/subsystems/python_tool_base.py
@@ -58,7 +58,7 @@ class PythonToolRequirementsBase(Subsystem):
             If specified, install the tool using the lockfile for this named resolve.
 
             This resolve must be defined in `[python].resolves`, as described in
-            {doc_url("python-third-party-dependencies#user-lockfiles")}.
+            {doc_url("docs/python/overview/third-party-dependencies#user-lockfiles")}.
 
             The resolve's entire lockfile will be installed, unless specific requirements are
             listed via the `requirements` option, in which case only those requirements

--- a/src/python/pants/backend/python/subsystems/repos.py
+++ b/src/python/pants/backend/python/subsystems/repos.py
@@ -78,19 +78,19 @@ class PythonRepos(Subsystem):
 
             This feature is intended to be used with `[python-repos].find_links`, rather than PEP
             440 direct reference requirements (see
-            {doc_url("python-third-party-dependencies#local-requirements")}.
+            {doc_url("docs/python/overview/third-party-dependencies#local-requirements")}.
             `[python-repos].find_links` must be configured to a valid absolute path for the
             current machine.
 
             Tip: you can avoid each user needing to manually configure this option and
             `[python-repos].find_links` by using a common file location, along with Pants's
-            interpolation support ({doc_url('options#config-file-interpolation')}. For example,
+            interpolation support ({doc_url('docs/using-pants/key-concepts/options#config-file-interpolation')}. For example,
             in `pants.toml`, you could set both options to `%(buildroot)s/python_wheels`
             to point to the directory `python_wheels` in the root of
             your repository; or, use the path `%(env.HOME)s/pants_wheels` for the path
             `~/pants_wheels`. If you are not able to use a common path like this, then we
             recommend setting that each user set these options via a `.pants.rc` file
-            ({doc_url('options#pantsrc-file')}.
+            ({doc_url('docs/using-pants/key-concepts/options#pantsrc-file')}.
 
             Note: Only takes effect if using Pex lockfiles, i.e. using the
             `generate-lockfiles` goal.

--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -106,7 +106,7 @@ class PythonSetup(Subsystem):
                     if different parts of your codebase run against different python interpreter
                     versions in a single repo.
 
-                    See {doc_url("python-interpreter-compatibility")} for details.
+                    See {doc_url("docs/python/overview/interpreter-compatibility")} for details.
                     """
                 ),
             )
@@ -126,7 +126,7 @@ class PythonSetup(Subsystem):
             interpreter constraints, update `[python].interpreter_constraints`, the
             `interpreter_constraints` field, and relevant tool options like
             `[isort].interpreter_constraints` to tell Pants which interpreters your code
-            actually uses. See {doc_url('python-interpreter-compatibility')}.
+            actually uses. See {doc_url('docs/python/overview/interpreter-compatibility')}.
 
             All elements must be the minor and major Python version, e.g. `'2.7'` or `'3.10'`. Do
             not include the patch version.
@@ -187,7 +187,7 @@ class PythonSetup(Subsystem):
                 resolve with the `resolve` field.
 
             If a target can work with multiple resolves, you can either use the `parametrize`
-            mechanism or manually create a distinct target per resolve. See {doc_url("targets")}
+            mechanism or manually create a distinct target per resolve. See {doc_url("docs/using-pants/key-concepts/targets-and-build-files")}
             for information about `parametrize`.
 
             For example:
@@ -231,7 +231,7 @@ class PythonSetup(Subsystem):
             Use this version of Pip for resolving requirements and generating lockfiles.
 
             The value used here must be one of the Pip versions supported by the underlying PEX
-            version. See {doc_url("pex")} for details.
+            version. See {doc_url("docs/python/overview/pex")} for details.
 
             N.B.: The `latest` value selects the latest of the choices listed by PEX which is not
             necessarily the latest Pip version released on PyPI.

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -78,7 +78,7 @@ class TwineSubsystem(PythonToolBase):
 
             This option cannot be overridden via environment targets, so if you need a different
             value than what the rest of your organization is using, override the value via an
-            environment variable, CLI argument, or `.pants.rc` file. See {doc_url('options')}.
+            environment variable, CLI argument, or `.pants.rc` file. See {doc_url('docs/using-pants/key-concepts/options')}.
             """
         ),
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -113,7 +113,7 @@ class InterpreterConstraintsField(StringSequenceField):
 
         If the field is not set, it will default to the option `[python].interpreter_constraints`.
 
-        See {doc_url('python-interpreter-compatibility')} for how these interpreter
+        See {doc_url('docs/python/overview/interpreter-compatibility')} for how these interpreter
         constraints are merged with the constraints of dependencies.
         """
     )
@@ -459,7 +459,7 @@ class PexPlatformsField(StringSequenceField):
         f"""\
     The platforms field is a hack. The abbreviated information it provides is sometimes insufficient,
     leading to hard-to-debug build issues. Use complete_platforms instead.
-    See {doc_url('pex')} for details.
+    See {doc_url('docs/python/overview/pex')} for details.
     """
     )
     help = help_text(
@@ -508,7 +508,7 @@ class PexCompletePlatformsField(SpecialCasedDependencies):
         complete platform JSON as described by Pex
         (https://pex.readthedocs.io/en/latest/buildingpex.html#complete-platform).
 
-        See {doc_url('pex')} for details.
+        See {doc_url('docs/python/overview/pex')} for details.
         """
     )
 
@@ -797,7 +797,7 @@ class PexBinary(Target):
         A Python target that can be converted into an executable PEX file.
 
         PEX files are self-contained executable files that contain a complete Python environment
-        capable of running the target. For more information, see {doc_url('pex')}.
+        capable of running the target. For more information, see {doc_url('docs/python/overview/pex')}.
         """
     )
 
@@ -1059,7 +1059,7 @@ class PythonTestTarget(Target):
         target and then be included in the `dependencies` field. (You can use the
         `python_test_utils` target to generate these `python_source` targets.)
 
-        See {doc_url('python-test-goal')}
+        See {doc_url('docs/python/goals/test')}
         """
     )
 
@@ -1398,7 +1398,7 @@ class PythonRequirementTarget(Target):
         requirement into a `python_requirement` target automatically. For Poetry, use
         `poetry_requirements`.
 
-        See {doc_url('python-third-party-dependencies')}.
+        See {doc_url('docs/python/overview/third-party-dependencies')}.
         """
     )
 
@@ -1443,7 +1443,7 @@ class PythonProvidesField(ScalarField, AsyncFieldMixin):
         in the `setup()` function:
         (https://packaging.python.org/guides/distributing-packages-using-setuptools/#setup-args).
 
-        See {doc_url('plugins-setup-py')} for how to write a plugin to dynamically generate kwargs.
+        See {doc_url('docs/writing-plugins/common-plugin-tasks/custom-python-artifact-kwargs')} for how to write a plugin to dynamically generate kwargs.
         """
     )
 
@@ -1677,7 +1677,7 @@ class PythonDistribution(Target):
         f"""
         A publishable Python setuptools distribution (e.g. an sdist or wheel).
 
-        See {doc_url('python-distributions')}.
+        See {doc_url('docs/python/overview/building-distributions')}.
         """
     )
 
@@ -1786,6 +1786,6 @@ class VCSVersion(Target):
         a subset of that config in this target's fields.
 
         If you need functionality that is not currently exposed here, please reach out to us at
-        {doc_url("getting-help")}.
+        {doc_url("community/getting-help")}.
         """
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1786,6 +1786,6 @@ class VCSVersion(Target):
         a subset of that config in this target's fields.
 
         If you need functionality that is not currently exposed here, please reach out to us at
-        {doc_url("community/getting-help", versioned=False)}.
+        {doc_url("community/getting-help")}.
         """
     )

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1786,6 +1786,6 @@ class VCSVersion(Target):
         a subset of that config in this target's fields.
 
         If you need functionality that is not currently exposed here, please reach out to us at
-        {doc_url("community/getting-help")}.
+        {doc_url("community/getting-help", versioned=False)}.
         """
     )

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -423,7 +423,7 @@ async def resolve_python_distribution_entry_points(
                     target type {target.alias}.
 
                     Alternatively, you can use a module like "project.app:main".
-                    See {doc_url('python-distributions')}.
+                    See {doc_url('docs/python/overview/building-distributions')}.
                     """
                 )
             )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -114,7 +114,7 @@ class MyPy(PythonToolBase):
 
             To instead load third-party plugins, set the option `[mypy].install_from_resolve`
             to a resolve whose lockfile includes those plugins, and set the `plugins` option
-            in `mypy.ini`.  See {doc_url('python-check-goal')}.
+            in `mypy.ini`.  See {doc_url('docs/python/goals/check')}.
             """
         ),
     )
@@ -161,7 +161,7 @@ class MyPy(PythonToolBase):
                     f"""
                     You set {formatted_configured}. Normally, Pants would automatically set this
                     for you based on your code's interpreter constraints
-                    ({doc_url('python-interpreter-compatibility')}). Instead, it will
+                    ({doc_url('docs/python/overview/interpreter-compatibility')}). Instead, it will
                     use what you set.
 
                     (Allowing Pants to automatically set the option allows Pants to partition your

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -73,7 +73,7 @@ async def isolate_local_dist_wheels(
                 code will be used directly from sources, without a distribution being built,
                 and any native extensions in it will not be built.
 
-                See {doc_url('python-distributions')} for details on how to set up a
+                See {doc_url('docs/python/overview/building-distributions')} for details on how to set up a
                 {tgt.target.alias} target to produce a wheel.
                 """
             )

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660.py
@@ -281,7 +281,7 @@ async def isolate_local_dist_pep660_wheels(
                 code will be used directly from sources, without a distribution being built,
                 and any native extensions in it will not be built.
 
-                See {doc_url('python-distributions')} for details on how to set up a
+                See {doc_url('docs/python/overview/building-distributions')} for details on how to set up a
                 {tgt.target.alias} target to produce a wheel.
                 """
             )

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -94,7 +94,7 @@ logger = logging.getLogger(__name__)
 
 class SetupPyError(Exception):
     def __init__(self, msg: str):
-        super().__init__(f"{msg} See {doc_url('python-distributions')}.")
+        super().__init__(f"{msg} See {doc_url('docs/python/overview/building-distributions')}.")
 
 
 class InvalidSetupPyArgs(SetupPyError):
@@ -116,7 +116,7 @@ class OwnershipError(SetupPyError):
         super().__init__(
             softwrap(
                 f"""
-                {msg} See {doc_url('python-distributions')} for
+                {msg} See {doc_url('docs/python/overview/building-distributions')} for
                 how python_sources targets are mapped to distributions.
                 """
             )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -269,7 +269,7 @@ async def choose_python_resolve(
             raise NoCompatibleResolveException.bad_input_roots(
                 transitive_targets.roots,
                 maybe_get_resolve=maybe_get_resolve,
-                doc_url_slug="python-third-party-dependencies#multiple-lockfiles",
+                doc_url_slug="docs/python/overview/lockfiles#multiple-lockfiles",
                 workaround=None,
             )
 
@@ -283,7 +283,7 @@ async def choose_python_resolve(
             ):
                 raise NoCompatibleResolveException.bad_dependencies(
                     maybe_get_resolve=maybe_get_resolve,
-                    doc_url_slug="python-third-party-dependencies#multiple-lockfiles",
+                    doc_url_slug="docs/python/overview/lockfiles#multiple-lockfiles",
                     root_resolve=chosen_resolve,
                     root_targets=transitive_targets.roots,
                     dependencies=transitive_targets.dependencies,
@@ -475,7 +475,7 @@ async def _determine_requirements_for_pex_from_targets(
                     f"""
                     [python].run_against_entire_lockfile was set, but could not find a
                     lockfile or constraints file for this target set. See
-                    {doc_url('python-third-party-dependencies')} for details.
+                    {doc_url('docs/python/overview/third-party-dependencies')} for details.
                     """
                 )
             )

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -626,13 +626,13 @@ def _invalid_lockfile_error(
             (see below).
             """
         )
-        yield f"\n\nSee {doc_url('python-interpreter-compatibility')} for details."
+        yield f"\n\nSee {doc_url('docs/python/overview/interpreter-compatibility')} for details."
 
     yield "\n\n"
     yield from _common_failure_reasons(validation.failure_reasons, maybe_constraints_file_path)
     yield "To regenerate your lockfile, "
     yield f"run `{bin_name()} generate-lockfiles --resolve={resolve}`."
-    yield f"\n\nSee {doc_url('python-third-party-dependencies')} for details.\n\n"
+    yield f"\n\nSee {doc_url('docs/python/overview/third-party-dependencies')} for details.\n\n"
 
 
 def rules():

--- a/src/python/pants/bin/pants_runner.py
+++ b/src/python/pants/bin/pants_runner.py
@@ -96,7 +96,7 @@ class PantsRunner:
                         softwrap(
                             f"""
                             The `pants` launcher binary is now the only supported way of running Pants.
-                            See {doc_url("installation")} for details.
+                            See {doc_url("docs/getting-started/installing-pants")} for details.
                             """
                         ),
                     )
@@ -117,7 +117,7 @@ class PantsRunner:
                         f"using a `pants` launcher binary older than {MINIMUM_SCIE_PANTS_VERSION}",
                         softwrap(
                             f"""
-                            {current_version_text}, and see {doc_url("installation")} for how to upgrade.
+                            {current_version_text}, and see {doc_url("docs/getting-started/installing-pants")} for how to upgrade.
                             """
                         ),
                     )

--- a/src/python/pants/core/goals/tailor.py
+++ b/src/python/pants/core/goals/tailor.py
@@ -318,7 +318,7 @@ class TailorSubsystem(GoalSubsystem):
             f"""
             A mapping from standard target type to custom type to use instead. The custom
             type can be a custom target type or a macro that offers compatible functionality
-            to the one it replaces (see {doc_url('macros')}).
+            to the one it replaces (see {doc_url('docs/writing-plugins/macros')}).
             """
         ),
         advanced=True,

--- a/src/python/pants/core/goals/update_build_files.py
+++ b/src/python/pants/core/goals/update_build_files.py
@@ -119,7 +119,7 @@ class UpdateBuildFilesSubsystem(GoalSubsystem):
 
         This does not handle the full Pants upgrade. You must still manually change
         `pants_version` in `pants.toml` and you may need to manually address some deprecations.
-        See {doc_url('upgrade-tips')} for upgrade tips.
+        See {doc_url('docs/releases/upgrade-tips')} for upgrade tips.
 
         This goal is run without arguments. It will run over all BUILD files in your
         project.
@@ -275,7 +275,7 @@ async def update_build_files(
             msg += softwrap(
                 f"""
                 However, there may still be deprecations that `update-build-files` doesn't know
-                how to fix. See {doc_url('upgrade-tips')} for upgrade tips.
+                how to fix. See {doc_url('docs/releases/upgrade-tips')} for upgrade tips.
                 """
             )
         logger.info(msg)

--- a/src/python/pants/core/util_rules/external_tool.py
+++ b/src/python/pants/core/util_rules/external_tool.py
@@ -319,7 +319,7 @@ class TemplatedExternalToolOptionsMixin(ExternalToolOptionsMixin):
             (e.g. zip file). You can change this to point to your own hosted file, e.g. to
             work with proxies or for access via the filesystem through a `file:$abspath` URL (e.g.
             `file:/this/is/absolute`, possibly by
-            [templating the buildroot in a config file]({doc_url('options#config-file-entries')})).
+            [templating the buildroot in a config file]({doc_url('docs/using-pants/key-concepts/options#config-file-entries')})).
 
             Use `{{version}}` to have the value from `--version` substituted, and `{{platform}}` to
             have a value from `--url-platform-mapping` substituted in, depending on the

--- a/src/python/pants/core/util_rules/subprocess_environment.py
+++ b/src/python/pants/core/util_rules/subprocess_environment.py
@@ -30,7 +30,7 @@ class SubprocessEnvironment(Subsystem):
                 Entries are either strings in the form `ENV_VAR=value` to set an explicit value;
                 or just `ENV_VAR` to copy the value from Pants's own environment.
 
-                See {doc_url('options#addremove-semantics')} for how to add and remove Pants's
+                See {doc_url('docs/using-pants/key-concepts/options#addremove-semantics')} for how to add and remove Pants's
                 default for this option.
                 """
             ),

--- a/src/python/pants/engine/goal.py
+++ b/src/python/pants/engine/goal.py
@@ -94,7 +94,7 @@ class Goal:
         f""" Indicates that the goal chooses the environments to use to execute rules within the goal.
 
         This requires migration work to be done by the goal author. See
-        {doc_url('plugin-upgrade-guide')}.
+        {doc_url('docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide')}.
         """
         USES_ENVIRONMENTS = 3
 
@@ -106,7 +106,7 @@ class Goal:
     All goals in `pantsbuild/pants` should be migrated before the 2.15.x branch is cut, but end
     user goals have until `2.17.0.dev4` to migrate.
 
-    See {doc_url('plugin-upgrade-guide')}.
+    See {doc_url('docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide')}.
     """
     environment_behavior: ClassVar[EnvironmentBehavior]
 

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -928,7 +928,7 @@ def _log_or_raise_unmatched_owners(
             f"target whose `sources` field includes the file."
         )
     msg = (
-        f"{prefix} See {doc_url('targets')} for more information on target definitions."
+        f"{prefix} See {doc_url('docs/using-pants/key-concepts/targets-and-build-files')} for more information on target definitions."
         f"\n\nYou may want to run `{bin_name()} tailor` to autogenerate your BUILD files. See "
         f"{doc_url('create-initial-build-files')}.{option_msg}"
     )

--- a/src/python/pants/engine/internals/parser.py
+++ b/src/python/pants/engine/internals/parser.py
@@ -195,7 +195,7 @@ class ParseState(threading.local):
     @docstring(
         f"""Provide default field values.
 
-        Learn more {doc_url("targets#field-default-values")}
+        Learn more {doc_url("docs/using-pants/key-concepts/targets-and-build-files#field-default-values")}
         """
     )
     def set_defaults(
@@ -442,7 +442,7 @@ class Parser:
             help_str = softwrap(
                 f"""
                 If you expect to see more symbols activated in the below list, refer to
-                {doc_url('enabling-backends')} for all available backends to activate.
+                {doc_url('docs/using-pants/key-concepts/backends')} for all available backends to activate.
                 """
             )
             valid_symbols = sorted(s for s in global_symbols.keys() if s != "__builtins__")
@@ -479,7 +479,7 @@ def error_on_imports(build_file_content: str, filepath: str) -> None:
             f"Import used in {filepath} at line {lineno}. Import statements are banned in "
             "BUILD files and macros (that act like a normal BUILD file) because they can easily "
             "break Pants caching and lead to stale results. "
-            f"\n\nInstead, consider writing a plugin ({doc_url('plugins-overview')})."
+            f"\n\nInstead, consider writing a plugin ({doc_url('docs/writing-plugins/overview')})."
         )
 
 

--- a/src/python/pants/engine/internals/parser_test.py
+++ b/src/python/pants/engine/internals/parser_test.py
@@ -91,7 +91,7 @@ def test_unrecognized_symbol(defaults_parser_state: BuildFileDefaultsParserState
             dir/BUILD:1: Name 'FAKE' is not defined.
 
             {dym}If you expect to see more symbols activated in the below list, refer to
-            {doc_url('enabling-backends')} for all available backends to activate.
+            {doc_url('docs/using-pants/key-concepts/backends')} for all available backends to activate.
 
             All registered symbols: [{fmt_extra_sym}'__defaults__', '__dependencies_rules__',
             '__dependents_rules__', 'build_file_dir', 'caof', 'env', 'obj', 'prelude', 'tgt']
@@ -249,7 +249,7 @@ def test_unrecognized_symbol_in_prelude(
         Did you mean macro?
 
         If you expect to see more symbols activated in the below list, refer to
-        {doc_url('enabling-backends')} for all available backends to activate.
+        {doc_url('docs/using-pants/key-concepts/backends')} for all available backends to activate.
 
         All registered symbols: ['__defaults__', '__dependencies_rules__', '__dependents_rules__',
         'build_file_dir', 'caof', 'env', 'macro', 'obj']

--- a/src/python/pants/engine/target.py
+++ b/src/python/pants/engine/target.py
@@ -1687,7 +1687,7 @@ class UnrecognizedTargetTypeException(InvalidTargetException):
                 All valid target types: {sorted(registered_target_types.aliases)}
 
                 (If {target_type!r} is a custom target type, refer to
-                {doc_url('target-api-concepts')} for getting it registered with Pants.)
+                {doc_url('docs/writing-plugins/the-target-api/concepts')} for getting it registered with Pants.)
 
                 """
             ),
@@ -2517,7 +2517,7 @@ class Dependencies(StringSequenceField, AsyncFieldMixin):
         `{bin_name()} dependencies` or `{bin_name()} peek` on this target to get the final
         result.
 
-        See {doc_url('targets')} for more about how addresses are formed, including for generated
+        See {doc_url('docs/using-pants/key-concepts/targets-and-build-files')} for more about how addresses are formed, including for generated
         targets. You can also run `{bin_name()} list ::` to find all addresses in your project, or
         `{bin_name()} list dir` to find all addresses defined in that directory.
 
@@ -2658,7 +2658,7 @@ class ExplicitlyProvidedDependencies:
             f"with `!` or `!!` so that one or no targets are left."
             f"\n\nAlternatively, you can remove the ambiguity by deleting/changing some of the "
             f"targets so that only 1 target owns this {import_reference}. Refer to "
-            f"{doc_url('troubleshooting#import-errors-and-missing-dependencies')}."
+            f"{doc_url('docs/using-pants/troubleshooting-common-issues#import-errors-and-missing-dependencies')}."
         )
 
     def disambiguated(

--- a/src/python/pants/goal/anonymous_telemetry.py
+++ b/src/python/pants/goal/anonymous_telemetry.py
@@ -12,7 +12,7 @@ from pants.util.strutil import softwrap
 
 logger = logging.getLogger(__name__)
 
-_telemetry_docs_referral = f"See {doc_url('anonymous-telemetry')} for details"
+_telemetry_docs_referral = f"See {doc_url('docs/using-pants/anonymous-telemetry')} for details"
 
 
 # This subsystem is orphaned (but not quite deprecated/removed).

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -176,7 +176,7 @@ def test_help_provided_target_plugin_field() -> None:
 
             A publishable Python setuptools distribution (e.g. an sdist or wheel).
 
-            See {doc_url("python-distributions")}.
+            See {doc_url("docs/python/overview/building-distributions")}.
 
 
             Activated by pants.backend.python

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -61,7 +61,7 @@ class _ExceptionFormatter(Formatter):
 
         return (
             f"{stacktrace}\n\n{debug_instructions}\nSee {doc_url('docs/using-pants/troubleshooting-common-issues')} for common "
-            f"issues.\nConsider reaching out for help: {doc_url('community/getting-help')}\n"
+            f"issues.\nConsider reaching out for help: {doc_url('community/getting-help', versioned=False)}\n"
         )
 
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -60,8 +60,8 @@ class _ExceptionFormatter(Formatter):
         )
 
         return (
-            f"{stacktrace}\n\n{debug_instructions}\nSee {doc_url('troubleshooting')} for common "
-            f"issues.\nConsider reaching out for help: {doc_url('getting-help')}\n"
+            f"{stacktrace}\n\n{debug_instructions}\nSee {doc_url('docs/using-pants/troubleshooting-common-issues')} for common "
+            f"issues.\nConsider reaching out for help: {doc_url('community/getting-help')}\n"
         )
 
 

--- a/src/python/pants/init/logging.py
+++ b/src/python/pants/init/logging.py
@@ -61,7 +61,7 @@ class _ExceptionFormatter(Formatter):
 
         return (
             f"{stacktrace}\n\n{debug_instructions}\nSee {doc_url('docs/using-pants/troubleshooting-common-issues')} for common "
-            f"issues.\nConsider reaching out for help: {doc_url('community/getting-help', versioned=False)}\n"
+            f"issues.\nConsider reaching out for help: {doc_url('community/getting-help')}\n"
         )
 
 

--- a/src/python/pants/jvm/resolve/coursier_fetch.py
+++ b/src/python/pants/jvm/resolve/coursier_fetch.py
@@ -99,7 +99,7 @@ class NoCompatibleResolve(Exception):
             f"{msg_prefix}:\n\n"
             f"{formatted_resolve_lists}\n\n"
             "Targets which will be merged onto the same classpath must share a resolve (from the "
-            f"[resolve]({doc_url('reference-deploy_jar#coderesolvecode')}) field)."
+            f"[resolve]({doc_url('reference/targets/deploy_jar#resolve')}) field)."
         )
 
 

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -174,7 +174,7 @@ class RemoteProvider(Enum):
             return softwrap(
                 f"""
                 The type of provider to use, if using a remote cache and/or remote execution, See
-                {doc_url('remote-caching-execution')} for details.
+                {doc_url('docs/using-pants/remote-caching-and-execution')} for details.
 
                 Each provider supports different `remote_store_address` and (optional)
                 `remote_execution_address` URIs.
@@ -924,7 +924,7 @@ class BootstrapOptions:
             using the requested version, as Pants cannot dynamically change the version it
             is using once the program is already running.
 
-            If you use the `{bin_name()}` script from {doc_url('installation')}, however, changing
+            If you use the `{bin_name()}` script from {doc_url('docs/getting-started/installing-pants')}, however, changing
             the value in your `pants.toml` will cause the new version to be installed and run automatically.
 
             Run `{bin_name()} --version` to check what is being used.
@@ -1389,7 +1389,7 @@ class BootstrapOptions:
 
             This option cannot be overridden via environment targets, so if you need a different
             value than what the rest of your organization is using, override the value via an
-            environment variable, CLI argument, or `.pants.rc` file. See {doc_url('options')}.
+            environment variable, CLI argument, or `.pants.rc` file. See {doc_url('docs/using-pants/key-concepts/options')}.
             """
         ),
     )
@@ -1597,7 +1597,7 @@ class BootstrapOptions:
             """
         ),
         removal_version="2.21.0.dev0",
-        removal_hint=f'use `[GLOBAL].remote_oauth_bearer_token = "@/path/to/token.txt"` instead, see {doc_url("reference-global#remote_oauth_bearer_token")}',
+        removal_hint=f'use `[GLOBAL].remote_oauth_bearer_token = "@/path/to/token.txt"` instead, see {doc_url("reference/global-options#remote_oauth_bearer_token")}',
     )
 
     remote_oauth_bearer_token = StrOption(
@@ -1617,7 +1617,7 @@ class BootstrapOptions:
             the token via the environment variable (`PANTS_REMOTE_OAUTH_BEARER_TOKEN`), CLI option
             (`--remote-oauth-bearer-token`), or store the token in a file and set the option to
             `"@/path/to/token.txt"` to [read the value from that
-            file]({doc_url('options#reading-individual-option-values-from-files')}).
+            file]({doc_url('docs/using-pants/key-concepts/options#reading-individual-option-values-from-files')}).
             """
         ),
     )
@@ -1791,7 +1791,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         help=softwrap(
             f"""
             Include only targets with these tags (optional '+' prefix) or without these
-            tags ('-' prefix). See {doc_url('advanced-target-selection')}.
+            tags ('-' prefix). See {doc_url('docs/using-pants/advanced-target-selection')}.
             """
         ),
         metavar="[+-]tag1,tag2,...",
@@ -1857,7 +1857,7 @@ class GlobalOptions(BootstrapOptions, Subsystem):
         help=softwrap(
             f"""
             Python files to evaluate and whose symbols should be exposed to all BUILD files.
-            See {doc_url('macros')}.
+            See {doc_url('docs/writing-plugins/macros')}.
             """
         ),
         advanced=True,

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -43,7 +43,9 @@ class SourceRootError(Exception):
     """An error related to SourceRoot computation."""
 
     def __init__(self, msg: str):
-        super().__init__(f"{msg}See {doc_url('docs/using-pants/key-concepts/source-roots')} for how to define source roots.")
+        super().__init__(
+            f"{msg}See {doc_url('docs/using-pants/key-concepts/source-roots')} for how to define source roots."
+        )
 
 
 class InvalidSourceRootPatternError(SourceRootError):

--- a/src/python/pants/source/source_root.py
+++ b/src/python/pants/source/source_root.py
@@ -43,7 +43,7 @@ class SourceRootError(Exception):
     """An error related to SourceRoot computation."""
 
     def __init__(self, msg: str):
-        super().__init__(f"{msg}See {doc_url('source-roots')} for how to define source roots.")
+        super().__init__(f"{msg}See {doc_url('docs/using-pants/key-concepts/source-roots')} for how to define source roots.")
 
 
 class InvalidSourceRootPatternError(SourceRootError):
@@ -124,7 +124,7 @@ class SourceRootConfig(Subsystem):
 
             Use `/` to signify that the buildroot itself is a source root.
 
-            See {doc_url('source-roots')}.
+            See {doc_url('docs/using-pants/key-concepts/source-roots')}.
             """
         ),
         advanced=True,

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -16,8 +16,15 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
     return shutil.get_terminal_size(fallback=(fallback, 24)).columns - padding
 
 
-def doc_url(slug: str) -> str:
-    return f"https://www.pantsbuild.org/v{MAJOR_MINOR}/docs/{slug}"
+def doc_url(path: str, versioned: bool = True) -> str:
+    """Return a URL to the specified `path` on the Pants website.
+
+    Most URLs are associated with a particular pants version (e.g. docs for a backend), indicated
+    with `versioned == True`, while some are ever-green and unversioned (e.g. info about the project
+    governance).
+    """
+    version_info = f"{MAJOR_MINOR}/" if versioned else ""
+    return f"https://www.pantsbuild.org/{version_info}{path}"
 
 
 def git_url(fp: str) -> str:

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -16,13 +16,21 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
     return shutil.get_terminal_size(fallback=(fallback, 24)).columns - padding
 
 
-def doc_url(path: str, versioned: bool = True) -> str:
+_VERSIONED_PREFICES = ("docs/", "reference/")
+
+
+def doc_url(path: str) -> str:
     """Return a URL to the specified `path` on the Pants website.
 
-    Most URLs are associated with a particular pants version (e.g. docs for a backend), indicated
-    with `versioned == True`, while some are ever-green and unversioned (e.g. info about the project
-    governance).
+    The path should be the part of the URL after the domain, ignoring the version, e.g.:
+
+    - to link to https://www.pantsbuild.org/community/getting-help, pass `"/community/getting-help"`
+
+    - to link to the current version of
+      https://www.pantsbuild.org/2.19/docs/python/overview/enabling-python-support, pass
+      `"docs/python/overview/enabling-python-support"`
     """
+    versioned = any(path.startswith(prefix) for prefix in _VERSIONED_PREFICES)
     version_info = f"{MAJOR_MINOR}/" if versioned else ""
     return f"https://www.pantsbuild.org/{version_info}{path}"
 

--- a/src/python/pants/util/docutil.py
+++ b/src/python/pants/util/docutil.py
@@ -16,7 +16,7 @@ def terminal_width(*, fallback: int = 96, padding: int = 2) -> int:
     return shutil.get_terminal_size(fallback=(fallback, 24)).columns - padding
 
 
-_VERSIONED_PREFICES = ("docs/", "reference/")
+_VERSIONED_PREFIXES = ("docs/", "reference/")
 
 
 def doc_url(path: str) -> str:
@@ -30,7 +30,7 @@ def doc_url(path: str) -> str:
       https://www.pantsbuild.org/2.19/docs/python/overview/enabling-python-support, pass
       `"docs/python/overview/enabling-python-support"`
     """
-    versioned = any(path.startswith(prefix) for prefix in _VERSIONED_PREFICES)
+    versioned = any(path.startswith(prefix) for prefix in _VERSIONED_PREFIXES)
     version_info = f"{MAJOR_MINOR}/" if versioned else ""
     return f"https://www.pantsbuild.org/{version_info}{path}"
 

--- a/src/python/pants/util/docutil_test.py
+++ b/src/python/pants/util/docutil_test.py
@@ -9,9 +9,13 @@ from pants.util import docutil
 from pants.util.docutil import doc_url, git_url
 
 
-def test_doc_url(monkeypatch) -> None:
+def test_doc_url_when_versioned(monkeypatch) -> None:
     monkeypatch.setattr(docutil, "MAJOR_MINOR", "1.29")
-    assert doc_url("some-slug") == "https://www.pantsbuild.org/v1.29/docs/some-slug"
+    assert doc_url("some/path") == "https://www.pantsbuild.org/1.29/some/path"
+
+
+def test_doc_url_when_not_versioned(monkeypatch) -> None:
+    assert doc_url("some/path", versioned=False) == "https://www.pantsbuild.org/some/path"
 
 
 def test_git_url(monkeypatch) -> None:

--- a/src/python/pants/util/docutil_test.py
+++ b/src/python/pants/util/docutil_test.py
@@ -3,19 +3,32 @@
 
 from __future__ import annotations
 
+import pytest
 from packaging.version import Version
 
 from pants.util import docutil
 from pants.util.docutil import doc_url, git_url
 
 
-def test_doc_url_when_versioned(monkeypatch) -> None:
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        # versioned
+        ("docs/some/path", "https://www.pantsbuild.org/1.29/docs/some/path"),
+        ("reference/some/path", "https://www.pantsbuild.org/1.29/reference/some/path"),
+        # various things that aren't versioned
+        ("docs-extra/some/path", "https://www.pantsbuild.org/docs-extra/some/path"),
+        ("reference-extra/some/path", "https://www.pantsbuild.org/reference-extra/some/path"),
+        ("some/path", "https://www.pantsbuild.org/some/path"),
+        ("community/some/path", "https://www.pantsbuild.org/community/some/path"),
+        # a path that already includes the version preserves that version (although we may want to
+        # change the behaviour)
+        ("2.13/docs/some/path", "https://www.pantsbuild.org/2.13/docs/some/path"),
+    ],
+)
+def test_doc_url_when_versioned(monkeypatch, path: str, expected: str) -> None:
     monkeypatch.setattr(docutil, "MAJOR_MINOR", "1.29")
-    assert doc_url("some/path") == "https://www.pantsbuild.org/1.29/some/path"
-
-
-def test_doc_url_when_not_versioned(monkeypatch) -> None:
-    assert doc_url("some/path", versioned=False) == "https://www.pantsbuild.org/some/path"
+    assert doc_url(path) == expected
 
 
 def test_git_url(monkeypatch) -> None:

--- a/src/python/pants/vcs/changed.py
+++ b/src/python/pants/vcs/changed.py
@@ -145,7 +145,7 @@ class Changed(Subsystem):
         f"""
         Tell Pants to detect what files and targets have changed from Git.
 
-        See {doc_url('advanced-target-selection')}.
+        See {doc_url('docs/using-pants/advanced-target-selection')}.
         """
     )
 

--- a/src/rust/engine/src/nodes.rs
+++ b/src/rust/engine/src/nodes.rs
@@ -1593,7 +1593,7 @@ impl Node for NodeKey {
             path.push(path[0].clone());
         }
         let url = Python::with_gil(|py| {
-            externs::doc_url(py, "targets#dependencies-and-dependency-inference")
+            externs::doc_url(py, "docs/using-pants/key-concepts/targets-and-build-files#dependencies-and-dependency-inference")
         });
         throw(format!(
             "The dependency graph contained a cycle:\


### PR DESCRIPTION
This PR fixes #20427 by updating our use of `doc_url` to reflect the new website structure. It does this semi-automatically, spread across separate commits:

1. Update the `doc_url` function to reflect the new website structure, including support for unversioned URLs like https://www.pantsbuild.org/community/getting-help
2. Apply automated rewrites (see below for details)
3. Do one or two manual fix-ups

The automatic rewrites were done by:

1. finding the args passed to `doc_url`: `rg --only-matching "doc_url\([^)]*\)" . | cut -f2 -d\( | cut -f1 -d\) | tr \' \" | sort -u`
2. put them into CSV file, then use https://github.com/pantsbuild/pantsbuild.org/blob/92d5ce8d3442890c3fbeb0fade620b762ae2aa7e/old_site_redirects.js to find the new URL for each one
3. transform the CSV into a long series of `s@...@...@` substitutions for `sed`
4. apply them with `git ls-files '*.py' '*.rs' | xargs sed -i '' "..."`
5. do a basic check that the appropriate files that call `doc_url` were updated: identify non-updated files via `comm -13 <(git diff --name-only be42bc0def^...be42bc0def) <( rg --files-with-matches doc_url | sort)`. The files without updates are expected, e.g.
   - `src/python/pants/util/docutil.py` that defines `doc_url` itself (and the test file etc.)
   - `src/python/pants/backend/codegen/avro/target_types.py` that didn't have an immediately obvious replacement, with more examples in #20584

This is marked for cherry-picking to 2.20.x. There _are_ redirects for the URLs for 2.20, but it seems a bit annoying to rely on them, if we don't have to.

<details>

```csv
old,new
"getting-help","community/getting-help"
"advanced-target-selection","docs/using-pants/advanced-target-selection"
"anonymous-telemetry","docs/using-pants/anonymous-telemetry"
"awslambda-python","docs/python/integrations/aws-lambda"
"enabling-backends","docs/using-pants/key-concepts/backends"
"google-cloud-function-python","docs/python/integrations/google-cloud-functions"
"installation","docs/getting-started/installing-pants"
"macros","docs/writing-plugins/macros"
"options","docs/using-pants/key-concepts/options"
"options#addremove-semantics","docs/using-pants/key-concepts/options#addremove-semantics"
"options#config-file-entries","docs/using-pants/key-concepts/options#config-file-entries"
"options#config-file-interpolation","docs/using-pants/key-concepts/options#config-file-interpolation"
"options#pantsrc-file","docs/using-pants/key-concepts/options#pantsrc-file"
"options#reading-individual-option-values-from-files","docs/using-pants/key-concepts/options#reading-individual-option-values-from-files"
"pex","docs/python/overview/pex"
"plugin-upgrade-guide","docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide"
"plugins-overview","docs/writing-plugins/overview"
"plugins-setup-py","docs/writing-plugins/common-plugin-tasks/custom-python-artifact-kwargs"
"protobuf-go","docs/go/integrations/protobuf"
"protobuf-python","docs/python/integrations/protobuf-and-grpc"
"python-check-goal","docs/python/goals/check"
"python-distributions","docs/python/overview/building-distributions"
"python-interpreter-compatibility","docs/python/overview/interpreter-compatibility"
"python-lockfiles#lockfiles-for-tools","docs/python/overview/lockfiles#lockfiles-for-tools"
"python-test-goal","docs/python/goals/test"
"python-test-goal#pytest-version-and-plugins","docs/python/goals/test#pytest-version-and-plugins"
"python-third-party-dependencies","docs/python/overview/third-party-dependencies"
"python-third-party-dependencies#local-requirements","docs/python/overview/third-party-dependencies#local-requirements"
"python-third-party-dependencies#multiple-lockfiles","docs/python/overview/lockfiles#multiple-lockfiles"
"python-third-party-dependencies#user-lockfiles","docs/python/overview/third-party-dependencies#user-lockfiles"
"reference-deploy_jar#coderesolvecode","reference/targets/deploy_jar#resolve"
"reference-global#remote_oauth_bearer_token","reference/global-options#remote_oauth_bearer_token"
"remote-caching-execution","docs/using-pants/remote-caching-and-execution"
"source-roots","docs/using-pants/key-concepts/source-roots"
"tagging-docker-images","docs/docker/tagging-docker-images"
"target-api-concepts","docs/writing-plugins/the-target-api/concepts"
"targets","docs/using-pants/key-concepts/targets-and-build-files"
"targets#field-default-values","docs/using-pants/key-concepts/targets-and-build-files#field-default-values"
"targets#dependencies-and-dependency-inference","docs/using-pants/key-concepts/targets-and-build-files#dependencies-and-dependency-inference"
"thrift-python","docs/python/integrations/thrift"
"troubleshooting","docs/using-pants/troubleshooting-common-issues"
"troubleshooting#import-errors-and-missing-dependencies","docs/using-pants/troubleshooting-common-issues#import-errors-and-missing-dependencies"
"upgrade-tips","docs/releases/upgrade-tips"
```

```python
import pandas as pd
print("\n".join(
  f"""s@\\(doc_url.*[\\"']\\){r.old}\\([\\"']\\)@\\1{r.new}\\2@g;"""
  for _, r in pd.read_csv("replacements.csv").iterrows()
))
```

```shell
git ls-files '*.py' '*.rs' | xargs sed -i '' "
s@\(doc_url.*[\"']\)getting-help\([\"']\)@\1community/getting-help\2@g;
s@\(doc_url.*[\"']\)advanced-target-selection\([\"']\)@\1docs/using-pants/advanced-target-selection\2@g;
s@\(doc_url.*[\"']\)anonymous-telemetry\([\"']\)@\1docs/using-pants/anonymous-telemetry\2@g;
s@\(doc_url.*[\"']\)awslambda-python\([\"']\)@\1docs/python/integrations/aws-lambda\2@g;
s@\(doc_url.*[\"']\)enabling-backends\([\"']\)@\1docs/using-pants/key-concepts/backends\2@g;
s@\(doc_url.*[\"']\)google-cloud-function-python\([\"']\)@\1docs/python/integrations/google-cloud-functions\2@g;
s@\(doc_url.*[\"']\)installation\([\"']\)@\1docs/getting-started/installing-pants\2@g;
s@\(doc_url.*[\"']\)macros\([\"']\)@\1docs/writing-plugins/macros\2@g;
s@\(doc_url.*[\"']\)options\([\"']\)@\1docs/using-pants/key-concepts/options\2@g;
s@\(doc_url.*[\"']\)options#addremove-semantics\([\"']\)@\1docs/using-pants/key-concepts/options#addremove-semantics\2@g;
s@\(doc_url.*[\"']\)options#config-file-entries\([\"']\)@\1docs/using-pants/key-concepts/options#config-file-entries\2@g;
s@\(doc_url.*[\"']\)options#config-file-interpolation\([\"']\)@\1docs/using-pants/key-concepts/options#config-file-interpolation\2@g;
s@\(doc_url.*[\"']\)options#pantsrc-file\([\"']\)@\1docs/using-pants/key-concepts/options#pantsrc-file\2@g;
s@\(doc_url.*[\"']\)options#reading-individual-option-values-from-files\([\"']\)@\1docs/using-pants/key-concepts/options#reading-individual-option-values-from-files\2@g;
s@\(doc_url.*[\"']\)pex\([\"']\)@\1docs/python/overview/pex\2@g;
s@\(doc_url.*[\"']\)plugin-upgrade-guide\([\"']\)@\1docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide\2@g;
s@\(doc_url.*[\"']\)plugins-overview\([\"']\)@\1docs/writing-plugins/overview\2@g;
s@\(doc_url.*[\"']\)plugins-setup-py\([\"']\)@\1docs/writing-plugins/common-plugin-tasks/custom-python-artifact-kwargs\2@g;
s@\(doc_url.*[\"']\)protobuf-go\([\"']\)@\1docs/go/integrations/protobuf\2@g;
s@\(doc_url.*[\"']\)protobuf-python\([\"']\)@\1docs/python/integrations/protobuf-and-grpc\2@g;
s@\(doc_url.*[\"']\)python-check-goal\([\"']\)@\1docs/python/goals/check\2@g;
s@\(doc_url.*[\"']\)python-distributions\([\"']\)@\1docs/python/overview/building-distributions\2@g;
s@\(doc_url.*[\"']\)python-interpreter-compatibility\([\"']\)@\1docs/python/overview/interpreter-compatibility\2@g;
s@\(doc_url.*[\"']\)python-lockfiles#lockfiles-for-tools\([\"']\)@\1docs/python/overview/lockfiles#lockfiles-for-tools\2@g;
s@\(doc_url.*[\"']\)python-test-goal\([\"']\)@\1docs/python/goals/test\2@g;
s@\(doc_url.*[\"']\)python-test-goal#pytest-version-and-plugins\([\"']\)@\1docs/python/goals/test#pytest-version-and-plugins\2@g;
s@\(doc_url.*[\"']\)python-third-party-dependencies\([\"']\)@\1docs/python/overview/third-party-dependencies\2@g;
s@\(doc_url.*[\"']\)python-third-party-dependencies#local-requirements\([\"']\)@\1docs/python/overview/third-party-dependencies#local-requirements\2@g;
s@\(doc_url.*[\"']\)python-third-party-dependencies#multiple-lockfiles\([\"']\)@\1docs/python/overview/lockfiles#multiple-lockfiles\2@g;
s@\(doc_url.*[\"']\)python-third-party-dependencies#user-lockfiles\([\"']\)@\1docs/python/overview/third-party-dependencies#user-lockfiles\2@g;
s@\(doc_url.*[\"']\)reference-deploy_jar#coderesolvecode\([\"']\)@\1reference/targets/deploy_jar#resolve\2@g;
s@\(doc_url.*[\"']\)reference-global#remote_oauth_bearer_token\([\"']\)@\1reference/global-options#remote_oauth_bearer_token\2@g;
s@\(doc_url.*[\"']\)remote-caching-execution\([\"']\)@\1docs/using-pants/remote-caching-and-execution\2@g;
s@\(doc_url.*[\"']\)source-roots\([\"']\)@\1docs/using-pants/key-concepts/source-roots\2@g;
s@\(doc_url.*[\"']\)tagging-docker-images\([\"']\)@\1docs/docker/tagging-docker-images\2@g;
s@\(doc_url.*[\"']\)target-api-concepts\([\"']\)@\1docs/writing-plugins/the-target-api/concepts\2@g;
s@\(doc_url.*[\"']\)targets\([\"']\)@\1docs/using-pants/key-concepts/targets-and-build-files\2@g;
s@\(doc_url.*[\"']\)targets#field-default-values\([\"']\)@\1docs/using-pants/key-concepts/targets-and-build-files#field-default-values\2@g;
s@\(doc_url.*[\"']\)targets#dependencies-and-dependency-inference\([\"']\)@\1docs/using-pants/key-concepts/targets-and-build-files#dependencies-and-dependency-inference\2@g;
s@\(doc_url.*[\"']\)thrift-python\([\"']\)@\1docs/python/integrations/thrift\2@g;
s@\(doc_url.*[\"']\)troubleshooting\([\"']\)@\1docs/using-pants/troubleshooting-common-issues\2@g;
s@\(doc_url.*[\"']\)troubleshooting#import-errors-and-missing-dependencies\([\"']\)@\1docs/using-pants/troubleshooting-common-issues#import-errors-and-missing-dependencies\2@g;
s@\(doc_url.*[\"']\)upgrade-tips\([\"']\)@\1docs/releases/upgrade-tips\2@g;
"
```

</details>