### PR TITLE
Bundle OpenAPI files as a single resource

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -26,7 +26,7 @@ Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.exper
 
 #### OpenAPI
 
-The `openapi_document` target will now bundle itself and its `openapi_source` dependencies into a single file when dependent on by other targets. Do note that this change will make the `openapi_document` target behave more like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.
+The `openapi_document` target will now bundle itself and its `openapi_source` dependencies into a single file when depended on by other targets. Do note that this change will make the `openapi_document` target behave more like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.
 
 #### Python
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -24,6 +24,10 @@ Keep reading to see the details and what's also included.
 
 Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.
 
+#### OpenAPI
+
+The `openapi_document` target will now bundle itself and its `openapi_source` dependencies into a single file when dependent on by other targets. Do note that this change will make the `openapi_document` target behave more like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.
+
 #### Python
 
 [The `pants.backend.experimental.python.lint.ruff` backend](https://www.pantsbuild.org/2.22/reference/subsystems/ruff) now uses version 0.4.1 by default.

--- a/src/python/pants/backend/experimental/openapi/register.py
+++ b/src/python/pants/backend/experimental/openapi/register.py
@@ -14,13 +14,19 @@ from pants.backend.openapi.target_types import (
     OpenApiSourceTarget,
 )
 from pants.backend.openapi.target_types import rules as target_types_rules
+from pants.backend.openapi.util_rules import openapi_document
 from pants.engine.rules import Rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return [*dependency_inference.rules(), *tailor.rules(), *target_types_rules()]
+    return [
+        *dependency_inference.rules(),
+        *openapi_document.rules(),
+        *tailor.rules(),
+        *target_types_rules(),
+    ]
 
 
 def target_types() -> Iterable[type[Target]]:

--- a/src/python/pants/backend/openapi/subsystems/redocly.py
+++ b/src/python/pants/backend/openapi/subsystems/redocly.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from pants.backend.javascript.subsystems.nodejs_tool import NodeJSToolBase
+
+
+class Redocly(NodeJSToolBase):
+    options_scope = "redocly"
+    name = "redocly"
+    help = "Redocly CLI toolbox with rich validation and bundling features (https://github.com/Redocly/redocly-cli)."
+
+    default_version = "@redocly/cli@1.10.5"

--- a/src/python/pants/backend/openapi/util_rules/openapi_document.py
+++ b/src/python/pants/backend/openapi/util_rules/openapi_document.py
@@ -1,0 +1,116 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from pathlib import PurePath
+
+from pants.backend.javascript.subsystems import nodejs_tool
+from pants.backend.javascript.subsystems.nodejs_tool import NodeJSToolRequest
+from pants.backend.openapi.subsystems.redocly import Redocly
+from pants.backend.openapi.target_types import (
+    OpenApiDocumentField,
+    OpenApiDocumentGeneratorTarget,
+    OpenApiDocumentTarget,
+    OpenApiSourceField,
+)
+from pants.core.target_types import ResourceSourceField
+from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
+from pants.engine.internals.native_engine import AddPrefix, Digest, Snapshot
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.process import ProcessResult
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    GeneratedSources,
+    GenerateSourcesRequest,
+    StringField,
+    TransitiveTargets,
+    TransitiveTargetsRequest,
+)
+from pants.engine.unions import UnionRule
+from pants.source.source_root import SourceRoot, SourceRootRequest
+from pants.util.logging import LogLevel
+from pants.util.strutil import help_text, pluralize
+
+
+class BundleOpenApiDocumentRequest(GenerateSourcesRequest):
+    input = OpenApiDocumentField
+    output = ResourceSourceField
+
+
+class BundleSourceRootField(StringField):
+    alias = "bundle_source_root"
+    help = help_text(
+        """
+        The source root to bundle OpenAPI documents under.
+
+        If unspecified, the source root the `openapi_documents` is under will be used.
+        """
+    )
+
+
+@rule
+async def bundle_openapi_document(
+    request: BundleOpenApiDocumentRequest, redocly: Redocly
+) -> GeneratedSources:
+    target = request.protocol_target
+    bundle_source_root = request.protocol_target.get(BundleSourceRootField).value
+    transitive_targets = await Get(TransitiveTargets, TransitiveTargetsRequest([target.address]))
+    source_root_request = Get(
+        SourceRoot,
+        SourceRootRequest,
+        SourceRootRequest(PurePath(bundle_source_root))
+        if bundle_source_root
+        else SourceRootRequest.for_target(request.protocol_target),
+    )
+
+    target_stripped_sources_request = Get(
+        StrippedSourceFiles, SourceFilesRequest([target[OpenApiDocumentField]])
+    )
+    all_stripped_sources_request = Get(
+        StrippedSourceFiles,
+        SourceFilesRequest(
+            tgt[OpenApiSourceField]
+            for tgt in transitive_targets.closure
+            if tgt.has_field(OpenApiSourceField)
+        ),
+    )
+
+    source_root, target_stripped_sources, all_stripped_sources = await MultiGet(
+        source_root_request,
+        target_stripped_sources_request,
+        all_stripped_sources_request,
+    )
+
+    result = await Get(
+        ProcessResult,
+        NodeJSToolRequest,
+        redocly.request(
+            args=(
+                "bundle",
+                target_stripped_sources.snapshot.files[0],
+                "-o",
+                target_stripped_sources.snapshot.files[0],
+            ),
+            input_digest=all_stripped_sources.snapshot.digest,
+            output_files=(target_stripped_sources.snapshot.files[0],),
+            description=f"Run redocly on {pluralize(len(target_stripped_sources.snapshot.files), 'file')}.",
+            level=LogLevel.DEBUG,
+        ),
+    )
+
+    source_root_restored = (
+        await Get(Snapshot, AddPrefix(result.output_digest, source_root.path))
+        if source_root.path != "."
+        else await Get(Snapshot, Digest, result.output_digest)
+    )
+
+    return GeneratedSources(source_root_restored)
+
+
+def rules():
+    return (
+        *collect_rules(),
+        *nodejs_tool.rules(),
+        UnionRule(GenerateSourcesRequest, BundleOpenApiDocumentRequest),
+        OpenApiDocumentTarget.register_plugin_field(BundleSourceRootField),
+        OpenApiDocumentGeneratorTarget.register_plugin_field(BundleSourceRootField),
+    )

