### PR TITLE
add `path_env_modify` field to `adhoc_tool` and `shell_command` to control how PATH is augmented

### DIFF
--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -14,6 +14,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
+    AdhocToolPathEnvModifyModeField,
     AdhocToolRunnableDependenciesField,
     AdhocToolRunnableField,
     AdhocToolSourcesField,
@@ -101,6 +102,7 @@ async def run_in_sandbox_request(
         tool_runner.extra_env,
         target.get(AdhocToolExtraEnvVarsField).value or (),
         extra_paths=tool_runner.extra_paths,
+        path_env_modify_mode=target.get(AdhocToolPathEnvModifyModeField).as_enum(),
         description_of_origin=f"`{AdhocToolExtraEnvVarsField.alias}` for `adhoc_tool` target at `{target.address}`",
     )
 

--- a/src/python/pants/backend/adhoc/adhoc_tool.py
+++ b/src/python/pants/backend/adhoc/adhoc_tool.py
@@ -102,7 +102,7 @@ async def run_in_sandbox_request(
         tool_runner.extra_env,
         target.get(AdhocToolExtraEnvVarsField).value or (),
         extra_paths=tool_runner.extra_paths,
-        path_env_modify_mode=target.get(AdhocToolPathEnvModifyModeField).as_enum(),
+        path_env_modify_mode=target.get(AdhocToolPathEnvModifyModeField).enum_value,
         description_of_origin=f"`{AdhocToolExtraEnvVarsField.alias}` for `adhoc_tool` target at `{target.address}`",
     )
 

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import ClassVar
 
+from pants.core.util_rules.adhoc_process_support import PathEnvModifyMode
 from pants.core.util_rules.environments import EnvironmentField
 from pants.engine.target import (
     COMMON_TARGET_FIELDS,
@@ -274,6 +275,35 @@ class AdhocToolWorkspaceInvalidationSourcesField(StringSequenceField):
     )
 
 
+class AdhocToolPathEnvModifyModeField(StringField):
+    alias = "path_env_modify"
+    default = PathEnvModifyMode.PREPEND.value
+    help = help_text(
+        """
+        When executing the command of an `adhoc_tool` or `shell_command` target, Pants will augment the `PATH`
+        environment variable with the location of any binary shims created for `tools` and for
+        any runnable dependencies.
+
+        Modification of the `PATH` environment variable can be configured as follows:
+        - `prepend`: Prepend the extra path components to any existing `PATH` value.
+        - `append`: Append the extra path componenets to any existing `PATH` value.
+        - `off`: Do not modify the existing `PATH` value.
+        """
+    )
+    valid_choices = PathEnvModifyMode
+
+    def as_enum(self) -> PathEnvModifyMode:
+        value = self.value
+        if value == PathEnvModifyMode.PREPEND.value:
+            return PathEnvModifyMode.PREPEND
+        elif value == PathEnvModifyMode.APPEND.value:
+            return PathEnvModifyMode.APPEND
+        elif value == PathEnvModifyMode.OFF.value:
+            return PathEnvModifyMode.OFF
+        else:
+            raise AssertionError(f"Invalid value for {self.alias} field: {value}")
+
+
 class AdhocToolTarget(Target):
     alias: ClassVar[str] = "adhoc_tool"
     core_fields = (
@@ -294,6 +324,7 @@ class AdhocToolTarget(Target):
         AdhocToolStdoutFilenameField,
         AdhocToolStderrFilenameField,
         AdhocToolWorkspaceInvalidationSourcesField,
+        AdhocToolPathEnvModifyModeField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -274,20 +274,6 @@ class AdhocToolWorkspaceInvalidationSourcesField(StringSequenceField):
     )
 
 
