### PR TITLE
Remove the deprecated implicit_value option kwarg.

### DIFF
--- a/src/python/pants/help/help_info_extracter_test.py
+++ b/src/python/pants/help/help_info_extracter_test.py
@@ -40,12 +40,6 @@ def test_global_scope():
 
     do_test(["-f"], {"type": bool}, ["-f"], ["-f"])
     do_test(["--foo"], {"type": bool}, ["--[no-]foo"], ["--foo", "--no-foo"])
-    do_test(
-        ["--foo"],
-        {"type": bool, "implicit_value": False},
-        ["--[no-]foo"],
-        ["--foo", "--no-foo"],
-    )
     do_test(["-f", "--foo"], {"type": bool}, ["-f", "--[no-]foo"], ["-f", "--foo", "--no-foo"])
 
     do_test(["--foo"], {}, ["--foo=<str>"], ["--foo"])
@@ -98,13 +92,6 @@ def test_non_global_scope():
         ["--bar-baz-foo", "--no-bar-baz-foo"],
         ["--foo", "--no-foo"],
     )
-    do_test(
-        ["--foo"],
-        {"type": bool, "implicit_value": False},
-        ["--[no-]bar-baz-foo"],
-        ["--bar-baz-foo", "--no-bar-baz-foo"],
-        ["--foo", "--no-foo"],
-    )
 
 
 def test_default() -> None:
@@ -128,8 +115,6 @@ def test_default() -> None:
 
     do_test(["--foo"], {"type": bool}, "False")
     do_test(["--foo"], {"type": bool, "default": True}, "True")
-    do_test(["--foo"], {"type": bool, "implicit_value": False}, "True")
-    do_test(["--foo"], {"type": bool, "implicit_value": False, "default": False}, "False")
     do_test(["--foo"], {}, "None")
     do_test(["--foo"], {"type": int}, "None")
     do_test(["--foo"], {"type": int, "default": 42}, "42")

--- a/src/python/pants/option/errors.py
+++ b/src/python/pants/option/errors.py
@@ -53,10 +53,6 @@ class HelpType(RegistrationError):
     """The `help=` argument must be a string, but was of type `{help_type}`."""
 
 
-class ImplicitValIsNone(RegistrationError):
-    """Implicit value cannot be None."""
-
-
 class InvalidKwarg(RegistrationError):
     """Invalid registration kwarg {kwarg}."""
 

--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -29,7 +29,6 @@ from pants.option.errors import (
     DefaultValueType,
     FromfileError,
     HelpType,
-    ImplicitValIsNone,
     InvalidKwarg,
     InvalidMemberType,
     MemberTypeNotAllowed,
@@ -98,18 +97,6 @@ def register_bool_opts(opts: Options) -> None:
     opts.register(GLOBAL_SCOPE, "--default-true", type=bool, default=True)
     opts.register(GLOBAL_SCOPE, "--default-false", type=bool, default=False)
     opts.register(GLOBAL_SCOPE, "--unset", type=bool, default=UnsetBool)
-    opts.register(GLOBAL_SCOPE, "--implicit-true", type=bool, implicit_value=True)
-    opts.register(GLOBAL_SCOPE, "--implicit-false", type=bool, implicit_value=False)
-    opts.register(
-        GLOBAL_SCOPE,
-        "--implicit-false-default-false",
-        type=bool,
-        implicit_value=False,
-        default=False,
-    )
-    opts.register(
-        GLOBAL_SCOPE, "--implicit-false-default-true", type=bool, implicit_value=False, default=True
-    )
 
 
 def test_bool_explicit_values() -> None:
@@ -136,11 +123,6 @@ def test_bool_defaults() -> None:
 
     assert opts.unset is None
 
-    assert opts.implicit_true is False
-    assert opts.implicit_false is True
-    assert opts.implicit_false_default_false is False
-    assert opts.implicit_false_default_true is True
-
 
 def test_bool_args() -> None:
     opts = create_options(
@@ -151,10 +133,6 @@ def test_bool_args() -> None:
             "--default-true",
             "--default-false",
             "--unset",
-            "--implicit-true",
-            "--implicit-false",
-            "--implicit-false-default-false",
-            "--implicit-false-default-true",
         ],
     ).for_global_scope()
     assert opts.default_missing is True
