### PR TITLE
Resolve @fromfile paths relative to the buildroot.

### DIFF
--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -17,7 +17,7 @@ where
 {
     ArgsReader::new(
         Args::new(args.into_iter().map(|x| x.to_string())),
-        FromfileExpander::new(),
+        FromfileExpander::new(""),
     )
 }
 

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -17,7 +17,7 @@ where
 {
     ArgsReader::new(
         Args::new(args.into_iter().map(|x| x.to_string())),
-        FromfileExpander::new(""),
+        FromfileExpander::relative_to_cwd(),
     )
 }
 

--- a/src/rust/engine/options/src/build_root.rs
+++ b/src/rust/engine/options/src/build_root.rs
@@ -8,11 +8,16 @@ use std::path::{Path, PathBuf};
 use log::debug;
 use std::os::unix::ffi::OsStrExt;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct BuildRoot(PathBuf);
 
 impl BuildRoot {
     const SENTINEL_FILES: &'static [&'static str] = &["pants.toml", "BUILDROOT", "BUILD_ROOT"];
+
+    // Useful in tests.
+    pub fn for_path(path: PathBuf) -> Self {
+        Self(path)
+    }
 
     pub fn find() -> Result<BuildRoot, String> {
         match env::var_os("PANTS_BUILDROOT_OVERRIDE") {

--- a/src/rust/engine/options/src/build_root.rs
+++ b/src/rust/engine/options/src/build_root.rs
@@ -6,6 +6,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use log::debug;
+use std::os::unix::ffi::OsStrExt;
 
 #[derive(Debug)]
 pub struct BuildRoot(PathBuf);
@@ -58,6 +59,16 @@ impl BuildRoot {
                 sentinel_files = Self::SENTINEL_FILES.join(", ")
             ))?;
         }
+    }
+
+    pub fn convert_to_string(&self) -> Result<String, String> {
+        String::from_utf8(self.0.as_os_str().as_bytes().to_vec()).map_err(|e| {
+            format!(
+                "Failed to decode build root path {}: {}",
+                self.0.display(),
+                e
+            )
+        })
     }
 }
 

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -32,7 +32,7 @@ fn maybe_config(file_content: &str) -> Result<ConfigReader, String> {
             ("seed2".to_string(), "seed2val".to_string()),
         ]),
     )
-    .map(|config| ConfigReader::new(config, FromfileExpander::new("")))
+    .map(|config| ConfigReader::new(config, FromfileExpander::relative_to_cwd()))
 }
 
 fn config(file_content: &str) -> ConfigReader {

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -32,7 +32,7 @@ fn maybe_config(file_content: &str) -> Result<ConfigReader, String> {
             ("seed2".to_string(), "seed2val".to_string()),
         ]),
     )
-    .map(|config| ConfigReader::new(config, FromfileExpander::new()))
+    .map(|config| ConfigReader::new(config, FromfileExpander::new("")))
 }
 
 fn config(file_content: &str) -> ConfigReader {

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -18,7 +18,7 @@ fn env<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(vars: I) -> EnvReader {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect::<HashMap<_, _>>(),
         ),
-        FromfileExpander::new(""),
+        FromfileExpander::relative_to_cwd(),
     )
 }
 

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -18,7 +18,7 @@ fn env<'a, I: IntoIterator<Item = (&'a str, &'a str)>>(vars: I) -> EnvReader {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect::<HashMap<_, _>>(),
         ),
-        FromfileExpander::new(),
+        FromfileExpander::new(""),
     )
 }
 

--- a/src/rust/engine/options/src/fromfile_tests.rs
+++ b/src/rust/engine/options/src/fromfile_tests.rs
@@ -22,15 +22,15 @@ macro_rules! check_err {
 }
 
 fn expand(value: String) -> Result<Option<String>, ParseError> {
-    FromfileExpander::new().expand(value)
+    FromfileExpander::new("").expand(value)
 }
 
 fn expand_to_list<T: Parseable>(value: String) -> Result<Option<Vec<ListEdit<T>>>, ParseError> {
-    FromfileExpander::new().expand_to_list(value)
+    FromfileExpander::new("").expand_to_list(value)
 }
 
 fn expand_to_dict(value: String) -> Result<Option<Vec<DictEdit>>, ParseError> {
-    FromfileExpander::new().expand_to_dict(value)
+    FromfileExpander::new("").expand_to_dict(value)
 }
 
 #[test]
@@ -50,6 +50,19 @@ fn test_expand_fromfile() {
     assert!(err
         .render("XXX")
         .starts_with("Problem reading /does/not/exist for XXX: No such file or directory"))
+}
+
+#[test]
+fn test_fromfile_relative_to_buildroot() {
+    let (_tmpdir, fromfile_pathbuf) = write_fromfile("fromfile.txt", "FOO");
+    let fromfile_relpath_pathbuf = fromfile_pathbuf.strip_prefix(&_tmpdir).unwrap();
+    assert!(fromfile_relpath_pathbuf.is_relative());
+    let tmpdir_str = format!("{}", &_tmpdir.path().display());
+    let fromfile_relpath_str = format!("{}", fromfile_relpath_pathbuf.display());
+    assert_eq!(
+        Ok(Some("FOO".to_string())),
+        FromfileExpander::new(&tmpdir_str).expand(format!("@{}", fromfile_relpath_str))
+    );
 }
 
 #[test]

