### PR TITLE
Handle env vars for dotted scopes

### DIFF
--- a/src/rust/engine/options/src/args.rs
+++ b/src/rust/engine/options/src/args.rs
@@ -158,11 +158,8 @@ impl ArgsReader {
     }
 
     #[allow(dead_code)]
-    pub fn get_passthrough_args(&self) -> Option<Vec<&str>> {
-        self.args
-            .passthrough_args
-            .as_ref()
-            .map(|v| Vec::from_iter(v.iter().map(String::as_str)))
+    pub fn get_passthrough_args(&self) -> Option<&Vec<String>> {
+        self.args.passthrough_args.as_ref()
     }
 
     fn to_bool(&self, arg: &Arg) -> Result<Option<bool>, ParseError> {

--- a/src/rust/engine/options/src/args_tests.rs
+++ b/src/rust/engine/options/src/args_tests.rs
@@ -388,7 +388,11 @@ fn test_passthrough_args() {
     assert_string("debug", option_id!(-'l', "level"));
 
     assert_eq!(
-        Some(vec!["--passthrough0", "passthrough1", "-p",]),
+        Some(&vec![
+            "--passthrough0".to_string(),
+            "passthrough1".to_string(),
+            "-p".to_string(),
+        ]),
         args.get_passthrough_args()
     );
 }
@@ -397,5 +401,5 @@ fn test_passthrough_args() {
 fn test_empty_passthrough_args() {
     let args = mk_args(["-ldebug", "--foo=bar", "--"]);
 
-    assert_eq!(Some(vec![]), args.get_passthrough_args());
+    assert_eq!(Some(&vec![]), args.get_passthrough_args());
 }

--- a/src/rust/engine/options/src/env.rs
+++ b/src/rust/engine/options/src/env.rs
@@ -71,7 +71,10 @@ impl EnvReader {
         let name = id.name("_", NameTransform::ToUpper);
         let mut names = vec![format!(
             "PANTS_{}_{}",
-            id.scope.name().replace('-', "_").to_ascii_uppercase(),
+            id.scope
+                .name()
+                .replace(['-', '.'], "_")
+                .to_ascii_uppercase(),
             name
         )];
         if id.scope == Scope::Global {

--- a/src/rust/engine/options/src/env_tests.rs
+++ b/src/rust/engine/options/src/env_tests.rs
@@ -71,9 +71,9 @@ fn test_display() {
 
 #[test]
 fn test_scope() {
-    let env = env([("PANTS_PYTHON_EXAMPLE", "true")]);
+    let env = env([("PANTS_FOO_BAR_EXAMPLE", "true")]);
     assert!(env
-        .get_bool(&option_id!(["python"], "example"))
+        .get_bool(&option_id!(["foo.bar"], "example"))
         .unwrap()
         .unwrap());
 }


### PR DESCRIPTION
If the scope name is foo.bar, the env var should 
start with PANTS_FOO_BAR_, as is done
in the Python parser.

In practice dots aren't allowed in scope names,
and a dotted scope indicates "nested subsystems"
which aren't a thing any more. But some aspects
of this are still tested in the Python parser, and we
want those tests to continue to pass under the 
Rust parser.

This PR also changes the return value of
get_passthrough_args to one that turns
out to be more useful in practice, but which wasn't
worth an independent PR.