### PR TITLE
fix: Use statically linked `coursier` binary

### DIFF
--- a/src/python/pants/jvm/resolve/coursier_setup.py
+++ b/src/python/pants/jvm/resolve/coursier_setup.py
@@ -112,7 +112,7 @@ class CoursierSubsystem(TemplatedExternalTool):
     default_known_versions = [
         "v2.1.6|macos_arm64 |746b3e346fa2c0107fdbc8a627890d495cb09dee4f8dcc87146bdb45941088cf|20829782|https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.6/cs-aarch64-apple-darwin.gz",
         "v2.1.6|linux_arm64 |33330ca433781c9db9458e15d2d32e5d795de3437771647e26835e8b1391af82|20899290|https://github.com/VirtusLab/coursier-m1/releases/download/v2.1.6/cs-aarch64-pc-linux.gz",
-        "v2.1.6|linux_x86_64|af7234f8802107f5e1130307ef8a5cc90262d392f16ddff7dce27a4ed0ddd292|20681688",
+        "v2.1.6|linux_x86_64|d03e90e5f60acfdb57dee4be308c8ce7227f96d74c320aba700a97e5681e3c90|20222461|https://github.com/coursier/coursier/releases/download/v2.1.6/cs-x86_64-pc-linux-static.gz",
         "v2.1.6|macos_x86_64|36a5d42a0724be2ac39d0ebd8869b985e3d58ceb121bc60389ee2d6d7408dd56|20037412",
         "v2.1.0-M5-18-gfebf9838c|linux_arm64 |d4ad15ba711228041ad8a46d848c83c8fbc421d7b01c415d8022074dd609760f|19264005",
         "v2.1.0-M5-18-gfebf9838c|linux_x86_64|3e1a1ad1010d5582e9e43c5a26b273b0147baee5ebd27d3ac1ab61964041c90b|19551533",


### PR DESCRIPTION
This should improve reproducability across different flavours of Linux, especially some more esoteric flavours like Nix, where not all shared libraries reside in `/usr/lib`.

I'm currently overriding this in `known_versions` locally but thought the change might be useful to others as well.

The reason why only 2.1.6 is affected is because static builds of coursier doesn't exist for the earlier versions.