### PR TITLE
scala source file should not depend on scalac plugins

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -90,6 +90,8 @@ The internal code for exporting JVM tools was refactored.
 
 Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.
 
+Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.
+
 #### OpenAPI
 
 Added an `openapi_bundle` target that will provide the ability to bundle `openapi_document` and its `openapi_source` dependencies into a single file when depended on by other targets. Do note that the `openapi_bundle` target behaves like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -90,8 +90,6 @@ The internal code for exporting JVM tools was refactored.
 
 Setting the `orphan_files_behaviour = "ignore"` option for [`pants.backend.experimental.scala.lint.scalafix`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafix#orphan_files_behavior) or [`pants.backend.experimental.scala.lint.scalafmt`](https://www.pantsbuild.org/2.22/reference/subsystems/scalafmt#orphan_files_behavior) backend is now properly silent. It previously showed spurious warnings.
 
-Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.
-
 #### OpenAPI
 
 Added an `openapi_bundle` target that will provide the ability to bundle `openapi_document` and its `openapi_source` dependencies into a single file when depended on by other targets. Do note that the `openapi_bundle` target behaves like a `resource` target rather than a `file` target, which in turn will likely affect which mechanism you need to use when loading it in dependent code.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -18,6 +18,9 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Backends
 
+#### Scala
+
+Source files no longer produce a dependency on Scala plugins. If you are using a Scala plugin that is also required by the source code (such as acyclic), please add an explicit dependency or set the `packages` field on the artifact.
 
 ### Plugin API changes
 

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -586,6 +586,7 @@ def test_compile_with_local_scalac_plugin(
 
                 scala_sources(
                     scalac_plugins=["acyclic"],
+                    dependencies=["3rdparty/jvm:com.lihaoyi_acyclic_2.13"],
                 )
                 """
             ),
@@ -1028,6 +1029,7 @@ def test_cross_compile_with_scalac_plugin(
                 scala_sources(
                     name="main",
                     scalac_plugins=["acyclic"],
+                    dependencies=["3rdparty/jvm:acyclic"],
                     resolve=parametrize("scala2.12", "scala2.13")
                 )
                 """


### PR DESCRIPTION
These are compile-time-only dependencies and should not be packaged with the source file or included in the classpath for the source file.

In our repository, this caused a conflict because the semanticdb package internally wraps the fastparse library with a different version than the one we are using. There is no need for semanticdb to be packaged or run within a test of a target; it is a compile-time-only dependency. Moreover, the scalac compile goal handles the scalac plugins on its own and doesn't use that.

I ran this on our Scala repository, and it compiled successfully.