### PR TITLE
Make all "local dists" PEXes internal-only

### DIFF
--- a/src/python/pants/backend/python/goals/pytest_runner.py
+++ b/src/python/pants/backend/python/goals/pytest_runner.py
@@ -311,7 +311,6 @@ async def setup_pytest_for_target(
         LocalDistsPex,
         LocalDistsPexRequest(
             addresses,
-            internal_only=True,
             interpreter_constraints=interpreter_constraints,
             sources=prepared_sources,
         ),

--- a/src/python/pants/backend/python/goals/repl.py
+++ b/src/python/pants/backend/python/goals/repl.py
@@ -90,7 +90,6 @@ async def create_python_repl_request(
         LocalDistsPex,
         LocalDistsPexRequest(
             request.addresses,
-            internal_only=True,
             interpreter_constraints=interpreter_constraints,
         ),
     )
@@ -156,7 +155,6 @@ async def create_ipython_repl_request(
         LocalDistsPex,
         LocalDistsPexRequest(
             request.addresses,
-            internal_only=True,
             interpreter_constraints=interpreter_constraints,
             sources=sources,
         ),

--- a/src/python/pants/backend/python/util_rules/local_dists.py
+++ b/src/python/pants/backend/python/util_rules/local_dists.py
@@ -106,7 +106,6 @@ class LocalDistsPexRequest:
     """Request to build the local dists from the dependency closure of a set of addresses."""
 
     addresses: Addresses
-    internal_only: bool
     interpreter_constraints: InterpreterConstraints
     # The result will return these with the sources provided by the dists subtracted out.
     # This will help the caller prevent sources from appearing twice on sys.path.
@@ -116,12 +115,10 @@ class LocalDistsPexRequest:
         self,
         addresses: Iterable[Address],
         *,
-        internal_only: bool,
         interpreter_constraints: InterpreterConstraints,
         sources: PythonSourceFiles = PythonSourceFiles.empty(),
     ) -> None:
         object.__setattr__(self, "addresses", Addresses(addresses))
-        object.__setattr__(self, "internal_only", internal_only)
         object.__setattr__(self, "interpreter_constraints", interpreter_constraints)
         object.__setattr__(self, "sources", sources)
 
@@ -185,7 +182,9 @@ async def build_local_dists(
             requirements=PexRequirements(wheels),
             interpreter_constraints=request.interpreter_constraints,
             additional_inputs=wheels_digest,
-            internal_only=request.internal_only,
+            # a "local dists" PEX is always just for consumption by some downstream Pants process,
+            # i.e. internal
+            internal_only=True,
             additional_args=["--intransitive"],
         ),
     )

--- a/src/python/pants/backend/python/util_rules/local_dists_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_test.py
@@ -90,7 +90,6 @@ def test_build_local_dists(rule_runner: PythonRuleRunner) -> None:
     )
     request = LocalDistsPexRequest(
         addresses,
-        internal_only=True,
         sources=sources,
         interpreter_constraints=interpreter_constraints,
     )

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -566,7 +566,6 @@ async def create_pex_from_targets(
             LocalDistsPex,
             LocalDistsPexRequest(
                 request.addresses,
-                internal_only=request.internal_only,
                 interpreter_constraints=interpreter_constraints,
                 sources=sources,
             ),


### PR DESCRIPTION
This marks all local dist PEXes as internal-only, removing the ability for them to be anything but internal. This is almost true already, except for PEXes built via `PexFromTargetsRequest`, where the local dists PEX used for building the "real" PEX has the same internal status as that real PEX. In this case, the local dists PEX still isn't surfaced to users, so it's appropriate for that one to be internal too.

This will probably be slightly faster in isolation (building a `pex_binary` that uses in-repo `python_distribution`s will be able to just copy them around with less zip-file manipulation, more often, by creating packed-layout PEXes). However, the real motivation is unblocking #20670, where having this PEX built with `--no-pre-install-wheels` (as internal-only PEXes will, by default) is required to support downstream PEXes using that argument, at least until https://github.com/pex-tool/pex/issues/2299 is fixed.

NB. there's still a separate consideration of changing how local dists are incorporated, which isn't changed or considered here: https://github.com/pex-tool/pex/pull/2392#discussion_r1536931827