### PR TITLE
Support parsing Config from memory in Rust.

### DIFF
--- a/src/python/pants/option/config.py
+++ b/src/python/pants/option/config.py
@@ -92,7 +92,7 @@ class Config:
             **normalized_seed_values,
             **toml_values.get(DEFAULT_SECTION, {}),
         }
-        return _ConfigValues(config_source.path, toml_values, seed_values)
+        return _ConfigValues(config_source, toml_values, seed_values)
 
     def verify(self, section_to_valid_options: dict[str, set[str]]):
         error_log = []
@@ -155,9 +155,9 @@ class Config:
                 available_vals.append(val)
         return available_vals
 
-    def sources(self) -> list[str]:
-        """Returns the sources of this config as a list of filenames."""
-        return [vals.path for vals in self.values]
+    def sources(self) -> list[ConfigSource]:
+        """Returns the sources of this config."""
+        return [vals.source for vals in self.values]
 
     def get_sources_for_option(self, section: str, option: str) -> list[str]:
         """Returns the path(s) to the source file(s) the given option was defined in."""
@@ -176,9 +176,13 @@ _TomlValue = Union[_TomlPrimitive, List[_TomlPrimitive], Dict[str, _TomlPrimitiv
 class _ConfigValues:
     """The parsed contents of a TOML config file."""
 
-    path: str
+    source: ConfigSource
     section_to_values: dict[str, dict[str, Any]]
     seed_values: dict[str, Any]
+
+    @property
+    def path(self) -> str:
+        return self.source.path
 
     def _possibly_interpolate_value(
         self,

--- a/src/python/pants/option/config_test.py
+++ b/src/python/pants/option/config_test.py
@@ -254,14 +254,13 @@ def _compare(config: Config, expected: dict[str, dict[str, list[str]]]) -> None:
 
 @pytest.mark.parametrize("filedata", [FILE_0, FILE_1])
 def test_individual_file_parsing(filedata: ConfigFile) -> None:
+    file_contents = [FileContent("file.toml", filedata.content.encode())]
     config = Config.load(
-        file_contents=[
-            FileContent("file.toml", filedata.content.encode()),
-        ],
+        file_contents=file_contents,
         seed_values=_seed_values,
         env=_env,
     )
-    assert ["file.toml"] == config.sources()
+    assert file_contents == config.sources()
 
     _compare(config, filedata.expected_options)
 
@@ -273,15 +272,16 @@ def test_individual_file_parsing(filedata: ConfigFile) -> None:
 
 
 def test_merged_config() -> None:
+    file_contents = [
+        FileContent("file0.toml", FILE_0.content.encode()),
+        FileContent("file1.toml", FILE_1.content.encode()),
+    ]
     config = Config.load(
-        file_contents=[
-            FileContent("file0.toml", FILE_0.content.encode()),
-            FileContent("file1.toml", FILE_1.content.encode()),
-        ],
+        file_contents=file_contents,
         seed_values=_seed_values,
         env=_env,
     )
-    assert ["file0.toml", "file1.toml"] == config.sources()
+    assert file_contents == config.sources()
 
     _compare(config, _expected_combined_values)
 

--- a/src/python/pants/option/options_bootstrapper.py
+++ b/src/python/pants/option/options_bootstrapper.py
@@ -146,18 +146,17 @@ class OptionsBootstrapper:
 
             # Now re-read the config, post-bootstrapping. Note the order: First whatever we bootstrapped
             # from (typically pants.toml), then config override, then rcfiles.
-            full_config_paths = pre_bootstrap_config.sources()
+            full_config_sources = pre_bootstrap_config.sources()
             if allow_pantsrc and bootstrap_option_values.pantsrc:
                 rcfiles = [
                     os.path.expanduser(str(rcfile))
                     for rcfile in bootstrap_option_values.pantsrc_files
                 ]
-                existing_rcfiles = list(filter(os.path.exists, rcfiles))
-                full_config_paths.extend(existing_rcfiles)
+                existing_rcfiles = [filecontent_for(p) for p in filter(os.path.exists, rcfiles)]
+                full_config_sources.extend(existing_rcfiles)
 
-            full_config_files_products = [filecontent_for(p) for p in full_config_paths]
             post_bootstrap_config = Config.load(
-                full_config_files_products,
+                full_config_sources,
                 seed_values=bootstrap_option_values.as_dict(),
                 env=env,
             )

--- a/src/rust/engine/options/src/config_tests.rs
+++ b/src/rust/engine/options/src/config_tests.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::Write;
 
-use crate::config::interpolate_string;
+use crate::config::{interpolate_string, ConfigSource};
 use crate::{
     option_id, DictEdit, DictEditAction, ListEdit, ListEditAction, OptionId, OptionsSource, Val,
 };
@@ -26,7 +26,7 @@ fn maybe_config(file_content: &str) -> Result<ConfigReader, String> {
         .write_all(file_content.as_bytes())
         .unwrap();
     Config::parse(
-        &path,
+        &ConfigSource::from_file(&path)?,
         &HashMap::from([
             ("seed1".to_string(), "seed1val".to_string()),
             ("seed2".to_string(), "seed2val".to_string()),

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 // Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+use crate::config::ConfigSource;
 use crate::{
     option_id, Args, BuildRoot, DictEdit, DictEditAction, Env, ListEdit, ListEditAction,
     OptionParser, Source, Val,
@@ -60,10 +61,12 @@ fn with_setup(
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect::<HashMap<_, _>>(),
         },
-        Some(vec![
-            config_path.to_str().unwrap(),
-            extra_config_path.to_str().unwrap(),
-        ]),
+        Some(
+            vec![config_path, extra_config_path]
+                .iter()
+                .map(|cp| ConfigSource::from_file(cp).unwrap())
+                .collect(),
+        ),
         false,
         true,
         Some(BuildRoot::find_from(buildroot.path()).unwrap()),


### PR DESCRIPTION
Previously it required actual files on disk.

This change also includes a minor modification
to the equivalent logic in the Python parser, to
prepare for connecting the two: The _ConfigValues
struct now remembers the ConfigSource it was
parsed from, instead of just the path.