### PR TITLE
Scala: Support the usage of the `_root_` package name

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -47,7 +47,7 @@ Source files no longer produce a dependency on Scala plugins. If you are using a
 
 The deprecation for `crossversion="partial"` on `scala_artifact` has expired. Use [`crossversion="binary"`](https://www.pantsbuild.org/2.23/reference/targets/scala_artifact#crossversion) instead.
 
-The Scala dependency inference now understand usages of the `_root_` package name as a marker for disambiguating between colliding dependencies and will try to resolve those symbols as absolute.
+The Scala dependency inference now understand usages of the `_root_` package name as a marker for disambiguating between colliding dependencies and will try to resolve those symbols as absolute. For instance, `import _root_.io.circe.syntax` will now be understood as an import of `io.circie.syntax`.
 
 #### NEW: Trufflehog
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -47,6 +47,8 @@ Source files no longer produce a dependency on Scala plugins. If you are using a
 
 The deprecation for `crossversion="partial"` on `scala_artifact` has expired. Use [`crossversion="binary"`](https://www.pantsbuild.org/2.23/reference/targets/scala_artifact#crossversion) instead.
 
+The Scala dependency inference now understand usages of the `_root_` package name as a marker for disambiguating between colliding dependencies and will try to resolve those symbols as absolute.
+
 #### NEW: Trufflehog
 
 A new experimental `pants.backend.experimental.tools.trufflehog` backend was added to support

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -109,7 +109,7 @@ class SourceAnalysisTraverser extends Traverser {
 
   def currentScope: QualifiedName = {
     // We know `nameParts` is always non-empty, so we can be unsafe here
-    QualifiedName(NonEmptyChain.fromChainUnsafe(Chain.fromSeq(nameParts.toList)))
+    QualifiedName(NonEmptyChain.fromChainUnsafe(Chain.fromSeq(nameParts.toVector)))
   }
 
   // Extract a qualified name from a tree.
@@ -265,7 +265,7 @@ class SourceAnalysisTraverser extends Traverser {
     case Pkg(ref, stats) => {
       extractName(ref).foreach { qname =>
         recordScope(qname)
-        qname.parents.toList.foreach(nameParts.append(_))
+        qname.parents.iterator.foreach(nameParts.append(_))
         qname.simpleName.foreach { name =>
           withNamePart(name, () => super.apply(stats))
         }    
@@ -340,7 +340,7 @@ class SourceAnalysisTraverser extends Traverser {
       visitMods(mods)
       extractName(nameNode).foreach { name =>
         recordProvidedName(name)
-        extractNamesFromTypeTree(body).toList.foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(body).iterator.foreach(recordConsumedSymbol(_))
       }
     }
 
@@ -350,7 +350,7 @@ class SourceAnalysisTraverser extends Traverser {
         extractName(pat).foreach(recordProvidedName(_))
       })
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).iterator.foreach(recordConsumedSymbol(_))
       })
       super.apply(rhs)
     }
@@ -361,7 +361,7 @@ class SourceAnalysisTraverser extends Traverser {
         extractName(pat).foreach(recordProvidedName(_))
       })
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).iterator.foreach(recordConsumedSymbol(_))
       })
       super.apply(rhs)
     }
@@ -371,7 +371,7 @@ class SourceAnalysisTraverser extends Traverser {
       extractName(nameNode).foreach(recordProvidedName(_))
 
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).iterator.foreach(recordConsumedSymbol(_))
       })
 
       apply(tparams)
