### PR TITLE
Pick provider closest to the rule/subsystem/target type.

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -12,6 +12,7 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Highlights
 
+- The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.
 
 ### Goals
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -12,7 +12,6 @@ We offer [formal sponsorship tiers for companies](https://www.pantsbuild.org/spo
 
 ### Highlights
 
-- The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.
 
 ### Goals
 
@@ -42,6 +41,10 @@ silently ignored.
 ### Plugin API changes
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.
+
+### Other minor tweaks
+
+The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.
 
 ## Full Changelog
 

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -680,10 +680,10 @@ class HelpInfoExtracter:
 
     @staticmethod
     def get_provider(providers: tuple[str, ...] | None, hint: str | None = None) -> str:
-        """
-        Get the best match for the provider.
-        
-        To take advantage of provider names being modules, `hint` should be something like the a subsystem's `__module__` or a rule's `canonical_name`
+        """Get the best match for the provider.
+
+        To take advantage of provider names being modules, `hint` should be something like the a
+        subsystem's `__module__` or a rule's `canonical_name`.
         """
         if not providers:
             return ""

--- a/src/python/pants/help/help_info_extracter.py
+++ b/src/python/pants/help/help_info_extracter.py
@@ -680,6 +680,11 @@ class HelpInfoExtracter:
 
     @staticmethod
     def get_provider(providers: tuple[str, ...] | None, hint: str | None = None) -> str:
+        """
+        Get the best match for the provider.
+        
+        To take advantage of provider names being modules, `hint` should be something like the a subsystem's `__module__` or a rule's `canonical_name`
+        """
         if not providers:
             return ""
         if not hint:


### PR DESCRIPTION
Instead of picking the "shortest" provider available, pick the one closest to the thing being provided for a more accurate result.

When a particular thing is available "out of backend" as a dependency, it will be listed as "activated by" the shortest plugin module path, for the docs site, all backends are enabled so everything will be activated by their primary backend. Meaning the online docs will be accurate, as well as the local CLI help will be accurate in reflecting which backend actually activated a particular feature.

Replaces #21023.
