### PR TITLE
upgrade Rust to v1.77.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -276,7 +276,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -367,7 +367,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -232,7 +232,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -441,7 +441,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 
@@ -508,7 +508,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.76.0-*
+        path: '~/.rustup/toolchains/1.77.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/nailgun_pool.rs
@@ -449,7 +449,10 @@ impl NailgunProcessFingerprint {
 /// A wrapper around a NailgunProcess checked out from the pool. If `release` is not called, the
 /// guard assumes cancellation, and kills the underlying process.
 ///
-pub struct BorrowedNailgunProcess(Option<NailgunProcessRef>, OwnedSemaphorePermit);
+pub struct BorrowedNailgunProcess(
+    Option<NailgunProcessRef>,
+    #[allow(dead_code)] OwnedSemaphorePermit,
+);
 
 impl BorrowedNailgunProcess {
     fn new(process: NailgunProcessRef, permit: OwnedSemaphorePermit) -> Self {

--- a/src/rust/engine/process_execution/pe_nailgun/src/parsed_jvm_command_lines.rs
+++ b/src/rust/engine/process_execution/pe_nailgun/src/parsed_jvm_command_lines.rs
@@ -72,7 +72,7 @@ impl ParsedJVMCommandLines {
             .next()
             .filter(|e| ParsedJVMCommandLines::is_classpath_flag(e))
             .ok_or_else(|| "No classpath flag found.".to_string())
-            .map(|e| e.clone())?;
+            .cloned()?;
 
         let classpath_value = args_to_consume
             .next()
@@ -101,7 +101,7 @@ impl ParsedJVMCommandLines {
             .next()
             .filter(|e| !ParsedJVMCommandLines::is_flag(e))
             .ok_or_else(|| "No main class provided.".to_string())
-            .map(|e| e.clone())
+            .cloned()
     }
 
     fn parse_to_end(args_to_consume: &mut Iter<String>) -> Result<Vec<String>, String> {

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.77.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed

--- a/src/rust/engine/src/externs/fs.rs
+++ b/src/rust/engine/src/externs/fs.rs
@@ -377,7 +377,7 @@ impl PyRemovePrefix {
 // PathGlobs
 // -----------------------------------------------------------------------------
 
-struct PyPathGlobs(PathGlobs);
+struct PyPathGlobs(#[allow(dead_code)] PathGlobs);
 
 impl<'source> FromPyObject<'source> for PyPathGlobs {
     fn extract(obj: &'source PyAny) -> PyResult<Self> {

--- a/src/rust/engine/workunit_store/src/lib.rs
+++ b/src/rust/engine/workunit_store/src/lib.rs
@@ -784,7 +784,7 @@ pub struct WorkunitStoreHandle {
 }
 
 thread_local! {
-  static THREAD_WORKUNIT_STORE_HANDLE: RefCell<Option<WorkunitStoreHandle >> = RefCell::new(None)
+  static THREAD_WORKUNIT_STORE_HANDLE: RefCell<Option<WorkunitStoreHandle >> = const { RefCell::new(None) }
 }
 
 task_local! {


### PR DESCRIPTION
Upgrade Rust to v1.77.0.

Changes:
- Use `#[allow(dead_code)]` in two places where a value was stored for its `Drop` impl but not otherwise read. (Both sites were compile errors.)
- Clippy-related fixes
