### PR TITLE
Pass through remote execution platform in Rust codebase via options

### DIFF
--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -212,6 +212,17 @@ impl TryFrom<String> for Platform {
     }
 }
 
+impl AsRef<str> for Platform {
+    fn as_ref(&self) -> &str {
+        match self {
+            Platform::Linux_x86_64 => "linux_x86_64",
+            Platform::Linux_arm64 => "linux_arm64",
+            Platform::Macos_arm64 => "macos_arm64",
+            Platform::Macos_x86_64 => "macos_x86_64",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, DeepSizeOf, Eq, PartialEq, Hash, Serialize)]
 pub enum ProcessCacheScope {
     // Cached in all locations, regardless of success or failure.

--- a/src/rust/engine/process_execution/src/lib.rs
+++ b/src/rust/engine/process_execution/src/lib.rs
@@ -188,14 +188,20 @@ impl Platform {
     }
 }
 
+impl AsRef<str> for Platform {
+    fn as_ref(&self) -> &str {
+        match self {
+            Platform::Linux_x86_64 => "linux_x86_64",
+            Platform::Linux_arm64 => "linux_arm64",
+            Platform::Macos_arm64 => "macos_arm64",
+            Platform::Macos_x86_64 => "macos_x86_64",
+        }
+    }
+}
+
 impl From<Platform> for String {
     fn from(platform: Platform) -> String {
-        match platform {
-            Platform::Linux_x86_64 => "linux_x86_64".to_string(),
-            Platform::Linux_arm64 => "linux_arm64".to_string(),
-            Platform::Macos_arm64 => "macos_arm64".to_string(),
-            Platform::Macos_x86_64 => "macos_x86_64".to_string(),
-        }
+        platform.as_ref().to_string()
     }
 }
 
@@ -208,17 +214,6 @@ impl TryFrom<String> for Platform {
             "linux_x86_64" => Ok(Platform::Linux_x86_64),
             "linux_arm64" => Ok(Platform::Linux_arm64),
             other => Err(format!("Unknown platform {other:?} encountered in parsing")),
-        }
-    }
-}
-
-impl AsRef<str> for Platform {
-    fn as_ref(&self) -> &str {
-        match self {
-            Platform::Linux_x86_64 => "linux_x86_64",
-            Platform::Linux_arm64 => "linux_arm64",
-            Platform::Macos_arm64 => "macos_arm64",
-            Platform::Macos_x86_64 => "macos_x86_64",
         }
     }
 }

--- a/src/rust/engine/process_executor/src/main.rs
+++ b/src/rust/engine/process_executor/src/main.rs
@@ -135,7 +135,7 @@ struct Opt {
 
     /// The platform that the remote process will be executed on.
     /// MUST be set if executing remotely.
-    #[structopt(long, parse(try_from_str = parse_platform_from_str), default_value = Platform::Linux_x86_64.as_ref(), requires("server"))]
+    #[structopt(long, parse(try_from_str = parse_platform_from_str), default_value = Platform::Linux_x86_64.as_ref())]
     remote_execution_platform: Platform,
 
     /// Path to file containing root certificate authority certificates for the execution server.


### PR DESCRIPTION
Partial solve for https://github.com/pantsbuild/pants/issues/21016.

The remote execution platform was previously hardcoded to be Linux x86. This change allows passing through a new setting called `remote_execution_platform` containing a platform string; it requires that `server` be set as well to ensure that it is only used with remote execution, and defaults to Linux x86 to retain backwards compatibility.

This still needs some work on the rule/execution side to actually pass this setting through when the remote environment has a platform set.