### PR TITLE
add intrinsic rule for in-workspace process execution

### DIFF
--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -62,7 +62,6 @@ from pants.engine.process import (
     Process,
     ProcessResultMetadata,
     WorkspaceProcess,
-    WorkspaceProcessResult,
 )
 from pants.engine.rules import Rule, RuleIndex, TaskRule
 from pants.engine.unions import UnionMembership, is_union, union_in_scope_types
@@ -179,7 +178,6 @@ class Scheduler:
             parsed_python_deps_result=NativeParsedPythonDependencies,
             parsed_javascript_deps_result=NativeParsedJavascriptDependencies,
             workspace_process=WorkspaceProcess,
-            workspace_process_result=WorkspaceProcessResult,
         )
         remoting_options = PyRemotingOptions(
             provider=execution_options.remote_provider.value,

--- a/src/python/pants/engine/internals/scheduler.py
+++ b/src/python/pants/engine/internals/scheduler.py
@@ -61,6 +61,8 @@ from pants.engine.process import (
     InteractiveProcessResult,
     Process,
     ProcessResultMetadata,
+    WorkspaceProcess,
+    WorkspaceProcessResult,
 )
 from pants.engine.rules import Rule, RuleIndex, TaskRule
 from pants.engine.unions import UnionMembership, is_union, union_in_scope_types
@@ -176,6 +178,8 @@ class Scheduler:
             docker_resolve_image_result=DockerResolveImageResult,
             parsed_python_deps_result=NativeParsedPythonDependencies,
             parsed_javascript_deps_result=NativeParsedJavascriptDependencies,
+            workspace_process=WorkspaceProcess,
+            workspace_process_result=WorkspaceProcessResult,
         )
         remoting_options = PyRemotingOptions(
             provider=execution_options.remote_provider.value,

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -14,7 +14,6 @@ from pants.engine.fs import EMPTY_DIGEST, Digest, FileDigest
 from pants.engine.internals.native_engine import (  # noqa: F401
     ProcessExecutionEnvironment as ProcessExecutionEnvironment,
 )
-from pants.engine.internals.native_engine import Snapshot
 from pants.engine.internals.selectors import Get
 from pants.engine.internals.session import RunId
 from pants.engine.platform import Platform

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -408,17 +408,6 @@ class InteractiveProcess(SideEffecting):
 
 
 @dataclass(frozen=True)
-class WorkspaceProcessResult:
-    exit_code: int
-    output_snapshot: Snapshot
-    stdout_bytes: bytes
-    stderr_bytes: bytes
-
-    # TODO: For the actual implementation, return a full FallibleProcessResult.
-    # result: FallibleProcessResult
-
-
-@dataclass(frozen=True)
 class WorkspaceProcess:
     process: Process
     keep_sandboxes: KeepSandboxes

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -30,7 +30,7 @@ from pants.engine.process import (
     WorkspaceProcess,
 )
 from pants.option.global_options import KeepSandboxes
-from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule, RuleRunner, mock_console
+from pants.testutil.rule_runner import QueryRule, RuleRunner, mock_console
 from pants.util.contextutil import environment_as
 
 

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -314,8 +314,8 @@ def test_workspace_process_basic(rule_runner: RuleRunner) -> None:
         if result.exit_code != 0:
             raise ProcessExecutionFailure(
                 result.exit_code,
-                result.stdout_bytes,
-                result.stderr_bytes,
+                result.stdout,
+                result.stderr,
                 "ProcessResult",
                 keep_sandboxes=KeepSandboxes.never,
             )
@@ -382,11 +382,11 @@ def test_workspace_process_basic(rule_runner: RuleRunner) -> None:
         digest_contents = rule_runner.request(DigestContents, [result.output_digest])
         assert len(digest_contents) == 2
 
-        digest_contents = sorted(digest_contents, key=lambda x: x.path)
-        assert digest_contents[0].path == "output.txt"
-        assert digest_contents[0].content == b"generated\n"
-        assert digest_contents[1].path == "subdir/file.txt"
-        assert digest_contents[1].content == b"subdir\n"
+        contents = sorted(digest_contents, key=lambda x: x.path)
+        assert contents[0].path == "output.txt"
+        assert contents[0].content == b"generated\n"
+        assert contents[1].path == "subdir/file.txt"
+        assert contents[1].content == b"subdir\n"
 
         new_file = Path(rule_runner.build_root, "new-file.txt")
         assert new_file.exists()

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -2817,7 +2817,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset 0.9.0",
- "parking_lot 0.11.2",
+ "parking_lot 0.12.1",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -4751,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96f8f25c15a0edc9b07eb66e7e6e97d124c0505435c382fde1ab7ceb188aa956"
+checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -4761,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855e0f6af9cd72b87d8a6c586f3cb583f5cdcc62c2c80869d8cd7e96fdf7ee20"
+checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/engine/process_execution/src/local.rs
+++ b/src/rust/engine/process_execution/src/local.rs
@@ -80,7 +80,7 @@ impl CommandRunner {
         }
     }
 
