### PR TITLE
Docker: fix base image dependency inference for parametrized targets. (Cherry-pick of #20633)

### DIFF
--- a/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
+++ b/src/python/pants/backend/docker/subsystems/dockerfile_wrapper_script.py
@@ -28,7 +28,22 @@ class ParsedDockerfileInfo:
 
 _address_regexp = re.compile(
     r"""
-    (?://)?[^:# ]*:[^:#!@?/\= ]+(?:\#[^:#!@?= ]+)?$
+    # Optionally root:ed.
+    (?://)?
+    # Optional path.
+    [^:# ]*
+    # Optional target name.
+    (?::[^:#!@?/\= ]+)?
+    # Optional generated name.
+    (?:\#[^:#!@?= ]+)?
+    # Optional parametrizations.
+    (?:@
+      # key=value
+      [^=: ]+=[^,: ]*
+      # Optional additional `,key=value`s
+      (?:,[^=: ]+=[^,: ]*)*
+    )?
+    $
     """,
     re.VERBOSE,
 )


### PR DESCRIPTION
Fixes #20632 