--- a/src/python/pants/backend/openapi/util_rules/openapi_document_test.py
+++ b/src/python/pants/backend/openapi/util_rules/openapi_document_test.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from pants.backend.openapi import dependency_inference
+from pants.backend.openapi.subsystems.redocly import Redocly
+from pants.backend.openapi.target_types import (
+    OpenApiDocumentField,
+    OpenApiDocumentGeneratorTarget,
+    OpenApiSourceGeneratorTarget,
+)
+from pants.backend.openapi.target_types import rules as target_types_rules
+from pants.backend.openapi.util_rules.openapi_document import BundleOpenApiDocumentRequest
+from pants.backend.openapi.util_rules.openapi_document import rules as openapi_document_rules
+from pants.core.util_rules import stripped_source_files
+from pants.engine.addresses import Address
+from pants.engine.fs import DigestContents
+from pants.engine.target import GeneratedSources, HydratedSources, HydrateSourcesRequest
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *target_types_rules(),
+            *openapi_document_rules(),
+            *dependency_inference.rules(),
+            *stripped_source_files.rules(),
+            QueryRule(HydratedSources, [HydrateSourcesRequest]),
+            QueryRule(GeneratedSources, [BundleOpenApiDocumentRequest, Redocly]),
+        ],
+        target_types=[OpenApiSourceGeneratorTarget, OpenApiDocumentGeneratorTarget],
+    )
+
+
+def assert_files_generated(
+    rule_runner: RuleRunner,
+    address: Address,
+    *,
+    expected_files: dict[str, bytes],
+    source_roots: list[str],
+    extra_args: list[str] | None = None,
+) -> None:
+    args = [
+        f"--source-root-patterns={repr(source_roots)}",
+        *(extra_args or ()),
+    ]
+    rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    tgt = rule_runner.get_target(address)
+    protocol_sources = rule_runner.request(
+        HydratedSources, [HydrateSourcesRequest(tgt[OpenApiDocumentField])]
+    )
+    generated_sources = rule_runner.request(
+        GeneratedSources,
+        [BundleOpenApiDocumentRequest(protocol_sources.snapshot, tgt)],
+    )
+
+    assert set(generated_sources.snapshot.files) == set(expected_files.keys())
+
+    generated_sources_contents = rule_runner.request(
+        DigestContents, [generated_sources.snapshot.digest]
+    )
+
+    for file_content in generated_sources_contents:
+        assert file_content.content == expected_files[file_content.path]
+
+
+def test_bundle(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/openapi/foo/BUILD": 'openapi_sources()\nopenapi_documents(name="openapi")\n',
+            "src/openapi/foo/openapi.json": textwrap.dedent(
+                """\
+            {
+              "openapi": "3.0.0",
+              "components": {
+                "schemas": {
+                  "$ref": "bar/models.json"
+                }
+              }
+            }"""
+            ),
+            "src/openapi/foo/bar/BUILD": "openapi_sources()\n",
+            "src/openapi/foo/bar/models.json": '{"bar": "baz"}\n',
+        }
+    )
+
+    assert_files_generated(
+        rule_runner,
+        Address("src/openapi/foo", target_name="openapi", relative_file_path="openapi.json"),
+        source_roots=["src/openapi"],
+        expected_files={
+            "src/openapi/foo/openapi.json": textwrap.dedent(
+                """\
+            {
+              "openapi": "3.0.0",
+              "components": {
+                "schemas": {
+                  "bar": "baz"
+                }
+              }
+            }"""
+            ).encode(),
+        },
+    )
+
+
+def test_bundle_with_source_root(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/openapi/foo/BUILD": 'openapi_sources()\nopenapi_documents(name="openapi", bundle_source_root="src/python")\n',
+            "src/openapi/foo/openapi.json": textwrap.dedent(
+                """\
+            {
+              "openapi": "3.0.0",
+              "components": {
+                "schemas": {
+                  "$ref": "bar/models.json"
+                }
+              }
+            }"""
+            ),
+            "src/openapi/foo/bar/BUILD": "openapi_sources()\n",
+            "src/openapi/foo/bar/models.json": '{"bar": "baz"}\n',
+        }
+    )
+
+    assert_files_generated(
+        rule_runner,
+        Address("src/openapi/foo", target_name="openapi", relative_file_path="openapi.json"),
+        source_roots=["src/openapi", "src/python"],
+        expected_files={
+            "src/python/foo/openapi.json": textwrap.dedent(
+                """\
+            {
+              "openapi": "3.0.0",
+              "components": {
+                "schemas": {
+                  "bar": "baz"
+                }
+              }
+            }"""
+            ).encode(),
+        },
+    )


