### PR TITLE
[Call-by-name] Fixed ignored compound statements and generator MultiGets 

### DIFF
--- a/src/python/pants/goal/migrate_call_by_name.py
+++ b/src/python/pants/goal/migrate_call_by_name.py
@@ -12,7 +12,7 @@ import tokenize
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path, PurePath
-from typing import Callable, TypedDict
+from typing import Callable, Literal, TypedDict
 
 from pants.base.build_environment import get_buildroot
 from pants.base.exiter import PANTS_SUCCEEDED_EXIT_CODE, ExitCode
@@ -225,8 +225,6 @@ class MigrateCallByNameBuiltinGoal(BuiltinGoal):
         This function is not idempotent, so it should be run only once per file (per migration plan).
 
         Replacement imports are bulk added below the existing "pants.engine.rules" import.
-
-
         """
 
         imports_added = False
@@ -614,18 +612,27 @@ class CallByNameVisitor(ast.NodeVisitor):
             return
 
         for child in node.body:
-            if call := self._maybe_replaceable_call(child):
-                if replacement := self.syntax_mapper.map_get_to_new_syntax(
-                    call, self.filename, calling_func=node.name
-                ):
-                    self.replacements.append(replacement)
+            if isinstance(child, ast.If):
+                for if_child in child.body:
+                    self._maybe_add_replacements(node.name, if_child)
+            else:
+                self._maybe_add_replacements(node.name, child)
 
-            for call in self._maybe_replaceable_multiget(child):
-                if replacement := self.syntax_mapper.map_get_to_new_syntax(
-                    call, self.filename, calling_func=node.name
-                ):
-                    replacement.is_argument = True
-                    self.replacements.append(replacement)
+    def _maybe_add_replacements(self, calling_func: str, statement: ast.stmt):
+        if call := self._maybe_replaceable_call(statement):
+            if replacement := self.syntax_mapper.map_get_to_new_syntax(
+                call, self.filename, calling_func=calling_func
+            ):
+                self.replacements.append(replacement)
+
+        for call, statement_type in self._maybe_replaceable_multiget(statement):
+            if replacement := self.syntax_mapper.map_get_to_new_syntax(
+                call, self.filename, calling_func=calling_func
+            ):
+                # Fixes an issue with generators having trailing commas causing a syntax error
+                # TODO: A better solution might be to use libcst or similar, rather than an ast
+                replacement.is_argument = statement_type == "call"
+                self.replacements.append(replacement)
 
     def _should_visit_node(self, decorator_list: list[ast.expr]) -> bool:
         """Only interested in async functions with the @rule(...) or @goal_rule(...) decorator."""
@@ -667,23 +674,37 @@ class CallByNameVisitor(ast.NodeVisitor):
             return call_node
         return None
 
-    def _maybe_replaceable_multiget(self, statement: ast.stmt) -> list[ast.Call]:
-        """Looks for the following form of MultiGet that we want to replace:
+    def _maybe_replaceable_multiget(
+        self, statement: ast.stmt
+    ) -> list[tuple[ast.Call, Literal["call", "generator"]]]:
+        """Looks for the following forms of MultiGet that we want to replace:
 
         - multigot = await MultiGet(Get(...), Get(...), ...)
+        - multigot = await MultiGet(Get(...) for x in y)
         """
