### PR TITLE
rename `workspace_environment` to `experimental_workspace_environment` (Cherry-pick of #21024)

### DIFF
--- a/docs/docs/using-pants/environments.mdx
+++ b/docs/docs/using-pants/environments.mdx
@@ -73,7 +73,7 @@ The `environment=` field may either:
 1. refer to an environment by name
 2. use one of the following special environment names to select a matching environment: (see "Environment matching" below)
   1. `__local__` resolves to any matching `local_environment`
-  2. `__local_workspace__` resolves to any matching `workspace_environment` 
+  2. `__local_workspace__` resolves to any matching `experimental_workspace_environment` 
 
 :::caution Environment compatibility
 Currently, there is no static validation that a target's environment is compatible with its dependencies' environments -- only the implicit validation of the goals that you run successfully against those targets (`check`, `lint`, `test`, `package`, etc).
@@ -110,7 +110,7 @@ A single environment name may end up referring to different environment targets 
 - `local_environment` targets will match if their `compatible_platforms=` field matches localhost's platform.
 - `docker_environment` targets will match [if Docker is enabled](../../reference/global-options.mdx#docker_execution), and if their `platform=` field is compatible with localhost's platform.
 - `remote_environment` targets will match [if Remote execution is enabled](../../reference/global-options.mdx#remote_execution).
-- `workspace_environment` targets will match if their `compatible_platforms=` field matches localhost's platform.
+- `experimental_workspace_environment` targets will match if their `compatible_platforms=` field matches localhost's platform.
 
 If a particular environment target _doesn't_ match (other than for `workspace_enviroment` targets), it can configure a `fallback_environment=` which will be attempted next. This allows for forming preference chains which are referred to by whichever environment name is at the head of the chain. This does not apply to `workspace_enviroment` targets because in-workspace execution differs significantly from the execution in the other environments due to the lack of an execution sandbox.
 
@@ -243,7 +243,7 @@ You could then _override_ that name definition in `pants.ci.toml` (note the use 
 macos = "//:macos_ci"
 ```
 
-### In-Workspace Execution (`workspace_environment`)
+### In-Workspace Execution (`experimental_workspace_environment`)
 
 The `workspace_enviroment` target type configures a special "workspace" environment in which build actions are invoked in the repository / workspace instead of an execution sandbox as would be done with `local_environment` executions.
 
@@ -259,7 +259,7 @@ If a process isn't reproducible, re-running a build from the same source code co
 
 :::
 
-The special environment name `__local_workspace__` can be used to select a matching `workspace_environment` based on its `compatible_platforms` attribute.
+The special environment name `__local_workspace__` can be used to select a matching `experimental_workspace_environment` based on its `compatible_platforms` attribute.
 
 There is no `fallback_environment=` atribute on `workspace_enviroment` targets because in-workspace execution differs significantly from
 the other environemnts due to the lack of an execution sandbox.

--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -14,7 +14,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 - A new implementation of the options system.
 - Source globs are now less strict, using a "match any" conjunction rather than the previous "match all".
-- In-workspace execution of processes via `workspace_environment` target type.
+- In-workspace execution of processes via `experimental_workspace_environment` target type.
 
 ### New options system
 
@@ -26,7 +26,7 @@ If you encounter such discrepancies, and you can't resolve them easily, please [
 
 ### Environments: In-Workspace Execution
 
-Pants now supports executing processes locally within the repository itself via the new "workspace" environment which is configured by the new `workspace_environment` target type. The primary motivation for this feature is to better support integration with third-party build orchestration tools (e.g., Bazel) which may not operate properly when not invoked in the repository (including in some cases signifcant performance penalties).
+Pants now supports executing processes locally within the repository itself via the new "workspace" environment which is configured by the new `experimental_workspace_environment` target type. The primary motivation for this feature is to better support integration with third-party build orchestration tools (e.g., Bazel) which may not operate properly when not invoked in the repository (including in some cases signifcant performance penalties).
 
 There is a significant trade-off though: Pants cannot reasonbly guarantee that build processes are reproducible if they run in the workspace
 environment. Thus, Pants puts that burden on you, the Pants user, to guarantee that any process executed in the workspace environment is reproducible

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -320,7 +320,7 @@ def test_adhoc_tool_with_workspace_execution(rule_runner: PythonRuleRunner) -> N
                 environment="workspace",
                 stderr="stderr",
             )
-            workspace_environment(name="workspace")
+            experimental_workspace_environment(name="workspace")
             """
             )
         }

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -853,7 +853,7 @@ def test_shell_command_with_workspace_execution(rule_runner: RuleRunner) -> None
                 output_files=["out.log"],
                 environment="workspace",
             )
-            workspace_environment(name="workspace")
+            experimental_workspace_environment(name="workspace")
             """
             )
         }

--- a/src/python/pants/core/util_rules/environments.py
+++ b/src/python/pants/core/util_rules/environments.py
@@ -191,7 +191,7 @@ class LocalWorkspaceCompatiblePlatformsField(CompatiblePlatformsField):
 
 
 class LocalWorkspaceEnvironmentTarget(Target):
-    alias = "workspace_environment"
+    alias = "experimental_workspace_environment"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         LocalWorkspaceCompatiblePlatformsField,
@@ -213,9 +213,9 @@ class LocalWorkspaceEnvironmentTarget(Target):
         `[environments-preview].names`. You can then consume this environment by specifying the name in
         the `environment` field defined on other targets.
 
-        Only one `workspace_environment` may be defined in `[environments-preview].names` per platform, and
+        Only one `experimental_workspace_environment` may be defined in `[environments-preview].names` per platform, and
         when `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` is specified as the environment, the
-        `workspace_environment` that matches the current platform (if defined) will be selected.
+        `experimental_workspace_environment` that matches the current platform (if defined) will be selected.
 
         Caching and reproducibility:
 
@@ -226,6 +226,9 @@ class LocalWorkspaceEnvironmentTarget(Target):
 
         If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly,
         or give different output to an earlier build.
+
+        NOTE: This target type is EXPERIMENTAL and may change its semantics in subsequent Pants versions
+        without a deprecation cycle.
         """
     )
 
@@ -746,16 +749,16 @@ async def determine_local_workspace_environment(
     ]
 
     if not compatible_name_and_targets:
-        # Raise an exception since, unlike with `local_environment`, a `workspace_environment`
+        # Raise an exception since, unlike with `local_environment`, a `experimental_workspace_environment`
         # cannot be configured via global options.
         raise AmbiguousEnvironmentError(
             softwrap(
                 f"""
                 A target requested a compatible workspace environment via the
-                `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` special environment name. No `workspace_environment`
+                `{LOCAL_WORKSPACE_ENVIRONMENT_MATCHER}` special environment name. No `experimental_workspace_environment`
                 target exists, however, to satisfy that request.
 
-                Unlike local environmnts, with workspace environments, at least one `workspace_environment`
+                Unlike local environmnts, with workspace environments, at least one `experimental_workspace_environment`
                 target must exist and be named in the `[environments-preview.names]` option.
                 """
             )
@@ -768,7 +771,7 @@ async def determine_local_workspace_environment(
     raise AmbiguousEnvironmentError(
         softwrap(
             f"""
-            Multiple `workspace_environment` targets from `[environments-preview].names`
+            Multiple `experimental_workspace_environment` targets from `[environments-preview].names`
             are compatible with the current platform `{platform.value}`, so it is ambiguous
             which to use:
             {sorted(tgt.address.spec for _name, tgt in compatible_name_and_targets)}
@@ -777,7 +780,7 @@ async def determine_local_workspace_environment(
             targets so that only one includes the value `{platform.value}`, or change
             `[environments-preview].names` so that it does not define some of those targets.
 
-            It is often useful to still keep the same `workspace_environment` target definitions in
+            It is often useful to still keep the same `experimental_workspace_environment` target definitions in
             BUILD files; instead, do not give a name to each of them in
             `[environments-preview].names` to avoid ambiguity. Then, you can override which target
             a particular name points to by overriding `[environments-preview].names`. For example,
@@ -986,7 +989,7 @@ async def get_target_for_environment_name(
             softwrap(
                 f"""
                 Expected to use the address to a `local_environment`, `docker_environment`,
-                `remote_environment`, or `workspace_environment` target in the option `[environments-preview].names`,
+                `remote_environment`, or `experimental_workspace_environment` target in the option `[environments-preview].names`,
                 but the name `{env_name.val}` was set to the target {address.spec} with the target type
                 `{tgt.alias}`.
                 """

--- a/src/python/pants/core/util_rules/environments_test.py
+++ b/src/python/pants/core/util_rules/environments_test.py
@@ -530,13 +530,13 @@ def test_executable_search_path_cache_scope() -> None:
 
 
 # Test for regression in choosing local environments.
-def test_find_chosen_local_and_workspace_environments(rule_runner: RuleRunner) -> None:
+def test_find_chosen_local_and_experimental_workspace_environments(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": dedent(
                 """\
             local_environment(name="local")
-            workspace_environment(name="workspace")
+            experimental_workspace_environment(name="workspace")
             """
             )
         }

--- a/src/python/pants/engine/process_test.py
+++ b/src/python/pants/engine/process_test.py
@@ -324,7 +324,7 @@ def test_workspace_execution_support() -> None:
     )
     rule_runner.write_files(
         {
-            "BUILD": "workspace_environment(name='workspace')",
+            "BUILD": "experimental_workspace_environment(name='workspace')",
         }
     )
     rule_runner.set_options(

--- a/src/python/pants/help/help_integration_test.py
+++ b/src/python/pants/help/help_integration_test.py
@@ -33,8 +33,29 @@ def test_help_advanced_global() -> None:
 def test_help_targets() -> None:
     pants_run = run_pants(["help", "targets"])
     pants_run.assert_success()
-    lines = [" ".join(line.split()) for line in pants_run.stdout.splitlines()]
-    assert "archive A ZIP or TAR file containing loose files and code packages." in lines
+
+    # The target help text may be split over several lines depending on what targets there are
+    # and how Pants views the terminal size. Extract the full texts consistently to reduce this test's
+    # brittle nature.
+    target_help_texts: list[str] = []
+    current = ""
+    for line in pants_run.stdout.splitlines():
+        line = line.rstrip()
+        if not line:
+            continue
+
+        if not line[0:1].isspace():
+            target_help_texts.append(current)
+            current = ""
+
+        line = re.sub(r"\s+", " ", line.strip())
+        current += f" {line}"
+    if current:
+        target_help_texts.append(current)
+
+    assert (
+        " archive A ZIP or TAR file containing loose files and code packages." in target_help_texts
+    )
     assert "to get help for a specific target" in pants_run.stdout
 
 


### PR DESCRIPTION
Rename the `workspace_environment` to `experimental_workspace_environment` to highlight the fact that the workspace environment is not a polished feature and is subject to change without a deprecation cycle if  need be.
