### PR TITLE
docs: how to publish a Pants config schema file in Schema Store

### DIFF
--- a/docs/docs/contributions/development/maintenance-tasks-and-scripts.mdx
+++ b/docs/docs/contributions/development/maintenance-tasks-and-scripts.mdx
@@ -62,14 +62,6 @@ Some tools use `NodeJSToolBase` to install executable npm packages. To update th
 
 Example: [#21007](https://github.com/pantsbuild/pants/pull/21007).
 
-## Generate a new JSON schema file
-
-Some editors can use JSON Schema for better completions (etc.) when editing TOML files like  `pants.toml`. To generate such a schema:
-
-1. Run `pants help-all > all-help.json`
-2. Run `pants run build-support/bin/generate_json_schema.py -- --all-help-file=all-help.json`
-3. For a new release, upload the resulting file to https://www.schemastore.org/json/
-
 ## Update or create FaaS complete platforms files
 
 The function-as-a-service (FaaS) subsystems provide some built-in PEX complete platforms JSON files, for specific runtimes. To update or create these:

--- a/docs/docs/contributions/releases/release-process.mdx
+++ b/docs/docs/contributions/releases/release-process.mdx
@@ -158,6 +158,30 @@ Once the workflow finishes, look through any failures and determine if there's a
 
 Alternatively, after starting the workflow, post the link to the in-progress run in `#development` in Slack, so that someone can come back to it when it does finish.
 
+## Step 5: Publish a schema in JSON Schema Store
+
+Some editors can use JSON Schema for better completions when editing TOML files like `pants.toml`.
+Pants configuration file schema is published at https://www.schemastore.org/. For every stable `2.x.0` release,
+a new schema needs to be generated and uploaded by submitting a PR against https://github.com/SchemaStore/schemastore.
+This is an example pull request for reference: https://github.com/SchemaStore/schemastore/pull/3880.
+
+To produce `pantsbuild-<version>.json` schema file, run:
+
+```bash
+pants help-all > all-help.json
+pants run build-support/bin/generate_json_schema.py -- --all-help-file=all-help.json
+```
+
+It may be helpful to compare the last schema file with the newly produced one to make sure there are no discrepancies
+(e.g. the config values have a sensible type and the help strings are rendered adequately). You can download the
+schemas of previous releases from the store website; the JSON files are available at
+`https://json.schemastore.org/pantsbuild-<version>.json`.
+
+Watch out for any configuration parameters that may rely on your local environment as certain default config values
+will be expanded using local runtime environment which is undesirable. The script handles those known config values
+by keeping a list of them, however, it may need to be extended as more options with environment specific default
+values are added.
+
 ## When Things Go Wrong
 
 From time to time, a release will fail. It's a complex process. The first thing to do after you've


### PR DESCRIPTION
As I publish Pants config schemas to the SchemaStore every release, it is probably helpful to document the steps briefly.