### PR TITLE
python-infer: Avoid false positive strings (Cherry-pick of #20472)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies.py
@@ -210,16 +210,15 @@ async def parse_python_dependencies(
 
         if python_infer_subsystem.string_imports or python_infer_subsystem.assets:
             for string, line in native_result.string_candidates.items():
-                slash_count = string.count("/")
                 if (
                     python_infer_subsystem.string_imports
-                    and not slash_count
                     and string.count(".") >= python_infer_subsystem.string_imports_min_dots
+                    and all(part.isidentifier() for part in string.split("."))
                 ):
                     imports.setdefault(string, (line, True))
                 if (
                     python_infer_subsystem.assets
-                    and slash_count >= python_infer_subsystem.assets_min_slashes
+                    and string.count("/") >= python_infer_subsystem.assets_min_slashes
                 ):
                     assets.add(string)
 

--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
@@ -322,12 +322,16 @@ def test_imports_from_strings(rule_runner: RuleRunner, min_dots: int) -> None:
             'a.b2.c.D',
             'a.b.c_狗',
 
-            # Invalid module names, but we don't check that hard
+            # Invalid module names are no longer permitted
+            '.',
+            '..',
+            'a.b.',
             '..a.b.c.d',
             'a.2b.d',
             'a..b..c',
             'a.b.c.d.2Bar',
             'a.2b.c.D',
+            'a.b.c_狗.',
 
             # Definitely invalid strings
             'I/have/a/slash',
@@ -354,11 +358,6 @@ def test_imports_from_strings(rule_runner: RuleRunner, min_dots: int) -> None:
         "a.b_c.d._bar": ImpInfo(lineno=11, weak=True),
         "a.b2.c.D": ImpInfo(lineno=12, weak=True),
         "a.b.c_狗": ImpInfo(lineno=13, weak=True),
-        "..a.b.c.d": ImpInfo(lineno=16, weak=True),
-        "a.2b.d": ImpInfo(lineno=17, weak=True),
-        "a..b..c": ImpInfo(lineno=18, weak=True),
-        "a.b.c.d.2Bar": ImpInfo(lineno=19, weak=True),
-        "a.2b.c.D": ImpInfo(lineno=20, weak=True),
     }
     expected = {sym: info for sym, info in potentially_valid.items() if sym.count(".") >= min_dots}
 


### PR DESCRIPTION
Ignores strings that are not valid python modules such as strings that end in "." (such as "." and "..").

Related: #20324 (fixes only points 2 and 3 where the strings end in ".").
