### PR TITLE
Properly format error about invalid scope names

### DIFF
--- a/src/python/pants/option/subsystem.py
+++ b/src/python/pants/option/subsystem.py
@@ -261,7 +261,7 @@ class Subsystem(metaclass=_SubsystemMeta):
         if not cls.is_valid_scope_name(options_scope):
             raise OptionsError(
                 softwrap(
-                    """
+                    f"""
                     Options scope "{options_scope}" is not valid.
 
                     Replace in code with a new scope name consisting of only lower-case letters,


### PR DESCRIPTION
A missing `f` meant the error came out with literal `{options_scope}` rather than the actual `name = "..."` value that the user had supplied to their `Subsystem` subclass.