### PR TITLE
Restore stub release notes files, with links to new location

### DIFF
--- a/src/python/pants/notes/1.0.x.rst
+++ b/src/python/pants/notes/1.0.x.rst
@@ -1,0 +1,4 @@
+1.0.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.0.x.rst <../../../../docs/notes/1.0.x.rst>`_

--- a/src/python/pants/notes/1.1.x.rst
+++ b/src/python/pants/notes/1.1.x.rst
@@ -1,0 +1,4 @@
+1.1.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.1.x.rst <../../../../docs/notes/1.1.x.rst>`_

--- a/src/python/pants/notes/1.10.x.rst
+++ b/src/python/pants/notes/1.10.x.rst
@@ -1,0 +1,4 @@
+1.10.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.10.x.rst <../../../../docs/notes/1.10.x.rst>`_

--- a/src/python/pants/notes/1.11.x.rst
+++ b/src/python/pants/notes/1.11.x.rst
@@ -1,0 +1,4 @@
+1.11.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.11.x.rst <../../../../docs/notes/1.11.x.rst>`_

--- a/src/python/pants/notes/1.12.x.rst
+++ b/src/python/pants/notes/1.12.x.rst
@@ -1,0 +1,4 @@
+1.12.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.12.x.rst <../../../../docs/notes/1.12.x.rst>`_

--- a/src/python/pants/notes/1.13.x.rst
+++ b/src/python/pants/notes/1.13.x.rst
@@ -1,0 +1,4 @@
+1.13.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.13.x.rst <../../../../docs/notes/1.13.x.rst>`_

--- a/src/python/pants/notes/1.14.x.rst
+++ b/src/python/pants/notes/1.14.x.rst
@@ -1,0 +1,4 @@
+1.14.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.14.x.rst <../../../../docs/notes/1.14.x.rst>`_

--- a/src/python/pants/notes/1.15.x.rst
+++ b/src/python/pants/notes/1.15.x.rst
@@ -1,0 +1,4 @@
+1.15.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.15.x.rst <../../../../docs/notes/1.15.x.rst>`_

--- a/src/python/pants/notes/1.16.x.rst
+++ b/src/python/pants/notes/1.16.x.rst
@@ -1,0 +1,4 @@
+1.16.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.16.x.rst <../../../../docs/notes/1.16.x.rst>`_

--- a/src/python/pants/notes/1.17.x.rst
+++ b/src/python/pants/notes/1.17.x.rst
@@ -1,0 +1,4 @@
+1.17.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.17.x.rst <../../../../docs/notes/1.17.x.rst>`_

--- a/src/python/pants/notes/1.18.x.rst
+++ b/src/python/pants/notes/1.18.x.rst
@@ -1,0 +1,4 @@
+1.18.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.18.x.rst <../../../../docs/notes/1.18.x.rst>`_

--- a/src/python/pants/notes/1.19.x.rst
+++ b/src/python/pants/notes/1.19.x.rst
@@ -1,0 +1,4 @@
+1.19.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.19.x.rst <../../../../docs/notes/1.19.x.rst>`_

--- a/src/python/pants/notes/1.2.x.rst
+++ b/src/python/pants/notes/1.2.x.rst
@@ -1,0 +1,4 @@
+1.2.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.2.x.rst <../../../../docs/notes/1.2.x.rst>`_

--- a/src/python/pants/notes/1.20.x.rst
+++ b/src/python/pants/notes/1.20.x.rst
@@ -1,0 +1,4 @@
+1.20.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.20.x.rst <../../../../docs/notes/1.20.x.rst>`_

--- a/src/python/pants/notes/1.21.x.rst
+++ b/src/python/pants/notes/1.21.x.rst
@@ -1,0 +1,4 @@
+1.21.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.21.x.rst <../../../../docs/notes/1.21.x.rst>`_

--- a/src/python/pants/notes/1.22.x.rst
+++ b/src/python/pants/notes/1.22.x.rst
@@ -1,0 +1,4 @@
+1.22.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.22.x.rst <../../../../docs/notes/1.22.x.rst>`_

--- a/src/python/pants/notes/1.23.x.rst
+++ b/src/python/pants/notes/1.23.x.rst
@@ -1,0 +1,4 @@
+1.23.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.23.x.rst <../../../../docs/notes/1.23.x.rst>`_

--- a/src/python/pants/notes/1.24.x.rst
+++ b/src/python/pants/notes/1.24.x.rst
@@ -1,0 +1,4 @@
+1.24.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.24.x.rst <../../../../docs/notes/1.24.x.rst>`_

