### PR TITLE
add workspace environment support

### DIFF
--- a/docs/docs/using-pants/environments.mdx
+++ b/docs/docs/using-pants/environments.mdx
@@ -16,6 +16,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 1. locally in Docker containers
 2. remotely via [remote execution](./remote-caching-and-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
+4. locally, with execution performed in the workspace / repository and not an execution sandbox (with the trade-off that this is inherently UNSAFE)
 
 ### Defining environments
 
@@ -70,7 +71,8 @@ To declare which environment they should build with, many target types (but part
 The `environment=` field may either:
 
 1. refer to an environment by name
-2. use a special `__local__` environment name, which resolves to any matching `local_environment` (see "Environment matching" below)
+2. use a special `__local__` environment name, which resolves to any matching `local_environment` 
+3. use a special `__local_workspace__` environment environment name, which resolves to any matching `workspace_environment` (see "Environment matching" below)
 
 :::caution Environment compatibility
 Currently, there is no static validation that a target's environment is compatible with its dependencies' environments -- only the implicit validation of the goals that you run successfully against those targets (`check`, `lint`, `test`, `package`, etc).
@@ -107,8 +109,9 @@ A single environment name may end up referring to different environment targets 
 - `local_environment` targets will match if their `compatible_platforms=` field matches localhost's platform.
 - `docker_environment` targets will match [if Docker is enabled](../../reference/global-options.mdx#docker_execution), and if their `platform=` field is compatible with localhost's platform.
 - `remote_environment` targets will match [if Remote execution is enabled](../../reference/global-options.mdx#remote_execution).
+- `workspace_environment` targets will match if their `compatible_platforms=` field matches localhost's platform.
 
-If a particular environment target _doesn't_ match, it can configure a `fallback_environment=` which will be attempted next. This allows for forming preference chains which are referred to by whichever environment name is at the head of the chain.
+If a particular environment target _doesn't_ match (other than for `workspace_enviroment` targets), it can configure a `fallback_environment=` which will be attempted next. This allows for forming preference chains which are referred to by whichever environment name is at the head of the chain. This does not apply to `workspace_enviroment` targets because in-workspace execution differs significantly from the execution in the other environments due to the lack of an execution sandbox.
 
 For example: a chain like "prefer remote execution if enabled, but fall back to local execution if the platform matches, otherwise use docker" might be configured via the targets:
 
@@ -238,3 +241,15 @@ You could then _override_ that name definition in `pants.ci.toml` (note the use 
 [environments-preview.names.add]
 macos = "//:macos_ci"
 ```
+
+### In-Workspace Execution (`workspace_environment`)
+
+The `workspace_enviroment` target type configures a special "workspace" environment in which build actions are invoked in the repository / workspace instead of an execution sandbox as would be done with `local_environment` executions.
+
+The primary motivation for this feature is to better support integration with third-party build orchestration tools (for example, Bazel) which may not operate properly when not invoked in the repository (including in some cases incurring signifcant performance penalties).
+
+There is a significant trade-off though which makes this feature inherently **UNSAFE**: Pants cannot reasonbly guarantee that build processes are reproducible if they run in the workspace environment. Thus, Pants puts that burden on you, the Pants user, to guarantee that any process executed in the workspace environment is reproducible based solely on inputs in the repository. If a process is not reproducible, then unknown side effects may occur.
+
+The special environment name `__local_workspace__` can be used to select a matching `workspace_environment` based on its `compatible_platforms` attribute.
+
+There is no `fallback_environment=` atribute on `workspace_enviroment` targets because in-workspace execution differs significantly from the other environemnts due to the lack of an execution sandbox.

--- a/docs/docs/using-pants/environments.mdx
+++ b/docs/docs/using-pants/environments.mdx
@@ -16,7 +16,7 @@ By default, Pants will execute all sandboxed build work directly on localhost. B
 1. locally in Docker containers
 2. remotely via [remote execution](./remote-caching-and-execution/remote-execution.mdx)
 3. locally, but with a non-default set of environment variables and settings (such as when different platforms need different values, or when cross-building)
-4. locally, with execution performed in the workspace / repository and not an execution sandbox (with the trade-off that this is inherently UNSAFE)
+4. locally, but with execution performed in the workspace / repository and not an execution sandbox (with the trade-off that you must be cognizant of build reproducibility)
 
 ### Defining environments
 
@@ -71,8 +71,9 @@ To declare which environment they should build with, many target types (but part
 The `environment=` field may either:
 
 1. refer to an environment by name
-2. use a special `__local__` environment name, which resolves to any matching `local_environment` 
-3. use a special `__local_workspace__` environment environment name, which resolves to any matching `workspace_environment` (see "Environment matching" below)
+2. use one of the following special environment names to select a matching environment: (see "Environment matching" below)
+  1. `__local__` resolves to any matching `local_environment`
+  2. `__local_workspace__` resolves to any matching `workspace_environment` 
 
 :::caution Environment compatibility
 Currently, there is no static validation that a target's environment is compatible with its dependencies' environments -- only the implicit validation of the goals that you run successfully against those targets (`check`, `lint`, `test`, `package`, etc).
@@ -248,8 +249,18 @@ The `workspace_enviroment` target type configures a special "workspace" environm
 
 The primary motivation for this feature is to better support integration with third-party build orchestration tools (for example, Bazel) which may not operate properly when not invoked in the repository (including in some cases incurring signifcant performance penalties).
 
-There is a significant trade-off though which makes this feature inherently **UNSAFE**: Pants cannot reasonbly guarantee that build processes are reproducible if they run in the workspace environment. Thus, Pants puts that burden on you, the Pants user, to guarantee that any process executed in the workspace environment is reproducible based solely on inputs in the repository. If a process is not reproducible, then unknown side effects may occur.
+:::caution Caching and reproducibility
+
+Pants' caching relies on all process being reproducible based solely on inputs in the repository.
+Processes executed in a workspace environment can easily accidentally read unexpected files, that aren't specified as a dependency. 
+Thus, Pants puts that burden on you, the Pants user, to ensure a process output only depends on its specified input files, and doesn't read anything else.
+
+If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly, or give different output to an earlier build.
+
+:::
 
 The special environment name `__local_workspace__` can be used to select a matching `workspace_environment` based on its `compatible_platforms` attribute.
 
-There is no `fallback_environment=` atribute on `workspace_enviroment` targets because in-workspace execution differs significantly from the other environemnts due to the lack of an execution sandbox.
+There is no `fallback_environment=` atribute on `workspace_enviroment` targets because in-workspace execution differs significantly from
+the other environemnts due to the lack of an execution sandbox.
+

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -14,6 +14,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 - A new implementation of the options system.
 - Source globs are now less strict, using a "match any" conjunction rather than the previous "match all".
+- In-workspace execution of processes via `workspace_environment` target type.
 
 ### New options system
 
@@ -22,6 +23,16 @@ This release introduces a major re-implementation of the Pants [options system](
 The two systems are expected to be more-or-less functionally identical. We plan to switch to the native system in release 2.23.x, and remove the legacy system in release 2.24.x. However to ensure that this transition is not disruptive, this release and the next one will run both systems and compare their results, issuing a warning if they differ.
 
 If you encounter such discrepancies, and you can't resolve them easily, please [reach out to us on Slack or file an issue](https://www.pantsbuild.org/community/getting-help).
+
+### Environments: In-Workspace Execution
+
+Pants now supports executing processes locally within the repository itself via the new "workspace" environment which is configured by the new `workspace_environment` target type. The primary motivation for this feature is to better support integration with third-party build orchestration tools (e.g., Bazel) which may not operate properly when not invoked in the repository (including in some cases signifcant performance penalties).
+
+There is a significant trade-off though: Pants cannot reasonbly guarantee that build processes are reproducible if they run in the workspace
+environment. Thus, Pants puts that burden on you, the Pants user, to guarantee that any process executed in the workspace environment is reproducible
+based solely on inputs in the repository. If a process is not reproducible, then unknown side effects may occur.
+
+**Thus, this feature is inherently UNSAFE.**
 
 ### Backends
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -32,8 +32,6 @@ There is a significant trade-off though: Pants cannot reasonbly guarantee that b
 environment. Thus, Pants puts that burden on you, the Pants user, to guarantee that any process executed in the workspace environment is reproducible
 based solely on inputs in the repository. If a process is not reproducible, then unknown side effects may occur.
 
-**Thus, this feature is inherently UNSAFE.**
-
 ### Backends
 
 #### BUILD

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -28,7 +28,7 @@ from pants.core.util_rules.adhoc_process_support import (
     ToolRunnerRequest,
 )
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
-from pants.core.util_rules.environments import EnvironmentNameRequest
+from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
 from pants.engine.environment import EnvironmentName
 from pants.engine.fs import Digest, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
@@ -48,6 +48,7 @@ class GenerateFilesFromAdhocToolRequest(GenerateSourcesRequest):
 @rule(desc="Running run_in_sandbox target", level=LogLevel.DEBUG)
 async def run_in_sandbox_request(
     request: GenerateFilesFromAdhocToolRequest,
+    env_target: EnvironmentTarget,
 ) -> GeneratedSources:
     target = request.protocol_target
     description = f"the `{target.alias}` at {target.address}"
@@ -78,6 +79,8 @@ async def run_in_sandbox_request(
     output_files = target.get(AdhocToolOutputFilesField).value or ()
     output_directories = target.get(AdhocToolOutputDirectoriesField).value or ()
 
+    cache_scope = env_target.default_cache_scope
+
     process_request = AdhocProcessRequest(
         description=description,
         address=target.address,
@@ -96,6 +99,7 @@ async def run_in_sandbox_request(
         log_output=target[AdhocToolLogOutputField].value,
         capture_stderr_file=target[AdhocToolStderrFilenameField].value,
         capture_stdout_file=target[AdhocToolStdoutFilenameField].value,
+        cache_scope=cache_scope,
     )
 
     adhoc_result = await Get(

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import shlex
+from pathlib import Path
 from textwrap import dedent
 
 import pytest
@@ -26,6 +27,7 @@ from pants.core.target_types import ArchiveTarget, FilesGeneratorTarget, FileSou
 from pants.core.target_types import rules as core_target_type_rules
 from pants.core.util_rules import archive, source_files
 from pants.core.util_rules.adhoc_process_support import AdhocProcessRequest
+from pants.core.util_rules.environments import LocalWorkspaceEnvironmentTarget
 from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
 from pants.engine.addresses import Address
 from pants.engine.environment import EnvironmentName
@@ -65,6 +67,7 @@ def rule_runner() -> RuleRunner:
             ShellSourcesGeneratorTarget,
             ArchiveTarget,
             FilesGeneratorTarget,
+            LocalWorkspaceEnvironmentTarget,
         ],
     )
     rule_runner.set_options([], env_inherit={"PATH"})
@@ -837,3 +840,35 @@ def test_working_directory_special_values(
         Address("src", target_name="workdir"),
         expected_contents={"out.log": f"{expected_dir}\n"},
     )
+
+
+def test_shell_command_with_workspace_execution(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """
+            shell_command(
+                name="make-file",
+                command="echo workspace > foo.txt && echo sandbox > {chroot}/out.log",
+                output_files=["out.log"],
+                environment="workspace",
+            )
+            workspace_environment(name="workspace")
+            """
+            )
+        }
+    )
+    rule_runner.set_options(
+        ["--environments-preview-names={'workspace': '//:workspace'}", "--no-local-cache"],
+        env_inherit={"PATH"},
+    )
+
+    print(f"build root = {rule_runner.build_root}")
+    assert_shell_command_result(
+        rule_runner,
+        Address("", target_name="make-file"),
+        expected_contents={"out.log": "sandbox\n"},
+    )
+    workspace_output_path = Path(rule_runner.build_root).joinpath("foo.txt")
+    assert workspace_output_path.exists()
+    assert workspace_output_path.read_text().strip() == "workspace"

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -859,11 +859,10 @@ def test_shell_command_with_workspace_execution(rule_runner: RuleRunner) -> None
         }
     )
     rule_runner.set_options(
-        ["--environments-preview-names={'workspace': '//:workspace'}", "--no-local-cache"],
+        ["--environments-preview-names={'workspace': '//:workspace'}"],
         env_inherit={"PATH"},
     )
 
-    print(f"build root = {rule_runner.build_root}")
     assert_shell_command_result(
         rule_runner,
         Address("", target_name="make-file"),

--- a/src/python/pants/core/register.py
+++ b/src/python/pants/core/register.py
@@ -54,6 +54,7 @@ from pants.core.util_rules import (
 from pants.core.util_rules.environments import (
     DockerEnvironmentTarget,
     LocalEnvironmentTarget,
+    LocalWorkspaceEnvironmentTarget,
     RemoteEnvironmentTarget,
 )
 from pants.core.util_rules.wrap_source import wrap_source_rule_and_target
@@ -113,6 +114,7 @@ def target_types():
         FileTarget,
         GenericTarget,
         LocalEnvironmentTarget,
+        LocalWorkspaceEnvironmentTarget,
         LockfilesGeneratorTarget,
         LockfileTarget,
         RelocatedFiles,

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -71,6 +71,7 @@ class AdhocProcessRequest:
     log_output: bool
     capture_stdout_file: str | None
     capture_stderr_file: str | None
+    cache_scope: ProcessCacheScope | None = None
 
 
 @dataclass(frozen=True)
@@ -587,10 +588,7 @@ async def prepare_adhoc_process(
         working_directory=working_directory,
         append_only_caches=append_only_caches,
         immutable_input_digests=immutable_input_digests,
-        # TODO: This is necessary for tests of `adhoc_tool` and `shell_command` with
-        # workspace execution to pass repeatedly in local Pants development.
-        # We need a viable solution instead of this hack.
-        cache_scope=ProcessCacheScope.PER_SESSION,
+        cache_scope=request.cache_scope or ProcessCacheScope.SUCCESSFUL,
     )
 
     return _output_at_build_root(proc, bash)

--- a/src/python/pants/core/util_rules/adhoc_process_support.py
+++ b/src/python/pants/core/util_rules/adhoc_process_support.py
@@ -30,7 +30,13 @@ from pants.engine.fs import (
     Snapshot,
 )
 from pants.engine.internals.native_engine import AddressInput, RemovePrefix
-from pants.engine.process import FallibleProcessResult, Process, ProcessResult, ProductDescription
+from pants.engine.process import (
+    FallibleProcessResult,
+    Process,
+    ProcessCacheScope,
+    ProcessResult,
+    ProductDescription,
+)
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     FieldSetsPerTarget,
@@ -581,6 +587,10 @@ async def prepare_adhoc_process(
         working_directory=working_directory,
         append_only_caches=append_only_caches,
         immutable_input_digests=immutable_input_digests,
+        # TODO: This is necessary for tests of `adhoc_tool` and `shell_command` with
+        # workspace execution to pass repeatedly in local Pants development.
+        # We need a viable solution instead of this hack.
+        cache_scope=ProcessCacheScope.PER_SESSION,
     )
 
     return _output_at_build_root(proc, bash)

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -197,15 +197,9 @@ class LocalWorkspaceEnvironmentTarget(Target):
         third-party build orchestration tools which may not run correctly when run from within the Pants
         execution sandbox.
 
-        SAFETY: Workspace environments are inherently UNSAFE since Pants cannot guarantee that any process invoked
-        as a workspace environment is in fact reproducible. By using this environment, you forgo the
-        "hermetic" nature of the Pants execution model and must guarantee to Pants that the invoked process
-        is repeatable and does not have side effects.
-
-        Environment configuration includes the platforms the environment is compatible with, and
-        optionally a fallback environment, along with environment-aware options (such as
-        environment variables and search paths) used by Pants to execute processes in this
-        environment.
+        Environment configuration includes the platforms the environment is compatible with along with
+        environment-aware options (such as environment variables and search paths) used by Pants to execute
+        processes in this environment.
 
         To use this environment, map this target's address with a memorable name in
         `[environments-preview].names`. You can then consume this environment by specifying the name in
@@ -214,6 +208,16 @@ class LocalWorkspaceEnvironmentTarget(Target):
         Only one `workspace_environment` may be defined in `[environments-preview].names` per platform, and
         when `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` is specified as the environment, the
         `workspace_environment` that matches the current platform (if defined) will be selected.
+
+        Caching and reproducibility:
+
+        Pants' caching relies on all process being reproducible based solely on inputs in the repository.
+        Processes executed in a workspace environment can easily accidentally read unexpected files,
+        that aren't specified as a dependency.  Thus, Pants puts that burden on you, the Pants user, to ensure
+        a process output only depends on its specified input files, and doesn't read anything else.
+
+        If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly,
+        or give different output to an earlier build.
         """
     )
 

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -186,13 +186,7 @@ class LocalWorkspaceFallbackEnvironmentField(FallbackEnvironmentField):
 
         Must be an environment name from the option `[environments-preview].names`, the
         special string `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` to use the relevant local environment, or the
-        Python value `None` to error when this specific local environment cannot be used.
-
-        Tip: when targeting Linux, it can be particularly helpful to fallback to a
-        `docker_environment` or `remote_environment` target. That allows you to prefer using the
-        local host when possible, which often has less overhead (particularly compared to Docker).
-        If the local host is not compatible, then Pants will use Docker or remote execution to
-        still run in a similar environment.
+        Python value `None` to error when this specific local workspace environment cannot be used.
         """
     )
 

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -563,6 +563,13 @@ class EnvironmentTarget:
         else:
             return ""
 
+    @property
+    def default_cache_scope(self) -> ProcessCacheScope:
+        if self.val and self.val.has_field(LocalWorkspaceCompatiblePlatformsField):
+            return ProcessCacheScope.PER_SESSION
+        else:
+            return ProcessCacheScope.SUCCESSFUL
+
 
 def _compute_env_field(field_set: FieldSet) -> EnvironmentField:
     for attr in dir(field_set):

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -646,10 +646,9 @@ async def find_binary(
     # which is not the current directory (since the process will execute in the workspace). Thus,
     # adjust the path used as argv[0] to find the script.
     script_name = "find_binary.sh"
+    sandbox_base_path = env_target.sandbox_base_path()
     script_exec_path = (
-        f"./{script_name}"
-        if not env_target.is_workspace_environment()
-        else f"{{chroot}}/{script_name}"
+        f"./{script_name}" if not sandbox_base_path else f"{sandbox_base_path}/{script_name}"
     )
 
     script_header = dedent(

--- a/src/python/pants/core/util_rules/system_binaries.py
+++ b/src/python/pants/core/util_rules/system_binaries.py
@@ -642,7 +642,16 @@ async def find_binary(
         bash = await Get(BashBinary)
         shebang = f"#!{bash.path}"
 
-    script_path = "./find_binary.sh"
+    # HACK: For workspace environments, the `find_binary.sh` will be mounted in the "chroot" directory
+    # which is not the current directory (since the process will execute in the workspace). Thus,
+    # adjust the path used as argv[0] to find the script.
+    script_name = "find_binary.sh"
+    script_exec_path = (
+        f"./{script_name}"
+        if not env_target.is_workspace_environment()
+        else f"{{chroot}}/{script_name}"
+    )
+
     script_header = dedent(
         f"""\
         {shebang}
@@ -674,7 +683,7 @@ async def find_binary(
     script_content = script_header + script_body
     script_digest = await Get(
         Digest,
-        CreateDigest([FileContent(script_path, script_content.encode(), is_executable=True)]),
+        CreateDigest([FileContent(script_name, script_content.encode(), is_executable=True)]),
     )
 
     # Some subtle notes about executing this script:
@@ -688,7 +697,7 @@ async def find_binary(
             description=f"Searching for `{request.binary_name}` on PATH={search_path}",
             level=LogLevel.DEBUG,
             input_digest=script_digest,
-            argv=[script_path, request.binary_name],
+            argv=[script_exec_path, request.binary_name],
             env={"PATH": search_path},
             cache_scope=env_target.executable_search_path_cache_scope(),
         ),

--- a/src/python/pants/engine/environment.py
+++ b/src/python/pants/engine/environment.py
@@ -9,9 +9,8 @@ from pants.engine.engine_aware import EngineAwareParameter
 # Reserved sentinel value directing Pants to find applicable local environment.
 LOCAL_ENVIRONMENT_MATCHER = "__local__"
 
-# Reserved sentinel value representing execution within the workspace and not local sandbox.
-# Note: This is temporary until support for `workspace_environment` target type lands.
-__LOCAL_WORKSPACE_ENV_NAME = "__local_workspace__"
+# Reserved sentinel value directing Pants to find applicable workspace environment.
+LOCAL_WORKSPACE_ENVIRONMENT_MATCHER = "__local_workspace__"
 
 
 @dataclass(frozen=True)
@@ -33,5 +32,13 @@ class EnvironmentName(EngineAwareParameter):
 @dataclass(frozen=True)
 class ChosenLocalEnvironmentName:
     """Which environment name from `[environments-preview].names` that __local__ resolves to."""
+
+    val: EnvironmentName
+
+
+@dataclass(frozen=True)
+class ChosenLocalWorkspaceEnvironmentName:
+    """Which environment name from `[environments-preview].names` that __local_workspace__ resolves
+    to."""
 
     val: EnvironmentName

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1599,9 +1599,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
  "bytes",
  "fnv",
@@ -3434,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.116"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",

--- a/src/rust/engine/Cargo.lock
+++ b/src/rust/engine/Cargo.lock
@@ -1599,9 +1599,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -3434,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",


### PR DESCRIPTION
Add support for a "workspace environment" which is similar to a local environment except that execution happens in the repository itself (i.e., the "workspace") and not in an execution sandbox.  This implements the user-visible experience of Design B from the ["In-Workspace Process Execution" design document](https://docs.google.com/document/d/1jUZTQHmUBr-Ij0nXOO0QX2Bq6XNANJg4-GNzhiOL4Xs/edit?usp=sharing).

This PR builds on top of the Rust support for in-workspace execution contained in https://github.com/pantsbuild/pants/pull/20772.

Users will use the new `workspace_environment` target type to configure workspace execution support.

The [pants-workspace-exec-testing repository](https://github.com/tdyas/pants-workspace-exec-testing) contains an example of how to use this support to allow Pants to invoke Bazel in the workspace.