### PR TITLE
Rudimentary export goal support for `node_modules`

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -127,6 +127,9 @@ Now, this is delegated to the package managers, using each package manager's sup
 
 This fixes an issue with integrity file collisions when newer versions of package managers (e.g. the [hidden lockfiles](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json#hidden-lockfiles) introduced in npm v7).
 
+`pants export --resolve=<js-resolve>` now has basic support for exporting the package manager installation artifacts
+including `node_modules`. This can be used to inspect the installation, or to enable IDE:s to discover the packages.
+
 
 #### Shell
 
@@ -143,11 +146,6 @@ Fixed pulling `helm_artifact`s from OCI repositories.
 #### Shell
 
 Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work with the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
-
-#### Javascript
-
-`pants export --resolve=<js-resolve>` now has basic support for exporting the package manager installation artifacts
-including `node_modules`. This can be used to inspect the installation, or to enable IDE:s to discover the packages.
 
 ### Plugin API changes
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -144,6 +144,11 @@ Fixed pulling `helm_artifact`s from OCI repositories.
 
 Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work with the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
 
+#### Javascript
+
+`pants export --resolve=<js-resolve>` now has basic support for exporting the package manager installation artifacts
+including `node_modules`. This can be used to inspect the installation, or to enable IDE:s to discover the packages.
+
 ### Plugin API changes
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.

--- a/src/python/pants/backend/experimental/javascript/register.py
+++ b/src/python/pants/backend/experimental/javascript/register.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from pants.backend.javascript import package_json
-from pants.backend.javascript.goals import lockfile, tailor, test
+from pants.backend.javascript.goals import lockfile, tailor, test, export
 from pants.backend.javascript.package.rules import rules as package_rules
 from pants.backend.javascript.run.rules import rules as run_rules
 from pants.backend.javascript.subsystems import nodejs
@@ -30,6 +30,7 @@ def rules() -> Iterable[Rule | UnionRule]:
         *package_rules(),
         *run_rules(),
         *test.rules(),
+        *export.rules(),
     )
 
 

--- a/src/python/pants/backend/experimental/javascript/register.py
+++ b/src/python/pants/backend/experimental/javascript/register.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from typing import Iterable
 
 from pants.backend.javascript import package_json
-from pants.backend.javascript.goals import lockfile, tailor, test, export
+from pants.backend.javascript.goals import export, lockfile, tailor, test
 from pants.backend.javascript.package.rules import rules as package_rules
 from pants.backend.javascript.run.rules import rules as run_rules
 from pants.backend.javascript.subsystems import nodejs

--- a/src/python/pants/backend/javascript/goals/export.py
+++ b/src/python/pants/backend/javascript/goals/export.py
@@ -1,0 +1,83 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from pants.backend.javascript.install_node_package import InstalledNodePackage, InstalledNodePackageRequest
+from pants.backend.javascript.resolve import FirstPartyNodePackageResolves
+from pants.backend.javascript.subsystems.nodejs import NodeJS
+from pants.core.goals.export import (
+    ExportRequest,
+    ExportResult,
+    ExportResults,
+    ExportSubsystem,
+)
+from pants.engine.engine_aware import EngineAwareParameter
+from pants.engine.internals.native_engine import (
+    Digest, RemovePrefix,
+)
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.unions import UnionMembership, UnionRule
+
+
+@dataclass(frozen=True)
+class ExportNodeModulesRequest(ExportRequest):
+    pass
+
+
+@dataclass(frozen=True)
+class _ExportNodeModulesForResolveRequest(EngineAwareParameter):
+    resolve: str
+
+
+@dataclass(frozen=True)
+class MaybeExportResult:
+    result: ExportResult | None
+
+
+@rule
+async def export_node_modules_for_resolve(
+    request: _ExportNodeModulesForResolveRequest,
+    nodejs: NodeJS,
+    union_membership: UnionMembership,
+    resolves: FirstPartyNodePackageResolves,
+) -> MaybeExportResult:
+    resolve = request.resolve
+
+    target = resolves.get(request.resolve)
+
+    if not target:
+        return MaybeExportResult(None)
+
+    installation = await Get(InstalledNodePackage, InstalledNodePackageRequest(target.address))
+
+    return MaybeExportResult(
+        ExportResult(
+            description=f"generated node_modules for {resolve} (using NodeJS {nodejs.version})",
+            reldir=f"nodejs/modules/{resolve}",
+            digest=await Get(Digest, RemovePrefix(installation.digest, installation.project_dir)),
+            resolve=resolve,
+        )
+    )
+
+
+@rule
+async def export_node_modules(
+    request: ExportNodeModulesRequest,
+    export_subsys: ExportSubsystem,
+) -> ExportResults:
+    maybe_packages = await MultiGet(
+        Get(MaybeExportResult, _ExportNodeModulesForResolveRequest(resolve))
+        for resolve in export_subsys.options.resolve
+    )
+    return ExportResults(pkg.result for pkg in maybe_packages if pkg.result is not None)
+
+
+def rules():
+    return [
+        *collect_rules(),
+        UnionRule(ExportRequest, ExportNodeModulesRequest),
+    ]

--- a/src/python/pants/backend/javascript/goals/export.py
+++ b/src/python/pants/backend/javascript/goals/export.py
@@ -43,12 +43,14 @@ async def export_node_modules_for_resolve(
 ) -> MaybeExportResult:
     resolve = request.resolve
 
-    target = resolves.get(request.resolve)
+    requested_resolve = resolves.get(request.resolve)
 
-    if not target:
+    if not requested_resolve:
         return MaybeExportResult(None)
 
-    installation = await Get(InstalledNodePackage, InstalledNodePackageRequest(target.address))
+    installation = await Get(
+        InstalledNodePackage, InstalledNodePackageRequest(requested_resolve.address)
+    )
 
     return MaybeExportResult(
         ExportResult(

--- a/src/python/pants/backend/javascript/goals/export.py
+++ b/src/python/pants/backend/javascript/goals/export.py
@@ -5,19 +5,15 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from pants.backend.javascript.install_node_package import InstalledNodePackage, InstalledNodePackageRequest
+from pants.backend.javascript.install_node_package import (
+    InstalledNodePackage,
+    InstalledNodePackageRequest,
+)
 from pants.backend.javascript.resolve import FirstPartyNodePackageResolves
 from pants.backend.javascript.subsystems.nodejs import NodeJS
-from pants.core.goals.export import (
-    ExportRequest,
-    ExportResult,
-    ExportResults,
-    ExportSubsystem,
-)
+from pants.core.goals.export import ExportRequest, ExportResult, ExportResults, ExportSubsystem
 from pants.engine.engine_aware import EngineAwareParameter
-from pants.engine.internals.native_engine import (
-    Digest, RemovePrefix,
-)
+from pants.engine.internals.native_engine import Digest, RemovePrefix
 from pants.engine.internals.selectors import Get, MultiGet
 from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionMembership, UnionRule

--- a/src/python/pants/backend/javascript/goals/export_test.py
+++ b/src/python/pants/backend/javascript/goals/export_test.py
@@ -1,0 +1,60 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+import json
+from pathlib import Path
+
+import pytest
+
+from pants.backend.javascript import install_node_package
+from pants.backend.javascript.goals import export
+from pants.backend.javascript.goals.export import ExportNodeModulesRequest
+from pants.backend.javascript.package_json import PackageJsonTarget
+from pants.base.specs import RawSpecs
+from pants.core.goals.export import ExportResults
+from pants.engine.internals.native_engine import Digest, Snapshot
+from pants.engine.rules import QueryRule
+from pants.engine.target import (
+    Targets,
+)
+from pants.testutil.rule_runner import RuleRunner
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    return RuleRunner(
+        rules=[
+            *export.rules(),
+            *install_node_package.rules(),
+            QueryRule(Targets, [RawSpecs]),
+            QueryRule(ExportResults, [ExportNodeModulesRequest]),
+            QueryRule(Snapshot, [Digest])
+        ],
+        target_types=[PackageJsonTarget],
+    )
+
+
+def given_package_with_name(name: str) -> str:
+    return json.dumps({"name": name, "version": "0.0.1", "devDependencies": {"jest": "*"}})
+
+
+def get_snapshot(rule_runner: RuleRunner, digest: Digest) -> Snapshot:
+    return rule_runner.request(Snapshot, [digest])
+
+
+def test_export_node_modules(rule_runner: RuleRunner) -> None:
+    rule_runner.set_options(["--export-resolve=nodejs-default"], env_inherit={"PATH"})
+    rule_runner.write_files(
+        {
+            "BUILD": "package_json(name='root')",
+            "package-lock.json": (Path(__file__).parent / "jest_resources/package-lock.json").read_text(),
+            "package.json": given_package_with_name("ham"),
+        }
+    )
+    results = rule_runner.request(ExportResults, [ExportNodeModulesRequest(tuple())])
+    assert len(results) == 1
+    result = results[0]
+
+    snapshot = get_snapshot(rule_runner, result.digest)
+
+    assert result.resolve == 'nodejs-default'
+    assert 'node_modules/jest' in snapshot.dirs

--- a/src/python/pants/backend/javascript/goals/export_test.py
+++ b/src/python/pants/backend/javascript/goals/export_test.py
@@ -13,9 +13,7 @@ from pants.base.specs import RawSpecs
 from pants.core.goals.export import ExportResults
 from pants.engine.internals.native_engine import Digest, Snapshot
 from pants.engine.rules import QueryRule
-from pants.engine.target import (
-    Targets,
-)
+from pants.engine.target import Targets
 from pants.testutil.rule_runner import RuleRunner
 
 
@@ -27,7 +25,7 @@ def rule_runner() -> RuleRunner:
             *install_node_package.rules(),
             QueryRule(Targets, [RawSpecs]),
             QueryRule(ExportResults, [ExportNodeModulesRequest]),
-            QueryRule(Snapshot, [Digest])
+            QueryRule(Snapshot, [Digest]),
         ],
         target_types=[PackageJsonTarget],
     )
@@ -46,7 +44,9 @@ def test_export_node_modules(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "BUILD": "package_json(name='root')",
-            "package-lock.json": (Path(__file__).parent / "jest_resources/package-lock.json").read_text(),
+            "package-lock.json": (
+                Path(__file__).parent / "jest_resources/package-lock.json"
+            ).read_text(),
             "package.json": given_package_with_name("ham"),
         }
     )
