### PR TITLE
Subset lockfile as a separately cacheable process before building any PEX

### DIFF
--- a/src/python/pants/backend/python/subsystems/setup.py
+++ b/src/python/pants/backend/python/subsystems/setup.py
@@ -568,6 +568,29 @@ class PythonSetup(Subsystem):
         default=True,
         help="Whether to use the standard Python command history file when running a repl.",
     )
+    subset_lockfiles_before_builds = BoolOption(
+        default=True,  # FIXME: change default; deprecate setting?
+        help=softwrap(
+            """Compute a subset of a PEX lockfile before building with it.
+
+            This reduces spurious rebuilds of targets that aren't affected by a lockfile change. For
+            instance, a lockfile may include a dev-dependency like `pytest`, and a production
+            `pex_binary` target is likely to use that library.
+
+            - When this option is false, the whole lockfile contents is fed to the build of the target,
+              so any change to any library within the lockfile requires rerunning the whole build,
+              even when they aren't relevent.
+
+            - When this option is true, the relevant subset of the lockfile is extracted as a separate
+              step and only the result of that is fed into the build of the target. If irrelevant
+              dependencies change, the subsetting step will run, but the output will be identical, and
+              thus the build of the target can be served from cache. The subsetting is typically much
+              faster than a full pex build, so spending a bit of time to compute the subset usually
+              results in faster overall builds, by serving more from cache.
+
+            """
+        ),
+    )
 
     @property
     def enable_synthetic_lockfiles(self) -> bool:

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -704,6 +704,7 @@ def test_setup_pex_requirements() -> None:
         *,
         is_pex_lock: bool = True,
         include_find_links: bool = False,
+        subset_lockfiles_before_builds: bool = False,
     ) -> None:
         request = PexRequest(
             output_filename="foo.pex",
@@ -712,7 +713,12 @@ def test_setup_pex_requirements() -> None:
         )
         result = run_rule_with_mocks(
             _setup_pex_requirements,
-            rule_args=[request, create_subsystem(PythonSetup)],
+            rule_args=[
+                request,
+                create_subsystem(
+                    PythonSetup, subset_lockfiles_before_builds=subset_lockfiles_before_builds
+                ),
+            ],
             mock_gets=[
                 MockGet(
                     output_type=Lockfile,

--- a/src/python/pants/backend/python/util_rules/pex_test.py
+++ b/src/python/pants/backend/python/util_rules/pex_test.py
@@ -799,12 +799,22 @@ def test_setup_pex_requirements() -> None:
         is_pex_lock=False,
     )
 
-    # Subset of Pex lockfile.
+    # Subset of Pex lockfile - without explicitly subsetting
     assert_setup(
         PexRequirements(["req1"], from_superset=Resolve("resolve", False)),
         _BuildPexRequirementsSetup(
             [lockfile_digest], ["req1", "--lock", lockfile_path, *pex_args], 1
         ),
+        subset_lockfiles_before_builds=False,
+    )
+
+    # Subset of Pex lockfile - without explicitly subsetting
+    assert_setup(
+        PexRequirements(["req1"], from_superset=Resolve("resolve", False)),
+        _BuildPexRequirementsSetup(
+            [lockfile_digest], ["req1", "--lock", lockfile_path, *pex_args], 1
+        ),
+        subset_lockfiles_before_builds=True,
     )
 
     # Subset of repository Pex.


### PR DESCRIPTION
Currently just experimenting.

Intention is to make the input digests to PEX builds more precise.

Fixes #15694 