### PR TITLE
Fall back to [DEFAULT] section in rust config parser

### DIFF
--- a/src/python/pants/option/options_test.py
+++ b/src/python/pants/option/options_test.py
@@ -737,9 +737,11 @@ def test_list_option() -> None:
         config2_val: str | None = None,
     ) -> None:
         env = {"PANTS_GLOBAL_LISTY": env_val} if env_val else None
-        config = {"GLOBAL": {"listy": config_val}} if config_val else None
+        config = {}
         if config_default:
             config["DEFAULT"] = {"listy": config_default}
+        if config_val:
+            config["GLOBAL"] = {"listy": config_val}
         config2 = {"GLOBAL": {"listy": config2_val}} if config2_val else None
         global_options = _parse(
             flags=flags, env=env, config=config, config2=config2
@@ -933,9 +935,11 @@ def test_dict_option() -> None:
         config_val: str | None = None,
         config2_val: str | None = None,
     ) -> None:
-        config = {"GLOBAL": {"dicty": config_val}} if config_val else None
+        config = {}
         if config_default:
             config["DEFAULT"] = {"dicty": config_default}
+        if config_val:
+            config["GLOBAL"] = {"dicty": config_val}
         config2 = {"GLOBAL": {"dicty": config2_val}} if config2_val else None
         global_options = _parse(flags=flags, config=config, config2=config2).for_global_scope()
         assert global_options.dicty == expected

--- a/src/rust/engine/options/src/config.rs
+++ b/src/rust/engine/options/src/config.rs
@@ -17,6 +17,8 @@ use crate::parse::Parseable;
 
 type InterpolationMap = HashMap<String, String>;
 
+static DEFAULT_SECTION: &str = "DEFAULT";
+
 lazy_static! {
     static ref PLACEHOLDER_RE: Regex = Regex::new(r"%\(([a-zA-Z0-9_.]+)\)s").unwrap();
 }
@@ -269,7 +271,7 @@ impl Config {
         }
 
         let default_imap =
-            add_section_to_interpolation_map(seed_values.clone(), config.get("DEFAULT"))?;
+            add_section_to_interpolation_map(seed_values.clone(), config.get(DEFAULT_SECTION))?;
 
         let new_sections: Result<Vec<(String, Value)>, String> = match config {
             Value::Table(t) => t
@@ -285,7 +287,7 @@ impl Config {
                             section
                         ));
                     }
