### PR TITLE
Fix help text for `stevedore_namespace` BUILD file symbol.

### DIFF
--- a/src/python/pants/backend/python/framework/stevedore/target_types.py
+++ b/src/python/pants/backend/python/framework/stevedore/target_types.py
@@ -17,14 +17,16 @@ class StevedoreNamespace(str):
     based on the `stevedore_namespaces` field.
 
     For example:
-        python_distribution(
-            ...
-            entry_points={{
-                stevedore_namespace("a.b.c"): {{
-                    "plugin_name": "some.entry:point",
-                }},
-            }},
-        )
+    ```python
+    python_distribution(
+        ...
+        entry_points={
+            stevedore_namespace("a.b.c"): {
+                "plugin_name": "some.entry:point",
+            },
+        },
+    )
+    ```
     """
 
     alias = "stevedore_namespace"

--- a/src/python/pants/backend/python/framework/stevedore/target_types.py
+++ b/src/python/pants/backend/python/framework/stevedore/target_types.py
@@ -11,13 +11,13 @@ from pants.util.strutil import help_text
 
 
 class StevedoreNamespace(str):
-    f"""Tag a namespace in entry_points as a stevedore namespace.
+    """Tag a namespace in entry_points as a stevedore namespace.
 
     This is required for the entry_point to be visible to dep inference
     based on the `stevedore_namespaces` field.
 
     For example:
-        {PythonDistribution.alias}(
+        python_distribution(
             ...
             entry_points={{
                 stevedore_namespace("a.b.c"): {{


### PR DESCRIPTION
Closes #20977

```
❯ pants --backend-packages=pants.backend.experimental.python.framework.stevedore stevedore_namespace --help
`stevedore_namespace` BUILD file symbol
---------------------------------------

Tag a namespace in entry_points as a stevedore namespace.

This is required for the entry_point to be visible to dep inference
based on the `stevedore_namespaces` field.

For example:
    python_distribution(
        ...
        entry_points={{
            stevedore_namespace("a.b.c"): {{
                "plugin_name": "some.entry:point",
            }},
        }},
    )
```