### PR TITLE
Change help text for subsystems to choose the closest backend

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -30,6 +30,10 @@ Source files no longer produce a dependency on Scala plugins. If you are using a
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.
 
+### Other minor tweaks
+
+Help text for subsystems will now show the closest backend that registers the subsystem, rather than showing the one with the shortest name (usually `pants.core`).
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -520,8 +520,9 @@ class HelpInfoExtracter:
                 subsystem_cls = scope_info.subsystem_cls
                 assert subsystem_cls is not None
                 if build_configuration is not None:
-                    provider = cls.get_provider(
-                        build_configuration.subsystem_to_providers.get(subsystem_cls)
+                    provider = cls.get_closest_provider_for_subsystem(
+                        subsystem_cls,
+                        build_configuration.subsystem_to_providers.get(subsystem_cls),
                     )
                 goal_subsystem_cls = cast(Type[GoalSubsystem], subsystem_cls)
                 return GoalHelpInfo(
@@ -682,7 +683,9 @@ class HelpInfoExtracter:
         return sorted(providers, key=len)[0]
 
     @classmethod
-    def get_closest_provider_for_subsystem(cls, subsystem_cls: Type, providers: tuple[str, ...] | None) -> str:
+    def get_closest_provider_for_subsystem(
+        cls, subsystem_cls: Type, providers: tuple[str, ...] | None
+    ) -> str:
         if not providers:
             return ""
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -682,9 +682,9 @@ class HelpInfoExtracter:
         # Pick the shortest backend name.
         return sorted(providers, key=len)[0]
 
-    @classmethod
+    @staticmethod
     def get_closest_provider_for_subsystem(
-        cls, subsystem_cls: Type, providers: tuple[str, ...] | None
+        subsystem_cls: Type, providers: tuple[str, ...] | None
     ) -> str:
         if not providers:
             return ""


### PR DESCRIPTION
This is a partial fix for https://github.com/pantsbuild/pants/issues/20981, implemented based on https://github.com/pantsbuild/pants/issues/20981#issuecomment-2141342033 - based on what backends are enabled, we can now choose the backend whose package path is closest to the path of the subsystem itself.


Examples of what the text looks like before/after: https://github.com/pantsbuild/pants/issues/20981#issuecomment-2151141245