### PR TITLE
Refactor venv export to use explicit `PythonExecutable` lookup

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -76,6 +76,8 @@ The default version of the pex tool has been updated from 2.3.1 to 2.3.3.
 
 Fix running python source files that have dashes in them (bug introduced in 2.20). For example: `pants run path/to/some-executable.py`
 
+Exported virtualenvs can use Pants-provided Python if a `PythonProvider` backend is enabled (like `pants.backend.python.providers.experimental.pyenv`). Before Pants 2.23, virtualenv exports could only use pre-installed python binaries.
+
 #### Terraform
 
 The `tfsec` linter now works on all supported platforms without extra config.

--- a/src/python/pants/backend/python/goals/export.py
+++ b/src/python/pants/backend/python/goals/export.py
@@ -10,7 +10,7 @@ import textwrap
 import uuid
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, cast
+from typing import cast
 
 from pants.backend.python.subsystems.python_tool_base import PythonToolBase
 from pants.backend.python.subsystems.setup import PythonSetup
@@ -20,9 +20,9 @@ from pants.backend.python.util_rules.local_dists_pep660 import (
     EditableLocalDists,
     EditableLocalDistsRequest,
 )
-from pants.backend.python.util_rules.pex import Pex, PexProcess, PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import Pex, PexRequest, VenvPex
 from pants.backend.python.util_rules.pex_cli import PexPEX
-from pants.backend.python.util_rules.pex_environment import PexEnvironment
+from pants.backend.python.util_rules.pex_environment import PexEnvironment, PythonExecutable
 from pants.backend.python.util_rules.pex_requirements import EntireLockfile, Lockfile
 from pants.core.goals.export import (
     Export,
@@ -46,7 +46,7 @@ from pants.engine.internals.native_engine import (
     Snapshot,
 )
 from pants.engine.internals.selectors import Get, MultiGet
-from pants.engine.process import ProcessCacheScope, ProcessResult
+from pants.engine.process import Process, ProcessCacheScope, ProcessResult
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import AllTargets, HydratedSources, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionMembership, UnionRule
@@ -148,28 +148,20 @@ class ExportPluginOptions:
     )
 
 
-async def _get_full_python_version(pex_or_venv_pex: Pex | VenvPex) -> str:
+async def _get_full_python_version(python: PythonExecutable) -> str:
     # Get the full python version (including patch #).
-    is_venv_pex = isinstance(pex_or_venv_pex, VenvPex)
-    kwargs: dict[str, Any] = dict(
-        description="Get interpreter version",
-        argv=[
-            "-c",
-            "import sys; print('.'.join(str(x) for x in sys.version_info[0:3]))",
-        ],
-        extra_env={"PEX_INTERPRETER": "1"},
-    )
-    if is_venv_pex:
-        kwargs["venv_pex"] = pex_or_venv_pex
-        res = await Get(ProcessResult, VenvPexProcess(**kwargs))
-    else:
-        kwargs["pex"] = pex_or_venv_pex
-        res = await Get(ProcessResult, PexProcess(**kwargs))
+    argv = [
+        python.path,
+        "-c",
+        "import sys; print('.'.join(str(x) for x in sys.version_info[0:3]))",
+    ]
+    res = await Get(ProcessResult, Process(argv, description="Get interpreter version"))
     return res.stdout.strip().decode()
 
 
 @dataclass(frozen=True)
 class VenvExportRequest:
+    py_version: str
     pex_request: PexRequest
     dest_prefix: str
     resolve_name: str
@@ -212,13 +204,12 @@ async def do_export(
             PexRequest,
             dataclasses.replace(req.pex_request, cache_scope=ProcessCacheScope.PER_SESSION),
         )
-        py_version = await _get_full_python_version(requirements_venv_pex)
         # Note that for symlinking we ignore qualify_path_with_python_version and always qualify,
         # since we need some name for the symlink anyway.
