### PR TITLE
Fix RuleRunner to work without BUILD_ROOT file in pytest sandbox

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -134,6 +134,8 @@ Support documenting macro constants using `MY_CONSTANT: Annotated[some_type, Doc
 
 Fixed bug where files larger than 512KB were being materialized to a process's sandbox without write permissions if the file was only globbed by `output_directories=(".",)`.
 
+Fixed bug where using `RuleRunner` in plugin tests caused `ValueError` that complains about not finding build root sentinel files. Note that you may have to adjust your tests to account for the new `BUILDROOT` file that `RuleRunner` now injects in the sandbox it creates for each test.
+
 ### Other minor tweaks
 
 The "Provided by" information in the documentation now correctly reflects the proper backend to enable to activate a certain feature.

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -134,7 +134,7 @@ Support documenting macro constants using `MY_CONSTANT: Annotated[some_type, Doc
 
 Fixed bug where files larger than 512KB were being materialized to a process's sandbox without write permissions if the file was only globbed by `output_directories=(".",)`.
 
-Fixed bug where using `RuleRunner` in plugin tests caused `ValueError` that complains about not finding build root sentinel files. Note that you may have to adjust your tests to account for the new `BUILDROOT` file that `RuleRunner` now injects in the sandbox it creates for each test.
+Fixed bug where using `RuleRunner` in plugin tests caused `ValueError` that complains about not finding build root sentinel files. Note that you may have to adjust your tests to account for the new `BUILDROOT` file that `RuleRunner` now injects in the sandbox it creates for each test. For example, a test that uses a `**` glob might have to add `!BUILDROOT` to exclude the `BUILDROOT` file, or otherwise account for its presence when inspecting a sandbox or its digest.
 
 ### Other minor tweaks
 

--- a/pants-plugins/pants_explorer/server/graphql/query/conftest.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/conftest.py
@@ -49,7 +49,9 @@ def all_help_info(rule_runner: RuleRunner) -> AllHelpInfo:
             ),
             union_membership=rule_runner.union_membership,
             consumed_scopes_mapper=fake_consumed_scopes_mapper,
-            registered_target_types=RegisteredTargetTypes.create(rule_runner.build_config.target_types),
+            registered_target_types=RegisteredTargetTypes.create(
+                rule_runner.build_config.target_types
+            ),
             build_symbols=BuildFileSymbolsInfo.from_info(),
             build_configuration=rule_runner.build_config,
         )

--- a/pants-plugins/pants_explorer/server/graphql/query/conftest.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/conftest.py
@@ -42,16 +42,18 @@ def all_help_info(rule_runner: RuleRunner) -> AllHelpInfo:
     def fake_consumed_scopes_mapper(scope: str) -> tuple[str, ...]:
         return ("somescope", f"used_by_{scope or 'GLOBAL_SCOPE'}")
 
-    return HelpInfoExtracter.get_all_help_info(
-        options=rule_runner.options_bootstrapper.full_options(
-            rule_runner.build_config, union_membership=UnionMembership({})
-        ),
-        union_membership=rule_runner.union_membership,
-        consumed_scopes_mapper=fake_consumed_scopes_mapper,
-        registered_target_types=RegisteredTargetTypes.create(rule_runner.build_config.target_types),
-        build_symbols=BuildFileSymbolsInfo.from_info(),
-        build_configuration=rule_runner.build_config,
-    )
+    with rule_runner.pushd():
+        all_help_info = HelpInfoExtracter.get_all_help_info(
+            options=rule_runner.options_bootstrapper.full_options(
+                rule_runner.build_config, union_membership=UnionMembership({})
+            ),
+            union_membership=rule_runner.union_membership,
+            consumed_scopes_mapper=fake_consumed_scopes_mapper,
+            registered_target_types=RegisteredTargetTypes.create(rule_runner.build_config.target_types),
+            build_symbols=BuildFileSymbolsInfo.from_info(),
+            build_configuration=rule_runner.build_config,
+        )
+    return all_help_info
 
 
 @pytest.fixture

