### PR TITLE
Use the FromfileExpander to expand @fromfile values.

### DIFF
--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -7,7 +7,7 @@ use std::ffi::OsString;
 
 use super::id::{NameTransform, OptionId, Scope};
 use super::{DictEdit, OptionsSource};
-use crate::fromfile::{expand, expand_to_dict, expand_to_list, FromfileExpander};
+use crate::fromfile::FromfileExpander;
 use crate::parse::Parseable;
 use crate::ListEdit;
 
@@ -86,7 +86,9 @@ impl EnvReader {
     fn get_list<T: Parseable>(&self, id: &OptionId) -> Result<Option<Vec<ListEdit<T>>>, String> {
         for env_var_name in &Self::env_var_names(id) {
             if let Some(value) = self.env.env.get(env_var_name) {
-                return expand_to_list::<T>(value.to_owned())
+                return self
+                    .fromfile_expander
+                    .expand_to_list::<T>(value.to_owned())
                     .map_err(|e| e.render(self.display(id)));
             }
         }
@@ -111,7 +113,10 @@ impl OptionsSource for EnvReader {
     fn get_string(&self, id: &OptionId) -> Result<Option<String>, String> {
         for env_var_name in &Self::env_var_names(id) {
             if let Some(value) = self.env.env.get(env_var_name) {
-                return expand(value.to_owned()).map_err(|e| e.render(self.display(id)));
+                return self
+                    .fromfile_expander
+                    .expand(value.to_owned())
+                    .map_err(|e| e.render(self.display(id)));
             }
         }
         Ok(None)
@@ -146,7 +151,10 @@ impl OptionsSource for EnvReader {
     fn get_dict(&self, id: &OptionId) -> Result<Option<Vec<DictEdit>>, String> {
         for env_var_name in &Self::env_var_names(id) {
             if let Some(value) = self.env.env.get(env_var_name) {
-                return expand_to_dict(value.to_owned()).map_err(|e| e.render(self.display(id)));
+                return self
+                    .fromfile_expander
+                    .expand_to_dict(value.to_owned())
+                    .map_err(|e| e.render(self.display(id)));
             }
         }
         Ok(None)

--- a/src/rust/engine/options/src/fromfile.rs
+++ b/src/rust/engine/options/src/fromfile.rs
@@ -134,20 +134,6 @@ impl FromfileExpander {
     }
 }
 
-pub(crate) fn expand(value: String) -> Result<Option<String>, ParseError> {
-    FromfileExpander::new().expand(value)
-}
-
-pub(crate) fn expand_to_list<T: Parseable>(
-    value: String,
-) -> Result<Option<Vec<ListEdit<T>>>, ParseError> {
-    FromfileExpander::new().expand_to_list(value)
-}
-
-pub(crate) fn expand_to_dict(value: String) -> Result<Option<Vec<DictEdit>>, ParseError> {
-    FromfileExpander::new().expand_to_dict(value)
-}
-
 #[cfg(test)]
 pub(crate) mod test_util {
     use std::fs::File;

--- a/src/rust/engine/options/src/fromfile_tests.rs
+++ b/src/rust/engine/options/src/fromfile_tests.rs
@@ -21,6 +21,18 @@ macro_rules! check_err {
     };
 }
 
+fn expand(value: String) -> Result<Option<String>, ParseError> {
+    FromfileExpander::new().expand(value)
+}
+
+fn expand_to_list<T: Parseable>(value: String) -> Result<Option<Vec<ListEdit<T>>>, ParseError> {
+    FromfileExpander::new().expand_to_list(value)
+}
+
+fn expand_to_dict(value: String) -> Result<Option<Vec<DictEdit>>, ParseError> {
+    FromfileExpander::new().expand_to_dict(value)
+}
+
 #[test]
 fn test_expand_fromfile() {
     let (_tmpdir, fromfile_pathbuf) = write_fromfile("fromfile.txt", "FOO");


### PR DESCRIPTION
Now that it's plumbed through, we can use it directly
instead of the free functions, which are now deleted
(or more precisely, moved into the test file, for
convenience there).

A final change will actually add buildroot context to
the FromfileExpander, and use it to correctly handle
@relpath/to/fromfile situations.