--- a/src/python/pants/notes/1.25.x.rst
+++ b/src/python/pants/notes/1.25.x.rst
@@ -1,0 +1,4 @@
+1.25.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.25.x.rst <../../../../docs/notes/1.25.x.rst>`_

--- a/src/python/pants/notes/1.26.x.rst
+++ b/src/python/pants/notes/1.26.x.rst
@@ -1,0 +1,4 @@
+1.26.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.26.x.rst <../../../../docs/notes/1.26.x.rst>`_

--- a/src/python/pants/notes/1.27.x.rst
+++ b/src/python/pants/notes/1.27.x.rst
@@ -1,0 +1,4 @@
+1.27.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.27.x.rst <../../../../docs/notes/1.27.x.rst>`_

--- a/src/python/pants/notes/1.28.x.rst
+++ b/src/python/pants/notes/1.28.x.rst
@@ -1,0 +1,4 @@
+1.28.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.28.x.rst <../../../../docs/notes/1.28.x.rst>`_

--- a/src/python/pants/notes/1.29.x.rst
+++ b/src/python/pants/notes/1.29.x.rst
@@ -1,0 +1,4 @@
+1.29.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.29.x.rst <../../../../docs/notes/1.29.x.rst>`_

--- a/src/python/pants/notes/1.3.x.rst
+++ b/src/python/pants/notes/1.3.x.rst
@@ -1,0 +1,4 @@
+1.3.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.3.x.rst <../../../../docs/notes/1.3.x.rst>`_

--- a/src/python/pants/notes/1.30.x.rst
+++ b/src/python/pants/notes/1.30.x.rst
@@ -1,0 +1,4 @@
+1.30.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.30.x.rst <../../../../docs/notes/1.30.x.rst>`_

--- a/src/python/pants/notes/1.4.x.rst
+++ b/src/python/pants/notes/1.4.x.rst
@@ -1,0 +1,4 @@
+1.4.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.4.x.rst <../../../../docs/notes/1.4.x.rst>`_

--- a/src/python/pants/notes/1.5.x.rst
+++ b/src/python/pants/notes/1.5.x.rst
@@ -1,0 +1,4 @@
+1.5.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.5.x.rst <../../../../docs/notes/1.5.x.rst>`_

--- a/src/python/pants/notes/1.6.x.rst
+++ b/src/python/pants/notes/1.6.x.rst
@@ -1,0 +1,4 @@
+1.6.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.6.x.rst <../../../../docs/notes/1.6.x.rst>`_

--- a/src/python/pants/notes/1.7.x.rst
+++ b/src/python/pants/notes/1.7.x.rst
@@ -1,0 +1,4 @@
+1.7.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.7.x.rst <../../../../docs/notes/1.7.x.rst>`_

--- a/src/python/pants/notes/1.8.x.rst
+++ b/src/python/pants/notes/1.8.x.rst
@@ -1,0 +1,4 @@
+1.8.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.8.x.rst <../../../../docs/notes/1.8.x.rst>`_

--- a/src/python/pants/notes/1.9.x.rst
+++ b/src/python/pants/notes/1.9.x.rst
@@ -1,0 +1,4 @@
+1.9.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/1.9.x.rst <../../../../docs/notes/1.9.x.rst>`_

--- a/src/python/pants/notes/2.0.x.md
+++ b/src/python/pants/notes/2.0.x.md
@@ -1,0 +1,3 @@
+# 2.0.x Stable releases
+
+These notes have moved to [`docs/notes/2.0.x.md`](../../../../docs/notes/2.0.x.md)

--- a/src/python/pants/notes/2.0.x.rst
+++ b/src/python/pants/notes/2.0.x.rst
@@ -1,0 +1,4 @@
+2.0.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/2.0.x.md <../../../../docs/notes/2.0.x.md>`_

--- a/src/python/pants/notes/2.1.x.md
+++ b/src/python/pants/notes/2.1.x.md
@@ -1,0 +1,3 @@
+# 2.1.x Stable releases
+
+These notes have moved to [`docs/notes/2.1.x.md`](../../../../docs/notes/2.1.x.md)

