### PR TITLE
Upgrade to shfmt 3.8.0

### DIFF
--- a/src/python/pants/backend/shell/lint/shfmt/subsystem.py
+++ b/src/python/pants/backend/shell/lint/shfmt/subsystem.py
@@ -17,7 +17,7 @@ class Shfmt(TemplatedExternalTool):
     name = "shfmt"
     help = "An autoformatter for shell scripts (https://github.com/mvdan/sh)."
 
-    default_version = "v3.6.0"
+    default_version = "v3.8.0"
     default_known_versions = [
         "v3.2.4|macos_arm64 |e70fc42e69debe3e400347d4f918630cdf4bf2537277d672bbc43490387508ec|2998546",
         "v3.2.4|macos_x86_64|43a0461a1b54070ddc04fbbf1b78f7861ee39a65a61f5466d15a39c4aba4f917|2980208",
@@ -27,6 +27,10 @@ class Shfmt(TemplatedExternalTool):
         "v3.6.0|macos_x86_64|b8c9c025b498e2816b62f0b717f6032e9ab49e725a45b8205f52f66318f17185|3047552",
         "v3.6.0|linux_arm64 |fb1cf0af3dbe9aac7d98e38e3c7426765208ecfe23cb2da51037bb234776fd70|2818048",
         "v3.6.0|linux_x86_64|5741a02a641de7e56b8da170e71a97e58050d66a3cf485fb268d6a5a8bb74afb|2850816",
+        "v3.8.0|macos_arm64 |1481240d2a90d4f0b530688d76d4f9117d17a756b6027cfa42b96f0707317f83|2736466",
+        "v3.8.0|macos_x86_64|c0218b47a0301bb006f49fad85d2c08de23df303472834faf5639d04121320f8|2747696",
+        "v3.8.0|linux_arm64 |27e1f69b0d57c584bcbf5c882b4c4f78ffcf945d0efef45c1fbfc6692213c7c3|2687128",
+        "v3.8.0|linux_x86_64|27b3c6f9d9592fc5b4856c341d1ff2c88856709b9e76469313642a1d7b558fe0|2703512",
     ]
 
     default_url_template = (


### PR DESCRIPTION
This adds 3.8.0 as a known version of shfmt and bumps to that version by default, from 3.6.0 previously. It's easy enough to retain the old versions as known versions, so they're kept.

Changelogs:

- https://github.com/mvdan/sh/releases/tag/v3.7.0
- https://github.com/mvdan/sh/releases/tag/v3.8.0