### PR TITLE
Add missing sql backends in pants packaging

### DIFF
--- a/src/python/pants/backend/experimental/sql/BUILD
+++ b/src/python/pants/backend/experimental/sql/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# NOTE: Sources restricted from the default for python_sources due to conflict with
+#   - //:all-__init__.py-files
+#   - //src/python/pants/backend/experimental/sql/__init__.py:../../../../../../all-__init__.py-files
+python_sources(
+    sources=[
+        "register.py",
+    ],
+)

--- a/src/python/pants/backend/experimental/sql/BUILD
+++ b/src/python/pants/backend/experimental/sql/BUILD
@@ -1,11 +1,4 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# NOTE: Sources restricted from the default for python_sources due to conflict with
-#   - //:all-__init__.py-files
-#   - //src/python/pants/backend/experimental/sql/__init__.py:../../../../../../all-__init__.py-files
-python_sources(
-    sources=[
-        "register.py",
-    ],
-)
+python_sources()

--- a/src/python/pants/backend/experimental/sql/lint/sqlfluff/BUILD
+++ b/src/python/pants/backend/experimental/sql/lint/sqlfluff/BUILD
@@ -1,11 +1,4 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-# NOTE: Sources restricted from the default for python_sources due to conflict with
-#   - //:all-__init__.py-files
-#   - //src/python/pants/backend/experimental/sql/lint/sqlfluff/__init__.py:../../../../../../../../all-__init__.py-files
-python_sources(
-    sources=[
-        "register.py",
-    ],
-)
+python_sources()

--- a/src/python/pants/backend/experimental/sql/lint/sqlfluff/BUILD
+++ b/src/python/pants/backend/experimental/sql/lint/sqlfluff/BUILD
@@ -1,0 +1,11 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# NOTE: Sources restricted from the default for python_sources due to conflict with
+#   - //:all-__init__.py-files
+#   - //src/python/pants/backend/experimental/sql/lint/sqlfluff/__init__.py:../../../../../../../../all-__init__.py-files
+python_sources(
+    sources=[
+        "register.py",
+    ],
+)

--- a/src/python/pants/bin/BUILD
+++ b/src/python/pants/bin/BUILD
@@ -72,6 +72,8 @@ target(
         "src/python/pants/backend/experimental/scala/debug_goals",
         "src/python/pants/backend/experimental/scala/lint/scalafix",
         "src/python/pants/backend/experimental/scala/lint/scalafmt",
+        "src/python/pants/backend/experimental/sql",
+        "src/python/pants/backend/experimental/sql/lint/sqlfluff",
         "src/python/pants/backend/experimental/swift",
         "src/python/pants/backend/experimental/terraform",
         "src/python/pants/backend/experimental/terraform/lint/tfsec",


### PR DESCRIPTION
The SQL related backends were not added to pants_loader. The release notes announce the availability of this new backend so no need to make new modifications to them.