### PR TITLE
Improve exported mutable_virtualenv prompt

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -230,11 +230,14 @@ async def do_export(
         tmpdir_under_digest_root = os.path.join("{digest_root}", tmpdir_prefix)
         merged_digest_under_tmpdir = await Get(Digest, AddPrefix(merged_digest, tmpdir_prefix))
 
+        venv_prompt = f"{req.resolve_name}/{py_version}" if req.resolve_name else py_version
+
         pex_args = [
             os.path.join(tmpdir_under_digest_root, requirements_pex.name),
             "venv",
             "--pip",
             "--collisions-ok",
+            f"--prompt={venv_prompt}",
             output_path,
         ]
         if not export_subsys.options.py_hermetic_scripts:

--- a/src/python/pants/backend/python/goals/export_integration_test.py
+++ b/src/python/pants/backend/python/goals/export_integration_test.py
@@ -110,6 +110,12 @@ def test_export(py_resolve_format: PythonResolveExportFormat, py_hermetic_script
         ), f"expected dist-info for ansicolors '{expected_ansicolors_dir}' does not exist"
 
         if py_resolve_format == PythonResolveExportFormat.mutable_virtualenv:
+            activate_path = os.path.join(export_dir, "bin", "activate")
+            assert os.path.isfile(activate_path), "virtualenv's bin/activate is missing"
+            with open(activate_path) as activate_file:
+                prompt = f'PS1="({resolve}/{platform.python_version()}) '
+                assert prompt in activate_file.read()
+
             script_path = os.path.join(export_dir, "bin", "wheel")
             assert os.path.isfile(
                 script_path

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -145,15 +145,16 @@ def test_export_venv_new_codepath(
             assert req_pex_dir == tmpdir
             assert req_pex_name == f"{resolve}.pex"
 
-            assert ppc0.argv[3:6] == (
+            assert ppc0.argv[3:7] == (
                 "venv",
                 "--pip",
                 "--collisions-ok",
+                f"--prompt={resolve}/{current_interpreter}",
             )
             if py_hermetic_scripts:
                 assert "--non-hermetic-scripts" not in ppc0.argv
             else:
-                assert ppc0.argv[6] == "--non-hermetic-scripts"
+                assert ppc0.argv[7] == "--non-hermetic-scripts"
             assert ppc0.argv[-1] == "{digest_root}"
             assert ppc0.extra_env["PEX_MODULE"] == "pex.tools"
             assert ppc0.extra_env.get("PEX_ROOT") is not None


### PR DESCRIPTION
This includes resolve name and python version in the PS1 prompt of `mutable_virtualenv` exports. This does not make the prompt configurable, it just improves the default.

The implementation relies on pex's `venv --prompt=` cli arg, which passes it to its `virtualenv` (or `-m venv`) subprocess:
- https://github.com/pex-tool/pex/blob/v2.3.1/pex/venv/installer_options.py#L86-L89
- https://github.com/pex-tool/pex/blob/v2.3.1/pex/venv/virtualenv.py#L215
- https://github.com/pex-tool/pex/blob/v2.3.1/pex/venv/virtualenv.py#L252

Related: #17727
(#17727 requests an improved prompt for `symlinked_immutable_virtualenv`. This PR adds that for `mutable_virtualenv` not for `symlinked_immutable_virtualenv`)