### PR TITLE
Fix dependencies and dependents to use output file when using json formatting (Cherry-pick of #20843)

### DIFF
--- a/src/python/pants/backend/project_info/dependencies.py
+++ b/src/python/pants/backend/project_info/dependencies.py
@@ -109,7 +109,9 @@ async def list_dependencies_as_json(
     # for them, the lists of dependencies are returned in the very same order.
     mapping = dict(zip([str(tgt.address) for tgt in target_roots], iterated_targets))
     output = json.dumps(mapping, indent=4)
-    console.print_stdout(output)
+
+    with dependencies_subsystem.line_oriented(console) as print_stdout:
+        print_stdout(output)
 
 
 async def list_dependencies_as_plain_text(

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -85,12 +85,15 @@ def assert_dependencies(
     specs: List[str],
     expected: List[str],
     transitive: bool = False,
+    output_file: Optional[str] = None,
     closed: bool = False,
     output_format: DependenciesOutputFormat = DependenciesOutputFormat.text,
 ) -> None:
     args = []
     if transitive:
         args.append("--transitive")
+    if output_file:
+        args.extend([f"--output-file={output_file}"])
     if closed:
         args.append("--closed")
     args.append(f"--format={output_format.value}")
@@ -98,10 +101,19 @@ def assert_dependencies(
     result = rule_runner.run_goal_rule(
         Dependencies, args=[*args, *specs], env_inherit={"PATH", "PYENV_ROOT", "HOME"}
     )
-    if output_format == DependenciesOutputFormat.text:
-        assert result.stdout.splitlines() == expected
-    elif output_format == DependenciesOutputFormat.json:
-        assert json.loads(result.stdout) == expected
+
+    if output_file is None:
+        if output_format == DependenciesOutputFormat.text:
+            assert result.stdout.splitlines() == expected
+        elif output_format == DependenciesOutputFormat.json:
+            assert json.loads(result.stdout) == expected
+    else:
+        assert not result.stdout
+        with open(output_file) as f:
+            if output_format == DependenciesOutputFormat.text:
+                assert f.read().splitlines() == expected
+            elif output_format == DependenciesOutputFormat.json:
+                assert json.load(f) == expected
 
 
 def test_no_target(rule_runner: PythonRuleRunner) -> None:
@@ -223,6 +235,12 @@ def test_python_dependencies(rule_runner: PythonRuleRunner) -> None:
         ],
         closed=True,
     )
+    assert_deps(
+        specs=["some/other/target:target"],
+        transitive=False,
+        output_file="dependencies.txt",
+        expected=["some/other/target/a.py"],
+    )
 
 
 def test_python_dependencies_output_format_json_direct_deps(rule_runner: PythonRuleRunner) -> None:
@@ -333,6 +351,17 @@ def test_python_dependencies_output_format_json_direct_deps(rule_runner: PythonR
                 "some/other/target/a.py",
                 "some/other/target:target",
                 "some/target/a.py",
+            ]
+        },
+    )
+    assert_deps(
+        specs=["some/target/a.py"],
+        transitive=False,
+        output_file="dependencies.json",
+        expected={
+            "some/target/a.py": [
+                "3rdparty/python:req1",
+                "dep/target/a.py",
             ]
         },
     )

--- a/src/python/pants/backend/project_info/dependents.py
+++ b/src/python/pants/backend/project_info/dependents.py
@@ -167,7 +167,8 @@ async def list_dependents_as_json(
         iterated_addresses.append(sorted([str(address) for address in dependents]))
     mapping = dict(zip([str(address) for address in addresses], iterated_addresses))
     output = json.dumps(mapping, indent=4)
-    console.print_stdout(output)
+    with dependents_subsystem.line_oriented(console) as print_stdout:
+        print_stdout(output)
 
 
 @goal_rule


### PR DESCRIPTION
Fix dependencies and dependents goals to use the provided output file when formatting with json. See https://github.com/pantsbuild/pants/issues/20842 for more details.
