### PR TITLE
Helm: warn on missing docker image

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -142,7 +142,7 @@ Pants will output a more helpful error message if there is no `name` field defin
 
 #### Shell
 
-The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.22/reference/subsystems/shell-setup#tailor_shunit2_tests).
+The `tailor` goal now has independent options for tailoring `shell_sources` and `shunit2_tests` targets. The option was split from `tailor` into [`tailor_sources`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_sources) and [`tailor_shunit2_tests`](https://www.pantsbuild.org/2.23/reference/subsystems/shell-setup#tailor_shunit2_tests).
 
 #### Docker
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -152,6 +152,8 @@ Fixed a bug where the internal Docker BuildKit parser would return `<unknown> im
 
 Fixed pulling `helm_artifact`s from OCI repositories.
 
+Improve warning on dependent images not being found. Pants can now validate that values passed into Helm charts that will be used for container images are valid `docker_image` targets or known 3rd-party images. See the [documentation in the helm-infer subsystem](https://www.pantsbuild.org/2.23/reference/subsystems/helm-infer).
+
 #### Shell
 
 Added `workspace_invalidation_sources` field to `adhoc_tool` and `shell_command` target types. This new field allows declaring that these targets depend on files without bringing those files into the execution sandbox, but that the target should still be re-executed if those files change. This is intended to work with the `workspace_environment` support where processes are executed in the workspace and not in a separate sandbox.

--- a/src/python/pants/backend/docker/utils.py
+++ b/src/python/pants/backend/docker/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import difflib
 import os.path
+import re
 from fnmatch import fnmatch
 from typing import Callable, Iterable, Iterator, Sequence, TypeVar
 
@@ -14,6 +15,23 @@ from pants.help.maybe_color import MaybeColor
 from pants.util.ordered_set import FrozenOrderedSet
 
 _T = TypeVar("_T", bound="KeyValueSequenceUtil")
+
+
+image_ref_regexp = re.compile(
+    r"""
+    ^
+    # Optional registry.
+    ((?P<registry>[^/:_ ]+:?[^/:_ ]*)/)?
+    # Repository.
+    (?P<repository>[^:@ \t\n\r\f\v]+)
+    # Optionally with `:tag`.
+    (:(?P<tag>[^@ ]+))?
+    # Optionally with `@digest`.
+    (@(?P<digest>\S+))?
+    $
+    """,
+    re.VERBOSE,
+)
 
 
 class KeyValueSequenceUtil(FrozenOrderedSet[str]):

--- a/src/python/pants/backend/helm/check/kubeconform/deployment_test.py
+++ b/src/python/pants/backend/helm/check/kubeconform/deployment_test.py
@@ -111,6 +111,7 @@ def test_valid_deployment(rule_runner: RuleRunner) -> None:
             "src/deployment/BUILD": "helm_deployment(name='foo', chart='//src/mychart')",
         }
     )
+    rule_runner.set_options("--helm-infer-external-docker-images=['*']")
 
     addr = Address("src/deployment", target_name="foo")
     checked = run_check(rule_runner, addr)
@@ -186,7 +187,6 @@ def test_valid_deployment_ignoring_sources(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-
     addr = Address("src/deployment", target_name="foo")
     checked = run_check(rule_runner, addr)
 
@@ -266,7 +266,11 @@ def run_check(
     rule_runner: RuleRunner, address: Address, *, source_root_patterns: Iterable[str] = ("/src/*",)
 ) -> CheckResults:
     rule_runner.set_options(
-        [f"--source-root-patterns={repr(source_root_patterns)}", "--kubeconform-summary"],
+        [
+            f"--source-root-patterns={repr(source_root_patterns)}",
+            "--kubeconform-summary",
+            "--helm-infer-external-docker-images=['*']",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
 

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -196,9 +196,9 @@ class ImageReferenceResolver:
                 message = f"""\
                 `{image_ref}` was supplied, but Pants cannot determine
                 whether this should be a target's address or a 3rd-party dependency.
-                One of the following should resolve the situation:
+                One of the following should resolve this:
 
-                - add `{image_ref}` to `[helm-infer].external_docker_images`
+                - add `{image_ref}` to `[{HelmInferSubsystem.options_scope}].external_docker_images`
                 - add the registry component of the docker image. For example, `python:3.9` becomes `docker.io/library/python:3.9`; or `myapp:latest` becomes `registry.example.com/myapp:latest`.
                 """
                 self._handle_missing_docker_image(message)
@@ -229,7 +229,13 @@ class ImageReferenceResolver:
         return False
 
     def _handle_missing_docker_image(self, message):
-        message = "Error resolving Docker image dependency of a Helm chart.\n" + message
+        message = "\n".join(
+            [
+                "Error resolving Docker image dependency of a Helm chart.",
+                message,
+                f"The behavior for unowned imports can also be set with the `[{HelmInferSubsystem.options_scope}].unowned_dependency_behavior`",
+            ]
+        )
         if self.helm_infer.unowned_dependency_behavior == UnownedDependencyUsage.RaiseError:
             raise UnownedDependencyError(message)
         elif self.helm_infer.unowned_dependency_behavior == UnownedDependencyUsage.LogWarning:

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -198,7 +198,7 @@ class ImageReferenceResolver:
                 whether this should be a target's address or a 3rd-party dependency.
                 One of the following should resolve the situation:
 
-                - add `{image_ref}` to `[helm-infer].third_party_docker_images`
+                - add `{image_ref}` to `[helm-infer].external_docker_images`
                 - add the registry component of the docker image. For example, `python:3.9` becomes `docker.io/library/python:3.9`; or `myapp:latest` becomes `registry.example.com/myapp:latest`.
                 """
                 self._handle_missing_docker_image(message)
@@ -221,9 +221,9 @@ class ImageReferenceResolver:
 
         # Putting this wildcard check after parsing
         # will mean that we don't approve things that don't look like docker images.
-        if "*" in self.helm_infer.third_party_docker_images:
+        if "*" in self.helm_infer.external_docker_images:
             return True
-        if image_name in self.helm_infer.third_party_docker_images:
+        if image_name in self.helm_infer.external_docker_images:
             return True
 
         return False

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -169,7 +169,10 @@ async def first_party_helm_deployment_mapping(
         if not maybe_addr:
             return None
         if not isinstance(maybe_addr.val, Address):
+            if image_ref.startswith("//") or image_ref.startswith("./"):
+                _handle_missing_docker_image(helm_infer, image_ref, maybe_addr)
             return None
+
         if maybe_addr.val not in docker_target_addresses:
             _handle_missing_docker_image(helm_infer, image_ref, maybe_addr)
             return None

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -165,8 +165,6 @@ async def first_party_helm_deployment_mapping(
 
     resolver = ImageReferenceResolver(helm_infer, maybe_addresses_by_ref, docker_target_addresses)
 
-
-    print(f"{indexed_address_inputs=} aaa")
     return FirstPartyHelmDeploymentMapping(
         address=request.field_set.address,
         indexed_docker_addresses=indexed_address_inputs.transform_values(
@@ -196,8 +194,8 @@ class ImageReferenceResolver:
                 return None
             else:
                 message = f"""\
-                `{image_ref}` was supplied, but Pants cannot determine 
-                whether this should be a target's address or a 3rd-party dependency. 
+                `{image_ref}` was supplied, but Pants cannot determine
+                whether this should be a target's address or a 3rd-party dependency.
                 One of the following should resolve the situation:
 
                 - add `{image_ref}` to `[helm-infer].third_party_docker_images`
@@ -221,6 +219,10 @@ class ImageReferenceResolver:
         else:
             image_name = parsed.group("repository")
 
+        # Putting this wildcard check after parsing
+        # will mean that we don't approve things that don't look like docker images.
+        if "*" in self.helm_infer.third_party_docker_images:
+            return True
         if image_name in self.helm_infer.third_party_docker_images:
             return True
 

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -231,7 +231,10 @@ class ImageReferenceResolver:
         # will mean that we don't approve things that don't look like docker images.
         if "*" in self.helm_infer.external_docker_images:
             return True
-        if image_name in self.helm_infer.external_docker_images:
+        if (
+            image_name in self.helm_infer.external_docker_images
+            or image_ref in self.helm_infer.external_docker_images
+        ):
             return True
 
         return False

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -195,7 +195,11 @@ class ImageReferenceResolver:
             return None
         if not isinstance(maybe_addr.val, Address):
             # obviously intended to be a Pants target
-            if image_ref.startswith("//") or image_ref.startswith("./"):
+            if (
+                image_ref.startswith("//")
+                or image_ref.startswith("./")
+                or image_ref.startswith(":")
+            ):
                 message = f"`{image_ref}` was supplied but the docker_image target at `{maybe_addr.val}` does not exist."
                 self._handle_missing_docker_image(message)
                 return None

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -180,7 +180,8 @@ async def first_party_helm_deployment_mapping(
 class ImageReferenceResolver:
     """Attempt to resolve images to their references.
 
-    Errors are stored internally and are surfaced by a call to `report_errors`
+    Errors are stored internally and are surfaced by a call to `report_errors`, so we can report all
+    problems and avoid only raising 1 per run.
     """
 
     helm_infer: HelmInferSubsystem
@@ -190,6 +191,7 @@ class ImageReferenceResolver:
     errors: list[str] = field(default_factory=list)
 
     def image_ref_to_actual_address(self, image_ref: str) -> tuple[str, Address] | None:
+        """Attempt to resolve an image reference to its Pants Address or the docker image."""
         maybe_addr = self.maybe_addresses_by_ref.get(image_ref)
         if not maybe_addr:
             return None
@@ -247,6 +249,10 @@ class ImageReferenceResolver:
         self.errors.append(message)
 
     def report_errors(self):
+        """Raise all gathered errors.
+
+        Invoke this method after all resolving is done.
+        """
         if not self.errors:
             return
 

--- a/src/python/pants/backend/helm/dependency_inference/deployment.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment.py
@@ -15,7 +15,7 @@ from pants.backend.docker.utils import image_ref_regexp
 from pants.backend.helm.dependency_inference.subsystem import (
     HelmInferSubsystem,
     UnownedDependencyError,
-    UnownedDependencyUsage,
+    UnownedHelmDependencyUsage,
 )
 from pants.backend.helm.subsystems import k8s_parser
 from pants.backend.helm.subsystems.k8s_parser import ParsedKubeManifest, ParseKubeManifestRequest
@@ -257,9 +257,9 @@ class ImageReferenceResolver:
                 f"The behavior for unowned imports can also be set with the `[{HelmInferSubsystem.options_scope}].unowned_dependency_behavior`",
             ]
         )
-        if self.helm_infer.unowned_dependency_behavior == UnownedDependencyUsage.RaiseError:
+        if self.helm_infer.unowned_dependency_behavior == UnownedHelmDependencyUsage.RaiseError:
             raise UnownedDependencyError(message)
-        elif self.helm_infer.unowned_dependency_behavior == UnownedDependencyUsage.LogWarning:
+        elif self.helm_infer.unowned_dependency_behavior == UnownedHelmDependencyUsage.LogWarning:
             logging.warning(message)
         else:
             return

--- a/src/python/pants/backend/helm/dependency_inference/deployment_test.py
+++ b/src/python/pants/backend/helm/dependency_inference/deployment_test.py
@@ -243,7 +243,7 @@ def test_resolving_docker_image() -> None:
     target_not_found = "//testprojects/src/helm/deployment/oops:docker"
     target_wrong_type = "testprojects/src/helm/deployment:file"
     resolver = ImageReferenceResolver(
-        create_subsystem(HelmInferSubsystem, third_party_docker_images=["busybox"]),
+        create_subsystem(HelmInferSubsystem, external_docker_images=["busybox"]),
         {
             "busybox:latest": MaybeAddress(val=ResolveError("short error")),
             "python:latest": MaybeAddress(val=ResolveError("short error")),
@@ -307,7 +307,7 @@ def test_resolving_docker_image() -> None:
 
 def test_resolving_docker_image_no_thirdparty() -> None:
     resolver = ImageReferenceResolver(
-        create_subsystem(HelmInferSubsystem, third_party_docker_images=["*"]),
+        create_subsystem(HelmInferSubsystem, external_docker_images=["*"]),
         {
             "busybox:latest": MaybeAddress(val=ResolveError("short error")),
         },

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -23,6 +23,14 @@ class UnownedDependencyError(Exception):
 
 
 class HelmInferSubsystem(Subsystem):
+    """Settings controlling the dependency inference behaviour of the Helm backend.
+
+    Adding "*" to `external_docker_images` is different from setting `unowned_dependency_behavior`
+    to something other than "error". The key is that `external_docker_images` with "*" will only
+    allow anything that could be a docker image, but will still raise errors for other inference
+    problems.
+    """
+
     options_scope = "helm-infer"
     help = "Options controlling which dependencies will be inferred for Helm targets."
 

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -10,7 +10,7 @@ from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
 
-class UnownedDependencyUsage(Enum):
+class UnownedHelmDependencyUsage(Enum):
     """What action to take when an inferred dependency is unowned."""
 
     RaiseError = "error"
@@ -27,7 +27,7 @@ class HelmInferSubsystem(Subsystem):
     help = "Options controlling which dependencies will be inferred for Helm targets."
 
     unowned_dependency_behavior = EnumOption(
-        default=UnownedDependencyUsage.RaiseError,
+        default=UnownedHelmDependencyUsage.RaiseError,
         help=softwrap(
             """
             How to handle inferred dependencies that don't have an inferrable owner.

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -27,7 +27,7 @@ class HelmInferSubsystem(Subsystem):
     help = "Options controlling which dependencies will be inferred for Helm targets."
 
     unowned_dependency_behavior = EnumOption(
-        default=UnownedDependencyUsage.LogWarning,
+        default=UnownedDependencyUsage.RaiseError,
         help=softwrap(
             """
             How to handle inferred dependencies that don't have an inferrable owner.

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -58,6 +58,9 @@ class HelmInferSubsystem(Subsystem):
                 values={"container.image_ref": "python:3.10"},
             )
             ```
+
+            Use the value '*' to disable this check.
+            This will limit Pants's ability to warn on unknown docker images.
             """
         ),
     )

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from enum import Enum
+from functools import cached_property
 
-from pants.option.option_types import EnumOption
+from pants.option.option_types import EnumOption, StrListOption
 from pants.option.subsystem import Subsystem
 from pants.util.strutil import softwrap
 
@@ -38,3 +39,29 @@ class HelmInferSubsystem(Subsystem):
             """
         ),
     )