-        if (
+        if not (
             isinstance(statement, ast.Assign)
             and isinstance((await_node := statement.value), ast.Await)
             and isinstance((call_node := await_node.value), ast.Call)
             and isinstance(call_node.func, ast.Name)
             and call_node.func.id == "MultiGet"
         ):
-            return [
-                arg
-                for arg in call_node.args
-                if isinstance(arg, ast.Call)
+            return []
+
+        args: list[tuple[ast.Call, Literal["call", "generator"]]] = []
+        for arg in call_node.args:
+            if (
+                isinstance(arg, ast.Call)
                 and isinstance(arg.func, ast.Name)
                 and arg.func.id == "Get"
-            ]
-        return []
+            ):
+                args.append((arg, "call"))
+
+            if (
+                isinstance(arg, ast.GeneratorExp)
+                and isinstance((call_arg := arg.elt), ast.Call)
+                and isinstance(call_arg.func, ast.Name)
+                and call_arg.func.id == "Get"
+            ):
+                args.append((call_arg, "generator"))
+        return args

--- a/src/python/pants/goal/migrate_call_by_name_integration_test.py
+++ b/src/python/pants/goal/migrate_call_by_name_integration_test.py
@@ -95,8 +95,20 @@ RULES1_FILE = dedent(
         pex = await Get(VenvPex, PexRequest, black.to_pex_request())
         digest = await Get(Digest, CreateArchive(EMPTY_SNAPSHOT))
         paths = await Get(BinaryPaths, {{BinaryPathRequest(binary_name="time", search_path=("/usr/bin")): BinaryPathRequest, local_env.val: EnvironmentName}})
+        try:
+            try_all_targets_try = await Get(AllTargets)
+        except:
+            try_all_targets_except = await Get(AllTargets)
+        else:
+            try_all_targets_else = await Get(AllTargets)
+        finally:
+            try_all_targets_finally = await Get(AllTargets)
         if True:
-            conditional_all_targets = await Get(AllTargets)
+            conditional_all_targets_if = await Get(AllTargets)
+        elif False:
+            conditional_all_targets_elif = await Get(AllTargets)
+        else:
+            conditional_all_targets_else = await Get(AllTargets)
 
     class Bar:
         pass
@@ -174,8 +186,20 @@ MIGRATED_RULES1_FILE = dedent(
         pex = await create_venv_pex(**implicitly({black.to_pex_request(): PexRequest}))
         digest = await create_archive(CreateArchive(EMPTY_SNAPSHOT), **implicitly())
         paths = await find_binary(**implicitly({BinaryPathRequest(binary_name='time', search_path='/usr/bin'): BinaryPathRequest, local_env.val: EnvironmentName}))
+        try:
+            try_all_targets_try = await find_all_targets(**implicitly())
+        except:
+            try_all_targets_except = await find_all_targets(**implicitly())
+        else:
+            try_all_targets_else = await find_all_targets(**implicitly())
+        finally:
+            try_all_targets_finally = await find_all_targets(**implicitly())
         if True:
-            conditional_all_targets = await find_all_targets(**implicitly())
+            conditional_all_targets_if = await find_all_targets(**implicitly())
+        elif False:
+            conditional_all_targets_elif = await find_all_targets(**implicitly())
+        else:
+            conditional_all_targets_else = await find_all_targets(**implicitly())
 
     class Bar:
         pass
@@ -287,8 +311,9 @@ def test_migrate_call_by_name_syntax():
         # Ensure the JSON output contains the paths to the files we expect to migrate
         assert all(str(p) in result.stdout for p in [register_path, rules1_path, rules2_path])
         # Ensure the warning for embedded comments is logged
+        # Note: This assertion is brittle - adding extra content to rules1.py will probably mean updating the range
         assert (
-            f"Comments found in {tmpdir}/src/migrateme/rules1.py within replacement range: (39, 44)"
+            f"Comments found in {tmpdir}/src/migrateme/rules1.py within replacement range: (51, 56)"
             in result.stderr
         )
 

--- a/src/python/pants/goal/migrate_call_by_name_integration_test.py
+++ b/src/python/pants/goal/migrate_call_by_name_integration_test.py
@@ -95,6 +95,8 @@ RULES1_FILE = dedent(
         pex = await Get(VenvPex, PexRequest, black.to_pex_request())
         digest = await Get(Digest, CreateArchive(EMPTY_SNAPSHOT))
         paths = await Get(BinaryPaths, {{BinaryPathRequest(binary_name="time", search_path=("/usr/bin")): BinaryPathRequest, local_env.val: EnvironmentName}})
+        if True:
+            conditional_all_targets = await Get(AllTargets)
 
     class Bar:
         pass
@@ -136,6 +138,10 @@ RULES1_FILE = dedent(
             ),
             digest_get
         )
+        multigot_forloop = await MultiGet(
+            Get(Digest, CreateArchive(EMPTY_SNAPSHOT))
+            for i in [0, 1, 2]
+        )
 
     def rules():
         return collect_rules()
@@ -168,6 +174,8 @@ MIGRATED_RULES1_FILE = dedent(
         pex = await create_venv_pex(**implicitly({black.to_pex_request(): PexRequest}))
         digest = await create_archive(CreateArchive(EMPTY_SNAPSHOT), **implicitly())
         paths = await find_binary(**implicitly({BinaryPathRequest(binary_name='time', search_path='/usr/bin'): BinaryPathRequest, local_env.val: EnvironmentName}))
+        if True:
+            conditional_all_targets = await find_all_targets(**implicitly())
 
     class Bar:
         pass
@@ -200,6 +208,10 @@ MIGRATED_RULES1_FILE = dedent(
             all_targets_get,
             create_venv_pex(**implicitly({black.to_pex_request(): PexRequest})),
             digest_get
+        )
+        multigot_forloop = await concurrently(
+            create_archive(CreateArchive(EMPTY_SNAPSHOT), **implicitly())
+            for i in [0, 1, 2]
         )
 
     def rules():
@@ -276,7 +288,7 @@ def test_migrate_call_by_name_syntax():
         assert all(str(p) in result.stdout for p in [register_path, rules1_path, rules2_path])
         # Ensure the warning for embedded comments is logged
         assert (
-            f"Comments found in {tmpdir}/src/migrateme/rules1.py within replacement range: (37, 42)"
+            f"Comments found in {tmpdir}/src/migrateme/rules1.py within replacement range: (39, 44)"
             in result.stderr
         )
 


### PR DESCRIPTION
This PR captures two missing cases from migration. Specifically, `Get` calls within [compound statements](https://docs.python.org/3/reference/compound_stmts.html) and generator-based `MultiGet`s.

The generator-based `MultiGet`s are a big deal, because they're used everywhere in Pants and plugin code. The compound statement use cases are less frequent (e.g. conditional rule calls), but the recursive approach in this PR should capture most of edge cases we'd otherwise have to manually port.

I've opened https://github.com/pantsbuild/pants/issues/21040 to investigate using `libcst` or another CST, in place of the native ast. Pros/Cons - but I think a lot of the code here could be cleaned up, and we already have the tests :) 

See #19730 