### PR TITLE
Separate discovery for tfsec config and checks

### DIFF
--- a/docs/docs/writing-plugins/common-subsystem-tasks.mdx
+++ b/docs/docs/writing-plugins/common-subsystem-tasks.mdx
@@ -78,3 +78,97 @@ Only some language backends support `pants export`. These include the Python and
             UnionRule(ExportableTool, FortranLint)
         ]
     ```
+
+## Loading config files
+
+1. Add an option to toggle config discovery:
+
+    ```python
+    from pants.option.subsystem import Subsystem
+    from pants.option.option_types import BoolOption
+    from pants.util.strutil import softwrap
+
+    class FortranLint(Subsystem):
+        config_discovery = BoolOption(
+            default=True,
+            advanced=True,
+            help=lambda cls: softwrap(
+                f"""
+                If true, Pants will include all relevant config files during runs.
+
+                Use `[{cls.options_scope}].config` and `[{cls.options_scope}].custom_check_dir` instead if your config is in a non-standard location.
+                """
+            ),
+        )
+    ```
+
+2. Add an option for the configuration file itself. Several options are useful depending on what types of config files you need: `FileOption`, `FileListOption`, `DirOption`, `DirListOption`.
+
+    ```python
+    from pants.option.subsystem import Subsystem
+    from pants.option.option_types import FileOption
+    from pants.util.strutil import softwrap
+
+    class FortranLint(Subsystem):
+        config = FileOption(
+            default=None,
+            advanced=True,
+            help=lambda cls: softwrap(
+                """
+                Path to the fortran-lint config file.
+
+                Setting this option will disable config discovery for the config file. Use this option if the config is located in a non-standard location.
+                """
+            ),
+        )
+    ```
+
+3. Add a helper function to generate the `ConfigFilesRequest`. The `check_existence` field is used for config discovery. `specified` can also be a list for using one of the list options.
+
+    ```python
+    from pants.core.util_rules.config_files import ConfigFilesRequest
+    from pants.option.subsystem import Subsystem
+
+    class FortranLint(Subsystem):
+        def config_request(self) -> ConfigFilesRequest:
+            return ConfigFilesRequest(
+                specified=self.config,
+                specified_option_name=f"[{self.options_scope}].config",
+                discovery=self.config_discovery,
+                check_existence=["fortran_lint.ini"],
+            )
+    ```
+
+4. Make a request for the config files in a rule for running the tool. Use a `Get(ConfigFiles, ConfigFilesRequest)` to get the config files. This has a snapshot that contains the config files (or will be empty if none are found). You can merge these with the other digests to pass the files to your `Process`. If a custom value was provided for the config file, you may need to pass that as an argument to the `Process`. You may also need to register rules from `pants.core.util_rules.config_files`.
+
+    ```python
+    from pants.core.goals.lint import LintResult
+    from pants.core.util_rules import config_files
+    from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
+    from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+    from pants.engine.fs import Digest, MergeDigests
+    from pants.engine.rules import Get, MultiGet, collect_rules, rule
+
+    @rule
+    async def run_fortran_lint(request: FortranlintRequest.Batch, subsystem: FortranLint) -> LintResult:
+        sources, config_file = await MultiGet(
+            Get(SourceFiles, SourceFilesRequest(fs.sources for fs in request.elements)),
+            Get(ConfigFiles, ConfigFilesRequest, subsystem.config_request()),
+        )
+
+        input_digest = await Get(
+            Digest, MergeDigests((sources.snapshot.digest, config_file.snapshot.digest))
+        )
+
+        args = []
+        if subsystem.config_request:
+            args.append(f"--config-file={subsystem.config}")
+
+        # run your process with the digest and args
+
+    def rules():
+        return [
+            *collect_rules(),
+            *config_files.rules(),
+        ]
+    ```

--- a/docs/docs/writing-plugins/the-rules-api/testing-plugins.mdx
+++ b/docs/docs/writing-plugins/the-rules-api/testing-plugins.mdx
@@ -369,7 +369,7 @@ To set options, call `rule_runer.set_options()` with a list of the arguments, e.
 You can also set the keyword argument `env: dict[str, str]`. If the option starts with `PANTS_`, it will change which options Pants uses. You can include any arbitrary environment variable here; some rules use the parent Pants process to read arbitrary env vars, e.g. the `--test-extra-env-vars` option, so this allows you to mock the environment in your test. Alternatively, use the keyword argument `env_inherit: set[str]` to set the specified environment variables using the test runner's environment, which is useful to set values like `PATH` which may vary across machines.
 
 :::caution Calling `rule_runner.set_options()` will override any options that were previously set.
-you will need to register everything you want in a single call.
+You will need to register everything you want in a single call.
 :::
 
 ### Running your rules

--- a/docs/docs/writing-plugins/the-rules-api/testing-plugins.mdx
+++ b/docs/docs/writing-plugins/the-rules-api/testing-plugins.mdx
@@ -364,11 +364,13 @@ def test_example() -> None:
 
 Often, you will want to set Pants options, such as activating a certain backend or setting a `--config` option.
 
-To set options, call `rule_runer.set_options()` with a list of the arguments, e.g. `rule_runner.set_options(["--pytest-version=pytest>=6.0"])`.
+To set options, call `rule_runer.set_options()` with a list of the arguments, e.g. `rule_runner.set_options(["--pytest-version=pytest>=6.0"])`. Global options will need to be set when constructing the `rule_runner` using the `bootstrap_args` parameter. For example, `bootstrap_args=["--pants-ignore=['!/.normally_ignored/']"]` will allow a test to read from a normally ignored directory, which can be useful for reading config files.
 
 You can also set the keyword argument `env: dict[str, str]`. If the option starts with `PANTS_`, it will change which options Pants uses. You can include any arbitrary environment variable here; some rules use the parent Pants process to read arbitrary env vars, e.g. the `--test-extra-env-vars` option, so this allows you to mock the environment in your test. Alternatively, use the keyword argument `env_inherit: set[str]` to set the specified environment variables using the test runner's environment, which is useful to set values like `PATH` which may vary across machines.
 
-Warning: calling `rule_runner.set_options()` will override any options that were previously set, so you will need to register everything you want in a single call.
+:::caution Calling `rule_runner.set_options()` will override any options that were previously set.
+you will need to register everything you want in a single call.
+:::
 
 ### Running your rules
 

--- a/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
@@ -17,6 +17,27 @@ from pants.engine.internals.native_engine import Address
 from pants.engine.rules import QueryRule
 from pants.testutil.rule_runner import RuleRunner
 
+TFSEC_CUSTOM_ERROR_CODE = "CUS001"
+TFSEC_CUSTOM_CHECK = f"""\
+checks:
+  - code: {TFSEC_CUSTOM_ERROR_CODE}
+    description: Custom check taken from the docs, lightly adapted to apply to this test case
+    impact: By not having CostCentre we can't keep track of billing
+    resolution: Add the CostCentre tag
+    requiredTypes:
+      - resource
+    requiredLabels:
+      - aws_s3_bucket
+    severity: ERROR
+    matchSpec:
+      name: tags
+      action: contains
+      value: CostCentre
+    errorMessage: The required CostCentre tag was missing
+    relatedLinks:
+      - https://aquasecurity.github.io/tfsec/latest/guides/configuration/custom-checks/
+"""
+
 
 def test_run_tfsec():
     rule_runner = RuleRunner(
@@ -33,7 +54,7 @@ def test_run_tfsec():
     rule_runner.set_options(
         [
             "--terraform-tfsec-args='--no-colour'",
-            "--terraform-tfsec-config=.tfsec_config.json",  # changing the config since changing pants_ignore isn't possible with the rule_runner
+            "--terraform-tfsec-config=.tfsec_config.json",  # the config dir is readable, but we're testing the extra setting
         ]
     )
 
@@ -54,6 +75,7 @@ def test_run_tfsec():
                 """
             ),
             ".tfsec_config.json": '{"exclude":["aws-s3-block-public-acls"]}',
+            ".tfsec/custom_tfchecks.yaml": TFSEC_CUSTOM_CHECK,  # this is the default, config discovery should still work even though we've specified a value for the config itself
         }
     )
 
@@ -69,3 +91,6 @@ def test_run_tfsec():
     assert (
         "\x1b[1m" not in result.stdout
     ), "Found colour control code in ouput, are extra-args being passed?"
+    assert (
+        TFSEC_CUSTOM_ERROR_CODE.lower() in result.stdout
+    ), "Custom check code wasn't found in output, did we pull in our custom config (all files in .tfsec folder)?"

--- a/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
+++ b/src/python/pants/backend/terraform/lint/tfsec/tfsec_integration_test.py
@@ -27,6 +27,7 @@ def test_run_tfsec():
             *source_files.rules(),
             QueryRule(LintResult, (TfSecRequest.Batch,)),
         ],
+        bootstrap_args=["--pants-ignore=['!/.tfsec/']"],
     )
 
     rule_runner.set_options(


### PR DESCRIPTION
- Separate discovery for tfsec config and checks, also adds a test
- add doc on configuring global options to `rule_runner`s
- add doc on fetching config files in plugins
