### PR TITLE
docs: Fix GitHub brand notation

### DIFF
--- a/build-support/common.sh
+++ b/build-support/common.sh
@@ -43,7 +43,7 @@ function git_merge_base() {
   # This prints the tracking branch if set and otherwise falls back to the commit before HEAD.
   # We fall back to the commit before HEAD to attempt to account for situations without a tracking
   # branch, which might include `main` builds, but can also include branch-PR builds, where
-  # Travis checks out a specially crafted Github `+refs/pull/11516/merge` branch.
+  # Travis checks out a specially crafted GitHub `+refs/pull/11516/merge` branch.
   git rev-parse --symbolic-full-name --abbrev-ref HEAD@\{upstream\} 2> /dev/null || git rev-parse HEAD^
 }
 

--- a/docs/docs/contributions/releases/github-actions-macos-arm64-runners.mdx
+++ b/docs/docs/contributions/releases/github-actions-macos-arm64-runners.mdx
@@ -16,7 +16,7 @@ If you find any errors or omissions in this page, please let us know on [Slack](
 As yet there aren't many options for a hosted M1 system:
 
 - AWS has a [preview program](https://aws.amazon.com/about-aws/whats-new/2021/12/amazon-ec2-m1-mac-instances-macos/), which you can sign up for and hope to get into. Once these instances are generally available we can evaluate them as a solution.
-- You can buy an M1 machine and stick it in a closet. You take on the risk of compromising your  
+- You can buy an M1 machine and stick it in a closet. You take on the risk of compromising your
   network if the machine is compromised by a rogue CI job.
 - You can rent a cloud-hosted M1 machine by the month from [MacStadium](https://www.macstadium.com/).
 
@@ -139,7 +139,7 @@ This must be done from the remote desktop, via VNC, as `administrator`.
 
 Go to  > System Preferences > Users & Groups, and click the lock to make changes.
 
-Click on Login Options and for Automatic login choose Github Actions Runner. Enter the `gha` user's password when prompted.
+Click on Login Options and for Automatic login choose GitHub Actions Runner. Enter the `gha` user's password when prompted.
 
 ### Set up the role user
 
@@ -194,7 +194,7 @@ As `gha`, run:
 
 ## Testing it all out
 
-Now use the MacStadium web UI to restart the machine. Once it comes back up it  
+Now use the MacStadium web UI to restart the machine. Once it comes back up it
 should be able to pick up any job with this setting:
 
 ```

--- a/docs/docs/contributions/releases/release-process.mdx
+++ b/docs/docs/contributions/releases/release-process.mdx
@@ -31,9 +31,9 @@ See [https://docs.github.com/en/github/authenticating-to-github/telling-git-abou
 
 Note: the last step is required on macOS.
 
-### Authenticate with the Github API
+### Authenticate with the GitHub API
 
-Ensure that you have a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for your Github account in your `.netrc` file.
+Ensure that you have a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) for your GitHub account in your `.netrc` file.
 
 ```
 machine api.github.com

--- a/docs/docs/docker/index.mdx
+++ b/docs/docs/docker/index.mdx
@@ -224,7 +224,7 @@ docker_image(
 )
 ```
 
-For working examples, including multi-platform builds with Github Actions, refer to the [example-docker](https://github.com/pantsbuild/example-docker) repository.
+For working examples, including multi-platform builds with GitHub Actions, refer to the [example-docker](https://github.com/pantsbuild/example-docker) repository.
 
 ### Build Docker image example
 

--- a/docs/docs/using-pants/using-pants-in-ci.mdx
+++ b/docs/docs/using-pants/using-pants-in-ci.mdx
@@ -242,7 +242,7 @@ We recommend that you configure your CI system to store the pants log (`.pants.d
 Different CI providers and systems have different ways to configure build artifacts:
 
 - Circle CI - [Storing artifacts](https://circleci.com/docs/2.0/artifacts/)
-- Github Actions - [Storing Artifacts](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts) - [example in the pants repo](https://github.com/pantsbuild/pants/pull/11860)
+- GitHub Actions - [Storing Artifacts](https://docs.github.com/en/actions/guides/storing-workflow-data-as-artifacts) - [example in the pants repo](https://github.com/pantsbuild/pants/pull/11860)
 - Bitbucket pipelines - [Using artifacts](https://support.atlassian.com/bitbucket-cloud/docs/use-artifacts-in-steps/)
 - Jenkins - [Recording artifacts](https://www.jenkins.io/doc/pipeline/tour/tests-and-artifacts/)
 


### PR DESCRIPTION
`During a release, the contents of this directory is synced with our website repo (https://github.com/pantsbuild/pantsbuild.org) to be deployed.`
Does this mean it's okay to edit the docs file in either the pants repo or the pantsbuild.rog repo?
