### PR TITLE
separate shell tailoring between sources and tests

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -129,8 +129,6 @@ The default version of `semgrep` used by the `pants.backends.experimental.tool.s
 
 [The `pants.backend.shell.lint.shfmt` backend](https://www.pantsbuild.org/2.22/docs/shell#shfmt-autoformatter) now uses shfmt version 3.8.0 by default.
 
-The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_shunit2_tests). 
-
 #### Yaml
 
 Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.org/2.22/reference/subsystems/yamllint#orphan_files_behavior) the `pants.backend.experimental.tools.yamllint` backend is now properly silent. It previously showed spurious warnings.

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -129,7 +129,7 @@ The default version of `semgrep` used by the `pants.backends.experimental.tool.s
 
 [The `pants.backend.shell.lint.shfmt` backend](https://www.pantsbuild.org/2.22/docs/shell#shfmt-autoformatter) now uses shfmt version 3.8.0 by default.
 
-The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from "tailor" into "tailor_sources" and "tailor_shunit2_tests". 
+The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_shunit2_tests). 
 
 #### Yaml
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -129,6 +129,8 @@ The default version of `semgrep` used by the `pants.backends.experimental.tool.s
 
 [The `pants.backend.shell.lint.shfmt` backend](https://www.pantsbuild.org/2.22/docs/shell#shfmt-autoformatter) now uses shfmt version 3.8.0 by default.
 
+The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from "tailor" into "tailor_sources" and "tailor_shunit2_tests". 
+
 #### Yaml
 
 Setting [the `orphan_files_behaviour = "ignore"` option](https://www.pantsbuild.org/2.22/reference/subsystems/yamllint#orphan_files_behavior) the `pants.backend.experimental.tools.yamllint` backend is now properly silent. It previously showed spurious warnings.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -77,6 +77,10 @@ Nodejs processes configured with `extra_env_vars`, e.g.
 now supports extending the `PATH` variable of such processes. Passing `extra_env_vars=["PATH=/usr/bin"]` was previously
 silently ignored.
 
+#### Shell
+
+The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_shunit2_tests). 
+
 #### Docker
 
 Fixed a bug where the internal Docker BuildKit parser would return `<unknown> image_id` if the BuildKit output used step durations.

--- a/src/python/pants/backend/shell/goals/tailor.py
+++ b/src/python/pants/backend/shell/goals/tailor.py
@@ -47,7 +47,10 @@ def classify_source_files(paths: Iterable[str]) -> dict[type[Target], set[str]]:
 async def find_putative_targets(
     req: PutativeShellTargetsRequest, all_owned_sources: AllOwnedSources, shell_setup: ShellSetup
 ) -> PutativeTargets:
-    if not (shell_setup.tailor or shell_setup.tailor_shunit2_tests):
+    if not shell_setup.tailor:
+        return PutativeTargets()
+
+    if not (shell_setup.tailor_sources or shell_setup.tailor_shunit2_tests):
         return PutativeTargets()
 
     all_shell_files = await Get(Paths, PathGlobs, req.path_globs("*.sh"))

--- a/src/python/pants/backend/shell/subsystems/shell_setup.py
+++ b/src/python/pants/backend/shell/subsystems/shell_setup.py
@@ -18,18 +18,21 @@ class ShellSetup(Subsystem):
         help="Infer Shell dependencies on other Shell files by analyzing `source` statements.",
         advanced=True,
     )
+    tailor = BoolOption(
+        default=True,
+        help=softwrap("If true, add `shell_sources` targets with the `tailor` goal."),
+        removal_version="2.25.0.dev0",
+        removal_hint="use `tailor_sources` and/or `tailor_shunit2_tests` instead",
+        advanced=True,
+    )
     tailor_sources = BoolOption(
         default=True,
-        help=softwrap(
-            "If true, add `shell_sources` targets with the `tailor` goal."
-        ),
+        help=softwrap("If true, add `shell_sources` targets with the `tailor` goal."),
         advanced=True,
     )
     tailor_shunit2_tests = BoolOption(
         default=True,
-        help=softwrap(
-            "If true, add `shunit2_tests` targets with the `tailor` goal."
-        ),
+        help=softwrap("If true, add `shunit2_tests` targets with the `tailor` goal."),
         advanced=True,
     )
 

--- a/src/python/pants/backend/shell/subsystems/shell_setup.py
+++ b/src/python/pants/backend/shell/subsystems/shell_setup.py
@@ -22,7 +22,12 @@ class ShellSetup(Subsystem):
         default=True,
         help=softwrap("If true, add `shell_sources` targets with the `tailor` goal."),
         removal_version="2.25.0.dev0",
-        removal_hint="use `tailor_sources` and/or `tailor_shunit2_tests` instead",
+        removal_hint=softwrap(
+            """
+            Use `tailor_sources` and/or `tailor_shunit2_tests` instead.
+            For backwards compatibility, if this option is `False`, it will override the other options.
+            """
+        ),
         advanced=True,
     )
     tailor_sources = BoolOption(

--- a/src/python/pants/backend/shell/subsystems/shell_setup.py
+++ b/src/python/pants/backend/shell/subsystems/shell_setup.py
@@ -18,12 +18,17 @@ class ShellSetup(Subsystem):
         help="Infer Shell dependencies on other Shell files by analyzing `source` statements.",
         advanced=True,
     )
-    tailor = BoolOption(
+    tailor_sources = BoolOption(
         default=True,
         help=softwrap(
-            """
-            If true, add `shell_sources` and `shunit2_tests` targets with
-            the `tailor` goal."""
+            "If true, add `shell_sources` targets with the `tailor` goal."
+        ),
+        advanced=True,
+    )
+    tailor_shunit2_tests = BoolOption(
+        default=True,
+        help=softwrap(
+            "If true, add `shunit2_tests` targets with the `tailor` goal."
         ),
         advanced=True,
     )


### PR DESCRIPTION
The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from "tailor" into "tailor_sources" and "tailor_shunit2_tests".

The "tailor" option is now deprecated. For the duration, setting it to False will disable tailor for both source types. If set to True (the default), the other 2 options will be consulted.

fixes #20882

