### PR TITLE
Preserve Terraform deployment sandboxes

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -99,6 +99,8 @@ The `tfsec` linter now works on all supported platforms without extra config.
 
 `tfsec` versions are now provided in semver format, without "v" prefixes. 
 
+Sandboxes for the `experimental-deploy` deployment (the execution of `terraform apply`) can now be preserved with `--keep-sandboxes`.
+
 #### Javascript
 
 Nodejs processes configured with `extra_env_vars`, e.g.

--- a/src/python/pants/backend/terraform/goals/deploy.py
+++ b/src/python/pants/backend/terraform/goals/deploy.py
@@ -22,6 +22,7 @@ from pants.engine.process import InteractiveProcess, Process
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import SourcesField
 from pants.engine.unions import UnionRule
+from pants.option.global_options import KeepSandboxes
 from pants.util.logging import LogLevel
 
 logger = logging.getLogger(__name__)
@@ -42,6 +43,7 @@ async def prepare_terraform_deployment(
     request: TerraformDeploymentRequest,
     terraform_subsystem: TerraformTool,
     deploy_subsystem: DeploySubsystem,
+    keep_sandboxes: KeepSandboxes,
 ) -> InteractiveProcess:
     initialised_terraform = await Get(
         TerraformInitResponse,
@@ -85,7 +87,7 @@ async def prepare_terraform_deployment(
             chdir=initialised_terraform.chdir,
         ),
     )
-    return InteractiveProcess.from_process(process)
+    return InteractiveProcess.from_process(process, keep_sandboxes=keep_sandboxes)
 
 
 @rule(desc="Run Terraform deploy process", level=LogLevel.DEBUG)

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -353,6 +353,7 @@ class InteractiveProcess(SideEffecting):
         argv: Iterable[str],
         *,
         env: Mapping[str, str] | None = None,
+        description: str = "Interactive process",
         input_digest: Digest = EMPTY_DIGEST,
         run_in_workspace: bool = False,
         forward_signals_to_process: bool = True,
@@ -377,7 +378,7 @@ class InteractiveProcess(SideEffecting):
             "process",
             Process(
                 argv,
-                description="Interactive process",
+                description=description,
                 env=env,
                 input_digest=input_digest,
                 append_only_caches=append_only_caches,
@@ -401,6 +402,7 @@ class InteractiveProcess(SideEffecting):
         return InteractiveProcess(
             argv=process.argv,
             env=process.env,
+            description=process.description,
             input_digest=process.input_digest,
             forward_signals_to_process=forward_signals_to_process,
             restartable=restartable,

--- a/src/python/pants/engine/process.py
+++ b/src/python/pants/engine/process.py
@@ -396,6 +396,7 @@ class InteractiveProcess(SideEffecting):
         *,
         forward_signals_to_process: bool = True,
         restartable: bool = False,
+        keep_sandboxes: KeepSandboxes = KeepSandboxes.never,
     ) -> InteractiveProcess:
         return InteractiveProcess(
             argv=process.argv,
@@ -405,6 +406,7 @@ class InteractiveProcess(SideEffecting):
             restartable=restartable,
             append_only_caches=process.append_only_caches,
             immutable_input_digests=process.immutable_input_digests,
+            keep_sandboxes=keep_sandboxes,
         )
 
 


### PR DESCRIPTION
Seems we weren't preserving the sandbox used to deploy Terraform, probably because `InteractiveProcess.from_process` didn't have a way to do that. This MR adds the machinery to pass `KeepSandboxes` and wires it into Terraform.