### PR TITLE
Add test retries to remaining backends

### DIFF
--- a/docs/docs/go/index.mdx
+++ b/docs/docs/go/index.mdx
@@ -227,6 +227,15 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
+### Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 ## Gofmt
 
 Gofmt is activated by default when you activate the Go backend. Simply run `pants fmt` and `pants lint`:

--- a/docs/docs/helm/index.mdx
+++ b/docs/docs/helm/index.mdx
@@ -352,6 +352,15 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
+#### Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 ## Publishing Helm charts
 
 Pants only supports publishing Helm charts to OCI registries, a feature that was made generally available in Helm 3.8.

--- a/docs/docs/jvm/java-and-scala.mdx
+++ b/docs/docs/jvm/java-and-scala.mdx
@@ -229,6 +229,16 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
+
+### Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 ### Setting environment variables
 
 Test runs are _hermetic_, meaning that they are stripped of the parent `pants` process's environment variables. This is important for reproducibility, and it also increases cache hits.

--- a/docs/docs/jvm/kotlin.mdx
+++ b/docs/docs/jvm/kotlin.mdx
@@ -189,6 +189,16 @@ To run tests, use `pants test`:
 
 The Kotlin backend currently supports JUnit tests specified using the `kotlin_junit_tests` target type.
 
+
+#### Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 #### Setting environment variables
 
 Test runs are _hermetic_, meaning that they are stripped of the parent `pants` process's environment variables. This is important for reproducibility, and it also increases cache hits.

--- a/docs/docs/python/goals/test.mdx
+++ b/docs/docs/python/goals/test.mdx
@@ -400,6 +400,15 @@ $ pants test project/app_test.py --no-test-timeouts
 
 :::
 
+## Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 ## Test utilities and resources
 
 ### Test utilities

--- a/docs/docs/shell/index.mdx
+++ b/docs/docs/shell/index.mdx
@@ -350,6 +350,15 @@ If a target sets its `timeout` higher than `[test].timeout_maximum`, Pants will 
 
 Use the option `pants test --no-timeouts` to temporarily disable timeouts, e.g. when debugging.
 
+### Retries
+
+Pants can automatically retry failed tests. This can help keep your builds passing even with flaky tests, like integration tests.
+
+```toml tab={"label":"pants.toml"}
+[test]
+attempts_default = 3
+```
+
 ### Testing your packaging pipeline
 
 You can include the result of `pants package` in your test through the `runtime_package_dependencies field`. Pants will run the equivalent of `pants package` beforehand and copy the built artifact into the test's chroot, allowing you to test things like that the artifact has the correct files present and that it's executable.

--- a/src/python/pants/backend/go/goals/test.py
+++ b/src/python/pants/backend/go/goals/test.py
@@ -59,7 +59,13 @@ from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import EMPTY_FILE_DIGEST, AddPrefix, Digest, MergeDigests
 from pants.engine.internals.native_engine import EMPTY_DIGEST, Snapshot
-from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope, ProcessResult
+from pants.engine.process import (
+    Process,
+    ProcessCacheScope,
+    ProcessResult,
+    ProcessResultWithRetries,
+    ProcessWithRetries,
+)
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import Dependencies, DependenciesRequest, SourcesField, Target, Targets
 from pants.util.logging import LogLevel