-class AdhocToolIncludeShimsOnPathField(BoolField):
-    alias: ClassVar[str] = "include_shims_on_path"
-    default = True
-    help = help_text(
-        """
-        If True, then modify the `PATH` of the invoked process to include binary shims for the
-        `tools` configured for the target and also any runnable dependencies.
-
-        Set this to False when using in-workspace execution if you want to preserve the
-        configured `PATH` value.
-        """
-    )
-
-
 class AdhocToolTarget(Target):
     alias: ClassVar[str] = "adhoc_tool"
     core_fields = (
@@ -308,7 +294,6 @@ class AdhocToolTarget(Target):
         AdhocToolStdoutFilenameField,
         AdhocToolStderrFilenameField,
         AdhocToolWorkspaceInvalidationSourcesField,
-        AdhocToolIncludeShimsOnPathField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -280,7 +280,7 @@ class AdhocToolPathEnvModifyModeField(StringField):
     default = PathEnvModifyMode.PREPEND.value
     help = help_text(
         """
-        When executing the command of an `adhoc_tool` or `shell_command` target, Pants will augment the `PATH`
+        When executing the command of an `adhoc_tool` or `shell_command` target, Pants may augment the `PATH`
         environment variable with the location of any binary shims created for `tools` and for
         any runnable dependencies.
 
@@ -292,16 +292,9 @@ class AdhocToolPathEnvModifyModeField(StringField):
     )
     valid_choices = PathEnvModifyMode
 
-    def as_enum(self) -> PathEnvModifyMode:
-        value = self.value
-        if value == PathEnvModifyMode.PREPEND.value:
-            return PathEnvModifyMode.PREPEND
-        elif value == PathEnvModifyMode.APPEND.value:
-            return PathEnvModifyMode.APPEND
-        elif value == PathEnvModifyMode.OFF.value:
-            return PathEnvModifyMode.OFF
-        else:
-            raise AssertionError(f"Invalid value for {self.alias} field: {value}")
+    @property
+    def enum_value(self) -> PathEnvModifyMode:
+        return PathEnvModifyMode(self.value)
 
 
 class AdhocToolTarget(Target):

--- a/src/python/pants/backend/adhoc/target_types.py
+++ b/src/python/pants/backend/adhoc/target_types.py
@@ -274,6 +274,20 @@ class AdhocToolWorkspaceInvalidationSourcesField(StringSequenceField):
     )
 
 
+class AdhocToolIncludeShimsOnPathField(BoolField):
+    alias: ClassVar[str] = "include_shims_on_path"
+    default = True
+    help = help_text(
+        """
+        If True, then modify the `PATH` of the invoked process to include binary shims for the
+        `tools` configured for the target and also any runnable dependencies.
+
+        Set this to False when using in-workspace execution if you want to preserve the
+        configured `PATH` value.
+        """
+    )
+
+
 class AdhocToolTarget(Target):
     alias: ClassVar[str] = "adhoc_tool"
     core_fields = (
@@ -294,6 +308,7 @@ class AdhocToolTarget(Target):
         AdhocToolStdoutFilenameField,
         AdhocToolStderrFilenameField,
         AdhocToolWorkspaceInvalidationSourcesField,
+        AdhocToolIncludeShimsOnPathField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -10,7 +10,6 @@ from pants.backend.adhoc.target_types import (
     AdhocToolDependenciesField,
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
-    AdhocToolIncludeShimsOnPathField,
     AdhocToolLogOutputField,
     AdhocToolNamedCachesField,
     AdhocToolOutputDependenciesField,
@@ -385,8 +384,27 @@ class ShellCommandWorkspaceInvalidationSourcesField(AdhocToolWorkspaceInvalidati
     pass
 
 
-class ShellCommandIncludeShimsOnPathField(AdhocToolIncludeShimsOnPathField):
-    pass
+class PathShimsMode(Enum):
+    PREPEND = "prepend"
+    APPEND = "append"
+    OFF = "off"
+
+
+class ShellCommandPathShimsModeField(StringField):
+    alias = "path_shims_mode"
+    default = PathShimsMode.PREPEND.value
+    help = help_text(
+        """
+        When executing the command of a `shell_command`, Pants will augment the `PATH` environment variable
+        with the location of any binary shims created for `tools` and for any runnable dependencies.
+
+        Modification of the `PATH` environment variable can be configured as follows:
+        - `prepend`: Prepend the binary shim paths to any existing `PATH` value.
+        - `append`: Append the binary shim paths to any existing `PATH` value.
+        - `off`: Do not modify the existing `PATH` value.
+        """
+    )
+    valid_choices = PathShimsMode
 
 
 class SkipShellCommandTestsField(BoolField):
@@ -414,7 +432,7 @@ class ShellCommandTarget(Target):
         ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
         ShellCommandWorkspaceInvalidationSourcesField,
-        ShellCommandIncludeShimsOnPathField,
+        ShellCommandPathShimsModeField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -10,6 +10,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolDependenciesField,
     AdhocToolExecutionDependenciesField,
     AdhocToolExtraEnvVarsField,
+    AdhocToolIncludeShimsOnPathField,
     AdhocToolLogOutputField,
     AdhocToolNamedCachesField,
     AdhocToolOutputDependenciesField,
@@ -384,6 +385,10 @@ class ShellCommandWorkspaceInvalidationSourcesField(AdhocToolWorkspaceInvalidati
     pass
 
 
+class ShellCommandIncludeShimsOnPathField(AdhocToolIncludeShimsOnPathField):
+    pass
+
+
 class SkipShellCommandTestsField(BoolField):
     alias = "skip_tests"
     default = False
@@ -409,6 +414,7 @@ class ShellCommandTarget(Target):
         ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
         ShellCommandWorkspaceInvalidationSourcesField,
+        ShellCommandIncludeShimsOnPathField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -16,6 +16,7 @@ from pants.backend.adhoc.target_types import (
     AdhocToolOutputDirectoriesField,
     AdhocToolOutputFilesField,
     AdhocToolOutputRootDirField,
+    AdhocToolPathEnvModifyModeField,
     AdhocToolRunnableDependenciesField,
     AdhocToolTimeoutField,
     AdhocToolWorkdirField,
@@ -384,27 +385,8 @@ class ShellCommandWorkspaceInvalidationSourcesField(AdhocToolWorkspaceInvalidati
     pass
 
 
-class PathShimsMode(Enum):
-    PREPEND = "prepend"
-    APPEND = "append"
-    OFF = "off"
-
-
-class ShellCommandPathShimsModeField(StringField):
-    alias = "path_shims_mode"
-    default = PathShimsMode.PREPEND.value
-    help = help_text(
-        """
-        When executing the command of a `shell_command`, Pants will augment the `PATH` environment variable
-        with the location of any binary shims created for `tools` and for any runnable dependencies.
-
-        Modification of the `PATH` environment variable can be configured as follows:
-        - `prepend`: Prepend the binary shim paths to any existing `PATH` value.
-        - `append`: Append the binary shim paths to any existing `PATH` value.
-        - `off`: Do not modify the existing `PATH` value.
-        """
-    )
-    valid_choices = PathShimsMode
+class ShellCommandPathEnvModifyModeField(AdhocToolPathEnvModifyModeField):
+    pass
 
 
 class SkipShellCommandTestsField(BoolField):
@@ -432,7 +414,7 @@ class ShellCommandTarget(Target):
         ShellCommandNamedCachesField,
         ShellCommandOutputRootDirField,
         ShellCommandWorkspaceInvalidationSourcesField,
-        ShellCommandPathShimsModeField,
+        ShellCommandPathEnvModifyModeField,
         EnvironmentField,
     )
     help = help_text(

--- a/src/python/pants/backend/shell/target_types.py
+++ b/src/python/pants/backend/shell/target_types.py
@@ -484,6 +484,7 @@ class ShellCommandTestTarget(Target):
         ShellCommandTimeoutField,
         ShellCommandToolsField,
         ShellCommandExtraEnvVarsField,
+        ShellCommandPathEnvModifyModeField,
         EnvironmentField,
         SkipShellCommandTestsField,
         ShellCommandWorkdirField,

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -14,6 +14,7 @@ from pants.backend.shell.target_types import (
     ShellCommandCommandField,
     ShellCommandExecutionDependenciesField,
     ShellCommandExtraEnvVarsField,
+    ShellCommandIncludeShimsOnPathField,
     ShellCommandLogOutputField,
     ShellCommandNamedCachesField,
     ShellCommandOutputDirectoriesField,
@@ -138,6 +139,18 @@ async def _prepare_process_request_from_target(
                 extra_env=runnable_dependencies.extra_env,
             )
         )
+
+        runnable_dependencies = execution_environment.runnable_dependencies
+        if runnable_dependencies:
+            extra_sandbox_contents.append(
+                ExtraSandboxContents(
+                    EMPTY_DIGEST,
+                    f"{{chroot}}/{runnable_dependencies.path_component}",
+                    runnable_dependencies.immutable_input_digests,
+                    runnable_dependencies.append_only_caches,
+                    runnable_dependencies.extra_env,
+                )
+            )
 
     merged_extras = await Get(
         ExtraSandboxContents, MergeExtraSandboxContents(tuple(extra_sandbox_contents))

--- a/src/python/pants/backend/shell/util_rules/shell_command.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command.py
@@ -148,7 +148,7 @@ async def _prepare_process_request_from_target(
         merged_extras.extra_env,
         shell_command.get(ShellCommandExtraEnvVarsField).value or (),
         extra_paths=merged_extras.paths,
-        path_env_modify_mode=shell_command.get(ShellCommandPathEnvModifyModeField).as_enum(),
+        path_env_modify_mode=shell_command.get(ShellCommandPathEnvModifyModeField).enum_value,
         description_of_origin=f"`{ShellCommandExtraEnvVarsField.alias}` for `shell_command` target at `{shell_command.address}`",
     )
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -913,29 +913,40 @@ def test_shell_command_workspace_invalidation_sources(rule_runner: RuleRunner) -
     assert result1.snapshot != result3.snapshot
 
 
-def test_shell_command_include_shims_on_path(rule_runner: RuleRunner) -> None:
-    rule_runner.write_files({
-        "src/BUILD": dedent(
-            """\
+def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
+    expected_path = "/bin:/usr/bin"
+    rule_runner.write_files(
+        {
+            "src/BUILD": dedent(
+                f"""\
             shell_command(
-                name="shims_true",
+                name="shims_prepend",
                 tools=["echo"],
                 command="echo $PATH > path.txt",
-                extra_env_vars=["PATH=/bin:/usr/bin"],
+                extra_env_vars=["PATH={expected_path}"],
                 output_files=["path.txt"],
-                include_shims_on_path=True,
+                path_shims_mode="prepend",
             )
             shell_command(
-                name="shims_false",
+                name="shims_append",
                 tools=["echo"],
                 command="echo $PATH > path.txt",
-                extra_env_vars=["PATH=/bin:/usr/bin"],
+                extra_env_vars=["PATH={expected_path}"],
                 output_files=["path.txt"],
-                include_shims_on_path=False,
+                path_shims_mode="append",
+            )
+            shell_command(
+                name="shims_off",
+                tools=["echo"],
+                command="echo $PATH > path.txt",
+                extra_env_vars=["PATH={expected_path}"],
+                output_files=["path.txt"],
+                path_shims_mode="off",
             )
             """
-        )
-    })
+            )
+        }
+    )
 
     def run(target_name: str) -> str:
         result = execute_shell_command(rule_runner, Address("src", target_name=target_name))
