### PR TITLE
Fix markdown syntax in "Making subsystems exportable ..." docs

### DIFF
--- a/docs/docs/writing-plugins/common-subsystem-tasks.mdx
+++ b/docs/docs/writing-plugins/common-subsystem-tasks.mdx
@@ -54,11 +54,13 @@ class FortranLintFieldSet(FieldSet):
 
 :::note Support depends on language backend of the subsystem
 Only some language backends support `pants export`. These include the Python and JVM backends. Only tools which are themselves written to use a backend with this feature can be exported. For example, a Python-based tool which operates on a different language is exportable.
-
+:::
 
 1. Make the subsystem a subclass of `ExportableTool`
 
-:::note Language backends may have done this in their Tool base class. For example, the Python backend with `PythonToolRequirementsBase` and JVM with `JvmToolBase` are already subclasses.
+:::note Language backends may have done this in their Tool base class.
+For example, the Python backend with `PythonToolRequirementsBase` and JVM with `JvmToolBase` are already subclasses.
+:::
 
 ```python
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase

--- a/docs/docs/writing-plugins/common-subsystem-tasks.mdx
+++ b/docs/docs/writing-plugins/common-subsystem-tasks.mdx
@@ -58,23 +58,23 @@ Only some language backends support `pants export`. These include the Python and
 
 1. Make the subsystem a subclass of `ExportableTool`
 
-:::note Language backends may have done this in their Tool base class.
-For example, the Python backend with `PythonToolRequirementsBase` and JVM with `JvmToolBase` are already subclasses.
-:::
+    :::note Language backends may have done this in their Tool base class.
+    For example, the Python backend with `PythonToolRequirementsBase` and JVM with `JvmToolBase` are already subclasses.
+    :::
 
-```python
-from pants.backend.python.subsystems.python_tool_base import PythonToolBase
-from pants.core.goals.resolves import ExportableTool
+    ```python
+    from pants.backend.python.subsystems.python_tool_base import PythonToolBase
+    from pants.core.goals.resolves import ExportableTool
 
-class FortranLint(PythonToolBase, ExportableTool):
-    ...
-```
+    class FortranLint(PythonToolBase, ExportableTool):
+        ...
+    ```
 
 2. Register your class with a `UnionRule` with `ExportableTool`
 
-```python
-def rules():
-	return [
-		UnionRule(ExportableTool, FortranLint)
-	]
-```
+    ```python
+    def rules():
+        return [
+            UnionRule(ExportableTool, FortranLint)
+        ]
+    ```


### PR DESCRIPTION
This makes two minor adjustments to the "Making subsystems exportable ..." docs from #20730:

- close the `:::note` admonitions with `:::`
- indent some items to be nested within the relevant list items

Fixes #20891

![image](https://github.com/pantsbuild/pants/assets/1203825/6ad04be1-3d83-4ad0-a3ab-50427b7c77dc)