@@ -670,28 +676,29 @@ async def run_go_tests(
         maybe_profile_args.append("-test.trace=trace.out")
         output_files.append("trace.out")
 
-    result = await Get(
-        FallibleProcessResult,
-        Process(
-            argv=(
-                test_binary.test_binary_path,
-                *test_flags,
-                *maybe_profile_args,
-            ),
-            env=extra_env,
-            input_digest=test_input_digest,
-            description=f"Run Go tests: {field_set.address}",
-            cache_scope=cache_scope,
-            working_directory=working_dir,
-            output_files=output_files,
-            level=LogLevel.DEBUG,
+    go_test_process = Process(
+        argv=(
+            test_binary.test_binary_path,
+            *test_flags,
+            *maybe_profile_args,
         ),
+        env=extra_env,
+        input_digest=test_input_digest,
+        description=f"Run Go tests: {field_set.address}",
+        cache_scope=cache_scope,
+        working_directory=working_dir,
+        output_files=output_files,
+        level=LogLevel.DEBUG,
+    )
+    results = await Get(
+        ProcessResultWithRetries,
+        ProcessWithRetries(go_test_process, test_subsystem.attempts_default),
     )
 
     coverage_data: GoCoverageData | None = None
     if test_subsystem.use_coverage:
         coverage_data = GoCoverageData(
-            coverage_digest=result.output_digest,
+            coverage_digest=results.last.output_digest,
             import_path=test_binary.import_path,
             sources_digest=test_binary.pkg_digest.digest,
             sources_dir_path=test_binary.pkg_analysis.dir_path,
@@ -701,7 +708,7 @@ async def run_go_tests(
     output_files = [x for x in output_files if x != "cover.out"]
     extra_output: Snapshot | None = None
     if output_files or output_test_binary:
-        output_digest = result.output_digest
+        output_digest = results.last.output_digest
         if output_test_binary:
             output_digest = await Get(
                 Digest, MergeDigests([output_digest, test_binary.test_binary_digest])
@@ -709,7 +716,7 @@ async def run_go_tests(
         extra_output = await Get(Snapshot, Digest, output_digest)
 
     return TestResult.from_fallible_process_result(
-        process_results=(result,),
+        process_results=results.results,
         address=field_set.address,
         output_setting=test_subsystem.output,
         coverage_data=coverage_data,

--- a/src/python/pants/backend/go/goals/test_test.py
+++ b/src/python/pants/backend/go/goals/test_test.py
@@ -33,6 +33,8 @@ from pants.engine.addresses import Address
 from pants.engine.process import ProcessResult
 from pants.testutil.rule_runner import QueryRule, RuleRunner
 
+ATTEMPTS_DEFAULT_OPTION = 2
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -58,7 +60,10 @@ def rule_runner() -> RuleRunner:
         ],
         target_types=[GoModTarget, GoPackageTarget, FileTarget],
     )
-    rule_runner.set_options(["--go-test-args=-v -bench=."], env_inherit={"PATH"})
+    rule_runner.set_options(
+        ["--go-test-args=-v -bench=.", f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}"],
+        env_inherit={"PATH"},
+    )
     return rule_runner
 
 
@@ -220,6 +225,7 @@ def test_internal_test_fails(rule_runner: RuleRunner) -> None:
     )
     assert result.exit_code == 1
     assert b"FAIL: TestAdd" in result.stdout_bytes
+    assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 def test_internal_test_with_test_main(rule_runner: RuleRunner) -> None:
@@ -332,6 +338,7 @@ def test_external_test_fails(rule_runner: RuleRunner) -> None:
     )
     assert result.exit_code == 1
     assert b"FAIL: TestAdd" in result.stdout_bytes
+    assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 def test_external_test_with_test_main(rule_runner: RuleRunner) -> None:
@@ -421,6 +428,7 @@ def test_both_internal_and_external_tests_fail(rule_runner: RuleRunner) -> None:
     assert result.exit_code == 1
     assert b"FAIL: TestAddInternal" in result.stdout_bytes
     assert b"FAIL: TestAddExternal" in result.stdout_bytes
+    assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 @pytest.mark.no_error_if_skipped

--- a/src/python/pants/backend/helm/test/unittest_test.py
+++ b/src/python/pants/backend/helm/test/unittest_test.py
@@ -132,11 +132,14 @@ def test_simple_failure(rule_runner: RuleRunner) -> None:
         }
     )
 
+    attempts = 3
+    rule_runner.set_options([f"--test-attempts-default={attempts}"])
     target = rule_runner.get_target(Address("tests", target_name="test"))
     field_set = HelmUnitTestFieldSet.create(target)
 
     result = rule_runner.request(TestResult, [HelmUnitTestRequest.Batch("", (field_set,), None)])
     assert result.exit_code == 1
+    assert len(result.process_results) == attempts
 
 
 def test_test_with_local_resource_file(rule_runner: RuleRunner) -> None:
@@ -528,8 +531,11 @@ def test_failure_with_snapshot(rule_runner: RuleRunner) -> None:
         }
     )
 
