### PR TITLE
Support handling ReactJS source files in NodeJS-backends

### DIFF
--- a/src/python/pants/backend/javascript/target_types.py
+++ b/src/python/pants/backend/javascript/target_types.py
@@ -21,7 +21,7 @@ from pants.engine.target import (
 )
 from pants.util.strutil import help_text
 
-JS_FILE_EXTENSIONS = (".js", ".cjs", ".mjs")
+JS_FILE_EXTENSIONS = (".js", ".cjs", ".mjs", ".jsx")
 JS_TEST_FILE_EXTENSIONS = tuple(f"*.test{ext}" for ext in JS_FILE_EXTENSIONS)
 
 

--- a/src/python/pants/backend/typescript/target_types.py
+++ b/src/python/pants/backend/typescript/target_types.py
@@ -18,7 +18,7 @@ from pants.engine.target import (
 )
 from pants.util.strutil import help_text
 
-TS_FILE_EXTENSIONS = (".ts",)
+TS_FILE_EXTENSIONS = (".ts", ".tsx")
 TS_TEST_FILE_EXTENSIONS = tuple(f"*.test{ext}" for ext in TS_FILE_EXTENSIONS)
 
 


### PR DESCRIPTION
Adds ReactJS source file extensions to JavaScript and TypeScript backends.

It's unclear to me if there have been discussions on adding this feature using a different approach (couldn't find any open issue in this regard), this PR is just the minimal amount of effort required to do so.