### PR TITLE
Extend 2.21 deprecations: remote_oauth_bearer_token_path, crossversion=partial

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -180,7 +180,7 @@ class PythonAWSLambda(_AWSLambdaBaseTarget):
     alias = "python_aws_lambda_function"
 
     deprecated_alias = "python_awslambda"
-    deprecated_alias_removal_version = "2.23.0.dev0"
+    deprecated_alias_removal_version = "2.21.0.dev0"
 
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,

--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -180,7 +180,7 @@ class PythonAWSLambda(_AWSLambdaBaseTarget):
     alias = "python_aws_lambda_function"
 
     deprecated_alias = "python_awslambda"
-    deprecated_alias_removal_version = "2.21.0.dev0"
+    deprecated_alias_removal_version = "2.23.0.dev0"
 
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -435,7 +435,6 @@ class ScalaArtifactCrossversionField(StringField):
                 "2.23.0.dev0",
                 f"Scala cross version value '{computed_value}' in target: {address}",
                 "Use value `binary` instead",
-                start_version="2.20.0",
             )
         return computed_value
 
@@ -470,7 +469,6 @@ class ScalaArtifactExclusion(JvmArtifactExclusion):
                 "2.23.0.dev0",
                 f"Scala cross version value '{self.crossversion}' in list of exclusions at target: {address}",
                 "Use value `binary` instead",
-                start_version="2.20.0",
             )
         return errors
 

--- a/src/python/pants/backend/scala/target_types.py
+++ b/src/python/pants/backend/scala/target_types.py
@@ -432,7 +432,7 @@ class ScalaArtifactCrossversionField(StringField):
         computed_value = super().compute_value(raw_value, address)
         if computed_value == ScalaCrossVersionMode.PARTIAL.value:
             warn_or_error(
-                "2.21.0",
+                "2.23.0.dev0",
                 f"Scala cross version value '{computed_value}' in target: {address}",
                 "Use value `binary` instead",
                 start_version="2.20.0",
@@ -467,7 +467,7 @@ class ScalaArtifactExclusion(JvmArtifactExclusion):
             )
         if self.crossversion == ScalaCrossVersionMode.PARTIAL.value:
             warn_or_error(
-                "2.21.0",
+                "2.23.0.dev0",
                 f"Scala cross version value '{self.crossversion}' in list of exclusions at target: {address}",
                 "Use value `binary` instead",
                 start_version="2.20.0",

--- a/src/python/pants/option/global_options.py
+++ b/src/python/pants/option/global_options.py
@@ -1596,7 +1596,7 @@ class BootstrapOptions:
             dynamically set the relevant headers. Otherwise, no authorization will be performed.
             """
         ),
-        removal_version="2.21.0.dev0",
+        removal_version="2.23.0.dev0",
         removal_hint=f'use `[GLOBAL].remote_oauth_bearer_token = "@/path/to/token.txt"` instead, see {doc_url("reference/global-options#remote_oauth_bearer_token")}',
     )
 


### PR DESCRIPTION
There were three deprecations originally scheduled for 2.21 (#20609), two of will have only been deprecated for one release, and aren't a significant burden to support, so we can ease users life for a little longer:

| description | deprecation started in | what could be removed |
|---|---|---|
| the `[GLOBAL].remote_oauth_bearer_token_path` option | 2.20.0.dev1 (#20116) | configuration for the option, plus some a few small `if` statements, all in `global_options.py` |
| passing `crossversion="partial"` for scala artifacts | 2.20.0 (#20264) NB. due to an easy-to-make misuse of `start_version` I believe people will only be getting the deprecation warnings in 2.20.0 stable, not any of the release candidates | an extra enum variant, and a test |

The third (`python_awslambda`) is removed in #20619.