### PR TITLE
Fix bug when computing implicit kwargs in @rules called by name.

### DIFF
--- a/src/rust/engine/src/nodes/task.rs
+++ b/src/rust/engine/src/nodes/task.rs
@@ -283,7 +283,13 @@ impl Task {
                     let res = if let Some(args) = args {
                         let args = args.value.extract::<&PyTuple>(py)?;
                         let kwargs = PyDict::new(py);
-                        for ((name, _), value) in self.task.args.iter().zip(deps.into_iter()) {
+                        for ((name, _), value) in self
+                            .task
+                            .args
+                            .iter()
+                            .skip(self.args_arity.into())
+                            .zip(deps.into_iter())
+                        {
                             kwargs.set_item(name, &value)?;
                         }
                         func.call(args, Some(kwargs))


### PR DESCRIPTION
Previously, when invoking a rule by name, if there were explicit
positional args, we would fail to skip over them when computing
the implicit arguments to be provided as kwargs.