### PR TITLE
Publish: sort the results output at the end.

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -107,6 +107,10 @@ The `PythonToolRequirementsBase` and `PythonToolBase` classes now have a new `he
 
 The process execution intrinsic rule in Rust now contains support for "in workspace" execution. This is local execution from within the repository itself without using an execution sandbox. `ProcessExecutionEnvironment`'s constructor has a new `execute_in_workspace` parameter which enables workspace execution.
 
+### Other minor tweaks
+
+- The results summary at the end are now sorted for the `publish` goal.
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases

--- a/src/python/pants/core/goals/publish.py
+++ b/src/python/pants/core/goals/publish.py
@@ -279,7 +279,7 @@ async def run_publish(
 
     # We collect all results to the end, so all output from the interactive processes are done,
     # before printing the results.
-    for line in results:
+    for line in sorted(results):
         console.print_stderr(line)
 
     # Log structured output


### PR DESCRIPTION
Make the output easier to scan/read as the number of artifacts grows.. e.g. I found this hard to spot the docker images among all python libs, sorting them also groups them nicely:
```
12:33:21  ✓ acme_configuration-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_certifi-2024.4.25-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_utils-10.0.2-py3-none-any.whl published to @acme.
12:33:21  - acme_inventory-1.0.0-py3-none-any.whl skipped (by `skip_twine` on libs/acme-inventory:acme-inventory).
12:33:21  ✓ acme_pm-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_logging-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_templating-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_cd_tools-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ docker.acme.com:8888/cdi-inventory/main:1.0.0 published.
12:33:21  ✓ acme_giturlparse-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_mq_tools-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_stats-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_cdi_server-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_cd_lint-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ docker.acme.com:8888/cdi-ddata/main:10.0.2 published.
```
vs sorted (with the added benefit of grouping skipped, failed and successful ones):
```
12:33:21  - acme_inventory-1.0.0-py3-none-any.whl skipped (by `skip_twine` on libs/acme-inventory:acme-inventory).
12:33:21  ✓ acme_cd_lint-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_cd_tools-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_cdi_server-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_certifi-2024.4.25-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_configuration-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_giturlparse-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_logging-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_mq_tools-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_pm-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_stats-10.0.1-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_templating-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ acme_utils-10.0.2-py3-none-any.whl published to @acme.
12:33:21  ✓ docker.acme.com:8888/cdi-ddata/main:10.0.2 published.
12:33:21  ✓ docker.acme.com:8888/cdi-inventory/main:1.0.0 published.
```
