### PR TITLE
provide a more friendly pointer on unconfigured constraint file

### DIFF
--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -532,7 +532,7 @@ def _common_failure_reasons(
     if InvalidPythonLockfileReason.CONSTRAINTS_FILE_MISMATCH in failure_reasons:
         if maybe_constraints_file_path is None:
             yield softwrap(
-                f"""
+                """
                 - Constraint file expected from lockfile metadata but no
                 constraints file configured.  See the option
                 `[python].resolves_to_constraints_file`.
@@ -660,7 +660,10 @@ def _invalid_lockfile_error(
         yield f"\n\nSee {doc_url('docs/python/overview/interpreter-compatibility')} for details."
 
     yield "\n\n"
-    yield from (f"{fail}\n" for fail in _common_failure_reasons(validation.failure_reasons, maybe_constraints_file_path))
+    yield from (
+        f"{fail}\n"
+        for fail in _common_failure_reasons(validation.failure_reasons, maybe_constraints_file_path)
+    )
     yield "To regenerate your lockfile, "
     yield f"run `{bin_name()} generate-lockfiles --resolve={resolve}`."
     yield f"\n\nSee {doc_url('docs/python/overview/third-party-dependencies')} for details.\n\n"

--- a/src/python/pants/backend/python/util_rules/pex_requirements.py
+++ b/src/python/pants/backend/python/util_rules/pex_requirements.py
@@ -530,14 +530,22 @@ def _common_failure_reasons(
     failure_reasons: set[InvalidPythonLockfileReason], maybe_constraints_file_path: str | None
 ) -> Iterator[str]:
     if InvalidPythonLockfileReason.CONSTRAINTS_FILE_MISMATCH in failure_reasons:
-        assert maybe_constraints_file_path is not None
-        yield softwrap(
-            f"""
-            - The constraints file at {maybe_constraints_file_path} has changed from when the
-            lockfile was generated. (Constraints files are set via the option
-            `[python].resolves_to_constraints_file`)
-            """
-        )
+        if maybe_constraints_file_path is None:
+            yield softwrap(
+                f"""
+                - Constraint file expected from lockfile metadata but no
+                constraints file configured.  See the option
+                `[python].resolves_to_constraints_file`.
+                """
+            )
+        else:
+            yield softwrap(
+                f"""
+                - The constraints file at {maybe_constraints_file_path} has changed from when the
+                lockfile was generated. (Constraints files are set via the option
+                `[python].resolves_to_constraints_file`)
+                """
+            )
     if InvalidPythonLockfileReason.ONLY_BINARY_MISMATCH in failure_reasons:
         yield softwrap(
             """
@@ -652,7 +660,7 @@ def _invalid_lockfile_error(
         yield f"\n\nSee {doc_url('docs/python/overview/interpreter-compatibility')} for details."
 
     yield "\n\n"
-    yield from _common_failure_reasons(validation.failure_reasons, maybe_constraints_file_path)
+    yield from (f"{fail}\n" for fail in _common_failure_reasons(validation.failure_reasons, maybe_constraints_file_path))
     yield "To regenerate your lockfile, "
     yield f"run `{bin_name()} generate-lockfiles --resolve={resolve}`."
     yield f"\n\nSee {doc_url('docs/python/overview/third-party-dependencies')} for details.\n\n"


### PR DESCRIPTION
Or more formally, a mismatch between the lockfile metadata saying there should be constraints when none is configured.  Previously this showed up as a bare:

```
Engine traceback:
  in `package` goal

AssertionError:
```