### PR TITLE
use explicit Pex options for package "binary-ness"

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -79,18 +79,6 @@ async def _setup_pip_args_and_constraints_file(resolve_name: str) -> _PipArgsAnd
     args = list(resolve_config.pex_args())
     digests = []
 
-    if resolve_config.no_binary or resolve_config.only_binary:
-        pip_args_file = "__pip_args.txt"
-        args.extend(["-r", pip_args_file])
-        pip_args_file_content = "\n".join(
-            [f"--no-binary {pkg}" for pkg in resolve_config.no_binary]
-            + [f"--only-binary {pkg}" for pkg in resolve_config.only_binary]
-        )
-        pip_args_digest = await Get(
-            Digest, CreateDigest([FileContent(pip_args_file, pip_args_file_content.encode())])
-        )
-        digests.append(pip_args_digest)
-
     if resolve_config.constraints_file:
         args.append(f"--constraints={resolve_config.constraints_file.path}")
         digests.append(resolve_config.constraints_file.digest)

--- a/src/python/pants/backend/python/util_rules/pex_cli.py
+++ b/src/python/pants/backend/python/util_rules/pex_cli.py
@@ -40,7 +40,7 @@ class PexCli(TemplatedExternalTool):
 
     default_version = "v2.1.163"
     default_url_template = "https://github.com/pex-tool/pex/releases/download/{version}/pex"
-    version_constraints = ">=2.1.148,<3.0"
+    version_constraints = ">=2.1.161,<3.0"
 
     @classproperty
     def default_known_versions(cls):

--- a/src/python/pants/backend/python/util_rules/pex_requirements_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements_test.py
@@ -393,7 +393,7 @@ class TestResolvePexConfigPexArgs:
         args = self.simple_config_args(only_binary=[":all:"])
         assert "--wheel" in args
         assert "--no-build" in args
-        assert "--only-binary" not in " ".join(self.simple_config_args(only_binary=[":all:"]))
+        assert "--only-binary" not in " ".join(args)
 
         args = self.simple_config_args(only_binary=["foo", ":all:"])
         assert "--wheel" in args


### PR DESCRIPTION
Previously to pass along only/no-binary options Pants would create a "requirements" file and use Pip's ability to put cli args in said file [1].  This worked fine to generate the artifacts in a lockfile from scratch, but meant that the lockfile itself did not contain sufficient information to carry its own configuration forward.  That is if one did `pex3 lock update` on a Pants created lockfile that originally required everything to use wheels, that specification could not be preserved in the updated lockfile.  Since v2.1.161 [2] Pex has provided `--only-{wheel,build}` options to support this directly.

[1] https://pip.pypa.io/en/stable/reference/requirements-file-format/#global-options

[2] https://github.com/pex-tool/pex/releases/tag/v2.1.161

ref #15704