+
+    third_party_docker_images = StrListOption(
+        default=[],
+        help=softwrap(
+            """
+            Docker image names that are not provided by targets in this repository
+            and should be ignored for calculating dependencies.
+
+            For example, adding `python` to this setting
+            will cause Pants to not try to find the target `python:3.10`
+            in the following `helm_deployment`:
+
+            ```
+            helm_deployment(
+                name="my-deployment",
+                chart=":mychart",
+                values={"container.image_ref": "python:3.10"},
+            )
+            ```
+            """
+        ),
+    )
+
+    @cached_property
+    def third_party_base_images(self) -> set[str]:
+        return set(self.third_party_docker_images)

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -1,0 +1,40 @@
+# Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+from __future__ import annotations
+
+from enum import Enum
+
+from pants.option.option_types import EnumOption
+from pants.option.subsystem import Subsystem
+from pants.util.strutil import softwrap
+
+
+class UnownedDependencyUsage(Enum):
+    """What action to take when an inferred dependency is unowned."""
+
+    RaiseError = "error"
+    LogWarning = "warning"
+    DoNothing = "ignore"
+
+
+class UnownedDependencyError(Exception):
+    """The inferred dependency does not have any owner."""
+
+
+class HelmInferSubsystem(Subsystem):
+    options_scope = "helm-infer"
+    help = "Options controlling which dependencies will be inferred for Helm targets."
+
+    unowned_dependency_behavior = EnumOption(
+        default=UnownedDependencyUsage.LogWarning,
+        help=softwrap(
+            """
+            How to handle inferred dependencies that don't have an inferrable owner.
+
+            Usually when an import cannot be inferred, it represents an issue like Pants not being
+            properly configured, e.g. targets not set up. Often, missing dependencies will result
+            in confusing runtime errors where Docker images haven't been published,
+            so this option can be helpful to error more eagerly.
+            """
+        ),
+    )

