### PR TITLE
OpenAPI Java codegen fails with an ambiguous class path

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -75,7 +75,7 @@ Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.exper
 
 #### OpenAPI
 
-The `openapi_document` target will now bundle itself and its `openapi_source` dependencies into a single file when depended on by other targets. Do note that this change will make the `openapi_document` target behave more like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.
+Added an `openapi_bundle` target that will provide the ability to bundle `openapi_document` and its `openapi_source` dependencies into a single file when depended on by other targets. Do note that the `openapi_bundle` target behaves like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.
 
 #### Python
 

--- a/src/python/pants/backend/experimental/openapi/register.py
+++ b/src/python/pants/backend/experimental/openapi/register.py
@@ -12,9 +12,10 @@ from pants.backend.openapi.target_types import (
     OpenApiDocumentTarget,
     OpenApiSourceGeneratorTarget,
     OpenApiSourceTarget,
+    OpenApiBundleTarget
 )
 from pants.backend.openapi.target_types import rules as target_types_rules
-from pants.backend.openapi.util_rules import openapi_document
+from pants.backend.openapi.util_rules import openapi_bundle
 from pants.engine.rules import Rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
@@ -23,7 +24,7 @@ from pants.engine.unions import UnionRule
 def rules() -> Iterable[Rule | UnionRule]:
     return [
         *dependency_inference.rules(),
-        *openapi_document.rules(),
+        *openapi_bundle.rules(),
         *tailor.rules(),
         *target_types_rules(),
     ]
@@ -35,4 +36,5 @@ def target_types() -> Iterable[type[Target]]:
         OpenApiDocumentGeneratorTarget,
         OpenApiSourceTarget,
         OpenApiSourceGeneratorTarget,
+        OpenApiBundleTarget
     )

--- a/src/python/pants/backend/experimental/openapi/register.py
+++ b/src/python/pants/backend/experimental/openapi/register.py
@@ -8,11 +8,11 @@ from typing import Iterable
 from pants.backend.openapi import dependency_inference
 from pants.backend.openapi.goals import tailor
 from pants.backend.openapi.target_types import (
+    OpenApiBundleTarget,
     OpenApiDocumentGeneratorTarget,
     OpenApiDocumentTarget,
     OpenApiSourceGeneratorTarget,
     OpenApiSourceTarget,
-    OpenApiBundleTarget
 )
 from pants.backend.openapi.target_types import rules as target_types_rules
 from pants.backend.openapi.util_rules import openapi_bundle
@@ -36,5 +36,5 @@ def target_types() -> Iterable[type[Target]]:
         OpenApiDocumentGeneratorTarget,
         OpenApiSourceTarget,
         OpenApiSourceGeneratorTarget,
-        OpenApiBundleTarget
+        OpenApiBundleTarget,
     )

--- a/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
@@ -18,7 +18,6 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JavaSour
 from pants.backend.openapi.codegen.java.rules import GenerateJavaFromOpenAPIRequest
 from pants.backend.openapi.codegen.java.rules import rules as java_codegen_rules
 from pants.backend.openapi.sample.resources import PETSTORE_SAMPLE_SPEC
-from pants.backend.openapi.util_rules import openapi_document
 from pants.backend.openapi.target_types import (
     OpenApiDocumentDependenciesField,
     OpenApiDocumentField,
@@ -28,6 +27,7 @@ from pants.backend.openapi.target_types import (
     OpenApiSourceTarget,
 )
 from pants.backend.openapi.target_types import rules as target_types_rules
+from pants.backend.openapi.util_rules import openapi_bundle
 from pants.engine.addresses import Address, Addresses
 from pants.engine.target import (
     Dependencies,
@@ -62,7 +62,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *java_backend_rules(),
             *java_codegen_rules(),
-            *openapi_document.rules(),
+            *openapi_bundle.rules(),
             *target_types_rules(),
             *testutil.rules(),
             QueryRule(HydratedSources, (HydrateSourcesRequest,)),

--- a/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
+++ b/src/python/pants/backend/openapi/codegen/java/rules_integration_test.py
@@ -18,6 +18,7 @@ from pants.backend.java.target_types import JavaSourcesGeneratorTarget, JavaSour
 from pants.backend.openapi.codegen.java.rules import GenerateJavaFromOpenAPIRequest
 from pants.backend.openapi.codegen.java.rules import rules as java_codegen_rules
 from pants.backend.openapi.sample.resources import PETSTORE_SAMPLE_SPEC
+from pants.backend.openapi.util_rules import openapi_document
 from pants.backend.openapi.target_types import (
     OpenApiDocumentDependenciesField,
     OpenApiDocumentField,
@@ -61,6 +62,7 @@ def rule_runner() -> RuleRunner:
         rules=[
             *java_backend_rules(),
             *java_codegen_rules(),
+            *openapi_document.rules(),
             *target_types_rules(),
             *testutil.rules(),
             QueryRule(HydratedSources, (HydrateSourcesRequest,)),

--- a/src/python/pants/jvm/compile.py
+++ b/src/python/pants/jvm/compile.py
@@ -138,8 +138,8 @@ class ClasspathEntryRequestFactory:
             if set(partial[0].field_sets).issubset(set(consume_only[0].field_sets_consume_only)):
                 return partial[0](component, resolve, consume_only[0](component, resolve, None))
 
-        impls_str = ", ".join(sorted(impl.__name__ for impl in impls))
         if compatible:
+            impls_str = ", ".join(sorted(impl.__name__ for impl in compatible))
             raise ClasspathSourceAmbiguity(
                 f"More than one JVM classpath provider ({impls_str}) was compatible with "
                 f"the inputs:\n{component.bullet_list()}"
@@ -148,6 +148,7 @@ class ClasspathEntryRequestFactory:
             # TODO: There is more subtlety of error messages possible here if there are multiple
             # partial providers, but can cross that bridge when we have them (multiple Scala or Java
             # compiler implementations, for example).
+            impls_str = ", ".join(sorted(impl.__name__ for impl in impls))
             raise ClasspathSourceMissing(
                 f"No JVM classpath providers (from: {impls_str}) were compatible with the "
                 f"combination of inputs:\n{component.bullet_list()}"


### PR DESCRIPTION
In #20695 it was added the capability of bundling OpenAPI sources as resources. This however creates a conflict with other rules as reported in #20965.

The solution proposed here is to take an opt-in approach via an additional `openapi_bundle` target. The motivation for adding another target is as follows:
- Reflects clear intention when declaring it as a dependency of another target as we are no longer referencing _the sources_ but _a documentation bundle_
- OpenAPI documents can be used with multiple purposes.  Generating bundled documentation is one of them, others are generating code either client or server side. In large repos all those usages may be required at different stages of the build process.
- Projects that use OpenAPI specs to generate client code for third party services may not want to bundle those specs.

cc @jyggen 

Fixes #20965