### PR TITLE
Add release notes file for 2.23.x

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -1,0 +1,27 @@
+# 2.23.x Release Series
+
+Pants 2 is a fast, scalable, user-friendly build system for codebases of all sizes. It's currently focused on Python, Go, Java, Scala, Kotlin, Shell, and Docker, with support for other languages and frameworks coming soon.
+
+Individuals and companies can now [sponsor Pants financially](https://www.pantsbuild.org/sponsorship).
+
+Pants is an open-source project that is not owned or controlled by any one company or organization, and does incur some expenses. These expenses are managed by Pants Build, a non-profit that was established for this purpose. This non-profit's only source of revenue is sponsorship by individuals and companies that use Pants.
+
+We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/sponsorship), as well as individual sponsorships via [GitHub](https://github.com/sponsors/pantsbuild).
+
+## What's New
+
+### Highlights
+
+
+### Goals
+
+
+### Backends
+
+
+### Plugin API changes
+
+
+## Full Changelog
+
+For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases


### PR DESCRIPTION
We're just releasing 2.22.0a0 now, and thus have branched `2.22.x`. Work landing on `main` is now for `2.23.x` and so we need a release notes file for that series. This adds it, with just a few top-level headings from the 2.22.x notes files.