### PR TITLE
Fix direct_url in python PEP660 editable wheels (Cherry-pick of #20486)

### DIFF
--- a/src/python/pants/backend/python/util_rules/dists.py
+++ b/src/python/pants/backend/python/util_rules/dists.py
@@ -117,6 +117,7 @@ class DistBuildRequest:
     build_sdist: bool
     input: Digest
     working_directory: str  # Relpath within the input digest.
+    dist_source_root: str  # Source root of the python_distribution target
     build_time_source_roots: tuple[str, ...]  # Source roots for 1st party build-time deps.
     output_path: str  # Location of the output directory within dist dir.
 

--- a/src/python/pants/backend/python/util_rules/dists_test.py
+++ b/src/python/pants/backend/python/util_rules/dists_test.py
@@ -58,6 +58,7 @@ def do_test_backend_shim(rule_runner: RuleRunner, constraints: str) -> None:
         build_sdist=True,
         input=input_digest,
         working_directory="",
+        dist_source_root=".",
         build_time_source_roots=tuple(),
         output_path="dist",
         wheel_config_settings=FrozenDict({"setting1": ("value1",), "setting2": ("value2",)}),

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -78,6 +78,7 @@ def do_test_backend_wrapper(rule_runner: PythonRuleRunner, constraints: str) -> 
         build_sdist=True,
         input=input_digest,
         working_directory="",
+        dist_source_root=".",
         build_time_source_roots=tuple(),
         output_path="dist",
         wheel_config_settings=FrozenDict({"setting1": ("value1",), "setting2": ("value2",)}),

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -417,7 +417,9 @@ async def create_dist_build_request(
             },
         ),
     )
-    source_roots = tuple(sorted({sr.path for sr in source_roots_result.path_to_root.values()}))
+    path_to_root = source_roots_result.path_to_root
+    dist_source_root = next(iter(path_to_root.values())).path if path_to_root else "."
+    source_roots = tuple(sorted({sr.path for sr in path_to_root.values()}))
 
     # Get any extra build-time environment (e.g., native extension requirements).
     build_env_requests = []
@@ -467,6 +469,7 @@ async def create_dist_build_request(
         build_sdist=sdist,
         input=prefixed_input,
         working_directory=working_directory,
+        dist_source_root=dist_source_root,
         build_time_source_roots=source_roots,
         target_address_spec=exported_target.target.address.spec,
         wheel_config_settings=wheel_config_settings,


### PR DESCRIPTION
We were using the first entry in `build_time_source_roots` to populate the editable wheel's `direct_url`. However, that does not work as I expected it to because `build_time_source_roots` gets sorted before creating the `DistBuildRequest`, so the first entry is not actually the `source_root` of the `python_distribution` target.

To fix this, we capture the dist's source_root before the source_roots get sorted and use that when building the PEP660 editable wheel.

Functionally, the editable wheels get installed just fine. However, the output of `pip list` in an exported venv might show the wrong path if there happens to be a source_root that sorted before the source_root of the distribution. Importing the python code still works, however, as all of the source_roots are included in the `.pth` file. Thus, this is a cosmetic / correctness bug.

This is the relevant section of the `pip list` output for the StackStorm project so you can see how odd it looks to have the wrong path showing:
```
dist/export/python/virtualenvs/st2/3.8.18/bin/pip list
Package                        Version    Editable project location
------------------------------ ---------- -------------------------------------------------------------------------
[snip]
st2actions                     3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2actions
st2api                         3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2actions
st2auth                        3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2auth
st2client                      3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2client
st2common                      3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2actions
st2reactor                     3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2client
st2stream                      3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/st2api
st2tests                       3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/python_runner
stackstorm-runner-action-chain 3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/action_chain_runner
stackstorm-runner-announcement 3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/announcement_runner
stackstorm-runner-http         3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/http_runner
stackstorm-runner-inquirer     3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/inquirer_runner
stackstorm-runner-local        3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/local_runner
stackstorm-runner-noop         3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/noop_runner
stackstorm-runner-orquesta     3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/orquesta_runner
stackstorm-runner-python       3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/python_runner
stackstorm-runner-remote       3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/remote_runner
stackstorm-runner-winrm        3.9.dev0   /home/cognifloyd/p/st2sandbox/st2.git/contrib/runners/winrm_runner
[snip]
```
