### PR TITLE
Replace non-custom flake8 linting with ruff

### DIFF
--- a/3rdparty/python/flake8-requirements.txt
+++ b/3rdparty/python/flake8-requirements.txt
@@ -1,4 +1,2 @@
 flake8>=5.0.4,<7
-flake8-2020>=1.7.0,<2
 flake8-no-implicit-concat
-flake8-comprehensions>=3.10.0,<4.0

--- a/3rdparty/python/flake8-requirements.txt
+++ b/3rdparty/python/flake8-requirements.txt
@@ -1,2 +1,1 @@
 flake8>=5.0.4,<7
-flake8-no-implicit-concat

--- a/3rdparty/python/flake8.lock
+++ b/3rdparty/python/flake8.lock
@@ -9,7 +9,6 @@
 //     "CPython==3.9.*"
 //   ],
 //   "generated_with_requirements": [
-//     "flake8-no-implicit-concat",
 //     "flake8<7,>=5.0.4"
 //   ],
 //   "manylinux": "manylinux2014",
@@ -54,44 +53,6 @@
           "artifacts": [
             {
               "algorithm": "sha256",
-              "hash": "5c056e06f22820865cb34962a1da80767fed5273920b0768e97739021d428de5",
-              "url": "https://files.pythonhosted.org/packages/87/04/983ec9268488911103bc3b30bcdef3936cb9ed55a53d8ad25f023e76243a/flake8_no_implicit_concat-0.3.4-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "1b522becd7568ee2e288bc58e294ebd0d771996ee3138a5322a3cefb21c8464b",
-              "url": "https://files.pythonhosted.org/packages/00/f2/f7616a05059683e4e3970c21f7ed820b18eca08ab272e774dc5ed07aa9c6/flake8-no-implicit-concat-0.3.4.tar.gz"
-            }
-          ],
-          "project_name": "flake8-no-implicit-concat",
-          "requires_dists": [
-            "black; extra == \"dev\"",
-            "codecov; extra == \"dev\"",
-            "coverage; extra == \"dev\"",
-            "darglint; extra == \"dev\"",
-            "flake8",
-            "flake8-2020; extra == \"dev\"",
-            "flake8-black; extra == \"dev\"",
-            "flake8-broken-line; extra == \"dev\"",
-            "flake8-builtins; extra == \"dev\"",
-            "flake8-docstrings; extra == \"dev\"",
-            "flake8-isort; extra == \"dev\"",
-            "flake8-rst-docstrings; extra == \"dev\"",
-            "flake8; extra == \"dev\"",
-            "hacking>=4; extra == \"dev\"",
-            "isort; extra == \"dev\"",
-            "more-itertools; python_version < \"3.10\"",
-            "mypy; extra == \"dev\"",
-            "pep8-naming; extra == \"dev\"",
-            "typing; python_version < \"3.5\""
-          ],
-          "requires_python": ">=3.3",
-          "version": "0.3.4"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
               "hash": "6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e",
               "url": "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl"
             },
@@ -105,24 +66,6 @@
           "requires_dists": [],
           "requires_python": ">=3.6",
           "version": "0.7.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "d2bc7f02446e86a68911e58ded76d6561eea00cddfb2a91e7019bbb586c799f3",
