### PR TITLE
Experiment: Avoid preemtive cache search requests with GitHub Actions Cache provider

### DIFF
--- a/src/rust/engine/remote_provider/remote_provider_traits/src/lib.rs
+++ b/src/rust/engine/remote_provider/remote_provider_traits/src/lib.rs
@@ -12,6 +12,16 @@ use remexec::ActionResult;
 use tokio::fs::File;
 use tokio::io::{AsyncSeekExt, AsyncWrite};
 
+pub enum ListMissingDigestsAssurance {
+    /// The caller just wants an estimate of what's missing, if it's quick. Digests that do exist in
+    /// the remote _can_ be reported as missing. Digests that do NOT exist _must_ be reported as
+    /// missing.
+    AllowFalsePositives,
+    /// The caller needs to know the current state of what's missing. Digests that do in the remote
+    /// _must not_ be reported as missing. Digests that do NOT exist _must_ be reported as missing.
+    ConfirmExistence,
+}
+
 // TODO: this is duplicated with global_options.py, it'd be good to have this be the single source
 // of truth.
 #[derive(Clone, Copy, Debug, strum_macros::EnumString)]
@@ -70,6 +80,7 @@ pub trait ByteStoreProvider: Sync + Send + 'static {
     async fn list_missing_digests(
         &self,
         digests: &mut (dyn Iterator<Item = Digest> + Send),
+        assurance: ListMissingDigestsAssurance,
     ) -> Result<HashSet<Digest>, String>;
 }
 

--- a/src/rust/engine/remote_provider/src/lib.rs
+++ b/src/rust/engine/remote_provider/src/lib.rs
@@ -6,7 +6,8 @@ use std::sync::Arc;
 // Re-export these so that consumers don't have to know about the exact arrangement of underlying
 // crates.
 pub use remote_provider_traits::{
-    ActionCacheProvider, ByteStoreProvider, LoadDestination, RemoteProvider, RemoteStoreOptions,
+    ActionCacheProvider, ByteStoreProvider, ListMissingDigestsAssurance, LoadDestination,
+    RemoteProvider, RemoteStoreOptions,
 };
 
 // TODO(#19902): a unified view of choosing a provider would be nice


### PR DESCRIPTION
Experiment for #20133 

Maybe we can reduce the severity of rate limiting by not doing thousands of "does the cache entry exist?" requests.