### PR TITLE
An option for excluding certain files from all deploy jars

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -42,6 +42,11 @@ targets generator from `pom.xml`.
 
 Exclusions for `jvm_artifact` and `scala_artifact` now correctly handle a `jvm_exclude` with only the group defined.
 
+Added a `deploy_jar_exclude_files` option to the `[jvm]` subsystem, containing file patterns to exclude from all 
+deploy jars, in addition to those specified on a per-jar basis in the `deploy_jar` target's `exclude_files` field. 
+This option's default value excludes signature files from constituent jars, which are known to cause the deploy jar
+to fail to execute (since naturally it doesn't match those signatures).
+
 ##### Scala
 
 Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.

--- a/src/python/pants/jvm/package/deploy_jar.py
+++ b/src/python/pants/jvm/package/deploy_jar.py
@@ -138,7 +138,7 @@ async def package_deploy_jar(
                 (rule.pattern, rule.action)
                 for rule in field_set.duplicate_policy.value_or_default()
             ],
-            skip=field_set.exclude_files.value,
+            skip=[*(jvm.deploy_jar_exclude_files or []), *(field_set.exclude_files.value or [])],
             compress=True,
         ),
     )

--- a/src/python/pants/jvm/subsystems.py
+++ b/src/python/pants/jvm/subsystems.py
@@ -100,6 +100,24 @@ class JvmSubsystem(Subsystem):
         ),
         advanced=True,
     )
+    deploy_jar_exclude_files = StrListOption(
+        default=[
+            # Signature files.
+            r"^META-INF/[^/]+\.SF$",
+            r"^META-INF/[^/]+\.DSA$",
+            r"^META-INF/[^/]+\.RSA$",
+            # interferes with Class-Path: see man jar for i option.
+            "META-INF/INDEX.LIST$",
+        ],
+        help=softwrap(
+            """
+            A list of patterns to exclude from all deploy jars.
+            An individual deploy_jar target can also exclude other files, in addition to these,
+            by setting its `exclude_files` field.
+            """
+        ),
+    )
+
     # See https://github.com/pantsbuild/pants/issues/14937 for discussion of one way to improve
     # our behavior around cancellation with nailgun.
     nailgun_remote_cache_speculation_delay = IntOption(


### PR DESCRIPTION
The default value will strip signature files from deploy jars, which is necessary since
the deploy jar will naturally not match the signature of some random jar that was
splatted into it.

The alternative was to set this as the default on `deploy_jar`'s `exclude_files` field.
But then anyone setting that field would overrwrite the default, and be surprised when 
everything broke due to their being *more* files in their jar than before.

The previous workaround was to set these patterns manually on each deploy_jar, 
but that is an unnecessary gotcha.

