### PR TITLE
Throw an error when generating an empty Python lockfile

### DIFF
--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -100,6 +100,11 @@ async def generate_lockfile(
 ) -> GenerateLockfileResult:
     pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
 
+    if not req.requirements:
+        raise ValueError(
+            f"Cannot generate lockfile with no requirements. Please add some requirements to {req.resolve_name}."
+        )
+
     header_delimiter = "//"
     result = await Get(
         ProcessResult,

--- a/src/python/pants/backend/python/goals/lockfile.py
+++ b/src/python/pants/backend/python/goals/lockfile.py
@@ -98,13 +98,12 @@ async def generate_lockfile(
     python_setup: PythonSetup,
     pex_subsystem: PexSubsystem,
 ) -> GenerateLockfileResult:
-    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
-
     if not req.requirements:
         raise ValueError(
             f"Cannot generate lockfile with no requirements. Please add some requirements to {req.resolve_name}."
         )
 
+    pip_args_setup = await _setup_pip_args_and_constraints_file(req.resolve_name)
     header_delimiter = "//"
     result = await Get(
         ProcessResult,

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -20,6 +20,7 @@ from pants.backend.python.util_rules import pex
 from pants.backend.python.util_rules.interpreter_constraints import InterpreterConstraints
 from pants.core.goals.generate_lockfiles import GenerateLockfileResult, UserGenerateLockfiles
 from pants.engine.fs import DigestContents
+from pants.engine.internals.scheduler import ExecutionError
 from pants.testutil.python_rule_runner import PythonRuleRunner
 from pants.testutil.rule_runner import PYTHON_BOOTSTRAP_ENV, QueryRule
 from pants.util.ordered_set import FrozenOrderedSet
@@ -42,7 +43,7 @@ def rule_runner() -> PythonRuleRunner:
 def _generate(
     *,
     rule_runner: PythonRuleRunner,
-    ansicolors_version: str = "==1.1.8",
+    requirements_string: str = "ansicolors==1.1.8",
     requirement_constraints_str: str = '//   "requirement_constraints": [],\n',
     only_binary_and_no_binary_str: str = '//   "only_binary": [],\n//   "no_binary": []',
 ) -> str:
@@ -50,7 +51,7 @@ def _generate(
         GenerateLockfileResult,
         [
             GeneratePythonLockfile(
-                requirements=FrozenOrderedSet([f"ansicolors{ansicolors_version}"]),
+                requirements=FrozenOrderedSet([requirements_string] if requirements_string else []),
                 find_links=FrozenOrderedSet([]),
                 interpreter_constraints=InterpreterConstraints(),
                 resolve_name="test",
@@ -75,7 +76,7 @@ def _generate(
             //   "version": 3,
             //   "valid_for_interpreter_constraints": [],
             //   "generated_with_requirements": [
-            //     "ansicolors{ansicolors_version}"
+            //     "{requirements_string}"
             //   ],
             //   "manylinux": "manylinux2014",
             """
@@ -179,7 +180,7 @@ def test_constraints_file(rule_runner: PythonRuleRunner) -> None:
     lock_entry = json.loads(
         _generate(
             rule_runner=rule_runner,
-            ansicolors_version=">=1.0",
+            requirements_string="ansicolors>=1.0",
             requirement_constraints_str=dedent(
                 """\
                 //   "requirement_constraints": [
@@ -252,3 +253,13 @@ def test_multiple_resolves() -> None:
             diff=False,
         ),
     }
+
+
+def test_empty_requirements(rule_runner: PythonRuleRunner) -> None:
+    with pytest.raises(ExecutionError):
+        json.loads(
+            _generate(
+                rule_runner=rule_runner,
+                requirements_string="",
+            )
+        )

--- a/src/python/pants/backend/python/goals/lockfile_test.py
+++ b/src/python/pants/backend/python/goals/lockfile_test.py
@@ -256,10 +256,15 @@ def test_multiple_resolves() -> None:
 
 
 def test_empty_requirements(rule_runner: PythonRuleRunner) -> None:
-    with pytest.raises(ExecutionError):
+    with pytest.raises(ExecutionError) as excinfo:
         json.loads(
             _generate(
                 rule_runner=rule_runner,
                 requirements_string="",
             )
         )
+
+    assert (
+        "Cannot generate lockfile with no requirements. Please add some requirements to test."
+        in str(excinfo.value)
+    )


### PR DESCRIPTION
Closes #18624, closes #21026.

I ran into this myself recently and figured I would just fix it while I'm here...