--- a/src/python/pants/notes/2.1.x.rst
+++ b/src/python/pants/notes/2.1.x.rst
@@ -1,0 +1,4 @@
+2.1.x Stable releases
+=====================
+
+These notes have moved to `docs/notes/2.1.x.md <../../../../docs/notes/2.1.x.md>`_

--- a/src/python/pants/notes/2.10.x.md
+++ b/src/python/pants/notes/2.10.x.md
@@ -1,0 +1,3 @@
+# 2.10.x Stable releases
+
+These notes have moved to [`docs/notes/2.10.x.md`](../../../../docs/notes/2.10.x.md)

--- a/src/python/pants/notes/2.11.x.md
+++ b/src/python/pants/notes/2.11.x.md
@@ -1,0 +1,3 @@
+# 2.11.x Stable releases
+
+These notes have moved to [`docs/notes/2.11.x.md`](../../../../docs/notes/2.11.x.md)

--- a/src/python/pants/notes/2.12.x.md
+++ b/src/python/pants/notes/2.12.x.md
@@ -1,0 +1,3 @@
+# 2.12.x Stable releases
+
+These notes have moved to [`docs/notes/2.12.x.md`](../../../../docs/notes/2.12.x.md)

--- a/src/python/pants/notes/2.13.x.md
+++ b/src/python/pants/notes/2.13.x.md
@@ -1,0 +1,3 @@
+# 2.13.x Stable releases
+
+These notes have moved to [`docs/notes/2.13.x.md`](../../../../docs/notes/2.13.x.md)

--- a/src/python/pants/notes/2.14.x.md
+++ b/src/python/pants/notes/2.14.x.md
@@ -1,0 +1,3 @@
+# 2.14.x Stable releases
+
+These notes have moved to [`docs/notes/2.14.x.md`](../../../../docs/notes/2.14.x.md)

--- a/src/python/pants/notes/2.15.x.md
+++ b/src/python/pants/notes/2.15.x.md
@@ -1,0 +1,3 @@
+# 2.15.x Stable releases
+
+These notes have moved to [`docs/notes/2.15.x.md`](../../../../docs/notes/2.15.x.md)

--- a/src/python/pants/notes/2.16.x.md
+++ b/src/python/pants/notes/2.16.x.md
@@ -1,0 +1,3 @@
+# 2.16.x Stable releases
+
+These notes have moved to [`docs/notes/2.16.x.md`](../../../../docs/notes/2.16.x.md)

--- a/src/python/pants/notes/2.17.x.md
+++ b/src/python/pants/notes/2.17.x.md
@@ -1,0 +1,3 @@
+# 2.17.x Stable releases
+
+These notes have moved to [`docs/notes/2.17.x.md`](../../../../docs/notes/2.17.x.md)

--- a/src/python/pants/notes/2.18.x.md
+++ b/src/python/pants/notes/2.18.x.md
@@ -1,0 +1,3 @@
+# 2.18.x Stable releases
+
+These notes have moved to [`docs/notes/2.18.x.md`](../../../../docs/notes/2.18.x.md)

--- a/src/python/pants/notes/2.19.x.md
+++ b/src/python/pants/notes/2.19.x.md
@@ -1,0 +1,3 @@
+# 2.19.x Stable releases
+
+These notes have moved to [`docs/notes/2.19.x.md`](../../../../docs/notes/2.19.x.md)

--- a/src/python/pants/notes/2.2.x.md
+++ b/src/python/pants/notes/2.2.x.md
@@ -1,0 +1,3 @@
+# 2.2.x Stable releases
+
+These notes have moved to [`docs/notes/2.2.x.md`](../../../../docs/notes/2.2.x.md)

--- a/src/python/pants/notes/2.20.x.md
+++ b/src/python/pants/notes/2.20.x.md
@@ -1,0 +1,3 @@
+# 2.20.x Stable releases
+
+These notes have moved to [`docs/notes/2.20.x.md`](../../../../docs/notes/2.20.x.md)

--- a/src/python/pants/notes/2.21.x.md
+++ b/src/python/pants/notes/2.21.x.md
@@ -1,0 +1,3 @@
+# 2.21.x Stable releases
+
+These notes have moved to [`docs/notes/2.21.x.md`](../../../../docs/notes/2.21.x.md)