@@ -943,8 +954,13 @@ def test_shell_command_include_shims_on_path(rule_runner: RuleRunner) -> None:
         assert len(contents) == 1
         return contents[0].content.decode().strip()
 
-    path_true = run("shims_true")
-    assert "/bin:/usr/bin" not in path_true
+    path_prepend = run("shims_prepend")
+    assert path_prepend.endswith(expected_path)
+    assert len(path_prepend) > len(expected_path)
 
-    path_false = run("shims_false")
-    assert path_false == "/bin:/usr/bin"
+    path_append = run("shims_false")
+    assert path_append.startswith(expected_path)
+    assert len(path_append) > len(expected_path)
+
+    path_off = run("shims_off")
+    assert path_off == expected_path

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -958,7 +958,7 @@ def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
     assert path_prepend.endswith(expected_path)
     assert len(path_prepend) > len(expected_path)
 
-    path_append = run("shims_false")
+    path_append = run("shims_append")
     assert path_append.startswith(expected_path)
     assert len(path_append) > len(expected_path)
 

--- a/src/python/pants/backend/shell/util_rules/shell_command_test.py
+++ b/src/python/pants/backend/shell/util_rules/shell_command_test.py
@@ -913,7 +913,7 @@ def test_shell_command_workspace_invalidation_sources(rule_runner: RuleRunner) -
     assert result1.snapshot != result3.snapshot
 
 
