### PR TITLE
Use correct GHA workflow syntax in new cache-clearing action, be more resilient

### DIFF
--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -13,15 +13,15 @@ jobs:
     - name: df before
       run: df -h
     - name: Deleting ~/Library/Caches
-      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
     - name: Deleting ~/.cache
-      run: du -sh ~/.cache || true; rm -rf ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
     - name: Deleting ~/.nce
-      run: du -sh ~/.nce || true; rm -rf ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
     - name: Deleting ~/.rustup
-      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
     - name: Deleting ~/.pex
-      run: du -sh ~/.pex || true; rm -rf ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
     - name: df after
       run: df -h
   clean_macos10_15_x86_64:
@@ -32,15 +32,15 @@ jobs:
     - name: df before
       run: df -h
     - name: Deleting ~/Library/Caches
-      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
     - name: Deleting ~/.cache
-      run: du -sh ~/.cache || true; rm -rf ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
     - name: Deleting ~/.nce
-      run: du -sh ~/.nce || true; rm -rf ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
     - name: Deleting ~/.rustup
-      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
     - name: Deleting ~/.pex
-      run: du -sh ~/.pex || true; rm -rf ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
     - name: df after
       run: df -h
   clean_macos11_arm64:
@@ -51,15 +51,15 @@ jobs:
     - name: df before
       run: df -h
     - name: Deleting ~/Library/Caches
-      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches || true
     - name: Deleting ~/.cache
-      run: du -sh ~/.cache || true; rm -rf ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache || true
     - name: Deleting ~/.nce
-      run: du -sh ~/.nce || true; rm -rf ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce || true
     - name: Deleting ~/.rustup
-      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup || true
     - name: Deleting ~/.pex
-      run: du -sh ~/.pex || true; rm -rf ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex || true
     - name: df after
       run: df -h
 name: Clear persistent caches on long-lived self-hosted runners

--- a/.github/workflows/clear_self_hosted_persistent_caches.yaml
+++ b/.github/workflows/clear_self_hosted_persistent_caches.yaml
@@ -4,64 +4,64 @@
 
 
 jobs:
-- name: clear_linux_arm64
-  runs-on:
-  - self-hosted
-  - Linux
-  - ARM64
-  steps:
-  - name: df before
-    run: df -h
-  - name: Deleting ~/Library/Caches
-    run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
-  - name: Deleting ~/.cache
-    run: du -sh ~/.cache || true; rm -rf ~/.cache
-  - name: Deleting ~/.nce
-    run: du -sh ~/.nce || true; rm -rf ~/.nce
-  - name: Deleting ~/.rustup
-    run: du -sh ~/.rustup || true; rm -rf ~/.rustup
-  - name: Deleting ~/.pex
-    run: du -sh ~/.pex || true; rm -rf ~/.pex
-  - name: df after
-    run: df -h
-- name: clear_macos10_15_x86_64
-  runs-on:
-  - self-hosted
-  - macOS-10.15-X64
-  steps:
-  - name: df before
-    run: df -h
-  - name: Deleting ~/Library/Caches
-    run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
-  - name: Deleting ~/.cache
-    run: du -sh ~/.cache || true; rm -rf ~/.cache
-  - name: Deleting ~/.nce
-    run: du -sh ~/.nce || true; rm -rf ~/.nce
-  - name: Deleting ~/.rustup
-    run: du -sh ~/.rustup || true; rm -rf ~/.rustup
-  - name: Deleting ~/.pex
-    run: du -sh ~/.pex || true; rm -rf ~/.pex
-  - name: df after
-    run: df -h
-- name: clear_macos11_arm64
-  runs-on:
-  - self-hosted
-  - macOS-11-ARM64
-  steps:
-  - name: df before
-    run: df -h
-  - name: Deleting ~/Library/Caches
-    run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
-  - name: Deleting ~/.cache
-    run: du -sh ~/.cache || true; rm -rf ~/.cache
-  - name: Deleting ~/.nce
-    run: du -sh ~/.nce || true; rm -rf ~/.nce
-  - name: Deleting ~/.rustup
-    run: du -sh ~/.rustup || true; rm -rf ~/.rustup
-  - name: Deleting ~/.pex
-    run: du -sh ~/.pex || true; rm -rf ~/.pex
-  - name: df after
-    run: df -h
+  clean_linux_arm64:
+    runs-on:
+    - self-hosted
+    - Linux
+    - ARM64
+    steps:
+    - name: df before
+      run: df -h
+    - name: Deleting ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+    - name: Deleting ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache
+    - name: Deleting ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce
+    - name: Deleting ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+    - name: Deleting ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex
+    - name: df after
+      run: df -h
+  clean_macos10_15_x86_64:
+    runs-on:
+    - self-hosted
+    - macOS-10.15-X64
+    steps:
+    - name: df before
+      run: df -h
+    - name: Deleting ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+    - name: Deleting ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache
+    - name: Deleting ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce
+    - name: Deleting ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+    - name: Deleting ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex
+    - name: df after
+      run: df -h
+  clean_macos11_arm64:
+    runs-on:
+    - self-hosted
+    - macOS-11-ARM64
+    steps:
+    - name: df before
+      run: df -h
+    - name: Deleting ~/Library/Caches
+      run: du -sh ~/Library/Caches || true; rm -rf ~/Library/Caches
+    - name: Deleting ~/.cache
+      run: du -sh ~/.cache || true; rm -rf ~/.cache
+    - name: Deleting ~/.nce
+      run: du -sh ~/.nce || true; rm -rf ~/.nce
+    - name: Deleting ~/.rustup
+      run: du -sh ~/.rustup || true; rm -rf ~/.rustup
+    - name: Deleting ~/.pex
+      run: du -sh ~/.pex || true; rm -rf ~/.pex
+    - name: df after
+      run: df -h
 name: Clear persistent caches on long-lived self-hosted runners
 'on':
   workflow_dispatch: {}

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1570,8 +1570,10 @@ def public_repos() -> PublicReposOutput:
     return PublicReposOutput(jobs=jobs, inputs=inputs, run_name=run_name)
 
 
