### PR TITLE
Allow passing arguments to PEX invocation used for `pex_binary`

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -16,6 +16,7 @@ from pants.backend.python.target_types import (
     PexExecutableField,
     PexExecutionMode,
     PexExecutionModeField,
+    PexExtraBuildArgsField,
     PexIgnoreErrorsField,
     PexIncludeRequirementsField,
     PexIncludeSourcesField,
@@ -83,6 +84,7 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     venv_hermetic_scripts: PexVenvHermeticScripts
     environment: EnvironmentField
     check: PexCheckField
+    extra_build_args: PexExtraBuildArgsField
 
     @property
     def _execution_mode(self) -> PexExecutionMode:
@@ -116,6 +118,8 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
             args.append("--venv-site-packages-copies")
         if self.venv_hermetic_scripts.value is False:
             args.append("--non-hermetic-venv-scripts")
+        if self.extra_build_args.value:
+            args.extend(self.extra_build_args.value)
         return tuple(args)
 
 

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -415,11 +415,32 @@ class PexExecutableField(Field):
 
 
 class PexArgsField(StringSequenceField):
-    alias = "args"
+    alias: ClassVar[str] = "args"
     help = help_text(
-        """
+        lambda: f"""
         Freeze these command-line args into the PEX. Allows you to run generic entry points
         on specific arguments without creating a shim file.
+
+        This is different to `{PexExtraBuildArgsField.alias}`: `{PexArgsField.alias}`
+        records arguments used by the packaged PEX when executed,
+        `{PexExtraBuildArgsField.alias}` passes arguments to the process that does the
+        packaging.
+        """
+    )
+
+
+class PexExtraBuildArgsField(StringSequenceField):
+    alias: ClassVar[str] = "extra_build_args"
+    default = ()
+    help = help_text(
+        lambda: f"""
+        Extra arguments to pass to the `pex` invocation used to build this PEX. These are
+        passed after all other arguments. This can be used to pass extra options that
+        Pants doesn't have built-in support for.
+
+        This is different to `{PexArgsField.alias}`: `{PexArgsField.alias}` records
+        arguments used by the packaged PEX when executed, `{PexExtraBuildArgsField.alias}`
+        passes arguments to the process that does the packaging.
         """
     )
 
@@ -789,6 +810,7 @@ class PexBinary(Target):
         PexScriptField,
         PexExecutableField,
         PexArgsField,
+        PexExtraBuildArgsField,
         PexEnvField,
         OutputPathField,
     )


### PR DESCRIPTION
This adds a new field `extra_build_args` to `pex_binary` that just faithfully passes through arbitrary arguments to the `pex ...` invocation used to build the PEX. This gives users more control and flexibility for new PEX features that Pants might not (yet) expose natively.

For instance, the functionality requested in #20227 can now be solved by passing `extra_build_args=["--no-compress"]`, and similarly people can now start taking advantage of the `--no-pre-install-wheels` functionality for their own PEXes (relates to #20562).