--- a/src/python/pants/backend/helm/dependency_inference/subsystem.py
+++ b/src/python/pants/backend/helm/dependency_inference/subsystem.py
@@ -40,7 +40,7 @@ class HelmInferSubsystem(Subsystem):
         ),
     )
 
-    third_party_docker_images = StrListOption(
+    external_docker_images = StrListOption(
         default=[],
         help=softwrap(
             """
@@ -66,5 +66,5 @@ class HelmInferSubsystem(Subsystem):
     )
 
     @cached_property
-    def third_party_base_images(self) -> set[str]:
-        return set(self.third_party_docker_images)
+    def external_base_images(self) -> set[str]:
+        return set(self.external_docker_images)

--- a/src/python/pants/backend/helm/goals/deploy_test.py
+++ b/src/python/pants/backend/helm/goals/deploy_test.py
@@ -226,8 +226,14 @@ def test_can_deploy_3rd_party_chart(rule_runner: RuleRunner) -> None:
             ),
         }
     )
-
-    deploy_process = _run_deployment(rule_runner, "", "deploy_3rd_party")
+    deploy_process = _run_deployment(
+        rule_runner,
+        "",
+        "deploy_3rd_party",
+        args=[
+            "--helm-infer-external-docker-images=['quay.io/kiwigrid/k8s-sidecar','grafana/grafana','bats/bats','k8s.gcr.io/kube-state-metrics/kube-state-metrics','quay.io/prometheus/node-exporter','quay.io/prometheus-operator/prometheus-operator']"
+        ],
+    )
 
     assert deploy_process.process
     assert len(deploy_process.publish_dependencies) == 0

--- a/src/python/pants/backend/helm/util_rules/post_renderer_test.py
+++ b/src/python/pants/backend/helm/util_rules/post_renderer_test.py
@@ -83,7 +83,10 @@ def rule_runner() -> RuleRunner:
     )
     source_root_patterns = ("src/*",)
     rule_runner.set_options(
-        [f"--source-root-patterns={repr(source_root_patterns)}"],
+        [
+            f"--source-root-patterns={repr(source_root_patterns)}",
+            "--helm-infer-external-docker-images=['busybox']",
+        ],
         env_inherit=PYTHON_BOOTSTRAP_ENV,
     )
     return rule_runner


### PR DESCRIPTION
Add a toggle for warning if something that will be used as an image looks like a target but does not exist. Also adds an option for known 3rd-party images (and the option to disable it).

This allows us to ensure that an image is valid. Obviously, if it's a valid `docker_image` target, it's valid. Otherwise, the value being passed to an image could fit into several categories, which we can warn about:

- a 3rd party image : we check that this is a known image, so `busybox:latest` isn't interpreted as a target
- an image that was produced by a `docker_image` target, but taken from the registry : `myproject/docker:1.0.0`. we treat is as a 3rd party chart, which isn't accurate but has the same outcome.
- something that is obviously a Pants target but that isn't found : `//myproject:oops`, which we can warn must be a typo
- targets of the wrong type : `myproject:files`

closes to #18346 
