### PR TITLE
Add Python 3.13 to the default interpreter universe

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -60,6 +60,7 @@ class PythonSetup(Subsystem):
         "3.10",
         "3.11",
         "3.12",
+        "3.13",
     ]
 
     _interpreter_constraints = StrListOption(


### PR DESCRIPTION
This adds Python 3.13 to the default interpreter universe, so that we're more ready to hit the ground running when it is eventually released.

https://peps.python.org/pep-0719/ suggests the plan is 3.13.0 stable release on 2024-10-01. This PR will flow into Pants 2.22.0. We won't be releasing 2.22.0 before 2024-07-09 (12 weeks after 2.20.0, on 2024-04-16), so there's a bit of slack even if 2.21 and 2.22 take longer than 6 weeks to get out the door.

It looks like we won't be perfectly ready, because there's a similar lockfile issue to #20354 for Python 3.12: our lockfiles use pip 24.0 which apparently doesn't support Python 3.13 (needs https://github.com/pypa/pip/pull/12462). Thus, we'll need to regenerate our lockfiles once there's a pex release with a pip release with https://github.com/pypa/pip/pull/12462. I've filed https://github.com/pantsbuild/pants/issues/20852 to track this.