### PR TITLE
fix(scala): dependency inference for typed patterns referring same package

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -57,6 +57,8 @@ The deprecation for `crossversion="partial"` on `scala_artifact` has expired. Us
 
 The Scala dependency inference now understand usages of the `_root_` package name as a marker for disambiguating between colliding dependencies and will try to resolve those symbols as absolute. For instance, `import _root_.io.circe.syntax` will now be understood as an import of `io.circie.syntax`.
 
+Scala dependency inference now also understands types refered to only by pattern matching cases such as `case MyType() =>`. These used to require manually adding a dependency if the type was defined in a separate file even if it was in the same package. This is now inferred.
+
 #### NEW: Trufflehog
 
 A new experimental `pants.backend.experimental.tools.trufflehog` backend was added to support

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -471,6 +471,9 @@ class SourceAnalysisTraverser extends Traverser {
       extractName(node).foreach(recordConsumedSymbol(_))
     }
 
+    case Pat.Typed((_name, decltpe)) =>
+      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+
     case node => super.apply(node)
   }
 

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -472,7 +472,7 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Pat.Typed((_name, decltpe)) =>
-      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).iterator.foreach(recordConsumedSymbol(_))
 
     case node => super.apply(node)
   }

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -778,3 +778,26 @@ def test_self_types_on_same_package(rule_runner: RuleRunner) -> None:
     assert sorted(analysis.fully_qualified_consumed_symbols()) == [
         "foo.Foo",
     ]
+
+
+def test_typed_pattern_on_same_package(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """\
+            package foo
+            class A
+            object B {
+                def fn(v: Any) = v match {
+                    case _: A =>
+                }
+            }
+            """
+        ),
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == [
+        "foo.A",
+        "foo.Any",
+        "foo.v",
+    ]


### PR DESCRIPTION
Fixes https://github.com/pantsbuild/pants/issues/20302

Types in match patterns are not detected as consumed symbols. So dependency inference fails to detect symbols in the same package in a different file unless imported or added to dependencies manually.

This fixes inference for cases like:
```scala
// A.scala
package pkg
class AClass

// B.scala
package pkg
def myFn = {
  case v: AClass =>
}
```

Similar to a another recent fix [here](https://github.com/pantsbuild/pants/pull/20960)