### PR TITLE
add new default module mappings for py-healthcheck

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -175,6 +175,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
     "progressbar2": ("progressbar",),
     "protobuf": ("google.protobuf",),
     "psycopg2-binary": ("psycopg2",),
+    "py-healthcheck": ("healthcheck",),
     "pycrypto": ("Crypto",),
     "pygithub": ("github",),
     "pygobject": ("gi",),


### PR DESCRIPTION
Title says it all. Just adding a new default module mapping.