### PR DESCRIPTION
An old branch I decided to dust off and finish.  🧹

The OpenAPI targets were a great addition to allow futher OpenAPI-related functionality in Pants (codegen, linters, etc.), but I failed to dogfood them for my own use case. My problem with the current implementation is that it's hard to use an `openapi_document` as a dependency of a `python_source` due to it behaving more or less like a `file()` would.

At work we currently have all our API descriptions as `resource()` so they're bundled with the Python code that uses them for request validation and whatnot. With `openapi_document` this would require you to manually specify your `openapi_document` and all its `openapi_source` dependencies as inputs to `experimental_wrap_as_resources`, which is annoying when the OpenAPI targets all have dependency inference.

This PR uses codegen and `redocly bundle` to bundle an `openapi_document` and its `openapi_source`s into a single file when the `openapi_document` is needed as a dependency by another target. This allow developers to keep their multi-file approach when writing the API description, existing OpenAPI backends will (should?) continue to work as-is, but when consuming it elsewhere as a dependency they now only have to care about one single OpenAPI file.

I initially wrote this code back when `experimental_wrap_as_resources` didn't exist and `openapi_document` was (in our case) unusable, which is why I made it part of the main OpenAPI backend (and thus enforced). Nowadays you can, as I mentioned, likely get work around the issue with `experimental_wrap_as_resources` - so maybe it's better to move this functionality into its own, opt-in, backend? That being said, resolving `$ref`s in a multi-file approach is _tricky_ to get right, which is why a lot of OpenAPI tools don't even bother supporting it (or behave differently), so Pants "always" passing a single file around could be seen as a good thing. 🤷

Edit: `redocly bundle` could also be useful as a package goal to prepare the API definition for distribution by dereferencing includes, stripping `x-internal` paths etc., but that's a separate feature.

