### PR TITLE
Rust options parser tweaks

### DIFF
--- a/src/rust/engine/options/src/parse.rs
+++ b/src/rust/engine/options/src/parse.rs
@@ -332,63 +332,63 @@ pub(crate) fn parse_dict(value: &str) -> Result<DictEdit, ParseError> {
 }
 
 pub(crate) trait Parseable: Sized + DeserializeOwned {
-    fn option_type() -> &'static str;
+    const OPTION_TYPE: &'static str;
     fn parse(value: &str) -> Result<Self, ParseError>;
     fn parse_list(value: &str) -> Result<Vec<ListEdit<Self>>, ParseError>;
+
+    fn format_parse_error(value: &str, e: peg::error::ParseError<peg::str::LineCol>) -> ParseError {
+        format_parse_error(Self::OPTION_TYPE, value, e)
+    }
+
+    fn format_list_parse_error(
+        value: &str,
+        e: peg::error::ParseError<peg::str::LineCol>,
+    ) -> ParseError {
+        format_parse_error(&format!("{} list", Self::OPTION_TYPE), value, e)
+    }
 }
 
 impl Parseable for bool {
-    fn option_type() -> &'static str {
-        "bool"
-    }
+    const OPTION_TYPE: &'static str = "bool";
 
     fn parse(value: &str) -> Result<bool, ParseError> {
-        option_value_parser::bool(value)
-            .map_err(|e| format_parse_error(Self::option_type(), value, e))
+        option_value_parser::bool(value).map_err(|e| Self::format_parse_error(value, e))
     }
 
     fn parse_list(value: &str) -> Result<Vec<ListEdit<bool>>, ParseError> {
         option_value_parser::bool_list_edits(value)
-            .map_err(|e| format_parse_error("bool list", value, e))
+            .map_err(|e| Self::format_list_parse_error(value, e))
     }
 }
 
 impl Parseable for i64 {
-    fn option_type() -> &'static str {
-        "int"
-    }
+    const OPTION_TYPE: &'static str = "int";
 
     fn parse(value: &str) -> Result<i64, ParseError> {
-        option_value_parser::int(value)
-            .map_err(|e| format_parse_error(Self::option_type(), value, e))
+        option_value_parser::int(value).map_err(|e| Self::format_parse_error(value, e))
     }
 
     fn parse_list(value: &str) -> Result<Vec<ListEdit<i64>>, ParseError> {
         option_value_parser::int_list_edits(value)
-            .map_err(|e| format_parse_error("int list", value, e))
+            .map_err(|e| Self::format_list_parse_error(value, e))
     }
 }
 
 impl Parseable for f64 {
-    fn option_type() -> &'static str {
-        "float"
-    }
+    const OPTION_TYPE: &'static str = "float";
 
     fn parse(value: &str) -> Result<f64, ParseError> {
-        option_value_parser::float(value)
-            .map_err(|e| format_parse_error(Self::option_type(), value, e))
+        option_value_parser::float(value).map_err(|e| Self::format_parse_error(value, e))
     }
 
     fn parse_list(value: &str) -> Result<Vec<ListEdit<f64>>, ParseError> {
         option_value_parser::float_list_edits(value)
-            .map_err(|e| format_parse_error("float list", value, e))
+            .map_err(|e| Self::format_list_parse_error(value, e))
     }
 }
 
 impl Parseable for String {
-    fn option_type() -> &'static str {
-        "string"
-    }
+    const OPTION_TYPE: &'static str = "string";
 
     fn parse(value: &str) -> Result<String, ParseError> {
         Ok(value.to_owned())
@@ -396,6 +396,6 @@ impl Parseable for String {
 
     fn parse_list(value: &str) -> Result<Vec<ListEdit<String>>, ParseError> {
         option_value_parser::string_list_edits(value)
-            .map_err(|e| format_parse_error("string list", value, e))
+            .map_err(|e| Self::format_list_parse_error(value, e))
     }
 }

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -163,10 +163,24 @@ fn test_parse_float() {
 
 #[test]
 fn test_parse_list_from_empty_string() {
-    assert!(String::parse_list("").unwrap().is_empty());
-    assert!(bool::parse_list("").unwrap().is_empty());
-    assert!(i64::parse_list("").unwrap().is_empty());
-    assert!(f64::parse_list("").unwrap().is_empty());
+    assert_eq!(
+        String::parse_list(""),
+        Ok(vec![string_list_edit(ListEditAction::Add, [""])])
+    );
+
+    fn check_err<T: Parseable + Debug>() {
+        let expected = format!("Problem parsing foo {} list value", T::option_type());
+        let actual = T::parse_list("").unwrap_err().render("foo");
+        assert!(
+            actual.contains(&expected),
+            "Error message `{}` did not contain `{}`",
+            actual,
+            expected
+        );
+    }
+    check_err::<bool>();
+    check_err::<i64>();
+    check_err::<f64>();
 }
 
 fn string_list_edit<I: IntoIterator<Item = &'static str>>(

--- a/src/rust/engine/options/src/parse_tests.rs
+++ b/src/rust/engine/options/src/parse_tests.rs
@@ -169,7 +169,7 @@ fn test_parse_list_from_empty_string() {
     );
 
     fn check_err<T: Parseable + Debug>() {
-        let expected = format!("Problem parsing foo {} list value", T::option_type());
+        let expected = format!("Problem parsing foo {} list value", T::OPTION_TYPE);
         let actual = T::parse_list("").unwrap_err().render("foo");
         assert!(
             actual.contains(&expected),

--- a/src/rust/engine/options/src/tests.rs
+++ b/src/rust/engine/options/src/tests.rs
@@ -185,7 +185,7 @@ fn test_parse_list_options() {
     ) {
         with_setup(args, env, config, extra_config, |option_parser| {
             let id = option_id!(["scope"], "foo");
-            let option_value = option_parser.parse_int_list(&id, &[0]).unwrap();
+            let option_value = option_parser.parse_int_list(&id, vec![0]).unwrap();
             assert_eq!(expected, option_value.value);
             assert_eq!(expected_derivation, option_value.derivation.unwrap());
         });

--- a/src/rust/engine/pantsd/src/lib.rs
+++ b/src/rust/engine/pantsd/src/lib.rs
@@ -297,10 +297,7 @@ pub fn fingerprint_compute(
                 Digest::update(&mut hasher, val.value.as_bytes());
             }
             OptionType::StringList(default) => {
-                let default = default.iter().map(|s| s.as_str()).collect::<Vec<_>>();
-                let val = options_parser
-                    .parse_string_list(&option.id, &default)?
-                    .value;
+                let val = options_parser.parse_string_list(&option.id, default)?.value;
                 for item in val {
                     Digest::update(&mut hasher, item.as_bytes());
                 }


### PR DESCRIPTION
Various changes needed to support access to the 
Rust parser from Python code. 

These include:

1. Modeling option source "rank", using the same
  enum values as the Python model.
2. Making the OptionsParser concurrency-friendly
  (making it Send + Sync, and using Arc instead of Rc).
3. Plumbing passthrough args in. 
4. Having get_list()'s `default` be Vec instead of array.
5. Ensuring that `--string-list-option=` is interpreted as adding
  an empty string to the list, rather than setting it to an empty list,
  and ensuring that for other list types, `--foo=` is an error.
  This is how the Python options parser treats these cases, so we
  must comply with that.

The actual Python bindings will be provided in 
a future PR. 