### PR TITLE
Use GitHub-hosted macos-12 in CI, not deprecated macos-11 (Cherry-pick of #21003)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -202,16 +202,16 @@ jobs:
 
         ./cargo doc'
     timeout-minutes: 60
-  bootstrap_pants_macos11_x86_64:
+  bootstrap_pants_macos12_x86_64:
     env:
       PANTS_REMOTE_CACHE_READ: 'false'
       PANTS_REMOTE_CACHE_WRITE: 'false'
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
-    name: Bootstrap Pants, test Rust (macOS11-x86_64)
+    name: Bootstrap Pants, test Rust (macOS12-x86_64)
     needs:
     - classify_changes
     runs-on:
-    - macos-11
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -231,7 +231,7 @@ jobs:
     - name: Cache Rust toolchain
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
+        key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
         path: '~/.rustup/toolchains/1.75.0-*
 
           ~/.rustup/update-hashes
@@ -252,7 +252,7 @@ jobs:
     - name: Cache native engine
       uses: actions/cache@v3
       with:
-        key: macOS11-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
+        key: macOS12-x86_64-engine-${{ steps.get-engine-hash.outputs.hash }}-v1
         path: 'src/python/pants/bin/native_client
 
           src/python/pants/engine/internals/native_engine.so
@@ -277,12 +277,12 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-bootstrap-macOS11-x86_64
+        name: logs-bootstrap-macOS12-x86_64
         path: .pants.d/workdir/*.log
     - name: Upload native binaries
       uses: actions/upload-artifact@v3
       with:
-        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS12-x86_64
         path: 'src/python/pants/bin/native_client
 
           src/python/pants/engine/internals/native_engine.so
@@ -660,7 +660,7 @@ jobs:
     - check_labels
     - bootstrap_pants_linux_arm64
     - bootstrap_pants_linux_x86_64
-    - bootstrap_pants_macos11_x86_64
+    - bootstrap_pants_macos12_x86_64
     - build_wheels_linux_arm64
     - build_wheels_linux_x86_64
     - build_wheels_macos10_15_x86_64
@@ -679,7 +679,7 @@ jobs:
     - test_python_linux_x86_64_7
     - test_python_linux_x86_64_8
     - test_python_linux_x86_64_9
-    - test_python_macos11_x86_64
+    - test_python_macos12_x86_64
     outputs:
       merge_ok: ${{ steps.set_merge_ok.outputs.merge_ok }}
     runs-on:
@@ -1651,16 +1651,16 @@ jobs:
         name: logs-python-test-9_10-Linux-x86_64
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
-  test_python_macos11_x86_64:
+  test_python_macos12_x86_64:
     env:
       ARCHFLAGS: -arch x86_64
     if: (github.repository_owner == 'pantsbuild') && (needs.classify_changes.outputs.docs_only != 'true')
-    name: Test Python (macOS11-x86_64)
+    name: Test Python (macOS12-x86_64)
     needs:
-    - bootstrap_pants_macos11_x86_64
+    - bootstrap_pants_macos12_x86_64
     - classify_changes
     runs-on:
-    - macos-11
+    - macos-12
     steps:
     - name: Check out code
       uses: actions/checkout@v3
@@ -1680,7 +1680,7 @@ jobs:
     - name: Download native binaries
       uses: actions/download-artifact@v3
       with:
-        name: native_binaries.${{ matrix.python-version }}.macOS11-x86_64
+        name: native_binaries.${{ matrix.python-version }}.macOS12-x86_64
         path: src/python/pants
     - name: Make native-client runnable
       run: chmod +x src/python/pants/bin/native_client
@@ -1694,7 +1694,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       if: always()
       name: Upload test reports
-      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS11-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
+      run: 'export S3_DST=s3://logs.pantsbuild.org/test/reports/macOS12-x86_64/$(git show --no-patch --format=%cd --date=format:%Y-%m-%d)/${GITHUB_REF_NAME//\//_}/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${GITHUB_JOB}
 
         echo "Uploading test reports to ${S3_DST}"
 
@@ -1706,7 +1706,7 @@ jobs:
       name: Upload pants.log
       uses: actions/upload-artifact@v3
       with:
-        name: logs-python-test-macOS11-x86_64
+        name: logs-python-test-macOS12-x86_64
         path: .pants.d/workdir/*.log
     timeout-minutes: 90
 name: Pull Request CI

--- a/src/python/pants_release/generate_github_workflows.py
+++ b/src/python/pants_release/generate_github_workflows.py
@@ -37,11 +37,12 @@ class Platform(Enum):
     LINUX_X86_64 = "Linux-x86_64"
     LINUX_ARM64 = "Linux-ARM64"
     MACOS10_15_X86_64 = "macOS10-15-x86_64"
-    MACOS11_X86_64 = "macOS11-x86_64"
+    # the oldest version of macOS supported by GitHub self-hosted runners
+    MACOS12_X86_64 = "macOS12-x86_64"
     MACOS11_ARM64 = "macOS11-ARM64"
 
 
-GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS11_X86_64}
+GITHUB_HOSTED = {Platform.LINUX_X86_64, Platform.MACOS12_X86_64}
 SELF_HOSTED = {Platform.LINUX_ARM64, Platform.MACOS10_15_X86_64, Platform.MACOS11_ARM64}
 CARGO_AUDIT_IGNORED_ADVISORY_IDS = (
     "RUSTSEC-2020-0128",  # returns a false positive on the cache crate, which is a local crate not a 3rd party crate
@@ -364,8 +365,8 @@ class Helper:
         # any platform-specific labels, so we don't run on future GH-hosted
         # platforms without realizing it.
         ret = ["self-hosted"] if self.platform in SELF_HOSTED else []
-        if self.platform == Platform.MACOS11_X86_64:
-            ret += ["macos-11"]
+        if self.platform == Platform.MACOS12_X86_64:
+            ret += ["macos-12"]
         elif self.platform == Platform.MACOS11_ARM64:
             ret += ["macOS-11-ARM64"]
         elif self.platform == Platform.MACOS10_15_X86_64:
@@ -380,7 +381,7 @@ class Helper:
 
     def platform_env(self):
         ret = {}
-        if self.platform in {Platform.MACOS10_15_X86_64, Platform.MACOS11_X86_64}:
+        if self.platform in {Platform.MACOS10_15_X86_64, Platform.MACOS12_X86_64}:
             # Works around bad `-arch arm64` flag embedded in Xcode 12.x Python interpreters on
             # intel machines. See: https://github.com/giampaolo/psutil/issues/1832
             ret["ARCHFLAGS"] = "-arch x86_64"
@@ -773,8 +774,8 @@ def linux_arm64_test_jobs() -> Jobs:
     return jobs
 
 
-def macos11_x86_64_test_jobs() -> Jobs:
-    helper = Helper(Platform.MACOS11_X86_64)
+def macos12_x86_64_test_jobs() -> Jobs:
+    helper = Helper(Platform.MACOS12_X86_64)
     jobs = {
         helper.job_name("bootstrap_pants"): bootstrap_jobs(
             helper,
@@ -960,7 +961,7 @@ def test_workflow_jobs() -> Jobs:
     }
     jobs.update(**linux_x86_64_test_jobs())
     jobs.update(**linux_arm64_test_jobs())
-    jobs.update(**macos11_x86_64_test_jobs())
+    jobs.update(**macos12_x86_64_test_jobs())
     jobs.update(**build_wheels_jobs())
     jobs.update(
         {


### PR DESCRIPTION
GitHub Actions has deprecated their `macos-11` hosted runners, and removing them at the end of the month. This thus bumps to `macos-12`, the oldest supported version.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

This cherry-picks to all active branches to ensure their CI continues to work.

Fixes #20938
