### PR TITLE
upgrade Rust to v1.79.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,7 +192,7 @@ jobs:
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -276,7 +276,7 @@ jobs:
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain')
           }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -367,7 +367,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -130,7 +130,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: Linux-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -232,7 +232,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS12-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -441,7 +441,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS10-15-x86_64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 
@@ -508,7 +508,7 @@ jobs:
       uses: actions/cache@v3
       with:
         key: macOS11-ARM64-rustup-${{ hashFiles('src/rust/engine/rust-toolchain') }}-v2
-        path: '~/.rustup/toolchains/1.78.0-*
+        path: '~/.rustup/toolchains/1.79.0-*
 
           ~/.rustup/update-hashes
 

--- a/src/rust/engine/Cargo.toml
+++ b/src/rust/engine/Cargo.toml
@@ -72,7 +72,7 @@ process_execution = { path = "process_execution" }
 pyo3 = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
-reqwest = { version = "0.11", default_features = false, features = ["stream", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["stream", "rustls-tls"] }
 rule_graph = { path = "rule_graph" }
 smallvec = { version = "1", features = ["union"] }
 stdio = { path = "stdio" }

--- a/src/rust/engine/rule_graph/src/builder.rs
+++ b/src/rust/engine/rule_graph/src/builder.rs
@@ -1138,7 +1138,7 @@ impl<R: Rule> Builder<R> {
                 // affect our identity) rather than dependents.
                 #[allow(clippy::comparison_chain)]
                 let chosen_edges = {
-                    let mut minimum_param_set_size = ::std::usize::MAX;
+                    let mut minimum_param_set_size = usize::MAX;
                     let mut chosen_edges = Vec::new();
                     for edge_ref in relevant_edge_refs {
                         let param_set_size = graph[edge_ref.target()].0.in_set.len();

--- a/src/rust/engine/rust-toolchain
+++ b/src/rust/engine/rust-toolchain
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 # NB: We don't list the components (namely `clippy` and `rustfmt`) and instead rely on either the
 #  the profile being "default" (by-and-large the default profile) or the nice error message from
 #  `cargo fmt` and `cargo clippy` if the required component isn't installed


### PR DESCRIPTION
Upgrade Rust to v1.79.0. [Release Notes](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html)

Fixed one clippy lint issue and deprecation of `default_features` in `Cargo.toml` syntax (it is now called `default-features`).