-              "url": "https://files.pythonhosted.org/packages/85/01/e2678ee4e0d7eed4fd6be9e5b043fff9d22d245d06c8c91def8ced664189/more_itertools-9.1.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d",
-              "url": "https://files.pythonhosted.org/packages/2e/d0/bea165535891bd1dcb5152263603e902c0ec1f4c9a2e152cc4adff6b3a38/more-itertools-9.1.0.tar.gz"
-            }
-          ],
-          "project_name": "more-itertools",
-          "requires_dists": [],
-          "requires_python": ">=3.7",
-          "version": "9.1.0"
         },
         {
           "artifacts": [
@@ -169,7 +112,6 @@
   "pip_version": "23.1.2",
   "prefer_older_binary": false,
   "requirements": [
-    "flake8-no-implicit-concat",
     "flake8<7,>=5.0.4"
   ],
   "requires_python": [

--- a/3rdparty/python/flake8.lock
+++ b/3rdparty/python/flake8.lock
@@ -9,8 +9,6 @@
 //     "CPython==3.9.*"
 //   ],
 //   "generated_with_requirements": [
-//     "flake8-2020<2,>=1.7.0",
-//     "flake8-comprehensions<4.0,>=3.10.0",
 //     "flake8-no-implicit-concat",
 //     "flake8<7,>=5.0.4"
 //   ],
@@ -51,47 +49,6 @@
           ],
           "requires_python": ">=3.8.1",
           "version": "6.0.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "1553b2b3638135b276f7a3252301e81376901e7b6a5eaccb07a969771f178375",
-              "url": "https://files.pythonhosted.org/packages/a5/6e/df5766df36c1280d0b96996e89e160cab2f1fa4ffd7434ff252c51025ca7/flake8_2020-1.8.0-py2.py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "f5312b3634266bd0f1957f64ecabeb62d67bbd9cee637e33a2651a80091f90aa",
-              "url": "https://files.pythonhosted.org/packages/3d/0e/29c1a6d15baa70865daa1ae6887742d5907fb75b92c4c1a8281915f8550d/flake8_2020-1.8.0.tar.gz"
-            }
-          ],
-          "project_name": "flake8-2020",
-          "requires_dists": [
-            "flake8>=5"
-          ],
-          "requires_python": ">=3.8",
-          "version": "1.8.0"
-        },
-        {
-          "artifacts": [
-            {
-              "algorithm": "sha256",
-              "hash": "013234637ec7dfcb7cd2900578fb53c512f81db909cefe371c019232695c362d",
-              "url": "https://files.pythonhosted.org/packages/9b/8d/b70f791311a8c6975c0c6634dd44db8fd712d6ad9ed6a3fe888b9be7c89b/flake8_comprehensions-3.12.0-py3-none-any.whl"
-            },
-            {
-              "algorithm": "sha256",
-              "hash": "419ef1a6e8de929203791a5e8ff5e3906caeba13eb3290eebdbf88a9078d502e",
-              "url": "https://files.pythonhosted.org/packages/65/b4/9a2cbbac095aaf1e8dbe3eac55a5155cb9f7860fbb0d9fa23443b5a3afd1/flake8_comprehensions-3.12.0.tar.gz"
-            }
-          ],
-          "project_name": "flake8-comprehensions",
-          "requires_dists": [
-            "flake8!=3.2.0,>=3.0",
-            "importlib-metadata; python_version < \"3.8\""
-          ],
-          "requires_python": ">=3.7",
-          "version": "3.12.0"
         },
         {
           "artifacts": [
@@ -212,8 +169,6 @@
   "pip_version": "23.1.2",
   "prefer_older_binary": false,
   "requirements": [
-    "flake8-2020<2,>=1.7.0",
-    "flake8-comprehensions<4.0,>=3.10.0",
     "flake8-no-implicit-concat",
     "flake8<7,>=5.0.4"
   ],

--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -1,10 +1,6 @@
 [flake8]
 extend-ignore:
-  # Implicitly concatenated string literals over multiple lines
-  NIC002,
-  # Implicitly concatenated bytes literals over multiple lines
-  NIC102,
-  # Handled by ruff:
+  # Defaults are all handled by ruff:
   F,
   E,
   W,

--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -1,23 +1,16 @@
 [flake8]
 extend-ignore:
-  # whitespace before ':' (conflicts with Black)
-  E203,
-  # Bad trailing comma (conflicts with Black)
-  E231,
-  # line too long (> 79 characters)
-  E501,
-  # Do not assign a lambda expression
-  E731,
-  # Ambiguous variable name (enable once fixed)
-  E741,
-  # line break before binary operator  (conflicts with Black)
-  W503,
   # Implicitly concatenated string literals over multiple lines
   NIC002,
   # Implicitly concatenated bytes literals over multiple lines
   NIC102,
   # Unnecessary dict call - rewrite as a literal
   C408,
+  # Handled by ruff:
+  F,
+  E,
+  W,
+  C90,
 
 [flake8:local-plugins]
 extension =

--- a/build-support/flake8/.flake8
+++ b/build-support/flake8/.flake8
@@ -4,8 +4,6 @@ extend-ignore:
   NIC002,
   # Implicitly concatenated bytes literals over multiple lines
   NIC102,
-  # Unnecessary dict call - rewrite as a literal
-  C408,
   # Handled by ruff:
   F,
   E,

--- a/pants.toml
+++ b/pants.toml
@@ -13,6 +13,7 @@ backend_packages.add = [
   "pants.backend.python.lint.docformatter",
   "pants.backend.python.lint.flake8",
   "pants.backend.python.lint.isort",
+  "pants.backend.experimental.python.lint.ruff.check",
   "pants.backend.python.typecheck.mypy",
   "pants.backend.python.lint.pyupgrade",
   "pants.backend.python.mixed_interpreter_constraints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,4 +78,21 @@ line-length = 100
 
 [tool.ruff.lint]
 select = [
+  # flake8 defaults:
+  "F",
+  "E",
+  "W",
+]
+
+ignore = [
+  # whitespace before ':' (conflicts with Black)
+  "E203",
+  # Bad trailing comma (conflicts with Black)
+  "E231",
+  # line too long (> 79 characters)
+  "E501",
+  # Do not assign a lambda expression
+  "E731",
+  # Ambiguous variable name (enable once fixed)
+  "E741",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ select = [
   "F",
   "E",
   "W",
+  # flake8-comprehensions
+  "C4",
+  # flake8-2020
+  "YTT",
 ]
 
 ignore = [
@@ -95,4 +99,6 @@ ignore = [
   "E731",
   # Ambiguous variable name (enable once fixed)
   "E741",
+  # Unnecessary dict call - rewrite as a literal
+  "C408",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,8 @@ select = [
   "C4",
   # flake8-2020
   "YTT",
+  # flake8-implicit-str-concat, but only on a single line (includes bytes)
+  "ISC001",
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,12 @@ module = [
   "psutil",
 ]
 ignore_missing_imports = true
+
+[tool.ruff]
+target-version = "py39"
+# same as black
+line-length = 100
+
+[tool.ruff.lint]
+select = [
+]


### PR DESCRIPTION
This swaps all flake8 usage to ruff via the built-in Ruff backend, except for the custom PNT20 and PNT30 custom rules.

We still have to run flake8, and it does not run much faster (still ~10s). So, this is doing "strictly" more work than previously: run flake8 _and_ ruff.

However this change does open the door for easily enabling some additional lints that are built-in to ruff, like #21018, rather than requiring searching out and installing a flake8 plugin.


I did some basic experiments running

- flake8 on `main`: `pants --no-local-cache lint --stats-log --only=flake8 ::`
- ruff on this PR: `pants --no-local-cache lint --stats-log --only=ruff-check ::`

| timing | flake8 | ruff |
|---|---|---|
| building requirements/PEX (A) | 0.8 | 0.9  |
| `local_process_total_time_run_ms` (B) | 27.757 | 8.643 |
| time spent actually running the linter (B - A) | ~27 | 7.7 |

Running ruff outside of pants runs much faster (e.g. `ruff check .` takes like 300ms, so I'd expect a lot of the 7.7 seconds is Pants overhead, e.g. setting up sandboxes or unzipping pexes or whatever. https://github.com/pantsbuild/pants/issues/18570 is potentially related. 


Thoughts?