### PR TITLE
Fix k8s-parser not able to load hikaru models

### DIFF
--- a/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
+++ b/src/python/pants/backend/helm/subsystems/k8s_parser_main.py
@@ -16,7 +16,12 @@ def main(args: list[str]):
     with open(input_filename) as file:
         try:
             parsed_docs = load_full_yaml(stream=file)
-        except RuntimeError:
+        except RuntimeError as e:
+            # If we couldn't load any hikaru-model packages
+            e_str = str(e)
+            if "No release packages found" in e_str or "install a hikaru-module package" in e_str:
+                raise
+
             # Hikaru fails with a `RuntimeError` when it finds a K8S manifest for an
             # API version and kind that doesn't understand.
             #


### PR DESCRIPTION
We use the hikaru package to parse kubernetes manifests. It recently split into a core package and packages for models for each version of kubernetes. This is a problem when deployed via PEX. The core package uses it's `__package__` attribute to locate the other members of the namespace package. But in a PEX, those are (by default) symlinked, and symlinked into special shards for the namespace (pex-ns-pkgs). This MR uses the `--venv-site-packages-copies` option, which was made for this situation:

> This can be used to around problems with tools or libraries that are by symlinked source files.