+    attempts = 3
+    rule_runner.set_options([f"--test-attempts-default={attempts}"])
     target = rule_runner.get_target(Address("src/tests", target_name="test"))
     field_set = HelmUnitTestFieldSet.create(target)
 
     result = rule_runner.request(TestResult, [HelmUnitTestRequest.Batch("", (field_set,), None)])
     assert result.exit_code == 1
+    assert len(result.process_results) == attempts

--- a/src/python/pants/backend/javascript/goals/test.py
+++ b/src/python/pants/backend/javascript/goals/test.py
@@ -52,7 +52,12 @@ from pants.engine.fs import DigestSubset, GlobExpansionConjunction
 from pants.engine.internals import graph, platform_rules
 from pants.engine.internals.native_engine import Digest, MergeDigests, Snapshot
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import FallibleProcessResult, Process, ProcessCacheScope
+from pants.engine.process import (
+    Process,
+    ProcessCacheScope,
+    ProcessResultWithRetries,
+    ProcessWithRetries,
+)
 from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import (
     Dependencies,
@@ -228,13 +233,15 @@ async def run_javascript_tests(
     if test.force:
         process = dataclasses.replace(process, cache_scope=ProcessCacheScope.PER_SESSION)
 
-    result = await Get(FallibleProcessResult, Process, process)
+    results = await Get(
+        ProcessResultWithRetries, ProcessWithRetries(process, test.attempts_default)
+    )
     coverage_data: JSCoverageData | None = None
     if test.use_coverage:
         coverage_snapshot = await Get(
             Snapshot,
             DigestSubset(
-                result.output_digest,
+                results.last.output_digest,
                 test_script.coverage_globs(installation.project_env.relative_workspace_directory()),
             ),
         )
@@ -247,7 +254,7 @@ async def run_javascript_tests(
         )
 
     return TestResult.from_batched_fallible_process_result(
-        (result,), batch, test.output, coverage_data=coverage_data
+        results.results, batch, test.output, coverage_data=coverage_data
     )
 
 

--- a/src/python/pants/backend/javascript/goals/test_integration_test.py
+++ b/src/python/pants/backend/javascript/goals/test_integration_test.py
@@ -29,6 +29,8 @@ from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
 
+ATTEMPTS_DEFAULT_OPTION = 2
+
 
 @pytest.fixture(params=["npm", "pnpm", "yarn"])
 def package_manager(request) -> str:
@@ -51,7 +53,13 @@ def rule_runner(package_manager: str) -> RuleRunner:
         ],
         objects=dict(package_json.build_file_aliases().objects),
     )
-    rule_runner.set_options([f"--nodejs-package-manager={package_manager}"], env_inherit={"PATH"})
+    rule_runner.set_options(
+        [
+            f"--nodejs-package-manager={package_manager}",
+            f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}",
+        ],
+        env_inherit={"PATH"},
+    )
     return rule_runner
 
 
@@ -81,13 +89,16 @@ def mocha_lockfile(package_manager: str) -> dict[str, str]:
     return _find_lockfile_resource(package_manager, "mocha_resources")
 
 
-_SOURCE_TO_TEST = textwrap.dedent(
-    """\
-    export function add(x, y) {
-      return x + y
-    }
-    """
-)
+def make_source_to_test(passing: bool = True):
+    operation = "+" if passing else "-"
+
+    return textwrap.dedent(
+        f"""\
+        export function add(x, y) {{
+          return x {operation} y
+        }}
+        """
+    )
 
 
 def given_package_json(*, test_script: dict[str, str], runner: dict[str, str]) -> str:
@@ -120,10 +131,12 @@ def given_package_json(*, test_script: dict[str, str], runner: dict[str, str]) -
         ),
     ],
 )
