### PR TITLE
stop using deprecated logging.warn method

### DIFF
--- a/src/python/pants/core/util_rules/config_files.py
+++ b/src/python/pants/core/util_rules/config_files.py
@@ -146,7 +146,7 @@ async def gather_config_files_by_workspace_dir(
             if request.orphan_filepath_behavior == OrphanFilepathConfigBehavior.ERROR:
                 raise ValueError(msg)
             else:
-                logger.warn(msg)
+                logger.warning(msg)
 
     return GatheredConfigFilesByDirectories(
         request.config_filename, config_files_snapshot, FrozenDict(source_dir_to_config_file)

--- a/src/python/pants/engine/streaming_workunit_handler.py
+++ b/src/python/pants/engine/streaming_workunit_handler.py
@@ -123,7 +123,7 @@ class StreamingWorkunitContext:
                 if source is None:
                     # This is a thing, that may need investigating to be fully understood.
                     # merely patches over a crash here. See #18564.
-                    logger.warn(
+                    logger.warning(
                         softwrap(
                             f"""
                             Unknown source address for target: {target_spec}


### PR DESCRIPTION
https://docs.python.org/3/library/logging.html#logging.Logger.warning
```
Note: There is an obsolete method warn which is functionally identical
to warning. As warn is deprecated, please do not use it - use warning
instead.
```

Besides tidyness, this avoids `DeprecationWarning` to the console.