-def clear_self_hosted_persistent_caches_jobs() -> list[dict[str, Any]]:
-    def make_job(platform: Platform) -> dict[str, Any]:
+def clear_self_hosted_persistent_caches_jobs() -> Jobs:
+    jobs = {}
+
+    for platform in sorted(SELF_HOSTED, key=lambda p: p.value):
         helper = Helper(platform)
 
         clear_steps = [
@@ -1589,8 +1591,7 @@ def clear_self_hosted_persistent_caches_jobs() -> list[dict[str, Any]]:
                 "~/.pex",
             ]
         ]
-        return {
-            "name": helper.job_name("clear"),
+        jobs[helper.job_name("clean")] = {
             "runs-on": helper.runs_on(),
             "steps": [
                 {"name": "df before", "run": "df -h"},
@@ -1599,7 +1600,7 @@ def clear_self_hosted_persistent_caches_jobs() -> list[dict[str, Any]]:
             ],
         }
 
-    return [make_job(platform) for platform in sorted(SELF_HOSTED, key=lambda p: p.value)]
+    return jobs
 
 
 # ----------------------------------------------------------------------

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -1579,7 +1579,10 @@ def clear_self_hosted_persistent_caches_jobs() -> Jobs:
         clear_steps = [
             {
                 "name": f"Deleting {directory}",
-                "run": f"du -sh {directory} || true; rm -rf {directory}",
+                # squash all errors: this is a best effort thing, so, for instance, it's fine if
+                # there's directories hanging around that this workflow doesn't have permission to
+                # delete
+                "run": f"du -sh {directory} || true; rm -rf {directory} || true",
             }
             for directory in [
                 # not all of these will necessarily exist (e.g. ~/Library/Caches is macOS-specific),


### PR DESCRIPTION
In #20755, I had a typo: formatting the jobs as a list, with `name`s keys... but that's the syntax for steps. Jobs need to be a dict with the ID as the key.

This also squashes any errors from `rm -rf ....`: on Mac, it seems that attempts to delete directories that the runner doesn't have permission for (particularly system ones  in `~/Library/Caches`). But that's fine, we'll still delete all of the caches created by "day-to-day" actions runs, which are the big ones.

(Why wasn't this caught in #20755? I attempted to run the workflow before merging, and got errors, but incorrectly assumed this was because the workflow didn't exist on `main`, but they were actually because it's invalid.)

This has now successfully run and cleared hundreds of gigs over two runs:

- https://github.com/pantsbuild/pants/actions/runs/8562624080 (required the "squash `rm` errors fix)
- https://github.com/pantsbuild/pants/actions/runs/8562947394/job/23467155450 (with that fix).