### PR TITLE
[Call-by-name] `cc.lint.clang-format` migration

### DIFF
--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -9,21 +9,15 @@ from typing import Iterable
 
 from pants.backend.cc.lint.clangformat.subsystem import ClangFormat
 from pants.backend.cc.target_types import CCSourceField
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest
-from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
-from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.partitions import PartitionerType
-from pants.engine.fs import Digest, MergeDigests
-from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, concurrently, Rule, collect_rules, rule
 from pants.backend.python.util_rules.pex import create_pex
+from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import find_config_file
+from pants.core.util_rules.partitions import PartitionerType
+from pants.engine.fs import MergeDigests
 from pants.engine.intrinsics import merge_digests_request_to_digest
-from pants.engine.rules import implicitly
+from pants.engine.rules import Rule, collect_rules, concurrently, rule
 from pants.engine.target import FieldSet
-from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
-from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 
@@ -43,38 +37,32 @@ class ClangFormatRequest(FmtTargetsRequest):
 
 @rule(level=LogLevel.DEBUG)
 async def clangformat_fmt(request: ClangFormatRequest.Batch, clangformat: ClangFormat) -> FmtResult:
-    # Look for any/all of the clang-format configuration files (recurse sub-dirs)
-    config_files_get = find_config_file(**implicitly({clangformat.config_request(request.snapshot.dirs): ConfigFilesRequest}))
-
     clangformat_pex, config_files = await concurrently(
-        create_pex(**implicitly({clangformat.to_pex_request(): PexRequest})),
+        create_pex(clangformat.to_pex_request()),
+        find_config_file(clangformat.config_request(request.snapshot.dirs)),
     )
 
     # Merge source files, config files, and clang-format pex process
-    input_digest = await merge_digests_request_to_digest(MergeDigests([request.snapshot.digest, config_files.snapshot.digest, clangformat_pex.digest]), **implicitly())
-
-    result = await Get(
-        ProcessResult,
-        PexProcess(
-            clangformat_pex,
-            argv=(
-                "--style=file",  # Look for .clang-format files
-                "--fallback-style=webkit",  # Use WebKit if there is no config file
-                "-i",  # In-place edits
-                "--Werror",  # Formatting warnings as errors
-                *clangformat.args,  # User-added arguments
-                *request.files,
-            ),
-            input_digest=input_digest,
-            output_files=request.files,
-            description=f"Run clang-format on {pluralize(len(request.files), 'file')}.",
-            level=LogLevel.DEBUG,
-        ),
+    input_digest = await merge_digests_request_to_digest(
+        MergeDigests(
+            [request.snapshot.digest, config_files.snapshot.digest, clangformat_pex.digest]
+        )
     )
-    return await FmtResult.create(request, result)
+
+    argv = (
+        "--style=file",  # Look for .clang-format files
+        "--fallback-style=webkit",  # Use WebKit if there is no config file
+        "-i",  # In-place edits
+        "--Werror",  # Formatting warnings as errors
+        *clangformat.args,  # User-added arguments
+        *request.files,
+    )
+    # result = await fallible_to_exec_result_or_raise(
+    #     PexProcess(clangformat_pex, argv=argv, input_digest=input_digest, output_files=request.files, description=f"Run clang-format on {pluralize(len(request.files), 'file')}.", level=LogLevel.DEBUG), **implicitly())
+    # return await FmtResult.create(request, result)
 
 
-def rules() -> Iterable[Rule | UnionRule]:
+def rules() -> Iterable[Rule]:
     return (
         *collect_rules(),
         *ClangFormatRequest.rules(),

--- a/src/python/pants/backend/cc/lint/clangformat/rules.py
+++ b/src/python/pants/backend/cc/lint/clangformat/rules.py
@@ -9,15 +9,18 @@ from typing import Iterable
 
 from pants.backend.cc.lint.clangformat.subsystem import ClangFormat
 from pants.backend.cc.target_types import CCSourceField
-from pants.backend.python.util_rules.pex import create_pex
+from pants.backend.python.util_rules.pex import PexProcess, create_pex
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.config_files import find_config_file
 from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.fs import MergeDigests
 from pants.engine.intrinsics import merge_digests_request_to_digest
-from pants.engine.rules import Rule, collect_rules, concurrently, rule
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.rules import Rule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSet
+from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
+from pants.util.strutil import pluralize
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +60,23 @@ async def clangformat_fmt(request: ClangFormatRequest.Batch, clangformat: ClangF
         *clangformat.args,  # User-added arguments
         *request.files,
     )
-    # result = await fallible_to_exec_result_or_raise(
-    #     PexProcess(clangformat_pex, argv=argv, input_digest=input_digest, output_files=request.files, description=f"Run clang-format on {pluralize(len(request.files), 'file')}.", level=LogLevel.DEBUG), **implicitly())
-    # return await FmtResult.create(request, result)
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            PexProcess(
+                clangformat_pex,
+                argv=argv,
+                input_digest=input_digest,
+                output_files=request.files,
+                description=f"Run clang-format on {pluralize(len(request.files), 'file')}.",
+                level=LogLevel.DEBUG,
+            )
+        ),
+    )
+
+    return await FmtResult.create(request, result)
 
 
-def rules() -> Iterable[Rule]:
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *ClangFormatRequest.rules(),


### PR DESCRIPTION
This PR was intended to be part of the `cc` migration (#21043), but I left it commented out from the backend packages by accident.

See issue https://github.com/pantsbuild/pants/issues/21065 for tracking list.