### PR TITLE
Resolve adhoc_tool, code_quality_tool execution dependencies relative to target location (Cherry-pick of #20581)

### DIFF
--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -411,7 +411,7 @@ async def create_tool_runner(
         Get(
             ResolvedExecutionDependencies,
             ResolveExecutionDependenciesRequest(
-                address=runnable_address,
+                address=request.target.address,
                 execution_dependencies=request.execution_dependencies,
                 runnable_dependencies=request.runnable_dependencies,
             ),


### PR DESCRIPTION
This PR fixes #20575 by adjusting the shared infrastructure for `adhoc_tool` and `code_quality_tool` to resolve the `execution_dependencies` field relative to the `adhoc_tool`/`code_quality_tool` target location, rather than relative to the `runnable=...` arg. I think this was a minor typo in #20255, and we didn't have tests covering it.

I imagine it's common that the runnable and `..._tool` targets are often in the same BUILD file (in which case the behaviour is the same either way), but it's not impossible to have them be different (e.g. my work repo has a a few shared runnable that are used by more than one `adhoc_tool`). I think being relative to the target is easier to reason about, and this was the old behaviour of `adhoc_tool`.

This PR also adds tests to confirm the behaviour of `execution_dependencies` (including its relative-path resolution behaviour), as well as the behaviour of `runnable_dependencies` while I'm there.
