### PR TITLE
Fix running python_sources with pex --executable

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -72,6 +72,8 @@ The deprecation for the `pants.backend.experimental.python.lint.ruff` backend pa
 
 The default version of the pex tool has been updated from 2.3.1 to 2.3.3.
 
+Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
+
 #### Terraform
 
 The `tfsec` linter now works on all supported platforms without extra config. 

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -57,7 +57,7 @@ class PythonSourceFieldSet(RunFieldSet):
         if not all(part.isidentifier() for part in source_name.split(".")):
             # If the python source is not importable (python modules can't be named with '-'),
             # then it must be an executable script.
-            executable = Executable(self.source.value)
+            executable = Executable.create(self.address, self.source.value)
         else:
             # The module is importable, so entry_point will do the heavy lifting instead.
             executable = None

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -301,6 +301,12 @@ class ConsoleScript(MainSpecification):
 class Executable(MainSpecification):
     executable: str
 
+    @classmethod
+    def create(cls, address: Address, filename: str) -> Executable:
+        # spec_path is relative to the workspace. The rule is responsible for
+        # stripping the source root as needed.
+        return cls(os.path.join(address.spec_path, filename).lstrip(os.path.sep))
+
     def iter_pex_args(self) -> Iterator[str]:
         yield "--executable"
         # We do NOT yield self.executable or self.spec
@@ -409,9 +415,7 @@ class PexExecutableField(Field):
             return None
         if not isinstance(value, str):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
-        # spec_path is relative to the workspace. The rule is responsible for
-        # stripping the source root as needed.
-        return Executable(os.path.join(address.spec_path, value).lstrip(os.path.sep))
+        return Executable.create(address, value)
 
 
 class PexArgsField(StringSequenceField):

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -555,14 +555,10 @@ async def create_pex_from_targets(
     if request.additional_sources:
         sources_digests.append(request.additional_sources)
     if request.include_source_files:
-        if executable_addresses:
-            addresses = (*request.addresses, *executable_addresses)
-        else:
-            addresses = request.addresses
         transitive_targets = await Get(
             TransitiveTargets,
             TransitiveTargetsRequest(
-                addresses,
+                (*request.addresses, *executable_addresses),
                 should_traverse_deps_predicate=TraverseIfNotPackageTarget(
                     roots=request.addresses,
                     union_membership=union_membership,


### PR DESCRIPTION
This fixes the feature added in #20497 as it broke using `pants run` on a python_source if the file name has `-` or other invalid characters. Bug reported here: 
https://pantsbuild.slack.com/archives/C046T6T9U/p1717624913138789?thread_ts=1717624913.138789&cid=C046T6T9U

The other integration test for the pex --executable feature only tested running pex_binary, not python_source. So, I missed applying some of the path logic to both cases.