### PR TITLE
Fix Rust option parser escape handling

### DIFF
--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -86,13 +86,14 @@ peg::parser! {
 
         // Python octal escapes take 1-3 digits.
         rule escaped_octal() -> char = "\\" s:$(['0'..='7']*<1,3>) {
-            char::from_u32(usize::from_str_radix(s, 8).unwrap().try_into().unwrap()).unwrap()
+            char::from_u32(u32::from_str_radix(s, 8).unwrap()).unwrap()
         }
 
         // Python hex escapes take exactly 2 digits. Note that we mirror the Python behavior of
         // always consuming the next two characters and failing if they aren't valid hex digits.
         rule escaped_hex() -> char = "\\x" s:$([_] [_]) {
-            char::from_u32(usize::from_str_radix(s, 16).unwrap_or_else(|_| panic!("expected two hex digits, found {}", s)).try_into().unwrap()).unwrap()
+            char::from_u32(u32::from_str_radix(s, 16).unwrap_or_else(
+                |_| panic!("expected two hex digits, found {}", s))).unwrap()
         }
 
         rule escaped_character() -> char = c:(

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -63,9 +63,10 @@ fn test_parse_quoted_string() {
     check_str("some\tembedded\nescapes\\", r"'some\tembedded\nescapes\\'");
     check_str("non-escaping \\w backslash", r"'non-escaping \w backslash'");
     check_str(
-        "some \u{0} octal \u{3f} values \u{53}",
-        r"'some \0 octal \77 values \123'",
+        "some \u{0} octal \u{3f} values \u{53} \u{1ff}",
+        r"'some \0 octal \77 values \123 \777'",
     );
+    check_str("almost octal \\8 &8", r"'almost octal \8 \468'");
     check_str(
         "some \u{ab} hex \u{00} values \u{cd}",
         r"'some \xab hex \x00 values \xCD'",

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -68,15 +68,28 @@ fn test_parse_quoted_string() {
     );
     check_str("almost octal \\8 &8", r"'almost octal \8 \468'");
     check_str(
-        "some \u{ab} hex \u{00} values \u{cd}",
-        r"'some \xab hex \x00 values \xCD'",
+        "some \u{ab} hex \u{00} values \u{cd}0",
+        r"'some \xab hex \x00 values \xCD0'",
     );
+    check_str("Escaped backslash-x \\x00", r"'Escaped backslash-x \\x00'");
 }
 
 #[test]
-#[should_panic(expected = "expected two hex digits, found ZZ")]
+#[should_panic(expected = "two hex digits at line 1 column 7")]
+fn test_no_hex_digits_in_quoted_string() {
+    check_str("", r"'\x'");
+}
+
+#[test]
+#[should_panic(expected = "two hex digits at line 1 column 7")]
+fn test_too_few_hex_digits_in_quoted_string() {
+    check_str("", r"'\xZ'");
+}
+
+#[test]
+#[should_panic(expected = "two hex digits at line 1 column 7")]
 fn test_bad_hex_digits_in_quoted_string() {
-    check_str("", r"'\xZZ'");
+    check_str("", r"'\x0Z'");
 }
 
 #[test]


### PR DESCRIPTION
Previously the parser naively handled escapes in quoted
strings by returning the character following the escape. 
E.g., `\'` returned a single quote. 

This worked fine for single quote, double quote and
backslash, but not in other cases. For one obvious 
example, `\n` does not mean `n`... Also, most 
subsequent characters aren't escape sequences. 
E.g., `\w` means literal `\w`, not `w`.

This change makes the Rust parser behave like
the Python parser (which eval'd strings, and
therefore used Python escape syntax).