--- a/src/python/pants/notes/2.22.x.md
+++ b/src/python/pants/notes/2.22.x.md
@@ -1,0 +1,3 @@
+# 2.22.x Stable releases
+
+These notes have moved to [`docs/notes/2.22.x.md`](../../../../docs/notes/2.22.x.md)

--- a/src/python/pants/notes/2.3.x.md
+++ b/src/python/pants/notes/2.3.x.md
@@ -1,0 +1,3 @@
+# 2.3.x Stable releases
+
+These notes have moved to [`docs/notes/2.3.x.md`](../../../../docs/notes/2.3.x.md)

--- a/src/python/pants/notes/2.4.x.md
+++ b/src/python/pants/notes/2.4.x.md
@@ -1,0 +1,3 @@
+# 2.4.x Stable releases
+
+These notes have moved to [`docs/notes/2.4.x.md`](../../../../docs/notes/2.4.x.md)

--- a/src/python/pants/notes/2.5.x.md
+++ b/src/python/pants/notes/2.5.x.md
@@ -1,0 +1,3 @@
+# 2.5.x Stable releases
+
+These notes have moved to [`docs/notes/2.5.x.md`](../../../../docs/notes/2.5.x.md)

--- a/src/python/pants/notes/2.6.x.md
+++ b/src/python/pants/notes/2.6.x.md
@@ -1,0 +1,3 @@
+# 2.6.x Stable releases
+
+These notes have moved to [`docs/notes/2.6.x.md`](../../../../docs/notes/2.6.x.md)

--- a/src/python/pants/notes/2.7.x.md
+++ b/src/python/pants/notes/2.7.x.md
@@ -1,0 +1,3 @@
+# 2.7.x Stable releases
+
+These notes have moved to [`docs/notes/2.7.x.md`](../../../../docs/notes/2.7.x.md)

--- a/src/python/pants/notes/2.8.x.md
+++ b/src/python/pants/notes/2.8.x.md
@@ -1,0 +1,3 @@
+# 2.8.x Stable releases
+
+These notes have moved to [`docs/notes/2.8.x.md`](../../../../docs/notes/2.8.x.md)

--- a/src/python/pants/notes/2.9.x.md
+++ b/src/python/pants/notes/2.9.x.md
@@ -1,0 +1,3 @@
+# 2.9.x Stable releases
+
+These notes have moved to [`docs/notes/2.9.x.md`](../../../../docs/notes/2.9.x.md)

--- a/src/python/pants/notes/master.rst
+++ b/src/python/pants/notes/master.rst
@@ -1,0 +1,4 @@
+master Stable releases
+=====================
+
+These notes have moved to `docs/notes/master.rst <../../../../docs/notes/master.rst>`_


### PR DESCRIPTION
This is a fix to paper over the move of release notes in https://github.com/pantsbuild/pants/pull/20847 from `src/python/pants/notes` to `docs/notes`. This is to ensure that links to the old `src/python/pants/notes` locations are not dead, so people land on them and get directed to the right place.

These links appear in various blog posts and old doc snapshots (https://github.com/pantsbuild/pantsbuild.org/issues/209) and potentially places that cannot be updated too (e.g. slack, and other people linking them privately).

We should still update the ones we can, do the new location, but these stubs provide a fallback for ones that we miss.

These were generated by running this script in the `src/python/pants/notes` location:

```shell
#!/bin/bash

for p in ../../../../docs/notes/*; do
    filename=$(basename $p)
    release=$(echo $filename | sed 's/.md//; s/.rst//')
    if [[ $filename == *.md ]]; then
        # Markdown:
        echo -e "# $release Stable releases\n\nThese notes have moved to [\`docs/notes/$filename\`]($p)"
    else
        # Restructured text:
        echo -e "$release Stable releases\n=====================\n\nThese notes have moved to \`docs/notes/$filename <$p>\`_"
    fi > $filename
done

# there's a few links to 2.{0,1}.x.rst, but they're now .md
echo -e "2.0.x Stable releases\n=====================\n\nThese notes have moved to \`docs/notes/2.0.x.md <../../../../docs/notes/2.0.x.md>\`_" > 2.0.x.rst
echo -e "2.1.x Stable releases\n=====================\n\nThese notes have moved to \`docs/notes/2.1.x.md <../../../../docs/notes/2.1.x.md>\`_" > 2.1.x.rst
```

We don't need to adding new ones in future, since future releases won't ever have files in the old place.