### PR TITLE
[Call-by-name] cue/debian/makeself/sql migration

### DIFF
--- a/docs/notes/2.23.x.md
+++ b/docs/notes/2.23.x.md
@@ -144,6 +144,10 @@ Metadata for paths in the repository can now be requested via the `PathMetadataR
 
 Pants has a new mechanism for `@rule` invocation in backends. In this release the following backends were migrated to use this new mechanism. There should not be any user-visible effects, but please be on the lookout for any unusual bugs or error messages.
 - `cc`
+- `cue`
+- `debian`
+- `makeself`
+- `sql`
 - `swift`
 
 ## Full Changelog

--- a/src/python/pants/backend/cue/goals/fix.py
+++ b/src/python/pants/backend/cue/goals/fix.py
@@ -1,6 +1,9 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
+
+from typing import Iterable
 
 from pants.backend.cue.rules import _run_cue
 from pants.backend.cue.subsystem import Cue
@@ -8,7 +11,7 @@ from pants.backend.cue.target_types import CueFieldSet
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
 from pants.engine.platform import Platform
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule
 from pants.util.logging import LogLevel
 
 
@@ -30,8 +33,8 @@ async def run_cue_fmt(request: CueFmtRequest.Batch, cue: Cue, platform: Platform
     return await FmtResult.create(request, process_result)
 
 
-def rules():
-    return [
+def rules() -> Iterable[Rule]:
+    return (
         *collect_rules(),
         *CueFmtRequest.rules(),
-    ]
+    )

--- a/src/python/pants/backend/cue/goals/lint.py
+++ b/src/python/pants/backend/cue/goals/lint.py
@@ -1,17 +1,19 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Iterable
 
 from pants.backend.cue.rules import _run_cue
 from pants.backend.cue.subsystem import Cue
 from pants.backend.cue.target_types import CueFieldSet
 from pants.core.goals.lint import LintResult, LintTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest
 from pants.engine.platform import Platform
-from pants.engine.rules import Get, collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule
+from pants.core.util_rules.source_files import determine_source_files
 from pants.util.logging import LogLevel
 
 
@@ -27,16 +29,13 @@ async def run_cue_vet(
     cue: Cue,
     platform: Platform,
 ) -> LintResult:
-    sources = await Get(
-        SourceFiles,
-        SourceFilesRequest(sources_fields=[field_set.sources for field_set in request.elements]),
-    )
+    sources = await determine_source_files(SourceFilesRequest(sources_fields=[field_set.sources for field_set in request.elements]))
     process_result = await _run_cue("vet", cue=cue, snapshot=sources.snapshot, platform=platform)
     return LintResult.create(request, process_result)
 
 
-def rules():
-    return [
+def rules() -> Iterable[Rule]:
+    return (
         *collect_rules(),
         *CueLintRequest.rules(),
-    ]
+    )

--- a/src/python/pants/backend/cue/goals/lint.py
+++ b/src/python/pants/backend/cue/goals/lint.py
@@ -10,10 +10,9 @@ from pants.backend.cue.subsystem import Cue
 from pants.backend.cue.target_types import CueFieldSet
 from pants.core.goals.lint import LintResult, LintTargetsRequest
 from pants.core.util_rules.partitions import PartitionerType
-from pants.core.util_rules.source_files import SourceFilesRequest
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
 from pants.engine.platform import Platform
 from pants.engine.rules import Rule, collect_rules, rule
-from pants.core.util_rules.source_files import determine_source_files
 from pants.util.logging import LogLevel
 
 
@@ -29,7 +28,9 @@ async def run_cue_vet(
     cue: Cue,
     platform: Platform,
 ) -> LintResult:
-    sources = await determine_source_files(SourceFilesRequest(sources_fields=[field_set.sources for field_set in request.elements]))
+    sources = await determine_source_files(
+        SourceFilesRequest(sources_fields=[field_set.sources for field_set in request.elements])
+    )
     process_result = await _run_cue("vet", cue=cue, snapshot=sources.snapshot, platform=platform)
     return LintResult.create(request, process_result)
 

--- a/src/python/pants/backend/cue/rules.py
+++ b/src/python/pants/backend/cue/rules.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from pants.backend.cue.subsystem import Cue
-from pants.core.util_rules.external_tool import DownloadedExternalTool, ExternalToolRequest
-from pants.engine.fs import Digest, MergeDigests, Snapshot
+from pants.core.util_rules.external_tool import download_external_tool
+from pants.engine.fs import MergeDigests, Snapshot
+from pants.engine.intrinsics import merge_digests_request_to_digest
 from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process
-from pants.engine.rules import Get
+from pants.engine.process import FallibleProcessResult, Process, fallible_to_exec_result_or_raise
+from pants.engine.rules import implicitly
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
 
@@ -15,22 +16,24 @@ from pants.util.strutil import pluralize
 def generate_argv(*args: str, files: tuple[str, ...], cue: Cue) -> tuple[str, ...]:
     return args + cue.args + files
 
-
 async def _run_cue(
     *args: str, cue: Cue, snapshot: Snapshot, platform: Platform, **kwargs
 ) -> FallibleProcessResult:
-    downloaded_cue = await Get(
-        DownloadedExternalTool, ExternalToolRequest, cue.get_request(platform)
+    downloaded_cue = await download_external_tool(cue.get_request(platform))
+    input_digest = await merge_digests_request_to_digest(MergeDigests((downloaded_cue.digest, snapshot.digest)))
+    process_result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=[downloaded_cue.exe, *generate_argv(*args, files=snapshot.files, cue=cue)],
+                input_digest=input_digest,
+                description=f"Run `cue {args[0]}` on {pluralize(len(snapshot.files), 'file')}.",
+                level=LogLevel.DEBUG,
+                **kwargs,
+            ),
+        )
     )
-    input_digest = await Get(Digest, MergeDigests((downloaded_cue.digest, snapshot.digest)))
-    process_result = await Get(
-        FallibleProcessResult,
-        Process(
-            argv=[downloaded_cue.exe, *generate_argv(*args, files=snapshot.files, cue=cue)],
-            input_digest=input_digest,
-            description=f"Run `cue {args[0]}` on {pluralize(len(snapshot.files), 'file')}.",
-            level=LogLevel.DEBUG,
-            **kwargs,
-        ),
-    )
+    # process_result = await Get(
+    #     FallibleProcessResult,
+        
+    # )
     return process_result

--- a/src/python/pants/backend/cue/rules.py
+++ b/src/python/pants/backend/cue/rules.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from pants.backend.cue.subsystem import Cue
 from pants.core.util_rules.external_tool import download_external_tool
 from pants.engine.fs import MergeDigests, Snapshot
-from pants.engine.intrinsics import merge_digests_request_to_digest
+from pants.engine.intrinsics import (
+    merge_digests_request_to_digest,
+    process_request_to_process_result,
+)
 from pants.engine.platform import Platform
-from pants.engine.process import FallibleProcessResult, Process, fallible_to_exec_result_or_raise
+from pants.engine.process import FallibleProcessResult, Process
 from pants.engine.rules import implicitly
 from pants.util.logging import LogLevel
 from pants.util.strutil import pluralize
@@ -16,24 +19,22 @@ from pants.util.strutil import pluralize
 def generate_argv(*args: str, files: tuple[str, ...], cue: Cue) -> tuple[str, ...]:
     return args + cue.args + files
 
+
 async def _run_cue(
     *args: str, cue: Cue, snapshot: Snapshot, platform: Platform, **kwargs
 ) -> FallibleProcessResult:
     downloaded_cue = await download_external_tool(cue.get_request(platform))
-    input_digest = await merge_digests_request_to_digest(MergeDigests((downloaded_cue.digest, snapshot.digest)))
-    process_result = await fallible_to_exec_result_or_raise(
-        **implicitly(
-            Process(
-                argv=[downloaded_cue.exe, *generate_argv(*args, files=snapshot.files, cue=cue)],
-                input_digest=input_digest,
-                description=f"Run `cue {args[0]}` on {pluralize(len(snapshot.files), 'file')}.",
-                level=LogLevel.DEBUG,
-                **kwargs,
-            ),
-        )
+    input_digest = await merge_digests_request_to_digest(
+        MergeDigests((downloaded_cue.digest, snapshot.digest))
     )
-    # process_result = await Get(
-    #     FallibleProcessResult,
-        
-    # )
+    process_result = await process_request_to_process_result(
+        Process(
+            argv=[downloaded_cue.exe, *generate_argv(*args, files=snapshot.files, cue=cue)],
+            input_digest=input_digest,
+            description=f"Run `cue {args[0]}` on {pluralize(len(snapshot.files), 'file')}.",
+            level=LogLevel.DEBUG,
+            **kwargs,
+        ),
+        **implicitly(),
+    )
     return process_result

--- a/src/python/pants/backend/cue/target_types.py
+++ b/src/python/pants/backend/cue/target_types.py
@@ -1,5 +1,6 @@
 # Copyright 2023 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/src/python/pants/backend/debian/rules.py
+++ b/src/python/pants/backend/debian/rules.py
@@ -1,7 +1,11 @@
 # Copyright 2022 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 from dataclasses import dataclass
 from pathlib import PurePath
+from typing import Iterable
 
 from pants.backend.debian.target_types import (
     DebianInstallPrefix,
@@ -14,13 +18,16 @@ from pants.core.goals.package import (
     OutputPathField,
     PackageFieldSet,
 )
-from pants.core.util_rules.system_binaries import BinaryPathRequest, BinaryPaths, TarBinary
-from pants.engine.fs import CreateDigest, DigestEntries, FileEntry
-from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get
-from pants.engine.process import Process, ProcessResult
-from pants.engine.rules import collect_rules, rule
-from pants.engine.target import HydratedSources, HydrateSourcesRequest
+from pants.core.util_rules.system_binaries import BinaryPathRequest, TarBinary
+from pants.engine.fs import CreateDigest, FileEntry
+from pants.engine.process import Process
+from pants.engine.rules import Rule, collect_rules, rule, implicitly
+from pants.core.util_rules.system_binaries import find_binary
+from pants.engine.internals.graph import hydrate_sources
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.intrinsics import directory_digest_to_digest_entries
+from pants.engine.intrinsics import create_digest_to_digest
+from pants.engine.target import HydrateSourcesRequest
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
 
@@ -39,17 +46,14 @@ class DebianPackageFieldSet(PackageFieldSet):
 async def package_debian_package(
     field_set: DebianPackageFieldSet, tar_binary_path: TarBinary
 ) -> BuiltPackage:
-    dpkg_deb_path = await Get(
-        BinaryPaths,
-        BinaryPathRequest(
+    dpkg_deb_path = await find_binary(BinaryPathRequest(
             binary_name="dpkg-deb",
             search_path=["/usr/bin"],
-        ),
-    )
+        ), **implicitly())
     if not dpkg_deb_path.first_path:
         raise OSError(f"Could not find the `{dpkg_deb_path.binary_name}` program in `/usr/bin`.")
 
-    hydrated_sources = await Get(HydratedSources, HydrateSourcesRequest(field_set.sources_dir))
+    hydrated_sources = await hydrate_sources(HydrateSourcesRequest(field_set.sources_dir), **implicitly())
 
     # Since all the sources are coming only from a single directory, it is
     # safe to pick an arbitrary file and get its root directory name.
@@ -57,37 +61,38 @@ async def package_debian_package(
     # snapshot.files isn't empty.
     sources_directory_name = PurePath(hydrated_sources.snapshot.files[0]).parts[0]
 
-    result = await Get(
-        ProcessResult,
-        Process(
-            argv=(
-                dpkg_deb_path.first_path.path,
-                "--build",
-                sources_directory_name,
-            ),
-            description="Create a Debian package from the produced packages.",
-            input_digest=hydrated_sources.snapshot.digest,
-            # dpkg-deb produces a file with the same name as the input directory
-            output_files=(f"{sources_directory_name}.deb",),
-            env={"PATH": str(PurePath(tar_binary_path.path).parent)},
-        ),
+    result = await fallible_to_exec_result_or_raise(
+        **implicitly(
+            Process(
+                argv=(
+                    dpkg_deb_path.first_path.path,
+                    "--build",
+                    sources_directory_name,
+                ),
+                description="Create a Debian package from the produced packages.",
+                input_digest=hydrated_sources.snapshot.digest,
+                # dpkg-deb produces a file with the same name as the input directory
+                output_files=(f"{sources_directory_name}.deb",),
+                env={"PATH": str(PurePath(tar_binary_path.path).parent)},
+            )
+        )
     )
     # The output Debian package file needs to be renamed to match the output_path field.
     output_filename = field_set.output_path.value_or_default(
         file_ending="deb",
     )
-    digest_entries = await Get(DigestEntries, Digest, result.output_digest)
+    digest_entries = await directory_digest_to_digest_entries(result.output_digest)
     assert len(digest_entries) == 1
     result_file_entry = digest_entries[0]
     assert isinstance(result_file_entry, FileEntry)
     new_file = FileEntry(output_filename, result_file_entry.file_digest)
 
-    final_result = await Get(Digest, CreateDigest([new_file]))
+    final_result = await create_digest_to_digest(CreateDigest([new_file]))
     return BuiltPackage(final_result, artifacts=(BuiltPackageArtifact(output_filename),))
 
 
-def rules():
-    return [
+def rules() -> Iterable[Rule | UnionRule]:
+    return (
         *collect_rules(),
         UnionRule(PackageFieldSet, DebianPackageFieldSet),
-    ]
+    )

--- a/src/python/pants/backend/makeself/goals/package.py
+++ b/src/python/pants/backend/makeself/goals/package.py
@@ -1,11 +1,14 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from __future__ import annotations
+
 import dataclasses
 import logging
 import os
 from dataclasses import dataclass
 from pathlib import PurePath
-from typing import Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from pants.backend.makeself.subsystem import MakeselfTool
 from pants.backend.makeself.system_binaries import MakeselfBinaryShimsRequest
@@ -41,7 +44,7 @@ from pants.engine.intrinsics import (
     merge_digests_request_to_digest,
 )
 from pants.engine.process import Process, ProcessCacheScope, fallible_to_exec_result_or_raise
-from pants.engine.rules import collect_rules, concurrently, implicitly, rule
+from pants.engine.rules import Rule, collect_rules, concurrently, implicitly, rule
 from pants.engine.target import FieldSetsPerTargetRequest, HydrateSourcesRequest, SourcesField
 from pants.engine.unions import UnionRule
 from pants.util.logging import LogLevel
@@ -129,7 +132,7 @@ async def create_makeself_archive(
 @dataclass(frozen=True)
 class BuiltMakeselfArchiveArtifact(BuiltPackageArtifact):
     @classmethod
-    def create(cls, relpath: str) -> "BuiltMakeselfArchiveArtifact":
+    def create(cls, relpath: str) -> BuiltMakeselfArchiveArtifact:
         return cls(
             relpath=relpath,
             extra_log_lines=(f"Built Makeself binary: {relpath}",),
@@ -209,7 +212,7 @@ async def package_makeself_binary(field_set: MakeselfArchiveFieldSet) -> BuiltPa
     )
 
 
-def rules():
+def rules() -> Iterable[Rule | UnionRule]:
     return (
         *collect_rules(),
         *package.rules(),

--- a/src/python/pants/backend/makeself/goals/package_run_integration_test.py
+++ b/src/python/pants/backend/makeself/goals/package_run_integration_test.py
@@ -7,8 +7,11 @@ import pytest
 from pants.backend.makeself import subsystem
 from pants.backend.makeself import system_binaries as makeself_system_binaries
 from pants.backend.makeself.goals import package, run
-from pants.backend.makeself.goals.package import BuiltMakeselfArchiveArtifact
-from pants.backend.makeself.goals.run import MakeselfArchiveFieldSet, RunMakeselfArchive
+from pants.backend.makeself.goals.package import (
+    BuiltMakeselfArchiveArtifact,
+    MakeselfArchiveFieldSet,
+)
+from pants.backend.makeself.subsystem import RunMakeselfArchive
 from pants.backend.makeself.target_types import MakeselfArchiveTarget
 from pants.backend.shell import register
 from pants.core.goals.package import BuiltPackage

--- a/src/python/pants/backend/makeself/goals/run.py
+++ b/src/python/pants/backend/makeself/goals/run.py
@@ -10,11 +10,9 @@ from pants.backend.makeself.goals.package import MakeselfArchiveFieldSet, packag
 from pants.backend.makeself.subsystem import RunMakeselfArchive
 from pants.backend.makeself.system_binaries import MakeselfBinaryShimsRequest
 from pants.core.goals.run import RunRequest
-
-from pants.engine.process import Process
-from pants.engine.rules import Rule, collect_rules, rule
 from pants.core.util_rules.system_binaries import create_binary_shims
-from pants.engine.rules import implicitly
+from pants.engine.process import Process
+from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 
 
@@ -45,6 +43,7 @@ async def run_makeself_archive(request: RunMakeselfArchive) -> Process:
         env={"PATH": shims.path_component},
     )
 
+
 @rule
 async def create_makeself_archive_run_request(field_set: MakeselfArchiveFieldSet) -> RunRequest:
     package = await package_makeself_binary(field_set)
@@ -53,12 +52,14 @@ async def create_makeself_archive_run_request(field_set: MakeselfArchiveFieldSet
     if exe is None:
         raise RuntimeError(f"Invalid package artifact: {package}")
 
-    process = await run_makeself_archive(RunMakeselfArchive(
+    process = await run_makeself_archive(
+        RunMakeselfArchive(
             exe=exe,
             input_digest=package.digest,
             description="Run makeself archive",
             extra_tools=field_set.tools.value or (),
-    ))
+        )
+    )
 
     return RunRequest(
         digest=process.input_digest,

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -1,19 +1,19 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-import logging
-from typing import Iterable
 
-from pants.backend.makeself.goals.run import RunMakeselfArchive
+from dataclasses import dataclass
+import logging
+from typing import Iterable, Optional
+
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
-    ExternalToolRequest,
     TemplatedExternalTool,
 )
-from pants.engine.fs import Digest, RemovePrefix
+from pants.engine.fs import Digest
+from pants.engine.fs import RemovePrefix
 from pants.engine.platform import Platform
-from pants.engine.process import ProcessResult
-from pants.engine.rules import Get, Rule, collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule
 from pants.core.util_rules.external_tool import download_external_tool
 from pants.engine.process import fallible_to_exec_result_or_raise
 from pants.engine.intrinsics import remove_prefix_request_to_digest
@@ -66,6 +66,16 @@ async def download_makeself_distribution(
 
 class MakeselfTool(DownloadedExternalTool):
     """The Makeself tool."""
+
+@dataclass(frozen=True)
+class RunMakeselfArchive:
+    exe: str
+    input_digest: Digest
+    description: str
+    level: LogLevel = LogLevel.INFO
+    output_directory: Optional[str] = None
+    extra_args: Optional[tuple[str, ...]] = None
+    extra_tools: tuple[str, ...] = ()
 
 
 @rule(desc="Extract makeself distribution", level=LogLevel.DEBUG)

--- a/src/python/pants/backend/makeself/subsystem.py
+++ b/src/python/pants/backend/makeself/subsystem.py
@@ -1,23 +1,21 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 from pants.core.util_rules import external_tool
 from pants.core.util_rules.external_tool import (
     DownloadedExternalTool,
     TemplatedExternalTool,
+    download_external_tool,
 )
-from pants.engine.fs import Digest
-from pants.engine.fs import RemovePrefix
-from pants.engine.platform import Platform
-from pants.engine.rules import Rule, collect_rules, rule
-from pants.core.util_rules.external_tool import download_external_tool
-from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.fs import Digest, RemovePrefix
 from pants.engine.intrinsics import remove_prefix_request_to_digest
-from pants.engine.rules import implicitly
+from pants.engine.platform import Platform
+from pants.engine.process import fallible_to_exec_result_or_raise
+from pants.engine.rules import Rule, collect_rules, implicitly, rule
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 
@@ -66,6 +64,7 @@ async def download_makeself_distribution(
 
 class MakeselfTool(DownloadedExternalTool):
     """The Makeself tool."""
+
 
 @dataclass(frozen=True)
 class RunMakeselfArchive:

--- a/src/python/pants/backend/makeself/system_binaries.py
+++ b/src/python/pants/backend/makeself/system_binaries.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Iterable, Tuple
 
 from pants.backend.shell.subsystems.shell_setup import ShellSetup
 from pants.backend.shell.util_rules.builtin import BASH_BUILTIN_COMMANDS
@@ -38,7 +38,7 @@ from pants.core.util_rules.system_binaries import (
     WcBinary,
     XargsBinary,
 )
-from pants.engine.rules import collect_rules, rule
+from pants.engine.rules import Rule, collect_rules, rule
 from pants.util.logging import LogLevel
 
 
@@ -133,5 +133,5 @@ async def get_binaries_required_for_makeself(
     )
 
 
-def rules():
+def rules() -> Iterable[Rule]:
     return collect_rules()

--- a/src/python/pants/backend/sql/lint/sqlfluff/rules.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/rules.py
@@ -8,24 +8,22 @@ from typing import Any, Iterable, Tuple
 from typing_extensions import assert_never
 
 from pants.backend.python.util_rules import pex
-from pants.backend.python.util_rules.pex import PexRequest, VenvPex, VenvPexProcess
+from pants.backend.python.util_rules.pex import PexRequest, VenvPexProcess, create_venv_pex
 from pants.backend.sql.lint.sqlfluff.subsystem import Sqlfluff, SqlfluffFieldSet, SqlfluffMode
 from pants.core.goals.fix import FixResult, FixTargetsRequest
 from pants.core.goals.fmt import FmtResult, FmtTargetsRequest
 from pants.core.goals.lint import LintResult, LintTargetsRequest
-from pants.core.util_rules.config_files import ConfigFiles, ConfigFilesRequest
-from pants.core.util_rules.partitions import PartitionerType
-from pants.core.util_rules.source_files import SourceFiles, SourceFilesRequest
-from pants.engine.fs import Digest, MergeDigests
-from pants.engine.internals.native_engine import Snapshot
-from pants.engine.process import FallibleProcessResult
-from pants.engine.rules import Get, Rule, concurrently, collect_rules, rule
-from pants.backend.python.util_rules.pex import create_venv_pex
 from pants.core.util_rules.config_files import find_config_file
-from pants.engine.intrinsics import merge_digests_request_to_digest
-from pants.engine.intrinsics import process_request_to_process_result
-from pants.core.util_rules.source_files import determine_source_files
-from pants.engine.rules import implicitly
+from pants.core.util_rules.partitions import PartitionerType
+from pants.core.util_rules.source_files import SourceFilesRequest, determine_source_files
+from pants.engine.fs import MergeDigests
+from pants.engine.internals.native_engine import Snapshot
+from pants.engine.intrinsics import (
+    merge_digests_request_to_digest,
+    process_request_to_process_result,
+)
+from pants.engine.process import FallibleProcessResult
+from pants.engine.rules import Rule, collect_rules, concurrently, implicitly, rule
 from pants.util.logging import LogLevel
 from pants.util.meta import classproperty
 from pants.util.strutil import pluralize
@@ -74,7 +72,9 @@ async def run_sqlfluff(
     sqlfluff_pex_get = create_venv_pex(**implicitly({sqlfluff.to_pex_request(): PexRequest}))
     config_files_get = find_config_file(sqlfluff.config_request(request.snapshot.dirs))
     sqlfluff_pex, config_files = await concurrently(sqlfluff_pex_get, config_files_get)
-    input_digest = await merge_digests_request_to_digest(MergeDigests((request.snapshot.digest, config_files.snapshot.digest)))
+    input_digest = await merge_digests_request_to_digest(
+        MergeDigests((request.snapshot.digest, config_files.snapshot.digest))
+    )
 
     initial_args: Tuple[str, ...] = ()
     if request.mode is SqlfluffMode.FMT:
@@ -89,33 +89,46 @@ async def run_sqlfluff(
     conf_args = ["--config", sqlfluff.config] if sqlfluff.config else []
 
     result = await process_request_to_process_result(
-        **implicitly(VenvPexProcess(
-            sqlfluff_pex,
-            argv=(*initial_args, *conf_args, *sqlfluff.args, *request.snapshot.files),
-            input_digest=input_digest,
-            output_files=request.snapshot.files,
-            description=f"Run sqlfluff {' '.join(initial_args)} on {pluralize(len(request.snapshot.files), 'file')}.",
-            level=LogLevel.DEBUG,
-        )))
+        **implicitly(
+            VenvPexProcess(
+                sqlfluff_pex,
+                argv=(*initial_args, *conf_args, *sqlfluff.args, *request.snapshot.files),
+                input_digest=input_digest,
+                output_files=request.snapshot.files,
+                description=f"Run sqlfluff {' '.join(initial_args)} on {pluralize(len(request.snapshot.files), 'file')}.",
+                level=LogLevel.DEBUG,
+            )
+        )
+    )
     return result
 
 
 @rule(desc="Fix with sqlfluff fix", level=LogLevel.DEBUG)
 async def sqlfluff_fix(request: SqlfluffFixRequest.Batch, sqlfluff: Sqlfluff) -> FixResult:
-    result = await run_sqlfluff(_RunSqlfluffRequest(snapshot=request.snapshot, mode=SqlfluffMode.FIX), sqlfluff)
+    result = await run_sqlfluff(
+        _RunSqlfluffRequest(snapshot=request.snapshot, mode=SqlfluffMode.FIX), sqlfluff
+    )
     return await FixResult.create(request, result)
 
 
 @rule(desc="Lint with sqlfluff lint", level=LogLevel.DEBUG)
-async def sqlfluff_lint(request: SqlfluffLintRequest.Batch[SqlfluffFieldSet, Any], sqlfluff: Sqlfluff) -> LintResult:
-    source_files = await determine_source_files(SourceFilesRequest(field_set.source for field_set in request.elements))
-    result = await run_sqlfluff(_RunSqlfluffRequest(snapshot=source_files.snapshot, mode=SqlfluffMode.LINT), sqlfluff)
+async def sqlfluff_lint(
+    request: SqlfluffLintRequest.Batch[SqlfluffFieldSet, Any], sqlfluff: Sqlfluff
+) -> LintResult:
+    source_files = await determine_source_files(
+        SourceFilesRequest(field_set.source for field_set in request.elements)
+    )
+    result = await run_sqlfluff(
+        _RunSqlfluffRequest(snapshot=source_files.snapshot, mode=SqlfluffMode.LINT), sqlfluff
+    )
     return LintResult.create(request, result)
 
 
 @rule(desc="Format with sqlfluff format", level=LogLevel.DEBUG)
 async def sqlfluff_fmt(request: SqlfluffFormatRequest.Batch, sqlfluff: Sqlfluff) -> FmtResult:
-    result = await run_sqlfluff(_RunSqlfluffRequest(snapshot=request.snapshot, mode=SqlfluffMode.FMT), sqlfluff)
+    result = await run_sqlfluff(
+        _RunSqlfluffRequest(snapshot=request.snapshot, mode=SqlfluffMode.FMT), sqlfluff
+    )
     return await FmtResult.create(request, result)
 
 

--- a/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 from typing import Iterable
+
 from pants.backend.sql.target_types import SqlSourcesGeneratorTarget, SqlSourceTarget
 from pants.engine.target import BoolField
 from pants.engine.unions import UnionRule

--- a/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/skip_field.py
@@ -1,7 +1,10 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from typing import Iterable
 from pants.backend.sql.target_types import SqlSourcesGeneratorTarget, SqlSourceTarget
 from pants.engine.target import BoolField
+from pants.engine.unions import UnionRule
 
 
 class SkipSqlfluffField(BoolField):
@@ -10,8 +13,8 @@ class SkipSqlfluffField(BoolField):
     help = "If true, don't run sqlfluff on this target's code."
 
 
-def rules():
-    return [
+def rules() -> Iterable[UnionRule]:
+    return (
         SqlSourcesGeneratorTarget.register_plugin_field(SkipSqlfluffField),
         SqlSourceTarget.register_plugin_field(SkipSqlfluffField),
-    ]
+    )

--- a/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 from __future__ import annotations
 
 import os.path
@@ -12,7 +13,7 @@ from pants.backend.python.target_types import ConsoleScript
 from pants.backend.sql.lint.sqlfluff.skip_field import SkipSqlfluffField
 from pants.backend.sql.target_types import SqlSourceField
 from pants.core.util_rules.config_files import ConfigFilesRequest
-from pants.engine.rules import collect_rules
+from pants.engine.rules import Rule, collect_rules
 from pants.engine.target import FieldSet, Target
 from pants.option.option_types import ArgsListOption, BoolOption, FileOption, SkipOption
 from pants.util.strutil import softwrap
@@ -100,5 +101,6 @@ class Sqlfluff(PythonToolBase):
         )
 
 
-def rules():
+
+def rules() -> Iterable[Rule]:
     return collect_rules()

--- a/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
+++ b/src/python/pants/backend/sql/lint/sqlfluff/subsystem.py
@@ -101,6 +101,5 @@ class Sqlfluff(PythonToolBase):
         )
 
 
-
 def rules() -> Iterable[Rule]:
     return collect_rules()

--- a/src/python/pants/backend/sql/tailor.py
+++ b/src/python/pants/backend/sql/tailor.py
@@ -12,11 +12,8 @@ from pants.core.goals.tailor import (
     PutativeTargets,
     PutativeTargetsRequest,
 )
-from pants.engine.fs import PathGlobs, Paths
-from pants.engine.internals.selectors import Get
-from pants.engine.rules import collect_rules, rule
 from pants.engine.intrinsics import path_globs_to_paths
-from pants.engine.rules import implicitly
+from pants.engine.rules import collect_rules, rule
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel

--- a/src/python/pants/backend/sql/tailor.py
+++ b/src/python/pants/backend/sql/tailor.py
@@ -15,6 +15,8 @@ from pants.core.goals.tailor import (
 from pants.engine.fs import PathGlobs, Paths
 from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
+from pants.engine.intrinsics import path_globs_to_paths
+from pants.engine.rules import implicitly
 from pants.engine.unions import UnionRule
 from pants.util.dirutil import group_by_dir
 from pants.util.logging import LogLevel
@@ -29,7 +31,7 @@ class PutativeSqlTargetsRequest(PutativeTargetsRequest):
 async def find_putative_targets(
     req: PutativeSqlTargetsRequest, all_owned_sources: AllOwnedSources
 ) -> PutativeTargets:
-    all_sql_files = await Get(Paths, PathGlobs, req.path_globs("*.sql"))
+    all_sql_files = await path_globs_to_paths(req.path_globs("*.sql"))
     unowned_sql_files = set(all_sql_files.files) - set(all_owned_sources)
     targets = PutativeTargets(
         [


### PR DESCRIPTION
This is a PR for the call-by-name migration on multiple, smaller, experimental backends. Cue, Debian, MakeSelf, SQL

Tested on https://github.com/sureshjoshi/pantsanity (as much as reasonably possible) via `pants sanity ::`

See issue https://github.com/pantsbuild/pants/issues/21065 for tracking list.

cc'ing @grihabor for the SQL and MakeSelf backends