### PR TITLE
Generate entry_points.txt for python_tests that require entry points from a python_distribution

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -74,6 +74,13 @@ The default version of the `ruff` tool has been updated from 0.4.4 to 0.4.9.
 
 The default version of the pex tool has been updated from 2.3.1 to 2.3.3.
 
+A new `entry_point_dependencies` field is now available for `python_tests` and `python_test` targets. This allows tests
+to depend on a subset (or all) of the `entry_points` defined on `python_distribution` targets. A dependency defined in
+`entry_point_dependencies` emulates an editable install of those `python_distribution` targets. Instead of including
+all of the `python_distribution`'s sources, only the specified entry points are made available. The entry_points metadata
+is also installed in the pytest sandbox so that tests (or the code under test) can load that metadata via `pkg_resources`.
+To use this, enable the `pants.backend.experimental.python` backend.
+
 #### Terraform
 
 The `tfsec` linter now works on all supported platforms without extra config.

--- a/src/python/pants/backend/experimental/python/framework/stevedore/register.py
+++ b/src/python/pants/backend/experimental/python/framework/stevedore/register.py
@@ -10,6 +10,7 @@ from pants.backend.python.framework.stevedore import python_target_dependencies
 from pants.backend.python.framework.stevedore import rules as stevedore_rules
 from pants.backend.python.framework.stevedore.target_types import StevedoreNamespace
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.entry_points import rules as entry_points_rules
 from pants.build_graph.build_file_aliases import BuildFileAliases
 
 
@@ -19,6 +20,7 @@ def build_file_aliases():
 
 def rules():
     return [
+        *entry_points_rules(),
         *stevedore_rules.rules(),
         *python_target_dependencies.rules(),
         *python_target_types_rules(),

--- a/src/python/pants/backend/experimental/python/register.py
+++ b/src/python/pants/backend/experimental/python/register.py
@@ -3,7 +3,12 @@
 
 from pants.backend.python.goals import debug_goals, publish
 from pants.backend.python.subsystems import setuptools_scm, twine
-from pants.backend.python.target_types import VCSVersion
+from pants.backend.python.target_types import (
+    PythonTestsEntryPointDependenciesField,
+    PythonTestsGeneratorTarget,
+    PythonTestTarget,
+    VCSVersion,
+)
 from pants.backend.python.util_rules import pex, vcs_versioning
 
 
@@ -15,6 +20,11 @@ def rules():
         *setuptools_scm.rules(),
         *twine.rules(),
         *debug_goals.rules(),
+        PythonTestTarget.register_plugin_field(PythonTestsEntryPointDependenciesField),
+        PythonTestsGeneratorTarget.register_plugin_field(
+            PythonTestsEntryPointDependenciesField,
+            as_moved_field=True,
+        ),
     )
 
 

--- a/src/python/pants/backend/experimental/python/register.py
+++ b/src/python/pants/backend/experimental/python/register.py
@@ -4,6 +4,7 @@
 from pants.backend.python.goals import debug_goals, publish
 from pants.backend.python.subsystems import setuptools_scm, twine
 from pants.backend.python.target_types import VCSVersion
+from pants.backend.python.target_types_rules import rules as target_types_rules
 from pants.backend.python.util_rules import entry_points, pex, vcs_versioning
 
 
@@ -15,6 +16,7 @@ def rules():
         *setuptools_scm.rules(),
         *twine.rules(),
         *debug_goals.rules(),
+        *target_types_rules(),
         *entry_points.rules(),
     )
 

--- a/src/python/pants/backend/experimental/python/register.py
+++ b/src/python/pants/backend/experimental/python/register.py
@@ -3,13 +3,8 @@
 
 from pants.backend.python.goals import debug_goals, publish
 from pants.backend.python.subsystems import setuptools_scm, twine
-from pants.backend.python.target_types import (
-    PythonTestsEntryPointDependenciesField,
-    PythonTestsGeneratorTarget,
-    PythonTestTarget,
-    VCSVersion,
-)
-from pants.backend.python.util_rules import pex, vcs_versioning
+from pants.backend.python.target_types import VCSVersion
+from pants.backend.python.util_rules import entry_points, pex, vcs_versioning
 
 
 def rules():
@@ -20,11 +15,7 @@ def rules():
         *setuptools_scm.rules(),
         *twine.rules(),
         *debug_goals.rules(),
