### PR TITLE
Fix issue with explicit dependency when using parametrize groups. (Cherry-pick of #20768)

### DIFF
--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1627,6 +1627,55 @@ def test_parametrize_group_on_target_generator_20418(
     )
 
 
+def test_parametrize_explicit_dependencies_20739(
+    generated_targets_rule_runner: RuleRunner,
+) -> None:
+    assert_generated(
+        generated_targets_rule_runner,
+        Address("demo", target_name="tst"),
+        dedent(
+            """\
+            generator(
+              name='src',
+              sources=['src1.ext'],
+              **parametrize('b1', resolve='a'),
+              **parametrize('b2', resolve='b'),
+            )
+            generator(
+              name='tst',
+              sources=['tst1.ext'],
+              dependencies=['./src1.ext:src'],
+              **parametrize('b1', resolve='a'),
+              **parametrize('b2', resolve='b'),
+            )
+            """
+        ),
+        ["src1.ext", "tst1.ext"],
+        expected_dependencies={
+            "demo/src1.ext:src@parametrize=b1": set(),
+            "demo/src1.ext:src@parametrize=b2": set(),
+            "demo/tst1.ext:tst@parametrize=b1": {
+                "demo/src1.ext:src@parametrize=b1",
+            },
+            "demo/tst1.ext:tst@parametrize=b2": {
+                "demo/src1.ext:src@parametrize=b2",
+            },
+            "demo:src@parametrize=b1": {
+                "demo/src1.ext:src@parametrize=b1",
+            },
+            "demo:src@parametrize=b2": {
+                "demo/src1.ext:src@parametrize=b2",
+            },
+            "demo:tst@parametrize=b1": {
+                "demo/tst1.ext:tst@parametrize=b1",
+            },
+            "demo:tst@parametrize=b2": {
+                "demo/tst1.ext:tst@parametrize=b2",
+            },
+        },
+    )
+
+
 # -----------------------------------------------------------------------------------------------
 # Test `SourcesField`. Also see `engine/target_test.py`.
 # -----------------------------------------------------------------------------------------------

--- a/src/python/pants/engine/internals/parametrize.py
+++ b/src/python/pants/engine/internals/parametrize.py
@@ -427,12 +427,20 @@ class _TargetParametrizations(Collection[_TargetParametrization]):
             ):
                 return parametrization.original_target
 
-            # Else, see whether any of the generated targets match.
-            for candidate in parametrization.parametrization.values():
-                if address.is_parametrized_subset_of(candidate.address) and remaining_fields_match(
-                    candidate
-                ):
-                    return candidate
+        consumer_parametrize_group = consumer.address.parameters.get("parametrize")
+
+        def matching_parametrize_group(candidate: Target) -> bool:
+            return candidate.address.parameters.get("parametrize") == consumer_parametrize_group
+
+        for candidate in sorted(
+            self.parametrizations.values(), key=matching_parametrize_group, reverse=True
+        ):
+            # Else, see whether any of the generated targets match, preferring a matching
+            # parametrize group when available.
+            if address.is_parametrized_subset_of(candidate.address) and remaining_fields_match(
+                candidate
+            ):
+                return candidate
 
         raise ValueError(
             f"The explicit dependency `{address}` of the target at `{consumer.address}` does "


### PR DESCRIPTION
When both a target and a explicitly provided dependency is using parametrize groups (the `**parametrize(..)` syntax), and the dependency does not explicitly provide the parametrization to use, pick the matching parametrization group with the target if available, rather than just the first one.

Closes #20739 

