### PR TITLE
Start the release notes for 2.22

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -1,0 +1,53 @@
+# 2.20.x Release Series
+
+Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
+
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+## What's New
+
+### Highlights
+
+- (no highlights yet, check back later 😃 )
+
+Keep reading to see the details and what's also included.
+
+### Backends
+
+#### JVM
+
+##### Scala
+
+Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.
+
+#### Python
+
+[The `pants.backend.experimental.python.lint.ruff` backend](https://www.pantsbuild.org/2.22/reference/subsystems/ruff) now uses version 0.4.1 by default.
+
+The new `layout="loose"` field for AWS Lambda [function](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_function#layout), [layer](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#layout) and [Google Cloud Function](https://www.pantsbuild.org/2.22/reference/targets/python_google_cloud_function#layout) targets outputs the artefact as a directory, rather than a zip file.
+
+Initial support for Python 3.13 (pre-release) has been added. NB. built-in tool like black will [not yet](https://github.com/pantsbuild/pants/issues/20852) run with Python 3.13.
+
+The [PyOxizider tool is effectively stagnant](https://github.com/indygreg/PyOxidizer/issues/7410). [The `pants.backend.experimental.python.packaging.pyoxidizer` backend](https://www.pantsbuild.org/2.22/docs/python/integrations/pyoxidizer) docs now have a note reflecting this.
+
+Default module mappings were added for more modules:
+
+The deprecation for the `platforms` field for the `pex_binary` and `pex_binaries` targets has expired, and so has been removed. The `resolve_local_platforms` field is now meaningless and is thus deprecated.
+
+#### Shell
+
+[The `pants.backend.shell.lint.shfmt` backend](https://www.pantsbuild.org/2.22/docs/shell#shfmt-autoformatter) now uses shfmt version 3.8.0 by default.
+
+#### Yaml
+
+Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.org/2.22/reference/subsystems/yamllint#orphan_files_behavior) the `pants.backend.experimental.tools.yamllint` backend is now properly silent. It previously showed spurious warnings.
+
+### Plugin API changes
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -1,4 +1,4 @@
-# 2.20.x Release Series
+# 2.22.x Release Series
 
 Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
 


### PR DESCRIPTION
This starts a `2.22.x.md` for work-in-progress features on the `main` branch. This is preparation for #20850: once that's in, we'll be maintaining this file as we go, so it helps to seed it.

Currently includes everything up to b75eb0747792afc577feaecc97cc8ca5a764809d. https://github.com/pantsbuild/pants/compare/release_2.21.0a0...b75eb0747792afc577feaecc97cc8ca5a764809d
