### PR TITLE
Include extra_build_args on pex_binaries too

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -58,6 +58,8 @@ Initial support for Python 3.13 (pre-release) has been added. NB. built-in tool 
 
 The [PyOxizider tool is effectively stagnant](https://github.com/indygreg/PyOxidizer/issues/7410). [The `pants.backend.experimental.python.packaging.pyoxidizer` backend](https://www.pantsbuild.org/2.22/docs/python/integrations/pyoxidizer) docs now have a note reflecting this.
 
+[The `extra_build_args` field](https://www.pantsbuild.org/2.22/reference/targets/pex_binaries#extra_build_args) is now available on the `pex_binaries` target generator, in addition to `pex_binary`.
+
 Default module mappings were added for more modules:
 
 The deprecation for the `platforms` field for the `pex_binary` and `pex_binaries` targets has expired, and so has been removed. The `resolve_local_platforms` field is now meaningless and is thus deprecated.

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -755,6 +755,7 @@ _PEX_BINARY_COMMON_FIELDS = (
     PexIncludeToolsField,
     PexVenvSitePackagesCopies,
     PexVenvHermeticScripts,
+    PexExtraBuildArgsField,
     RestartableField,
 )
 
@@ -768,7 +769,6 @@ class PexBinary(Target):
         PexScriptField,
         PexExecutableField,
         PexArgsField,
-        PexExtraBuildArgsField,
         PexEnvField,
         OutputPathField,
     )


### PR DESCRIPTION
This moves the `extra_build_args` from being a field on `pex_binary` only to being a common field, so it appears on both `pex_binary` and the `pex_binaries` target generator.

I'd missed this in #20737.