### PR TITLE
docs: Remove note about abbreviated form

### DIFF
--- a/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
+++ b/docs/docs/using-pants/key-concepts/targets-and-build-files.mdx
@@ -76,7 +76,6 @@ The `name` field defaults to the directory name. So, this target has the address
 python_sources()
 ```
 
-You can refer to this target with either `helloworld/greet:greet` or the abbreviated form `helloworld/greet`.
 :::
 
 :::note Use `//:tgt` for the root of your repository


### PR DESCRIPTION
According to [this slack thread](https://pantsbuild.slack.com/archives/C046T6T9U/p1713806621261089?thread_ts=1713794785.830859&cid=C046T6T9U), this line in the pants docs is no longer correct.