-        dest = f"{dest_prefix}/{py_version}"
+        dest = f"{dest_prefix}/{req.py_version}"
         description = (
             f"symlink to immutable virtualenv for {req.resolve_name or 'requirements'} "
-            f"(using Python {py_version})"
+            f"(using Python {req.py_version})"
         )
         venv_abspath = os.path.join(complete_pex_env.pex_root, requirements_venv_pex.venv_rel_dir)
         return ExportResult(
@@ -237,14 +228,13 @@ async def do_export(
         # See the build_pex() rule and _determine_pex_python_and_platforms() helper in pex.py.
         requirements_pex = await Get(Pex, PexRequest, req.pex_request)
         assert requirements_pex.python is not None
-        py_version = await _get_full_python_version(requirements_pex)
         if req.qualify_path_with_python_version:
-            dest = f"{dest_prefix}/{py_version}"
+            dest = f"{dest_prefix}/{req.py_version}"
         else:
             dest = dest_prefix
         description = (
             f"mutable virtualenv for {req.resolve_name or 'requirements'} "
-            f"(using Python {py_version})"
+            f"(using Python {req.py_version})"
         )
 
         merged_digest = await Get(Digest, MergeDigests([pex_pex.digest, requirements_pex.digest]))
@@ -252,7 +242,7 @@ async def do_export(
         tmpdir_under_digest_root = os.path.join("{digest_root}", tmpdir_prefix)
         merged_digest_under_tmpdir = await Get(Digest, AddPrefix(merged_digest, tmpdir_prefix))
 
-        venv_prompt = f"{req.resolve_name}/{py_version}" if req.resolve_name else py_version
+        venv_prompt = f"{req.resolve_name}/{req.py_version}" if req.resolve_name else req.py_version
 
         pex_args = [
             os.path.join(tmpdir_under_digest_root, requirements_pex.name),
@@ -286,7 +276,7 @@ async def do_export(
             #   - pkg_name-1.2.3-0.editable-py3-none-any.whl
             wheels_snapshot = await Get(Snapshot, Digest, req.editable_local_dists_digest)
             # We need the paths to the installed .dist-info directories to finish installation.
-            py_major_minor_version = ".".join(py_version.split(".", 2)[:2])
+            py_major_minor_version = ".".join(req.py_version.split(".", 2)[:2])
             lib_dir = os.path.join(
                 output_path, "lib", f"python{py_major_minor_version}", "site-packages"
             )
@@ -533,6 +523,9 @@ async def export_virtualenv_for_resolve(
         )
     )
 
+    python = await Get(PythonExecutable, InterpreterConstraints, interpreter_constraints)
+    py_version = await _get_full_python_version(python)
+
     if resolve in export_subsys.options.py_editable_in_resolve:
         editable_local_dists = await Get(
             EditableLocalDists, EditableLocalDistsRequest(resolve=resolve)
@@ -547,7 +540,7 @@ async def export_virtualenv_for_resolve(
         internal_only=True,
         requirements=EntireLockfile(lockfile),
         sources=editable_local_dists_digest,
-        interpreter_constraints=interpreter_constraints,
+        python=python,
         # Packed layout should lead to the best performance in this use case.
         layout=PexLayout.PACKED,
     )
@@ -556,6 +549,7 @@ async def export_virtualenv_for_resolve(
     export_result = await Get(
         ExportResult,
         VenvExportRequest(
+            py_version,
             pex_request,
             dest_prefix,
             resolve,

--- a/src/python/pants/backend/python/util_rules/pex.py
+++ b/src/python/pants/backend/python/util_rules/pex.py
@@ -643,7 +643,7 @@ async def build_pex(
 ) -> BuildPexResult:
     """Returns a PEX with the given settings."""
 
-    if not request.interpreter_constraints:
+    if not request.python and not request.interpreter_constraints:
         # Blank ICs in the request means that the caller wants us to use the ICs configured
         # for the resolve (falling back to the global ICs).
         resolve_name = ""


### PR DESCRIPTION
Instead of relying on the implicit pex interpreter resolution--based on interpreter_constraints--this PR makes the export pre-calculate which interpreter to use.

This has the benefit of allowing pants to provide the python interpreter (eg with pyenv) if configured to do so. Without this, the exports can only use pre-installed interpreters.

To make this work, I had to prevent the injection of `PexRequest.interpreter_constraints` when `PexRequest.python` is set.

This refactor is pre-work for #20516.