### PR TITLE
javascript: add node v20 to default known versions

### DIFF
--- a/src/python/pants/backend/javascript/subsystems/nodejs.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejs.py
@@ -63,6 +63,10 @@ class NodeJS(Subsystem, TemplatedExternalToolOptionsMixin):
 
     default_version = "v16.15.0"
     default_known_versions = [
+        "v20.11.1|macos_arm64|e0065c61f340e85106a99c4b54746c5cee09d59b08c5712f67f99e92aa44995d|41902956",
+        "v20.11.1|macos_x86_64|c52e7fb0709dbe63a4cbe08ac8af3479188692937a7bd8e776e0eedfa33bb848|43536000",
+        "v20.11.1|linux_arm64|e34ab2fc2726b4abd896bcbff0250e9b2da737cbd9d24267518a802ed0606f3b|46350617",
+        "v20.11.1|linux_x86_64|bf3a779bef19452da90fb88358ec2c57e0d2f882839b20dc6afc297b6aafc0d7|46621070",
         "v16.15.0|macos_arm64|ad8d8fc5330ef47788f509c2af398c8060bb59acbe914070d0df684cd2d8d39b|29126014",
         "v16.15.0|macos_x86_64|a6bb12bbf979d32137598e49d56d61bcddf8a8596c3442b44a9b3ace58dd4de8|30561503",
         "v16.15.0|linux_arm64|b4080b86562c5397f32da7a0723b95b1df523cab4c757688a184e3f733a7df56|21403276",


### PR DESCRIPTION
Add nodejs v20 to default known versions as its the current LTS https://endoflife.date/nodejs.

I naively tried to bump the `default_version` to `v20.11.1`, but a lot of tests fails for reasons I'm still not sure.

Adding the v20 to `default_known_versions` at least reduces the `pants.toml` file when anyone wants to use the v20 as only the `version` option of the `nodejs` subsystem will need to be specified.

I plan to explore more about the upgrade from node v16 to v20 and putting a PR to change the `default_version` to v20 soon.

Related to https://github.com/pantsbuild/pants/issues/19131