+@pytest.mark.parametrize("passing", [True, False])
 def test_jest_tests_are_successful(
     rule_runner: RuleRunner,
     test_script: dict[str, str],
     package_json_target: str,
+    passing: bool,
     jest_lockfile: dict[str, str],
 ) -> None:
     rule_runner.write_files(
@@ -134,7 +147,7 @@ def test_jest_tests_are_successful(
             ),
             **{f"foo/{key}": value for key, value in jest_lockfile.items()},
             "foo/src/BUILD": "javascript_sources()",
-            "foo/src/index.mjs": _SOURCE_TO_TEST,
+            "foo/src/index.mjs": make_source_to_test(passing),
             "foo/src/tests/BUILD": "javascript_tests(name='tests')",
             "foo/src/tests/index.test.js": textwrap.dedent(
                 """\
@@ -156,8 +169,12 @@ def test_jest_tests_are_successful(
     tgt = rule_runner.get_target(Address("foo/src/tests", relative_file_path="index.test.js"))
     package = rule_runner.get_target(Address("foo", generated_name="pkg"))
     result = rule_runner.request(TestResult, [given_request_for(tgt, package=package)])
-    assert b"Test Suites: 1 passed, 1 total" in result.stderr_bytes
-    assert result.exit_code == 0
+    if passing:
+        assert b"Test Suites: 1 passed, 1 total" in result.stderr_bytes
+        assert result.exit_code == 0
+    else:
+        assert result.exit_code == 1
+        assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 def test_batched_jest_tests_are_successful(
@@ -172,7 +189,7 @@ def test_batched_jest_tests_are_successful(
             ),
             **{f"foo/{key}": value for key, value in jest_lockfile.items()},
             "foo/src/BUILD": "javascript_sources()",
-            "foo/src/index.mjs": _SOURCE_TO_TEST,
+            "foo/src/index.mjs": make_source_to_test(),
             "foo/src/tests/BUILD": "javascript_tests(name='tests', batch_compatibility_tag='default')",
             "foo/src/tests/index.test.js": textwrap.dedent(
                 """\
@@ -214,8 +231,9 @@ def test_batched_jest_tests_are_successful(
     assert result.exit_code == 0
 
 
-def test_mocha_tests_are_successful(
-    mocha_lockfile: dict[str, str], rule_runner: RuleRunner
+@pytest.mark.parametrize("passing", [True, False])
+def test_mocha_tests(
+    passing: bool, mocha_lockfile: dict[str, str], rule_runner: RuleRunner
 ) -> None:
     rule_runner.write_files(
         {
@@ -225,7 +243,7 @@ def test_mocha_tests_are_successful(
             ),
             **{f"foo/{key}": value for key, value in mocha_lockfile.items()},
             "foo/src/BUILD": "javascript_sources()",
-            "foo/src/index.mjs": _SOURCE_TO_TEST,
+            "foo/src/index.mjs": make_source_to_test(passing),
             "foo/src/tests/BUILD": "javascript_tests(name='tests')",
             "foo/src/tests/index.test.mjs": textwrap.dedent(
                 """\
@@ -243,8 +261,12 @@ def test_mocha_tests_are_successful(
     tgt = rule_runner.get_target(Address("foo/src/tests", relative_file_path="index.test.mjs"))
     package = rule_runner.get_target(Address("foo", generated_name="pkg"))
     result = rule_runner.request(TestResult, [given_request_for(tgt, package=package)])
-    assert b"1 passing" in result.stdout_bytes
-    assert result.exit_code == 0
+    if passing:
+        assert b"1 passing" in result.stdout_bytes
+        assert result.exit_code == 0
+    else:
+        assert result.exit_code == 1
+        assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 def test_jest_test_with_coverage_reporting(
@@ -274,7 +296,7 @@ def test_jest_test_with_coverage_reporting(
             ),
             **{f"foo/{key}": value for key, value in jest_lockfile.items()},
             "foo/src/BUILD": "javascript_sources()",
-            "foo/src/index.mjs": _SOURCE_TO_TEST,
+            "foo/src/index.mjs": make_source_to_test(),
             "foo/src/tests/BUILD": "javascript_tests(name='tests')",
             "foo/src/tests/index.test.js": textwrap.dedent(
                 """\

--- a/src/python/pants/backend/scala/test/scalatest.py
+++ b/src/python/pants/backend/scala/test/scalatest.py
@@ -27,10 +27,11 @@ from pants.engine.addresses import Addresses
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import Digest, DigestSubset, MergeDigests, PathGlobs, RemovePrefix, Snapshot
 from pants.engine.process import (
-    FallibleProcessResult,
     InteractiveProcess,
     Process,
     ProcessCacheScope,
+    ProcessResultWithRetries,
+    ProcessWithRetries,
 )
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import SourcesField, TransitiveTargets, TransitiveTargetsRequest
@@ -176,16 +177,20 @@ async def run_scalatest_test(
     field_set = batch.single_element
 
     test_setup = await Get(TestSetup, TestSetupRequest(field_set, is_debug=False))
-    process_result = await Get(FallibleProcessResult, JvmProcess, test_setup.process)
+    process = await Get(Process, JvmProcess, test_setup.process)
+    process_results = await Get(
+        ProcessResultWithRetries, ProcessWithRetries(process, test_subsystem.attempts_default)
+    )
     reports_dir_prefix = test_setup.reports_dir_prefix
 
     xml_result_subset = await Get(
-        Digest, DigestSubset(process_result.output_digest, PathGlobs([f"{reports_dir_prefix}/**"]))
+        Digest,
+        DigestSubset(process_results.last.output_digest, PathGlobs([f"{reports_dir_prefix}/**"])),
     )
     xml_results = await Get(Snapshot, RemovePrefix(xml_result_subset, reports_dir_prefix))
 
     return TestResult.from_fallible_process_result(
-        process_results=(process_result,),
+        process_results=process_results.results,
         address=field_set.address,
         output_setting=test_subsystem.output,
         xml_results=xml_results,

--- a/src/python/pants/backend/scala/test/scalatest_test.py
+++ b/src/python/pants/backend/scala/test/scalatest_test.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import Iterable, Mapping
+from typing import List, Mapping
 
 import pytest
 
@@ -40,6 +40,8 @@ from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner
 
 # TODO(12812): Switch tests to using parsed scalatest.xml results instead of scanning stdout strings.
+
+ATTEMPTS_DEFAULT_OPTION = 2
 
 
 @pytest.fixture
@@ -95,7 +97,12 @@ def scalatest_lockfile(
 
 
 @maybe_skip_jdk_test
-def test_simple_success(rule_runner: RuleRunner, scalatest_lockfile: JVMLockfileFixture) -> None:
+@pytest.mark.parametrize("passing", [True, False])
+def test_simple(
+    rule_runner: RuleRunner, scalatest_lockfile: JVMLockfileFixture, passing: bool
+) -> None:
+    value_in_test = "simple" if passing else "wrong"
+
     rule_runner.write_files(
         {
             "3rdparty/jvm/default.lock": scalatest_lockfile.serialized_lockfile,
@@ -119,22 +126,27 @@ def test_simple_success(rule_runner: RuleRunner, scalatest_lockfile: JVMLockfile
                 class SimpleSpec extends AnyFunSpec {
                   describe("Simple") {
                     it("should be simple") {
-                      assert("Simple".toLowerCase == "simple")
+                      assert("Simple".toLowerCase == "%s")
                     }
                   }
                 }
                 """
+                % value_in_test
             ),
         }
     )
 
     test_result = run_scalatest_test(rule_runner, "example-test", "SimpleSpec.scala")
 
-    assert test_result.exit_code == 0
-    assert (
-        b"Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0"
-        in test_result.stdout_bytes
-    )
+    if passing:
+        assert test_result.exit_code == 0
+        assert (
+            b"Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0"
+            in test_result.stdout_bytes
+        )
+    else:
+        assert test_result.exit_code == 1
+        assert len(test_result.process_results) == ATTEMPTS_DEFAULT_OPTION
     assert test_result.xml_results and test_result.xml_results.files
 
 
@@ -275,10 +287,11 @@ def run_scalatest_test(
     target_name: str,
     relative_file_path: str,
     *,
-    extra_args: Iterable[str] | None = None,
+    extra_args: List[str] | None = None,
     env: Mapping[str, str] | None = None,
 ) -> TestResult:
     args = extra_args or []
+    args.append(f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}")
     rule_runner.set_options(args, env=env, env_inherit=PYTHON_BOOTSTRAP_ENV)
     tgt = rule_runner.get_target(
         Address(spec_path="", target_name=target_name, relative_file_path=relative_file_path)

--- a/src/python/pants/backend/shell/goals/test_test.py
+++ b/src/python/pants/backend/shell/goals/test_test.py
@@ -23,6 +23,8 @@ from pants.engine.rules import QueryRule
 from pants.engine.target import Target
 from pants.testutil.rule_runner import RuleRunner
 
+ATTEMPTS_DEFAULT_OPTION = 2
+
 
 @pytest.fixture
 def rule_runner() -> RuleRunner:
@@ -41,7 +43,9 @@ def rule_runner() -> RuleRunner:
             ShellCommandTestTarget,
         ],
     )
-    rule_runner.set_options([], env_inherit={"PATH"})
+    rule_runner.set_options(
+        [f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}"], env_inherit={"PATH"}
+    )
     return rule_runner
 
 
@@ -105,3 +109,4 @@ def test_shell_command_as_test(rule_runner: RuleRunner) -> None:
     fail_result = run_test(fail_target)
     assert fail_result.exit_code == 1
     assert fail_result.stdout_bytes == b"does not contain 'xyzzy'\n"
+    assert len(fail_result.process_results) == ATTEMPTS_DEFAULT_OPTION

--- a/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
+++ b/src/python/pants/backend/shell/shunit2_test_runner_integration_test.py
@@ -40,6 +40,8 @@ from pants.engine.target import Target
 from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.testutil.rule_runner import QueryRule, mock_console
 
+ATTEMPTS_DEFAULT_OPTION = 2
+
 
 @pytest.fixture
 def rule_runner() -> PythonRuleRunner:
@@ -87,6 +89,7 @@ def run_shunit2(
     rule_runner.set_options(
         [
             "--backend-packages=pants.backend.shell",
+            f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}",
             *(extra_args or ()),
         ],
         env=env,
@@ -131,6 +134,7 @@ def test_failing(rule_runner: PythonRuleRunner) -> None:
     result = run_shunit2(rule_runner, tgt)
     assert result.exit_code == 1
     assert "Ran 1 test.\n\nFAILED" in result.stdout_simplified_str
+    assert len(result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 def test_dependencies(rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/jvm/test/junit_test.py
+++ b/src/python/pants/jvm/test/junit_test.py
@@ -34,7 +34,7 @@ from pants.jvm.strip_jar import strip_jar
 from pants.jvm.target_types import JvmArtifactTarget
 from pants.jvm.test.junit import JunitTestRequest
 from pants.jvm.test.junit import rules as junit_rules
-from pants.jvm.test.testutil import run_junit_test
+from pants.jvm.test.testutil import ATTEMPTS_DEFAULT_OPTION, run_junit_test
 from pants.jvm.testutil import maybe_skip_jdk_test
 from pants.jvm.util_rules import rules as util_rules
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -189,6 +189,7 @@ def test_vintage_simple_failure(
     )
     assert re.search(r"1 tests failed", stdout_text) is not None
     assert re.search(r"1 tests found", stdout_text) is not None
+    assert len(test_result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 @maybe_skip_jdk_test
@@ -410,6 +411,7 @@ def test_jupiter_simple_failure(
     )
     assert re.search(r"1 tests failed", stdout_text) is not None
     assert re.search(r"1 tests found", stdout_text) is not None
+    assert len(test_result.process_results) == ATTEMPTS_DEFAULT_OPTION
 
 
 @maybe_skip_jdk_test

--- a/src/python/pants/jvm/test/testutil.py
+++ b/src/python/pants/jvm/test/testutil.py
@@ -9,6 +9,8 @@ from pants.engine.internals.native_engine import Address
 from pants.jvm.test.junit import JunitTestFieldSet, JunitTestRequest
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 
+ATTEMPTS_DEFAULT_OPTION = 2
+
 
 def run_junit_test(
     rule_runner: RuleRunner,
@@ -20,6 +22,7 @@ def run_junit_test(
 ) -> TestResult:
     args = [
         "--junit-args=['--disable-ansi-colors','--details=flat','--details-theme=ascii']",
+        f"--test-attempts-default={ATTEMPTS_DEFAULT_OPTION}",
         *(extra_args or ()),
     ]
     rule_runner.set_options(args, env=env, env_inherit=PYTHON_BOOTSTRAP_ENV)


### PR DESCRIPTION
Test retries are opt-in, so this MR opts the remaining backends in.

closes #20378 