### PR TITLE
Allow explicit dependencies to resolve ambiguities

### DIFF
--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1332,6 +1332,16 @@ def test_explicitly_provided_dependencies_disambiguated() -> None:
         == addr_a
     )
 
+    # Verify that ignores works for parametrized targets
+    assert get_disambiguated(
+        ambiguous=[
+            Address(spec_path="", target_name="src", parameters={"tag": "a"}),
+            Address(spec_path="", target_name="src", parameters={"tag": "b"}),
+        ],
+        includes=[Address(spec_path="", target_name="src", parameters={"tag": "a"})],
+        ignores=[Address(spec_path="", target_name="src", parameters={"tag": "b"})],
+    )
+
 
 def test_explicitly_provided_dependencies_maybe_warn_of_ambiguous_dependency_inference(
     caplog,


### PR DESCRIPTION
In case of an ambiguous dependency inference, we give the help text:

> Please explicitly include the dependency you want in the `dependencies` field of a:a, or ignore the ones you do not want by prefixing with `!` or `!!` so that one or no targets are left.

However, adding an explicit dependency doesn't actually resolve that.
In [ExplicitlyProvidedDependencies.disambiguated](https://github.com/pantsbuild/pants/blob/164f322c47439c593087ded2ab84508fc3ae2a8c/src/python/pants/engine/target.py#L2704), if the target is in the explicitly provided dependencies, we just return. This results in the dependency being unowned, but included because of the explicit dependency link.

This MR rebuilds that function to use the explicitly provided dependencies to attempt to resolve an ambiguity. The logic is now as follows:
1. If there are no ambiguities, return
2. Use excludes to eliminate candidates. If there is a single owner, return it
3. Use includes to filter the remaining candidates (after excludes). If there is a single owner, return it

This algorithm change does result in changes to dependency inference. We can now resolve a situation which had both includes and excludes, and the excludes would resolve it. Previously, this would not be resolved.
I don't think this will result in other changes in resolution. (I considered the case of the same address being included and excluded, but it seems that the excludes currently functionally take priority).

fixes #20806