### PR TITLE
Fix running python_sources with pex --executable (Cherry-pick of #21047)

### DIFF
--- a/docs/notes/2.22.x.md
+++ b/docs/notes/2.22.x.md
@@ -121,6 +121,8 @@ The `runtime` field of [`aws_python_lambda_layer`](https://www.pantsbuild.org/2.
 
 `pants export` of a Python resolve will now include generated Python sources (for example, from `protobuf_sources` or `thrift_sources` targets) if the option `--export-py-generated-sources` is enabled.
 
+Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
+
 #### Semgrep
 
 The default version of `semgrep` used by the `pants.backends.experimental.tool.semgrep` backend is now version 1.72.0, upgraded from 1.46.0. This version requires Python 3.8 or greater.

--- a/src/python/pants/backend/python/goals/run_python_source.py
+++ b/src/python/pants/backend/python/goals/run_python_source.py
@@ -57,7 +57,7 @@ class PythonSourceFieldSet(RunFieldSet):
         if not all(part.isidentifier() for part in source_name.split(".")):
             # If the python source is not importable (python modules can't be named with '-'),
             # then it must be an executable script.
-            executable = Executable(self.source.value)
+            executable = Executable.create(self.address, self.source.value)
         else:
             # The module is importable, so entry_point will do the heavy lifting instead.
             executable = None

--- a/src/python/pants/backend/python/target_types.py
+++ b/src/python/pants/backend/python/target_types.py
@@ -301,6 +301,12 @@ class ConsoleScript(MainSpecification):
 class Executable(MainSpecification):
     executable: str
 
+    @classmethod
+    def create(cls, address: Address, filename: str) -> Executable:
+        # spec_path is relative to the workspace. The rule is responsible for
+        # stripping the source root as needed.
+        return cls(os.path.join(address.spec_path, filename).lstrip(os.path.sep))
+
     def iter_pex_args(self) -> Iterator[str]:
         yield "--executable"
         # We do NOT yield self.executable or self.spec
@@ -409,9 +415,7 @@ class PexExecutableField(Field):
             return None
         if not isinstance(value, str):
             raise InvalidFieldTypeException(address, cls.alias, value, expected_type="a string")
-        # spec_path is relative to the workspace. The rule is responsible for
-        # stripping the source root as needed.
-        return Executable(os.path.join(address.spec_path, value).lstrip(os.path.sep))
+        return Executable.create(address, value)
 
 
 class PexArgsField(StringSequenceField):

--- a/src/python/pants/backend/python/util_rules/pex_from_targets.py
+++ b/src/python/pants/backend/python/util_rules/pex_from_targets.py
@@ -12,6 +12,7 @@ from packaging.utils import canonicalize_name as canonicalize_project_name
 
 from pants.backend.python.subsystems.setup import PythonSetup
 from pants.backend.python.target_types import (
+    Executable,
     MainSpecification,
     PexLayout,
     PythonRequirementsField,
@@ -49,6 +50,7 @@ from pants.core.target_types import FileSourceField
 from pants.engine.addresses import Address, Addresses
 from pants.engine.collection import DeduplicatedCollection
 from pants.engine.fs import Digest, DigestContents, GlobMatchErrorBehavior, MergeDigests, PathGlobs
+from pants.engine.internals.graph import Owners, OwnersRequest
 from pants.engine.rules import Get, MultiGet, collect_rules, rule
 from pants.engine.target import (
     Target,
@@ -554,6 +556,17 @@ async def create_pex_from_targets(
             await _warn_about_any_files_targets(
                 request.addresses, transitive_targets, union_membership
             )
+    elif isinstance(request.main, Executable):
+        # The source for an --executable main must be embedded in the pex even if request.include_source_files is False.
+        # If include_source_files is True, the executable source should be included in the (transitive) dependencies.
+        owners = await Get(
+            Owners,
+            OwnersRequest(
+                (request.main.spec,), owners_not_found_behavior=GlobMatchErrorBehavior.error
+            ),
+        )
+        owning_targets = await Get(Targets, Addresses(owners))
+        sources = await Get(PythonSourceFiles, PythonSourceFilesRequest(owning_targets))
     else:
         sources = PythonSourceFiles.empty()
 


### PR DESCRIPTION
This fixes the feature added in #20497 as it broke using `pants run` on a python_source if the file name has `-` or other invalid characters. Bug reported here: 
https://pantsbuild.slack.com/archives/C046T6T9U/p1717624913138789?thread_ts=1717624913.138789&cid=C046T6T9U

The other integration test for the pex --executable feature only tested running pex_binary, not python_source. So, I missed applying some of the path logic to both cases.
