### PR TITLE
Always match source globs using the `any` conjunction.

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -13,6 +13,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 ### Highlights
 
 - A new implementation of the options system.
+- Source globs are now less strict, using a "match any" conjunction rather than the previous "match all".
 
 ### New options system
 

--- a/src/python/pants/engine/target_test.py
+++ b/src/python/pants/engine/target_test.py
@@ -1061,7 +1061,7 @@ expected_path_globs = namedtuple(
                     "test/b",
                 ),
                 glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-                conjunction=GlobExpansionConjunction.all_match,
+                conjunction=GlobExpansionConjunction.any_match,
                 description_of_origin="test:test's `sources` field",
             ),
             id="provided value warns on glob match error",
@@ -1108,7 +1108,7 @@ def test_multiple_sources_path_globs(
             expected_path_globs(
                 globs=("test/other_file",),
                 glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-                conjunction=GlobExpansionConjunction.all_match,
+                conjunction=GlobExpansionConjunction.any_match,
                 description_of_origin="test:test's `source` field",
             ),
             id="provided value warns on glob match error",
@@ -1119,7 +1119,7 @@ def test_multiple_sources_path_globs(
             expected_path_globs(
                 globs=("test/life",),
                 glob_match_error_behavior=GlobMatchErrorBehavior.warn,
-                conjunction=GlobExpansionConjunction.all_match,
+                conjunction=GlobExpansionConjunction.any_match,
                 description_of_origin="test:test's `source` field",
             ),
             id="default glob conjunction",

--- a/tests/python/pants_test/integration/graph_integration_test.py
+++ b/tests/python/pants_test/integration/graph_integration_test.py
@@ -15,7 +15,6 @@ _NO_BUILD_FILE_TARGET_BASE = "testprojects/src/python/no_build_file"
 _SOURCES_TARGET_BASE = "testprojects/src/python/sources"
 
 _ERR_TARGETS = {
-    "testprojects/src/python/sources:some-missing-some-not": 'Unmatched glob from testprojects/src/python/sources:some-missing-some-not\'s `sources` field: "testprojects/src/python/sources/*.rs"',
     "testprojects/src/python/sources:missing-sources": 'Unmatched glob from testprojects/src/python/sources:missing-sources\'s `sources` field: "testprojects/src/python/sources/*.scala", excludes: ["testprojects/src/python/sources/*Spec.scala", "testprojects/src/python/sources/*Suite.scala", "testprojects/src/python/sources/*Test.scala"]',
 }
 


### PR DESCRIPTION
Relax the glob matching conjunction to only err if none match rather than requiring all to match.

See #20947 for background and linked alternative abandoned solution.

Closes #20947.
