### PR TITLE
Mark all Python tools as exportable

### DIFF
--- a/docs/docs/python/overview/lockfiles.mdx
+++ b/docs/docs/python/overview/lockfiles.mdx
@@ -184,10 +184,7 @@ It is strongly recommended that these tools be installed from a hermetic lockfil
 
 The only time you need to think about this is if you want to customize the tool requirements that Pants uses. This might be the case if you want to modify the version of a tool or add extra requirements (for example, tool plugins).
 
-:::caution Exporting tools requires a custom lockfile
-:::
-
-If you want a tool to be installed from some resolve, instead of from the built-in lockfile, you set `install_from_resolve` and `requirements` on the tool's config section:
+Tools can also be installed from a specific resolve instead of from the built-in lockfile. This is useful for specifying a version of the tool and including extra packages. To do this, set `install_from_resolve` and `requirements` on the tool's config section:
 
 ```toml title="pants.toml"
 [python.resolves]

--- a/docs/docs/using-pants/setting-up-an-ide.mdx
+++ b/docs/docs/using-pants/setting-up-an-ide.mdx
@@ -49,7 +49,7 @@ The `--py-resolve-format=symlinked_immutable_virtualenv` option symlinks to an i
 
 ### Tool virtualenvs
 
-`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. Follow [the instructions for creating a tool lockfile](../python/overview/lockfiles#lockfiles-for-tools).
+`pants export` can also create a virtualenv for each of the Python tools you use via Pants, such as `black`, `isort`, `pytest`, `mypy`, `flake8` and so on. This allows you to configure your editor to use the same version of the tool as Pants does for workflows like formatting on save. To use a custom version of these tools, follow [the instructions for creating a tool lockfile](../python/overview/lockfiles#lockfiles-for-tools).
 
 ## Generated code
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -73,7 +73,7 @@ The deprecation for the `platforms` field for the `pex_binary` and `pex_binaries
 
 Python tool subsystem docs and help text now include the default version of the tool, along with instructions on how to override this version using a custom lockfile. Additionally, the help text for the `install_from_resolve` option for Python tools now includes this same information.
 
-Python tools can be exported from their default bundled lockfiles.
+Python tools can be [exported from their default bundled lockfiles](https://www.pantsbuild.org/2.22/docs/using-pants/setting-up-an-ide#tool-virtualenvs). For instance, when using the default `black` subsystem, `pants export --resolve=black` will export a venv containing the version of black that Pants runs.
 
 #### Semgrep
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -73,6 +73,8 @@ The deprecation for the `platforms` field for the `pex_binary` and `pex_binaries
 
 Python tool subsystem docs and help text now include the default version of the tool, along with instructions on how to override this version using a custom lockfile. Additionally, the help text for the `install_from_resolve` option for Python tools now includes this same information.
 
+Python tools can be exported from their default bundled lockfiles.
+
 #### Semgrep
 
 The default version of `semgrep` used by the `pants.backends.experimental.tool.semgrep` backend is now version 1.72.0, upgraded from 1.46.0. This version requires Python 3.8 or greater.

--- a/src/python/pants/backend/cc/lint/clangformat/subsystem.py
+++ b/src/python/pants/backend/cc/lint/clangformat/subsystem.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.unions import UnionRule
@@ -51,4 +52,7 @@ class ClangFormat(PythonToolBase):
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, ClangFormat),
+    ]