--- a/src/rust/engine/options/src/fromfile_tests.rs
+++ b/src/rust/engine/options/src/fromfile_tests.rs
@@ -4,7 +4,7 @@
 use crate::fromfile::test_util::write_fromfile;
 use crate::fromfile::*;
 use crate::parse::{ParseError, Parseable};
-use crate::{DictEdit, DictEditAction, ListEdit, ListEditAction, Val};
+use crate::{BuildRoot, DictEdit, DictEditAction, ListEdit, ListEditAction, Val};
 use maplit::hashmap;
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -22,15 +22,15 @@ macro_rules! check_err {
 }
 
 fn expand(value: String) -> Result<Option<String>, ParseError> {
-    FromfileExpander::new("").expand(value)
+    FromfileExpander::relative_to_cwd().expand(value)
 }
 
 fn expand_to_list<T: Parseable>(value: String) -> Result<Option<Vec<ListEdit<T>>>, ParseError> {
-    FromfileExpander::new("").expand_to_list(value)
+    FromfileExpander::relative_to_cwd().expand_to_list(value)
 }
 
 fn expand_to_dict(value: String) -> Result<Option<Vec<DictEdit>>, ParseError> {
-    FromfileExpander::new("").expand_to_dict(value)
+    FromfileExpander::relative_to_cwd().expand_to_dict(value)
 }
 
 #[test]
@@ -57,11 +57,11 @@ fn test_fromfile_relative_to_buildroot() {
     let (_tmpdir, fromfile_pathbuf) = write_fromfile("fromfile.txt", "FOO");
     let fromfile_relpath_pathbuf = fromfile_pathbuf.strip_prefix(&_tmpdir).unwrap();
     assert!(fromfile_relpath_pathbuf.is_relative());
-    let tmpdir_str = format!("{}", &_tmpdir.path().display());
     let fromfile_relpath_str = format!("{}", fromfile_relpath_pathbuf.display());
     assert_eq!(
         Ok(Some("FOO".to_string())),
-        FromfileExpander::new(&tmpdir_str).expand(format!("@{}", fromfile_relpath_str))
+        FromfileExpander::relative_to(BuildRoot::for_path(_tmpdir.into_path()))
+            .expand(format!("@{}", fromfile_relpath_str))
     );
 }
 

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -37,7 +37,6 @@ mod types;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::hash::Hash;
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::rc::Rc;
 
@@ -257,14 +256,8 @@ impl OptionParser {
         buildroot: Option<BuildRoot>,
     ) -> Result<OptionParser, String> {
         let buildroot = buildroot.unwrap_or(BuildRoot::find()?);
-        let buildroot_string = String::from_utf8(buildroot.as_os_str().as_bytes().to_vec())
-            .map_err(|e| {
-                format!(
-                    "Failed to decode build root path {}: {}",
-                    buildroot.display(),
-                    e
-                )
-            })?;
+        let buildroot_string = buildroot.convert_to_string()?;
+        let fromfile_expander = FromfileExpander::new(&buildroot_string);
 
         let mut seed_values = HashMap::from_iter(
             env.env
@@ -275,11 +268,11 @@ impl OptionParser {
         let mut sources: BTreeMap<Source, Rc<dyn OptionsSource>> = BTreeMap::new();
         sources.insert(
             Source::Env,
-            Rc::new(EnvReader::new(env, FromfileExpander::new())),
+            Rc::new(EnvReader::new(env, fromfile_expander.clone())),
         );
         sources.insert(
             Source::Flag,
-            Rc::new(ArgsReader::new(args, FromfileExpander::new())),
+            Rc::new(ArgsReader::new(args, fromfile_expander.clone())),
         );
         let mut parser = OptionParser {
             sources: sources.clone(),
@@ -342,7 +335,7 @@ impl OptionParser {
                     ordinal,
                     path: path_strip(&buildroot_string, path),
                 },
-                Rc::new(ConfigReader::new(config, FromfileExpander::new())),
+                Rc::new(ConfigReader::new(config, fromfile_expander.clone())),
             );
             ordinal += 1;
         }
@@ -371,7 +364,7 @@ impl OptionParser {
                             ordinal,
                             path: rcfile,
                         },
-                        Rc::new(ConfigReader::new(rc_config, FromfileExpander::new())),
+                        Rc::new(ConfigReader::new(rc_config, fromfile_expander.clone())),
                     );
                     ordinal += 1;
                 }

--- a/src/rust/engine/options/src/lib.rs
+++ b/src/rust/engine/options/src/lib.rs
@@ -257,7 +257,7 @@ impl OptionParser {
     ) -> Result<OptionParser, String> {
         let buildroot = buildroot.unwrap_or(BuildRoot::find()?);
         let buildroot_string = buildroot.convert_to_string()?;
-        let fromfile_expander = FromfileExpander::new(&buildroot_string);
+        let fromfile_expander = FromfileExpander::relative_to(buildroot);
 
         let mut seed_values = HashMap::from_iter(
             env.env


### PR DESCRIPTION
This is how the Python options parser works, so
now the Rust parser follows suit.