### PR TITLE
Make various JDK tests work on all platforms.

### DIFF
--- a/src/python/pants/backend/java/compile/javac_test.py
+++ b/src/python/pants/backend/java/compile/javac_test.py
@@ -84,13 +84,15 @@ JAVA_LIB_SOURCE = dedent(
 )
 
 
-JAVA_LIB_JDK12_SOURCE = dedent(
+JAVA_LIB_JDK17_SOURCE = dedent(
     """
     package org.pantsbuild.example.lib;
 
+    import javax.lang.model.SourceVersion;
+
     public class ExampleLib {
         public static String hello() {
-            return "Hello!".indent(4);
+            return "Hello " + SourceVersion.RELEASE_17 + "!";
         }
     }
     """
@@ -188,12 +190,12 @@ def test_compile_jdk_specified_in_build_file(rule_runner: RuleRunner) -> None:
                 """\
                 java_sources(
                     name = 'lib',
-                    jdk = 'adopt:1.12',
+                    jdk = 'temurin:1.17',
                 )
                 """
             ),
             "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
-            "ExampleLib.java": JAVA_LIB_JDK12_SOURCE,
+            "ExampleLib.java": JAVA_LIB_JDK17_SOURCE,
         }
     )
 
@@ -210,19 +212,19 @@ def test_compile_jdk_specified_in_build_file(rule_runner: RuleRunner) -> None:
 
 
 @maybe_skip_jdk_test
-def test_compile_jdk_12_file_fails_with_jdk_11(rule_runner: RuleRunner) -> None:
+def test_compile_jdk_17_file_fails_with_jdk_11(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
                 """\
                 java_sources(
                     name = 'lib',
-                    jdk = 'adopt:1.11',
+                    jdk = 'temurin:1.11.0.23',
                 )
                 """
             ),
             "3rdparty/jvm/default.lock": EMPTY_JVM_LOCKFILE,
-            "ExampleLib.java": JAVA_LIB_JDK12_SOURCE,
+            "ExampleLib.java": JAVA_LIB_JDK17_SOURCE,
         }
     )
 

--- a/src/python/pants/backend/scala/compile/scalac_test.py
+++ b/src/python/pants/backend/scala/compile/scalac_test.py
@@ -111,12 +111,14 @@ SCALA_LIB_SOURCE = dedent(
     """
 )
 
-SCALA_LIB_JDK12_SOURCE = dedent(
+SCALA_LIB_JDK17_SOURCE = dedent(
     """
     package org.pantsbuild.example.lib
 
+    import javax.lang.model.SourceVersion
+
     class C {
-        val hello = "hello!".indent(4)
+        val hello = "hello " + SourceVersion.RELEASE_17 + "!"
     }
     """
 )
@@ -185,7 +187,7 @@ def test_compile_no_deps(
 
 
 @maybe_skip_jdk_test
-def test_compile_no_deps_jdk_12(
+def test_compile_no_deps_jdk_17(
     rule_runner: RuleRunner, scala_stdlib_jvm_lockfile: JVMLockfileFixture
 ) -> None:
     rule_runner.write_files(
@@ -194,13 +196,13 @@ def test_compile_no_deps_jdk_12(
                 """\
                 scala_sources(
                     name = 'lib',
-                    jdk = 'adopt:1.12',
+                    jdk = 'temurin:1.17',
                 )
                 """
             ),
             "3rdparty/jvm/BUILD": scala_stdlib_jvm_lockfile.requirements_as_jvm_artifact_targets(),
             "3rdparty/jvm/default.lock": scala_stdlib_jvm_lockfile.serialized_lockfile,
-            "ExampleLib.scala": SCALA_LIB_JDK12_SOURCE,
+            "ExampleLib.scala": SCALA_LIB_JDK17_SOURCE,
         }
     )
     coarsened_target = expect_single_expanded_coarsened_target(
@@ -215,7 +217,7 @@ def test_compile_no_deps_jdk_12(
 
 @logging
 @maybe_skip_jdk_test
-def test_compile_jdk_12_file_fails_on_jdk_11(
+def test_compile_jdk_17_file_fails_on_jdk_11(
     rule_runner: RuleRunner, scala_stdlib_jvm_lockfile: JVMLockfileFixture
 ) -> None:
     rule_runner.write_files(
@@ -224,13 +226,13 @@ def test_compile_jdk_12_file_fails_on_jdk_11(
                 """\
                 scala_sources(
                     name = 'lib',
-                    jdk = 'adopt:1.11',
+                    jdk = 'temurin:1.11.0.23',
                 )
                 """
             ),
             "3rdparty/jvm/BUILD": scala_stdlib_jvm_lockfile.requirements_as_jvm_artifact_targets(),
             "3rdparty/jvm/default.lock": scala_stdlib_jvm_lockfile.serialized_lockfile,
-            "ExampleLib.scala": SCALA_LIB_JDK12_SOURCE,
+            "ExampleLib.scala": SCALA_LIB_JDK17_SOURCE,
         }
     )
     coarsened_target = expect_single_expanded_coarsened_target(

--- a/src/python/pants/jvm/jdk_rules_test.py
+++ b/src/python/pants/jvm/jdk_rules_test.py
@@ -96,11 +96,8 @@ def test_java_binary_versions(rule_runner: RuleRunner) -> None:
     # default version is 1.11
     assert 'openjdk version "11.0' in run_javac_version(rule_runner)
 
-    rule_runner.set_options(["--jvm-tool-jdk=adopt:1.8"], env_inherit=PYTHON_BOOTSTRAP_ENV)
-    assert 'openjdk version "1.8' in run_javac_version(rule_runner)
-
-    rule_runner.set_options(["--jvm-tool-jdk=adopt:1.14"], env_inherit=PYTHON_BOOTSTRAP_ENV)
-    assert 'openjdk version "14"' in run_javac_version(rule_runner)
+    rule_runner.set_options(["--jvm-tool-jdk=temurin:1.17"], env_inherit=PYTHON_BOOTSTRAP_ENV)
+    assert 'openjdk version "17"' in run_javac_version(rule_runner)
 
     rule_runner.set_options(["--jvm-tool-jdk=bogusjdk:999"], env_inherit=PYTHON_BOOTSTRAP_ENV)
     expected_exception_msg = r".*?JVM bogusjdk:999 not found in index.*?"
@@ -163,7 +160,7 @@ def test_pass_jvm_options_to_java_program(rule_runner: RuleRunner) -> None:
 
     # Rely on JEP-330 to run a Java file from source so we don´t need a compile step.
     rule_runner.set_options(
-        ["--jvm-tool-jdk=adopt:1.11", f"--jvm-global-options={repr(global_jvm_options)}"],
+        ["--jvm-tool-jdk=temurin:1.11.0.23", f"--jvm-global-options={repr(global_jvm_options)}"],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
 


### PR DESCRIPTION
Previously the tests failed on MacOS ARM64 machines, because 
the custom JDKs it tried to download aren't available in the coursier
index for that platform.

This PR replaces those with JDKs available on all platforms.