--- a/pants-plugins/pants_explorer/server/graphql/query/targets.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/targets.py
@@ -18,8 +18,6 @@ from pants.engine.target import AllUnexpandedTargets, UnexpandedTargets
 from pants.help.help_info_extracter import TargetTypeHelpInfo
 from pants.util.strutil import softwrap
 
-specs_parser = SpecsParser()
-
 
 @strawberry.type(description="Describes a target field type.")
 class TargetTypeField:
@@ -165,7 +163,7 @@ class QueryTargetsMixin:
     async def targets(self, info: Info, query: Optional[TargetsQuery] = None) -> List[Target]:
         req = GraphQLContext.request_state_from_info(info).product_request
         specs = (
-            specs_parser.parse_specs(
+            SpecsParser().parse_specs(
                 query.specs, description_of_origin="GraphQL targets `query.specs`"
             )
             if query is not None and query.specs

--- a/pants-plugins/pants_explorer/server/graphql/query/targets.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/targets.py
@@ -18,6 +18,15 @@ from pants.engine.target import AllUnexpandedTargets, UnexpandedTargets
 from pants.help.help_info_extracter import TargetTypeHelpInfo
 from pants.util.strutil import softwrap
 
+_specs_parser: SpecsParser | None = None
+
+
+def _get_specs_parser() -> SpecsParser:
+    global _specs_parser
+    if _specs_parser is None:
+        _specs_parser = SpecsParser()
+    return _specs_parser
+
 
 @strawberry.type(description="Describes a target field type.")
 class TargetTypeField:
@@ -163,7 +172,7 @@ class QueryTargetsMixin:
     async def targets(self, info: Info, query: Optional[TargetsQuery] = None) -> List[Target]:
         req = GraphQLContext.request_state_from_info(info).product_request
         specs = (
-            SpecsParser().parse_specs(
+            _get_specs_parser().parse_specs(
                 query.specs, description_of_origin="GraphQL targets `query.specs`"
             )
             if query is not None and query.specs

--- a/pants-plugins/pants_explorer/server/graphql/query/targets_test.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/targets_test.py
@@ -41,7 +41,10 @@ async def test_targets_query(
     )
     with rule_runner.pushd():
         actual_result = await schema.execute(
-            queries, variable_values=variables, context_value=context, operation_name="TestTargetsQuery"
+            queries,
+            variable_values=variables,
+            context_value=context,
+            operation_name="TestTargetsQuery",
         )
     assert actual_result.errors is None
     assert actual_result.data == expected_data

--- a/pants-plugins/pants_explorer/server/graphql/query/targets_test.py
+++ b/pants-plugins/pants_explorer/server/graphql/query/targets_test.py
@@ -39,9 +39,10 @@ async def test_targets_query(
             "src/test/Dockerfile": "",
         }
     )
-    actual_result = await schema.execute(
-        queries, variable_values=variables, context_value=context, operation_name="TestTargetsQuery"
-    )
+    with rule_runner.pushd():
+        actual_result = await schema.execute(
+            queries, variable_values=variables, context_value=context, operation_name="TestTargetsQuery"
+        )
     assert actual_result.errors is None
     assert actual_result.data == expected_data
 

--- a/src/python/pants/backend/project_info/BUILD
+++ b/src/python/pants/backend/project_info/BUILD
@@ -3,4 +3,10 @@
 
 python_sources()
 
-python_tests(name="tests", timeout=180)
+python_tests(
+    name="tests",
+    timeout=180,
+    overrides={
+        "list_targets_test.py": {"dependencies": ["//BUILD_ROOT:files"]},
+    },
+)

--- a/src/python/pants/backend/project_info/dependencies_test.py
+++ b/src/python/pants/backend/project_info/dependencies_test.py
@@ -109,11 +109,12 @@ def assert_dependencies(
             assert json.loads(result.stdout) == expected
     else:
         assert not result.stdout
-        with open(output_file) as f:
-            if output_format == DependenciesOutputFormat.text:
-                assert f.read().splitlines() == expected
-            elif output_format == DependenciesOutputFormat.json:
-                assert json.load(f) == expected
+        with rule_runner.pushd():
+            with open(output_file) as f:
+                if output_format == DependenciesOutputFormat.text:
+                    assert f.read().splitlines() == expected
+                elif output_format == DependenciesOutputFormat.json:
+                    assert json.load(f) == expected
 
 
 def test_no_target(rule_runner: PythonRuleRunner) -> None:

--- a/src/python/pants/backend/project_info/dependents_test.py
+++ b/src/python/pants/backend/project_info/dependents_test.py
@@ -65,11 +65,12 @@ def assert_dependents(
             assert json.loads(result.stdout) == expected
     else:
         assert not result.stdout
-        with open(output_file) as f:
-            if output_format == DependentsOutputFormat.text:
-                assert f.read().splitlines() == expected
-            elif output_format == DependentsOutputFormat.json:
-                assert json.load(f) == expected
+        with rule_runner.pushd():
+            with open(output_file) as f:
+                if output_format == DependentsOutputFormat.text:
+                    assert f.read().splitlines() == expected
+                elif output_format == DependentsOutputFormat.json:
+                    assert json.load(f) == expected
 
 
 def test_no_targets(rule_runner: RuleRunner) -> None:

--- a/src/python/pants/backend/tools/taplo/rules_integration_test.py
+++ b/src/python/pants/backend/tools/taplo/rules_integration_test.py
@@ -42,7 +42,7 @@ def run_taplo(
     rule_runner.set_options(
         ["--backend-packages=pants.backend.tools.taplo", *(extra_args or ())],
     )
-    snapshot = rule_runner.request(Snapshot, [PathGlobs(["**"])])
+    snapshot = rule_runner.request(Snapshot, [PathGlobs(["**", "!BUILDROOT"])])
     partition = rule_runner.request(
         Partitions[Any], [TaploFmtRequest.PartitionRequest(snapshot.files)]
     )[0]

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -7,9 +7,7 @@ python_tests(
     name="tests",
     sources=["*_test.py", "!exception_sink_test.py", "!*_integration_test.py"],
     overrides={
-        "build_root_test.py": dict(
-            dependencies=["//BUILD_ROOT:files"],
-        )
+        "build_root_test.py": {"dependencies": ["//BUILD_ROOT:files"]},
     },
 )
 

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -6,7 +6,11 @@ python_sources()
 python_tests(
     name="tests",
     sources=["*_test.py", "!exception_sink_test.py", "!*_integration_test.py"],
-    dependencies=["//BUILD_ROOT:files"],
+    overrides={
+        "build_root_test.py": dict(
+            dependencies=["//BUILD_ROOT:files"],
+        )
+    }
 )
 
 python_tests(

--- a/src/python/pants/base/BUILD
+++ b/src/python/pants/base/BUILD
@@ -10,7 +10,7 @@ python_tests(
         "build_root_test.py": dict(
             dependencies=["//BUILD_ROOT:files"],
         )
-    }
+    },
 )
 
 python_tests(

--- a/src/python/pants/bsp/testutil.py
+++ b/src/python/pants/bsp/testutil.py
@@ -95,7 +95,7 @@ def setup_bsp_server(
     notification_names = notification_names or set()
     thread_locals = PyThreadLocals.get_for_current_thread()
 
-    with setup_pipes() as pipes:
+    with setup_pipes() as pipes, rule_runner.pushd():
         context = BSPContext()
         rule_runner.set_session_values({BSPContext: context})
         conn = BSPConnection(

--- a/src/python/pants/core/goals/BUILD
+++ b/src/python/pants/core/goals/BUILD
@@ -3,7 +3,13 @@
 
 python_sources()
 
-python_tests(name="tests", sources=["*_test.py", "!*_integration_test.py"])
+python_tests(
+    name="tests",
+    sources=["*_test.py", "!*_integration_test.py"],
+    overrides={
+        "publish_test.py": {"timeout": 70},
+    },
+)
 
 python_tests(
     name="integration",

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -157,8 +157,8 @@ def run_typecheck_rule(
 ) -> Tuple[int, str]:
     union_membership = UnionMembership({CheckRequest: request_types})
     check_subsystem = create_subsystem(CheckSubsystem, only=only or [])
-    with mock_console(create_options_bootstrapper(["-lwarn"])) as (console, stdio_reader):
-        rule_runner = RuleRunner()
+    rule_runner = RuleRunner(bootstrap_args=["-lwarn"])
+    with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         result: Check = run_rule_with_mocks(
             check,
             rule_args=[

--- a/src/python/pants/core/goals/check_test.py
+++ b/src/python/pants/core/goals/check_test.py
@@ -31,7 +31,7 @@ from pants.engine.process import (
 )
 from pants.engine.target import FieldSet, MultipleSourcesField, Target, Targets
 from pants.engine.unions import UnionMembership
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import MockGet, RuleRunner, mock_console, run_rule_with_mocks
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty

--- a/src/python/pants/core/goals/export_test.py
+++ b/src/python/pants/core/goals/export_test.py
@@ -36,7 +36,7 @@ from pants.engine.process import InteractiveProcess, InteractiveProcessResult
 from pants.engine.rules import QueryRule
 from pants.engine.target import Target, Targets
 from pants.engine.unions import UnionMembership, UnionRule
-from pants.testutil.option_util import create_options_bootstrapper, create_subsystem
+from pants.testutil.option_util import create_subsystem
 from pants.testutil.rule_runner import (
     MockEffect,
     MockGet,
@@ -90,7 +90,7 @@ def run_export_rule(rule_runner: RuleRunner, targets: List[Target]) -> Tuple[int
     union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
     with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
         fp.write(b"SOMEFILE")
-    with mock_console(create_options_bootstrapper()) as (console, stdio_reader):
+    with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         digest = rule_runner.request(Digest, [CreateDigest([FileContent("foo/bar", b"BAR")])])
         result: Export = run_rule_with_mocks(
             export,
@@ -223,7 +223,7 @@ def test_warnings_for_non_local_target_environments(
     union_membership = UnionMembership({ExportRequest: [MockExportRequest]})
     with open(os.path.join(rule_runner.build_root, "somefile"), "wb") as fp:
         fp.write(b"SOMEFILE")
-    with mock_console(create_options_bootstrapper()) as (console, stdio_reader):
+    with mock_console(rule_runner.options_bootstrapper) as (console, stdio_reader):
         digest = rule_runner.request(Digest, [CreateDigest([FileContent("foo/bar", b"BAR")])])
         run_rule_with_mocks(
             export,

--- a/src/python/pants/core/goals/publish_test.py
+++ b/src/python/pants/core/goals/publish_test.py
@@ -183,9 +183,10 @@ def test_structured_output(rule_runner: RuleRunner) -> None:
         },
     ]
 
-    with open("published.json") as fd:
-        data = json.load(fd)
-        assert data == expected
+    with rule_runner.pushd():
+        with open("published.json") as fd:
+            data = json.load(fd)
+            assert data == expected
 
 
 @pytest.mark.skip("Can not run interactive process from test..?")

--- a/src/python/pants/engine/BUILD
+++ b/src/python/pants/engine/BUILD
@@ -8,6 +8,9 @@ python_tests(
     dependencies=["src/python/pants/engine/internals:fs_test_data"],
     sources=["*_test.py", "!streaming_workunit_handler_integration_test.py"],
     timeout=90,
+    overrides={
+        "goal_test.py": {"dependencies": ["//BUILD_ROOT:files"]},
+    },
 )
 
 python_tests(

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -112,6 +112,8 @@ def setup_fs_test_tar(rule_runner: RuleRunner) -> None:
             └── 2
         c.ln -> a/b
         d.ln -> a
+
+    NB: The RuleRunner injects a BUILDROOT file in the build_root.
     """
     data = pkgutil.get_data("pants.engine.internals", "fs_test_data/fs_test.tar")
     assert data is not None
@@ -123,6 +125,7 @@ def setup_fs_test_tar(rule_runner: RuleRunner) -> None:
 
 
 FS_TAR_ALL_FILES = (
+    "BUILDROOT",  # injected by RuleRunner, not present in tar
     "4.txt",
     "a/3.txt",
     "a/4.txt.ln",
@@ -221,7 +224,7 @@ def test_path_globs_glob_pattern(rule_runner: RuleRunner) -> None:
     )
     assert_path_globs(rule_runner, ["*/0.txt"], expected_files=[], expected_dirs=[])
     assert_path_globs(
-        rule_runner, ["*"], expected_files=["4.txt"], expected_dirs=["a", "c.ln", "d.ln"]
+        rule_runner, ["*"], expected_files=["BUILDROOT", "4.txt"], expected_dirs=["a", "c.ln", "d.ln"]
     )
     assert_path_globs(
         rule_runner,
@@ -302,7 +305,7 @@ def test_path_globs_ignore_pattern(rule_runner: RuleRunner) -> None:
     assert_path_globs(
         rule_runner,
         ["**", "!*.ln"],
-        expected_files=["4.txt", "a/3.txt", "a/b/1.txt", "a/b/2"],
+        expected_files=["BUILDROOT", "4.txt", "a/3.txt", "a/b/1.txt", "a/b/2"],
         expected_dirs=["a", "a/b"],
     )
 
@@ -318,7 +321,7 @@ def test_path_globs_ignore_sock(rule_runner: RuleRunner) -> None:
     assert_path_globs(
         rule_runner,
         ["**"],
-        expected_files=["non-sock.txt"],
+        expected_files=["BUILDROOT", "non-sock.txt"],
         expected_dirs=[],
     )
 

--- a/src/python/pants/engine/fs_test.py
+++ b/src/python/pants/engine/fs_test.py
@@ -224,7 +224,10 @@ def test_path_globs_glob_pattern(rule_runner: RuleRunner) -> None:
     )
     assert_path_globs(rule_runner, ["*/0.txt"], expected_files=[], expected_dirs=[])
     assert_path_globs(
-        rule_runner, ["*"], expected_files=["BUILDROOT", "4.txt"], expected_dirs=["a", "c.ln", "d.ln"]
+        rule_runner,
+        ["*"],
+        expected_files=["BUILDROOT", "4.txt"],
+        expected_dirs=["a", "c.ln", "d.ln"],
     )
     assert_path_globs(
         rule_runner,

--- a/src/python/pants/engine/internals/BUILD
+++ b/src/python/pants/engine/internals/BUILD
@@ -10,6 +10,7 @@ python_tests(
     sources=["*_test.py", "!scheduler_integration_test.py"],
     timeout=90,
     overrides={
+        "engine_test.py": {"dependencies": ["//BUILD_ROOT:files"]},
         "platform_rules_test.py": {"tags": ["platform_specific_behavior"], "timeout": 120},
     },
 )

--- a/src/python/pants/engine/internals/graph_test.py
+++ b/src/python/pants/engine/internals/graph_test.py
@@ -1779,7 +1779,7 @@ def test_sources_output_type(sources_rule_runner: RuleRunner) -> None:
         HydratedSources,
         [HydrateSourcesRequest(valid_sources, for_sources_types=[SourcesSubclass])],
     )
-    assert hydrated_valid_sources.snapshot.files == ("f1.f95",)
+    assert hydrated_valid_sources.snapshot.files == ("BUILDROOT", "f1.f95")
     assert hydrated_valid_sources.sources_type == SourcesSubclass
 
     valid_single_sources = SingleSourceSubclass("f1.f95", addr)

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -793,14 +793,14 @@ def test_resolve_specs_paths(rule_runner: RuleRunner) -> None:
     )
     assert_paths(["demo/*.foo", "-demo/unowned.foo"], set(), set())
 
-    assert_paths([":"], {"f.txt"}, set())
+    assert_paths([":"], {"BUILDROOT", "f.txt"}, set())
     for dir_suffix in ("", ":"):
         assert_paths([f"unowned{dir_suffix}"], {"unowned/f.txt"}, {"unowned"})
         assert_paths([f"demo{dir_suffix}"], {*all_expected_demo_files, "demo/BUILD"}, {"demo"})
 
     assert_paths(
         ["::"],
-        {*all_expected_demo_files, "demo/BUILD", "f.txt", "unowned/f.txt", "unowned/subdir/f.txt"},
+        {*all_expected_demo_files, "BUILDROOT", "demo/BUILD", "f.txt", "unowned/f.txt", "unowned/subdir/f.txt"},
         {"demo", "unowned", "unowned/subdir"},
     )
     assert_paths(

--- a/src/python/pants/engine/internals/specs_rules_test.py
+++ b/src/python/pants/engine/internals/specs_rules_test.py
@@ -800,7 +800,14 @@ def test_resolve_specs_paths(rule_runner: RuleRunner) -> None:
 
     assert_paths(
         ["::"],
-        {*all_expected_demo_files, "BUILDROOT", "demo/BUILD", "f.txt", "unowned/f.txt", "unowned/subdir/f.txt"},
+        {
+            *all_expected_demo_files,
+            "BUILDROOT",
+            "demo/BUILD",
+            "f.txt",
+            "unowned/f.txt",
+            "unowned/subdir/f.txt",
+        },
         {"demo", "unowned", "unowned/subdir"},
     )
     assert_paths(

--- a/src/python/pants/source/filespec_test.py
+++ b/src/python/pants/source/filespec_test.py
@@ -48,7 +48,7 @@ def assert_rule_match(
         ("*/[be]*/b*", ("foo/bar/baz", "foo/bar/bar")),
         ("foo*/bar", ("foofighters/bar", "foofighters.venv/bar")),
         # Double stars.
-        ("**", ("a/b/c", "b")),
+        ("**", ("BUILDROOT", "a/b/c", "b")),
         ("a/**/f", ("a/f", "a/b/c/d/e/f")),
         ("a/b/**", ("a/b/d", "a/b/c/d/e/f")),
         # Dots.

--- a/src/python/pants/testutil/BUILD
+++ b/src/python/pants/testutil/BUILD
@@ -24,7 +24,6 @@ python_sources(
         "pants_integration_test.py": {
             "dependencies": ["//BUILD_ROOT:files", "src/python/pants/__main__.py"]
         },
-        "rule_runner.py": {"dependencies": ["//BUILD_ROOT:files"]},
     },
 )
 

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -317,7 +317,9 @@ class RuleRunner:
         # Change cwd and add sentinel file (BUILDROOT) so NativeOptionParser can find build_root.
         with pushd(self.build_root):
             Path("BUILDROOT").touch()
-            self.options_bootstrapper = self.create_options_bootstrapper(args=bootstrap_args, env=None)
+            self.options_bootstrapper = self.create_options_bootstrapper(
+                args=bootstrap_args, env=None
+            )
             options = self.options_bootstrapper.full_options(
                 self.build_config,
                 union_membership=UnionMembership.from_rules(

--- a/src/python/pants/testutil/rule_runner.py
+++ b/src/python/pants/testutil/rule_runner.py
@@ -404,7 +404,8 @@ class RuleRunner:
             if self.inherent_environment
             else Params(*inputs)
         )
-        result = assert_single_element(self.scheduler.product_request(output_type, [params]))
+        with pushd(self.build_root):
+            result = assert_single_element(self.scheduler.product_request(output_type, [params]))
         return cast(_O, result)
 
     def run_goal_rule(
@@ -471,7 +472,8 @@ class RuleRunner:
             **{k: os.environ[k] for k in (env_inherit or set()) if k in os.environ},
             **(env or {}),
         }
-        self.options_bootstrapper = self.create_options_bootstrapper(args=args, env=env)
+        with pushd(self.build_root):
+            self.options_bootstrapper = self.create_options_bootstrapper(args=args, env=env)
         self.environment = CompleteEnvironmentVars(env)
         self._set_new_session(self.scheduler.scheduler)
 

--- a/src/python/pants/vcs/git_test.py
+++ b/src/python/pants/vcs/git_test.py
@@ -464,6 +464,7 @@ def test_worktree_invalidation(origin: Path) -> None:
                 QueryRule(str, []),
             ]
         )
+        rule_runner.build_root = origin.as_posix()
 
         rule_runner.set_options([], env_inherit={"PATH"})
         worktree_id_1 = rule_runner.request(str, [])

--- a/tests/python/pants_test/init/BUILD
+++ b/tests/python/pants_test/init/BUILD
@@ -11,7 +11,8 @@ python_tests(
                 # These tests load `pants.toml`, which references many of these plugins.
                 "src/python/pants/bin:plugins",
             ],
-        }
+        },
+        "test_logging.py": {"dependencies": ["//BUILD_ROOT:files"]},
     },
 )
 

--- a/tests/python/pants_test/init/test_util.py
+++ b/tests/python/pants_test/init/test_util.py
@@ -14,8 +14,8 @@ from pants.util.contextutil import temporary_dir
 
 
 @contextmanager
-def physical_workdir_base() -> Iterator[OptionValueContainer]:
-    with temporary_dir(cleanup=False) as physical_workdir_base:
+def physical_workdir_base(rule_runner: RuleRunner) -> Iterator[OptionValueContainer]:
+    with temporary_dir(cleanup=False) as physical_workdir_base, rule_runner.pushd():
         bootstrap_options = create_options_bootstrapper(
             [f"--pants-physical-workdir-base={physical_workdir_base}"]
         ).bootstrap_options.for_global_scope()
@@ -42,7 +42,7 @@ def physical_workdir(pants_workdir: str, bootstrap_options: OptionValueContainer
 
 def test_init_workdir() -> None:
     rule_runner = RuleRunner()
-    with physical_workdir_base() as bootstrap_options:
+    with physical_workdir_base(rule_runner) as bootstrap_options:
         # Assert pants_workdir exists
         assert_exists(rule_runner.pants_workdir)
 


### PR DESCRIPTION
After #20887 (pants 2.22.0.dev2), `RuleRunner`-based tests do not work in external repos:
https://pantsbuild.slack.com/archives/C0D7TNJHL/p1719344475216619

This test run shows the `ValueError`s that show up in `RuleRunner`-based tests:
https://github.com/StackStorm/st2/actions/runs/9667956659/job/26670955784

The tests were passing in the pants repo because `rule_runner.py` had an explicit dependency on `//BUILD_ROOT:files`. So, the `BUILD_ROOT` file was added to the pytest sandbox for every `RuleRunner`-based test. Removing the `rule_runner.py` dependency on `//BUILD_ROOT:files` causes the `RuleRunner`-based tests to fail in the pants repo as well.

This issue was exposed because the rust-based `NativeOptionParser` does not provide an API for overriding the `BuildRoot`, unlike the python layer which uses a singleton `BuildRoot` object and allows RuleRunner to replace the build_root, bypassing the sentinel file-lookup logic. The `NativeOptionParser` requires either the `PANTS_BUILDROOT_OVERRIDE` env var or a sentinel file (one of `BUILD_ROOT`, `BUILDROOT`, or `pants.toml`) in the current working directory (or a parent of the current working directory) to calculate the build_root.

This PR:
- Removes dependencies on `//BUILD_ROOT:files` for some tests that do not actually require it.
- Removes the explicit dependency on `//BUILD_ROOT:files` from `testutil/rule_runner.py`.
- Makes `RuleRunner` change the current working directory to the temporary build_root directory while bootstrapping options (ie for the codepaths that initialize the rust-based `NativeOptionParser`).
- Makes `RuleRunner` add the sentinel file in the temporary build_root directory that `RuleRunner` creates so `NativeOptionParser` can find it in the current working directory.
- Adds a `RuleRunner.pushd()` api method to allow tests to change the current directory to `RuleRunner.build_root`.
- Adds dependencies on `//BUILD_ROOT:files` for tests that relied on the transitive dep via `testutil/rule_runner.py`. These tests either did not use `RuleRunner` (eg they only used `mock_console`), or relied on working in the sandbox with the actual pants code under test (meaning the pytest sandbox IS the build_root for that test).
