### PR TITLE
Fix direct_url in python PEP660 editable wheels (again)

### DIFF
--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -280,8 +280,8 @@ def test_build_editable_local_dists_special_files(rule_runner: PythonRuleRunner)
 
                 pth_path = f"{pkg}__pants__.pth"
                 assert pth_path in whl_files
-                with whl.open(pth_path) as pth_contents:
-                    pth_lines = pth_contents.readlines()
+                pth_contents = zipfile.Path(whl, pth_path).read_text()
+                pth_lines = pth_contents.split("/n")
 
                 direct_url_path = f"{pkg}-9.8.7.dist-info/direct_url__pants__.json"
                 assert direct_url_path in whl_files
@@ -289,8 +289,8 @@ def test_build_editable_local_dists_special_files(rule_runner: PythonRuleRunner)
                     direct_url = json.loads(direct_url_contents.read())
 
         # make sure inferred dep on "a" is included as well
-        assert f"{rule_runner.build_root}/root_a\n" in pth_lines
-        assert f"{rule_runner.build_root}/root_{pkg}\n" in pth_lines
+        assert f"{rule_runner.build_root}/root_a" in pth_lines
+        assert f"{rule_runner.build_root}/root_{pkg}" in pth_lines
 
         assert len(direct_url) == 2
         assert "dir_info" in direct_url

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import io
+import json
 import zipfile
 from pathlib import PurePath
 from textwrap import dedent

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -230,9 +230,11 @@ def test_build_editable_local_dists_direct_url_contents(rule_runner: PythonRuleR
                 root
                 / "BUILD": dedent(
                     f"""
+                    python_sources()
+
                     python_distribution(
                         name="dist",
-                        dependencies=["./{pkg}"],
+                        dependencies=["./{pkg}", ":root_{pkg}"],
                         provides=python_artifact(name="{pkg}", version="9.8.7"),
                         sdist=False,
                         generate_setup=False,
@@ -248,7 +250,6 @@ def test_build_editable_local_dists_direct_url_contents(rule_runner: PythonRuleR
                         name="{pkg}",
                         version="9.8.7",
                         packages=["{pkg}"],
-                        package_dir=dict({pkg}="."),
                         entry_points={{"foo.plugins": ["{pkg} = {pkg}.bar.BAR"]}},
                     )
                     """

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -281,7 +281,7 @@ def test_build_editable_local_dists_special_files(rule_runner: PythonRuleRunner)
                 pth_path = f"{pkg}__pants__.pth"
                 assert pth_path in whl_files
                 pth_contents = zipfile.Path(whl, pth_path).read_text()
-                pth_lines = pth_contents.split("/n")
+                pth_lines = pth_contents.split("\n")
 
                 direct_url_path = f"{pkg}-9.8.7.dist-info/direct_url__pants__.json"
                 assert direct_url_path in whl_files
@@ -289,8 +289,8 @@ def test_build_editable_local_dists_special_files(rule_runner: PythonRuleRunner)
                     direct_url = json.loads(direct_url_contents.read())
 
         # make sure inferred dep on "a" is included as well
-        assert f"{rule_runner.build_root}/root_a\n" in pth_lines
-        assert f"{rule_runner.build_root}/root_{pkg}\n" in pth_lines
+        assert f"{rule_runner.build_root}/root_a" in pth_lines
+        assert f"{rule_runner.build_root}/root_{pkg}" in pth_lines
 
         assert len(direct_url) == 2
         assert "dir_info" in direct_url

--- a/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
+++ b/src/python/pants/backend/python/util_rules/local_dists_pep660_test.py
@@ -289,8 +289,8 @@ def test_build_editable_local_dists_special_files(rule_runner: PythonRuleRunner)
                     direct_url = json.loads(direct_url_contents.read())
 
         # make sure inferred dep on "a" is included as well
-        assert f"{rule_runner.build_root}/root_a" in pth_lines
-        assert f"{rule_runner.build_root}/root_{pkg}" in pth_lines
+        assert f"{rule_runner.build_root}/root_a\n" in pth_lines
+        assert f"{rule_runner.build_root}/root_{pkg}\n" in pth_lines
 
         assert len(direct_url) == 2
         assert "dir_info" in direct_url

--- a/src/python/pants/backend/python/util_rules/package_dists.py
+++ b/src/python/pants/backend/python/util_rules/package_dists.py
@@ -81,7 +81,12 @@ from pants.engine.target import (
     targets_with_sources_types,
 )
 from pants.engine.unions import UnionMembership, union
-from pants.source.source_root import SourceRootsRequest, SourceRootsResult
+from pants.source.source_root import (
+    OptionalSourceRoot,
+    SourceRootRequest,
+    SourceRootsRequest,
+    SourceRootsResult,
+)
 from pants.util.docutil import doc_url
 from pants.util.frozendict import FrozenDict
 from pants.util.logging import LogLevel
@@ -406,20 +411,27 @@ async def create_dist_build_request(
     )
 
     # Find the source roots for the build-time 1stparty deps (e.g., deps of setup.py).
-    source_roots_result = await Get(
-        SourceRootsResult,
-        SourceRootsRequest(
-            files=[],
-            dirs={
-                PurePath(tgt.address.spec_path)
-                for tgt in transitive_targets.closure
-                if tgt.has_field(PythonSourceField) or tgt.has_field(ResourceSourceField)
-            },
+    optional_dist_source_root, source_roots_result = await MultiGet(
+        Get(OptionalSourceRoot, SourceRootRequest.for_target(dist_tgt)),
+        Get(
+            SourceRootsResult,
+            SourceRootsRequest(
+                files=[],
+                dirs={
+                    PurePath(tgt.address.spec_path)
+                    for tgt in transitive_targets.closure
+                    if tgt.has_field(PythonSourceField) or tgt.has_field(ResourceSourceField)
+                },
+            ),
         ),
     )
-    path_to_root = source_roots_result.path_to_root
-    dist_source_root = next(iter(path_to_root.values())).path if path_to_root else "."
-    source_roots = tuple(sorted({sr.path for sr in path_to_root.values()}))
+
+    # We have to get `dist_source_root` independently from the other source roots because it is
+    # not a `python_source` target, and because `source_roots_result.path_to_root` is already sorted.
+    dist_source_root = (
+        optional_dist_source_root.source_root.path if optional_dist_source_root.source_root else "."
+    )
+    source_roots = tuple(sorted({sr.path for sr in source_roots_result.path_to_root.values()}))
 
     # Get any extra build-time environment (e.g., native extension requirements).
     build_env_requests = []


### PR DESCRIPTION
We were using the first entry in `source_roots_result.path_to_root` to populate the editable wheel's `direct_url`. However, that does not work as I expected it to because `SourceRootsRequest.dirs` and `SourceRootsResult.path_to_root` both get sorted as soon as the dataclass is created (if not before).

PR #20486 was my first attempt at fixing this, but that wasn't enough. Since the heuristics used before #20486 and in #20486 were both inaccurate due to dataclasses getting sorted, this abandons the heuristics altogether, explicitly requesting the source root for the `python_distribution` target.

This time, I added a test to make sure direct_url.json has the contents we expect.

Note: This is ultimately a cosmetic bug. The direct_url gets printed in the output of `pip list`, but is otherwise not really exposed anywhere. So, it's odd when it's the wrong directory, but does not break any functionality.