### PR TITLE
Plumb a FromfileExpander into option source readers

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -5,7 +5,7 @@ use std::env;
 
 use super::id::{is_valid_scope_name, NameTransform, OptionId, Scope};
 use super::{DictEdit, OptionsSource};
-use crate::fromfile::{expand, expand_to_dict, expand_to_list};
+use crate::fromfile::{expand, expand_to_dict, expand_to_list, FromfileExpander};
 use crate::parse::{ParseError, Parseable};
 use crate::ListEdit;
 use core::iter::once;
@@ -153,16 +153,33 @@ impl Args {
         args.next(); // Consume the process name (argv[0]).
         Self::new(env::args().collect::<Vec<_>>())
     }
+}
 
+pub(crate) struct ArgsReader {
+    args: Args,
+    #[allow(dead_code)]
+    fromfile_expander: FromfileExpander,
+}
+
+impl ArgsReader {
+    pub fn new(args: Args, fromfile_expander: FromfileExpander) -> Self {
+        Self {
+            args,
+            fromfile_expander,
+        }
+    }
+
+    #[allow(dead_code)]
     pub fn get_passthrough_args(&self) -> Option<Vec<&str>> {
-        self.passthrough_args
+        self.args
+            .passthrough_args
             .as_ref()
             .map(|v| Vec::from_iter(v.iter().map(String::as_str)))
     }
 
     fn get_list<T: Parseable>(&self, id: &OptionId) -> Result<Option<Vec<ListEdit<T>>>, String> {
         let mut edits = vec![];
-        for arg in &self.args {
+        for arg in &self.args.args {
             if arg.matches(id) {
                 let value = arg.value.as_ref().ok_or_else(|| {
                     format!("Expected list option {} to have a value.", self.display(id))
@@ -182,7 +199,7 @@ impl Args {
     }
 }
 
-impl OptionsSource for Args {
+impl OptionsSource for ArgsReader {
     fn display(&self, id: &OptionId) -> String {
         format!(
             "--{}{}",
@@ -197,7 +214,7 @@ impl OptionsSource for Args {
     fn get_string(&self, id: &OptionId) -> Result<Option<String>, String> {
         // We iterate in reverse so that the rightmost arg wins in case an option
         // is specified multiple times.
-        for arg in self.args.iter().rev() {
+        for arg in self.args.args.iter().rev() {
             if arg.matches(id) {
                 return expand(arg.value.clone().ok_or_else(|| {
                     format!("Expected list option {} to have a value.", self.display(id))
@@ -211,7 +228,7 @@ impl OptionsSource for Args {
     fn get_bool(&self, id: &OptionId) -> Result<Option<bool>, String> {
         // We iterate in reverse so that the rightmost arg wins in case an option
         // is specified multiple times.
-        for arg in self.args.iter().rev() {
+        for arg in self.args.args.iter().rev() {
             if arg.matches(id) {
                 return arg.to_bool().map_err(|e| e.render(&arg.flag));
             } else if arg.matches_negation(id) {
@@ -242,7 +259,7 @@ impl OptionsSource for Args {
 
     fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
         let mut edits = vec![];
-        for arg in self.args.iter() {
+        for arg in self.args.args.iter() {
             if arg.matches(id) {
                 let value = arg.value.clone().ok_or_else(|| {
                     format!("Expected dict option {} to have a value.", self.display(id))

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -4,18 +4,26 @@
 use core::fmt::Debug;
 use maplit::hashmap;
 
-use crate::args::Args;
+use crate::args::{Args, ArgsReader};
 use crate::fromfile::test_util::write_fromfile;
+use crate::fromfile::FromfileExpander;
 use crate::{option_id, DictEdit, DictEditAction, Val};
 use crate::{ListEdit, ListEditAction, OptionId, OptionsSource};
 
-fn mk_args<I: IntoIterator<Item = &'static str>>(args: I) -> Args {
-    Args::new(args.into_iter().map(str::to_owned))
+fn mk_args<I>(args: I) -> ArgsReader
+where
+    I: IntoIterator,
+    I::Item: ToString,
+{
+    ArgsReader::new(
+        Args::new(args.into_iter().map(|x| x.to_string())),
+        FromfileExpander::new(),
+    )
 }
 
 #[test]
 fn test_display() {
-    let args = mk_args([]);
+    let args = mk_args::<Vec<&str>>(vec![]);
     assert_eq!("--global".to_owned(), args.display(&option_id!("global")));
     assert_eq!(
         "--scope-name".to_owned(),
@@ -194,29 +202,35 @@ fn test_scalar_fromfile() {
     fn do_test<T: PartialEq + Debug>(
         content: &str,
         expected: T,
-        getter: fn(&Args, &OptionId) -> Result<Option<T>, String>,
+        getter: fn(&ArgsReader, &OptionId) -> Result<Option<T>, String>,
         negate: bool,
     ) {
         let (_tmpdir, fromfile_path) = write_fromfile("fromfile.txt", content);
-        let args = Args::new(vec![format!(
+        let args = mk_args(vec![format!(
             "--{}foo=@{}",
             if negate { "no-" } else { "" },
             fromfile_path.display()
-        )]);
+        )
+        .as_str()]);
         let actual = getter(&args, &option_id!("foo")).unwrap().unwrap();
         assert_eq!(expected, actual)
     }
 
-    do_test("true", true, Args::get_bool, false);
-    do_test("false", false, Args::get_bool, false);
-    do_test("true", false, Args::get_bool, true);
-    do_test("false", true, Args::get_bool, true);
-    do_test("-42", -42, Args::get_int, false);
-    do_test("3.14", 3.14, Args::get_float, false);
-    do_test("EXPANDED", "EXPANDED".to_owned(), Args::get_string, false);
+    do_test("true", true, ArgsReader::get_bool, false);
+    do_test("false", false, ArgsReader::get_bool, false);
+    do_test("true", false, ArgsReader::get_bool, true);
+    do_test("false", true, ArgsReader::get_bool, true);
+    do_test("-42", -42, ArgsReader::get_int, false);
+    do_test("3.14", 3.14, ArgsReader::get_float, false);
+    do_test(
+        "EXPANDED",
+        "EXPANDED".to_owned(),
+        ArgsReader::get_string,
+        false,
+    );
 
     let (_tmpdir, fromfile_path) = write_fromfile("fromfile.txt", "BAD INT");
-    let args = Args::new(vec![format!("--foo=@{}", fromfile_path.display())]);
+    let args = mk_args(vec![format!("--foo=@{}", fromfile_path.display())]);
     assert_eq!(
         args.get_int(&option_id!("foo")).unwrap_err(),
         "Problem parsing --foo int value:\n1:BAD INT\n  ^\n\
@@ -228,7 +242,7 @@ fn test_scalar_fromfile() {
 fn test_list_fromfile() {
     fn do_test(content: &str, expected: &[ListEdit<i64>], filename: &str) {
         let (_tmpdir, fromfile_path) = write_fromfile(filename, content);
-        let args = Args::new(vec![format!("--foo=@{}", &fromfile_path.display())]);
+        let args = mk_args(vec![format!("--foo=@{}", &fromfile_path.display()).as_str()]);
         let actual = args.get_int_list(&option_id!("foo")).unwrap().unwrap();
         assert_eq!(expected.to_vec(), actual)
     }
@@ -299,9 +313,9 @@ fn test_dict_fromfile() {
         ];
 
         let (_tmpdir, fromfile_path) = write_fromfile(filename, content);
-        let args = Args::new(vec![
-            format!("--foo=@{}", &fromfile_path.display()),
-            "--foo=+{'KEY':'VALUE'}".to_string(),
+        let args = mk_args(vec![
+            &format!("--foo=@{}", &fromfile_path.display()),
+            "--foo=+{'KEY':'VALUE'}",
         ]);
         let actual = args.get_dict(&option_id!("foo")).unwrap().unwrap();
         assert_eq!(expected, actual)
@@ -335,7 +349,7 @@ fn test_dict_fromfile() {
     }];
 
     let (_tmpdir, fromfile_path) = write_fromfile("fromfile.txt", "+{'FOO':42}");
-    let args = Args::new(vec![format!("--foo=@{}", &fromfile_path.display())]);
+    let args = mk_args(vec![format!("--foo=@{}", &fromfile_path.display()).as_str()]);
     assert_eq!(
         expected_add,
         args.get_dict(&option_id!("foo")).unwrap().unwrap()
@@ -344,14 +358,14 @@ fn test_dict_fromfile() {
 
 #[test]
 fn test_nonexistent_required_fromfile() {
-    let args = Args::new(vec!["--foo=@/does/not/exist".to_string()]);
+    let args = mk_args(vec!["--foo=@/does/not/exist"]);
     let err = args.get_string(&option_id!("foo")).unwrap_err();
     assert!(err.starts_with("Problem reading /does/not/exist for --foo: No such file or directory"));
 }
 
 #[test]
 fn test_nonexistent_optional_fromfile() {
-    let args = Args::new(vec!["--foo=@?/does/not/exist".to_string()]);
+    let args = mk_args(vec!["--foo=@?/does/not/exist"]);
     assert!(args.get_string(&option_id!("foo")).unwrap().is_none());
 }
 

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -13,11 +13,12 @@ use crate::{
     option_id, DictEdit, DictEditAction, ListEdit, ListEditAction, OptionId, OptionsSource, Val,
 };
 
-use crate::config::Config;
+use crate::config::{Config, ConfigReader};
 use crate::fromfile::test_util::write_fromfile;
+use crate::fromfile::FromfileExpander;
 use tempfile::TempDir;
 
-fn maybe_config(file_content: &str) -> Result<Config, String> {
+fn maybe_config(file_content: &str) -> Result<ConfigReader, String> {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("pants.toml");
     File::create(&path)
@@ -31,9 +32,10 @@ fn maybe_config(file_content: &str) -> Result<Config, String> {
             ("seed2".to_string(), "seed2val".to_string()),
         ]),
     )
+    .map(|config| ConfigReader::new(config, FromfileExpander::new()))
 }
 
-fn config(file_content: &str) -> Config {
+fn config(file_content: &str) -> ConfigReader {
     maybe_config(file_content).unwrap()
 }
 
@@ -178,7 +180,7 @@ fn test_scalar_fromfile() {
     fn do_test<T: PartialEq + Debug>(
         content: &str,
         expected: T,
-        getter: fn(&Config, &OptionId) -> Result<Option<T>, String>,
+        getter: fn(&ConfigReader, &OptionId) -> Result<Option<T>, String>,
     ) {
         let (_tmpdir, fromfile_path) = write_fromfile("fromfile.txt", content);
         let conf = config(format!("[GLOBAL]\nfoo = '@{}'\n", fromfile_path.display()).as_str());
@@ -186,10 +188,10 @@ fn test_scalar_fromfile() {
         assert_eq!(expected, actual)
     }
 
-    do_test("true", true, Config::get_bool);
-    do_test("-42", -42, Config::get_int);
-    do_test("3.14", 3.14, Config::get_float);
-    do_test("EXPANDED", "EXPANDED".to_owned(), Config::get_string);
+    do_test("true", true, ConfigReader::get_bool);
+    do_test("-42", -42, ConfigReader::get_int);
+    do_test("3.14", 3.14, ConfigReader::get_float);
+    do_test("EXPANDED", "EXPANDED".to_owned(), ConfigReader::get_string);
 }
 
 #[test]

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -1,8 +1,9 @@
 // Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-use crate::env::Env;
+use crate::env::{Env, EnvReader};
 use crate::fromfile::test_util::write_fromfile;
+use crate::fromfile::FromfileExpander;
 use crate::{option_id, DictEdit, DictEditAction};
 use crate::{ListEdit, ListEditAction, OptionId, OptionsSource, Val};
 use maplit::hashmap;
@@ -10,13 +11,15 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::fmt::Debug;
 
-fn env<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(vars: I) -> Env {
-    Env {
-        env: vars
-            .into_iter()
-            .map(|(k, v)| (k.to_owned(), v.to_owned()))
-            .collect::<HashMap<_, _>>(),
-    }
+fn env<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(vars: I) -> EnvReader {
+    EnvReader::new(
+        Env::new(
+            vars.into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect::<HashMap<_, _>>(),
+        ),
+        FromfileExpander::new(),
+    )
 }
 
 #[test]
@@ -208,7 +211,7 @@ fn test_scalar_fromfile() {
     fn do_test<T: PartialEq + Debug>(
         content: &str,
         expected: T,
-        getter: fn(&Env, &OptionId) -> Result<Option<T>, String>,
+        getter: fn(&EnvReader, &OptionId) -> Result<Option<T>, String>,
     ) {
         let (_tmpdir, fromfile_path) = write_fromfile("fromfile.txt", content);
         let env = env([(
@@ -219,10 +222,10 @@ fn test_scalar_fromfile() {
         assert_eq!(expected, actual)
     }
 
-    do_test("true", true, Env::get_bool);
-    do_test("-42", -42, Env::get_int);
-    do_test("3.14", 3.14, Env::get_float);
-    do_test("EXPANDED", "EXPANDED".to_owned(), Env::get_string);
+    do_test("true", true, EnvReader::get_bool);
+    do_test("-42", -42, EnvReader::get_int);
+    do_test("3.14", 3.14, EnvReader::get_float);
+    do_test("EXPANDED", "EXPANDED".to_owned(), EnvReader::get_string);
 }
 
 #[test]

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -45,7 +45,7 @@ use serde::Deserialize;
 
 pub use self::args::Args;
 use self::args::ArgsReader;
-use self::config::Config;
+use self::config::{Config, ConfigReader};
 pub use self::env::Env;
 use self::env::EnvReader;
 use crate::fromfile::FromfileExpander;
@@ -342,7 +342,7 @@ impl OptionParser {
                     ordinal,
                     path: path_strip(&buildroot_string, path),
                 },
-                Rc::new(config),
+                Rc::new(ConfigReader::new(config, FromfileExpander::new())),
             );
             ordinal += 1;
         }
@@ -371,7 +371,7 @@ impl OptionParser {
                             ordinal,
                             path: rcfile,
                         },
-                        Rc::new(rc_config),
+                        Rc::new(ConfigReader::new(rc_config, FromfileExpander::new())),
                     );
                     ordinal += 1;
                 }

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -44,6 +44,7 @@ use std::rc::Rc;
 use serde::Deserialize;
 
 pub use self::args::Args;
+use self::args::ArgsReader;
 use self::config::Config;
 pub use self::env::Env;
 use self::env::EnvReader;
@@ -276,7 +277,10 @@ impl OptionParser {
             Source::Env,
             Rc::new(EnvReader::new(env, FromfileExpander::new())),
         );
-        sources.insert(Source::Flag, Rc::new(args));
+        sources.insert(
+            Source::Flag,
+            Rc::new(ArgsReader::new(args, FromfileExpander::new())),
+        );
         let mut parser = OptionParser {
             sources: sources.clone(),
             include_derivation: false,

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -46,6 +46,8 @@ use serde::Deserialize;
 pub use self::args::Args;
 use self::config::Config;
 pub use self::env::Env;
+use self::env::EnvReader;
+use crate::fromfile::FromfileExpander;
 use crate::parse::Parseable;
 pub use build_root::BuildRoot;
 pub use id::{OptionId, Scope};
@@ -270,7 +272,10 @@ impl OptionParser {
         );
 
         let mut sources: BTreeMap<Source, Rc<dyn OptionsSource>> = BTreeMap::new();
-        sources.insert(Source::Env, Rc::new(env));
+        sources.insert(
+            Source::Env,
+            Rc::new(EnvReader::new(env, FromfileExpander::new())),
+        );
         sources.insert(Source::Flag, Rc::new(args));
         let mut parser = OptionParser {
             sources: sources.clone(),


### PR DESCRIPTION
This is done by splitting each of the structs representing
option sources (Args, Env, Config) into two:

The existing {Args/Env/Config} is what the user creates
and passes in to OptionParser::new. These handle
loading their data from the CLI/env vars/config files.

The actual reading of option values is now handled
by three new structs: {Args/Env/Config}Reader.
These structs have a FromfileExpander, but don't
use it yet (that will be taken care of in a followup).
