### PR TITLE
Use code blocks in nodejs-test example docs

### DIFF
--- a/src/python/pants/backend/javascript/subsystems/nodejstest.py
+++ b/src/python/pants/backend/javascript/subsystems/nodejstest.py
@@ -19,6 +19,7 @@ from pants.util.strutil import help_text, softwrap
 _EXAMPLE = """\
 Consider a directory-layout:
 
+```
 ├── BUILD
 ├── src/
 │   ├── BUILD
@@ -27,10 +28,11 @@ Consider a directory-layout:
 │   │   └── index.test.js
 │   └── index.js
 └── package.json
+```
 
 where package.json contains
 
-# package.json
+```json title=\"package.json\"
 {
     ...
     "scripts": {
@@ -40,6 +42,7 @@ where package.json contains
         ...
     }
 }
+```
 """
 
 


### PR DESCRIPTION
The `nodejs-test` subsystem docs currently don't render great because some code-like content isn't wrapped in a code block: https://www.pantsbuild.org/2.22/reference/subsystems/nodejs-test

Before:

<img width="822" alt="image" src="https://github.com/pantsbuild/pants/assets/1203825/d8279aa9-b555-49da-8228-69a3825a698d">

After:

<img width="682" alt="image" src="https://github.com/pantsbuild/pants/assets/1203825/da56d967-328a-4570-ac5e-963dfe28fd9a">
