### PR TITLE
Upgrade default `pyright` version from 1.1.316 to 1.1.365

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -18,6 +18,9 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Backends
 
+#### Python
+
+[The `pants.backend.experimental.python.typecheck.pyright` backend](https://www.pantsbuild.org/2.23/reference/subsystems/pyright) now uses version 1.1.365 by default.
 
 ### Plugin API changes
 

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -92,16 +92,17 @@ UNDEFINED_VARIABLE_TOML_CONFIG = dedent(
     """
 )
 
+PYRIGHT_VERSION = "1.1.365"
 PYRIGHT_LOCKFILE = json.dumps(
     {
         "name": "@the-company/project",
         "lockfileVersion": 2,
         "requires": True,
         "packages": {
-            "": {"name": "@the-company/project", "devDependencies": {"pyright": "1.1.316"}},
+            "": {"name": "@the-company/project", "devDependencies": {"pyright": PYRIGHT_VERSION}},
             "node_modules/pyright": {
-                "version": "1.1.316",
-                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.316.tgz",
+                "version": PYRIGHT_VERSION,
+                "resolved": f"https://registry.npmjs.org/pyright/-/pyright-{PYRIGHT_VERSION}.tgz",
                 "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
                 "dev": True,
                 "bin": {"pyright": "index.js", "pyright-langserver": "langserver.index.js"},
@@ -110,8 +111,8 @@ PYRIGHT_LOCKFILE = json.dumps(
         },
         "dependencies": {
             "pyright": {
-                "version": "1.1.316",
-                "resolved": "https://registry.npmjs.org/pyright/-/pyright-1.1.316.tgz",
+                "version": PYRIGHT_VERSION,
+                "resolved": f"https://registry.npmjs.org/pyright/-/pyright-{PYRIGHT_VERSION}.tgz",
                 "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
                 "dev": True,
             }
@@ -221,7 +222,7 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "src/js/lib3/BUILD": "package_json()",
                 "src/js/lib3/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION}}
                 ),
                 "src/js/lib3/package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -239,7 +240,7 @@ LIB_2_PACKAGE = f"{PACKAGE}/lib2"
                 f"{LIB_2_PACKAGE}/core/BUILD": "python_sources()",
                 "BUILD": "package_json(name='root_package')",
                 "package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION}}
                 ),
                 "package-lock.json": PYRIGHT_LOCKFILE,
             },
@@ -361,7 +362,7 @@ def test_passing_cache_clear(rule_runner: PythonRuleRunner) -> None:
                 f"{PACKAGE}/BUILD": "python_sources()",
                 "src/js/BUILD": "package_json()",
                 "src/js/package.json": json.dumps(
-                    {"name": "@the-company/project", "dependencies": {"pyright": "1.1.316"}}
+                    {"name": "@the-company/project", "dependencies": {"pyright": PYRIGHT_VERSION}}
                 ),
                 "src/js/package-lock.json": PYRIGHT_LOCKFILE,
             },

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -93,6 +93,7 @@ UNDEFINED_VARIABLE_TOML_CONFIG = dedent(
 )
 
 PYRIGHT_VERSION = "1.1.365"
+PYRIGHT_INTEGRITY_HASH = "sha512-A5RHXB782m2wCeazfrPGSvFUd1WAjpHrD83M/Umc/tcAhyC5pzhrh23US1yv9DH/GMilQeWdJ4W8pGxmgej4DQ=="
 PYRIGHT_LOCKFILE = json.dumps(
     {
         "name": "@the-company/project",
@@ -100,21 +101,46 @@ PYRIGHT_LOCKFILE = json.dumps(
         "requires": True,
         "packages": {
             "": {"name": "@the-company/project", "devDependencies": {"pyright": PYRIGHT_VERSION}},
+            "node_modules/fsevents": {
+                "version": "2.3.3",
+                "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                "dev": True,
+                "hasInstallScript": True,
+                "optional": True,
+                "os": [
+                    "darwin"
+                ],
+                "engines": {
+                    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+                }
+            },
             "node_modules/pyright": {
                 "version": PYRIGHT_VERSION,
                 "resolved": f"https://registry.npmjs.org/pyright/-/pyright-{PYRIGHT_VERSION}.tgz",
-                "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
+                "integrity": PYRIGHT_INTEGRITY_HASH,
                 "dev": True,
                 "bin": {"pyright": "index.js", "pyright-langserver": "langserver.index.js"},
-                "engines": {"node": ">=12.0.0"},
+                "engines": {"node": ">=14.0.0"},
+                "optionalDependencies": {"fsevents": "~2.3.3"},
             },
         },
         "dependencies": {
+            "fsevents": {
+                "version": "2.3.3",
+                "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                "dev": True,
+                "optional": True
+            },
             "pyright": {
                 "version": PYRIGHT_VERSION,
                 "resolved": f"https://registry.npmjs.org/pyright/-/pyright-{PYRIGHT_VERSION}.tgz",
-                "integrity": "sha512-Pdb9AwOO07uNOuEVtwCThyDpB0wigWmLjeCw5vdPG7gVbVYYgY2iw64kBdwTu78NrO0igVKzmoRuApMoL6ZE0w==",
+                "integrity": PYRIGHT_INTEGRITY_HASH,
                 "dev": True,
+                "requires": {
+                    "fsevents": "~2.3.3"
+                }
             }
         },
     }

--- a/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
+++ b/src/python/pants/backend/python/typecheck/pyright/rules_integration_test.py
@@ -108,12 +108,7 @@ PYRIGHT_LOCKFILE = json.dumps(
                 "dev": True,
                 "hasInstallScript": True,
                 "optional": True,
-                "os": [
-                    "darwin"
-                ],
-                "engines": {
-                    "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-                }
+                "engines": {"node": "^8.16.0 || ^10.6.0 || >=11.0.0"},
             },
             "node_modules/pyright": {
                 "version": PYRIGHT_VERSION,
@@ -131,17 +126,15 @@ PYRIGHT_LOCKFILE = json.dumps(
                 "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
                 "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
                 "dev": True,
-                "optional": True
+                "optional": True,
             },
             "pyright": {
                 "version": PYRIGHT_VERSION,
                 "resolved": f"https://registry.npmjs.org/pyright/-/pyright-{PYRIGHT_VERSION}.tgz",
                 "integrity": PYRIGHT_INTEGRITY_HASH,
                 "dev": True,
-                "requires": {
-                    "fsevents": "~2.3.3"
-                }
-            }
+                "requires": {"fsevents": "~2.3.3"},
+            },
         },
     }
 )

--- a/src/python/pants/backend/python/typecheck/pyright/subsystem.py
+++ b/src/python/pants/backend/python/typecheck/pyright/subsystem.py
@@ -20,7 +20,7 @@ class Pyright(NodeJSToolBase):
         """
     )
 
-    default_version = "pyright@1.1.316"
+    default_version = "pyright@1.1.365"
 
     skip = SkipOption("check")
     args = ArgsListOption(example="--version")


### PR DESCRIPTION
Pyright is rather out-of-date at the current version, so this PR updates the default to the latest release as of 1 week ago.

In addition to the simple change made in `subsystem.py` I've also included some changes to the tests. The example lockfile was updated based on the results of running `npm i --save-dev pyright@1.1.365` in an empty directory using Node 16 and `npm` 8.19.4.

I debated whether to make this PR before or after upgrading the Node version, but upgrading Node will require me to regenerate a bunch of the lockfiles anyways. Thus, I figured I would upgrade Pyright first before upgrading the Node version.