-def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
+def test_shell_command_path_env_modify_mode(rule_runner: RuleRunner) -> None:
     expected_path = "/bin:/usr/bin"
     rule_runner.write_files(
         {
@@ -925,7 +925,7 @@ def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
                 command="echo $PATH > path.txt",
                 extra_env_vars=["PATH={expected_path}"],
                 output_files=["path.txt"],
-                path_shims_mode="prepend",
+                path_env_modify="prepend",
             )
             shell_command(
                 name="shims_append",
@@ -933,7 +933,7 @@ def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
                 command="echo $PATH > path.txt",
                 extra_env_vars=["PATH={expected_path}"],
                 output_files=["path.txt"],
-                path_shims_mode="append",
+                path_env_modify="append",
             )
             shell_command(
                 name="shims_off",
@@ -941,7 +941,7 @@ def test_shell_command_path_shims_mode(rule_runner: RuleRunner) -> None:
                 command="echo $PATH > path.txt",
                 extra_env_vars=["PATH={expected_path}"],
                 output_files=["path.txt"],
-                path_shims_mode="off",
+                path_env_modify="off",
             )
             """
             )


### PR DESCRIPTION
As described in https://github.com/pantsbuild/pants/issues/21136, Pants currently has a bug where any `PATH` value in the `extra_env_vars` field of the `shell_command` target type is ignored and the `PATH` is set to only the binary shim directory.

This PR builds on top of https://github.com/pantsbuild/pants/pull/21185 to allow the user to configure how the `PATH` is augmented. It adds a new `path_env_modify` field on `adhoc_tool` and `shell_command` targets which configures whether the shims are prepended (`prepend`), appended (`append`), or ignored (`off`) to the existing `PATH` value.