### PR TITLE
Remove now-expired deprecated `python_awslambda` alias

### DIFF
--- a/src/python/pants/backend/awslambda/python/target_types.py
+++ b/src/python/pants/backend/awslambda/python/target_types.py
@@ -179,9 +179,6 @@ class _AWSLambdaBaseTarget(Target):
 class PythonAWSLambda(_AWSLambdaBaseTarget):
     alias = "python_aws_lambda_function"
 
-    deprecated_alias = "python_awslambda"
-    deprecated_alias_removal_version = "2.21.0.dev0"
-
     core_fields = (
         *_AWSLambdaBaseTarget.core_fields,
         PythonFaaSDependencies,


### PR DESCRIPTION
The `python_awslambda` target was replaced by `python_aws_lambda_function` in #19216, first released in 2.18.0.dev1 (the deprecation was extended in #20101). We're now up to 2.21 (#20609), and thus the deprecation has expired and this can be removed.

This has been deprecated for 3 versions, and is easy for users to adapt to, so doesn't seem worth extending.