### PR TITLE
Mark most JVM-based subsystems as exportable

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -47,6 +47,8 @@ deploy jars, in addition to those specified on a per-jar basis in the `deploy_ja
 This option's default value excludes signature files from constituent jars, which are known to cause the deploy jar
 to fail to execute (since naturally it doesn't match those signatures).
 
+The internal code for exporting JVM tools was refactored.
+
 ##### Scala
 
 Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.

--- a/src/python/pants/jvm/test/junit.py
+++ b/src/python/pants/jvm/test/junit.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from pants.backend.java.subsystems.junit import JUnit
-from pants.core.goals.generate_lockfiles import GenerateToolLockfileSentinel
+from pants.core.goals.resolves import ExportableTool
 from pants.core.goals.test import (
     TestDebugRequest,
     TestExtraEnv,
@@ -37,7 +37,7 @@ from pants.jvm.classpath import Classpath
 from pants.jvm.goals import lockfile
 from pants.jvm.jdk_rules import JdkEnvironment, JdkRequest, JvmProcess
 from pants.jvm.resolve.coursier_fetch import ToolClasspath, ToolClasspathRequest
-from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool, GenerateJvmToolLockfileSentinel
+from pants.jvm.resolve.jvm_tool import GenerateJvmLockfileFromTool
 from pants.jvm.subsystems import JvmSubsystem
 from pants.jvm.target_types import (
     JunitTestSourceField,
@@ -70,10 +70,6 @@ class JunitTestRequest(TestRequest):
     supports_debug = True
 
 
-class JunitToolLockfileSentinel(GenerateJvmToolLockfileSentinel):
-    resolve_name = JUnit.options_scope
-
-
 @dataclass(frozen=True)
 class TestSetupRequest:
     field_set: JunitTestFieldSet
@@ -99,7 +95,7 @@ async def setup_junit_for_target(
         Get(TransitiveTargets, TransitiveTargetsRequest([request.field_set.address])),
     )
 
-    lockfile_request = await Get(GenerateJvmLockfileFromTool, JunitToolLockfileSentinel())
+    lockfile_request = GenerateJvmLockfileFromTool.create(junit)
     classpath, junit_classpath, files = await MultiGet(
         Get(Classpath, Addresses([request.field_set.address])),
         Get(ToolClasspath, ToolClasspathRequest(lockfile=lockfile_request)),
@@ -207,17 +203,10 @@ async def setup_junit_debug_request(
     )
 
 
-@rule
-def generate_junit_lockfile_request(
-    _: JunitToolLockfileSentinel, junit: JUnit
-) -> GenerateJvmLockfileFromTool:
-    return GenerateJvmLockfileFromTool.create(junit)
-
-
 def rules():
     return [
         *collect_rules(),
         *lockfile.rules(),
-        UnionRule(GenerateToolLockfileSentinel, JunitToolLockfileSentinel),
+        UnionRule(ExportableTool, JUnit),
         *JunitTestRequest.rules(),
     ]


### PR DESCRIPTION
Converts all JVM tools which are subsystems to use ExportableTool for lockfile generation.

Some internal tools still use `GenerateJvmToolLockfileSentinel` subclasses. They aren't subsystems, so they'd need some more work. We could either convert them into subsystems (as is done in Python-based backends) although if we don't plan on exposing them (which is the current case) we could also remove the subclass and rule and replace it with a function.