### PR TITLE
Add "workspace invalidation" sources support for shell / adhoc backends

### DIFF
--- a/docs/docs/using-pants/environments.mdx
+++ b/docs/docs/using-pants/environments.mdx
@@ -257,6 +257,8 @@ Thus, Pants puts that burden on you, the Pants user, to ensure a process output 
 
 If a process isn't reproducible, re-running a build from the same source code could fail unexpectedly, or give different output to an earlier build.
 
+You should use the `workspace_invalidation_sources` field available on the `adhoc_tool` and `shell_command` target types to inform Pants of what files should cause re-execution of the target's process if they change.
+
 :::
 
 The special environment name `__local_workspace__` can be used to select a matching `experimental_workspace_environment` based on its `compatible_platforms` attribute.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -93,6 +93,10 @@ Fixed a bug where the internal Docker BuildKit parser would return `<unknown> im
 
 Fixed pulling `helm_artifact`s from OCI repositories.
 
+#### Shell
+
+Added `hash_only_souces_globs` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files (and should the target should be invalidated when those files change) without bringing those files into the execution sandbox. This is intended to work wih the `workspace_environment` support where processes are executed in the workspace and not in a sandbox.
+
 ### Plugin API changes
 
 Fixed bug with workspace environment support where Pants used a workspace environment when it was searching for a local environment.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -95,7 +95,7 @@ Fixed pulling `helm_artifact`s from OCI repositories.
 
 #### Shell
 
-Added `hash_only_souces_globs` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files (and should the target should be invalidated when those files change) without bringing those files into the execution sandbox. This is intended to work wih the `workspace_environment` support where processes are executed in the workspace and not in a sandbox.
+Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work wih the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
 
 ### Plugin API changes
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -95,7 +95,7 @@ Fixed pulling `helm_artifact`s from OCI repositories.
 
 #### Shell
 
-Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work wih the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
+Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work with the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.
 
 ### Plugin API changes
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
+import os
 
 from pants.backend.adhoc.target_types import (
     AdhocToolArgumentsField,
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
+    AdhocToolHashOnlySourcesGlobsField,
     AdhocToolLogOutputField,
     AdhocToolNamedCachesField,
     AdhocToolOutputDirectoriesField,
@@ -20,6 +22,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolStdoutFilenameField,
     AdhocToolWorkdirField,
 )
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.adhoc_process_support import (
     AdhocProcessRequest,
@@ -30,7 +33,7 @@ from pants.core.util_rules.adhoc_process_support import (
 from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_support_rules
 from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import Digest, Snapshot
+from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import GeneratedSources, GenerateSourcesRequest
 from pants.engine.unions import UnionRule
@@ -81,6 +84,16 @@ async def run_in_sandbox_request(
 
     cache_scope = env_target.default_cache_scope
 
+    hash_only_sources_globs: PathGlobs | None = None
+    raw_hash_only_sources_globs = target.get(AdhocToolHashOnlySourcesGlobsField).value or ()
+    if raw_hash_only_sources_globs:
+        spec_path = target.address.spec_path
+        hash_only_sources_globs = PathGlobs(
+            globs=(os.path.join(spec_path, glob) for glob in raw_hash_only_sources_globs),
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=f"`{AdhocToolHashOnlySourcesGlobsField.alias}` for `adhoc_tool` target at `{target.address}`",
+        )
+
     process_request = AdhocProcessRequest(
         description=description,
         address=target.address,
@@ -99,6 +112,7 @@ async def run_in_sandbox_request(
         log_output=target[AdhocToolLogOutputField].value,
         capture_stderr_file=target[AdhocToolStderrFilenameField].value,
         capture_stdout_file=target[AdhocToolStdoutFilenameField].value,
+        hash_only_sources_globs=hash_only_sources_globs,
         cache_scope=cache_scope,
     )
 

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -56,9 +56,19 @@ def rule_runner() -> PythonRuleRunner:
             PythonSourceTarget,
             LocalWorkspaceEnvironmentTarget,
         ],
+        isolated_local_store=True,
     )
     rule_runner.set_options([], env_inherit={"PATH"})
     return rule_runner
+
+
+def execute_adhoc_tool(
+    rule_runner: PythonRuleRunner,
+    address: Address,
+) -> GeneratedSources:
+    generator_type: type[GenerateSourcesRequest] = GenerateFilesFromAdhocToolRequest
+    target = rule_runner.get_target(address)
+    return rule_runner.request(GeneratedSources, [generator_type(EMPTY_SNAPSHOT, target)])
 
 
 def assert_adhoc_tool_result(
@@ -66,9 +76,7 @@ def assert_adhoc_tool_result(
     address: Address,
     expected_contents: dict[str, str],
 ) -> None:
-    generator_type: type[GenerateSourcesRequest] = GenerateFilesFromAdhocToolRequest
-    target = rule_runner.get_target(address)
-    result = rule_runner.request(GeneratedSources, [generator_type(EMPTY_SNAPSHOT, target)])
+    result = execute_adhoc_tool(rule_runner, address)
     assert result.snapshot.files == tuple(expected_contents)
     contents = rule_runner.request(DigestContents, [result.snapshot.digest])
     for fc in contents:
@@ -334,3 +342,35 @@ def test_adhoc_tool_with_workspace_execution(rule_runner: PythonRuleRunner) -> N
     workspace_output_path = Path(rule_runner.build_root).joinpath("foo.txt")
     assert workspace_output_path.exists()
     assert workspace_output_path.read_text().strip() == "workspace"
+
+
+def test_adhoc_tool_hash_only_sources_globs(rule_runner: PythonRuleRunner) -> None:
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                """\
+            system_binary(name="bash", binary_name="bash")
+            adhoc_tool(
+              name="cmd",
+              runnable=":bash",
+              # Use a random value so we can detect when re-execution occurs.
+              args=["-c", "echo $RANDOM > out.log"],
+              output_files=["out.log"],
+              hash_only_sources_globs=['a-file'],
+            )
+            """
+            ),
+            "src/a-file": "",
+        }
+    )
+    address = Address("src", target_name="cmd")
+
+    # Re-executing the initial execution should be cached.
+    result1 = execute_adhoc_tool(rule_runner, address)
+    result2 = execute_adhoc_tool(rule_runner, address)
+    assert result1.snapshot == result2.snapshot
+
+    # Update the hash-only source file's content. The adhoc_tool should be re-executed now.
+    (Path(rule_runner.build_root) / "src" / "a-file").write_text("xyzzy")
+    result3 = execute_adhoc_tool(rule_runner, address)
+    assert result1.snapshot != result3.snapshot

--- a/src/python/pants/backend/adhoc/adhoc_tool_test.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool_test.py
@@ -344,7 +344,7 @@ def test_adhoc_tool_with_workspace_execution(rule_runner: PythonRuleRunner) -> N
     assert workspace_output_path.read_text().strip() == "workspace"
 
 
-def test_adhoc_tool_hash_only_sources_globs(rule_runner: PythonRuleRunner) -> None:
+def test_adhoc_tool_workspace_invalidation_sources(rule_runner: PythonRuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/BUILD": dedent(
@@ -356,7 +356,7 @@ def test_adhoc_tool_hash_only_sources_globs(rule_runner: PythonRuleRunner) -> No
               # Use a random value so we can detect when re-execution occurs.
               args=["-c", "echo $RANDOM > out.log"],
               output_files=["out.log"],
-              hash_only_sources_globs=['a-file'],
+              workspace_invalidation_sources=['a-file'],
             )
             """
             ),

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -253,6 +253,22 @@ class AdhocToolOutputRootDirField(StringField):
     )
 
 
+class AdhocToolHashOnlySourcesGlobsField(StringSequenceField):
+    alias: ClassVar[str] = "hash_only_sources_globs"
+    help = help_text(
+        """
+        Path globs for source files on which this target depends indirectly, but which should not be
+        materlized into the execution sandbox. Pants will compute the hash of all of the files
+        references by the globs and include that hash as part of the cache key for the
+        process to be executed (as an environment variable).
+
+        Note: The files will not materialized into the execution sandbox because this field is intended
+        to be used with the `workspace_environment` target type which executes processes in the
+        repository itself.
+        """
+    )
+
+
 class AdhocToolTarget(Target):
     alias: ClassVar[str] = "adhoc_tool"
     core_fields = (
@@ -272,6 +288,7 @@ class AdhocToolTarget(Target):
         AdhocToolOutputRootDirField,
         AdhocToolStdoutFilenameField,
         AdhocToolStderrFilenameField,
+        AdhocToolHashOnlySourcesGlobsField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -10,7 +10,6 @@ from pants.backend.adhoc.target_types import (
     AdhocToolDependenciesField,
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
-    AdhocToolHashOnlySourcesGlobsField,
     AdhocToolLogOutputField,
     AdhocToolNamedCachesField,
     AdhocToolOutputDependenciesField,
@@ -20,6 +19,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolRunnableDependenciesField,
     AdhocToolTimeoutField,
     AdhocToolWorkdirField,
+    AdhocToolWorkspaceInvalidationSourcesField,
 )
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.core.goals.test import RuntimePackageDependenciesField, TestTimeoutField
@@ -380,7 +380,7 @@ class ShellCommandNamedCachesField(AdhocToolNamedCachesField):
     pass
 
 
-class ShellCommandHashOnlySourcesGlobsField(AdhocToolHashOnlySourcesGlobsField):
+class ShellCommandWorkspaceInvalidationSourcesField(AdhocToolWorkspaceInvalidationSourcesField):
     pass
 
 
@@ -408,7 +408,7 @@ class ShellCommandTarget(Target):
         ShellCommandWorkdirField,
         ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
-        ShellCommandHashOnlySourcesGlobsField,
+        ShellCommandWorkspaceInvalidationSourcesField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolDependenciesField,
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
+    AdhocToolHashOnlySourcesGlobsField,
     AdhocToolLogOutputField,
     AdhocToolNamedCachesField,
     AdhocToolOutputDependenciesField,
@@ -379,6 +380,10 @@ class ShellCommandNamedCachesField(AdhocToolNamedCachesField):
     pass
 
 
+class ShellCommandHashOnlySourcesGlobsField(AdhocToolHashOnlySourcesGlobsField):
+    pass
+
+
 class SkipShellCommandTestsField(BoolField):
     alias = "skip_tests"
     default = False
@@ -403,6 +408,7 @@ class ShellCommandTarget(Target):
         ShellCommandWorkdirField,
         ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
+        ShellCommandHashOnlySourcesGlobsField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -14,7 +14,6 @@ from pants.backend.shell.target_types import (
     ShellCommandCommandField,
     ShellCommandExecutionDependenciesField,
     ShellCommandExtraEnvVarsField,
-    ShellCommandHashOnlySourcesGlobsField,
     ShellCommandLogOutputField,
     ShellCommandNamedCachesField,
     ShellCommandOutputDirectoriesField,
@@ -26,6 +25,7 @@ from pants.backend.shell.target_types import (
     ShellCommandTimeoutField,
     ShellCommandToolsField,
     ShellCommandWorkdirField,
+    ShellCommandWorkspaceInvalidationSourcesField,
 )
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
 from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
@@ -152,16 +152,16 @@ async def _prepare_process_request_from_target(
 
     cache_scope = env_target.default_cache_scope
 
-    hash_only_sources_globs: PathGlobs | None = None
-    raw_hash_only_sources_globs = (
-        shell_command.get(ShellCommandHashOnlySourcesGlobsField).value or ()
+    workspace_invalidation_globs: PathGlobs | None = None
+    workspace_invalidation_sources = (
+        shell_command.get(ShellCommandWorkspaceInvalidationSourcesField).value or ()
     )
-    if raw_hash_only_sources_globs:
+    if workspace_invalidation_sources:
         spec_path = shell_command.address.spec_path
-        hash_only_sources_globs = PathGlobs(
-            globs=(os.path.join(spec_path, glob) for glob in raw_hash_only_sources_globs),
+        workspace_invalidation_globs = PathGlobs(
+            globs=(os.path.join(spec_path, glob) for glob in workspace_invalidation_sources),
             glob_match_error_behavior=GlobMatchErrorBehavior.error,
-            description_of_origin=f"`{ShellCommandHashOnlySourcesGlobsField.alias}` for `shell_command` target at `{shell_command.address}`",
+            description_of_origin=f"`{ShellCommandWorkspaceInvalidationSourcesField.alias}` for `shell_command` target at `{shell_command.address}`",
         )
 
     return AdhocProcessRequest(
@@ -182,7 +182,7 @@ async def _prepare_process_request_from_target(
         log_output=shell_command[ShellCommandLogOutputField].value,
         capture_stdout_file=None,
         capture_stderr_file=None,
-        hash_only_sources_globs=hash_only_sources_globs,
+        workspace_invalidation_globs=workspace_invalidation_globs,
         cache_scope=cache_scope,
     )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import shlex
 from dataclasses import dataclass
 
@@ -13,6 +14,7 @@ from pants.backend.shell.target_types import (
     ShellCommandCommandField,
     ShellCommandExecutionDependenciesField,
     ShellCommandExtraEnvVarsField,
+    ShellCommandHashOnlySourcesGlobsField,
     ShellCommandLogOutputField,
     ShellCommandNamedCachesField,
     ShellCommandOutputDirectoriesField,
@@ -26,6 +28,7 @@ from pants.backend.shell.target_types import (
     ShellCommandWorkdirField,
 )
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
+from pants.base.glob_match_error_behavior import GlobMatchErrorBehavior
 from pants.core.goals.run import RunFieldSet, RunInSandboxBehavior, RunRequest
 from pants.core.target_types import FileSourceField
 from pants.core.util_rules.adhoc_process_support import (
@@ -41,7 +44,7 @@ from pants.core.util_rules.adhoc_process_support import rules as adhoc_process_s
 from pants.core.util_rules.environments import EnvironmentNameRequest, EnvironmentTarget
 from pants.core.util_rules.system_binaries import BashBinary, BinaryShims, BinaryShimsRequest
 from pants.engine.environment import EnvironmentName
-from pants.engine.fs import Digest, Snapshot
+from pants.engine.fs import Digest, PathGlobs, Snapshot
 from pants.engine.internals.native_engine import EMPTY_DIGEST
 from pants.engine.process import Process
 from pants.engine.rules import Get, collect_rules, rule
@@ -149,6 +152,18 @@ async def _prepare_process_request_from_target(
 
     cache_scope = env_target.default_cache_scope
 
+    hash_only_sources_globs: PathGlobs | None = None
+    raw_hash_only_sources_globs = (
+        shell_command.get(ShellCommandHashOnlySourcesGlobsField).value or ()
+    )
+    if raw_hash_only_sources_globs:
+        spec_path = shell_command.address.spec_path
+        hash_only_sources_globs = PathGlobs(
+            globs=(os.path.join(spec_path, glob) for glob in raw_hash_only_sources_globs),
+            glob_match_error_behavior=GlobMatchErrorBehavior.error,
+            description_of_origin=f"`{ShellCommandHashOnlySourcesGlobsField.alias}` for `shell_command` target at `{shell_command.address}`",
+        )
+
     return AdhocProcessRequest(
         description=description,
         address=shell_command.address,
@@ -167,6 +182,7 @@ async def _prepare_process_request_from_target(
         log_output=shell_command[ShellCommandLogOutputField].value,
         capture_stdout_file=None,
         capture_stderr_file=None,
+        hash_only_sources_globs=hash_only_sources_globs,
         cache_scope=cache_scope,
     )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import shlex
+import time
 from pathlib import Path
 from textwrap import dedent
 
@@ -907,5 +908,6 @@ def test_shell_command_workspace_invalidation_sources(rule_runner: RuleRunner) -
 
     # Update the hash-only source file's content. The shell_command should be re-executed now.
     (Path(rule_runner.build_root) / "src" / "a-file").write_text("xyzzy")
+    time.sleep(0.100)
     result3 = execute_shell_command(rule_runner, address)
     assert result1.snapshot != result3.snapshot

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -881,7 +881,7 @@ def test_shell_command_with_workspace_execution(rule_runner: RuleRunner) -> None
     assert workspace_output_path.read_text().strip() == "workspace"
 
 
-def test_shell_command_hash_only_sources_globs(rule_runner: RuleRunner) -> None:
+def test_shell_command_workspace_invalidation_sources(rule_runner: RuleRunner) -> None:
     rule_runner.write_files(
         {
             "src/BUILD": dedent(
@@ -891,7 +891,7 @@ def test_shell_command_hash_only_sources_globs(rule_runner: RuleRunner) -> None:
               # Use a random value so we can detect when re-execution occurs.
               command='echo $RANDOM > out.log',
               output_files=["out.log"],
-              hash_only_sources_globs=['a-file'],
+              workspace_invalidation_sources=['a-file'],
             )
             """
             ),


### PR DESCRIPTION
Add support for "workspace invalidation" sources for the `adhoc_tool` and `shell_command` target types. This supports allows those targets to depend on the content of files in the repository without materializing those sources in the execution sandbox. This support is intended to be used in conjunction with the workspace environment where execution does not take place in a sandbox.

The new field `workspace_invalidation_sources` on both target types is a list of globs into the repository. The digest of the referenced files will be inserted as an environment variable in the process executed (which makes it part of the process's cache key).