### PR TITLE
Support extra env vars resolution of `PATH` in nodejs processes

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -30,6 +30,14 @@ Source files no longer produce a dependency on Scala plugins. If you are using a
 
 The `tfsec` linter now works on all supported platforms without extra config. 
 
+#### Javascript
+
+Nodejs processes configured with `extra_env_vars`, e.g.
+[`javascript_test`](https://www.pantsbuild.org/2.23/reference/targets/javascript_test),
+now supports extending the `PATH` variable of such processes. Passing `extra_env_vars=["PATH=/usr/bin"]` was previously
+silently ignored.
+
+
 ### Plugin API changes
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.


### PR DESCRIPTION
`PATH` was silently overwritten by rule code.