### PR TITLE
Print reduced `pants test ...` command to rerun, when on CI

### DIFF
--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -1100,7 +1100,7 @@ def _format_test_rerun_command(results: Iterable[TestResult]) -> None | str:
     goal = f"{bin_name()} {TestSubsystem.name}"
     invocation = " ".join([goal, *addresses])
 
-    return f"To rerun the failing tests, try:\n\n    {invocation}"
+    return f"To rerun the failing tests, use:\n\n    {invocation}"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test.py
+++ b/src/python/pants/core/goals/test.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import itertools
 import logging
+import os
+import shlex
 from abc import ABC, ABCMeta
 from dataclasses import dataclass, field
 from enum import Enum
@@ -663,6 +665,24 @@ class TestSubsystem(GoalSubsystem):
         ),
     )
 
+    show_rerun_command = BoolOption(
+        default="CI" in os.environ,
+        advanced=True,
+        help=softwrap(
+            f"""
+            If tests fail, show an appropriate `{bin_name()} {name} ...` invocation to rerun just
+            those tests.
+
+            This is to make it easy to run those tests on a new machine (for instance, run tests
+            locally if they fail in CI): caching of successful tests means that rerunning the exact
+            same command on the same machine will already automatically only rerun the failures.
+
+            This defaults to `True` when running in CI (as determined by the `CI` environment
+            variable being set) but `False` elsewhere.
+            """
+        ),
+    )
+
     def report_dir(self, distdir: DistDir) -> PurePath:
         return PurePath(self._report_dir.format(distdir=distdir.relpath))
 
@@ -943,6 +963,10 @@ async def run_tests(
                     f"Wrote extra output from test `{result.addresses[0]}` to `{path_prefix}`."
                 )
 
+    rerun_command = _format_test_rerun_command(results)
+    if rerun_command and test_subsystem.show_rerun_command:
+        console.print_stderr(f"\n{rerun_command}")
+
     if test_subsystem.report:
         report_dir = test_subsystem.report_dir(distdir)
         merged_reports = await Get(
@@ -1064,6 +1088,19 @@ def _format_test_summary(result: TestResult, run_id: RunId, console: Console) ->
         elapsed_print = f"in {elapsed_secs:.2f}s"
 
     return f"{sigil} {result.description} {status}{attempt_msg} {elapsed_print}{source_desc}."
+
+
+def _format_test_rerun_command(results: Iterable[TestResult]) -> None | str:
+    failures = [result for result in results if result.exit_code not in (None, 0)]
+    if not failures:
+        return None
+
+    # format an invocation like `pants test path/to/first:address path/to/second:address ...`
+    addresses = sorted(shlex.quote(str(addr)) for result in failures for addr in result.addresses)
+    goal = f"{bin_name()} {TestSubsystem.name}"
+    invocation = " ".join([goal, *addresses])
+
+    return f"To rerun the failing tests, try:\n\n    {invocation}"
 
 
 @dataclass(frozen=True)

--- a/src/python/pants/core/goals/test_test.py
+++ b/src/python/pants/core/goals/test_test.py
@@ -455,7 +455,7 @@ def test_skipped_target_noops(rule_runner: PythonRuleRunner) -> None:
                 ✓ //:good succeeded in 1.00s (memoized).
                 ✕ //:bad failed in 1.00s (memoized).
 
-                To rerun the failing tests, try:
+                To rerun the failing tests, use:
 
                     pants test //:bad
                 """
@@ -555,7 +555,7 @@ def test_format_summary_memoized_remote(rule_runner: PythonRuleRunner) -> None:
         ),
         pytest.param(
             [make_test_result([Address("", target_name="t3")], exit_code=1)],
-            "To rerun the failing tests, try:\n\n    pants test //:t3",
+            "To rerun the failing tests, use:\n\n    pants test //:t3",
             id="one_failure",
         ),
         pytest.param(
@@ -564,7 +564,7 @@ def test_format_summary_memoized_remote(rule_runner: PythonRuleRunner) -> None:
                 make_test_result([Address("", target_name="t2")], exit_code=None),
                 make_test_result([Address("", target_name="t3")], exit_code=1),
             ],
-            "To rerun the failing tests, try:\n\n    pants test //:t3",
+            "To rerun the failing tests, use:\n\n    pants test //:t3",
             id="one_of_each",
         ),
         pytest.param(
@@ -573,7 +573,7 @@ def test_format_summary_memoized_remote(rule_runner: PythonRuleRunner) -> None:
                 make_test_result([Address("another/path", target_name="t2")], exit_code=2),
                 make_test_result([Address("", target_name="t3")], exit_code=3),
             ],
-            "To rerun the failing tests, try:\n\n    pants test //:t3 another/path:t2 path/to:t1",
+            "To rerun the failing tests, use:\n\n    pants test //:t3 another/path:t2 path/to:t1",
             id="multiple_failures",
         ),
         pytest.param(
@@ -590,7 +590,7 @@ def test_format_summary_memoized_remote(rule_runner: PythonRuleRunner) -> None:
                     exit_code=1,
                 )
             ],
-            "To rerun the failing tests, try:\n\n    pants test 'path with spaces:$*#gn@key=value'",
+            "To rerun the failing tests, use:\n\n    pants test 'path with spaces:$*#gn@key=value'",
             id="special_characters_require_quoting",
         ),
     ],


### PR DESCRIPTION
This augments the existing test summary output to show an appropriate invocation for rerunning any failed tests. This is controlled by the new `[test].show_rerun_command` option, which defaults to:

- off for "local" dev: since just rerunning the exact same command will generally already only rerun the failures, due to caching
- on in CI: since people often won't be sharing a cache with the CI machines, so rerunning some bulk `pants test ::` command may need to chug through all the successful tests too

For instance, given three tests, where two fail:

```
✓ //:good-but-slow succeeded in 123.00s (run locally).
✕ //:bad1 failed in 2.00s (run locally).
✕ path/to:bad2 failed in 3.00s (run locally).

To rerun the failing tests, use:

    pants test //:bad1 path/to:bad2
```

If this appears in CI a dev can copy and paste that invocation to just those two bad tests locally, without having to spend time running `//:good-but-slow`. Currently, without this suggested invocation, the dev would have to copy and paste each target line from the individual summary lines.

With a lot of failures, the line might be very long, but I think that's okay: it should still be copy-paste-able just fine.

Potentially it'd be good to do this for other goals too (e.g. after `pants fix ::`, `To fix the problematic files, try: pants fix ...`), but I'm not sure we have a generic infrastructure that would make this easy, and usually those goals will be faster than tests.