### PR TITLE
add module mapping for cloud-sql-python-connector

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -112,6 +112,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
     "beautifulsoup4": ("bs4",),
     "bitvector": ("BitVector",),
     "cattrs": ("cattr", "cattrs"),
+    "cloud-sql-python-connector": ("google.cloud.sql.connector",),
     "databricks-sdk": ("databricks.sdk",),
     "databricks-sql-connector": (
         "databricks.sql",


### PR DESCRIPTION
Was trying to run tests using pants that imported `google.cloud.sql.connector`, but ended up getting a module not found error.