### PR TITLE
Switch OptionId from a tuple struct to named fields.

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -35,7 +35,7 @@ impl Args {
                 Negate::False => "",
                 Negate::True => "no-",
             },
-            match &id.0 {
+            match &id.scope {
                 Scope::Global => "".to_string(),
                 Scope::Scope(scope) => format!("{}-", scope.to_ascii_lowercase()),
             },
@@ -45,10 +45,10 @@ impl Args {
 
     fn arg_names(id: &OptionId, negate: Negate) -> HashMap<String, bool> {
         let mut arg_names = HashMap::new();
-        if let Some(switch) = id.2 {
-            arg_names.insert(format!("-{switch}"), false);
+        if let Some(short_name) = &id.short_name {
+            arg_names.insert(format!("-{short_name}"), false);
             if negate == Negate::True {
-                arg_names.insert(format!("--no-{switch}"), true);
+                arg_names.insert(format!("--no-{short_name}"), true);
             }
         }
         arg_names.insert(Self::arg_name(id, Negate::False), false);

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -321,7 +321,7 @@ impl Config {
 
     fn get_value(&self, id: &OptionId) -> Option<&Value> {
         self.value
-            .get(id.scope())
+            .get(id.scope.name())
             .and_then(|table| table.get(Self::option_name(id)))
     }
 
@@ -330,7 +330,7 @@ impl Config {
         id: &OptionId,
     ) -> Result<Option<Vec<ListEdit<T>>>, String> {
         let mut list_edits = vec![];
-        if let Some(table) = self.value.get(id.scope()) {
+        if let Some(table) = self.value.get(id.scope.name()) {
             let option_name = Self::option_name(id);
             if let Some(value) = table.get(&option_name) {
                 match value {
@@ -415,7 +415,7 @@ impl OptionsSource for Config {
     }
 
     fn get_dict(&self, id: &OptionId) -> Result<Option<DictEdit>, String> {
-        if let Some(table) = self.value.get(id.scope()) {
+        if let Some(table) = self.value.get(id.scope.name()) {
             let option_name = Self::option_name(id);
             if let Some(value) = table.get(&option_name) {
                 match value {

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -55,10 +55,10 @@ impl Env {
         let name = id.name("_", NameTransform::ToUpper);
         let mut names = vec![format!(
             "PANTS_{}_{}",
-            id.0.name().replace('-', "_").to_ascii_uppercase(),
+            id.scope.name().replace('-', "_").to_ascii_uppercase(),
             name
         )];
-        if id.0 == Scope::Global {
+        if id.scope == Scope::Global {
             names.push(format!("PANTS_{name}"));
         }
         if name.starts_with("PANTS_") {

--- a/src/rust/engine/options/src/id.rs
+++ b/src/rust/engine/options/src/id.rs
@@ -27,17 +27,17 @@ impl Scope {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct OptionId(
-    pub(crate) Scope,
-    pub(crate) Vec<String>,
-    pub(crate) Option<char>,
-);
+pub struct OptionId {
+    pub(crate) scope: Scope,
+    pub(crate) name_components: Vec<String>,
+    pub(crate) short_name: Option<String>,
+}
 
 impl OptionId {
     pub fn new<Component, Name>(
         scope: Scope,
         name: Name,
-        switch: Option<char>,
+        short_name: Option<char>,
     ) -> Result<OptionId, String>
     where
         Component: AsRef<str>,
@@ -51,7 +51,11 @@ impl OptionId {
                 "Cannot create an OptionId with an empty name. Given a scope of {scope:?}."
             ));
         }
-        Ok(OptionId(scope, name_components, switch))
+        Ok(OptionId {
+            scope,
+            name_components,
+            short_name: short_name.map(|c| c.to_string()),
+        })
     }
 }
 
@@ -60,7 +64,7 @@ impl Display for OptionId {
         write!(
             f,
             "[{}] {}",
-            self.scope(),
+            self.scope.name(),
             self.name("_", NameTransform::None)
         )
     }
@@ -105,12 +109,8 @@ pub(crate) enum NameTransform {
 }
 
 impl OptionId {
-    pub(crate) fn scope(&self) -> &str {
-        self.0.name()
-    }
-
     pub(crate) fn name(&self, sep: &str, transform: NameTransform) -> String {
-        self.1
+        self.name_components
             .iter()
             .map(|component| match transform {
                 NameTransform::None => component.to_owned(),

--- a/src/rust/engine/options/src/id_tests.rs
+++ b/src/rust/engine/options/src/id_tests.rs
@@ -11,7 +11,7 @@ fn test_option_id_global_switch() {
         OptionId::new(Scope::Global, ["bar", "baz"].iter(), Some('x')).unwrap(),
         option_id
     );
-    assert_eq!("GLOBAL", option_id.scope());
+    assert_eq!("GLOBAL", option_id.scope.name());
 }
 
 #[test]
@@ -21,7 +21,7 @@ fn test_option_id_global() {
         OptionId::new(Scope::Global, ["bar", "baz"].iter(), None).unwrap(),
         option_id
     );
-    assert_eq!("GLOBAL", option_id.scope());
+    assert_eq!("GLOBAL", option_id.scope.name());
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn test_option_id_scope_switch() {
         .unwrap(),
         option_id
     );
-    assert_eq!("foo-bar", option_id.scope());
+    assert_eq!("foo-bar", option_id.scope.name());
 }
 
 #[test]
@@ -51,5 +51,5 @@ fn test_option_id_scope() {
         .unwrap(),
         option_id
     );
-    assert_eq!("foo-bar", option_id.scope());
+    assert_eq!("foo-bar", option_id.scope.name());
 }


### PR DESCRIPTION
The named fields make the code easier to grok.

This also changes the type of the short name field
from Option<char> to Option<String>, to support
a subsequent change that will find it more 
convenient to have access to the short name as
a String.