### PR TITLE
Silence warnings from Pex by default, for now (Cherry-pick of #20590)

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -134,6 +134,8 @@ fmt = false
 
 [pex]
 venv_use_symlinks = true
+# This is off by default, but we want to dogfood it before switching on for everyone.
+emit_warnings = true
 
 [python]
 # N.B.: When upgrading to a new Python version, you must update the Pants

--- a/src/python/pants/backend/python/util_rules/pex_cli_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli_test.py
@@ -34,7 +34,10 @@ def test_custom_ca_certs(tmp_path: Path, rule_runner: RuleRunner) -> None:
         Process,
         [PexCliProcess(subcommand=(), extra_args=("some", "--args"), description="")],
     )
-    assert proc.argv[6:8] == ("--cert", "certsfile")
+
+    cert_index = proc.argv.index("--cert")
+    assert proc.argv[cert_index + 1] == "certsfile"
+
     files = rule_runner.request(DigestContents, [proc.input_digest])
     chrooted_certs_file = [f for f in files if f.path == "certsfile"]
     assert len(chrooted_certs_file) == 1

--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -82,10 +82,15 @@ class PexSubsystem(Subsystem):
         advanced=True,
     )
     emit_warnings = BoolOption(
-        default=True,
+        default=False,
         help=softwrap(
             """
             If warnings from Pex should be logged by Pants to the console.
+
+            Note: Pants uses Pex internally in some ways that trigger some warnings at the moment,
+            so enabling this may result in warnings not related to your code. See
+            <https://github.com/pantsbuild/pants/issues/20577> and
+            <https://github.com/pantsbuild/pants/issues/20586>.
             """
         ),
     )


### PR DESCRIPTION
This is a short-term workaround for #20577 and #20586, where Pants' internal/default use of Pex triggers user-visible warnings, and those warnings are now visible due to #20480... so, instead of showing them by default, let's hide them for now. Users with desire for insight into the warnings can still enable this.

Doing this means we're not having to rush in fixes for the root causes of these warnings for 2.20.0 stable release, and thus reduce feature-creep/risk. We can/should reenable warnings by default in a future release.

Per @cburroughs's idea in https://github.com/pantsbuild/pants/issues/20586#issuecomment-1958500163, this explicitly switches it on for the Pants repo itself, so we're eating our own dogfood and catching real and/or spurious errors earlier.