--- a/src/python/pants/backend/python/goals/coverage_py.py
+++ b/src/python/pants/backend/python/goals/coverage_py.py
@@ -19,6 +19,7 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.goals.test import (
     ConsoleCoverageReport,
     CoverageData,
@@ -621,4 +622,5 @@ def rules():
     return [
         *collect_rules(),
         UnionRule(CoverageDataCollection, PytestCoverageDataCollection),
+        UnionRule(ExportableTool, CoverageSubsystem),
     ]

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -20,12 +20,10 @@ from pants.backend.python.target_types import (
 from pants.backend.python.util_rules import local_dists_pep660, pex_from_targets
 from pants.base.specs import RawSpecs
 from pants.core.goals.export import ExportResults
-from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import distdir
 from pants.engine.internals.parametrize import Parametrize
 from pants.engine.rules import QueryRule
 from pants.engine.target import Targets
-from pants.engine.unions import UnionRule
 from pants.testutil.rule_runner import RuleRunner
 from pants.util.frozendict import FrozenDict
 
@@ -48,9 +46,6 @@ def rule_runner() -> RuleRunner:
             *distdir.rules(),
             *local_dists_pep660.rules(),
             *isort_subsystem.rules(),  # add a tool that we can try exporting
-            UnionRule(
-                ExportableTool, isort_subsystem.Isort
-            ),  # TODO: remove this manual export when we add ExportableTool to tools
             QueryRule(Targets, [RawSpecs]),
             QueryRule(ExportResults, [ExportVenvsRequest]),
         ],

--- a/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
+++ b/src/python/pants/backend/python/lint/add_trailing_comma/subsystem.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
 
@@ -29,4 +31,7 @@ class AddTrailingComma(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, AddTrailingComma),
+    ]

--- a/src/python/pants/backend/python/lint/autoflake/subsystem.py
+++ b/src/python/pants/backend/python/lint/autoflake/subsystem.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
 
@@ -32,4 +34,7 @@ class Autoflake(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, Autoflake),
+    ]

--- a/src/python/pants/backend/python/lint/bandit/subsystem.py
+++ b/src/python/pants/backend/python/lint/bandit/subsystem.py
@@ -13,9 +13,11 @@ from pants.backend.python.target_types import (
     InterpreterConstraintsField,
     PythonSourceField,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
 from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, FileOption, SkipOption
 
 
@@ -72,4 +74,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, Bandit),
     )

--- a/src/python/pants/backend/python/lint/black/subsystem.py
+++ b/src/python/pants/backend/python/lint/black/subsystem.py
@@ -14,9 +14,11 @@ from pants.backend.python.target_types import (
     InterpreterConstraintsField,
     PythonSourceField,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
 from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
@@ -89,4 +91,7 @@ class Black(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, Black),
+    ]

--- a/src/python/pants/backend/python/lint/docformatter/subsystem.py
+++ b/src/python/pants/backend/python/lint/docformatter/subsystem.py
@@ -4,7 +4,9 @@
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
 
@@ -25,4 +27,7 @@ class Docformatter(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, Docformatter),
+    ]

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.lint.flake8.skip_field import SkipFlake8Field
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import (
@@ -213,7 +212,6 @@ async def flake8_first_party_plugins(flake8: Flake8) -> Flake8FirstPartyPlugins:
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         *python_sources.rules(),
         UnionRule(ExportableTool, Flake8),
     )

--- a/src/python/pants/backend/python/lint/flake8/subsystem.py
+++ b/src/python/pants/backend/python/lint/flake8/subsystem.py
@@ -20,12 +20,14 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import AddPrefix, Digest
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.unions import UnionRule
 from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
@@ -213,4 +215,5 @@ def rules():
         *collect_rules(),
         *lockfile.rules(),
         *python_sources.rules(),
+        UnionRule(ExportableTool, Flake8),
     )

--- a/src/python/pants/backend/python/lint/isort/subsystem.py
+++ b/src/python/pants/backend/python/lint/isort/subsystem.py
@@ -8,8 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileListOption, SkipOption
 from pants.util.strutil import softwrap
 
@@ -93,4 +95,5 @@ class Isort(PythonToolBase):
 def rules():
     return [
         *collect_rules(),
+        UnionRule(ExportableTool, Isort),
     ]

--- a/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
+++ b/src/python/pants/backend/python/lint/pydocstyle/subsystem.py
@@ -9,9 +9,11 @@ from pants.backend.python.goals import lockfile
 from pants.backend.python.lint.pydocstyle.skip_field import SkipPydocstyleField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript, PythonSourceField
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
 from pants.engine.target import FieldSet, Target
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.docutil import bin_name
 from pants.util.strutil import softwrap
@@ -91,4 +93,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, Pydocstyle),
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -7,7 +7,6 @@ import os.path
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.lint.pylint.skip_field import SkipPylintField
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import (
@@ -204,6 +203,5 @@ async def pylint_first_party_plugins(pylint: Pylint) -> PylintFirstPartyPlugins:
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(ExportableTool, Pylint),
     )