-        PythonTestTarget.register_plugin_field(PythonTestsEntryPointDependenciesField),
-        PythonTestsGeneratorTarget.register_plugin_field(
-            PythonTestsEntryPointDependenciesField,
-            as_moved_field=True,
-        ),
+        *entry_points.rules(),
     )
 
 

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
@@ -152,8 +152,8 @@ async def infer_stevedore_namespaces_dependencies(
         EntryPointDependencies,
         GetEntryPointDependenciesRequest(
             targets,
-            lambda tgt, ns, ep_name: True,
-            lambda tgt, ns: ns in requested_namespaces_value,
+            lambda field, ns: ns in requested_namespaces_value,
+            lambda field, ns, ep_name: True,
         ),
     )
 

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
@@ -152,8 +152,8 @@ async def infer_stevedore_namespaces_dependencies(
         EntryPointDependencies,
         GetEntryPointDependenciesRequest(
             targets,
-            lambda field, ns: ns in requested_namespaces_value,
-            lambda field, ns, ep_name: True,
+            lambda tgt, ns: ns in requested_namespaces_value,
+            lambda tgt, ns, ep_name: True,
         ),
     )
 

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
@@ -152,7 +152,8 @@ async def infer_stevedore_namespaces_dependencies(
         EntryPointDependencies,
         GetEntryPointDependenciesRequest(
             targets,
-            lambda tgt, namespace, ep_name: namespace in requested_namespaces_value,
+            lambda tgt, ns, ep_name: True,
+            lambda tgt, ns: ns in requested_namespaces_value,
         ),
     )
 

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies.py
@@ -21,7 +21,6 @@ from pants.backend.python.target_types import (
     PythonTestsGeneratorTarget,
     PythonTestTarget,
 )
