### PR TITLE
add default module mapping for delta-spark

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -118,7 +118,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
         "databricks.sql",
         "databricks.sqlalchemy",
     ),
-    "delta-lake": ("delta",),
+    "delta-spark": ("delta",),
     "django-cors-headers": ("corsheaders",),
     "django-countries": ("django_countries",),
     "django-filter": ("django_filters",),

--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -118,6 +118,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple[str, ...]] = {
         "databricks.sql",
         "databricks.sqlalchemy",
     ),
+    "delta-lake": ("delta",),
     "django-cors-headers": ("corsheaders",),
     "django-countries": ("django_countries",),
     "django-filter": ("django_filters",),


### PR DESCRIPTION
The title says it all.

Sources:

- https://github.com/delta-io/delta/tree/master/python
- https://docs.delta.io/latest/quick-start.html#python