--- a/src/python/pants/backend/python/lint/pylint/subsystem.py
+++ b/src/python/pants/backend/python/lint/pylint/subsystem.py
@@ -22,11 +22,13 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFilesRequest,
     StrippedPythonSourceFiles,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, AddPrefix, Digest
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.unions import UnionRule
 from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
@@ -203,4 +205,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, Pylint),
     )

--- a/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
+++ b/src/python/pants/backend/python/lint/pyupgrade/subsystem.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, SkipOption
 
 
@@ -28,4 +30,7 @@ class PyUpgrade(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, PyUpgrade),
+    ]

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -85,4 +85,8 @@ class Ruff(PythonToolBase):
 
 
 def rules():
-    return (*collect_rules(), *python_sources.rules(), UnionRule(ExportableTool, Ruff))
+    return (
+        *collect_rules(),
+        *python_sources.rules(),
+        UnionRule(ExportableTool, Ruff),
+    )

--- a/src/python/pants/backend/python/lint/ruff/subsystem.py
+++ b/src/python/pants/backend/python/lint/ruff/subsystem.py
@@ -10,8 +10,10 @@ from typing import Iterable
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.backend.python.util_rules import python_sources
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
@@ -83,7 +85,4 @@ class Ruff(PythonToolBase):
 
 
 def rules():
-    return (
-        *collect_rules(),
-        *python_sources.rules(),
-    )
+    return (*collect_rules(), *python_sources.rules(), UnionRule(ExportableTool, Ruff))

--- a/src/python/pants/backend/python/lint/yapf/subsystem.py
+++ b/src/python/pants/backend/python/lint/yapf/subsystem.py
@@ -8,8 +8,10 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
 
@@ -88,4 +90,7 @@ class Yapf(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, Yapf),
+    ]

--- a/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
+++ b/src/python/pants/backend/python/packaging/pyoxidizer/subsystem.py
@@ -3,7 +3,9 @@
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption
 from pants.util.strutil import help_text
 
@@ -32,4 +34,7 @@ class PyOxidizer(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, PyOxidizer),
+    ]

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
 from pants.core.goals.resolves import ExportableTool
@@ -43,6 +42,5 @@ class IPython(PythonToolBase):
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(ExportableTool, IPython),
     )

--- a/src/python/pants/backend/python/subsystems/ipython.py
+++ b/src/python/pants/backend/python/subsystems/ipython.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.option_types import BoolOption
 from pants.util.strutil import softwrap
 
@@ -42,4 +44,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, IPython),
     )

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -7,7 +7,6 @@ import os.path
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import (
     ConsoleScript,
@@ -157,6 +156,5 @@ class PyTest(PythonToolBase):
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(ExportableTool, PyTest),
     )

--- a/src/python/pants/backend/python/subsystems/pytest.py
+++ b/src/python/pants/backend/python/subsystems/pytest.py
@@ -20,11 +20,13 @@ from pants.backend.python.target_types import (
     PythonTestsXdistConcurrencyField,
     SkipPythonTestsField,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.goals.test import RuntimePackageDependenciesField, TestFieldSet
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.rules import collect_rules
 from pants.engine.target import Target
+from pants.engine.unions import UnionRule
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
 from pants.util.strutil import softwrap
 
@@ -156,4 +158,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, PyTest),
     )

--- a/src/python/pants/backend/python/subsystems/setuptools_scm.py
+++ b/src/python/pants/backend/python/subsystems/setuptools_scm.py
@@ -3,7 +3,9 @@
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import EntryPoint
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 
 
 class SetuptoolsSCM(PythonToolBase):
@@ -21,4 +23,7 @@ class SetuptoolsSCM(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, SetuptoolsSCM),
+    ]

--- a/src/python/pants/backend/python/subsystems/twine.py
+++ b/src/python/pants/backend/python/subsystems/twine.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFilesRequest
 from pants.engine.fs import CreateDigest
 from pants.engine.rules import collect_rules
