### PR TITLE
Remove force flags from release tagging & confirm commit before doing so

### DIFF
--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -721,16 +721,17 @@ def check_pgp() -> None:
 
 def run_tag_release() -> None:
     tag_name = f"release_{CONSTANTS.pants_stable_version}"
+    # If you need to re-tag a release that's already been tagged once and definitely know what
+    # you're doing, feel free to do an ad-hoc addition of --force flags here.
     git(
         "tag",
-        "-f",
         f"--local-user={get_pgp_key_id()}",
         "-m",
         f"pantsbuild.pants release {CONSTANTS.pants_stable_version}",
         tag_name,
         capture_stdout=False,
     )
-    git("push", "-f", "git@github.com:pantsbuild/pants.git", tag_name, capture_stdout=False)
+    git("push", "git@github.com:pantsbuild/pants.git", tag_name, capture_stdout=False)
 
 
 def upload_wheels_via_twine() -> None:

--- a/src/python/pants_release/release.py
+++ b/src/python/pants_release/release.py
@@ -666,6 +666,7 @@ def build_fs_util() -> None:
 def tag_release() -> None:
     banner("Tagging release")
 
+    check_head_commit()
     check_clean_git_branch()
     check_pgp()
 
@@ -673,6 +674,17 @@ def tag_release() -> None:
 
     run_tag_release()
     banner("Successfully tagged release")
+
+
+def check_head_commit() -> None:
+    banner("Checking current HEAD commit")
+    git("show", capture_stdout=False)
+
+    key_confirmation = input(
+        f"\nIs this the correct commit to tag for {CONSTANTS.pants_stable_version}? [Y/n]: "
+    )
+    if key_confirmation and key_confirmation.lower() != "y":
+        die("Please check out the appropriate commit first")
 
 
 def check_clean_git_branch() -> None:


### PR DESCRIPTION
This does two changes in response to my mistake with retagging 2.21.0.dev0 (https://pantsbuild.slack.com/archives/C0D7TNJHL/p1709588198420159):

- adds a check that the commit-to-be-tagged is correct, via `git show`
- removes the `-f` (force) flags from both the `git tag` and `git push` invocation, so that if a tag already exists, we're not automatically overwriting it.
 
The second of these is explicitly revisiting #4504 (that introduced the flags). I believe our release process is quite different to how it was then, and thus we can be more careful with tags now. And, if someone really needs to move a tag, they can always add the `-f` flags themselves, as required (or delete the tag, or similar). This is referenced in a comment.