### PR TITLE
python-infer: respect ignore pragma w/ strings (Cherry-pick of #20477)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
+++ b/src/python/pants/backend/python/dependency_inference/parse_python_dependencies_test.py
@@ -329,6 +329,14 @@ def test_imports_from_strings(rule_runner: RuleRunner, min_dots: int) -> None:
             'a.b.c.d.2Bar',
             'a.2b.c.D',
 
+            # Explicitly ignored strings
+            'w.x',  # pants: no-infer-dep
+            'w.x.Foo',  # pants: no-infer-dep
+            'w.x.y.z',  # pants: no-infer-dep
+            'w.x.y.z.Foo',  # pants: no-infer-dep
+            'w.x.y.z.FooBar',  # pants: no-infer-dep
+            'u.v.w.x.y.z.Baz',  # pants: no-infer-dep
+
             # Definitely invalid strings
             'I/have/a/slash',
             'I\\\\have\\\\backslashes',

--- a/src/rust/engine/dep_inference/src/python/tests.rs
+++ b/src/rust/engine/dep_inference/src/python/tests.rs
@@ -685,6 +685,32 @@ fn string_candidates() {
     // Technically the value of the string doesn't contain whitespace, but the parser isn't that
     // sophisticated yet.
     assert_strings("'''\\\na'''", &[]);
+
+    // pragma ignored strings
+    assert_strings("'a' # pants: no-infer-dep", &[]);
+    assert_strings("'''a''' # pants: no-infer-dep", &[]);
+    assert_strings("'a.b' # pants: no-infer-dep", &[]);
+    assert_strings("'a.b.c_狗' # pants: no-infer-dep", &[]);
+    assert_strings("'..a.b.c.d' # pants: no-infer-dep", &[]);
+    assert_strings("['a.b'] # pants: no-infer-dep", &[]);
+    assert_strings("[{'a.b': 1}] # pants: no-infer-dep", &[]);
+    assert_strings("[{('a.b',): 1}] # pants: no-infer-dep", &[]);
+    assert_strings("[{2: 'a.b'}] # pants: no-infer-dep", &[]);
+    assert_strings("[{2: ('a.b',)}] # pants: no-infer-dep", &[]);
+    assert_strings("print('a.b') # pants: no-infer-dep", &[]);
+    assert_strings("print('a.b' if x else 3) # pants: no-infer-dep", &[]);
+    assert_strings("print(3 if x else 'a.b') # pants: no-infer-dep", &[]);
+    assert_strings(
+        "print([a for a in b if a not in ['a.b', 'c.d']]) # pants: no-infer-dep",
+        &[],
+    );
+    assert_strings(
+        r"
+    for a, b in foo['a.b'].items(): # pants: no-infer-dep
+        pass
+    ",
+        &[],
+    );
 }
 
 #[test]


### PR DESCRIPTION
Ignores any strings that have the ignore pragma comment.

This used to work with the python-based parser, but apparently there weren't tests so it was not carried into the rust-based parser.

Related: #20324, #20472