+from pants.engine.unions import UnionRule
 from pants.option.global_options import ca_certs_path_to_file_content
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption, StrOption
 from pants.util.docutil import doc_url
@@ -103,4 +105,7 @@ class TwineSubsystem(PythonToolBase):
 
 
 def rules():
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, TwineSubsystem),
+    ]

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -7,7 +7,6 @@ import logging
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
@@ -268,6 +267,5 @@ async def _mypy_interpreter_constraints(
 def rules():
     return (
         *collect_rules(),
-        *lockfile.rules(),
         UnionRule(ExportableTool, MyPy),
     )

--- a/src/python/pants/backend/python/typecheck/mypy/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/mypy/subsystem.py
@@ -25,11 +25,13 @@ from pants.backend.python.util_rules.python_sources import (
     PythonSourceFiles,
     PythonSourceFilesRequest,
 )
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import EMPTY_DIGEST, Digest, DigestContents, FileContent
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import FieldSet, Target, TransitiveTargets, TransitiveTargetsRequest
+from pants.engine.unions import UnionRule
 from pants.option.option_types import (
     ArgsListOption,
     BoolOption,
@@ -267,4 +269,5 @@ def rules():
     return (
         *collect_rules(),
         *lockfile.rules(),
+        UnionRule(ExportableTool, MyPy),
     )

--- a/src/python/pants/backend/python/typecheck/pytype/rules.py
+++ b/src/python/pants/backend/python/typecheck/pytype/rules.py
@@ -31,6 +31,7 @@ from pants.backend.python.util_rules.pex import (
 from pants.backend.python.util_rules.pex_environment import PexEnvironment
 from pants.backend.python.util_rules.pex_from_targets import RequirementsPexRequest
 from pants.core.goals.check import CheckRequest, CheckResult, CheckResults
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules import config_files
 from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
@@ -223,4 +224,5 @@ def rules() -> Iterable[Rule | UnionRule]:
         *lockfile.rules(),
         *pex_from_targets.rules(),
         UnionRule(CheckRequest, PytypeRequest),
+        UnionRule(ExportableTool, Pytype),
     )

--- a/src/python/pants/backend/python/typecheck/pytype/rules.py
+++ b/src/python/pants/backend/python/typecheck/pytype/rules.py
@@ -7,7 +7,6 @@ import logging
 from dataclasses import dataclass
 from typing import Iterable
 
-from pants.backend.python.goals import lockfile
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
     InterpreterConstraintsField,
@@ -221,7 +220,6 @@ def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *config_files.rules(),
-        *lockfile.rules(),
         *pex_from_targets.rules(),
         UnionRule(CheckRequest, PytypeRequest),
         UnionRule(ExportableTool, Pytype),

--- a/src/python/pants/backend/tools/semgrep/subsystem.py
+++ b/src/python/pants/backend/tools/semgrep/subsystem.py
@@ -8,6 +8,7 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.target import Dependencies, FieldSet, SingleSourceField, Target
 from pants.engine.unions import UnionRule
@@ -74,4 +75,7 @@ class SemgrepSubsystem(PythonToolBase):
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, SemgrepSubsystem),
+    ]

--- a/src/python/pants/backend/tools/yamllint/subsystem.py
+++ b/src/python/pants/backend/tools/yamllint/subsystem.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.target_types import ConsoleScript
+from pants.core.goals.resolves import ExportableTool
 from pants.core.util_rules.config_files import OrphanFilepathConfigBehavior
 from pants.engine.rules import Rule, collect_rules
 from pants.engine.unions import UnionRule
@@ -73,4 +74,7 @@ class Yamllint(PythonToolBase):
 
 
 def rules() -> Iterable[Rule | UnionRule]:
-    return collect_rules()
+    return [
+        *collect_rules(),
+        UnionRule(ExportableTool, Yamllint),
+    ]


### PR DESCRIPTION
Following to #20730 , this MR flags all Python tools as exportable. It omits some internal tools (for example, parsers for dependency inference).

I think there's a risk that someone tries to export a Python-based tool without activating the Python backend. I also want to look into a few instances where some lockfile rules are registered and see if those registrations are still necessary.