### PR TITLE
Add "what's new" in 2.20 (Cherry-pick of #20687)

### DIFF
--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -1,0 +1,188 @@
+# 2.20.x Release Series
+
+Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
+
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+## What's New
+
+### Highlights
+
+- Support for the Ruff formatter, for both `BUILD` files and normal Python files.
+- Built-in support for Terraform lockfiles.
+- Support for more remote-caching providers: file system and GitHub Actions Cache.
+- New helpers for defining "adhoc" code-quality tools, without requiring a full plugin.
+- JVM third-party artifacts can now be read from `pom.xml` files, and other related improvements.
+- Go 1.22 can now be used.
+
+Keep reading to see the details and what's also included.
+
+### Overall
+
+The dependency goals now support JSON output using the `--format` option for easier [introspection of the dependency graph](https://www.pantsbuild.org/2.20/docs/using-pants/project-introspection#export-dependency-graph). For instance, [`pants dependencies --format=json ...`](https://www.pantsbuild.org/2.20/reference/goals/dependencies#format) and [`pants dependents --format=json ...`](https://www.pantsbuild.org/2.20/reference/goals/dependents#format).
+
+The [new `[stats].output_file` option](https://www.pantsbuild.org/2.20/reference/subsystems/stats#output_file) allows appending the stats output to a file, rather than printing it on stdout. This allows hiding this output on CI, while still ensuring it's available when required.
+
+[The `[GLOBAL].pants_ignore` option](https://www.pantsbuild.org/2.20/reference/global-options#pants_ignore) no longer ignores `.github` by default, so files within that directory will now be visible to Pants automatically.
+
+Using [the `--changed-...` options](https://www.pantsbuild.org/2.20/reference/subsystems/changed) to only run on files that have been edited now no longer emits spurious warnings if files have been deleted.
+
+We've made many changes to documentation, including:
+
+- How to use [the `.pants.bootstrap` file](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/options#pantsbootstrap-file) for running commands before start-up or setting default environment variables or similar.
+- How to use [the `[cli].alias` option](https://www.pantsbuild.org/2.20/docs/using-pants/advanced-target-selection#using-cli-aliases) for abbreviating common pants invocations.
+- How to use [the `target` target](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/targets-and-build-files#using-the-generic-target) to abbreviate common `dependencies=["..."]` parameters.
+- An improved version of [the nuking script](https://www.pantsbuild.org/2.20/docs/using-pants/using-pants-in-ci#directories-to-cache) when doing coarse-grained caching in CI, like GitHub Actions.
+- Several pages have been renamed or moved: existing links to 2.19 and earlier will still work, but their locations in 2.20 may have changed.
+
+### BUILD files
+
+The new `pants.backend.build_files.fmt.ruff` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format `BUILD` files.
+
+### Remote caching/execution
+
+Pants now has experimental support for additional remote cache providers beyond the gRPC Remote Execution API. Set [the `[GLOBAL].remote_provider` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_provider), to be able to use:
+
+- [the GitHub Actions Cache](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#github-actions-cache)
+- [a local directory](https://www.pantsbuild.org/2.20/docs/using-pants/remote-caching-and-execution/remote-caching#local-file-system)
+
+In support of this, [the `[GLOBAL].remote_oauth_bearer_token` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_oauth_bearer_token) has been added to set the `Authorization: Bearer <token>` header. [The `[GLOBAL].remote_oauth_bearer_token_path` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_oauth_bearer_token_path) has been deprecated in favour of using the new option with [a file reference](https://www.pantsbuild.org/2.20/docs/using-pants/key-concepts/options#reading-individual-option-values-from-files): `remote_oauth_bearer_token = "@/path/to/file.txt"`.
+
+[The `[GLOBAL].remote_cache_warnings` option](https://www.pantsbuild.org/2.20/reference/global-options#remote_cache_warnings) now supports `always`.
+
+### Backends
+
+#### Adhoc
+
+The [new `code_quality_tool` target](https://www.pantsbuild.org/2.20/reference/targets/code_quality_tool) in the `pants.backend.experimental.adhoc` backend allows defining "adhoc" linters, formatters and fixers without requiring a full plugin. For example, in-repository scripts or a tool not already supported by Pants itself. See [#20135](https://github.com/pantsbuild/pants/pull/20135) for an example of how to use this.
+
+#### Docker
+
+The [new `{full_directory}` interpolation](https://www.pantsbuild.org/2.20/docs/docker/tagging-docker-images#setting-a-repository-name) in `repository` and `default_repository` options expands to the full path to the `BUILD` file that contains a `docker_image` target.
+
+The new `pants.backend.experimental.docker.podman` backend allows using [Podman](https://podman.io). Add that backend to `backend_packages` and the Docker backend will invoke Podman instead of Docker. [The new option `[docker].experimental_enable_podman`](https://www.pantsbuild.org/2.20/reference/subsystems/docker#experimental_enable_podman) allows disabling this once the backend is loaded.
+
+Dependency inference now works for parameterized targets, like `ARG base="path/to:target@param=value"`.
+
+Pants is now able to extract the image ID when building a docker image with a daemon using the containerd-snapshotter feature.
+
+The default version of Hadolint has been updated from 2.10.0 to 2.12.1-beta. This fixes an segmentation fault error when running on MacOS.
+
+#### Go
+
+Support for Go 1.22+, by no longer passing the `-compiling-runtime` flag when not necessary.
+
+Eliminated a non-linear blow-up in the algorthm for gathering pre-build Go object files when using CGo.
+
+#### Helm
+
+The [new `lint_quiet` field](https://www.pantsbuild.org/2.20/reference/targets/helm_chart#lint_quiet) on `helm_chart` allows passing `--quiet` to `helm lint ...`.
+
+The `repository` field on `helm_chart` now allows trailing slashes.
+
+The `--timeout` flag can now be passed through to `helm upgrade` operations.
+
+#### JavaScript
+
+The [`pants.backend.experimental.javascript` experimental backend](https://github.com/pantsbuild/example-javascript) has had a few bug-fixes:
+
+- [`package_json` targets](https://www.pantsbuild.org/2.20/reference/targets/package_json) that use `yarn` now support running `node_build_scripts`.
+- Dependencies are inferred from `export ... from ...` statements, similar to `import ... from ...`.
+
+#### JVM
+
+Several improvements have been made to Pants' support for third-party dependencies:
+
+- The [new `jvm_artifacts` target](https://www.pantsbuild.org/2.20/reference/targets/jvm_artifacts) supports creating `jvm_artifact` dependency targets from `pom.xml` files.
+- The [new `force_version` field on `jvm_artifact`](https://www.pantsbuild.org/2.20/reference/targets/jvm_artifact#force_version) allows passing the `--force-version` flag to Coursier for particular artifacts.
+- The [new `[coursier].jvm_index` option](https://www.pantsbuild.org/2.20/reference/subsystems/coursier#jvm_index) allows setting the index used by Coursier.
+
+Most codegen backends now support dependency inference, including Protobuf, SOAP, Thrift and OpenAPI.
+
+Pants support for [IDE integration via the BSP protocol](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala#working-in-an-ide) now supports Scala plugins.
+
+The JVM documentation has been rearranged to put [Java and Scala](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala) and [Kotlin](https://www.pantsbuild.org/2.20/docs/jvm/kotlin) on an equal footing.
+
+##### Scala
+
+Plugins that cause `scalac` to emit additional compilation results (such as `semanticdb`, `scalajs` and `scalanative`) are now supported, by wrapping all results into a single `jar`.
+
+Support for [the Scala REPL](https://www.pantsbuild.org/2.20/docs/jvm/java-and-scala#repl) is now documented.
+
+#### Python
+
+Several improvements have been made to Pants' support for Ruff:
+
+- The new `pants.backend.experimental.python.lint.ruff.format` backend allows using [the Ruff formatter](https://docs.astral.sh/ruff/formatter/) to format Python files.
+- The existing `pants.backend.experimental.python.lint.ruff` linter backend has been renamed to `pants.backend.experimental.python.lint.ruff.check`, and its tool ID (as used by commands like `pants lint --only=...`) has changed from `ruff` to `ruff-check`.
+- Pants now automatically finds Ruff configuration in `pyproject.toml` files in subdirectories, for instance, `python/pyproject.toml`.
+- Pants' built-in default version has been updated to 0.2.1.
+
+This release brings several changes related to [the pex tool](https://github.com/pex-tool/pex) and `pex_binary` targets:
+
+- It has been updated to to 2.1.163 by default. The minimum supported version is now 2.1.148.
+- The [new `sh_boot` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#sh_boot) allows opting in to using a shell script rather than a Python script, which can be faster and more reliable in some cases.
+- The [new `executable` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#executable) on `pex_binary` targets exposes pex's `--executable` option.
+- The [new `[pex].emit_warnings` option](https://www.pantsbuild.org/2.20/reference/subsystems/pex#emit_warnings) allows controlling whether warnings from pex invocations are shown or not.
+- The [existing `emit_warnings` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#emit_warnings) on `pex_binary` targets now works as described, when set to `True`.
+- Relatedly, Pants now exposes the recently-added `--check` option that allows being warned in advance if a `pex_binary` target will not be able to be opened by CPython. The [new `check` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#check) allows adjusting the behaviour (default: warn).
+- If a `pex_binary` has [an `entry_point` field](https://www.pantsbuild.org/2.20/reference/targets/pex_binary#entry_point) that is ambiguous, Pants now treats this as an unowned dependency. Previously this would silently do nothing.
+
+The new [`local_scheme`](https://www.pantsbuild.org/2.20/reference/targets/vcs_version#local_scheme) and [`version_scheme`](https://www.pantsbuild.org/2.20/reference/targets/vcs_version#version_scheme) fields on the `vcs_version` target allow additional customization of its behaviour.
+
+Improvements to dependency inference:
+
+- [Strings imports](https://www.pantsbuild.org/2.20/reference/subsystems/python-infer#string_imports) are handled more reliably, including obeying `pants: no-infer-dep` comments and having fewer false positives on invalid module names.
+- Django-specific dependency inference (via the `pants.backend.experimental.python.framework.django` backend) now infers migrations and management commands as dependencies of `apps.py`.
+
+[The `pants.backend.codegen.protobuf.python` backend](https://www.pantsbuild.org/2.20/docs/python/integrations/protobuf-and-grpc) now supports [using `grpclib`](https://www.pantsbuild.org/2.20/docs/python/integrations/protobuf-and-grpc#use-alternative-grpc-plugins) in addition to `grpcio` for generating GRPC service stubs.
+
+Default module mappings were added for more modules: `django-countries`, `django-fsm`, `django-object-actions`, `django-postgres-extra`, `django-redis`, `django-scim2`, `djangorestframework-api-key`, `djangorestframework-queryfields`, `google-api-python-client`, `google-auth`, `grpcio-health-checking`, `grpcio-reflection`, `honeycomb-opentelemetry`, `opencv-python-headless`, `opentelemetry-sdk` (expanded to cover more modules). The special `_typeshed` module no longer has errors if imported.
+
+`pip list` now behaves correctly in venvs created via `export` with [the `[export].py_editable_in_resolve` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_editable_in_resolve) enabled.
+
+There is now documentation on how to [exclude files from Black or isort](https://www.pantsbuild.org/2.20/docs/python/overview/linters-and-formatters#black-and-isort-excluding-files).
+
+The deprecation for the `[export].symlink_python_virtualenv` option has expired and it has been removed. Instead set [the `[export].py_resolve_format` option](https://www.pantsbuild.org/2.20/reference/goals/export#py_resolve_format) to `symlinked_immutable_virtualenv`.
+
+#### Terraform
+
+The `pants.backend.experimental.terraform` Terraform backend now has [built-in support for lockfiles](https://www.pantsbuild.org/2.20/docs/terraform#lockfiles), using the `pants generate-lockfiles --resolve=path/to:module` goal, passing the address of the `terraform_module` target as the resolve.
+
+There are now separate target types for [vars files](https://www.pantsbuild.org/2.20/reference/targets/terraform_var_files) and [backend configs](https://www.pantsbuild.org/2.20/reference/targets/terraform_backend), which are handled as normal dependencies in the `dependencies` field. See the new [instructions for Terraform deployments](https://www.pantsbuild.org/2.20/docs/terraform#deployments).
+
+The default built-in version of Terraform has been upgraded from 1.4.6 to 1.7.1. Pants now has [built-in knowledge of versions up to 1.7.1](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#known_versions), so the version can be overridden by setting [`[download-terraform].version`](https://www.pantsbuild.org/2.20/reference/subsystems/download-terraform#version) explicitly.
+
+
+#### NEW: TypeScript
+
+The `pants.backend.experimental.typescript` experimental backend now exists with support for tailoring [`typescript_sources`](https://www.pantsbuild.org/2.20/reference/targets/typescript_sources) and [`typescript_tests`](https://www.pantsbuild.org/2.20/reference/targets/typescript_tests) targets. Note: [dependency inference](https://github.com/pantsbuild/pants/pull/20293) and other built-in functionality is not yet implemented.
+
+### Plugin API changes
+
+Pants is undergoing a long term project to switch to [a new "call by name" syntax](https://github.com/pantsbuild/pants/issues/19730). There will be a "fix-up" tool once the new syntax is ready for wide-spread use. This release adds supports for positional arguments. ([#20366](https://github.com/pantsbuild/pants/pull/20366))
+
+`AbstractLintRequest` subclasses can now disable lint rules via the `enable_lint_rules` class var, if the automatic linter is not required. ([#20407](https://github.com/pantsbuild/pants/pull/20407))
+
+Plugins loaded from the current repository (by extending `[GLOBAL].pythonpath`) now support specifying their requirements in a `requirements.txt` file adjacent to `register.py`. ([#20355](https://github.com/pantsbuild/pants/pull/20355))
+
+`FrozenDict`s comparison and hashing functions now behave more like the superclass `dict` ones, being order-insensitive and allowing comparison to `dict` itself. ([#20221](https://github.com/pantsbuild/pants/pull/20221))
+
+Previously, backtraces have been improved, to lose less information when interacting with the Rust core code. ([#20517](https://github.com/pantsbuild/pants/pull/20517))
+
+The documentation has been extended with more information and additional examples:
+
+- how to [use `HydratedSources` to convert a list of file and target paths into just file paths](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/rules-and-the-target-api#sourcesfield) ([#20524](https://github.com/pantsbuild/pants/pull/20524))
+- how to [write an integration test that requires loading a backend](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-4-run_pants-integration-tests-for-pants) ([#20451](https://github.com/pantsbuild/pants/pull/20451))
+- how to [write a unit test for a `@rule`](https://www.pantsbuild.org/2.20/docs/writing-plugins/the-rules-api/testing-plugins#approach-2-run_rule_with_mocks-unit-tests-for-rules) ([#20452](https://github.com/pantsbuild/pants/pull/20452))
+- how to profile Pants with [py-spy](https://www.pantsbuild.org/2.20/docs/contributions/development/debugging-and-benchmarking#cpu-profiling-with-py-spy) and [memray](https://www.pantsbuild.org/2.20/docs/contributions/development/debugging-and-benchmarking#memory-profiling-with-memray) ([#20334](https://github.com/pantsbuild/pants/pull/20334))
+
+The deprecation has expired for the `@rule_helper` decorator. To resolve, just remove it: `@rule`s can now call any functions and `async` functions can now call `Get` and `MultiGet` directly.
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases


### PR DESCRIPTION
This was created by collecting the release notes of all 2.20.x releases up to 2.20.0rc1 and converting that into "What's new" style documentation.

Part of #20578
