### PR TITLE
[Call-by-name] `swift` backend migration

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -105,7 +105,9 @@ The "Provided by" information in the documentation now correctly reflects the pr
 
 ### New call-by-name syntax for @rules
 
-Pants has a new mechanism for `@rule` invocation in backends. In this release the `cc` backend was migrated to use this new mechanism. There should not be any user-visible effects, but please be on the lookout for any unusual bugs or error messages.
+Pants has a new mechanism for `@rule` invocation in backends. In this release the following backends were migrated to use this new mechanism. There should not be any user-visible effects, but please be on the lookout for any unusual bugs or error messages.
+- `cc`
+- `swift`
 
 ## Full Changelog
 

--- a/src/python/pants/backend/swift/goals/tailor.py
+++ b/src/python/pants/backend/swift/goals/tailor.py
@@ -13,9 +13,8 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs
 from pants.engine.intrinsics import path_globs_to_paths
-from pants.engine.rules import Rule, collect_rules, implicitly, rule
+from pants.engine.rules import Rule, collect_rules, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -39,7 +38,7 @@ async def find_putative_targets(
     all_owned_sources: AllOwnedSources,
 ) -> PutativeTargets:
     all_swift_files = await path_globs_to_paths(
-        **implicitly({req.path_globs(*(f"*{ext}" for ext in SWIFT_FILE_EXTENSIONS)): PathGlobs})
+        req.path_globs(*(f"*{ext}" for ext in SWIFT_FILE_EXTENSIONS))
     )
     unowned_swift_files = set(all_swift_files.files) - set(all_owned_sources)
     classified_unowned_swift_files = classify_source_files(unowned_swift_files)

--- a/src/python/pants/backend/swift/goals/tailor.py
+++ b/src/python/pants/backend/swift/goals/tailor.py
@@ -13,9 +13,9 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import Rule, collect_rules, rule
+from pants.engine.fs import PathGlobs
+from pants.engine.intrinsics import path_globs_to_paths
+from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.engine.target import Target
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
@@ -38,8 +38,8 @@ async def find_putative_targets(
     req: PutativeSwiftTargetsRequest,
     all_owned_sources: AllOwnedSources,
 ) -> PutativeTargets:
-    all_swift_files = await Get(
-        Paths, PathGlobs, req.path_globs(*(f"*{ext}" for ext in SWIFT_FILE_EXTENSIONS))
+    all_swift_files = await path_globs_to_paths(
+        **implicitly({req.path_globs(*(f"*{ext}" for ext in SWIFT_FILE_EXTENSIONS)): PathGlobs})
     )
     unowned_swift_files = set(all_swift_files.files) - set(all_owned_sources)
     classified_unowned_swift_files = classify_source_files(unowned_swift_files)


### PR DESCRIPTION
This is a PR of the `swift` backend, containing only a `tailor` goal (aka. `tailor swift`). 

Ran the migration, followed by removing extraneous `implicitly`s.

See PR https://github.com/pantsbuild/pants/pull/21043 for more context on the first PR'd migration (`cc` backend).

See issue https://github.com/pantsbuild/pants/issues/21065 for tracking list.