@@ -382,19 +382,19 @@ class SourceAnalysisTraverser extends Traverser {
 
     case Decl.Def(mods, _nameNode, tparams, params, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).iterator.foreach(recordConsumedSymbol(_))
       apply(tparams)
       params.foreach(param => apply(param))
     }
 
     case Decl.Val(mods, _pats, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).iterator.foreach(recordConsumedSymbol(_))
     }
 
     case Decl.Var(mods, _pats, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).iterator.foreach(recordConsumedSymbol(_))
     }
 
     case Import(importers) => {
@@ -424,21 +424,21 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Init(tpe, _name, argss) => {
-      extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(tpe).iterator.foreach(recordConsumedSymbol(_))
       argss.foreach(_.foreach(apply))
     }
 
     case Term.Param(mods, _name, decltpe, _default) => {
       visitMods(mods)
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).iterator.foreach(recordConsumedSymbol(_))
       })
     }
 
     case Type.Param(mods, _name, _tparams, bounds, _vbounds, cbounds) => {
       visitMods(mods)
-      extractNamesFromTypeTree(bounds).toList.foreach(recordConsumedSymbol(_))
-      Chain.fromSeq(cbounds).flatMap(extractNamesFromTypeTree(_)).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(bounds).iterator.foreach(recordConsumedSymbol(_))
+      Chain.fromSeq(cbounds).flatMap(extractNamesFromTypeTree(_)).iterator.foreach(recordConsumedSymbol(_))
     }
 
     case Ctor.Primary(mods, _name, params_list) => {
@@ -457,7 +457,7 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Self(_name, Some(decltpe)) =>
-      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).iterator.foreach(recordConsumedSymbol(_))
 
     case node @ Term.Select(_, _) => {
       extractName(node).foreach(recordConsumedSymbol(_))

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -4,6 +4,9 @@
   */
 package org.pantsbuild.backend.scala.dependency_inference
 
+import cats.data.{Chain, NonEmptyChain}
+import cats.syntax.all._
+
 import io.circe._
 import io.circe.generic.auto._
 import io.circe.syntax._
@@ -17,26 +20,68 @@ import scala.collection.SortedSet
 import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.reflect.NameTransformer
 
-case class AnImport(
+object Constants {
+  val RootPackageQualifier = "_root_"
+}
+
+case class QualifiedName(parts: NonEmptyChain[String]) {
+  def fromRoot: Boolean = parts.head == Constants.RootPackageQualifier
+
+  def rootlessParts: Chain[String] = {
+    if (fromRoot) parts.tail
+    else parts.toChain
+  }
+
+  def rootlessName: String = {
+    rootlessParts.intercalate(".")
+  }
+
+  def fullName: String =
+    parts.intercalate(".")
+
+  def qualify(name: String): QualifiedName =
+    if (name.isEmpty) this
+    else QualifiedName(parts ++ NonEmptyChain.one(name))
+
+  def qualify(other: QualifiedName): QualifiedName =
+    if (other.fromRoot) other
+    else QualifiedName(parts ++ other.parts)
+
+}
+object QualifiedName {
+  def apply(head: String, tail: String*): QualifiedName =
+    QualifiedName(NonEmptyChain.of(head, tail:_*))
+
+  def fromChain(parts: Chain[String]): QualifiedName =
+    QualifiedName(NonEmptyChain.fromChainUnsafe(parts))
+}
+
+case class AnImport[A](
     // The partially qualified input name for the import, which must be in scope at
     // the import site.
-    name: String,
+    name: A,
     // An optional single token alias for the import in this scope.
     alias: Option[String],
     // True if the import imports all symbols contained within the name.
     isWildcard: Boolean
-)
+) {
+  def map[B](f: A => B): AnImport[B] =
+    copy(name = f(name))
+}
 
 case class Analysis(
     providedSymbols: SortedSet[Analysis.ProvidedSymbol],
     providedSymbolsEncoded: SortedSet[Analysis.ProvidedSymbol],
-    importsByScope: HashMap[String, ArrayBuffer[AnImport]],
-    consumedSymbolsByScope: HashMap[String, HashSet[String]],
+    importsByScope: Map[String, List[AnImport[String]]],
+    consumedSymbolsByScope: Map[String, SortedSet[Analysis.ConsumedSymbol]],
     scopes: Vector[String]
 )
 object Analysis {
   case class ProvidedSymbol(name: String, recursive: Boolean)
+  case class ConsumedSymbol(name: String, fromRoot: Boolean)
+
   implicit val providedSymbolOrdering: Ordering[ProvidedSymbol] = Ordering.by(_.name)
+  implicit val consumedSymbolOrdering: Ordering[ConsumedSymbol] = Ordering.by(_.name)
 }
 
 case class ProvidedSymbol(
@@ -45,90 +90,92 @@ case class ProvidedSymbol(
 )
 
 class SourceAnalysisTraverser extends Traverser {
-  val nameParts = ArrayBuffer[String]()
+  val nameParts = ArrayBuffer[String](Constants.RootPackageQualifier)
   var skipProvidedNames = false
 
-  val providedSymbolsByScope = HashMap[String, HashMap[String, ProvidedSymbol]]()
-  val importsByScope = HashMap[String, ArrayBuffer[AnImport]]()
-  val consumedSymbolsByScope = HashMap[String, HashSet[String]]()
-  val scopes = HashSet[String]()
+  val providedSymbolsByScope = HashMap[QualifiedName, HashMap[String, ProvidedSymbol]]()
+  val importsByScope = HashMap[QualifiedName, ArrayBuffer[AnImport[QualifiedName]]]()
+  val consumedSymbolsByScope = HashMap[QualifiedName, HashSet[QualifiedName]]()
+  val scopes = HashSet[QualifiedName]()
+
+  def currentScope: QualifiedName =
+    QualifiedName.fromChain(Chain.fromSeq(nameParts.toList))
 
   // Extract a qualified name from a tree.
-  def extractName(tree: Tree): String = {
-    def extractNameSelect(qual: Tree, name: Tree): Option[String] =
+  def extractName(tree: Tree): Option[QualifiedName] = {
+    def extractNameSelect(qual: Tree, name: Tree): Option[QualifiedName] =
       (maybeExtractName(qual), maybeExtractName(name)) match {
-        case (Some(qual), Some(name)) => Some(s"$qual.$name")
+        case (Some(qual), Some(name)) => Some(qual.qualify(name))
         case (Some(qual), None)       => Some(qual)
         case (None, Some(name))       => Some(name)
         case (None, None)             => None
       }
 
-    def maybeExtractName(tree: Tree): Option[String] =
+    def maybeExtractName(tree: Tree): Option[QualifiedName] =
       tree match {
         case Term.Select(qual, name)  => extractNameSelect(qual, name)
         case Type.Select(qual, name)  => extractNameSelect(qual, name)
-        case Term.Name(name)          => Some(name)
-        case Type.Name(name)          => Some(name)
+        case Term.Name(name)          => Some(QualifiedName(name))
+        case Type.Name(name)          => Some(QualifiedName(name))
         case Pat.Var(node)            => maybeExtractName(node)
-        case Name.Indeterminate(name) => Some(name)
+        case Name.Indeterminate(name) => Some(QualifiedName(name))
         case _                        => None
       }
 
-    maybeExtractName(tree).getOrElse("")
+    maybeExtractName(tree)
   }
 
-  def extractNamesFromTypeTree(tree: Tree): Vector[String] = {
+  def extractNamesFromTypeTree(tree: Tree): Chain[QualifiedName] = {
     tree match {
-      case Type.Name(name) => Vector(name)
+      case Type.Name(name) => Chain.one(QualifiedName(name))
       case Type.Select(qual, Type.Name(name)) => {
-        val qualName = extractName(qual)
-        Vector(qualifyName(qualName, name))
+        val symbol = extractName(qual).map(_.qualify(name)).getOrElse(QualifiedName(name))
+        Chain.one(symbol)
       }
       case Type.Apply(tpe, args) =>
-        extractNamesFromTypeTree(tpe) ++ args.toVector.flatMap(extractNamesFromTypeTree(_))
+        extractNamesFromTypeTree(tpe) ++ Chain.fromSeq(args).flatMap(extractNamesFromTypeTree(_))
       case Type.ApplyInfix(lhs, _op, rhs) =>
         extractNamesFromTypeTree(lhs) ++ extractNamesFromTypeTree(rhs)
       case Type.Function(params, res) =>
-        params.toVector.flatMap(extractNamesFromTypeTree(_)) ++ extractNamesFromTypeTree(res)
+        Chain.fromSeq(params).flatMap(extractNamesFromTypeTree(_)) ++ extractNamesFromTypeTree(res)
       case Type.PolyFunction(_tparams, tpe) => extractNamesFromTypeTree(tpe)
       case Type.ContextFunction(params, res) =>
-        params.toVector.flatMap(extractNamesFromTypeTree(_)) ++ extractNamesFromTypeTree(res)
-      case Type.Tuple(args)    => args.toVector.flatMap(extractNamesFromTypeTree(_))
+        Chain.fromSeq(params).flatMap(extractNamesFromTypeTree(_)) ++ extractNamesFromTypeTree(res)
+      case Type.Tuple(args)    => Chain.fromSeq(args).flatMap(extractNamesFromTypeTree(_))
       case Type.With(lhs, rhs) => extractNamesFromTypeTree(lhs) ++ extractNamesFromTypeTree(rhs)
       case Type.And(lhs, rhs)  => extractNamesFromTypeTree(lhs) ++ extractNamesFromTypeTree(rhs)
       case Type.Or(lhs, rhs)   => extractNamesFromTypeTree(lhs) ++ extractNamesFromTypeTree(rhs)
       // TODO: Recurse into `_stats` to find additional types.
       // A `Type.Refine` represents syntax: A { def f: Int }
-      case Type.Refine(typeOpt, _stats)  => typeOpt.toVector.flatMap(extractNamesFromTypeTree(_))
+      case Type.Refine(typeOpt, _stats)  => Chain.fromOption(typeOpt).flatMap(extractNamesFromTypeTree(_))
       case Type.Existential(tpe, _stats) => extractNamesFromTypeTree(tpe)
       case Type.Annotate(tpe, _annots)   => extractNamesFromTypeTree(tpe)
       case Type.Lambda(_tparams, tpe)    => extractNamesFromTypeTree(tpe)
       case Type.Bounds(loOpt, hiOpt) =>
-        loOpt.toVector.flatMap(extractNamesFromTypeTree(_)) ++ hiOpt.toVector.flatMap(
-          extractNamesFromTypeTree(_)
-        )
+        Chain.fromOption(loOpt).flatMap(extractNamesFromTypeTree(_)) ++ Chain.fromOption(hiOpt).flatMap(extractNamesFromTypeTree(_))
       case Type.ByName(tpe)   => extractNamesFromTypeTree(tpe)
       case Type.Repeated(tpe) => extractNamesFromTypeTree(tpe)
       // TODO: Should we extract a type from _tpe?
       // `Type.Match` represents this Scala 3 syntax: type T = match { case A => B }
-      case Type.Match(_tpe, cases) => cases.toVector.flatMap(extractNamesFromTypeTree(_))
+      case Type.Match(_tpe, cases) => Chain.fromSeq(cases).flatMap(extractNamesFromTypeTree(_))
       case TypeCase(pat, body) => extractNamesFromTypeTree(pat) ++ extractNamesFromTypeTree(body)
-      case _                   => Vector()
+      case _                   => Chain.empty
     }
   }
 
   def recordProvidedName(
-      symbolName: String,
+      symbolQName: QualifiedName,
       sawObject: Boolean = false,
       recursive: Boolean = false
   ): Unit = {
     if (!skipProvidedNames) {
-      val fullPackageName = nameParts.mkString(".")
+      val fullPackageName = currentScope
       if (!providedSymbolsByScope.contains(fullPackageName)) {
         providedSymbolsByScope(fullPackageName) = HashMap[String, ProvidedSymbol]()
       }
       val providedSymbols = providedSymbolsByScope(fullPackageName)
 
+      val symbolName = symbolQName.fullName
       if (providedSymbols.contains(symbolName)) {
         val existingSymbol = providedSymbols(symbolName)
         val newSymbol = ProvidedSymbol(
@@ -159,25 +206,24 @@ class SourceAnalysisTraverser extends Traverser {
     skipProvidedNames = origSkipProvidedNames
   }
 
-  def recordImport(name: String, alias: Option[String], isWildcard: Boolean): Unit = {
-    val fullPackageName = nameParts.mkString(".")
+  def recordImport(name: QualifiedName, alias: Option[String], isWildcard: Boolean): Unit = {
+    val fullPackageName = currentScope
     if (!importsByScope.contains(fullPackageName)) {
-      importsByScope(fullPackageName) = ArrayBuffer[AnImport]()
+      importsByScope(fullPackageName) = ArrayBuffer[AnImport[QualifiedName]]()
     }
     importsByScope(fullPackageName).append(AnImport(name, alias, isWildcard))
   }
 
-  def recordConsumedSymbol(name: String): Unit = {
-    val fullPackageName = nameParts.mkString(".")
+  def recordConsumedSymbol(name: QualifiedName): Unit = {
+    val fullPackageName = currentScope
     if (!consumedSymbolsByScope.contains(fullPackageName)) {
-      consumedSymbolsByScope(fullPackageName) = HashSet[String]()
+      consumedSymbolsByScope(fullPackageName) = HashSet[QualifiedName]()
     }
     consumedSymbolsByScope(fullPackageName).add(name)
   }
 
   def recordScope(name: String): Unit = {
-    val scopeName = (nameParts.toVector ++ Vector(name)).mkString(".")
-    scopes.add(scopeName)
+    scopes.add(currentScope.qualify(name))
   }
 
   def visitTemplate(templ: Template, name: String): Unit = {
@@ -202,82 +248,90 @@ class SourceAnalysisTraverser extends Traverser {
 
   override def apply(tree: Tree): Unit = tree match {
     case Pkg(ref, stats) => {
-      val name = extractName(ref)
-      recordScope(name)
-      withNamePart(name, () => super.apply(stats))
+      extractName(ref).foreach { qname =>
+        val name = qname.fullName
+        recordScope(name)
+        withNamePart(name, () => super.apply(stats))
+      }
     }
 
     case Pkg.Object(mods, nameNode, templ) => {
       visitMods(mods)
-      val name = extractName(nameNode)
-      recordScope(name)
+      extractName(nameNode).foreach { qname =>
+        val name = qname.parts.last
+        recordScope(name)
 
-      // TODO: should object already be recursive?
-      // an object is recursive if extends another type because we cannot figure out the provided types
-      // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
-      val recursive = !templ.inits.isEmpty
-      recordProvidedName(name, sawObject = true, recursive = recursive)
+        // TODO: should object already be recursive?
+        // an object is recursive if extends another type because we cannot figure out the provided types
+        // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
+        val recursive = !templ.inits.isEmpty
+        recordProvidedName(qname, sawObject = true, recursive = recursive)
 
-      // visitTemplate visits the inits part of the template in the outer scope,
-      // however for a package object the inits part can actually be found both in the inner scope as well (package inner).
-      // therefore we are not calling visitTemplate, calling all the apply methods in the inner scope.
-      // issue https://github.com/pantsbuild/pants/issues/16259
-      withNamePart(
-        name,
-        () => {
-          templ.inits.foreach(init => apply(init))
-          apply(templ.early)
-          apply(templ.stats)
-        }
-      )
+        // visitTemplate visits the inits part of the template in the outer scope,
+        // however for a package object the inits part can actually be found both in the inner scope as well (package inner).
+        // therefore we are not calling visitTemplate, calling all the apply methods in the inner scope.
+        // issue https://github.com/pantsbuild/pants/issues/16259
+        withNamePart(
+          name,
+          () => {
+            templ.inits.foreach(init => apply(init))
+            apply(templ.early)
+            apply(templ.stats)
+          }
+        )
+      }
     }
 
     case defn: Member.Type with WithMods with WithTParamClause with WithCtor with WithTemplate => // traits, enums and classes
       visitMods(defn.mods)
-      val name = extractName(defn.name)
-      recordProvidedName(name)
-      apply(defn.tparamClause)
-      apply(defn.ctor)
-      visitTemplate(defn.templ, name)
+      extractName(defn.name).foreach { name =>
+        recordProvidedName(name)
+        apply(defn.tparamClause)
+        apply(defn.ctor)
+        visitTemplate(defn.templ, name.parts.last)
+      }
+
     case Defn.EnumCase.After_4_6_0(mods, nameNode, tparamClause, ctor, _) =>
       visitMods(mods)
-      val name = extractName(nameNode)
-      recordProvidedName(name)
-      apply(tparamClause)
-      apply(ctor)
+      extractName(nameNode).foreach { name =>
+        recordProvidedName(name)
+        apply(tparamClause)
+        apply(ctor)
+      }
 
     case Defn.Object(mods, nameNode, templ) => {
       visitMods(mods)
-      val name = extractName(nameNode)
+      extractName(nameNode).foreach { name =>
+        // TODO: should object already be recursive?
+        // an object is recursive if extends another type because we cannot figure out the provided types
+        // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
+        val recursive = !templ.inits.isEmpty
+        recordProvidedName(name, sawObject = true, recursive = recursive)
 
-      // TODO: should object already be recursive?
-      // an object is recursive if extends another type because we cannot figure out the provided types
-      // in the parents, we just mark the object as recursive (which is indicated by non-empty inits)
-      val recursive = !templ.inits.isEmpty
-      recordProvidedName(name, sawObject = true, recursive = recursive)
-
-      // If the object is recursive, no need to provide the symbols inside
-      if (recursive)
-        withSuppressProvidedNames(() => visitTemplate(templ, name))
-      else
-        visitTemplate(templ, name)
+        // If the object is recursive, no need to provide the symbols inside
+        val templateName = name.parts.last
+        if (recursive)
+          withSuppressProvidedNames(() => visitTemplate(templ, templateName))
+        else
+          visitTemplate(templ, templateName)
+      }
     }
 
     case Defn.Type(mods, nameNode, _tparams, body) => {
       visitMods(mods)
-      val name = extractName(nameNode)
-      recordProvidedName(name)
-      extractNamesFromTypeTree(body).foreach(recordConsumedSymbol(_))
+      extractName(nameNode).foreach { name =>
+        recordProvidedName(name)
+        extractNamesFromTypeTree(body).toList.foreach(recordConsumedSymbol(_))
+      }
     }
 
     case Defn.Val(mods, pats, decltpe, rhs) => {
       visitMods(mods)
       pats.headOption.foreach(pat => {
-        val name = extractName(pat)
-        recordProvidedName(name)
+        extractName(pat).foreach(recordProvidedName(_))
       })
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
       })
       super.apply(rhs)
     }
@@ -285,22 +339,20 @@ class SourceAnalysisTraverser extends Traverser {
     case Defn.Var(mods, pats, decltpe, rhs) => {
       visitMods(mods)
       pats.headOption.foreach(pat => {
-        val name = extractName(pat)
-        recordProvidedName(name)
+        extractName(pat).foreach(recordProvidedName(_))
       })
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
       })
       super.apply(rhs)
     }
 
     case Defn.Def(mods, nameNode, tparams, params, decltpe, body) => {
       visitMods(mods)
-      val name = extractName(nameNode)
-      recordProvidedName(name)
+      extractName(nameNode).foreach(recordProvidedName(_))
 
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
       })
 
       apply(tparams)
@@ -311,39 +363,39 @@ class SourceAnalysisTraverser extends Traverser {
 
     case Decl.Def(mods, _nameNode, tparams, params, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
       apply(tparams)
       params.foreach(param => apply(param))
     }
 
     case Decl.Val(mods, _pats, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
     }
 
     case Decl.Var(mods, _pats, decltpe) => {
       visitMods(mods)
-      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
     }
 
     case Import(importers) => {
       importers.foreach({ case Importer(ref, importees) =>
-        val baseName = extractName(ref)
+        val baseName = extractName(ref).get
         importees.foreach(importee => {
           importee match {
             case Importee.Wildcard() => recordImport(baseName, None, true)
             case Importee.Name(nameNode) => {
-              recordImport(s"${baseName}.${extractName(nameNode)}", None, false)
+              extractName(nameNode).foreach { name =>
+                recordImport(baseName.qualify(name), None, false)
+              }
             }
             case Importee.Rename(nameNode, aliasNode) => {
-              // If a type is aliased to `_`, it is not brought into scope. We still record
-              // the import though, since compilation will fail if an import is not present.
-              val alias = extractName(aliasNode)
-              recordImport(
-                s"${baseName}.${extractName(nameNode)}",
-                if (alias == "_") None else Some(alias),
-                false
-              )
+              extractName(nameNode).foreach { name =>
+                // If a type is aliased to `_`, it is not brought into scope. We still record
+                // the import though, since compilation will fail if an import is not present.
+                val alias = extractName(aliasNode).map(_.fullName).filterNot(_ == "_")
+                recordImport(baseName.qualify(name), alias, false)
+              }
             }
             case _ =>
           }
@@ -352,21 +404,21 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Init(tpe, _name, argss) => {
-      extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
       argss.foreach(_.foreach(apply))
     }
 
     case Term.Param(mods, _name, decltpe, _default) => {
       visitMods(mods)
       decltpe.foreach(tpe => {
-        extractNamesFromTypeTree(tpe).foreach(recordConsumedSymbol(_))
+        extractNamesFromTypeTree(tpe).toList.foreach(recordConsumedSymbol(_))
       })
     }
 
     case Type.Param(mods, _name, _tparams, bounds, _vbounds, cbounds) => {
       visitMods(mods)
-      extractNamesFromTypeTree(bounds).foreach(recordConsumedSymbol(_))
-      cbounds.flatMap(extractNamesFromTypeTree(_)).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(bounds).toList.foreach(recordConsumedSymbol(_))
+      Chain.fromSeq(cbounds).flatMap(extractNamesFromTypeTree(_)).toList.foreach(recordConsumedSymbol(_))
     }
 
     case Ctor.Primary(mods, _name, params_list) => {
@@ -385,17 +437,15 @@ class SourceAnalysisTraverser extends Traverser {
     }
 
     case Self(_name, Some(decltpe)) =>
-      extractNamesFromTypeTree(decltpe).foreach(recordConsumedSymbol(_))
+      extractNamesFromTypeTree(decltpe).toList.foreach(recordConsumedSymbol(_))
 
     case node @ Term.Select(_, _) => {
-      val name = extractName(node)
-      recordConsumedSymbol(name)
+      extractName(node).foreach(recordConsumedSymbol(_))
       apply(node.qual)
     }
 
     case node @ Term.Name(_) => {
-      val name = extractName(node)
-      recordConsumedSymbol(name)
+      extractName(node).foreach(recordConsumedSymbol(_))
     }
 
     case node => super.apply(node)
@@ -405,7 +455,7 @@ class SourceAnalysisTraverser extends Traverser {
     providedSymbolsByScope
       .flatMap({ case (scopeName, symbolsForScope) =>
         symbolsForScope.map { case (symbolName, symbol) =>
-          Analysis.ProvidedSymbol(qualifyName(scopeName, symbolName), symbol.recursive)
+          Analysis.ProvidedSymbol(scopeName.qualify(symbolName).rootlessName, symbol.recursive)
         }.toVector
       })
       .to(SortedSet)
@@ -430,24 +480,30 @@ class SourceAnalysisTraverser extends Traverser {
           }
         })
 
-        encodedSymbolsForScope.map(symbol => symbol.copy(name = qualifyName(scopeName, symbol.name)))
+        encodedSymbolsForScope.map(symbol => symbol.copy(name = scopeName.qualify(symbol.name).rootlessName))
       })
       .to(SortedSet)
+  }
+
+  def gatherImportsByScope(): Map[String, List[AnImport[String]]] =
+    importsByScope.toMap.map { case (scopeName, imports) =>
+      scopeName.rootlessName -> imports.toList.map(_.map(_.rootlessName))
+    }
+
+  def gatherConsumerSymbolsByScope(): Map[String, SortedSet[Analysis.ConsumedSymbol]] = {
+    consumedSymbolsByScope.toMap.map { case (scopeName, consumedSymbolNames) =>
+      scopeName.rootlessName -> consumedSymbolNames.map(qname => Analysis.ConsumedSymbol(qname.rootlessName, qname.fromRoot)).to(SortedSet)
+    }
   }
 
   def toAnalysis: Analysis = {
     Analysis(
       providedSymbols = gatherProvidedSymbols(),
       providedSymbolsEncoded = gatherEncodedProvidedSymbols(),
-      importsByScope = importsByScope,
-      consumedSymbolsByScope = consumedSymbolsByScope,
-      scopes = scopes.toVector
+      importsByScope = gatherImportsByScope(),
+      consumedSymbolsByScope = gatherConsumerSymbolsByScope(),
+      scopes = scopes.map(_.rootlessName).toVector
     )
-  }
-
-  private def qualifyName(qualifier: String, name: String): String = {
-    if (qualifier.length > 0) s"$qualifier.$name"
-    else name
   }
 }
 

--- a/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
+++ b/src/python/pants/backend/scala/dependency_inference/ScalaParser.scala
@@ -21,7 +21,10 @@ import scala.collection.mutable.{ArrayBuffer, HashMap, HashSet}
 import scala.reflect.NameTransformer
 
 object Constants {
+  // `_root_` is used in Scala as a marker for absolute qualified names
+  // https://docs.scala-lang.org/tour/packages-and-imports.html#imports
   val RootPackageQualifier = "_root_"
+
   val NameSeparator = '.'
 }
 

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser.py
@@ -93,11 +93,11 @@ class ScalaProvidedSymbol:
 @dataclass(frozen=True)
 class ScalaConsumedSymbol:
     name: str
-    from_root: bool
+    is_absolute: bool
 
     @classmethod
     def from_json_dict(cls, data: Mapping[str, Any]):
-        return cls(name=data["name"], from_root=data["fromRoot"])
+        return cls(name=data["name"], is_absolute=data["isAbsolute"])
 
     @property
     def is_qualified(self) -> bool:
@@ -111,7 +111,7 @@ class ScalaConsumedSymbol:
         return (symbol_rel_prefix, symbol_rel_suffix)
 
     def to_debug_json_dict(self) -> dict[str, Any]:
-        return {"name": self.name, "fromRoot": self.from_root}
+        return {"name": self.name, "isAbsolute": self.is_absolute}
 
 
 @dataclass(frozen=True)
@@ -146,10 +146,10 @@ class ScalaSourceDependencyAnalysis:
         for consumption_scope, consumed_symbols in self._consumed_symbols_by_scope.items():
             parent_scopes = tuple(scope_and_parents(consumption_scope))
             for symbol in consumed_symbols:
-                if not self.scopes or symbol.is_qualified or symbol.from_root:
+                if not self.scopes or symbol.is_qualified or symbol.is_absolute:
                     yield symbol.name
 
-                if symbol.from_root:
+                if symbol.is_absolute:
                     # We do not need to qualify this symbol any further as we know its
                     # name is the actual fully qualified name
                     continue

--- a/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
+++ b/src/python/pants/backend/scala/dependency_inference/scala_parser_test.py
@@ -256,39 +256,39 @@ def test_parser_simple(rule_runner: RuleRunner) -> None:
             "org.pantsbuild.example.OuterObject": FrozenOrderedSet(["Foo"]),
             "org.pantsbuild.example.Functions": FrozenOrderedSet(
                 [
-                    "TupleTypeArg2",
-                    "foo",
-                    "TupleTypeArg1",
-                    "LambdaReturnType",
                     "+",
-                    "Unit",
-                    "Integer",
-                    "LambdaTypeArg2",
                     "AParameterType",
+                    "Integer",
+                    "LambdaReturnType",
                     "LambdaTypeArg1",
+                    "LambdaTypeArg2",
                     "OuterObject",
-                    "bar",
                     "OuterObject.NestedVal",
+                    "TupleTypeArg1",
+                    "TupleTypeArg2",
+                    "Unit",
+                    "bar",
+                    "foo",
                 ]
             ),
             "org.pantsbuild.example.HasPrimaryConstructor": FrozenOrderedSet(
-                ["bar", "SomeTypeInSecondaryConstructor"]
+                ["SomeTypeInSecondaryConstructor", "bar"]
             ),
             "org.pantsbuild.example.OuterClass": FrozenOrderedSet(["Foo"]),
             "org.pantsbuild.example.ApplyQualifier": FrozenOrderedSet(
-                ["Integer", "a", "toInt", "calc.calcFunc", "calc"]
+                ["Integer", "a", "calc", "calc.calcFunc", "toInt"]
             ),
             "org.pantsbuild.example.OuterTrait": FrozenOrderedSet(
-                ["Integer", "TraitConsumedType", "Foo"]
+                ["Foo", "Integer", "TraitConsumedType"]
             ),
             "org.pantsbuild.example": FrozenOrderedSet(
                 [
                     "ABaseClass",
                     "ATrait1",
-                    "SomeTypeInPrimaryConstructor",
-                    "foo",
                     "ATrait2.Nested",
                     "BaseWithConstructor",
+                    "SomeTypeInPrimaryConstructor",
+                    "foo",
                 ]
             ),
         }
@@ -433,6 +433,31 @@ def test_relative_import(rule_runner: RuleRunner) -> None:
         "sio",
         "sio.apply",
     }
+
+
+def test_import_root_pacjage(rule_runner: RuleRunner) -> None:
+    analysis = _analyze(
+        rule_runner,
+        textwrap.dedent(
+            """
+            package foo
+
+            import _root_.io.circe.syntax._
+
+            object Foo {
+                val foo: _root_.foo.Bar = ???
+            }
+            """
+        ),
+    )
+
+    assert analysis.imports_by_scope == FrozenDict(
+        {"foo": (ScalaImport(name="io.circe.syntax", alias=None, is_wildcard=True),)}
+    )
+
+    assert sorted(analysis.fully_qualified_consumed_symbols()) == [
+        "foo.Bar",
+    ]
 
 
 def test_package_object(rule_runner: RuleRunner) -> None:


### PR DESCRIPTION
Scala has a magic `_root_` package name which can be used to disambiguate two colliding imports at a given scope. Its usage means that the actually fully qualified name of a symbol is what follows the `_root_` magic and therefore it should be resolved as an absolute qualified name in imports and other usages.

At the moment the Scala parser treats that as if it were a normal part of a qualified name which has these two consequences:
- Not capable of resolving dependencies of a given file since `_root_.foo. Foo` is understood to be different than `foo.Foo`, when they are a reference to the same symbol.
- Extra false positives in the consumed symbols of a given file, which can create ambiguous dependencies in the Pants' side.

This PR provides Pants with the ability to understand when a Scala qualified name is an absolute name (starts with `_root_`) or not and get more accurate dependency inference.

PD: Also took the liberty to modify usages of `Vector` by `Chain` where there could be a lot of concatenations, since the later has O(1) complexity on concatenation or appends.