-                    let section_imap = if section_name == "DEFAULT" {
+                    let section_imap = if section_name == *DEFAULT_SECTION {
                         default_imap.clone()
                     } else {
                         add_section_to_interpolation_map(default_imap.clone(), Some(&section))?
@@ -336,21 +338,46 @@ impl ConfigReader {
         id.name("_", NameTransform::None)
     }
 
-    fn get_value(&self, id: &OptionId) -> Option<&Value> {
+    fn get_from_section(&self, section_name: &str, option_name: &str) -> Option<&Value> {
         self.config
             .value
-            .get(id.scope.name())
-            .and_then(|table| table.get(Self::option_name(id)))
+            .get(section_name)
+            .and_then(|table| table.get(option_name))
+    }
+
+    fn get_value(&self, id: &OptionId) -> Option<&Value> {
+        let option_name = Self::option_name(id);
+        self.get_from_section(id.scope.name(), &option_name)
+            .or(self.get_from_section(DEFAULT_SECTION, &option_name))
     }
 
     fn get_list<T: FromValue + Parseable>(
         &self,
         id: &OptionId,
     ) -> Result<Option<Vec<ListEdit<T>>>, String> {
+        let from_scoped_section_opt = self.get_list_from_section(id.scope.name(), id)?;
+
+        Ok(
+            if let Some(from_default_section) = self.get_list_from_section(DEFAULT_SECTION, id)? {
+                Some(itertools::concat([
+                    from_default_section,
+                    from_scoped_section_opt.unwrap_or(vec![]),
+                ]))
+            } else {
+                from_scoped_section_opt
+            },
+        )
+    }
+
+    fn get_list_from_section<T: FromValue + Parseable>(
+        &self,
+        section_name: &str,
+        id: &OptionId,
+    ) -> Result<Option<Vec<ListEdit<T>>>, String> {
         let mut list_edits = vec![];
-        if let Some(table) = self.config.value.get(id.scope.name()) {
-            let option_name = Self::option_name(id);
-            if let Some(value) = table.get(&option_name) {
+        if let Some(table) = self.config.value.get(section_name) {
+            let option_name = &Self::option_name(id);
+            if let Some(value) = table.get(option_name) {
                 match value {
                     Value::Table(sub_table) => {
                         if sub_table.is_empty()
@@ -368,13 +395,13 @@ impl ConfigReader {
                             list_edits.push(ListEdit {
                                 action: ListEditAction::Add,
                                 items: T::extract_list(&format!("{option_name}.add"), add)?,
-                            })
+                            });
                         }
                         if let Some(remove) = sub_table.get("remove") {
                             list_edits.push(ListEdit {
                                 action: ListEditAction::Remove,
                                 items: T::extract_list(&format!("{option_name}.remove"), remove)?,
-                            })
+                            });
                         }
                     }
                     Value::String(v) => {
@@ -388,12 +415,17 @@ impl ConfigReader {
                     }
                     value => list_edits.push(ListEdit {
                         action: ListEditAction::Replace,
-                        items: T::extract_list(&option_name, value)?,
+                        items: T::extract_list(option_name, value)?,
                     }),
                 }
             }
         }
-        Ok(Some(list_edits))
+
+        Ok(if list_edits.is_empty() {
+            None
+        } else {
+            Some(list_edits)
+        })
     }
 }
 

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -176,6 +176,87 @@ fn test_interpolate_config() {
 }
 
 #[test]
+fn test_default_section_scalar() {
+    fn do_test<T: PartialEq + Debug>(
+        default_foo: &str,
+        default_bar: &str,
+        overridden_bar: &str,
+        expected_foo: T,
+        expected_bar: T,
+        getter: fn(&ConfigReader, &OptionId) -> Result<Option<T>, String>,
+    ) {
+        let conf = config(&format!(
+            "[DEFAULT]\nfoo = {default_foo}\nbar={default_bar}\n[scope]\nbar={overridden_bar}\n"
+        ));
+        let actual_foo = getter(&conf, &option_id!(["scope"], "foo"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(expected_foo, actual_foo);
+
+        let actual_bar = getter(&conf, &option_id!(["scope"], "bar"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(expected_bar, actual_bar);
+    }
+
+    do_test(
+        "false",
+        "false",
+        "true",
+        false,
+        true,
+        ConfigReader::get_bool,
+    );
+    do_test("11", "22", "33", 11, 33, ConfigReader::get_int);
+    do_test(
+        "3.14",
+        "1.23",
+        "99.88",
+        3.14,
+        99.88,
+        ConfigReader::get_float,
+    );
+    do_test(
+        "\"xx\"",
+        "\"yy\"",
+        "\"zz\"",
+        "xx".to_string(),
+        "zz".to_string(),
+        ConfigReader::get_string,
+    );
+}
+
+#[test]
+fn test_default_section_list() {
+    let conf = config("[DEFAULT]\nfoo = [11]\nbar=[22]\n[scope]\nbar=[33]\n");
+    assert_eq!(
+        conf.get_int_list(&option_id!(["scope"], "foo"))
+            .unwrap()
+            .unwrap(),
+        vec![ListEdit::<i64> {
+            action: ListEditAction::Replace,
+            items: vec![11]
+        }]
+    );
+
+    assert_eq!(
+        conf.get_int_list(&option_id!(["scope"], "bar"))
+            .unwrap()
+            .unwrap(),
+        vec![
+            ListEdit::<i64> {
+                action: ListEditAction::Replace,
+                items: vec![22]
+            },
+            ListEdit::<i64> {
+                action: ListEditAction::Replace,
+                items: vec![33]
+            }
+        ]
+    );
+}
+
+#[test]
 fn test_scalar_fromfile() {
     fn do_test<T: PartialEq + Debug>(
         content: &str,


### PR DESCRIPTION
Previously we only used DEFAULT for seeding ${placeholder}s, 
but we are also supposed to fall back to reading from it, when
the value doesn't exist in the specific section, as the Python 
parser does.
