### PR TITLE
re-add missing opentelemetry.util module mapping (Cherry-pick of #20804)

### DIFF
--- a/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
+++ b/src/python/pants/backend/python/dependency_inference/default_module_mapping.py
@@ -124,6 +124,7 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple] = {
     # opentelemetry
     "opentelemetry-api": (
         "opentelemetry._logs",
+        "opentelemetry.attributes",
         "opentelemetry.baggage",
         "opentelemetry.context",
         "opentelemetry.environment_variables",
@@ -131,6 +132,8 @@ DEFAULT_MODULE_MAPPING: Dict[str, Tuple] = {
         "opentelemetry.propagate",
         "opentelemetry.propagators",
         "opentelemetry.trace",
+        "opentelemetry.util",
+        "opentelemetry.version",
     ),
     "opentelemetry-exporter-otlp": ("opentelemetry.exporter.otlp",),
     "opentelemetry-exporter-otlp-proto-grpc": ("opentelemetry.exporter.otlp.proto.grpc",),


### PR DESCRIPTION
In #20551 the opentelemetry module mappings were expanded -- yeah! -- but in the transition of `opentelemetry-api` from a wildcard to explicit list, this sub-module was missed.

See https://github.com/open-telemetry/opentelemetry-python/tree/v1.24.0/opentelemetry-api/src/opentelemetry