-    async fn construct_output_snapshot(
+    pub async fn construct_output_snapshot(
         store: Store,
         posix_fs: Arc<fs::PosixFS>,
         output_file_paths: BTreeSet<RelativePath>,

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -202,7 +202,6 @@ impl PyTypes {
         parsed_python_deps_result: &PyType,
         parsed_javascript_deps_result: &PyType,
         workspace_process: &PyType,
-        workspace_process_result: &PyType,
         py: Python,
     ) -> Self {
         Self(RefCell::new(Some(Types {
@@ -244,7 +243,6 @@ impl PyTypes {
                 py.get_type::<externs::dep_inference::PyNativeDependenciesRequest>(),
             ),
             workspace_process: TypeId::new(workspace_process),
-            workspace_process_result: TypeId::new(workspace_process_result),
         })))
     }
 }

--- a/src/rust/engine/src/externs/interface.rs
+++ b/src/rust/engine/src/externs/interface.rs
@@ -201,6 +201,8 @@ impl PyTypes {
         docker_resolve_image_result: &PyType,
         parsed_python_deps_result: &PyType,
         parsed_javascript_deps_result: &PyType,
+        workspace_process: &PyType,
+        workspace_process_result: &PyType,
         py: Python,
     ) -> Self {
         Self(RefCell::new(Some(Types {
@@ -241,6 +243,8 @@ impl PyTypes {
             deps_request: TypeId::new(
                 py.get_type::<externs::dep_inference::PyNativeDependenciesRequest>(),
             ),
+            workspace_process: TypeId::new(workspace_process),
+            workspace_process_result: TypeId::new(workspace_process_result),
         })))
     }
 }

--- a/src/rust/engine/src/intrinsics/mod.rs
+++ b/src/rust/engine/src/intrinsics/mod.rs
@@ -151,7 +151,7 @@ impl Intrinsics {
         intrinsics.insert(
             Intrinsic {
                 id: RuleId::new("workspace_process"),
-                product: types.workspace_process_result,
+                product: types.process_result,
                 inputs: vec![
                     DependencyKey::new(types.workspace_process),
                     DependencyKey::new(types.process_config_from_environment),

--- a/src/rust/engine/src/intrinsics/mod.rs
+++ b/src/rust/engine/src/intrinsics/mod.rs
@@ -18,6 +18,7 @@ mod docker;
 mod interactive_process;
 mod process;
 mod values;
+mod workspace_process;
 
 type IntrinsicFn =
     Box<dyn Fn(Context, Vec<Value>) -> BoxFuture<'static, NodeResult<Value>> + Send + Sync>;
@@ -147,6 +148,18 @@ impl Intrinsics {
             },
             Box::new(self::interactive_process::interactive_process),
         );
+        intrinsics.insert(
+            Intrinsic {
+                id: RuleId::new("workspace_process"),
+                product: types.workspace_process_result,
+                inputs: vec![
+                    DependencyKey::new(types.workspace_process),
+                    DependencyKey::new(types.process_config_from_environment),
+                ],
+            },
+            Box::new(self::workspace_process::workspace_process),
+        );
+
         intrinsics.insert(
             Intrinsic {
                 id: RuleId::new("docker_resolve_image"),

--- a/src/rust/engine/src/intrinsics/workspace_process.rs
+++ b/src/rust/engine/src/intrinsics/workspace_process.rs
@@ -1,0 +1,178 @@
+// Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+// Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+use std::env::current_dir;
+use std::path::Path;
+use std::process::Stdio;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use futures::future::{BoxFuture, FutureExt};
+use process_execution::local::{
+    apply_chroot, create_sandbox, prepare_workdir, setup_run_sh_script, CommandRunner,
+    KeepSandboxes,
+};
+use process_execution::ProcessExecutionStrategy;
+use pyo3::{PyAny, Python, ToPyObject};
+
+use crate::context::Context;
+use crate::externs;
+use crate::nodes::{ExecuteProcess, NodeResult, Snapshot};
+use crate::python::Value;
+
+pub(crate) fn workspace_process(
+    context: Context,
+    args: Vec<Value>,
+) -> BoxFuture<'static, NodeResult<Value>> {
+    log::trace!("workspace_process generating work unit closure");
+    // TODO: in_workunit!("workspace_process", Level::Debug, |_workunit| async move {
+    async move {
+        let types = &context.core.types;
+        let workspace_process_result = types.workspace_process_result;
+
+        log::trace!("entering workspace_process");
+
+        let (py_workspace_process, py_process, process_config): (
+            Value,
+            Value,
+            externs::process::PyProcessExecutionEnvironment,
+        ) = Python::with_gil(|py| {
+            let py_workspace_process = (*args[0]).as_ref(py);
+            let py_process: Value = externs::getattr(py_workspace_process, "process").unwrap();
+            let process_config = (*args[1]).as_ref(py).extract().unwrap();
+            (
+                py_workspace_process.extract().unwrap(),
+                py_process,
+                process_config,
+            )
+        });
+        log::trace!("extracted py_workspace_process and friends");
+        match process_config.environment.strategy {
+            ProcessExecutionStrategy::Docker(_) | ProcessExecutionStrategy::RemoteExecution(_) => {
+                Err(format!(
+                    "Only local environments support running processes \
+               in the workspace, but a {} environment was used.",
+                    process_config.environment.strategy.strategy_type(),
+                ))
+            }
+            _ => Ok(()),
+        }?;
+        log::trace!("checked environment strategy");
+
+        let mut process = ExecuteProcess::lift(&context.core.store(), py_process, process_config)
+            .await?
+            .process;
+        log::trace!("process {process:?}");
+        let keep_sandboxes = Python::with_gil(|py| {
+            let py_interactive_process_obj = py_workspace_process.to_object(py);
+            let py_workspace_process = py_interactive_process_obj.as_ref(py);
+            let keep_sandboxes_value: &PyAny =
+                externs::getattr(py_workspace_process, "keep_sandboxes").unwrap();
+            KeepSandboxes::from_str(externs::getattr(keep_sandboxes_value, "value").unwrap())
+                .unwrap()
+        });
+        log::trace!("keep_sandboxes={keep_sandboxes:?}");
+
+        let mut tempdir = create_sandbox(
+            context.core.executor.clone(),
+            &context.core.local_execution_root_dir,
+            "workspace process",
+            keep_sandboxes,
+        )?;
+        log::trace!("tempdir = {}", tempdir.path().display());
+        prepare_workdir(
+            tempdir.path().to_owned(),
+            &context.core.local_execution_root_dir,
+            &process,
+            process.input_digests.inputs.clone(),
+            &context.core.store(),
+            &context.core.named_caches,
+            &context.core.immutable_inputs,
+            None,
+            None,
+        )
+        .await?;
+        apply_chroot(tempdir.path().to_str().unwrap(), &mut process);
+
+        let p = Path::new(&process.argv[0]);
+        // TODO: Deprecate this program name calculation, and recommend `{chroot}` replacement in args
+        // instead.
+        let program_name = p.to_path_buf();
+
+        let mut command = tokio::process::Command::new(program_name);
+        for arg in process.argv[1..].iter() {
+            command.arg(arg);
+        }
+        command.current_dir(context.context().core.build_root.clone());
+
+        command.env_clear();
+        command.envs(&process.env);
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let output = command.output().await.map_err(|e| e.to_string())?;
+
+        let store = context.core.store();
+        let posix_fs = Arc::new(
+            fs::PosixFS::new(
+                tempdir.path(),
+                fs::GitignoreStyleExcludes::empty(),
+                context.core.executor.clone(),
+            )
+            .map_err(|err| {
+                format!(
+                    "Error making posix_fs to fetch workspace process execution output files: {err}"
+                )
+            })?,
+        );
+
+        log::trace!("before construct_output_snapshot");
+
+        let snapshot = CommandRunner::construct_output_snapshot(
+            store,
+            posix_fs,
+            process.output_files,
+            process.output_directories,
+        )
+        .await?;
+
+        log::trace!("after construct_output_snapshot");
+
+        let code = output.status.code().unwrap_or(-1);
+        log::trace!("code = {code}");
+        if keep_sandboxes == KeepSandboxes::Always
+            || keep_sandboxes == KeepSandboxes::OnFailure && code != 0
+        {
+            tempdir.keep("workspace process");
+            let do_setup_run_sh_script = |workdir_path| -> Result<(), String> {
+                setup_run_sh_script(
+                    tempdir.path(),
+                    &process.env,
+                    &process.working_directory,
+                    &process.argv,
+                    workdir_path,
+                )
+            };
+            let cwd = current_dir()
+                .map_err(|e| format!("Could not detect current working directory: {e}"))?;
+            do_setup_run_sh_script(cwd.as_path())?;
+        }
+
+        Ok(Python::with_gil(|py| {
+            externs::unsafe_call(
+                py,
+                workspace_process_result,
+                &[
+                    externs::store_i64(py, i64::from(code)),
+                    Snapshot::store_snapshot(py, snapshot)
+                        .expect("TODO: Do proper error handling."),
+                    externs::store_bytes(py, &output.stdout),
+                    externs::store_bytes(py, &output.stderr),
+                ],
+            )
+        }))
+    }
+    .boxed()
+}

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -38,5 +38,4 @@ pub struct Types {
     pub parsed_javascript_deps_result: TypeId,
     pub deps_request: TypeId,
     pub workspace_process: TypeId,
-    pub workspace_process_result: TypeId,
 }

--- a/src/rust/engine/src/types.rs
+++ b/src/rust/engine/src/types.rs
@@ -37,4 +37,6 @@ pub struct Types {
     pub parsed_python_deps_result: TypeId,
     pub parsed_javascript_deps_result: TypeId,
     pub deps_request: TypeId,
+    pub workspace_process: TypeId,
+    pub workspace_process_result: TypeId,
 }


### PR DESCRIPTION
Add an intrinsic rule to execute processes in the workspace instead of an execution sandbox. This PR implements Design A of the ["In-Workspace Process Execution" design document](https://docs.google.com/document/d/1jUZTQHmUBr-Ij0nXOO0QX2Bq6XNANJg4-GNzhiOL4Xs/edit?usp=sharing).

The rule level support using this intrinsic is on [this branch of my Pants fork](https://github.com/tdyas/pants/tree/shell_workspace_support) (and which includes this PR). This [example repository](https://github.com/tdyas/pants-workspace-exec-testing) demonstrates how the support works in practice.