### PR TITLE
Update release notes links in Plugin Upgrade Guide docs after movement

### DIFF
--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
@@ -309,7 +309,7 @@ The `convert_dir_literal_to_address_literal` keyword argument for `RawSpecs.crea
 
 ## 2.14
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.14.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.14.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.14.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.14.x.md) for the changelog.
 
 ### Removed second type parameter from `Get`
 
@@ -365,7 +365,7 @@ The functionality is the same, but can have better performance because we don't 
 
 ## 2.13
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.13.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.13.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.13.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.13.x.md) for the changelog.
 
 ### `AddressInput` and `UnparsedAddressInputs` require `description_of_origin`
 
@@ -448,7 +448,7 @@ You must now use a long option name when [defining options](../the-rules-api/opt
 
 ## 2.12
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.12.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.12.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.12.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.12.x.md) for the changelog.
 
 ### Unified formatters
 
@@ -458,7 +458,7 @@ See [Add a formatter](./add-a-formatter.mdx) for more information.
 
 ## 2.11
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.11.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.11.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.11.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.11.x.md) for the changelog.
 
 ### Deprecated `Subsystem.register_options()`
 
@@ -516,7 +516,7 @@ See [https://github.com/pantsbuild/pants/pull/14313](https://github.com/pantsbui
 
 ## 2.10
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.10.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.10.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.10.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.10.x.md) for the changelog.
 
 ### Rename `LintRequest` to `LintTargetsRequest`
 
@@ -580,7 +580,7 @@ This type was used to determine the owners of a Python module. The new name make
 
 ## 2.9
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.9.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.9.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.9.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.9.x.md) for the changelog.
 
 ### Deprecated `RuleRunner.create_files()`, `.create_file()` and `.add_to_build_file()`
 
@@ -588,7 +588,7 @@ Instead, for your `RuleRunner` tests, use `.write_files()`. See [https://github.
 
 ## 2.8
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.8.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.8.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.8.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.8.x.md) for the changelog.
 
 ### Target modeling changes
 
@@ -618,7 +618,7 @@ The method `OutputPathField.value_or_default()` no longer takes `Address` as an 
 
 ## 2.7
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.7.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.7.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.7.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.7.x.md) for the changelog.
 
 ### Type hints work properly
 
@@ -630,7 +630,7 @@ For example, use `my-subsystem` instead of `my_subsystem`. This is to avoid ambi
 
 ## 2.6
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.6.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.6.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.6.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.6.x.md) for the changelog.
 
 ### `ProcessCacheScope`
 
@@ -644,7 +644,7 @@ Now called `InterpreterConstraints` and defined in `pants.backend.python.util_ru
 
 ## 2.5
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.5.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.5.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.5.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.5.x.md) for the changelog.
 
 ### `TriBoolField`
 
@@ -658,7 +658,7 @@ This is a more declarative way to set up files than the older API of `RuleRunner
 
 ## 2.4
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.4.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.4.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.4.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.4.x.md) for the changelog.
 
 ### `PexRequest` changes how entry point is set
 
@@ -674,11 +674,11 @@ For `RuleRunner` tests, you must now either set `env` or the new `env_inherit` a
 
 ## 2.3
 
-There were no substantial changes to the Plugin API in 2.3. See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.3.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.3.x.md) for the changelog.
+There were no substantial changes to the Plugin API in 2.3. See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.3.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.3.x.md) for the changelog.
 
 ## 2.2
 
-See [https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.2.x.md](https://github.com/pantsbuild/pants/blob/main/src/python/pants/notes/2.2.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.2.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.2.x.md) for the changelog.
 
 ### `PrimitiveField` and `AsyncField` are removed (2.2.0.dev0)
 
@@ -710,7 +710,7 @@ Pants will now properly wrap strings and preserve newlines. You may want to run 
 
 ## 2.1
 
-See [https://github.com/pantsbuild/pants/blob/master/src/python/pants/notes/2.1.x.rst](https://github.com/pantsbuild/pants/blob/master/src/python/pants/notes/2.1.x.rst) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.rst](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.rst) for the changelog.
 
 ### `SourcesSnapshot` is now `SpecsSnapshot` (2.1.0rc0)
 
@@ -718,7 +718,7 @@ The type was renamed for clarity. Still import it from `pants.engine.fs`.
 
 ## 2.0
 
-See [https://github.com/pantsbuild/pants/blob/master/src/python/pants/notes/2.0.x.rst](https://github.com/pantsbuild/pants/blob/master/src/python/pants/notes/2.0.x.rst) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.rst](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.rst) for the changelog.
 
 ### Use `TransitiveTargetsRequest` as input for resolving `TransitiveTargets` (2.0.0rc0)
 

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
@@ -710,7 +710,7 @@ Pants will now properly wrap strings and preserve newlines. You may want to run 
 
 ## 2.1
 
-See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.md](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.1.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.1.x.md) for the changelog.
 
 ### `SourcesSnapshot` is now `SpecsSnapshot` (2.1.0rc0)
 
@@ -718,7 +718,7 @@ The type was renamed for clarity. Still import it from `pants.engine.fs`.
 
 ## 2.0
 
-See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.md](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.md) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/main/docs/notes/2.0.x.md](https://github.com/pantsbuild/pants/blob/main/docs/notes/2.0.x.md) for the changelog.
 
 ### Use `TransitiveTargetsRequest` as input for resolving `TransitiveTargets` (2.0.0rc0)
 

--- a/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
+++ b/docs/docs/writing-plugins/common-plugin-tasks/plugin-upgrade-guide.mdx
@@ -710,7 +710,7 @@ Pants will now properly wrap strings and preserve newlines. You may want to run 
 
 ## 2.1
 
-See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.rst](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.rst) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.md](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.1.x.md) for the changelog.
 
 ### `SourcesSnapshot` is now `SpecsSnapshot` (2.1.0rc0)
 
@@ -718,7 +718,7 @@ The type was renamed for clarity. Still import it from `pants.engine.fs`.
 
 ## 2.0
 
-See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.rst](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.rst) for the changelog.
+See [https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.md](https://github.com/pantsbuild/pants/blob/master/docs/notes/2.0.x.md) for the changelog.
 
 ### Use `TransitiveTargetsRequest` as input for resolving `TransitiveTargets` (2.0.0rc0)
 


### PR DESCRIPTION
This makes three changes to the releases notes links in the "Plugin Upgrade Guide" docs:

- adjust the path for the movement in https://github.com/pantsbuild/pants/pull/20847
- fix `.rst` -> `.md` file extension for 2.0.x and 2.1.x
- fix `master` -> `main` branch name for 2.0.x and 2.1.x