### PR TITLE
Use `[]()` links not `<>` in `[pex].emit_warnings` docs (Cherry-pick of #20716)

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_environment.py
+++ b/src/python/pants/backend/python/util_rules/pex_environment.py
@@ -89,8 +89,8 @@ class PexSubsystem(Subsystem):
 
             Note: Pants uses Pex internally in some ways that trigger some warnings at the moment,
             so enabling this may result in warnings not related to your code. See
-            <https://github.com/pantsbuild/pants/issues/20577> and
-            <https://github.com/pantsbuild/pants/issues/20586>.
+            [#20577](https://github.com/pantsbuild/pants/issues/20577) and
+            [#20586](https://github.com/pantsbuild/pants/issues/20586).
             """
         ),
     )


### PR DESCRIPTION
The `[pex].emit_warnings` docs used `<>` links, but this style isn't supported by MDX as used by Docusaurus. See https://mdxjs.com/docs/what-is-mdx/#markdown: "Autolinks do not work in MDX".

This PR replaces them with `[]()` links which also allows making the references shorter.

<img width="575" alt="image" src="https://github.com/pantsbuild/pants/assets/1203825/2e5f0171-82f0-439f-9c8c-af90505a7bc7">


Fixes #20704 
