### PR TITLE
Change MyPy docs for third-party type stubs

### DIFF
--- a/docs/docs/python/goals/check.mdx
+++ b/docs/docs/python/goals/check.mdx
@@ -130,9 +130,7 @@ python_sources(name="lib")
 
 You can install third-party type stubs (for example, `types-requests`) like [normal Python requirements](../overview/third-party-dependencies.mdx). Pants will infer a dependency on both the type stub and the actual dependency, for example, both `types-requests` and `requests`, which you can confirm by running `pants dependencies path/to/f.py`.
 
-If you install MyPy from a [custom lockfile](../overview/lockfiles.mdx#lockfiles-for-tools) you can also add type stub requirements to that lockfile.
-This ensures that the stubs are only used when running MyPy and are not included when, for example,
-[packaging a PEX](./package.mdx).
+Type stubs must be installed in the same resolve as the code being checked, and not in the same resolve as MyPy itself.
 
 ### Add a third-party plugin
 

--- a/docs/docs/python/goals/check.mdx
+++ b/docs/docs/python/goals/check.mdx
@@ -130,7 +130,7 @@ python_sources(name="lib")
 
 You can install third-party type stubs (for example, `types-requests`) like [normal Python requirements](../overview/third-party-dependencies.mdx). Pants will infer a dependency on both the type stub and the actual dependency, for example, both `types-requests` and `requests`, which you can confirm by running `pants dependencies path/to/f.py`.
 
-Type stubs must be installed in the same resolve as the code being checked, and not in the same resolve as MyPy itself.
+Third-party type stubs must be installed in the same resolve as the third-party code they provide types for.
 
 ### Add a third-party plugin
 

--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -91,13 +91,15 @@ To use this, enable the `pants.backend.experimental.python` backend.
 
 Exported virtualenvs can use Pants-provided Python if a `PythonProvider` backend is enabled (like `pants.backend.python.providers.experimental.pyenv`). Before Pants 2.23, virtualenv exports could only use pre-installed python binaries.
 
+The docs for the `check` goal have been updated to state that third-party type stubs must be installed in the same resolve as the code.
+
 #### Terraform
 
 The default version of terraform has been updated from 1.7.1 to 1.9.0.
 
 The `tfsec` linter now works on all supported platforms without extra config.
 
-`tfsec` versions are now provided in semver format, without "v" prefixes. 
+`tfsec` versions are now provided in semver format, without "v" prefixes.
 
 #### Javascript
 
@@ -107,6 +109,7 @@ now supports extending the `PATH` variable of such processes. Passing `extra_env
 silently ignored.
 
 Two issues with pants `corepack` integration has been resolved:
+
 1. The `"packageManager"` package.json field is now respected for other package.json than the one at the build root.
 Previously, if for example a nodejs tool was configured with a resolve based off of such a package.json, the bug caused
 pants to invoke `corepack`s default versions of the package managers instead.


### PR DESCRIPTION
While the docs say that type stubs can be installed in the same resolve as MyPy, this is not true. We should fix the docs to correctly state where type stubs need to be installed.

Related issues:

https://github.com/pantsbuild/pants/issues/21114
https://github.com/pantsbuild/pants/issues/20259#issuecomment-1962236113