### PR TITLE
Require pants using normalized package names.

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -89,6 +89,8 @@ Fixed bug with workspace environment support where Pants used a workspace enviro
 
 The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.
 
+The plugin development BUILD file target `pants_requirements` now results in a `Requires-Dist: ` dependency on the normalized package name of `pantsbuild-pants` for the plugin.
+
 ## Full Changelog
 
 For the full changelog, see the individual GitHub Releases for this series: https://github.com/pantsbuild/pants/releases

--- a/src/python/pants/backend/plugin_development/pants_requirements.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements.py
@@ -92,9 +92,9 @@ def generate_from_pants_requirements(
             union_membership,
         )
 
-    result = [create_tgt("pantsbuild.pants", "pants")]
+    result = [create_tgt("pantsbuild-pants", "pants")]
     if generator[PantsRequirementsTestutilField].value:
-        result.append(create_tgt("pantsbuild.pants.testutil", "pants.testutil"))
+        result.append(create_tgt("pantsbuild-pants-testutil", "pants.testutil"))
     return GeneratedTargets(generator, result)
 
 

--- a/src/python/pants/backend/plugin_development/pants_requirements_test.py
+++ b/src/python/pants/backend/plugin_development/pants_requirements_test.py
@@ -46,17 +46,17 @@ def test_target_generator() -> None:
         ],
     ).parametrizations
     assert len(result) == 2
-    pants_req = next(t for t in result.values() if t.address.generated_name == "pantsbuild.pants")
+    pants_req = next(t for t in result.values() if t.address.generated_name == "pantsbuild-pants")
     testutil_req = next(
-        t for t in result.values() if t.address.generated_name == "pantsbuild.pants.testutil"
+        t for t in result.values() if t.address.generated_name == "pantsbuild-pants-testutil"
     )
     assert pants_req[PythonRequirementModulesField].value == ("pants",)
     assert testutil_req[PythonRequirementModulesField].value == ("pants.testutil",)
     assert pants_req[PythonRequirementsField].value == (
-        PipRequirement.parse(f"pantsbuild.pants=={VERSION}"),
+        PipRequirement.parse(f"pantsbuild-pants=={VERSION}"),
     )
     assert testutil_req[PythonRequirementsField].value == (
-        PipRequirement.parse(f"pantsbuild.pants.testutil=={VERSION}"),
+        PipRequirement.parse(f"pantsbuild-pants-testutil=={VERSION}"),
     )
     assert pants_req[PythonRequirementFindLinksField].value == (
         "https://wheels.pantsbuild.org/simple",
@@ -77,7 +77,7 @@ def test_target_generator() -> None:
         ],
     ).parametrizations
     assert len(result) == 1
-    assert next(iter(result.keys())).generated_name == "pantsbuild.pants"
+    assert next(iter(result.keys())).generated_name == "pantsbuild-pants"
     pants_req = next(iter(result.values()))
     assert pants_req[PythonRequirementResolveField].value == "a"
 
@@ -89,15 +89,15 @@ def test_target_generator() -> None:
             )
         ],
     ).parametrizations
-    pants_req = next(t for t in result.values() if t.address.generated_name == "pantsbuild.pants")
+    pants_req = next(t for t in result.values() if t.address.generated_name == "pantsbuild-pants")
     testutil_req = next(
-        t for t in result.values() if t.address.generated_name == "pantsbuild.pants.testutil"
+        t for t in result.values() if t.address.generated_name == "pantsbuild-pants-testutil"
     )
     assert pants_req[PythonRequirementsField].value == (
-        PipRequirement.parse("pantsbuild.pants>=2.16.0,<2.17.0"),
+        PipRequirement.parse("pantsbuild-pants>=2.16.0,<2.17.0"),
     )
     assert testutil_req[PythonRequirementsField].value == (
-        PipRequirement.parse("pantsbuild.pants.testutil>=2.16.0,<2.17.0"),
+        PipRequirement.parse("pantsbuild-pants-testutil>=2.16.0,<2.17.0"),
     )
     assert pants_req[PythonRequirementFindLinksField].value == (
         "https://wheels.pantsbuild.org/simple",


### PR DESCRIPTION
We may want to publish plugins that depend on the pants distribution using a normalized name, but this is not related to the issues reported in #21050.
