### PR TITLE
Add extra newlines to avoid softwrapping the :::caution in `export` docs (Cherry-pick of #20715)

### DIFF
--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -110,7 +110,9 @@ class ExportSubsystem(GoalSubsystem):
         Export Pants data for use in other tools, such as IDEs.
 
         :::caution Exporting tools requires creating a custom lockfile for them
+
         Follow [the instructions for creating tool lockfiles](../../docs/python/overview/lockfiles#lockfiles-for-tools)
+
         :::
         """
     )


### PR DESCRIPTION
The `export` goal has a `:::caution` call-out that was soft-wrapped, so the `:::` wasn't on its own line and thus the call-out was never closed. This adds extra newlines so that they're preserved in the `softwrap` call.

<img width="647" alt="image" src="https://github.com/pantsbuild/pants/assets/1203825/6087fa07-01aa-4b9b-b300-cd6061d02b30">

Fixes #20703 

