### PR TITLE
export generated python sources to exported venvs

### DIFF
--- a/docs/docs/python/integrations/protobuf-and-grpc.mdx
+++ b/docs/docs/python/integrations/protobuf-and-grpc.mdx
@@ -151,6 +151,8 @@ from project.example.f_pb2_grcp import GreeterServicer
 `pants export-codegen ::` will run all relevant code generators and write the files to `dist/codegen` using the same paths used normally by Pants.
 
 You do not need to run this goal for codegen to work when using Pants; `export-codegen` is only for external consumption outside of Pants.
+
+Note: You can also export the generated sources using the [`--export-py-generated-sources` option](reference/goals/export#py_generated_sources) to the [`pants export` goal](reference/goals/export). This is useful when you want to provide an IDE with third-party dependencies and generated sources in a single place.
 :::
 
 :::caution You likely need to add empty `__init__.py` files

--- a/docs/docs/python/integrations/thrift.mdx
+++ b/docs/docs/python/integrations/thrift.mdx
@@ -113,6 +113,8 @@ For example, compare `import user.ttypes` to `import codegen.models.user.ttypes`
 `pants export-codegen ::` will run all relevant code generators and write the files to `dist/codegen` using the same paths used normally by Pants.
 
 You do not need to run this goal for codegen to work when using Pants; `export-codegen` is only for external consumption outside of Pants.
+
+Note: You can also export the generated sources using the [`--export-py-generated-sources` option](reference/goals/export#py_generated_sources) to the [`pants export` goal](reference/goals/export). This is useful when you want to provide an IDE with third-party dependencies and generated sources in a single place.
 :::
 
 ## Multiple resolves

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -100,7 +100,7 @@ Python tools can be [exported from their default bundled lockfiles](https://www.
 New field `pex_build_extra_args` is available on FaaS targets [python_aws_lambda_function](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_function#pex_build_extra_args), 
 [python_aws_lambda_layer](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#pex_build_extra_args), and [python_google_cloud_function]((https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#pex_build_extra_args). This allows passing arguments to the `pex` invocation for collecting sources and packaging.
 
-`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the option `--export-py-include-codegen` is enabled.
+`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the option `--export-py-generated-sources` is enabled.
 
 #### Semgrep
 

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -100,6 +100,8 @@ Python tools can be [exported from their default bundled lockfiles](https://www.
 New field `pex_build_extra_args` is available on FaaS targets [python_aws_lambda_function](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_function#pex_build_extra_args), 
 [python_aws_lambda_layer](https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#pex_build_extra_args), and [python_google_cloud_function]((https://www.pantsbuild.org/2.22/reference/targets/python_aws_lambda_layer#pex_build_extra_args). This allows passing arguments to the `pex` invocation for collecting sources and packaging.
 
+`pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the option `--export-py-include-codegen` is enabled.
+
 #### Semgrep
 
 The default version of `semgrep` used by the `pants.backends.experimental.tool.semgrep` backend is now version 1.72.0, upgraded from 1.46.0. This version requires Python 3.8 or greater.

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -470,25 +470,22 @@ async def add_codegen_to_export_result(
         MergeDigests([export_result.digest, codegen_digest, codegen_setup.setup_script_digest]),
     )
 
+    pkg_dir_path = os.path.join(
+        "{digest_root}",
+        _ExportPythonCodegenSetup.PKG_DIR,
+    )
+    script_path = os.path.join(pkg_dir_path, _ExportPythonCodegenSetup.SCRIPT_NAME)
+
     codegen_post_processing_cmds = (
         PostProcessingCommand(
             [
                 os.path.join("{digest_root}", "bin", "python"),
-                os.path.join(
-                    "{digest_root}",
-                    _ExportPythonCodegenSetup.PKG_DIR,
-                    _ExportPythonCodegenSetup.SCRIPT_NAME,
-                ),
-                os.path.join("{digest_root}", _ExportPythonCodegenSetup.PKG_DIR),
+                script_path,
+                pkg_dir_path,
             ]
         ),
-        PostProcessingCommand(
-            [
-                "rm",
-                "-rf",
-                os.path.join("{digest_root}", _ExportPythonCodegenSetup.PKG_DIR),
-            ]
-        ),
+        PostProcessingCommand(["rm", script_path]),
+        PostProcessingCommand(["rmdir", pkg_dir_path]),
     )
 
     return dataclasses.replace(

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -51,7 +51,6 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, HydratedSources, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.option_types import BoolOption, EnumOption, StrListOption
-from pants.util.docutil import doc_url
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
@@ -566,17 +565,13 @@ async def export_virtualenv_for_resolve(
     )
 
     # Add generated Python sources from codegen targets to the virtualenv.
-    if export_subsys.options.py_generated_sources:
-        if export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv:
-            export_result = await add_codegen_to_export_result(
-                request.resolve, export_result, codegen_setup
-            )
-        else:
-            logger.info(
-                "Ignoring `--export-py-generated-sources` option because the export is not to a mutable virtualenv. "
-                f"See {doc_url('reference/goals/export#py_generated_sources')} and {doc_url('reference/goals/export#py_resolve_format')} "
-                "for additional details."
-            )
+    if (
+        export_subsys.options.py_generated_sources
+        and export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv
+    ):
+        export_result = await add_codegen_to_export_result(
+            request.resolve, export_result, codegen_setup
+        )
 
     return MaybeExportResult(export_result)
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -568,13 +568,15 @@ async def export_virtualenv_for_resolve(
     )
 
     # Add generated Python sources from codegen targets to the virtualenv.
-    if (
-        export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv
-        and export_subsys.options.py_generated_sources
-    ):
-        export_result = await add_codegen_to_export_result(
-            request.resolve, export_result, codegen_setup
-        )
+    if export_subsys.options.py_generated_sources:
+        if export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv:
+            export_result = await add_codegen_to_export_result(
+                request.resolve, export_result, codegen_setup
+            )
+        else:
+            logger.warning(
+                "Ignoring `--export-py-generated-sources` option because export is not to a mutable virtualenv."
+            )
 
     return MaybeExportResult(export_result)
 

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -414,13 +414,6 @@ async def python_codegen_export_setup() -> _ExportPythonCodegenSetup:
 async def export_python_codegen(
     request: _ExportPythonCodegenRequest, python_setup: PythonSetup, all_targets: AllTargets
 ) -> _ExportPythonCodegenResult:
-    print(f"all_targets={all_targets}")
-    print(
-        f"has_field(PythonResolveField)={[tgt.has_field(PythonResolveField) for tgt in all_targets]}"
-    )
-    print(
-        f"resolve={[tgt[PythonResolveField].normalized_value(python_setup) for tgt in all_targets]}"
-    )
     non_python_sources_in_python_resolve = [
         tgt.get(SourcesField)
         for tgt in all_targets
@@ -429,7 +422,6 @@ async def export_python_codegen(
         and tgt.has_field(SourcesField)
         and not tgt.has_field(PythonSourceField)
     ]
-    print(f"non_python_sources_in_python_resolve={non_python_sources_in_python_resolve}")
 
     if not non_python_sources_in_python_resolve:
         return _ExportPythonCodegenResult(EMPTY_DIGEST)

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -136,12 +136,12 @@ class ExportPluginOptions:
         advanced=True,
     )
 
-    py_include_codegen = BoolOption(
+    py_generated_sources = BoolOption(
         default=False,
         help=softwrap(
             """
             When exporting a mutable virtualenv for a resolve, generate any sources
-            which results from code generation (e.g., `protobuf_sources` and `thrift_sources` targets)
+            which result from code generation (for example, the `protobuf_sources` and `thrift_sources` targets)
             and place the generated files under the site-packages directory of the virtualenv.
             """
         ),
@@ -570,7 +570,7 @@ async def export_virtualenv_for_resolve(
     # Add generated Python sources from codegen targets to the virtualenv.
     if (
         export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv
-        and export_subsys.options.py_include_codegen
+        and export_subsys.options.py_generated_sources
     ):
         export_result = await add_codegen_to_export_result(
             request.resolve, export_result, codegen_setup

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -51,6 +51,7 @@ from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, HydratedSources, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.option_types import BoolOption, EnumOption, StrListOption
+from pants.util.docutil import doc_url
 from pants.util.strutil import path_safe, softwrap
 
 logger = logging.getLogger(__name__)
@@ -571,8 +572,10 @@ async def export_virtualenv_for_resolve(
                 request.resolve, export_result, codegen_setup
             )
         else:
-            logger.warning(
-                "Ignoring `--export-py-generated-sources` option because export is not to a mutable virtualenv."
+            logger.info(
+                "Ignoring `--export-py-generated-sources` option because the export is not to a mutable virtualenv. "
+                f"See {doc_url('reference/goals/export#py_generated_sources')} and {doc_url('reference/goals/export#py_resolve_format')} "
+                "for additional details."
             )
 
     return MaybeExportResult(export_result)

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
+import textwrap
 import uuid
 from dataclasses import dataclass
 from enum import Enum
@@ -13,7 +14,7 @@ from typing import Any, cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
-from pants.backend.python.target_types import PexLayout
+from pants.backend.python.target_types import PexLayout, PythonResolveField, PythonSourceField
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.backend.python.util_rules.local_dists_pep660 import (
     EditableLocalDists,
@@ -33,11 +34,21 @@ from pants.core.goals.export import (
     PostProcessingCommand,
 )
 from pants.core.goals.resolves import ExportableTool
+from pants.core.util_rules.source_files import SourceFiles
+from pants.core.util_rules.stripped_source_files import StrippedSourceFiles
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.native_engine import AddPrefix, Digest, MergeDigests, Snapshot
+from pants.engine.fs import CreateDigest, FileContent
+from pants.engine.internals.native_engine import (
+    EMPTY_DIGEST,
+    AddPrefix,
+    Digest,
+    MergeDigests,
+    Snapshot,
+)
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.process import ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
+from pants.engine.target import AllTargets, HydratedSources, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
 from pants.option.option_types import BoolOption, EnumOption, StrListOption
 from pants.util.strutil import path_safe, softwrap
@@ -123,6 +134,17 @@ class ExportPluginOptions:
             """
         ),
         advanced=True,
+    )
+
+    py_include_codegen = BoolOption(
+        default=False,
+        help=softwrap(
+            """
+            When exporting a mutable virtualenv for a resolve, generate any sources
+            which results from code generation (e.g., `protobuf_sources` and `thrift_sources` targets)
+            and place the generated files under the site-packages directory of the virtualenv.
+            """
+        ),
     )
 
 
@@ -334,12 +356,163 @@ class MaybeExportResult:
     result: ExportResult | None
 
 
+@dataclass(frozen=True)
+class _ExportPythonCodegenRequest:
+    resolve: str
+
+
+@dataclass(frozen=True)
+class _ExportPythonCodegenResult:
+    digest: Digest
+
+
+@dataclass(frozen=True)
+class _ExportPythonCodegenSetup:
+    PKG_DIR = "__pants_codegen__"
+    SCRIPT_NAME = "codegen_setup.py"
+
+    setup_script_digest: Digest
+
+
+@rule
+async def python_codegen_export_setup() -> _ExportPythonCodegenSetup:
+    codegen_setup_script_digest = await Get(
+        Digest,
+        CreateDigest(
+            [
+                FileContent(
+                    path=f"{_ExportPythonCodegenSetup.PKG_DIR}/{_ExportPythonCodegenSetup.SCRIPT_NAME}",
+                    is_executable=True,
+                    content=textwrap.dedent(
+                        f"""\
+                        import os
+                        import site
+                        import sys
+
+                        site_packages_dirs = site.getsitepackages()
+                        if not site_packages_dirs:
+                            raise Exception("Unable to determine location of site-packages directory in venv.")
+                        site_packages_dir = site_packages_dirs[0]
+
+                        codegen_dir = sys.argv[1]
+
+                        for item in os.listdir(codegen_dir):
+                            if item == "{_ExportPythonCodegenSetup.SCRIPT_NAME}":
+                                continue
+                            os.rename(os.path.join(codegen_dir, item), os.path.join(site_packages_dir, item))
+                        """
+                    ).encode(),
+                )
+            ]
+        ),
+    )
+
+    return _ExportPythonCodegenSetup(codegen_setup_script_digest)
+
+
+@rule
+async def export_python_codegen(
+    request: _ExportPythonCodegenRequest, python_setup: PythonSetup, all_targets: AllTargets
+) -> _ExportPythonCodegenResult:
+    print(f"all_targets={all_targets}")
+    print(
+        f"has_field(PythonResolveField)={[tgt.has_field(PythonResolveField) for tgt in all_targets]}"
+    )
+    print(
+        f"resolve={[tgt[PythonResolveField].normalized_value(python_setup) for tgt in all_targets]}"
+    )
+    non_python_sources_in_python_resolve = [
+        tgt.get(SourcesField)
+        for tgt in all_targets
+        if tgt.has_field(PythonResolveField)
+        and tgt[PythonResolveField].normalized_value(python_setup) == request.resolve
+        and tgt.has_field(SourcesField)
+        and not tgt.has_field(PythonSourceField)
+    ]
+    print(f"non_python_sources_in_python_resolve={non_python_sources_in_python_resolve}")
+
+    if not non_python_sources_in_python_resolve:
+        return _ExportPythonCodegenResult(EMPTY_DIGEST)
+
+    hydrated_non_python_sources = await MultiGet(
+        Get(
+            HydratedSources,
+            HydrateSourcesRequest(
+                sources,
+                for_sources_types=(PythonSourceField,),
+                enable_codegen=True,
+            ),
+        )
+        for sources in non_python_sources_in_python_resolve
+    )
+
+    merged_snapshot = await Get(
+        Snapshot,
+        MergeDigests(
+            hydrated_sources.snapshot.digest for hydrated_sources in hydrated_non_python_sources
+        ),
+    )
+
+    stripped_source_files = await Get(StrippedSourceFiles, SourceFiles(merged_snapshot, ()))
+
+    return _ExportPythonCodegenResult(stripped_source_files.snapshot.digest)
+
+
+# Generate codegen Python sources and add them to the virtualenv to be exported.
+async def add_codegen_to_export_result(
+    resolve: str, export_result: ExportResult, codegen_setup: _ExportPythonCodegenSetup
+) -> ExportResult:
+    # Generate Python sources from codegen targets in this resolve.
+    codegen_result = await Get(
+        _ExportPythonCodegenResult, _ExportPythonCodegenRequest(resolve=resolve)
+    )
+    if codegen_result.digest == EMPTY_DIGEST:
+        return export_result
+
+    codegen_digest = await Get(
+        Digest, AddPrefix(codegen_result.digest, _ExportPythonCodegenSetup.PKG_DIR)
+    )
+
+    export_digest_with_codegen = await Get(
+        Digest,
+        MergeDigests([export_result.digest, codegen_digest, codegen_setup.setup_script_digest]),
+    )
+
+    codegen_post_processing_cmds = (
+        PostProcessingCommand(
+            [
+                os.path.join("{digest_root}", "bin", "python"),
+                os.path.join(
+                    "{digest_root}",
+                    _ExportPythonCodegenSetup.PKG_DIR,
+                    _ExportPythonCodegenSetup.SCRIPT_NAME,
+                ),
+                os.path.join("{digest_root}", _ExportPythonCodegenSetup.PKG_DIR),
+            ]
+        ),
+        PostProcessingCommand(
+            [
+                "rm",
+                "-rf",
+                os.path.join("{digest_root}", _ExportPythonCodegenSetup.PKG_DIR),
+            ]
+        ),
+    )
+
+    return dataclasses.replace(
+        export_result,
+        digest=export_digest_with_codegen,
+        post_processing_cmds=export_result.post_processing_cmds + codegen_post_processing_cmds,
+    )
+
+
 @rule
 async def export_virtualenv_for_resolve(
     request: _ExportVenvForResolveRequest,
     python_setup: PythonSetup,
     export_subsys: ExportSubsystem,
     union_membership: UnionMembership,
+    codegen_setup: _ExportPythonCodegenSetup,
 ) -> MaybeExportResult:
     resolve = request.resolve
     lockfile_path = python_setup.resolves.get(resolve)
@@ -401,6 +574,16 @@ async def export_virtualenv_for_resolve(
             editable_local_dists_digest=editable_local_dists_digest,
         ),
     )
+
+    # Add generated Python sources from codegen targets to the virtualenv.
+    if (
+        export_subsys.options.py_resolve_format == PythonResolveExportFormat.mutable_virtualenv
+        and export_subsys.options.py_include_codegen
+    ):
+        export_result = await add_codegen_to_export_result(
+            request.resolve, export_result, codegen_setup
+        )
+
     return MaybeExportResult(export_result)
 
 

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -241,7 +241,7 @@ def test_export_codegen_outputs():
             "--python-resolves={'test-resolve': 'test-resolve.lock'}",
             "--source-root-patterns=src/python",
             "--export-resolve=test-resolve",
-            "--export-py-include-codegen",
+            "--export-py-generated-sources",
         ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )

--- a/src/python/pants/backend/python/goals/export_test.py
+++ b/src/python/pants/backend/python/goals/export_test.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+import dataclasses
 import os
 import re
 import sys
@@ -15,16 +16,28 @@ from pants.backend.python.macros.python_artifact import PythonArtifact
 from pants.backend.python.target_types import (
     PythonDistribution,
     PythonRequirementTarget,
+    PythonResolveField,
+    PythonSourceField,
     PythonSourcesGeneratorTarget,
 )
 from pants.backend.python.util_rules import local_dists_pep660, pex_from_targets
 from pants.base.specs import RawSpecs
 from pants.core.goals.export import ExportResults
 from pants.core.util_rules import distdir
+from pants.engine.fs import CreateDigest, DigestContents
+from pants.engine.internals.native_engine import Digest, Snapshot
 from pants.engine.internals.parametrize import Parametrize
-from pants.engine.rules import QueryRule
-from pants.engine.target import Targets
-from pants.testutil.rule_runner import RuleRunner
+from pants.engine.internals.selectors import Get
+from pants.engine.rules import QueryRule, rule
+from pants.engine.target import (
+    GeneratedSources,
+    GenerateSourcesRequest,
+    SingleSourceField,
+    Target,
+    Targets,
+)
+from pants.engine.unions import UnionRule
+from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, RuleRunner
 from pants.util.frozendict import FrozenDict
 
 pants_args_for_python_lockfiles = [
@@ -173,3 +186,82 @@ def test_export_tool(rule_runner: RuleRunner) -> None:
     result = results[0]
     assert result.resolve == isort_subsystem.Isort.options_scope
     assert "isort" in result.description
+
+
+def test_export_codegen_outputs():
+    class CodegenSourcesField(SingleSourceField):
+        pass
+
+    class CodegenTarget(Target):
+        alias = "codegen_target"
+        core_fields = (CodegenSourcesField, PythonResolveField)
+        help = "n/a"
+
+    class CodegenGenerateSourcesRequest(GenerateSourcesRequest):
+        input = CodegenSourcesField
+        output = PythonSourceField
+
+    @rule
+    async def do_codegen(request: CodegenGenerateSourcesRequest) -> GeneratedSources:
+        # Generate a Python file with the same contents as each input file.
+        input_files = await Get(DigestContents, Digest, request.protocol_sources.digest)
+        generated_files = [
+            dataclasses.replace(input_file, path=input_file.path + ".py")
+            for input_file in input_files
+        ]
+        result = await Get(Snapshot, CreateDigest(generated_files))
+        return GeneratedSources(result)
+
+    rule_runner = RuleRunner(
+        rules=[
+            *export.rules(),
+            *pex_from_targets.rules(),
+            *target_types_rules.rules(),
+            *distdir.rules(),
+            *local_dists_pep660.rules(),
+            do_codegen,
+            QueryRule(Targets, [RawSpecs]),
+            QueryRule(ExportResults, [ExportVenvsRequest]),
+            UnionRule(GenerateSourcesRequest, CodegenGenerateSourcesRequest),
+        ],
+        target_types=[
+            PythonRequirementTarget,
+            PythonSourcesGeneratorTarget,
+            PythonDistribution,
+            CodegenTarget,
+        ],
+    )
+
+    vinfo = sys.version_info
+    current_interpreter = f"{vinfo.major}.{vinfo.minor}.{vinfo.micro}"
+    rule_runner.set_options(
+        [
+            *pants_args_for_python_lockfiles,
+            f"--python-interpreter-constraints=['=={current_interpreter}']",
+            "--python-resolves={'test-resolve': 'test-resolve.lock'}",
+            "--source-root-patterns=src/python",
+            "--export-resolve=test-resolve",
+            "--export-py-include-codegen",
+        ],
+        env_inherit=PYTHON_BOOTSTRAP_ENV,
+    )
+
+    rule_runner.write_files(
+        {
+            "test-resolve.lock": "",
+            "src/python/foo/BUILD": dedent(
+                """\
+            codegen_target(name="codegen", source="an-input", resolve="test-resolve")
+            """
+            ),
+            "src/python/foo/an-input": "print('Hello World!')\n",
+        }
+    )
+
+    export_results = rule_runner.request(ExportResults, [ExportVenvsRequest(targets=())])
+    assert len(export_results) == 1
+    export_result = export_results[0]
+
+    export_snapshot = rule_runner.request(Snapshot, [export_result.digest])
+    assert any(p.endswith("__pants_codegen__/codegen_setup.py") for p in export_snapshot.files)
+    assert any(p.endswith("__pants_codegen__/foo/an-input.py") for p in export_snapshot.files)

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -635,8 +635,9 @@ async def find_all_targets() -> AllTargets:
     tgts = await Get(
         Targets,
         RawSpecsWithoutFileOwners(
-            recursive_globs=(RecursiveGlobSpec(""),), description_of_origin="the `AllTargets` rule",
-            unmatched_glob_behavior=GlobMatchErrorBehavior.warn,
+            recursive_globs=(RecursiveGlobSpec(""),),
+            description_of_origin="the `AllTargets` rule",
+            unmatched_glob_behavior=GlobMatchErrorBehavior.error,
         ),
     )
     return AllTargets(tgts)

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -635,7 +635,8 @@ async def find_all_targets() -> AllTargets:
     tgts = await Get(
         Targets,
         RawSpecsWithoutFileOwners(
-            recursive_globs=(RecursiveGlobSpec(""),), description_of_origin="the `AllTargets` rule"
+            recursive_globs=(RecursiveGlobSpec(""),), description_of_origin="the `AllTargets` rule",
+            unmatched_glob_behavior=GlobMatchErrorBehavior.warn,
         ),
     )
     return AllTargets(tgts)

--- a/src/python/pants/engine/internals/graph.py
+++ b/src/python/pants/engine/internals/graph.py
@@ -637,7 +637,6 @@ async def find_all_targets() -> AllTargets:
         RawSpecsWithoutFileOwners(
             recursive_globs=(RecursiveGlobSpec(""),),
             description_of_origin="the `AllTargets` rule",
-            unmatched_glob_behavior=GlobMatchErrorBehavior.error,
         ),
     )
     return AllTargets(tgts)


### PR DESCRIPTION
Issue: A user has developers who use VSCode and would like those developers to have easy access to the generated Python sources for `protobuf_sources` targets in VSCode. The user reported that their developers found having to run `pants export` and also `pants export-codegen` confusing and unwiedly.  The user would prefer a simpler DX involving just using `pants export`.

When exporting a mutable venv for a resolve, write generated Python codegen products to the venv as well when `--export-py-generated-sources` is enabled.

The codegen products are staged to a `__pants_codegen__` directory in the exported digest, and then a helper Python script moves the codegen products into the site-packages directory. A helper script was used since it  has access to the location of the site-packages directory programmatically via the `site` module.