### PR TITLE
Fix: Example config for local filesystem caching

### DIFF
--- a/docs/docs/using-pants/remote-caching-and-execution/remote-caching.mdx
+++ b/docs/docs/using-pants/remote-caching-and-execution/remote-caching.mdx
@@ -88,7 +88,7 @@ To read and write the cache to `/path/to/cache`, you will need to configure `pan
 
 ```toml
 [GLOBAL]
-remote_store_provider = "experimental-file"
+remote_provider = "experimental-file"
 remote_store_address = "file:///path/to/cache"
 remote_cache_read = true
 remote_cache_write = true


### PR DESCRIPTION
Using the original config snippet on a `pants` v.2.20 system results in:
> OptionsError: Value `file:///path/to/cache` from the `[GLOBAL].remote_store_address` option is invalid: it doesn't have a scheme that is supported by provider `reapi` from the `[GLOBAL].remote_provider` option.
>
> Did you mean to use a provider that does support this scheme (`experimental-file`) or to use a scheme that is supported by this provider (`grpc://`, `grpcs://`)?

This is because the first key should be [`remote_provider`](https://www.pantsbuild.org/2.20/reference/global-options#remote_provider) instead