### PR TITLE
Add "what's new" in 2.20

### DIFF
--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -21,3 +21,340 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases
+
+
+# release_2.20.0rc1
+
+## Bug Fixes
+
+* Docker: fix base image dependency inference for parametrized targets. (Cherry-pick of #20633) ([#20657](https://github.com/pantsbuild/pants/pull/20657))
+
+# release_2.20.0rc0
+
+## Bug Fixes
+
+* Resolve adhoc_tool, code_quality_tool execution dependencies relative to target location (Cherry-pick of #20581) ([#20608](https://github.com/pantsbuild/pants/pull/20608))
+
+* Silence warnings from Pex by default, for now (Cherry-pick of #20590) ([#20593](https://github.com/pantsbuild/pants/pull/20593))
+
+* Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
+
+* Remove asm -compiling-runtime flag for go 1.22+ compatible versions (Cherry-pick of #20554) ([#20562](https://github.com/pantsbuild/pants/pull/20562))
+
+* Add all new Ruff backends to list of plugins (Cherry-pick of #20555) ([#20556](https://github.com/pantsbuild/pants/pull/20556))
+
+## Documentation
+
+* Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
+
+* Update `doc_url` calls for new website (Cherry-pick of #20583) ([#20588](https://github.com/pantsbuild/pants/pull/20588))
+
+* docs: export dependency graph as adjacency list (Cherry-pick of #20566) ([#20585](https://github.com/pantsbuild/pants/pull/20585))
+
+* Restructure JVM docs. (Cherry-pick of #20544) ([#20564](https://github.com/pantsbuild/pants/pull/20564))
+
+# release_2.20.0a0
+
+## New Features
+
+* add more module mappings for popular packages ([#20551](https://github.com/pantsbuild/pants/pull/20551))
+
+* Docker: Add `full_directory` interpolation value for repository configuration. ([#20530](https://github.com/pantsbuild/pants/pull/20530))
+
+* stats: add output_file option to output the stats to a file ([#20512](https://github.com/pantsbuild/pants/pull/20512))
+
+* python: respect closed option when exporting dependency graph as JSON ([#20523](https://github.com/pantsbuild/pants/pull/20523))
+
+* Generate `jvm_artifact` targets from `pom.xml` ([#20336](https://github.com/pantsbuild/pants/pull/20336))
+
+* Add support for the pex `--executable` argument ([#20497](https://github.com/pantsbuild/pants/pull/20497))
+
+* python: improve error message when parsing Python interpreter constraints ([#20297](https://github.com/pantsbuild/pants/pull/20297))
+
+* upgrade known terraform versions ([#20469](https://github.com/pantsbuild/pants/pull/20469))
+
+* Allow using Ruff to format BUILD files ([#20411](https://github.com/pantsbuild/pants/pull/20411))
+
+* options: do not ignore .github directory with pants_ignore ([#20471](https://github.com/pantsbuild/pants/pull/20471))
+
+* Add (optional) support for podman. ([#20470](https://github.com/pantsbuild/pants/pull/20470))
+
+* python: add _typeshed module to the list of unowned dependencies ([#20468](https://github.com/pantsbuild/pants/pull/20468))
+
+* Terraform lockfiles (take 2) ([#20303](https://github.com/pantsbuild/pants/pull/20303))
+
+* Extend dependents goal with output format to support JSON ([#20453](https://github.com/pantsbuild/pants/pull/20453))
+
+* Extend dependencies goal with output format to support JSON ([#20443](https://github.com/pantsbuild/pants/pull/20443))
+
+## User API Changes
+
+* Update built-in ruff 0.1.6 -> 0.2.1 ([#20499](https://github.com/pantsbuild/pants/pull/20499))
+
+## Plugin API Changes
+
+* Allow AbstractLintRequest subclasses to disable lint rules ([#20407](https://github.com/pantsbuild/pants/pull/20407))
+
+## Bug Fixes
+
+* stop swallowing warnings from Pex by default ([#20480](https://github.com/pantsbuild/pants/pull/20480))
+
+* javascript: fix running scripts with yarn ([#20543](https://github.com/pantsbuild/pants/pull/20543))
+
+* docker: fix missing image_id when using containerd-snapshotter ([#20533](https://github.com/pantsbuild/pants/pull/20533))
+
+* Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
+
+* Fix formatting of the "pex.platforms is deprecated" message ([#20514](https://github.com/pantsbuild/pants/pull/20514))
+
+* Handle unresolved ambiguous entrypoint dependency for PEX as unowned dependency ([#20390](https://github.com/pantsbuild/pants/pull/20390))
+
+* plumb through Pex's --check zipapp validation ([#20481](https://github.com/pantsbuild/pants/pull/20481))
+
+* Allow unmatching "changed" globs  ([#20505](https://github.com/pantsbuild/pants/pull/20505))
+
+* add module mapping overrides for some django-* modules ([#20504](https://github.com/pantsbuild/pants/pull/20504))
+
+* upgrade Pex to 2.1.163 ([#20502](https://github.com/pantsbuild/pants/pull/20502))
+
+* upgrade Pex to 2.1.162 ([#20496](https://github.com/pantsbuild/pants/pull/20496))
+
+* Fix direct_url in python PEP660 editable wheels ([#20486](https://github.com/pantsbuild/pants/pull/20486))
+
+* python-infer: respect ignore pragma w/ strings ([#20477](https://github.com/pantsbuild/pants/pull/20477))
+
+* Introduce `ruff-check` and `ruff-format` tool ids ([#20358](https://github.com/pantsbuild/pants/pull/20358))
+
+* python-infer: Avoid false positive strings ([#20472](https://github.com/pantsbuild/pants/pull/20472))
+
+* Don't eagerly merge configs. ([#20459](https://github.com/pantsbuild/pants/pull/20459))
+
+* Docker: Update hadolint version to fix segmentation fault issue ([#20456](https://github.com/pantsbuild/pants/pull/20456))
+
+## Documentation
+
+* Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
+
+* fix pants.log location in docs ([#20547](https://github.com/pantsbuild/pants/pull/20547))
+
+* docs: mention .pants.bootstrap file ([#20538](https://github.com/pantsbuild/pants/pull/20538))
+
+* docs: provide example of having a --option in [cli.alias] ([#20539](https://github.com/pantsbuild/pants/pull/20539))
+
+* docs: provide options to refer to a group of targets ([#20522](https://github.com/pantsbuild/pants/pull/20522))
+
+* docs: mention that when piping xargs may end up invoking Pants goal more than once ([#20521](https://github.com/pantsbuild/pants/pull/20521))
+
+* docs: provide example how to convert target addresses to source files in rules API ([#20524](https://github.com/pantsbuild/pants/pull/20524))
+
+* Fix Pex references to point to new home. ([#20519](https://github.com/pantsbuild/pants/pull/20519))
+
+* Update broken link to default versioning scheme ([#20482](https://github.com/pantsbuild/pants/pull/20482))
+
+* docs: fix slack channel references ([#20475](https://github.com/pantsbuild/pants/pull/20475))
+
+* Add a test case for Pants integration testing docs ([#20451](https://github.com/pantsbuild/pants/pull/20451))
+
+* Add a test case for Pants unit testing docs ([#20452](https://github.com/pantsbuild/pants/pull/20452))
+
+* Rename tutorials section in the docs ([#20449](https://github.com/pantsbuild/pants/pull/20449))
+
+# release_2.20.0.dev7
+
+## New Features
+
+* Add version/local scheme fields to `vcs_version` ([#20446](https://github.com/pantsbuild/pants/pull/20446))
+
+* upgrade PEX to 2.1.159 ([#20416](https://github.com/pantsbuild/pants/pull/20416))
+
+* Add jvm_index Option to Coursier Subsystem ([#20271](https://github.com/pantsbuild/pants/pull/20271))
+
+* python-protobuf backend now support multiple protoc plugins. ([#20387](https://github.com/pantsbuild/pants/pull/20387))
+
+## User API Changes
+
+* Add remote_provider = "..." option, replacing scheme-look-ups ([#20240](https://github.com/pantsbuild/pants/pull/20240))
+
+## Bug Fixes
+
+* Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
+
+## Documentation
+
+* Mention the Scala repl and its current gotchas in the docs ([#20445](https://github.com/pantsbuild/pants/pull/20445))
+
+* Fix missing registration for environments rules in pants.core. ([#20444](https://github.com/pantsbuild/pants/pull/20444))
+
+* Actually call `bin_name` in help string  ([#20434](https://github.com/pantsbuild/pants/pull/20434))
+
+* Apply latest hand-edits to pantsbuild/pantsbuild.org repo ([#20419](https://github.com/pantsbuild/pants/pull/20419))
+
+* Fix the weird headings of `initial-configuration.mdx` ([#20422](https://github.com/pantsbuild/pants/pull/20422))
+
+* Update docker docs for buildx ([#20413](https://github.com/pantsbuild/pants/pull/20413))
+
+* What's new in 2.19 ([#20310](https://github.com/pantsbuild/pants/pull/20310))
+
+* Rename 'environments' docs file/URL to be simpler ([#20404](https://github.com/pantsbuild/pants/pull/20404))
+
+# release_2.20.0.dev6
+
+## New Features
+
+* plumb sh-boot through to pex_binary ([#19925](https://github.com/pantsbuild/pants/pull/19925))
+
+## Plugin API Changes
+
+* Add support for positional arguments in by-name `@rule` calls ([#20366](https://github.com/pantsbuild/pants/pull/20366))
+
+## Performance
+
+* Upgrade to PEX 2.1.156 ([#20391](https://github.com/pantsbuild/pants/pull/20391))
+
+* Update to Pex 2.1.155 ([#20347](https://github.com/pantsbuild/pants/pull/20347))
+
+## Documentation
+
+* Collapse "overview" pages ([#20401](https://github.com/pantsbuild/pants/pull/20401))
+
+* Replace this repo's docs content with the update docusaurus content ([#20395](https://github.com/pantsbuild/pants/pull/20395))
+
+* docs: update python test coverage docs ([#20335](https://github.com/pantsbuild/pants/pull/20335))
+
+* Update the docs on how to profile Pants. ([#20334](https://github.com/pantsbuild/pants/pull/20334))
+
+* Improve the cache nuking recommendation. ([#20385](https://github.com/pantsbuild/pants/pull/20385))
+
+# release_2.20.0.dev5
+
+## Bug Fixes
+
+* fix: in-repo plugin requirements.txt not loading ([#20355](https://github.com/pantsbuild/pants/pull/20355))
+
+* Fix: Include transitive dependencies for Terraform ([#20241](https://github.com/pantsbuild/pants/pull/20241))
+
+* Allow using scalac plugins that emit additional compilation results ([#20357](https://github.com/pantsbuild/pants/pull/20357))
+
+# release_2.20.0.dev4
+
+## New Features
+
+* Support dependency inference with JVM codegen backends ([#20285](https://github.com/pantsbuild/pants/pull/20285))
+
+* Support coursier `--force-version` argument ([#20238](https://github.com/pantsbuild/pants/pull/20238))
+
+## Bug Fixes
+
+* Make docker_environment's Pants-provided-PBS an absolute path ([#20314](https://github.com/pantsbuild/pants/pull/20314))
+
+* Fix algorithm for gathering prebuilt Go object files ([#20332](https://github.com/pantsbuild/pants/pull/20332))
+
+* Allow docker image pulling without creds ([#20307](https://github.com/pantsbuild/pants/pull/20307))
+
+* Ensure `experimental_test_shell_command` runs in relevant environment ([#20319](https://github.com/pantsbuild/pants/pull/20319))
+
+## Documentation
+
+* Update team.md ([#20329](https://github.com/pantsbuild/pants/pull/20329))
+
+* Change the slug of the Shell backend doc. ([#20326](https://github.com/pantsbuild/pants/pull/20326))
+
+# release_2.20.0.dev3
+
+## New Features
+
+* helm: add option to pass `--quiet` when linting charts ([#20204](https://github.com/pantsbuild/pants/pull/20204))
+
+* Allow passing arbitrary args to PEX invocation when building FaaS artifacts ([#20237](https://github.com/pantsbuild/pants/pull/20237))
+
+## Bug Fixes
+
+* fix: terraform_relpath works on files not in direct subpath ([#20276](https://github.com/pantsbuild/pants/pull/20276))
+
+* Fix: run `terraform validate` on modules again ([#20230](https://github.com/pantsbuild/pants/pull/20230))
+
+## Documentation
+
+* Don't use tabbed-codeblock in Markdown ([#20290](https://github.com/pantsbuild/pants/pull/20290))
+
+# release_2.20.0.dev2
+
+## New Features
+
+* allow passing --timeout along to helm commands ([#20273](https://github.com/pantsbuild/pants/pull/20273))
+
+* Add support for Scalac plugins in BSP ([#20267](https://github.com/pantsbuild/pants/pull/20267))
+
+* typescript: add tailor goal ([#20252](https://github.com/pantsbuild/pants/pull/20252))
+
+## Bug Fixes
+
+* Use fork of indicatif to work around output truncation ([#20269](https://github.com/pantsbuild/pants/pull/20269))
+
+* Validate that the file content has type bytes ([#20261](https://github.com/pantsbuild/pants/pull/20261))
+
+## Documentation
+
+* add `always` mode for `RemoteCacheWarningsBehavior` ([#20268](https://github.com/pantsbuild/pants/pull/20268))
+
+* Include guidance on skipping files under Black & isort ([#20262](https://github.com/pantsbuild/pants/pull/20262))
+
+# release_2.20.0.dev1
+
+## New Features
+
+* typescript: add TypeScript source and test targets ([#20226](https://github.com/pantsbuild/pants/pull/20226))
+
+* Infers Django migrations and management commands as dependencies of `apps.py` ([#20250](https://github.com/pantsbuild/pants/pull/20250))
+
+* Discover Ruff config in pyproject.toml in subdirectories ([#20248](https://github.com/pantsbuild/pants/pull/20248))
+
+## User API Changes
+
+* Update to Ruff 0.1.6 ([#20249](https://github.com/pantsbuild/pants/pull/20249))
+
+* Add `remote_oauth_bearer_token` option, deprecating `remote_oauth_bearer_token_path` ([#20116](https://github.com/pantsbuild/pants/pull/20116))
+
+## Bug Fixes
+
+* Fix wrong jar path given to shade jar process ([#20239](https://github.com/pantsbuild/pants/pull/20239))
+
+* Make FrozenDict comparisons & hash order-insensitive, compare to dict ([#20221](https://github.com/pantsbuild/pants/pull/20221))
+
+## Documentation
+
+* Add note in docker_environment image field help on tool requirements ([#20231](https://github.com/pantsbuild/pants/pull/20231))
+
+* Add link to talk at Hamburg Python Pizza ([#20223](https://github.com/pantsbuild/pants/pull/20223))
+
+# release_2.20.0.dev0
+
+## New Features
+
+* Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
+
+* Python: Enable code formatting using Ruff ([#20098](https://github.com/pantsbuild/pants/pull/20098))
+
+* Add docker image output field to support publish to repository when using BuildKit ([#20154](https://github.com/pantsbuild/pants/pull/20154))
+
+## User API Changes
+
+* Remove deprecated `[export].symlink_python_virtualenv` option ([#20214](https://github.com/pantsbuild/pants/pull/20214))
+
+## Plugin API Changes
+
+* Remove deprecated `@rule_helper` ([#20213](https://github.com/pantsbuild/pants/pull/20213))
+
+## Bug Fixes
+
+* Skip jvm dependencies without entries ([#20192](https://github.com/pantsbuild/pants/pull/20192))
+
+* Support inferring JS deps from `export ... from ...` statements ([#20190](https://github.com/pantsbuild/pants/pull/20190))
+
+* Remove print() statement ([#20196](https://github.com/pantsbuild/pants/pull/20196))
+
+* Do not choke on values from macros on environment targets during bootstrap. ([#20191](https://github.com/pantsbuild/pants/pull/20191))
+
+* Use a Zulu JDK 8 to run the Kotlin analyzer. ([#20184](https://github.com/pantsbuild/pants/pull/20184))
+
+* Fix: support helm repos with trailing slashes ([#20177](https://github.com/pantsbuild/pants/pull/20177))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -189,10 +189,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0a0
 
-## New Features
-
-## Plugin API Changes
-
 ## Bug Fixes
 
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
@@ -202,9 +198,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
 
 # release_2.20.0.dev7
-
-## New Features
-
 
 ## Bug Fixes
 
@@ -222,38 +215,12 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0.dev6
 
-## Plugin API Changes
-
-## Performance
-
 ## Documentation
 
 * Update the docs on how to profile Pants. ([#20334](https://github.com/pantsbuild/pants/pull/20334))
 
-# release_2.20.0.dev5
-
-## Bug Fixes
-
-# release_2.20.0.dev4
-
-## Bug Fixes
-
 # release_2.20.0.dev2
-
-## Bug Fixes
 
 ## Documentation
 
 * Include guidance on skipping files under Black & isort ([#20262](https://github.com/pantsbuild/pants/pull/20262))
-
-# release_2.20.0.dev1
-
-## Bug Fixes
-
-# release_2.20.0.dev0
-
-## New Features
-
-## Plugin API Changes
-
-## Bug Fixes

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -31,6 +31,26 @@ The `repository` field on `helm_chart` now allows trailing slashes.
 
 The `--timeout` flag can now be passed through to `helm upgrade` operations.
 
+#### JVM
+
+Several improvements have been made to Pants' support for third-party dependencies:
+
+- The [new `jvm_artifacts` target](https://www.pantsbuild.org/2.20/reference/targets/jvm_artifacts) supports creating `jvm_artifact` dependency targets from `pom.xml` files.
+- The [new `force_version` field on `jvm_artifact`](https://www.pantsbuild.org/2.20/reference/targets/jvm_artifact#force_version) allows passing the `--force-version` flag to Coursier for particular artifacts.
+- The [new `[coursier].jvm_index` option](https://www.pantsbuild.org/2.20/reference/subsystems/coursier#jvm_index) allows setting the index used by Coursier.
+
+Most codegen backends now support dependency inference, including Protobuf, SOAP, Thrift and OpenAPI.
+
+Pants support for [IDE integration via the BSP protocol](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala#working-in-an-ide) now supports Scala plugins.
+
+The JVM documentation has been rearranged to put [Java and Scala](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala) and [Kotlin](https://www.pantsbuild.org/2.20/docs/jvm/kotlin) on an equal footing.
+
+##### Scala
+
+Plugins that cause `scalac` to emit additional compilation results (such as `semanticdb`, `scalajs` and `scalanative`) are now supported, by wrapping all results into a single `jar`.
+
+Support for [the Scala REPL](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala#repl) is now documented.
+
 #### Python
 
 Several improvements have been made to Pants' support for Ruff:
@@ -79,8 +99,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * docs: export dependency graph as adjacency list (Cherry-pick of #20566) ([#20585](https://github.com/pantsbuild/pants/pull/20585))
 
-* Restructure JVM docs. (Cherry-pick of #20544) ([#20564](https://github.com/pantsbuild/pants/pull/20564))
-
 # release_2.20.0a0
 
 ## New Features
@@ -92,8 +110,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * stats: add output_file option to output the stats to a file ([#20512](https://github.com/pantsbuild/pants/pull/20512))
 
 * python: respect closed option when exporting dependency graph as JSON ([#20523](https://github.com/pantsbuild/pants/pull/20523))
-
-* Generate `jvm_artifact` targets from `pom.xml` ([#20336](https://github.com/pantsbuild/pants/pull/20336))
 
 * Add support for the pex `--executable` argument ([#20497](https://github.com/pantsbuild/pants/pull/20497))
 
@@ -183,8 +199,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * upgrade PEX to 2.1.159 ([#20416](https://github.com/pantsbuild/pants/pull/20416))
 
-* Add jvm_index Option to Coursier Subsystem ([#20271](https://github.com/pantsbuild/pants/pull/20271))
-
 * python-protobuf backend now support multiple protoc plugins. ([#20387](https://github.com/pantsbuild/pants/pull/20387))
 
 ## User API Changes
@@ -196,8 +210,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
 
 ## Documentation
-
-* Mention the Scala repl and its current gotchas in the docs ([#20445](https://github.com/pantsbuild/pants/pull/20445))
 
 * Fix missing registration for environments rules in pants.core. ([#20444](https://github.com/pantsbuild/pants/pull/20444))
 
@@ -247,15 +259,7 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * fix: in-repo plugin requirements.txt not loading ([#20355](https://github.com/pantsbuild/pants/pull/20355))
 
-* Allow using scalac plugins that emit additional compilation results ([#20357](https://github.com/pantsbuild/pants/pull/20357))
-
 # release_2.20.0.dev4
-
-## New Features
-
-* Support dependency inference with JVM codegen backends ([#20285](https://github.com/pantsbuild/pants/pull/20285))
-
-* Support coursier `--force-version` argument ([#20238](https://github.com/pantsbuild/pants/pull/20238))
 
 ## Bug Fixes
 
@@ -286,8 +290,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev2
 
 ## New Features
-
-* Add support for Scalac plugins in BSP ([#20267](https://github.com/pantsbuild/pants/pull/20267))
 
 * typescript: add tailor goal ([#20252](https://github.com/pantsbuild/pants/pull/20252))
 
@@ -345,12 +347,8 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Bug Fixes
 
-* Skip jvm dependencies without entries ([#20192](https://github.com/pantsbuild/pants/pull/20192))
-
 * Support inferring JS deps from `export ... from ...` statements ([#20190](https://github.com/pantsbuild/pants/pull/20190))
 
 * Remove print() statement ([#20196](https://github.com/pantsbuild/pants/pull/20196))
 
 * Do not choke on values from macros on environment targets during bootstrap. ([#20191](https://github.com/pantsbuild/pants/pull/20191))
-
-* Use a Zulu JDK 8 to run the Kotlin analyzer. ([#20184](https://github.com/pantsbuild/pants/pull/20184))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -21,6 +21,17 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format `BUILD` files.
 
+### Remote caching/execution
+
+Pants now has experimental support for additional remote cache providers beyond the GRPC Remote Execution API. Set [the `[GLOBAL].remote_provider` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_provider), to be able to use:
+
+- [the GitHub Actions Cache](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#github-actions-cache)
+- [a local directory](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#local-file-system)
+
+In support of this, [the `[GLOBAL].remote_oauth_bearer_token` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_oauth_bearer_token) has been added to set the `Authorization: Bearer <token>` header. [The `[GLOBAL].remote_oauth_bearer_token_path` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_oauth_bearer_token_path) has been deprecated in favour of using the new option with [a file reference](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/options#reading-individual-option-values-from-files): `remote_oauth_bearer_token = "@/path/to/file.txt"`.
+
+[The `[GLOBAL].remote_cache_warnings` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_cache_warnings) now supports `always`.
+
 ### Backends
 
 #### Docker
@@ -209,10 +220,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * python-protobuf backend now support multiple protoc plugins. ([#20387](https://github.com/pantsbuild/pants/pull/20387))
 
-## User API Changes
-
-* Add remote_provider = "..." option, replacing scheme-look-ups ([#20240](https://github.com/pantsbuild/pants/pull/20240))
-
 ## Bug Fixes
 
 * Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
@@ -287,8 +294,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Documentation
 
-* add `always` mode for `RemoteCacheWarningsBehavior` ([#20268](https://github.com/pantsbuild/pants/pull/20268))
-
 * Include guidance on skipping files under Black & isort ([#20262](https://github.com/pantsbuild/pants/pull/20262))
 
 # release_2.20.0.dev1
@@ -296,10 +301,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Infers Django migrations and management commands as dependencies of `apps.py` ([#20250](https://github.com/pantsbuild/pants/pull/20250))
-
-## User API Changes
-
-* Add `remote_oauth_bearer_token` option, deprecating `remote_oauth_bearer_token_path` ([#20116](https://github.com/pantsbuild/pants/pull/20116))
 
 ## Bug Fixes
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -50,6 +50,10 @@ In support of this, [the `[GLOBAL].remote_oauth_bearer_token` option](https://ww
 
 ### Backends
 
+#### Adhoc
+
+The [new `code_quality_tool` target](https://www.pantsbuild.org/2.20/reference/targets/code_quality_tool) in the `pants.backend.experimental.adhoc` backend allows defining "adhoc" linters, formatters and fixers without requiring a full plugin. For example, in-repository scripts or a tool not already supported by Pants itself. See [#20135](https://github.com/pantsbuild/pants/pull/20135) for an example of how to use this.
+
 #### Docker
 
 The [new `{full_directory}` interpolation](https://www.pantsbuild.org/2.20/docs/docker/tagging-docker-images#setting-a-repository-name) in `repository` and `default_repository` options expands to the full path to the `BUILD` file that contains a `docker_image` target.
@@ -167,8 +171,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Bug Fixes
 
-* Resolve adhoc_tool, code_quality_tool execution dependencies relative to target location (Cherry-pick of #20581) ([#20608](https://github.com/pantsbuild/pants/pull/20608))
-
 * Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
 
 * Remove asm -compiling-runtime flag for go 1.22+ compatible versions (Cherry-pick of #20554) ([#20562](https://github.com/pantsbuild/pants/pull/20562))
@@ -248,8 +250,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev0
 
 ## New Features
-
-* Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
 
 ## Plugin API Changes
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -162,11 +162,14 @@ Plugins loaded from the current repository (by extending `[GLOBAL].pythonpath`) 
 
 `FrozenDict`s comparison and hashing functions now behave more like the superclass `dict` ones, being order-insensitive and allowing comparison to `dict` itself. ([#20221](https://github.com/pantsbuild/pants/pull/20221))
 
-The documentation has been extended with a few additional examples:
+Previously, backtraces have been improved, to lose less information when interacting with the Rust core code. ([#20517](https://github.com/pantsbuild/pants/pull/20517))
+
+The documentation has been extended with more information and additional examples:
 
 - how to [use `HydratedSources` to convert a list of file and target paths into just file paths](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/rules-and-the-target-api#sourcesfield) ([#20524](https://github.com/pantsbuild/pants/pull/20524))
 - how to [write an integration test that requires loading a backend](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-4-run_pants-integration-tests-for-pants) ([#20451](https://github.com/pantsbuild/pants/pull/20451))
 - how to [write a unit test for a `@rule`](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-2-run_rule_with_mocks-unit-tests-for-rules) ([#20452](https://github.com/pantsbuild/pants/pull/20452))
+- how to profile Pants with [py-spy](https://www.pantsbuild.org/2.20/docs/contributions/development/debugging-and-benchmarking#cpu-profiling-with-py-spy) and [memray](https://www.pantsbuild.org/2.20/docs/contributions/development/debugging-and-benchmarking#memory-profiling-with-memray) ([#20334](https://github.com/pantsbuild/pants/pull/20334))
 
 The deprecation has expired for the `@rule_helper` decorator. To resolve, just remove it: `@rule`s can now call any functions and `async` functions can now call `Get` and `MultiGet` directly.
 
@@ -181,23 +184,11 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
 
-# release_2.20.0a0
-
-## Bug Fixes
-
-* Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
-
 # release_2.20.0.dev7
 
 ## Bug Fixes
 
 * Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
-
-# release_2.20.0.dev6
-
-## Documentation
-
-* Update the docs on how to profile Pants. ([#20334](https://github.com/pantsbuild/pants/pull/20334))
 
 # release_2.20.0.dev2
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -17,6 +17,22 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Overall
 
+The dependency goals now support JSON output using the `--format` option for easier [introspection of the dependency graph](https://www.pantsbuild.org/2.20/docs/using-pants/project-introspection#export-dependency-graph). For instance, [`pants dependencies --format=json ...`](https://www.pantsbuild.org/2.20/reference/goals/dependencies#format) and [`pants dependents --format=json ...`](https://www.pantsbuild.org/2.20/reference/goals/dependents#format).
+
+The [new `[stats].output_file` option](https://www.pantsbuild.org/2.20/reference/subsystems/stats#output_file) allows appending the stats output to a file, rather than printing it on stdout. This allows hiding this output on CI, while still ensuring it's available when required.
+
+[The `[GLOBAL].pants_ignore` option](https://www.pantsbuild.org/2.20/reference/global-options#pants_ignore) no longer ignores `.github` by default, so files within that directory will now be visible to Pants automatically.
+
+Using [the `--changed-...` options](https://www.pantsbuild.org/2.20/reference/subsystems/changed) to only run on files that have been edited now no longer emits spurious warnings if files have been deleted.
+
+We've made many changes to documentation, including:
+
+- How to use [the `.pants.bootstrap` file](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/options#pantsbootstrap-file) for running commands before start-up or setting default environment variables or similar.
+- How to use [the `[cli].alias` option](https://www.pantsbuild.org/2.20/docs/using-pants/advanced-target-selection#using-cli-aliases) for abbreviating common pants invocations.
+- How to use [the `target` target](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/targets-and-build-files#using-the-generic-target) to abbreviate common `dependencies=["..."]` parameters.
+- An improved version of [the nuking script](https://www.pantsbuild.org/2.20/docs/using-pants/using-pants-in-ci#directories-to-cache) when doing coarse-grained caching in CI, like GitHub Actions.
+- Several pages have been renamed or moved: existing links to 2.19 and earlier will still work, but their locations in 2.20 may have changed.
+
 ### BUILD files
 
 The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format `BUILD` files.
@@ -126,15 +142,11 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Update `doc_url` calls for new website (Cherry-pick of #20583) ([#20588](https://github.com/pantsbuild/pants/pull/20588))
 
-* docs: export dependency graph as adjacency list (Cherry-pick of #20566) ([#20585](https://github.com/pantsbuild/pants/pull/20585))
-
 # release_2.20.0a0
 
 ## New Features
 
 * add more module mappings for popular packages ([#20551](https://github.com/pantsbuild/pants/pull/20551))
-
-* stats: add output_file option to output the stats to a file ([#20512](https://github.com/pantsbuild/pants/pull/20512))
 
 * python: respect closed option when exporting dependency graph as JSON ([#20523](https://github.com/pantsbuild/pants/pull/20523))
 
@@ -142,13 +154,7 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * python: improve error message when parsing Python interpreter constraints ([#20297](https://github.com/pantsbuild/pants/pull/20297))
 
-* options: do not ignore .github directory with pants_ignore ([#20471](https://github.com/pantsbuild/pants/pull/20471))
-
 * python: add _typeshed module to the list of unowned dependencies ([#20468](https://github.com/pantsbuild/pants/pull/20468))
-
-* Extend dependents goal with output format to support JSON ([#20453](https://github.com/pantsbuild/pants/pull/20453))
-
-* Extend dependencies goal with output format to support JSON ([#20443](https://github.com/pantsbuild/pants/pull/20443))
 
 ## Plugin API Changes
 
@@ -166,8 +172,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * plumb through Pex's --check zipapp validation ([#20481](https://github.com/pantsbuild/pants/pull/20481))
 
-* Allow unmatching "changed" globs  ([#20505](https://github.com/pantsbuild/pants/pull/20505))
-
 * add module mapping overrides for some django-* modules ([#20504](https://github.com/pantsbuild/pants/pull/20504))
 
 * upgrade Pex to 2.1.163 ([#20502](https://github.com/pantsbuild/pants/pull/20502))
@@ -180,35 +184,17 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * python-infer: Avoid false positive strings ([#20472](https://github.com/pantsbuild/pants/pull/20472))
 
-* Don't eagerly merge configs. ([#20459](https://github.com/pantsbuild/pants/pull/20459))
-
 ## Documentation
 
 * Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
-
-* fix pants.log location in docs ([#20547](https://github.com/pantsbuild/pants/pull/20547))
-
-* docs: mention .pants.bootstrap file ([#20538](https://github.com/pantsbuild/pants/pull/20538))
-
-* docs: provide example of having a --option in [cli.alias] ([#20539](https://github.com/pantsbuild/pants/pull/20539))
-
-* docs: provide options to refer to a group of targets ([#20522](https://github.com/pantsbuild/pants/pull/20522))
-
-* docs: mention that when piping xargs may end up invoking Pants goal more than once ([#20521](https://github.com/pantsbuild/pants/pull/20521))
 
 * docs: provide example how to convert target addresses to source files in rules API ([#20524](https://github.com/pantsbuild/pants/pull/20524))
 
 * Fix Pex references to point to new home. ([#20519](https://github.com/pantsbuild/pants/pull/20519))
 
-* Update broken link to default versioning scheme ([#20482](https://github.com/pantsbuild/pants/pull/20482))
-
-* docs: fix slack channel references ([#20475](https://github.com/pantsbuild/pants/pull/20475))
-
 * Add a test case for Pants integration testing docs ([#20451](https://github.com/pantsbuild/pants/pull/20451))
 
 * Add a test case for Pants unit testing docs ([#20452](https://github.com/pantsbuild/pants/pull/20452))
-
-* Rename tutorials section in the docs ([#20449](https://github.com/pantsbuild/pants/pull/20449))
 
 # release_2.20.0.dev7
 
@@ -252,15 +238,9 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Documentation
 
-* Collapse "overview" pages ([#20401](https://github.com/pantsbuild/pants/pull/20401))
-
-* Replace this repo's docs content with the update docusaurus content ([#20395](https://github.com/pantsbuild/pants/pull/20395))
-
 * docs: update python test coverage docs ([#20335](https://github.com/pantsbuild/pants/pull/20335))
 
 * Update the docs on how to profile Pants. ([#20334](https://github.com/pantsbuild/pants/pull/20334))
-
-* Improve the cache nuking recommendation. ([#20385](https://github.com/pantsbuild/pants/pull/20385))
 
 # release_2.20.0.dev5
 
@@ -273,18 +253,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## Bug Fixes
 
 * Fix algorithm for gathering prebuilt Go object files ([#20332](https://github.com/pantsbuild/pants/pull/20332))
-
-## Documentation
-
-* Update team.md ([#20329](https://github.com/pantsbuild/pants/pull/20329))
-
-* Change the slug of the Shell backend doc. ([#20326](https://github.com/pantsbuild/pants/pull/20326))
-
-# release_2.20.0.dev3
-
-## Documentation
-
-* Don't use tabbed-codeblock in Markdown ([#20290](https://github.com/pantsbuild/pants/pull/20290))
 
 # release_2.20.0.dev2
 
@@ -305,10 +273,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## Bug Fixes
 
 * Make FrozenDict comparisons & hash order-insensitive, compare to dict ([#20221](https://github.com/pantsbuild/pants/pull/20221))
-
-## Documentation
-
-* Add link to talk at Hamburg Python Pizza ([#20223](https://github.com/pantsbuild/pants/pull/20223))
 
 # release_2.20.0.dev0
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -66,6 +66,12 @@ Pants is now able to extract the image ID when building a docker image with a da
 
 The default version of Hadolint has been updated from 2.10.0 to 2.12.1-beta.
 
+#### Go
+
+Support for Go 1.22+, by no longer passing the `-compiling-runtime` flag when not necessary.
+
+Eliminated a non-linear blow-up in the algorthm for gathering pre-build Go object files when using CGo.
+
 #### Helm
 
 The [new `lint_quiet` field](https://www.pantsbuild.org/2.20/reference/targets/helm_chart#lint_quiet) on `helm_chart` allows passing `--quiet` to `helm lint ...`.
@@ -175,8 +181,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
 
-* Remove asm -compiling-runtime flag for go 1.22+ compatible versions (Cherry-pick of #20554) ([#20562](https://github.com/pantsbuild/pants/pull/20562))
-
 ## Documentation
 
 * Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
@@ -233,8 +237,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev4
 
 ## Bug Fixes
-
-* Fix algorithm for gathering prebuilt Go object files ([#20332](https://github.com/pantsbuild/pants/pull/20332))
 
 # release_2.20.0.dev2
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -38,6 +38,8 @@ In support of this, [the `[GLOBAL].remote_oauth_bearer_token` option](https://ww
 
 The [new `{full_directory}` interpolation](https://www.pantsbuild.org/2.20/docs/docker/tagging-docker-images#setting-a-repository-name) in `repository` and `default_repository` options expands to the full path to the `BUILD` file that contains a `docker_image` target.
 
+The new `pants.backend.experimental.docker.podman` backend allows using [Podman](https://podman.io). Add that backend to `backend_packages` and the Docker backend will invoke Podman instead of Docker. [The new option `[docker].experimental_enable_podman`](https://www.pantsbuild.org/2.20/reference/subsystems/docker#experimental_enable_podman) allows disabling this once the backend is loaded.
+
 Dependency inference now works for parameterized targets, like `ARG base="path/to:target@param=value"`.
 
 Pants is now able to extract the image ID when building a docker image with a daemon using the containerd-snapshotter feature.
@@ -141,8 +143,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * python: improve error message when parsing Python interpreter constraints ([#20297](https://github.com/pantsbuild/pants/pull/20297))
 
 * options: do not ignore .github directory with pants_ignore ([#20471](https://github.com/pantsbuild/pants/pull/20471))
-
-* Add (optional) support for podman. ([#20470](https://github.com/pantsbuild/pants/pull/20470))
 
 * python: add _typeshed module to the list of unowned dependencies ([#20468](https://github.com/pantsbuild/pants/pull/20468))
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -177,15 +177,9 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0rc0
 
-## Bug Fixes
-
-* Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
-
 ## Documentation
 
 * Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
-
-* Update `doc_url` calls for new website (Cherry-pick of #20583) ([#20588](https://github.com/pantsbuild/pants/pull/20588))
 
 # release_2.20.0a0
 
@@ -193,25 +187,11 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
 
-## Documentation
-
-* Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
-
 # release_2.20.0.dev7
 
 ## Bug Fixes
 
 * Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
-
-## Documentation
-
-* Fix missing registration for environments rules in pants.core. ([#20444](https://github.com/pantsbuild/pants/pull/20444))
-
-* Actually call `bin_name` in help string  ([#20434](https://github.com/pantsbuild/pants/pull/20434))
-
-* Apply latest hand-edits to pantsbuild/pantsbuild.org repo ([#20419](https://github.com/pantsbuild/pants/pull/20419))
-
-* Fix the weird headings of `initial-configuration.mdx` ([#20422](https://github.com/pantsbuild/pants/pull/20422))
 
 # release_2.20.0.dev6
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -13,6 +13,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ### Highlights
 
 - Support for the Ruff formatter, for both `BUILD` files and normal Python files.
+- The Terraform backend now has built-in support for lockfiles.
 
 ### Overall
 
@@ -38,6 +39,12 @@ Several improvements have been made to Pants' support for Ruff:
 - The existing `pants.backend.experimental.python.lint.ruff` linter backend has been renamed to `pants.backend.experimental.python.lint.ruff.check`, and its tool ID (as used by commands like `pants lint --only=...`) has changed from `ruff` to `ruff-check`.
 - Pants now automatically finds Ruff configuration in `pyproject.toml` files in subdirectories, for instance, `python/pyproject.toml`.
 - Pants' built-in default version has been updated to 0.2.1.
+
+#### Terraform
+
+The Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
+
+The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1. Pants now has [built-in knowledge of versions up to 1.7.1](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#known_versions), so the version can be overridden by setting [`[download-terraform].version`](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#version) explicitly.
 
 ### Plugin API changes
 
@@ -92,15 +99,11 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * python: improve error message when parsing Python interpreter constraints ([#20297](https://github.com/pantsbuild/pants/pull/20297))
 
-* upgrade known terraform versions ([#20469](https://github.com/pantsbuild/pants/pull/20469))
-
 * options: do not ignore .github directory with pants_ignore ([#20471](https://github.com/pantsbuild/pants/pull/20471))
 
 * Add (optional) support for podman. ([#20470](https://github.com/pantsbuild/pants/pull/20470))
 
 * python: add _typeshed module to the list of unowned dependencies ([#20468](https://github.com/pantsbuild/pants/pull/20468))
-
-* Terraform lockfiles (take 2) ([#20303](https://github.com/pantsbuild/pants/pull/20303))
 
 * Extend dependents goal with output format to support JSON ([#20453](https://github.com/pantsbuild/pants/pull/20453))
 
@@ -244,8 +247,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * fix: in-repo plugin requirements.txt not loading ([#20355](https://github.com/pantsbuild/pants/pull/20355))
 
-* Fix: Include transitive dependencies for Terraform ([#20241](https://github.com/pantsbuild/pants/pull/20241))
-
 * Allow using scalac plugins that emit additional compilation results ([#20357](https://github.com/pantsbuild/pants/pull/20357))
 
 # release_2.20.0.dev4
@@ -277,12 +278,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Allow passing arbitrary args to PEX invocation when building FaaS artifacts ([#20237](https://github.com/pantsbuild/pants/pull/20237))
-
-## Bug Fixes
-
-* fix: terraform_relpath works on files not in direct subpath ([#20276](https://github.com/pantsbuild/pants/pull/20276))
-
-* Fix: run `terraform validate` on modules again ([#20230](https://github.com/pantsbuild/pants/pull/20230))
 
 ## Documentation
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -41,6 +41,13 @@ The `repository` field on `helm_chart` now allows trailing slashes.
 
 The `--timeout` flag can now be passed through to `helm upgrade` operations.
 
+#### JavaScript
+
+The [`pants.backend.experimental.javascript` experimental backend](https://github.com/pantsbuild/example-javascript) has had a few bug-fixes:
+
+- [`package_json` targets](https://www.pantsbuild.org/2.20/reference/targets/package_json) that use `yarn` now support running `node_build_scripts`.
+- Dependencies are inferred from `export ... from ...` statements, similar to `import ... from ...`.
+
 #### JVM
 
 Several improvements have been made to Pants' support for third-party dependencies:
@@ -75,6 +82,11 @@ Several improvements have been made to Pants' support for Ruff:
 The Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
 
 The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1. Pants now has [built-in knowledge of versions up to 1.7.1](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#known_versions), so the version can be overridden by setting [`[download-terraform].version`](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#version) explicitly.
+
+
+#### NEW: TypeScript
+
+The `pants.backend.experimental.typescript` experimental backend now exists with support for tailoring [`typescript_sources`](https://www.pantsbuild.org/2.20/reference/targets/typescript_sources) and [`typescript_tests`](https://www.pantsbuild.org/2.20/reference/targets/typescript_tests) targets. Note: [dependency inference](https://github.com/pantsbuild/pants/pull/20293) and other built-in functionality is not yet implemented.
 
 ### Plugin API changes
 
@@ -134,8 +146,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## Bug Fixes
 
 * stop swallowing warnings from Pex by default ([#20480](https://github.com/pantsbuild/pants/pull/20480))
-
-* javascript: fix running scripts with yarn ([#20543](https://github.com/pantsbuild/pants/pull/20543))
 
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
 
@@ -271,10 +281,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0.dev2
 
-## New Features
-
-* typescript: add tailor goal ([#20252](https://github.com/pantsbuild/pants/pull/20252))
-
 ## Bug Fixes
 
 * Validate that the file content has type bytes ([#20261](https://github.com/pantsbuild/pants/pull/20261))
@@ -288,8 +294,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev1
 
 ## New Features
-
-* typescript: add TypeScript source and test targets ([#20226](https://github.com/pantsbuild/pants/pull/20226))
 
 * Infers Django migrations and management commands as dependencies of `apps.py` ([#20250](https://github.com/pantsbuild/pants/pull/20250))
 
@@ -320,5 +324,3 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Remove deprecated `@rule_helper` ([#20213](https://github.com/pantsbuild/pants/pull/20213))
 
 ## Bug Fixes
-
-* Support inferring JS deps from `export ... from ...` statements ([#20190](https://github.com/pantsbuild/pants/pull/20190))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -70,7 +70,7 @@ Dependency inference now works for parameterized targets, like `ARG base="path/t
 
 Pants is now able to extract the image ID when building a docker image with a daemon using the containerd-snapshotter feature.
 
-The default version of Hadolint has been updated from 2.10.0 to 2.12.1-beta.
+The default version of Hadolint has been updated from 2.10.0 to 2.12.1-beta. This fixes an segmentation fault error when running on MacOS.
 
 #### Go
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -13,7 +13,13 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ### Highlights
 
 - Support for the Ruff formatter, for both `BUILD` files and normal Python files.
-- The Terraform backend now has built-in support for lockfiles.
+- Built-in support for Terraform lockfiles.
+- Support for more remote-caching providers: file system and GitHub Actions Cache.
+- New helpers for defining "adhoc" code-quality tools, without requiring a full plugin.
+- JVM third-party artifacts can now be read from `pom.xml` files, and other related improvements.
+- Go 1.22 can now be used.
+
+Keep reading to see the details and what's also included.
 
 ### Overall
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -145,11 +145,11 @@ The deprecation for the `[export].symlink_python_virtualenv` option has expired 
 
 #### Terraform
 
-The Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
+The `pants.backend.experimental.terraform` Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
+
+There are now separate target types for [vars files](https://www.pantsbuild.org/2.20/reference/targets/terraform_var_files) and [backend configs](https://www.pantsbuild.org/2.20/reference/targets/terraform_backend), which are handled as normal dependencies in the `dependencies` field. See the new [instructions for Terraform deployments](https://www.pantsbuild.org/2.20/docs/terraform#deployments).
 
 The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1. Pants now has [built-in knowledge of versions up to 1.7.1](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#known_versions), so the version can be overridden by setting [`[download-terraform].version`](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#version) explicitly.
-
-The Terraform backend now has separate target types for vars files and backend configs, and handles these as normal dependencies in the `dependencies` field. See the new [instructions for Terraform deployments](https://www.pantsbuild.org/2.20/docs/terraform#deployments).
 
 
 #### NEW: TypeScript

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -120,6 +120,8 @@ This release brings several changes related to [the pex tool](https://github.com
 - Relatedly, Pants now exposes the recently-added `--check` option that allows being warned in advance if a `pex_binary` target will not be able to be opened by CPython. The [new `check` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#check) allows adjusting the behaviour (default: warn).
 - If a `pex_binary` has [an `entry_point` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#entry_point) that is ambiguous, Pants now treats this as an unowned dependency. Previously this would silently do nothing.
 
+The new [`local_scheme`](https://www.pantsbuild.org/2.20/reference/targets/vcs_version#local_scheme) and [`version_scheme`](https://www.pantsbuild.org/2.20/reference/targets/vcs_version#version_scheme) fields on the `vcs_version` target allow additional customization of its behaviour.
+
 Improvements to dependency inference:
 
 - [Strings imports](https://www.pantsbuild.org/2.20/reference/subsystems/python-infer#string_imports) are handled more reliably, including obeying `pants: no-infer-dep` comments and having fewer false positives on invalid module names.
@@ -199,7 +201,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## New Features
 
-* Add version/local scheme fields to `vcs_version` ([#20446](https://github.com/pantsbuild/pants/pull/20446))
 
 ## Bug Fixes
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -142,6 +142,22 @@ The `pants.backend.experimental.typescript` experimental backend now exists with
 
 ### Plugin API changes
 
+Pants is undergoing a long term project to switch to [a new "call by name" syntax](https://github.com/pantsbuild/pants/issues/19730). There will be a "fix-up" tool once the new syntax is ready for wide-spread use. This release adds supports for positional arguments. ([#20366](https://github.com/pantsbuild/pants/pull/20366))
+
+`AbstractLintRequest` subclasses can now disable lint rules via the `enable_lint_rules` class var, if the automatic linter is not required. ([#20407](https://github.com/pantsbuild/pants/pull/20407))
+
+Plugins loaded from the current repository (by extending `[GLOBAL].pythonpath`) now support specifying their requirements in a `requirements.txt` file adjacent to `register.py`. ([#20355](https://github.com/pantsbuild/pants/pull/20355))
+
+`FrozenDict`s comparison and hashing functions now behave more like the superclass `dict` ones, being order-insensitive and allowing comparison to `dict` itself. ([#20221](https://github.com/pantsbuild/pants/pull/20221))
+
+The documentation has been extended with a few additional examples:
+
+- how to [use `HydratedSources` to convert a list of file and target paths into just file paths](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/rules-and-the-target-api#sourcesfield) ([#20524](https://github.com/pantsbuild/pants/pull/20524))
+- how to [write an integration test that requires loading a backend](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-4-run_pants-integration-tests-for-pants) ([#20451](https://github.com/pantsbuild/pants/pull/20451))
+- how to [write a unit test for a `@rule`](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-2-run_rule_with_mocks-unit-tests-for-rules) ([#20452](https://github.com/pantsbuild/pants/pull/20452))
+
+The deprecation has expired for the `@rule_helper` decorator. To resolve, just remove it: `@rule`s can now call any functions and `async` functions can now call `Get` and `MultiGet` directly.
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases
@@ -169,8 +185,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Plugin API Changes
 
-* Allow AbstractLintRequest subclasses to disable lint rules ([#20407](https://github.com/pantsbuild/pants/pull/20407))
-
 ## Bug Fixes
 
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
@@ -178,12 +192,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## Documentation
 
 * Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
-
-* docs: provide example how to convert target addresses to source files in rules API ([#20524](https://github.com/pantsbuild/pants/pull/20524))
-
-* Add a test case for Pants integration testing docs ([#20451](https://github.com/pantsbuild/pants/pull/20451))
-
-* Add a test case for Pants unit testing docs ([#20452](https://github.com/pantsbuild/pants/pull/20452))
 
 # release_2.20.0.dev7
 
@@ -209,8 +217,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Plugin API Changes
 
-* Add support for positional arguments in by-name `@rule` calls ([#20366](https://github.com/pantsbuild/pants/pull/20366))
-
 ## Performance
 
 ## Documentation
@@ -220,8 +226,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev5
 
 ## Bug Fixes
-
-* fix: in-repo plugin requirements.txt not loading ([#20355](https://github.com/pantsbuild/pants/pull/20355))
 
 # release_2.20.0.dev4
 
@@ -233,8 +237,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Bug Fixes
 
-* Validate that the file content has type bytes ([#20261](https://github.com/pantsbuild/pants/pull/20261))
-
 ## Documentation
 
 * Include guidance on skipping files under Black & isort ([#20262](https://github.com/pantsbuild/pants/pull/20262))
@@ -243,8 +245,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Bug Fixes
 
-* Make FrozenDict comparisons & hash order-insensitive, compare to dict ([#20221](https://github.com/pantsbuild/pants/pull/20221))
-
 # release_2.20.0.dev0
 
 ## New Features
@@ -252,7 +252,5 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
 
 ## Plugin API Changes
-
-* Remove deprecated `@rule_helper` ([#20213](https://github.com/pantsbuild/pants/pull/20213))
 
 ## Bug Fixes

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -39,7 +39,7 @@ The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff form
 
 ### Remote caching/execution
 
-Pants now has experimental support for additional remote cache providers beyond the GRPC Remote Execution API. Set [the `[GLOBAL].remote_provider` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_provider), to be able to use:
+Pants now has experimental support for additional remote cache providers beyond the gRPC Remote Execution API. Set [the `[GLOBAL].remote_provider` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_provider), to be able to use:
 
 - [the GitHub Actions Cache](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#github-actions-cache)
 - [a local directory](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#local-file-system)

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -106,6 +106,29 @@ Several improvements have been made to Pants' support for Ruff:
 - Pants now automatically finds Ruff configuration in `pyproject.toml` files in subdirectories, for instance, `python/pyproject.toml`.
 - Pants' built-in default version has been updated to 0.2.1.
 
+This release brings several changes related to [the pex tool](https://github.com/pex-tool/pex) and `pex_binary` targets:
+
+- It has been updated to to 2.1.163 by default. The minimum supported version is now 2.1.148.
+- The [new `sh_boot` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#sh_boot) allows opting in to using a shell script rather than a Python script, which can be faster and more reliable in some cases.
+- The [new `executable` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#executable) on `pex_binary` targets exposes pex's `--executable` option.
+- The [new `[pex].emit_warnings` option](https://www.pantsbuild.org/2.20/reference/subsystems/pex#emit_warnings) allows controlling whether warnings from pex invocations are shown or not.
+- The [existing `emit_warnings` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#emit_warnings) on `pex_binary` targets now works as described, when set to `True`.
+- Relatedly, Pants now exposes the recently-added `--check` option that allows being warned in advance if a `pex_binary` target will not be able to be opened by CPython. The [new `check` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#check) allows adjusting the behaviour (default: warn).
+- If a `pex_binary` has [an `entry_point` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#entry_point) that is ambiguous, Pants now treats this as an unowned dependency. Previously this would silently do nothing.
+
+Improvements to dependency inference:
+
+- [Strings imports](https://www.pantsbuild.org/2.20/reference/subsystems/python-infer#string_imports) are handled more reliably, including obeying `pants: no-infer-dep` comments and having fewer false positives on invalid module names.
+- Django-specific dependency inference (via the `pants.backend.experimental.python.framework.django` backend) now infers migrations and management commands as dependencies of `apps.py`.
+
+[The `pants.backend.codegen.protobuf.python` backend](https://www.pantsbuild.org/2.20/docs/python/integrations/protobuf-and-grpc) now supports [using `grpclib`](https://www.pantsbuild.org/2.20/docs/python/integrations/protobuf-and-grpc#use-alternative-grpc-plugins) in addition to `grpcio` for generating GRPC service stubs.
+
+Default module mappings were added for more modules: `django-countries`, `django-fsm`, `django-object-actions`, `django-postgres-extra`, `django-redis`, `django-scim2`, `djangorestframework-api-key`, `djangorestframework-queryfields`, `google-api-python-client`, `google-auth`, `grpcio-health-checking`, `grpcio-reflection`, `honeycomb-opentelemetry`, `opencv-python-headless`, `opentelemetry-sdk` (expanded to cover more modules). The special `_typeshed` module no longer has errors if imported.
+
+`pip list` now behaves correctly in venvs created via `export` with [the `[export].py_editable_in_resolve` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_editable_in_resolve) enabled.
+
+The deprecation for the `[export].symlink_python_virtualenv` option has expired and it has been removed. Instead set [the `[export].py_resolve_format` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_resolve_format) to `symlinked_immutable_virtualenv`.
+
 #### Terraform
 
 The Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
@@ -130,8 +153,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Resolve adhoc_tool, code_quality_tool execution dependencies relative to target location (Cherry-pick of #20581) ([#20608](https://github.com/pantsbuild/pants/pull/20608))
 
-* Silence warnings from Pex by default, for now (Cherry-pick of #20590) ([#20593](https://github.com/pantsbuild/pants/pull/20593))
-
 * Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
 
 * Remove asm -compiling-runtime flag for go 1.22+ compatible versions (Cherry-pick of #20554) ([#20562](https://github.com/pantsbuild/pants/pull/20562))
@@ -146,51 +167,19 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## New Features
 
-* add more module mappings for popular packages ([#20551](https://github.com/pantsbuild/pants/pull/20551))
-
-* python: respect closed option when exporting dependency graph as JSON ([#20523](https://github.com/pantsbuild/pants/pull/20523))
-
-* Add support for the pex `--executable` argument ([#20497](https://github.com/pantsbuild/pants/pull/20497))
-
-* python: improve error message when parsing Python interpreter constraints ([#20297](https://github.com/pantsbuild/pants/pull/20297))
-
-* python: add _typeshed module to the list of unowned dependencies ([#20468](https://github.com/pantsbuild/pants/pull/20468))
-
 ## Plugin API Changes
 
 * Allow AbstractLintRequest subclasses to disable lint rules ([#20407](https://github.com/pantsbuild/pants/pull/20407))
 
 ## Bug Fixes
 
-* stop swallowing warnings from Pex by default ([#20480](https://github.com/pantsbuild/pants/pull/20480))
-
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
-
-* Fix formatting of the "pex.platforms is deprecated" message ([#20514](https://github.com/pantsbuild/pants/pull/20514))
-
-* Handle unresolved ambiguous entrypoint dependency for PEX as unowned dependency ([#20390](https://github.com/pantsbuild/pants/pull/20390))
-
-* plumb through Pex's --check zipapp validation ([#20481](https://github.com/pantsbuild/pants/pull/20481))
-
-* add module mapping overrides for some django-* modules ([#20504](https://github.com/pantsbuild/pants/pull/20504))
-
-* upgrade Pex to 2.1.163 ([#20502](https://github.com/pantsbuild/pants/pull/20502))
-
-* upgrade Pex to 2.1.162 ([#20496](https://github.com/pantsbuild/pants/pull/20496))
-
-* Fix direct_url in python PEP660 editable wheels ([#20486](https://github.com/pantsbuild/pants/pull/20486))
-
-* python-infer: respect ignore pragma w/ strings ([#20477](https://github.com/pantsbuild/pants/pull/20477))
-
-* python-infer: Avoid false positive strings ([#20472](https://github.com/pantsbuild/pants/pull/20472))
 
 ## Documentation
 
 * Fix reference to default_run_goal_use_sandbox option in docs. ([#20546](https://github.com/pantsbuild/pants/pull/20546))
 
 * docs: provide example how to convert target addresses to source files in rules API ([#20524](https://github.com/pantsbuild/pants/pull/20524))
-
-* Fix Pex references to point to new home. ([#20519](https://github.com/pantsbuild/pants/pull/20519))
 
 * Add a test case for Pants integration testing docs ([#20451](https://github.com/pantsbuild/pants/pull/20451))
 
@@ -201,10 +190,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Add version/local scheme fields to `vcs_version` ([#20446](https://github.com/pantsbuild/pants/pull/20446))
-
-* upgrade PEX to 2.1.159 ([#20416](https://github.com/pantsbuild/pants/pull/20416))
-
-* python-protobuf backend now support multiple protoc plugins. ([#20387](https://github.com/pantsbuild/pants/pull/20387))
 
 ## Bug Fixes
 
@@ -222,23 +207,13 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0.dev6
 
-## New Features
-
-* plumb sh-boot through to pex_binary ([#19925](https://github.com/pantsbuild/pants/pull/19925))
-
 ## Plugin API Changes
 
 * Add support for positional arguments in by-name `@rule` calls ([#20366](https://github.com/pantsbuild/pants/pull/20366))
 
 ## Performance
 
-* Upgrade to PEX 2.1.156 ([#20391](https://github.com/pantsbuild/pants/pull/20391))
-
-* Update to Pex 2.1.155 ([#20347](https://github.com/pantsbuild/pants/pull/20347))
-
 ## Documentation
-
-* docs: update python test coverage docs ([#20335](https://github.com/pantsbuild/pants/pull/20335))
 
 * Update the docs on how to profile Pants. ([#20334](https://github.com/pantsbuild/pants/pull/20334))
 
@@ -266,10 +241,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 # release_2.20.0.dev1
 
-## New Features
-
-* Infers Django migrations and management commands as dependencies of `apps.py` ([#20250](https://github.com/pantsbuild/pants/pull/20250))
-
 ## Bug Fixes
 
 * Make FrozenDict comparisons & hash order-insensitive, compare to dict ([#20221](https://github.com/pantsbuild/pants/pull/20221))
@@ -279,10 +250,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
-
-## User API Changes
-
-* Remove deprecated `[export].symlink_python_virtualenv` option ([#20214](https://github.com/pantsbuild/pants/pull/20214))
 
 ## Plugin API Changes
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -149,6 +149,8 @@ The Terraform backend now has [built-in support for lockfiles](https://www.pants
 
 The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1. Pants now has [built-in knowledge of versions up to 1.7.1](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#known_versions), so the version can be overridden by setting [`[download-terraform].version`](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#version) explicitly.
 
+The Terraform backend now has separate target types for vars files and backend configs, and handles these as normal dependencies in the `dependencies` field. See the new [instructions for Terraform deployments](https://www.pantsbuild.org/2.20/docs/terraform#deployments).
+
 
 #### NEW: TypeScript
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -22,6 +22,14 @@ The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff form
 
 ### Backends
 
+#### Helm
+
+The [new `lint_quiet` field](https://www.pantsbuild.org/2.20/reference/targets/helm_chart#lint_quiet) on `helm_chart` allows passing `--quiet` to `helm lint ...`.
+
+The `repository` field on `helm_chart` now allows trailing slashes.
+
+The `--timeout` flag can now be passed through to `helm upgrade` operations.
+
 #### Python
 
 Several improvements have been made to Pants' support for Ruff:
@@ -268,8 +276,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## New Features
 
-* helm: add option to pass `--quiet` when linting charts ([#20204](https://github.com/pantsbuild/pants/pull/20204))
-
 * Allow passing arbitrary args to PEX invocation when building FaaS artifacts ([#20237](https://github.com/pantsbuild/pants/pull/20237))
 
 ## Bug Fixes
@@ -285,8 +291,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 # release_2.20.0.dev2
 
 ## New Features
-
-* allow passing --timeout along to helm commands ([#20273](https://github.com/pantsbuild/pants/pull/20273))
 
 * Add support for Scalac plugins in BSP ([#20267](https://github.com/pantsbuild/pants/pull/20267))
 
@@ -355,5 +359,3 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Do not choke on values from macros on environment targets during bootstrap. ([#20191](https://github.com/pantsbuild/pants/pull/20191))
 
 * Use a Zulu JDK 8 to run the Kotlin analyzer. ([#20184](https://github.com/pantsbuild/pants/pull/20184))
-
-* Fix: support helm repos with trailing slashes ([#20177](https://github.com/pantsbuild/pants/pull/20177))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -139,6 +139,8 @@ Default module mappings were added for more modules: `django-countries`, `django
 
 `pip list` now behaves correctly in venvs created via `export` with [the `[export].py_editable_in_resolve` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_editable_in_resolve) enabled.
 
+There is now documentation on how to [exclude files from Black or isort](https://www.pantsbuild.org/2.20/docs/python/overview/linters-and-formatters#black-and-isort-excluding-files).
+
 The deprecation for the `[export].symlink_python_virtualenv` option has expired and it has been removed. Instead set [the `[export].py_resolve_format` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_resolve_format) to `symlinked_immutable_virtualenv`.
 
 #### Terraform
@@ -176,16 +178,3 @@ The deprecation has expired for the `@rule_helper` decorator. To resolve, just r
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases
-
-
-# release_2.20.0rc0
-
-## Documentation
-
-* Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
-
-# release_2.20.0.dev2
-
-## Documentation
-
-* Include guidance on skipping files under Black & isort ([#20262](https://github.com/pantsbuild/pants/pull/20262))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -23,6 +23,16 @@ The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff form
 
 ### Backends
 
+#### Docker
+
+The [new `{full_directory}` interpolation](https://www.pantsbuild.org/2.20/docs/docker/tagging-docker-images#setting-a-repository-name) in `repository` and `default_repository` options expands to the full path to the `BUILD` file that contains a `docker_image` target.
+
+Dependency inference now works for parameterized targets, like `ARG base="path/to:target@param=value"`.
+
+Pants is now able to extract the image ID when building a docker image with a daemon using the containerd-snapshotter feature.
+
+The default version of Hadolint has been updated from 2.10.0 to 2.12.1-beta.
+
 #### Helm
 
 The [new `lint_quiet` field](https://www.pantsbuild.org/2.20/reference/targets/helm_chart#lint_quiet) on `helm_chart` allows passing `--quiet` to `helm lint ...`.
@@ -73,12 +83,6 @@ The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1.
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases
 
 
-# release_2.20.0rc1
-
-## Bug Fixes
-
-* Docker: fix base image dependency inference for parametrized targets. (Cherry-pick of #20633) ([#20657](https://github.com/pantsbuild/pants/pull/20657))
-
 # release_2.20.0rc0
 
 ## Bug Fixes
@@ -104,8 +108,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * add more module mappings for popular packages ([#20551](https://github.com/pantsbuild/pants/pull/20551))
-
-* Docker: Add `full_directory` interpolation value for repository configuration. ([#20530](https://github.com/pantsbuild/pants/pull/20530))
 
 * stats: add output_file option to output the stats to a file ([#20512](https://github.com/pantsbuild/pants/pull/20512))
 
@@ -135,8 +137,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * javascript: fix running scripts with yarn ([#20543](https://github.com/pantsbuild/pants/pull/20543))
 
-* docker: fix missing image_id when using containerd-snapshotter ([#20533](https://github.com/pantsbuild/pants/pull/20533))
-
 * Bump PyO3 to 0.20 to fix backtraces ([#20517](https://github.com/pantsbuild/pants/pull/20517))
 
 * Fix formatting of the "pex.platforms is deprecated" message ([#20514](https://github.com/pantsbuild/pants/pull/20514))
@@ -160,8 +160,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * python-infer: Avoid false positive strings ([#20472](https://github.com/pantsbuild/pants/pull/20472))
 
 * Don't eagerly merge configs. ([#20459](https://github.com/pantsbuild/pants/pull/20459))
-
-* Docker: Update hadolint version to fix segmentation fault issue ([#20456](https://github.com/pantsbuild/pants/pull/20456))
 
 ## Documentation
 
@@ -219,8 +217,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Fix the weird headings of `initial-configuration.mdx` ([#20422](https://github.com/pantsbuild/pants/pull/20422))
 
-* Update docker docs for buildx ([#20413](https://github.com/pantsbuild/pants/pull/20413))
-
 * What's new in 2.19 ([#20310](https://github.com/pantsbuild/pants/pull/20310))
 
 * Rename 'environments' docs file/URL to be simpler ([#20404](https://github.com/pantsbuild/pants/pull/20404))
@@ -263,11 +259,7 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Bug Fixes
 
-* Make docker_environment's Pants-provided-PBS an absolute path ([#20314](https://github.com/pantsbuild/pants/pull/20314))
-
 * Fix algorithm for gathering prebuilt Go object files ([#20332](https://github.com/pantsbuild/pants/pull/20332))
-
-* Allow docker image pulling without creds ([#20307](https://github.com/pantsbuild/pants/pull/20307))
 
 * Ensure `experimental_test_shell_command` runs in relevant environment ([#20319](https://github.com/pantsbuild/pants/pull/20319))
 
@@ -325,8 +317,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 ## Documentation
 
-* Add note in docker_environment image field help on tool requirements ([#20231](https://github.com/pantsbuild/pants/pull/20231))
-
 * Add link to talk at Hamburg Python Pizza ([#20223](https://github.com/pantsbuild/pants/pull/20223))
 
 # release_2.20.0.dev0
@@ -334,8 +324,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
-
-* Add docker image output field to support publish to repository when using BuildKit ([#20154](https://github.com/pantsbuild/pants/pull/20154))
 
 ## User API Changes
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -217,10 +217,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Fix the weird headings of `initial-configuration.mdx` ([#20422](https://github.com/pantsbuild/pants/pull/20422))
 
-* What's new in 2.19 ([#20310](https://github.com/pantsbuild/pants/pull/20310))
-
-* Rename 'environments' docs file/URL to be simpler ([#20404](https://github.com/pantsbuild/pants/pull/20404))
-
 # release_2.20.0.dev6
 
 ## New Features
@@ -261,8 +257,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Fix algorithm for gathering prebuilt Go object files ([#20332](https://github.com/pantsbuild/pants/pull/20332))
 
-* Ensure `experimental_test_shell_command` runs in relevant environment ([#20319](https://github.com/pantsbuild/pants/pull/20319))
-
 ## Documentation
 
 * Update team.md ([#20329](https://github.com/pantsbuild/pants/pull/20329))
@@ -270,10 +264,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Change the slug of the Shell backend doc. ([#20326](https://github.com/pantsbuild/pants/pull/20326))
 
 # release_2.20.0.dev3
-
-## New Features
-
-* Allow passing arbitrary args to PEX invocation when building FaaS artifacts ([#20237](https://github.com/pantsbuild/pants/pull/20237))
 
 ## Documentation
 
@@ -286,8 +276,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * typescript: add tailor goal ([#20252](https://github.com/pantsbuild/pants/pull/20252))
 
 ## Bug Fixes
-
-* Use fork of indicatif to work around output truncation ([#20269](https://github.com/pantsbuild/pants/pull/20269))
 
 * Validate that the file content has type bytes ([#20261](https://github.com/pantsbuild/pants/pull/20261))
 
@@ -310,8 +298,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Add `remote_oauth_bearer_token` option, deprecating `remote_oauth_bearer_token_path` ([#20116](https://github.com/pantsbuild/pants/pull/20116))
 
 ## Bug Fixes
-
-* Fix wrong jar path given to shade jar process ([#20239](https://github.com/pantsbuild/pants/pull/20239))
 
 * Make FrozenDict comparisons & hash order-insensitive, compare to dict ([#20221](https://github.com/pantsbuild/pants/pull/20221))
 
@@ -336,7 +322,3 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## Bug Fixes
 
 * Support inferring JS deps from `export ... from ...` statements ([#20190](https://github.com/pantsbuild/pants/pull/20190))
-
-* Remove print() statement ([#20196](https://github.com/pantsbuild/pants/pull/20196))
-
-* Do not choke on values from macros on environment targets during bootstrap. ([#20191](https://github.com/pantsbuild/pants/pull/20191))

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -1,0 +1,23 @@
+# 2.20.x Release Series
+
+Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
+
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+## What's New
+
+### Highlights
+
+### Overall
+
+### Backends
+
+### Plugin API changes
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -12,9 +12,24 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Highlights
 
+- Support for the Ruff formatter, for both `BUILD` files and normal Python files.
+
 ### Overall
 
+### BUILD files
+
+The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format `BUILD` files.
+
 ### Backends
+
+#### Python
+
+Several improvements have been made to Pants' support for Ruff:
+
+- The new `pants.backend.experimental.python.lint.ruff.format` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format Python files.
+- The existing `pants.backend.experimental.python.lint.ruff` linter backend has been renamed to `pants.backend.experimental.python.lint.ruff.check`, and its tool ID (as used by commands like `pants lint --only=...`) has changed from `ruff` to `ruff-check`.
+- Pants now automatically finds Ruff configuration in `pyproject.toml` files in subdirectories, for instance, `python/pyproject.toml`.
+- Pants' built-in default version has been updated to 0.2.1.
 
 ### Plugin API changes
 
@@ -40,8 +55,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Fix update build files formatter selection (Cherry-pick of #20580) ([#20582](https://github.com/pantsbuild/pants/pull/20582))
 
 * Remove asm -compiling-runtime flag for go 1.22+ compatible versions (Cherry-pick of #20554) ([#20562](https://github.com/pantsbuild/pants/pull/20562))
-
-* Add all new Ruff backends to list of plugins (Cherry-pick of #20555) ([#20556](https://github.com/pantsbuild/pants/pull/20556))
 
 ## Documentation
 
@@ -73,8 +86,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * upgrade known terraform versions ([#20469](https://github.com/pantsbuild/pants/pull/20469))
 
-* Allow using Ruff to format BUILD files ([#20411](https://github.com/pantsbuild/pants/pull/20411))
-
 * options: do not ignore .github directory with pants_ignore ([#20471](https://github.com/pantsbuild/pants/pull/20471))
 
 * Add (optional) support for podman. ([#20470](https://github.com/pantsbuild/pants/pull/20470))
@@ -86,10 +97,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Extend dependents goal with output format to support JSON ([#20453](https://github.com/pantsbuild/pants/pull/20453))
 
 * Extend dependencies goal with output format to support JSON ([#20443](https://github.com/pantsbuild/pants/pull/20443))
-
-## User API Changes
-
-* Update built-in ruff 0.1.6 -> 0.2.1 ([#20499](https://github.com/pantsbuild/pants/pull/20499))
 
 ## Plugin API Changes
 
@@ -122,8 +129,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 * Fix direct_url in python PEP660 editable wheels ([#20486](https://github.com/pantsbuild/pants/pull/20486))
 
 * python-infer: respect ignore pragma w/ strings ([#20477](https://github.com/pantsbuild/pants/pull/20477))
-
-* Introduce `ruff-check` and `ruff-format` tool ids ([#20358](https://github.com/pantsbuild/pants/pull/20358))
 
 * python-infer: Avoid false positive strings ([#20472](https://github.com/pantsbuild/pants/pull/20472))
 
@@ -307,11 +312,7 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Infers Django migrations and management commands as dependencies of `apps.py` ([#20250](https://github.com/pantsbuild/pants/pull/20250))
 
-* Discover Ruff config in pyproject.toml in subdirectories ([#20248](https://github.com/pantsbuild/pants/pull/20248))
-
 ## User API Changes
-
-* Update to Ruff 0.1.6 ([#20249](https://github.com/pantsbuild/pants/pull/20249))
 
 * Add `remote_oauth_bearer_token` option, deprecating `remote_oauth_bearer_token_path` ([#20116](https://github.com/pantsbuild/pants/pull/20116))
 
@@ -332,8 +333,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 ## New Features
 
 * Code Quality Tool Lib ([#20135](https://github.com/pantsbuild/pants/pull/20135))
-
-* Python: Enable code formatting using Ruff ([#20098](https://github.com/pantsbuild/pants/pull/20098))
 
 * Add docker image output field to support publish to repository when using BuildKit ([#20154](https://github.com/pantsbuild/pants/pull/20154))
 

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -184,12 +184,6 @@ For the full changelog, see the individual GitHub Releases for this series: http
 
 * Document the need for migrating tool to user lockfiles for export (Cherry-pick of #20604) ([#20613](https://github.com/pantsbuild/pants/pull/20613))
 
-# release_2.20.0.dev7
-
-## Bug Fixes
-
-* Fix issue with grouping parametrizations on target generators. ([#20429](https://github.com/pantsbuild/pants/pull/20429))
-
 # release_2.20.0.dev2
 
 ## Documentation


### PR DESCRIPTION
This was created by collecting the release notes of all 2.20.x releases up to 2.20.0rc1 and converting that into "What's new" style documentation.

Part of #20578