### PR TITLE
fix regression in choosing a compatible local environment (Cherry pick of #21011)

### DIFF
--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -135,6 +135,10 @@ class CompatiblePlatformsField(StringSequenceField):
     )
 
 
+class LocalCompatiblePlatformsField(CompatiblePlatformsField):
+    pass
+
+
 class LocalFallbackEnvironmentField(FallbackEnvironmentField):
     help = help_text(
         f"""
@@ -156,7 +160,11 @@ class LocalFallbackEnvironmentField(FallbackEnvironmentField):
 
 class LocalEnvironmentTarget(Target):
     alias = "local_environment"
-    core_fields = (*COMMON_TARGET_FIELDS, CompatiblePlatformsField, LocalFallbackEnvironmentField)
+    core_fields = (
+        *COMMON_TARGET_FIELDS,
+        LocalCompatiblePlatformsField,
+        LocalFallbackEnvironmentField,
+    )
     help = help_text(
         f"""
         Configuration of a local execution environment for specific platforms.
@@ -679,7 +687,7 @@ async def determine_local_environment(
     compatible_name_and_targets = [
         (name, tgt)
         for name, tgt in all_environment_targets.items()
-        if tgt.has_field(CompatiblePlatformsField)
+        if tgt.has_field(LocalCompatiblePlatformsField)
         and platform.value in tgt[CompatiblePlatformsField].value
     ]
     if not compatible_name_and_targets:
@@ -977,9 +985,9 @@ async def get_target_for_environment_name(
         raise ValueError(
             softwrap(
                 f"""
-                Expected to use the address to a `local_environment`, `docker_environment`, or
-                `remote_environment` target in the option `[environments-preview].names`, but the name
-                `{env_name.val}` was set to the target {address.spec} with the target type
+                Expected to use the address to a `local_environment`, `docker_environment`,
+                `remote_environment`, or `workspace_environment` target in the option `[environments-preview].names`,
+                but the name `{env_name.val}` was set to the target {address.spec} with the target type
                 `{tgt.alias}`.
                 """
             )

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -61,6 +61,8 @@ def rule_runner() -> RuleRunner:
             QueryRule(EnvironmentTarget, [EnvironmentName]),
             QueryRule(EnvironmentName, [EnvironmentNameRequest]),
             QueryRule(EnvironmentName, [SingleEnvironmentNameRequest]),
+            QueryRule(ChosenLocalEnvironmentName, []),
+            QueryRule(ChosenLocalWorkspaceEnvironmentName, []),
         ],
         target_types=[
             LocalEnvironmentTarget,
@@ -525,3 +527,26 @@ def test_executable_search_path_cache_scope() -> None:
     ):
         assert_cache(tgt, cache_failures=False, expected=ProcessCacheScope.SUCCESSFUL)
         assert_cache(tgt, cache_failures=True, expected=ProcessCacheScope.ALWAYS)
+
+
+# Test for regression in choosing local environments.
+def test_find_chosen_local_and_workspace_environments(rule_runner: RuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "BUILD": dedent(
+                """\
+            local_environment(name="local")
+            workspace_environment(name="workspace")
+            """
+            )
+        }
+    )
+    rule_runner.set_options(
+        ["--environments-preview-names={'local': '//:local', 'workspace': '//:workspace'}"]
+    )
+
+    chosen_local_env = rule_runner.request(ChosenLocalEnvironmentName, [])
+    assert chosen_local_env.val.val == "local"
+
+    chosen_workspace_env = rule_runner.request(ChosenLocalWorkspaceEnvironmentName, [])
+    assert chosen_workspace_env.val.val == "workspace"


### PR DESCRIPTION
Introduction of workspace environments also introduced a regression in the rule which selects a local environment compatible with the current platform: If you have both a local environment and a workspace environment defined in your configuration, then Pants will error that it is ambiguous which one to select as a _local_ environment. This is wrong of course; the rule should have ignored the workspace environment for that logic.

The issue is that the rule was looking for targets with the `CompatiblePlatformsField` which is now true of both `local_environment` and `workspace_environment` targets.

Solve the issue by subclassing `CompatiblePlatformsField` for `local_environment` target type and have the rule check for that. This is what was done for `workspace_environment` as well so fits nicely with that solution.