### PR TITLE
Remove deprecated `pex_binary(platforms=...)` for 2.22, deprecate `resolve_local_platforms`

### DIFF
--- a/src/python/pants/backend/python/goals/package_pex_binary.py
+++ b/src/python/pants/backend/python/goals/package_pex_binary.py
@@ -24,7 +24,6 @@ from pants.backend.python.target_types import (
     PexInheritPathField,
     PexLayout,
     PexLayoutField,
-    PexPlatformsField,
     PexResolveLocalPlatformsField,
     PexScriptField,
     PexShBootField,
@@ -35,7 +34,7 @@ from pants.backend.python.target_types import (
     ResolvedPexEntryPoint,
     ResolvePexEntryPointRequest,
 )
-from pants.backend.python.util_rules.pex import CompletePlatforms, Pex, PexPlatforms
+from pants.backend.python.util_rules.pex import CompletePlatforms, Pex
 from pants.backend.python.util_rules.pex_from_targets import PexFromTargetsRequest
 from pants.core.goals.package import (
     BuiltPackage,
@@ -72,7 +71,6 @@ class PexBinaryFieldSet(PackageFieldSet, RunFieldSet):
     sh_boot: PexShBootField
     shebang: PexShebangField
     strip_env: PexStripEnvField
-    platforms: PexPlatformsField
     complete_platforms: PexCompletePlatformsField
     resolve_local_platforms: PexResolveLocalPlatformsField
     layout: PexLayoutField
@@ -156,7 +154,6 @@ async def package_pex_binary(
         main=resolved_entry_point.val or field_set.script.value or field_set.executable.value,
         inject_args=field_set.args.value or [],
         inject_env=field_set.env.value or FrozenDict[str, str](),
-        platforms=PexPlatforms.create_from_platforms_field(field_set.platforms),
         complete_platforms=complete_platforms,
         output_filename=output_filename,
         layout=PexLayout(field_set.layout.value),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -473,47 +473,6 @@ class PexEnvField(DictStringToStringField):
     )
 
 
-class PexPlatformsField(StringSequenceField):
-    alias = "platforms"
-    removal_version = "2.22.0.dev0"
-    removal_hint = softwrap(
-        f"""\
-    The platforms field is a hack. The abbreviated information it provides is sometimes insufficient,
-    leading to hard-to-debug build issues. Use complete_platforms instead.
-    See {doc_url('docs/python/overview/pex')} for details.
-    """
-    )
-    help = help_text(
-        """
-        The abbreviated platforms the built PEX should be compatible with.
-
-        There must be built wheels available for all of the foreign platforms, rather than sdists.
-
-        You can give a list of multiple platforms to create a multiplatform PEX,
-        meaning that the PEX will be executable in all of the supported environments.
-
-        Platforms should be in the format defined by Pex
-        (https://pex.readthedocs.io/en/latest/buildingpex.html#platform), i.e.
-        PLATFORM-IMPL-PYVER-ABI (e.g. "linux_x86_64-cp-37-cp37m",
-        "macosx_10.12_x86_64-cp-310-cp310"):
-
-          - PLATFORM: the host platform, e.g. "linux-x86_64", "macosx-10.12-x86_64".
-          - IMPL: the Python implementation abbreviation, e.g. "cp" or "pp".
-          - PYVER: a two or more digit string representing the python major/minor version\
-            (e.g., "37" or "310") or else a component dotted version string (e.g., "3.7" or "3.10.1").
-          - ABI: the ABI tag, e.g. "cp37m", "cp310", "abi3", "none".
-
-        Note that using an abbreviated platform means that certain resolves will fail when they
-        encounter environment markers that cannot be deduced from the abbreviated platform
-        string. A common example of this is 'python_full_version' which requires knowing the
-        patch level version of the foreign Python interpreter. To remedy this you should use a
-        3-component dotted version for PYVER. If your resolves fail due to more esoteric
-        undefined environment markers, you should switch to specifying `complete_platforms`
-        instead.
-        """
-    )
-
-
 class PexCompletePlatformsField(SpecialCasedDependencies):
     alias = "complete_platforms"
     help = help_text(
@@ -633,15 +592,15 @@ class PexEmitWarningsField(TriBoolField):
 
 class PexResolveLocalPlatformsField(TriBoolField):
     alias = "resolve_local_platforms"
+    removal_version = "2.24.0.dev0"
+    removal_hint = softwrap(
+        f"""\
+        This {alias} field is no longer used now that the `platforms` field has been removed. Remove it.
+        """
+    )
     help = help_text(
-        f"""
-        For each of the `{PexPlatformsField.alias}` specified, attempt to find a local
-        interpreter that matches.
-
-        If a matching interpreter is found, use the interpreter to resolve distributions and build
-        any that are only available in source distribution form.
-        If no matching interpreter is found (or if this option is `False`), resolve for the
-        platform by accepting only pre-built binary distributions (wheels).
+        """
+        Now unused.
         """
     )
 
@@ -781,7 +740,6 @@ _PEX_BINARY_COMMON_FIELDS = (
     PythonResolveField,
     PexBinaryDependenciesField,
     PexCheckField,
-    PexPlatformsField,
     PexCompletePlatformsField,
     PexResolveLocalPlatformsField,
     PexInheritPathField,
@@ -933,14 +891,14 @@ class PexBinaryDefaults(Subsystem):
     resolve_local_platforms = BoolOption(
         default=False,
         help=softwrap(
-            f"""
-            For each of the `{PexPlatformsField.alias}` specified for a `{PexBinary.alias}`
-            target, attempt to find a local interpreter that matches.
-
-            If a matching interpreter is found, use the interpreter to resolve distributions and
-            build any that are only available in source distribution form. If no matching interpreter
-            is found (or if this option is `False`), resolve for the platform by accepting
-            only pre-built binary distributions (wheels).
+            """
+            Now unused.
+            """
+        ),
+        removal_version="2.24.0.dev0",
+        removal_hint=softwrap(
+            """\
+            This `resolve_local_platforms` option is no longer used now that the `platforms` field has been removed. You can safely delete this setting.
             """
         ),
         advanced=True,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -23,9 +23,6 @@ from pants.backend.python.target_types import (
     MainSpecification,
     PexCompletePlatformsField,
     PexLayout,
-)
-from pants.backend.python.target_types import PexPlatformsField as PythonPlatformsField
-from pants.backend.python.target_types import (
     PythonRequirementFindLinksField,
     PythonRequirementsField,
 )
@@ -97,10 +94,6 @@ class PythonProvider:
 
 class PexPlatforms(DeduplicatedCollection[str]):
     sort_input = True
-
-    @classmethod
-    def create_from_platforms_field(cls, field: PythonPlatformsField) -> PexPlatforms:
-        return cls(field.value or ())
 
     def generate_pex_arg_list(self) -> list[str]:
         args = []


### PR DESCRIPTION
This field was deprecated in #20012, released in 2.19. We've now branched for 2.21 and thus `main` is prepping for 2.22. So, the deprecation has expired!

In that PR, there was discussion about working out whether this should remain for longer. This has been deprecated for several releases now, and it's being removed early in the 2.22 release cycle: if someone comments, we can reinstate/reconsider.

---

Also, as part of this, I noticed the `resolve_local_platforms` field and option now seem to be meaningless: the underlying `pex --resolve-local-platforms` field is documented as `When --platforms are specified, ...`. Thus, this deprecates that field and the global option for 2.24.