### PR TITLE
docs: update docs for debian_package target

### DIFF
--- a/src/python/pants/backend/debian/target_types.py
+++ b/src/python/pants/backend/debian/target_types.py
@@ -114,12 +114,12 @@ class DebianPackage(Target):
         DebianPackageDependencies,
     )
     help = help_text(
-        f""""
+        f"""
         A Debian package containing an artifact.
 
-        This will not install the package, only create a .deb file
-        that you can then distribute and install, e.g. via dpkg.
+        This will not install the package, only create a `.deb` file
+        that you can then distribute and install, e.g. via `dpkg`.
 
-        "See {doc_url('debian-package')}.
+        See {doc_url('reference/targets/debian_package')}.
         """
     )


### PR DESCRIPTION
Fixing broken docs:

![image](https://github.com/pantsbuild/pants/assets/50622389/c3747231-0320-4260-ac76-c42b513d3498)


This has now been rendered correctly.

```
$ pants help debian_package

`debian_package` target
-----------------------

A Debian package containing an artifact.

This will not install the package, only create a `.deb` file that you can then distribute and install, e.g. via `dpkg`.

See https://www.pantsbuild.org/2.20/reference/targets/debian_package.
```