@@ -56,5 +56,5 @@ def test_export_node_modules(rule_runner: RuleRunner) -> None:
 
     snapshot = get_snapshot(rule_runner, result.digest)
 
-    assert result.resolve == 'nodejs-default'
-    assert 'node_modules/jest' in snapshot.dirs
+    assert result.resolve == "nodejs-default"
+    assert "node_modules/jest" in snapshot.dirs

--- a/src/python/pants/backend/javascript/nodejs_project_environment.py
+++ b/src/python/pants/backend/javascript/nodejs_project_environment.py
@@ -95,7 +95,11 @@ class NodeJsProjectEnvironmentProcess:
     extra_env: FrozenDict[str, str] = field(default_factory=FrozenDict)
 
     def targeted_args(self) -> tuple[str, ...]:
-        if not self.env.project.single_workspace and self.env.target and self.env.root_dir != self.env.package_dir():
+        if (
+            not self.env.project.single_workspace
+            and self.env.target
+            and self.env.root_dir != self.env.package_dir()
+        ):
             target = self.env.ensure_target()
             return (
                 self.env.project.workspace_specifier_arg,

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -513,9 +513,7 @@ async def export_virtualenv_for_resolve(
             lockfile = None
 
     if not lockfile:
-        raise ExportError(
-            f"No resolve named {resolve} found in [{python_setup.options_scope}].resolves."
-        )
+        return MaybeExportResult(None)
 
     interpreter_constraints = InterpreterConstraints(
         python_setup.resolves_to_interpreter_constraints.get(
@@ -575,10 +573,6 @@ async def export_virtualenvs(
     request: ExportVenvsRequest,
     export_subsys: ExportSubsystem,
 ) -> ExportResults:
-    if not export_subsys.options.resolve:
-        raise ExportError("Must specify at least one --resolve to export")
-    if request.targets:
-        raise ExportError("The `export` goal does not take target specs.")
     maybe_venvs = await MultiGet(
         Get(MaybeExportResult, _ExportVenvForResolveRequest(resolve))
         for resolve in export_subsys.options.resolve

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -146,6 +146,12 @@ async def export(
     export_subsys: ExportSubsystem,
 ) -> Export:
     request_types = cast("Iterable[type[ExportRequest]]", union_membership.get(ExportRequest))
+
+    if not export_subsys.options.resolve:
+        raise ExportError("Must specify at least one --resolve to export")
+    if targets:
+        raise ExportError("The `export` goal does not take target specs.")
+
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
     flattened_results = [res for results in all_results for res in results]

--- a/src/python/pants/core/goals/export.py
+++ b/src/python/pants/core/goals/export.py
@@ -16,7 +16,6 @@ from pants.core.goals.generate_lockfiles import (
     UnrecognizedResolveNamesError,
 )
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import _warn_on_non_local_environments
 from pants.engine.collection import Collection
 from pants.engine.console import Console
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
@@ -155,8 +154,6 @@ async def export(
     requests = tuple(request_type(targets) for request_type in request_types)
     all_results = await MultiGet(Get(ExportResults, ExportRequest, request) for request in requests)
     flattened_results = [res for results in all_results for res in results]
-
-    await _warn_on_non_local_environments(targets, "the `export` goal")
 
     prefixed_digests = await MultiGet(
         Get(Digest, AddPrefix(result.digest, result.reldir)) for result in flattened_results

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from typing import Iterable, List, Tuple
-
-import pytest
+from typing import List, Tuple
 
 from pants.base.build_root import BuildRoot
 from pants.core.goals.export import (
@@ -22,13 +20,7 @@ from pants.core.goals.export import (
 )
 from pants.core.goals.generate_lockfiles import KnownUserResolveNames, KnownUserResolveNamesRequest
 from pants.core.util_rules.distdir import DistDir
-from pants.core.util_rules.environments import (
-    EnvironmentField,
-    EnvironmentNameRequest,
-    EnvironmentTarget,
-    LocalEnvironmentTarget,
-    RemoteEnvironmentTarget,
-)
+from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.addresses import Address
 from pants.engine.env_vars import EnvironmentVars, EnvironmentVarsRequest
 from pants.engine.fs import AddPrefix, CreateDigest, Digest, FileContent, MergeDigests, Workspace
@@ -62,15 +54,16 @@ class MockExportRequest(ExportRequest):
 
 
 def mock_export(
-    edr: ExportRequest,
     digest: Digest,
     post_processing_cmds: tuple[PostProcessingCommand, ...],
+    resolve: str,
 ) -> ExportResult:
     return ExportResult(
-        description=f"mock export for {','.join(t.address.spec for t in edr.targets)}",
+        description=f"mock export for {resolve}",
         reldir="mock",
         digest=digest,
         post_processing_cmds=post_processing_cmds,
+        resolve=resolve,
     )
 
 
@@ -86,7 +79,7 @@ def _mock_run(rule_runner: RuleRunner, ip: InteractiveProcess) -> InteractivePro
     return InteractiveProcessResult(0)
 
 
-def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int, str]:
+def run_export_rule(rule_runner: RuleRunner, resolves: List[str]) -> Tuple[int, str]:
     union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
     with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
         fp.write(b"SOMEFILE")
@@ -96,12 +89,12 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
             export,
             rule_args=[
                 console,
-                Targets(targets),
+                Targets([]),
                 Workspace(rule_runner.scheduler, _enforce_effects=False),
                 union_membership,
                 BuildRoot(),
                 DistDir(relpath=Path("dist")),
-                create_subsystem(ExportSubsystem, resolve=[]),
+                create_subsystem(ExportSubsystem, resolve=resolves),
             ],
             mock_gets=[
                 MockGet(
@@ -110,7 +103,6 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                     mock=lambda req: ExportResults(
                         (
                             mock_export(
-                                req,
                                 digest,
                                 (
                                     PostProcessingCommand(
@@ -120,14 +112,10 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
                                         ["cp", "{digest_root}/foo/bar", "{digest_root}/foo/bar2"]
                                     ),
                                 ),
+                                resolves[0],
                             ),
                         )
                     ),
-                ),
-                MockGet(
-                    output_type=EnvironmentTarget,
-                    input_types=(EnvironmentNameRequest,),
-                    mock=lambda req: EnvironmentTarget(req.raw_value, None),
                 ),
                 rule_runner.do_not_use_mock(Digest, (MergeDigests,)),
                 rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
@@ -154,9 +142,9 @@ def test_run_export_rule() -> None:
         ],
         target_types=[MockTarget],
     )
-    exit_code, stdout = run_export_rule(rule_runner, [make_target("foo/bar", "baz")])
+    exit_code, stdout = run_export_rule(rule_runner, ["resolve"])
     assert exit_code == 0
-    assert "Wrote mock export for foo/bar:baz to dist/export/mock" in stdout
+    assert "Wrote mock export for resolve to dist/export/mock" in stdout
     for filename in ["bar", "bar1", "bar2"]:
         expected_dist_path = os.path.join(
             rule_runner.build_root, "dist", "export", "mock", "foo", filename
@@ -168,122 +156,3 @@ def test_run_export_rule() -> None:
 
 def _e(path, env):
     return make_target(path, path, env)
-
-
-@pytest.mark.parametrize(
-    ["targets", "err_present", "err_absent"],
-    [
-        # Only a local environment
-        [[_e("a", "l")], [], ["`a:a`"]],
-        # The remote environment should warn, the local environment should not
-        [[_e("a", "l"), _e("b", "r")], ["target `b:b`"], ["`a:a`"]],
-        # Only a remote environment, which should warn
-        [[_e("b", "r")], ["target `b:b`, which specifies", "environment `r`"], []],
-        # Two targets with the same remote environment (should trigger short plural message)
-        [
-            [_e("b", "r"), _e("c", "r")],
-            ["targets `b:b`, `c:c`, which specify", "environment `r`"],
-            [],
-        ],
-        # Two targets, each with their own remote environment, each should warn separately
-        [
-            [_e("b", "r"), _e("c", "r2")],
-            [
-                "target `b:b`, which specifies",
-                "target `c:c`, which specifies",
-                "environment `r`",
-                "environment `r2`",
-            ],
-            ["`b:b`, `c:c`"],
-        ],
-        # Four targets with the same remote environment (should trigger long plural message, omitting the later targets by lex order)
-        [
-            [_e("b", "r"), _e("c", "r"), _e("d", "r"), _e("e", "r")],
-            [
-                "targets including `b:b`, `c:c`, `d:d` (and others), which specify",
-                "environment `r`",
-            ],
-            ["`e:e`"],
-        ],
-    ],
-)
-def test_warnings_for_non_local_target_environments(
-    targets: Iterable[Target], err_present: Iterable[str], err_absent: Iterable[str]
-) -> None:
-    rule_runner = RuleRunner(
-        rules=[
-            UnionRule(ExportRequest, MockExportRequest),
-            QueryRule(Digest, [CreateDigest]),
-            QueryRule(EnvironmentVars, [EnvironmentVarsRequest]),
-            QueryRule(InteractiveProcessResult, [InteractiveProcess]),
-        ],
-        target_types=[MockTarget, LocalEnvironmentTarget, RemoteEnvironmentTarget],
-    )
-
-    union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
-    with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
-        fp.write(b"SOMEFILE")
-    with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
-        digest = rule_runner.request(Digest, [CreateDigest([FileContent("foo/bar", b"BAR")])])
-        run_rule_with_mocks(
-            export,
-            rule_args=[
-                console,
-                Targets(targets),
-                Workspace(rule_runner.scheduler, _enforce_effects=False),
-                union_membership,
-                BuildRoot(),
-                DistDir(relpath=Path("dist")),
-                create_subsystem(ExportSubsystem, resolve=[]),
-            ],
-            mock_gets=[
-                MockGet(
-                    output_type=ExportResults,
-                    input_types=(ExportRequest,),
-                    mock=lambda req: ExportResults(
-                        (
-                            mock_export(
-                                req,
-                                digest,
-                                (),
-                            ),
-                        )
-                    ),
-                ),
-                rule_runner.do_not_use_mock(Digest, (MergeDigests,)),
-                MockGet(
-                    output_type=EnvironmentTarget,
-                    input_types=(EnvironmentNameRequest,),
-                    mock=_give_an_environment,
-                ),
-                rule_runner.do_not_use_mock(Digest, (AddPrefix,)),
-                rule_runner.do_not_use_mock(EnvironmentVars, (EnvironmentVarsRequest,)),
-                rule_runner.do_not_use_mock(KnownUserResolveNames, (KnownUserResolveNamesRequest,)),
-                MockEffect(
-                    output_type=InteractiveProcessResult,
-                    input_types=(InteractiveProcess,),
-                    mock=lambda ip: _mock_run(rule_runner, ip),
-                ),
-            ],
-            union_membership=union_membership,
-        )
-
-        # Messages
-        stderr = stdio_reader.get_stderr()
-        for present in err_present:
-            assert present in stderr
-        for absent in err_absent:
-            assert absent not in stderr
-
-
-def _give_an_environment(enr: EnvironmentNameRequest) -> EnvironmentTarget:
-    if enr.raw_value.startswith("l"):
-        return EnvironmentTarget(
-            enr.raw_value, LocalEnvironmentTarget({}, Address("local", target_name="local"))
-        )
-    elif enr.raw_value.startswith("r"):
-        return EnvironmentTarget(
-            enr.raw_value, RemoteEnvironmentTarget({}, Address("remote", target_name="remote"))
-        )
-    else:
-        raise Exception()


### PR DESCRIPTION
This is fairly bare bones. I've tested it by exporting the in-repo test projects and then verifying that pycharm auto detects the `node_modules` produced.

I'm fairly certain the changes to the `export` goal are benign, but might have made it less flexible for plugin-implementors?

Fixes https://github.com/pantsbuild/pants/issues/19239