### PR TITLE
Fixed install_git_hooks.sh does not work if "python" is not found (but python3 exists)

### DIFF
--- a/build-support/bin/install_git_hooks.sh
+++ b/build-support/bin/install_git_hooks.sh
@@ -11,8 +11,12 @@ HOOK_DIR="${GIT_DIR:-${REPO_ROOT}/.git}/hooks"
 HOOK_SRC_DIR="${REPO_ROOT}/build-support/githooks"
 HOOK_NAMES="$(ls "${HOOK_SRC_DIR}")"
 
+# shellcheck source=build-support/common.sh
+source "${REPO_ROOT}/build-support/common.sh"
+PY="$(determine_python)"
+
 RELPATH_PREFIX="$(
-  cat << EOF | python
+  cat << EOF | ${PY}
 import os
 
 print(os.path.relpath("${HOOK_SRC_DIR}", "${HOOK_DIR}"))


### PR DESCRIPTION
Instead of calling "python", we now use the `determine`d python as per common.sh (which the rest of the bash scripts also use.

Closes #20671 