### PR TITLE
Adjust docs for python `export` goal option (Cherry-pick of #20903)

### DIFF
--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -84,16 +84,16 @@ class ExportPluginOptions:
         help=softwrap(
             """
             When exporting a mutable virtualenv for a resolve, do PEP-660 editable installs
-            of all 'python_distribution' targets that own code in the exported resolve.
+            of all `python_distribution` targets that own code in the exported resolve.
 
-            If a resolve name is not in this list, 'python_distribution' targets will not
+            If a resolve name is not in this list, `python_distribution` targets will not
             be installed in the virtualenv. This defaults to an empty list for backwards
             compatibility and to prevent unnecessary work to generate and install the
             PEP-660 editable wheels.
 
-            This only applies when '[python].enable_resolves' is true and when exporting a
-            'mutable_virtualenv' ('symlinked_immutable_virtualenv' exports are not "full"
-            virtualenvs because they must not be edited, and do not include 'pip').
+            This only applies when `[python].enable_resolves` is true and when exporting a
+            `mutable_virtualenv` (`symlinked_immutable_virtualenv` exports are not "full"
+            virtualenvs because they must not be edited, and do not include `pip`).
             """
         ),
         advanced=True,
@@ -107,16 +107,16 @@ class ExportPluginOptions:
             modify console script shebang lines to make them "hermetic".
             The shebang of hermetic console scripts uses the python args: `-sE`:
 
-            - `-s` skips inclusion of the user site-packages directoy,
-            - `-E` ignores all `PYTHON*` env vars like `PYTHONPATH`.
+              - `-s` skips inclusion of the user site-packages directory,
+              - `-E` ignores all `PYTHON*` env vars like `PYTHONPATH`.
 
             Set this to false if you need non-hermetic scripts with
             simple python shebangs that respect vars like `PYTHONPATH`,
             to, for example, allow IDEs like PyCharm to inject its debugger,
             coverage, or other IDE-specific libs when running a script.
 
-            This only applies when when exporting a 'mutable_virtualenv'
-            ('symlinked_immutable_virtualenv' exports are not "full"
+            This only applies when when exporting a `mutable_virtualenv`
+            (`symlinked_immutable_virtualenv` exports are not "full"
             virtualenvs because they are used internally by pants itself.
             Pants requires hermetic scripts to provide its reproduciblity
             guarantee, fine-grained caching, and other features).


### PR DESCRIPTION
This makes a few minor adjustments to the docs for the `py_editable_in_resolve` and `py_hermetic_scripts` options to `pants export ...`:

- add some indentation so that `softwrap` preserves the crucial newlines in a Markdown list 
- backticks around more things for code formatting
- minor typo


Fixes #20893

![image](https://github.com/pantsbuild/pants/assets/1203825/229a2070-36cf-4f41-b103-5335a18fdb78)