@@ -162,11 +140,6 @@ def test_bool_args() -> None:
     assert opts.default_false is True
 
     assert opts.unset is True
-
-    assert opts.implicit_true is True
-    assert opts.implicit_false is False
-    assert opts.implicit_false_default_false is False
-    assert opts.implicit_false_default_true is False
 
 
 def test_bool_negate() -> None:
@@ -178,10 +151,6 @@ def test_bool_negate() -> None:
             "--no-default-true",
             "--no-default-false",
             "--no-unset",
-            "--no-implicit-true",
-            "--no-implicit-false",
-            "--no-implicit-false-default-false",
-            "--no-implicit-false-default-true",
         ],
     ).for_global_scope()
     assert opts.default_missing is False
@@ -190,11 +159,6 @@ def test_bool_negate() -> None:
 
     assert opts.unset is False
 
-    assert opts.implicit_true is False
-    assert opts.implicit_false is True
-    assert opts.implicit_false_default_false is True
-    assert opts.implicit_false_default_true is True
-
 
 @pytest.mark.parametrize("val", [False, True])
 def test_bool_config(val: bool) -> None:
@@ -202,10 +166,6 @@ def test_bool_config(val: bool) -> None:
         "default_missing",
         "default_true",
         "default_false",
-        "implicit_true",
-        "implicit_false",
-        "implicit_false_default_false",
-        "implicit_false_default_true",
     )
     opts = create_options(
         [GLOBAL_SCOPE], register_bool_opts, config={"GLOBAL": {opt: val for opt in opt_names}}
@@ -609,9 +569,6 @@ def _register(options):
         member_type=shell_str,
         default="--default1 --default2=test",
     )
-
-    # Implicit value.
-    register_global("--implicit-valuey", default="default", implicit_value="implicit")
 
     # Mutual Exclusive options
     register_global("--mutex-foo", mutually_exclusive_group="mutex")
@@ -1053,7 +1010,6 @@ def test_validation() -> None:
     assertError(OptionNameDoubleDash, "badname")
     assertError(OptionNameDoubleDash, "-badname")
     assertError(InvalidKwarg, "--foo", badkwarg=42)
-    assertError(ImplicitValIsNone, "--foo", implicit_value=None)
     assertError(BooleanOptionNameWithNo, "--no-foo", type=bool)
     assertError(MemberTypeNotAllowed, "--foo", member_type=int)
     assertError(MemberTypeNotAllowed, "--foo", type=dict, member_type=int)
@@ -1061,16 +1017,6 @@ def test_validation() -> None:
     assertError(InvalidMemberType, "--foo", type=list, member_type=list)
     assertError(HelpType, "--foo", help=())
     assertError(HelpType, "--foo", help=("Help!",))
-
-
-def test_implicit_value() -> None:
-    def check(*, flag: str = "", expected: str) -> None:
-        options = _parse(flags=flag)
-        assert options.for_global_scope().implicit_valuey == expected
-
-    check(expected="default")
-    check(flag="--implicit-valuey", expected="implicit")
-    check(flag="--implicit-valuey=explicit", expected="explicit")
 
 
 def test_shadowing() -> None:

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -179,7 +179,7 @@ class Parser:
             specify the same flag multiple times, and that's sometimes OK (e.g., when appending to
             list- valued options).
             """
-            flag_value_map: DefaultDict[str, list[str | None]] = defaultdict(list)
+            flag_value_map: DefaultDict[str, list[str]] = defaultdict(list)
             for flag in flags:
                 flag_val: str | None
                 key, has_equals_sign, flag_val = flag.partition("=")

--- a/src/python/pants/option/parser.py
+++ b/src/python/pants/option/parser.py
@@ -18,7 +18,7 @@ from typing import Any, DefaultDict, Iterable, Mapping
 import yaml
 
 from pants.base.build_environment import get_buildroot
-from pants.base.deprecated import deprecated_conditional, validate_deprecation_semver, warn_or_error
+from pants.base.deprecated import validate_deprecation_semver, warn_or_error
 from pants.option.config import DEFAULT_SECTION, Config
 from pants.option.custom_types import (
     DictValueComponent,
@@ -36,7 +36,6 @@ from pants.option.errors import (
     DefaultValueType,
     FromfileError,
     HelpType,
-    ImplicitValIsNone,
     InvalidKwarg,
     InvalidKwargNonGlobalScope,
     InvalidMemberType,
@@ -173,7 +172,7 @@ class Parser:
             object.__setattr__(self, "allow_unknown_flags", allow_unknown_flags)
 
         @staticmethod
-        def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, list[str | None]]:
+        def _create_flag_value_map(flags: Iterable[str]) -> DefaultDict[str, list[str]]:
             """Returns a map of flag -> list of values, based on the given flag strings.
 
             None signals no value given (e.g., -x, --foo). The value is a list because the user may