-from pants.backend.python.util_rules import entry_points
 from pants.backend.python.util_rules.entry_points import (
     EntryPointDependencies,
     GetEntryPointDependenciesRequest,
@@ -163,7 +162,6 @@ async def infer_stevedore_namespaces_dependencies(
 def rules():
     return [
         *collect_rules(),
-        *entry_points.rules(),
         PythonTestsGeneratorTarget.register_plugin_field(StevedoreNamespacesField),
         PythonTestTarget.register_plugin_field(StevedoreNamespacesField),
         UnionRule(InferDependenciesRequest, InferStevedoreNamespacesDependencies),

--- a/src/python/pants/backend/python/framework/stevedore/python_target_dependencies_test.py
+++ b/src/python/pants/backend/python/framework/stevedore/python_target_dependencies_test.py
@@ -31,6 +31,7 @@ from pants.backend.python.target_types import (
     PythonTestTarget,
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.entry_points import rules as entry_points_rules
 from pants.engine.addresses import Address
 from pants.engine.target import InferredDependencies
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -74,6 +75,7 @@ def write_test_files(rule_runner: RuleRunner, extra_build_contents: str = ""):
 def rule_runner() -> RuleRunner:
     rule_runner = RuleRunner(
         rules=[
+            *entry_points_rules(),
             *python_target_types_rules(),
             *stevedore_dep_rules(),
             QueryRule(AllStevedoreExtensionTargets, ()),

--- a/src/python/pants/backend/python/framework/stevedore/rules.py
+++ b/src/python/pants/backend/python/framework/stevedore/rules.py
@@ -3,26 +3,19 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-
 from pants.backend.python.framework.stevedore.target_types import (
     StevedoreExtensionTargets,
     StevedoreNamespacesField,
     StevedoreNamespacesProviderTargetsRequest,
 )
 from pants.backend.python.goals.pytest_runner import PytestPluginSetup, PytestPluginSetupRequest
-from pants.backend.python.target_types import (
-    PythonDistribution,
-    PythonDistributionEntryPointsField,
-    ResolvedPythonDistributionEntryPoints,
-    ResolvePythonDistributionEntryPointsRequest,
-)
+from pants.backend.python.target_types import PythonDistribution
 from pants.backend.python.util_rules.entry_points import (
-    GenerateEntryPointsTxtRequest,
     EntryPointsTxt,
+    GenerateEntryPointsTxtRequest,
 )
-from pants.engine.fs import EMPTY_DIGEST, PathGlobs, Paths
-from pants.engine.rules import Get, MultiGet, collect_rules, rule
+from pants.engine.fs import EMPTY_DIGEST
+from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/python/framework/stevedore/rules_test.py
+++ b/src/python/pants/backend/python/framework/stevedore/rules_test.py
@@ -25,6 +25,7 @@ from pants.backend.python.target_types import (
     PythonTestTarget,
 )
 from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.entry_points import rules as entry_points_rules
 from pants.engine.addresses import Address
 from pants.engine.fs import EMPTY_DIGEST, CreateDigest, Digest, FileContent
 from pants.testutil.rule_runner import QueryRule, RuleRunner
@@ -37,6 +38,7 @@ st2_runners = ["noop", "python", "foobar"]
 def rule_runner() -> RuleRunner:
     return RuleRunner(
         rules=[
+            *entry_points_rules(),
             *python_target_types_rules(),
             *stevedore_dep_rules(),
             *stevedore_rules(),

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -936,6 +936,47 @@ class PythonTestsDependenciesField(PythonDependenciesField):
     supports_transitive_excludes = True
 
 
+class PythonTestsEntryPointDependenciesField(DictStringToStringSequenceField):
+    alias = "entry_point_dependencies"
+    help = help_text(
+        lambda: f"""
+        Dependencies on entry point metadata of `{PythonDistribution.alias}` targets.
+
+        This is a dict where each key is a `{PythonDistribution.alias}` address
+        and the value is a list or tuple of entry point groups and/or entry points
+        on that target. The strings in the value list/tuple must be one of:
+        - "entry.point.group/entry-point-name" to depend on a named entry point
+        - "entry.point.group" (without a "/") to depend on an entry point group
+        - "*" to get all entry points on the target
+        
+        For example:
+        
+            {PythonTestsEntryPointDependenciesField.alias}={{
+                "//foo/address:dist_tgt": ["*"],  # all entry points
+                "bar:dist_tgt": ["console_scripts"],  # only from this group
+                "foo/bar/baz:dist_tgt": ["console_scripts/my-script"],  # a single entry point
+                "another:dist_tgt": [  # multiple entry points
+                    "console_scripts/my-script",
+                    "console_scripts/another-script",
+                    "entry.point.group/entry-point-name",
+                    "other.group",
+                    "gui_scripts",
+                ],
+            }}
+
+        Code for matching `entry_points` on `{PythonDistribution.alias}` targets
+        will be added as dependencies so that they are available on PYTHONPATH
+        during tests.
+
+        Plus, an `entry_points.txt` file will be generated in the sandbox so that
+        each of the `{PythonDistribution.alias}`s appear to be "installed". The
+        `entry_points.txt` file will only include the entry points requested on this
+        field. This allows the tests, or the code under test, to lookup entry points
+        metadata using something like `pkg_resources.iter_entry_points` from `setuptools`.
+        """
+    )
+
+
 # TODO This field class should extend from a core `TestTimeoutField` once the deprecated options in `pytest` get removed.
 class PythonTestsTimeoutField(IntField):
     alias = "timeout"
@@ -1010,6 +1051,8 @@ class SkipPythonTestsField(BoolField):
 
 _PYTHON_TEST_MOVED_FIELDS = (
     PythonTestsDependenciesField,
+    # This field is registered in the experimental backend for now.
+    # PythonTestsEntryPointDependenciesField,
     PythonResolveField,
     PythonRunGoalUseSandboxField,
     PythonTestsTimeoutField,

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -948,9 +948,9 @@ class PythonTestsEntryPointDependenciesField(DictStringToStringSequenceField):
         - "entry.point.group/entry-point-name" to depend on a named entry point
         - "entry.point.group" (without a "/") to depend on an entry point group
         - "*" to get all entry points on the target
-        
+
         For example:
-        
+
             {PythonTestsEntryPointDependenciesField.alias}={{
                 "//foo/address:dist_tgt": ["*"],  # all entry points
                 "bar:dist_tgt": ["console_scripts"],  # only from this group

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -1680,7 +1680,7 @@ class LongDescriptionPathField(StringField):
 
 
 class PythonDistribution(Target):
-    alias = "python_distribution"
+    alias: ClassVar[str] = "python_distribution"
     core_fields = (
         *COMMON_TARGET_FIELDS,
         InterpreterConstraintsField,

--- a/src/python/pants/backend/python/target_types_rules.py
+++ b/src/python/pants/backend/python/target_types_rules.py
@@ -45,6 +45,9 @@ from pants.backend.python.target_types import (
     ResolvePexEntryPointRequest,
     ResolvePythonDistributionEntryPointsRequest,
 )
+from pants.backend.python.util_rules.entry_points import (
+    get_python_distribution_entry_point_unambiguous_module_owners,
+)
 from pants.backend.python.util_rules.interpreter_constraints import interpreter_constraints_contains
 from pants.backend.python.util_rules.package_dists import InvalidEntryPoint
 from pants.engine.addresses import Address, Addresses, UnparsedAddressInputs
@@ -538,24 +541,11 @@ async def infer_python_distribution_dependencies(
     )
     module_owners: OrderedSet[Address] = OrderedSet()
     for (category, name, entry_point), owners in zip(all_module_entry_points, all_module_owners):
-        field_str = repr({category: {name: entry_point.spec}})
-        explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
-            owners.ambiguous,
-            address,
-            import_reference="module",
-            context=softwrap(
-                f"""
-                The python_distribution target {address} has the field
-                `entry_points={field_str}`, which maps to the Python module
-                `{entry_point.module}`
-                """
-            ),
+        module_owners.update(
+            get_python_distribution_entry_point_unambiguous_module_owners(
+                address, category, name, entry_point, explicitly_provided_deps, owners
+            )
         )
-        maybe_disambiguated = explicitly_provided_deps.disambiguated(owners.ambiguous)
-        unambiguous_owners = owners.unambiguous or (
-            (maybe_disambiguated,) if maybe_disambiguated else ()
-        )
-        module_owners.update(unambiguous_owners)
 
     return InferredDependencies(
         Addresses(module_owners)

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -283,9 +283,9 @@ async def generate_entry_points_txt(request: GenerateEntryPointsTxtRequest) -> E
         Get(Paths, PathGlobs(module_candidate_paths)) for module_candidate_paths in possible_paths
     )
 
-    entry_points_by_path: dict[str, list[tuple[Target, ResolvedPythonDistributionEntryPoints]]] = (
-        defaultdict(list)
-    )
+    entry_points_by_path: dict[
+        str, list[tuple[Target, ResolvedPythonDistributionEntryPoints]]
+    ] = defaultdict(list)
 
     target: Target
     resolved_ep: ResolvedPythonDistributionEntryPoints

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -280,9 +280,9 @@ async def generate_entry_points_txt(request: GenerateEntryPointsTxtRequest) -> E
         Get(Paths, PathGlobs(module_candidate_paths)) for module_candidate_paths in possible_paths
     )
 
-    entry_points_by_path: dict[
-        str, list[tuple[Target, ResolvedPythonDistributionEntryPoints]]
-    ] = defaultdict(list)
+    entry_points_by_path: dict[str, list[tuple[Target, ResolvedPythonDistributionEntryPoints]]] = (
+        defaultdict(list)
+    )
 
     target: Target
     resolved_ep: ResolvedPythonDistributionEntryPoints
@@ -361,6 +361,7 @@ async def generate_entry_points_txt_from_entry_point_dependencies(
 def rules():
     return [
         *collect_rules(),
+        # TODO: remove these register_plugin_field calls once this moves out of experimental
         PythonTestTarget.register_plugin_field(PythonTestsEntryPointDependenciesField),
         PythonTestsGeneratorTarget.register_plugin_field(
             PythonTestsEntryPointDependenciesField,

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -169,7 +169,7 @@ class PythonTestsEntryPointDependenciesInferenceFieldSet(FieldSet):
 
 
 class InferEntryPointDependencies(InferDependenciesRequest):
-    infer_from = PythonTestsEntryPointDependenciesField
+    infer_from = PythonTestsEntryPointDependenciesInferenceFieldSet
 
 
 @rule(

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -15,16 +15,16 @@ from pants.backend.python.target_types import (
     PythonDistributionDependenciesField,
     PythonDistributionEntryPoint,
     PythonDistributionEntryPointsField,
-    PythonTestTarget,
     PythonTestsDependenciesField,
     PythonTestsEntryPointDependenciesField,
     PythonTestsGeneratorTarget,
-    ResolvePythonDistributionEntryPointsRequest,
+    PythonTestTarget,
     ResolvedPythonDistributionEntryPoints,
+    ResolvePythonDistributionEntryPointsRequest,
 )
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
 from pants.engine.fs import CreateDigest, FileContent, PathGlobs, Paths
-from pants.engine.internals.native_engine import Address, Digest, EMPTY_DIGEST
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Address, Digest
 from pants.engine.internals.selectors import MultiGet
 from pants.engine.rules import Get, collect_rules, rule
 from pants.engine.target import (
@@ -161,7 +161,6 @@ async def get_filtered_entry_point_dependencies(
 
 @dataclass(frozen=True)
 class PythonTestsEntryPointDependenciesInferenceFieldSet(FieldSet):
-
     required_fields = (
         PythonTestsDependenciesField,
         PythonTestsEntryPointDependenciesField,

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -1,0 +1,151 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from pants.backend.python.dependency_inference.module_mapper import (
+    PythonModuleOwners,
+    PythonModuleOwnersRequest,
+)
+from pants.backend.python.target_types import (
+    EntryPoint,
+    PythonDistribution,
+    PythonDistributionDependenciesField,
+    PythonDistributionEntryPointsField,
+    PythonTestTarget,
+    PythonTestsDependenciesField,
+    PythonTestsEntryPointDependenciesField,
+    PythonTestsGeneratorTarget,
+    ResolvePythonDistributionEntryPointsRequest,
+    ResolvedPythonDistributionEntryPoints,
+)
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.engine.internals.native_engine import Address
+from pants.engine.internals.selectors import MultiGet
+from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.target import (
+    DependenciesRequest,
+    ExplicitlyProvidedDependencies,
+    FieldSet,
+    InferDependenciesRequest,
+    InferredDependencies,
+    Targets,
+)
+from pants.engine.unions import UnionRule
+from pants.util.logging import LogLevel
+from pants.util.ordered_set import FrozenOrderedSet, OrderedSet
+from pants.util.strutil import softwrap
+
+
+def get_python_distribution_entry_point_unambiguous_module_owners(
+    address: Address,
+    entry_point_group: str,  # group is the pypa term; aka category or namespace
+    entry_point_name: str,
+    entry_point: EntryPoint,
+    explicitly_provided_deps: ExplicitlyProvidedDependencies,
+    owners: PythonModuleOwners,
+) -> tuple[Address]:
+    field_str = repr({entry_point_group: {entry_point_name: entry_point.spec}})
+    explicitly_provided_deps.maybe_warn_of_ambiguous_dependency_inference(
+        owners.ambiguous,
+        address,
+        import_reference="module",
+        context=softwrap(
+            f"""
+            The python_distribution target {address} has the field
+            `entry_points={field_str}`, which maps to the Python module
+            `{entry_point.module}`
+            """
+        ),
+    )
+    maybe_disambiguated = explicitly_provided_deps.disambiguated(owners.ambiguous)
+    unambiguous_owners = owners.unambiguous or (
+        (maybe_disambiguated,) if maybe_disambiguated else ()
+    )
+    return unambiguous_owners
+
+
+@dataclass(frozen=True)
+class GetEntryPointDependenciesRequest:
+    targets: Targets
+    predicate: Callable[[PythonDistribution, str, str], bool]
+
+
+@dataclass(frozen=True)
+class EntryPointDependencies:
+    addresses: FrozenOrderedSet[Address]
+
+    def __init__(self, addresses: Iterable[Address]) -> None:
+        object.__setattr__(self, "addresses", FrozenOrderedSet(sorted(addresses)))
+
+
+@rule
+async def get_filtered_entry_point_dependencies(
+    request: GetEntryPointDependenciesRequest,
+) -> EntryPointDependencies:
+    # This is based on pants.backend.python.target_type_rules.infer_python_distribution_dependencies,
+    # but handles multiple targets and filters the entry_points to just get the requested deps.
+    all_explicit_dependencies = await MultiGet(
+        Get(
+            ExplicitlyProvidedDependencies,
+            DependenciesRequest(tgt[PythonDistributionDependenciesField]),
+        )
+        for _, tgt in request.targets
+    )
+    resolved_entry_points = await MultiGet(
+        Get(
+            ResolvedPythonDistributionEntryPoints,
+            ResolvePythonDistributionEntryPointsRequest(tgt[PythonDistributionEntryPointsField]),
+        )
+        for _, tgt in request.targets
+    )
+
+    filtered_entry_point_pex_addresses: list[Address] = []
+    filtered_entry_point_modules: list[
+        tuple[Address, str, str, EntryPoint, ExplicitlyProvidedDependencies]
+    ] = []
+
+    distribution_entry_points: ResolvedPythonDistributionEntryPoints
+    for tgt, distribution_entry_points, explicitly_provided_deps in zip(
+        request.targets, resolved_entry_points, all_explicit_dependencies
+    ):
+        # use .val instead of .explicit_modules and .pex_binary_addresses to facilitate filtering
+        for ep_group, entry_points in distribution_entry_points.val.items():
+            for ep_name, ep_val in entry_points.items():
+                if request.predicate(tgt, ep_group, ep_name):
+                    if ep_val.pex_binary_address:
+                        filtered_entry_point_pex_addresses.append(ep_val.pex_binary_address)
+                    else:
+                        filtered_entry_point_modules.append(
+                            (
+                                tgt.address,
+                                ep_group,
+                                ep_name,
+                                ep_val.entry_point,
+                                explicitly_provided_deps,
+                            )
+                        )
+    filtered_module_owners = await MultiGet(
+        Get(PythonModuleOwners, PythonModuleOwnersRequest(entry_point.module, resolve=None))
+        for _, _, _, entry_point, _ in filtered_entry_point_modules
+    )
+
+    filtered_unambiguous_module_owners: OrderedSet[Address] = OrderedSet()
+    for (address, ep_group, ep_name, entry_point, explicitly_provided_deps), owners in zip(
+        filtered_entry_point_modules, filtered_module_owners
+    ):
+        filtered_unambiguous_module_owners.update(
+            get_python_distribution_entry_point_unambiguous_module_owners(
+                address, ep_group, ep_name, entry_point, explicitly_provided_deps, owners
+            )
+        )
+
+    return EntryPointDependencies(
+        Addresses(*filtered_entry_point_pex_addresses, *filtered_unambiguous_module_owners)
+    )
+
+
+def rules():
+    return [
+        *collect_rules(),
+    ]

--- a/src/python/pants/backend/python/util_rules/entry_points.py
+++ b/src/python/pants/backend/python/util_rules/entry_points.py
@@ -163,7 +163,11 @@ async def _get_entry_point_deps_targets_and_predicates(
 ) -> tuple[
     Targets, PythonDistributionEntryPointGroupPredicate, PythonDistributionEntryPointPredicate
 ]:
-    assert entry_point_deps.value, "Unexpected empty entry_point_dependencies field"
+    if not entry_point_deps.value:  # type narrowing for mypy
+        raise ValueError(
+            "Please file an issue if you see this error. This rule helper must not "
+            "be called with an empty entry_point_dependencies field."
+        )
     targets = await Get(
         Targets,
         UnparsedAddressInputs(

--- a/src/python/pants/backend/python/util_rules/entry_points_test.py
+++ b/src/python/pants/backend/python/util_rules/entry_points_test.py
@@ -1,0 +1,303 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Iterable
+
+import pytest
+
+from pants.backend.python.goals.pytest_runner import PytestPluginSetup
+from pants.backend.python.macros.python_artifact import PythonArtifact
+from pants.backend.python.target_types import (
+    PythonDistribution,
+    PythonSourcesGeneratorTarget,
+    PythonSourceTarget,
+    PythonTestsGeneratorTarget,
+    PythonTestTarget,
+)
+from pants.backend.python.target_types_rules import rules as python_target_types_rules
+from pants.backend.python.util_rules.entry_points import (
+    GenerateEntryPointsTxtFromEntryPointDependenciesRequest,
+    InferEntryPointDependencies,
+    PythonTestsEntryPointDependenciesInferenceFieldSet,
+)
+from pants.backend.python.util_rules.entry_points import rules as entry_points_rules
+from pants.engine.addresses import Address
+from pants.engine.fs import CreateDigest, DigestContents, FileContent
+from pants.engine.internals.native_engine import EMPTY_DIGEST, Digest
+from pants.engine.target import InferredDependencies
+from pants.testutil.rule_runner import QueryRule, RuleRunner
+
+# random set of runner names to use in tests
+st2_runners = ["noop", "foobar"]
+
+
+def write_test_files(rule_runner: RuleRunner, extra_build_contents: str = ""):
+    for runner in st2_runners:
+        rule_runner.write_files(
+            {
+                f"runners/{runner}_runner/BUILD": dedent(
+                    f"""\
+                    python_distribution(
+                        provides=python_artifact(
+                            name="stackstorm-runner-{runner}",
+                        ),
+                        entry_points={{
+                            "st2common.runners.runner": {{
+                                "{runner}": "{runner}_runner.{runner}_runner",
+                            }},
+                            "console_scripts": {{
+                                "some-thing": "{runner}_runner.thing:main",
+                            }},
+                        }},
+                    )
+                    """
+                )
+                + extra_build_contents.format(runner=runner),
+                f"runners/{runner}_runner/{runner}_runner/BUILD": "python_sources()",
+                f"runners/{runner}_runner/{runner}_runner/__init__.py": "",
+                f"runners/{runner}_runner/{runner}_runner/{runner}_runner.py": "",
+                f"runners/{runner}_runner/{runner}_runner/thing.py": dedent(
+                    """\
+                    def main():
+                        return True
+                    """
+                ),
+            }
+        )
+
+
+@pytest.fixture
+def rule_runner() -> RuleRunner:
+    rule_runner = RuleRunner(
+        rules=[
+            *entry_points_rules(),
+            *python_target_types_rules(),
+            QueryRule(InferredDependencies, (InferEntryPointDependencies,)),
+            QueryRule(
+                PytestPluginSetup,
+                (GenerateEntryPointsTxtFromEntryPointDependenciesRequest,),
+            ),
+        ],
+        target_types=[
+            PythonDistribution,
+            PythonSourceTarget,
+            PythonSourcesGeneratorTarget,
+            PythonTestTarget,
+            PythonTestsGeneratorTarget,
+        ],
+        objects={
+            "python_artifact": PythonArtifact,
+        },
+    )
+    write_test_files(rule_runner)
+    args = [
+        "--source-root-patterns=runners/*_runner",
+    ]
+    rule_runner.set_options(args, env_inherit={"PATH", "PYENV_ROOT", "HOME"})
+    return rule_runner
+
+
+# -----------------------------------------------------------------------------------------------
+# Tests for dependency inference of python targets (python_tests)
+# -----------------------------------------------------------------------------------------------
+
+
+_noop_runner_addresses = (
+    Address(
+        "runners/noop_runner/noop_runner",
+        relative_file_path="noop_runner.py",
+    ),
+    Address(
+        "runners/noop_runner/noop_runner",
+        relative_file_path="thing.py",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "requested_entry_points, expected_dep_addresses",
+    (
+        # return no entry points
+        ([], []),
+        (["undefined.group"], []),
+        (["console_scripts/undefined-script"], []),
+        # return one entry point
+        (["st2common.runners.runner"], [_noop_runner_addresses[0]]),
+        (["st2common.runners.runner/noop"], [_noop_runner_addresses[0]]),
+        (["console_scripts"], [_noop_runner_addresses[1]]),
+        (["console_scripts/some-thing"], [_noop_runner_addresses[1]]),
+        # return multiple entry points
+        (["st2common.runners.runner", "console_scripts"], _noop_runner_addresses),
+        (["st2common.runners.runner", "console_scripts/some-thing"], _noop_runner_addresses),
+        (["st2common.runners.runner/noop", "console_scripts/some-thing"], _noop_runner_addresses),
+        (["st2common.runners.runner/noop", "console_scripts"], _noop_runner_addresses),
+        # return all entry points
+        (["st2common.runners.runner", "*"], _noop_runner_addresses),
+        (["*", "gui_scripts"], _noop_runner_addresses),
+        (["*"], _noop_runner_addresses),
+    ),
+)
+def test_infer_entry_point_dependencies(  # also tests get_filtered_entry_point_dependencies
+    rule_runner: RuleRunner,
+    requested_entry_points: list[str],
+    expected_dep_addresses: Iterable[Address],
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/foobar/BUILD": dedent(
+                f"""\
+                python_tests(
+                    name="tests",
+                    entry_point_dependencies={{
+                        "//runners/noop_runner": {repr(requested_entry_points)},
+                    }},
+                )
+                """
+            ),
+            "src/foobar/test_something.py": "",
+        }
+    )
+
+    def run_dep_inference(address: Address) -> InferredDependencies:
+        target = rule_runner.get_target(address)
+        return rule_runner.request(
+            InferredDependencies,
+            [
+                InferEntryPointDependencies(
+                    PythonTestsEntryPointDependenciesInferenceFieldSet.create(target)
+                )
+            ],
+        )
+
+    # This also asserts that these should NOT be inferred dependencies:
+    #   - anything from distributions other than noop_runner
+    #   - the python_distribution itself at Address(f"runners/noop_runner")
+    assert run_dep_inference(
+        Address("src/foobar", target_name="tests", relative_file_path="test_something.py"),
+    ) == InferredDependencies(expected_dep_addresses)
+
+
+# -----------------------------------------------------------------------------------------------
+# Tests for entry_points.txt generation
+# -----------------------------------------------------------------------------------------------
+
+
+# based on get_snapshot from pantsbuild/pants.git/src/python/pants/backend/python/lint/black/rules_integration_test.py
+def get_digest(rule_runner: RuleRunner, source_files: dict[str, str]) -> Digest:
+    files = [FileContent(path, content.encode()) for path, content in source_files.items()]
+    return rule_runner.request(Digest, [CreateDigest(files)])
+
+
+def get_digest_contents(rule_runner: RuleRunner, digest: Digest) -> DigestContents:
+    return rule_runner.request(DigestContents, [digest])
+
+
+_foobar_entry_points_txt_files = (
+    dedent(
+        """\
+        [console_scripts]
+        some-thing = foobar_runner.thing:main
+
+        """
+    ),
+    dedent(
+        """\
+        [st2common.runners.runner]
+        foobar = foobar_runner.foobar_runner
+
+        """
+    ),
+    dedent(
+        """\
+        [console_scripts]
+        some-thing = foobar_runner.thing:main
+
+        [st2common.runners.runner]
+        foobar = foobar_runner.foobar_runner
+
+        """
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    "requested_entry_points, expected_entry_points_txt",
+    (
+        # return no entry points
+        ([], None),
+        (["undefined.group"], None),
+        (["console_scripts/undefined-script"], None),
+        # return one entry point
+        (["st2common.runners.runner"], _foobar_entry_points_txt_files[1]),
+        (["st2common.runners.runner/foobar"], _foobar_entry_points_txt_files[1]),
+        (["console_scripts"], _foobar_entry_points_txt_files[0]),
+        (["console_scripts/some-thing"], _foobar_entry_points_txt_files[0]),
+        # return multiple entry points
+        (["st2common.runners.runner", "console_scripts"], _foobar_entry_points_txt_files[2]),
+        (
+            ["st2common.runners.runner", "console_scripts/some-thing"],
+            _foobar_entry_points_txt_files[2],
+        ),
+        (
+            ["st2common.runners.runner/foobar", "console_scripts/some-thing"],
+            _foobar_entry_points_txt_files[2],
+        ),
+        (
+            ["st2common.runners.runner/foobar", "console_scripts"],
+            _foobar_entry_points_txt_files[2],
+        ),
+        # return all entry points
+        (["st2common.runners.runner", "*"], _foobar_entry_points_txt_files[2]),
+        (["*", "gui_scripts"], _foobar_entry_points_txt_files[2]),
+        (["*"], _foobar_entry_points_txt_files[2]),
+    ),
+)
+def test_generate_entry_points_txt_from_entry_point_dependencies(
+    rule_runner: RuleRunner,
+    requested_entry_points: list[str],
+    expected_entry_points_txt: str | None,
+) -> None:
+    rule_runner.write_files(
+        {
+            "src/foobar/BUILD": dedent(
+                f"""\
+                python_tests(
+                    name="tests",
+                    entry_point_dependencies={{
+                        "//runners/foobar_runner": {repr(requested_entry_points)},
+                    }},
+                )
+                """
+            ),
+            "src/foobar/test_something.py": "",
+        }
+    )
+
+    entry_points_txt_path = "runners/foobar_runner/foobar_runner.egg-info/entry_points.txt"
+    if expected_entry_points_txt is None:
+        expected_digest = EMPTY_DIGEST
+    else:
+        expected_digest = get_digest(
+            rule_runner,
+            {entry_points_txt_path: expected_entry_points_txt},
+        )
+
+    target = rule_runner.get_target(
+        Address("src/foobar", target_name="tests", relative_file_path="test_something.py"),
+    )
+    response = rule_runner.request(
+        PytestPluginSetup,
+        [GenerateEntryPointsTxtFromEntryPointDependenciesRequest(target)],
+    )
+    contents = get_digest_contents(rule_runner, response.digest)
+    if expected_entry_points_txt is None:
+        assert not contents
+    else:
+        assert len(contents) == 1
+        assert contents[0].path == entry_points_txt_path
+        assert contents[0].content == expected_entry_points_txt.encode()
+
+    assert response == PytestPluginSetup(expected_digest)


### PR DESCRIPTION
This adds a new `entry_point_dependencies` field to `python_tests` and `python_test` targets.

This allows tests to depend on a subset (or all) of the `entry_points` defined on `python_distribution` targets (only on the `entry_points` field, not in the `provides` field).

For example:
```python
python_tests(
    name="tests",
    entry_point_dependencies={
        "//address/to:python_distro_tgt_1": ["*"],  # all entry points
        # only one group of entry points
        "//address/to:python_distro_tgt_2": ["console_scripts"],
        "//address/to:python_distro_tgt_4": ["st2common.runners.runner"],
        # or multiple groups of entry points
        "//address/to:python_distro_tgt_5": ["console_scripts", "st2common.runners.runner"],
        # or 1+ individual entry points
        "//address/to:python_distro_tgt_6": ["console_scripts/foo-bar"],
        "//address/to:python_distro_tgt_7": ["console_scripts/foo-bar", "console_scripts/baz"],
        "//address/to:python_distro_tgt_8": ["st2common.runners.runner/action-chain", "console_scripts/foo-bar"],
    },
)
```

A dependency defined in `entry_point_dependencies` emulates an editable install of those `python_distribution` targets. Instead of including all of the `python_distribution`'s sources, only the specified entry points are made available. The entry_points metadata is also installed in the pytest sandbox so that tests (or the code under test) can load that metadata via `pkg_resources` or `importlib.metadata.entry_points` or similar.

Misc notes:
- I added this to the `pants.backend.experimental.python` backend and also registered the rules I extracted from `pants.backend.experimental.python.framework.stevedore` with the stevedore backend since it needs those rules.
- Unlike all other dependencies fields, `entry_point_dependencies` is a `dict[str, list[str]]`. The `.keys()` of the dict are logically similar to standard dependencies fields. Using a dict provides more granular control over the dependencies.
- Also unlike other dependencies fields, this field does NOT result in a dependency on the `python_distribution` target. Instead, that target provides the `entry_points` metadata to infer dependencies on the actual code for those entry points.
- I extracted most of the logic for this from the experimental stevedore plugin. Enabling the stevedore plugin is not required to use this feature.

Closes #11386
Closes #15481