@@ -189,10 +188,9 @@ class Parser:
                         key = flag[0:2]
                         flag_val = flag[2:]
                     if not flag_val:
-                        # Either a short option with no value or a long option with no equals sign.
-                        # Important so we can distinguish between no value ('--foo') and setting to an empty
-                        # string ('--foo='), for options with an implicit_value.
-                        flag_val = None
+                        # Either a short option with no value or a long option with no equals sign,
+                        # meaning a boolean option set to true.
+                        flag_val = "true"
                 flag_value_map[key].append(flag_val)
             return flag_value_map
 
@@ -221,21 +219,7 @@ class Parser:
             # We also check if the option is deprecated, but we only do so if the option is explicitly
             # specified as a command-line flag, so we don't spam users with deprecated option values
             # specified in config, which isn't something they control.
-            implicit_value = kwargs.get("implicit_value")
-            if implicit_value is None and self.is_bool(kwargs):
-                implicit_value = True  # Allows --foo to mean --foo=true.
-
             flag_vals: list[int | float | bool | str] = []
-
-            def add_flag_val(v: int | float | bool | str | None) -> None:
-                if v is None:
-                    if implicit_value is None:
-                        raise ParseError(
-                            f"Missing value for command line flag {arg} in {self._scope_str()}"
-                        )
-                    flag_vals.append(implicit_value)
-                else:
-                    flag_vals.append(v)
 
             for arg in args:
                 # If the user specified --no-foo on the cmd line, treat it as if the user specified
@@ -244,12 +228,11 @@ class Parser:
                     inverse_arg = self._inverse_arg(arg)
                     if inverse_arg in flag_value_map:
                         flag_value_map[arg] = [self._invert(v) for v in flag_value_map[inverse_arg]]
-                        implicit_value = self._invert(implicit_value)
                         del flag_value_map[inverse_arg]
 
                 if arg in flag_value_map:
                     for v in flag_value_map[arg]:
-                        add_flag_val(v)
+                        flag_vals.append(v)
                     del flag_value_map[arg]
 
             # Get the value for this option, falling back to defaults as needed.
@@ -343,9 +326,8 @@ class Parser:
             default = kwargs.get("default")
             if default is None:
                 # Unless a tri-state bool is explicitly opted into with the `UnsetBool` default value,
-                # boolean options always have an implicit boolean-typed default. We make that default
-                # explicit here.
-                kwargs["default"] = not self.ensure_bool(kwargs.get("implicit_value", True))
+                # boolean options always have an implicit default of False. We make that explicit here.
+                kwargs["default"] = False
             elif default is UnsetBool:
                 kwargs["default"] = None
 
@@ -377,7 +359,6 @@ class Parser:
         "dest",
         "default",
         "default_help_repr",
-        "implicit_value",
         "metavar",
         "help",
         "advanced",
@@ -424,15 +405,6 @@ class Parser:
                 error(OptionNameDoubleDash, arg_name=arg)
 
         # Validate kwargs.
-        deprecated_conditional(
-            lambda: "implicit_value" in kwargs,
-            removal_version="2.21.0a0",
-            entity="The 'implicit_value' option registration keyword",
-            hint="Command line flags specifying this option must provide its value explicitly, "
-            "except for boolean flags, where --foo is the same as --foo=true.",
-        )
-        if "implicit_value" in kwargs and kwargs["implicit_value"] is None:
-            error(ImplicitValIsNone)
         type_arg = kwargs.get("type", str)
         if "member_type" in kwargs and type_arg != list:
             error(MemberTypeNotAllowed, type_=type_arg.__name__)


### PR DESCRIPTION
Now the only implicit value is "True" for boolean
options (that is, --foo is the same as --foo=true).